### PR TITLE
fix(ci): use full run id in merge queue job-ref

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -277,7 +277,7 @@ jobs:
           elif [ "$EVENT_NAME" = "merge_group" ]; then
             MQ_PR_NUM=$(echo "$MQ_HEAD_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [ -n "$MQ_PR_NUM" ]; then
-              JOB_REF="pr-${MQ_PR_NUM}-mq-$(printf '%s' "$GITHUB_RUN_ID" | tail -c 6)-test"
+              JOB_REF="pr-${MQ_PR_NUM}-mq-${GITHUB_RUN_ID}-test"
             else
               echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_HEAD_REF"
               exit 1

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -202,8 +202,8 @@ jobs:
             MQ_REF="${{ github.event.merge_group.head_ref }}"
             PR_NUM=$(echo "$MQ_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [ -n "$PR_NUM" ]; then
-              echo "job-ref=pr-${PR_NUM}-mq-$(printf '%s' "$GITHUB_RUN_ID" | tail -c 6)" >> "$GITHUB_OUTPUT"
-              echo "Job ref set to: pr-${PR_NUM}-mq-$(printf '%s' "$GITHUB_RUN_ID" | tail -c 6)"
+              echo "job-ref=pr-${PR_NUM}-mq-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
+              echo "Job ref set to: pr-${PR_NUM}-mq-${GITHUB_RUN_ID}"
             else
               echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_REF"
               exit 1


### PR DESCRIPTION
## Summary
- Replace `printf | tail -c 6` truncation with full `GITHUB_RUN_ID` in merge queue job-ref
- Simpler, no reason to truncate — full ID is guaranteed unique

Follow-up to #6014.

## Test plan
- [ ] Merge queue run produces job-ref like `pr-XXXX-mq-23420198989-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)