### PR TITLE
refactor: remove ccstate-react/experimental from scope-review-modal

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -3,16 +3,19 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   CONNECTOR_TYPES,
   hasRequiredScopes,
+  zeroConnectorScopeDiffContract,
   zeroSecretsContract,
   zeroVariablesContract,
   type ConnectorType,
   type ConnectorResponse,
+  type ScopeDiff,
 } from "@vm0/core";
 import { featureSwitch$ } from "../../external/feature-switch.ts";
 import { connectors$, reloadConnectors$ } from "../../external/connectors.ts";
 import { apiBaseForNavigation$ } from "../../fetch.ts";
 import { zeroClient$ } from "../../api-client.ts";
-import { throwIfAbort } from "../../utils.ts";
+import { detach, Reason, throwIfAbort } from "../../utils.ts";
+import { logger } from "../../log.ts";
 import { delay } from "signal-timers";
 import { localStorageSignals } from "../../external/local-storage.ts";
 
@@ -174,13 +177,47 @@ export const setSelectedConnectorType$ = command(
 // Scope review modal state
 // ---------------------------------------------------------------------------
 
+const L = logger("ScopeReviewModal");
+
 const internalScopeReviewType$ = state<ConnectorType | null>(null);
 export const scopeReviewType$ = computed((get) =>
   get(internalScopeReviewType$),
 );
+
+const internalScopeDiff$ = state<ScopeDiff | null>(null);
+export const scopeDiff$ = computed((get) => get(internalScopeDiff$));
+
+const internalScopeReviewLoading$ = state(false);
+export const scopeReviewLoading$ = computed((get) =>
+  get(internalScopeReviewLoading$),
+);
+
+const loadScopeDiff$ = command(async ({ get, set }, type: ConnectorType) => {
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroConnectorScopeDiffContract);
+  try {
+    const result = await client.getScopeDiff({ params: { type } });
+    if (result.status === 200) {
+      set(internalScopeDiff$, result.body);
+    } else {
+      L.error(`Failed to fetch scope diff: ${result.status}`, result.body);
+    }
+  } catch (error: unknown) {
+    throwIfAbort(error);
+    L.error("Failed to fetch scope diff:", error);
+  } finally {
+    set(internalScopeReviewLoading$, false);
+  }
+});
+
 export const setScopeReviewType$ = command(
   ({ set }, type: ConnectorType | null) => {
     set(internalScopeReviewType$, type);
+    if (type) {
+      set(internalScopeDiff$, null);
+      set(internalScopeReviewLoading$, true);
+      detach(set(loadScopeDiff$, type), Reason.Entrance);
+    }
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
@@ -1,24 +1,16 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
-import { useGet, useSet } from "ccstate-react";
-import { useCCState, useCommand } from "ccstate-react/experimental";
+import { useGet } from "ccstate-react";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
-import {
-  CONNECTOR_TYPES,
-  zeroConnectorScopeDiffContract,
-  type ConnectorType,
-  type ScopeDiff,
-} from "@vm0/core";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { ConnectorIcon } from "./connector-icons.tsx";
-import { zeroClient$ } from "../../../../signals/api-client.ts";
-import { logger } from "../../../../signals/log.ts";
-import { onRef } from "../../../../signals/utils.ts";
-
-const L = logger("ScopeReviewModal");
+import {
+  scopeDiff$,
+  scopeReviewLoading$,
+} from "../../../../signals/zero-page/settings/connectors.ts";
 
 interface ScopeReviewModalProps {
   connectorType: ConnectorType | null;
@@ -31,52 +23,8 @@ export function ScopeReviewModal({
   onClose,
   onReconnect,
 }: ScopeReviewModalProps) {
-  const createClient = useGet(zeroClient$);
-  const scopeDiff$ = useCCState<ScopeDiff | null>(null);
-  const loading$ = useCCState(false);
   const scopeDiff = useGet(scopeDiff$);
-  const loading = useGet(loading$);
-  const setLoading = useSet(loading$);
-  const setScopeDiff = useSet(scopeDiff$);
-
-  // Guard: onRef() creates a new atom each render, so if the command
-  // synchronously changes state the component reads (loading$), the re-render
-  // produces a new ref callback → React re-attaches → onRef fires again → loop.
-  // The guard ensures the load only executes once.
-  const hasStartedLoad$ = useCCState(false);
-  const loadScopeDiffCmd$ = useCommand(({ get, set }) => {
-    if (get(hasStartedLoad$)) {
-      return;
-    }
-    set(hasStartedLoad$, true);
-    if (!connectorType) {
-      set(scopeDiff$, null);
-      return;
-    }
-    set(loading$, true);
-    const client = createClient(zeroConnectorScopeDiffContract);
-    client
-      .getScopeDiff({ params: { type: connectorType } })
-      .then((result) => {
-        if (result.status === 200) {
-          setScopeDiff(result.body);
-        } else {
-          L.error(`Failed to fetch scope diff: ${result.status}`, result.body);
-        }
-        setLoading(false);
-      })
-      .catch((error: unknown) => {
-        L.error("Failed to fetch scope diff:", error);
-        setLoading(false);
-      });
-  });
-
-  // Load on mount when connectorType is set
-  const initLoad$ = useCommand(({ set }) => {
-    set(loadScopeDiffCmd$);
-  });
-  const initRef$ = onRef(initLoad$);
-  const initRef = useSet(initRef$);
+  const loading = useGet(scopeReviewLoading$);
 
   if (!connectorType) {
     return null;
@@ -86,11 +34,7 @@ export function ScopeReviewModal({
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent
-        ref={initRef}
-        className="max-w-md"
-        aria-describedby={undefined}
-      >
+      <DialogContent className="max-w-md" aria-describedby={undefined}>
         <DialogHeader>
           <div className="flex items-center gap-3">
             <ConnectorIcon type={connectorType} size={28} />


### PR DESCRIPTION
## Summary
- Move `useCCState` and `useCommand` from `scope-review-modal.tsx` to `signals/zero-page/settings/connectors.ts`
- Scope diff loading now triggers automatically when `setScopeReviewType$` is called with a non-null type, eliminating the `onRef` mount hack
- Remove the `eslint-disable ccstate/no-use-ccstate-in-views` comment and `ccstate-react/experimental` import

## Test plan
- [x] All 12 existing integration tests in `zero-connector-card.test.tsx` pass
- [x] Lint passes with zero warnings/errors
- [x] Type check passes
- [x] Knip finds no unused exports

Closes #5804

🤖 Generated with [Claude Code](https://claude.com/claude-code)