### PR TITLE
fix: show skeleton on chat page refresh instead of send-message flash

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -14,6 +14,7 @@ import {
   zeroSessionListError$,
   zeroSessionError$,
   zeroChatThreadId$,
+  zeroSessionSwitching$,
   setZeroChatInput$,
   clearZeroChatInput$,
   fetchZeroSessionList$,
@@ -22,6 +23,7 @@ import {
   sendZeroChatMessage$,
   sendFromZeroDemo$,
   syncUrlSession$,
+  prepareSessionSwitch$,
 } from "../zero-chat.ts";
 
 const context = testContext();
@@ -293,6 +295,41 @@ describe("zero-chat signals", () => {
 
       expect(context.store.get(zeroChatMessages$)).toHaveLength(0);
       expect(context.store.get(zeroChatSending$)).toBeFalsy();
+    });
+  });
+
+  describe("prepareSessionSwitch$", () => {
+    it("should set sessionSwitching to true so skeleton shows immediately", async () => {
+      await setup();
+
+      expect(context.store.get(zeroSessionSwitching$)).toBeFalsy();
+
+      context.store.set(prepareSessionSwitch$);
+
+      expect(context.store.get(zeroSessionSwitching$)).toBeTruthy();
+    });
+
+    it("should be cleared after switchZeroSession$ completes", async () => {
+      server.use(
+        http.get("*/api/zero/chat-threads/:id", () => {
+          return HttpResponse.json({
+            id: "thread-1",
+            agentComposeId: "mock-compose-id",
+            chatMessages: [],
+            latestSessionId: null,
+            createdAt: "2026-03-10T00:00:00Z",
+            updatedAt: "2026-03-10T00:00:00Z",
+          });
+        }),
+      );
+
+      await setup();
+
+      context.store.set(prepareSessionSwitch$);
+      expect(context.store.get(zeroSessionSwitching$)).toBeTruthy();
+
+      await context.store.set(switchZeroSession$, "thread-1");
+      expect(context.store.get(zeroSessionSwitching$)).toBeFalsy();
     });
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -500,6 +500,15 @@ export const zeroSessionSwitching$ = computed((get) =>
   get(internalSessionSwitching$),
 );
 
+/**
+ * Mark session as switching immediately so the UI shows a skeleton
+ * instead of flashing "Send a message" while the page setup runs.
+ * Called from setupZeroPage$ before heavy data loads when a session URL is detected.
+ */
+export const prepareSessionSwitch$ = command(({ set }) => {
+  set(internalSessionSwitching$, true);
+});
+
 // Chat input
 const internalChatInput$ = state("");
 export const zeroChatInput$ = computed((get) => get(internalChatInput$));

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -9,9 +9,14 @@ import { initSlackOrg$ } from "./zero-slack.ts";
 import {
   zeroChatAgentName$,
   zeroInChat$,
+  zeroSessionId$,
   initSidebarCollapsed$,
 } from "./zero-nav.ts";
-import { switchActiveAgent$, syncUrlSession$ } from "./zero-chat.ts";
+import {
+  switchActiveAgent$,
+  syncUrlSession$,
+  prepareSessionSwitch$,
+} from "./zero-chat.ts";
 import {
   pinnedAgentIds$,
   updatePinnedAgentIds$,
@@ -147,6 +152,13 @@ async function resolveAndSwitchAgent(
 export const setupZeroPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroPage));
+
+    // When landing on /chat/:sessionId (e.g. page refresh), mark session as
+    // switching immediately so the UI shows a skeleton instead of briefly
+    // flashing the "Send a message" empty state while initial data loads.
+    if (get(zeroSessionId$)) {
+      set(prepareSessionSwitch$);
+    }
 
     await set(loadInitialData$, signal);
 


### PR DESCRIPTION
## Summary
- On page refresh at `/chat/:sessionId`, the UI briefly flashed "Send a message" before showing the loading skeleton
- Root cause: `sessionSwitching` was not set to `true` until after heavy initial data (agents, onboarding, slack) finished loading in `setupZeroPage$`
- Fix: added `prepareSessionSwitch$` command that sets `sessionSwitching=true` immediately when a session URL is detected, before the heavy data loads begin

## Test plan
- [x] New tests for `prepareSessionSwitch$` (sets flag, cleared after session load)
- [x] All 23 existing chat signal tests pass
- [ ] Manual: refresh `/chat/:sessionId` — should show skeleton immediately, never flash "Send a message"

🤖 Generated with [Claude Code](https://claude.com/claude-code)