### PR TITLE
fix: remove --delete-branch from coding-loop auto-merge

### DIFF
--- a/scripts/coding-loop.sh
+++ b/scripts/coding-loop.sh
@@ -239,7 +239,7 @@ Spawn a subagent: /pr-review ${PR_NUMBER}
 
 After review:
 - If P0/P1 issues found: git checkout ${BRANCH}, fix all P0/P1 issues, push, then git checkout main && git pull
-- If no P0/P1 issues: run gh pr merge ${PR_NUMBER} --merge --auto --delete-branch, then git checkout main && git pull
+- If no P0/P1 issues: run gh pr merge ${PR_NUMBER} --merge --auto, then git checkout main && git pull
 EOF
       exit 0
       ;;
@@ -250,7 +250,7 @@ EOF
 
     ci_passed)
       # Enable auto-merge directly — no subagent needed
-      gh pr merge "$PR_NUMBER" --repo "$REPO" --merge --auto --delete-branch 2>/dev/null || true
+      gh pr merge "$PR_NUMBER" --repo "$REPO" --merge --auto 2>/dev/null || true
       # Fall through to Phase B
       ;;
   esac


### PR DESCRIPTION
## Summary

- Remove `--delete-branch` flag from `gh pr merge` in `scripts/coding-loop.sh` (both the command and instruction text)
- The flag is incompatible with GitHub merge queues, causing auto-merge to silently fail
- Merge queue handles branch deletion automatically, so the flag is unnecessary

Closes #6025

## Test plan

- [x] Verified no remaining `--delete-branch` occurrences in `coding-loop.sh`
- [x] Change matches the verified working command from the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)