### PR TITLE
feat: handle no-model-provider error with dedicated deep link

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { mockLocation } from "../../../location.ts";
+import { testContext } from "../../../__tests__/test-helpers.ts";
+import { createPushStateMock } from "../../../../__tests__/page-helper.ts";
+import {
+  checkSettingsParam$,
+  orgManageDialogOpen$,
+} from "../org-manage-dialog.ts";
+import { activeTab$ } from "../org-manage-tabs-state.ts";
+import { searchParams$ } from "../../../route.ts";
+
+const context = testContext();
+
+describe("checkSettingsParam$", () => {
+  it("should open dialog on providers tab when ?settings=providers is present", () => {
+    const { store, signal } = context;
+    createPushStateMock(signal);
+    mockLocation({ pathname: "/", search: "?settings=providers" }, signal);
+
+    store.set(checkSettingsParam$);
+
+    expect(store.get(orgManageDialogOpen$)).toBe(true);
+    expect(store.get(activeTab$)).toBe("providers");
+    // The param should be stripped from the URL
+    expect(store.get(searchParams$).has("settings")).toBe(false);
+  });
+
+  it("should open dialog on billing tab when ?settings=billing is present", () => {
+    const { store, signal } = context;
+    createPushStateMock(signal);
+    mockLocation({ pathname: "/", search: "?settings=billing" }, signal);
+
+    store.set(checkSettingsParam$);
+
+    expect(store.get(orgManageDialogOpen$)).toBe(true);
+    expect(store.get(activeTab$)).toBe("billing");
+  });
+
+  it("should not open dialog when no settings param is present", () => {
+    const { store, signal } = context;
+    createPushStateMock(signal);
+    mockLocation({ pathname: "/", search: "" }, signal);
+
+    store.set(checkSettingsParam$);
+
+    expect(store.get(orgManageDialogOpen$)).toBe(false);
+  });
+
+  it("should not open dialog for unknown settings value", () => {
+    const { store, signal } = context;
+    createPushStateMock(signal);
+    mockLocation({ pathname: "/", search: "?settings=unknown" }, signal);
+
+    store.set(checkSettingsParam$);
+
+    expect(store.get(orgManageDialogOpen$)).toBe(false);
+    // The param should still be stripped
+    expect(store.get(searchParams$).has("settings")).toBe(false);
+  });
+
+  it("should preserve other search params when stripping settings", () => {
+    const { store, signal } = context;
+    createPushStateMock(signal);
+    mockLocation(
+      { pathname: "/", search: "?settings=providers&other=keep" },
+      signal,
+    );
+
+    store.set(checkSettingsParam$);
+
+    expect(store.get(orgManageDialogOpen$)).toBe(true);
+    const params = store.get(searchParams$);
+    expect(params.has("settings")).toBe(false);
+    expect(params.get("other")).toBe("keep");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
@@ -19,10 +19,10 @@ describe("checkSettingsParam$", () => {
 
     store.set(checkSettingsParam$);
 
-    expect(store.get(orgManageDialogOpen$)).toBe(true);
+    expect(store.get(orgManageDialogOpen$)).toBeTruthy();
     expect(store.get(activeTab$)).toBe("providers");
     // The param should be stripped from the URL
-    expect(store.get(searchParams$).has("settings")).toBe(false);
+    expect(store.get(searchParams$).has("settings")).toBeFalsy();
   });
 
   it("should open dialog on billing tab when ?settings=billing is present", () => {
@@ -32,7 +32,7 @@ describe("checkSettingsParam$", () => {
 
     store.set(checkSettingsParam$);
 
-    expect(store.get(orgManageDialogOpen$)).toBe(true);
+    expect(store.get(orgManageDialogOpen$)).toBeTruthy();
     expect(store.get(activeTab$)).toBe("billing");
   });
 
@@ -43,7 +43,7 @@ describe("checkSettingsParam$", () => {
 
     store.set(checkSettingsParam$);
 
-    expect(store.get(orgManageDialogOpen$)).toBe(false);
+    expect(store.get(orgManageDialogOpen$)).toBeFalsy();
   });
 
   it("should not open dialog for unknown settings value", () => {
@@ -53,9 +53,9 @@ describe("checkSettingsParam$", () => {
 
     store.set(checkSettingsParam$);
 
-    expect(store.get(orgManageDialogOpen$)).toBe(false);
+    expect(store.get(orgManageDialogOpen$)).toBeFalsy();
     // The param should still be stripped
-    expect(store.get(searchParams$).has("settings")).toBe(false);
+    expect(store.get(searchParams$).has("settings")).toBeFalsy();
   });
 
   it("should preserve other search params when stripping settings", () => {
@@ -68,9 +68,9 @@ describe("checkSettingsParam$", () => {
 
     store.set(checkSettingsParam$);
 
-    expect(store.get(orgManageDialogOpen$)).toBe(true);
+    expect(store.get(orgManageDialogOpen$)).toBeTruthy();
     const params = store.get(searchParams$);
-    expect(params.has("settings")).toBe(false);
+    expect(params.has("settings")).toBeFalsy();
     expect(params.get("other")).toBe("keep");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
@@ -14,15 +14,6 @@ export const setOrgManageDialogOpen$ = command(({ set }, open: boolean) => {
   set(internalOrgManageDialogOpen$, open);
 });
 
-const SETTINGS_TAB_MAP: Record<string, OrgManageTab> = {
-  providers: "providers",
-  general: "general",
-  members: "members",
-  billing: "billing",
-  credits: "credits",
-  invoices: "invoices",
-};
-
 /**
  * Check URL for `?settings=<tab>` param and auto-open the org manage dialog
  * on the specified tab. Strips the param from the URL after consuming it.
@@ -34,7 +25,15 @@ export const checkSettingsParam$ = command(({ get, set }) => {
     return;
   }
 
-  const tab = SETTINGS_TAB_MAP[settingsValue];
+  const settingsTabMap: Record<string, OrgManageTab> = {
+    providers: "providers",
+    general: "general",
+    members: "members",
+    billing: "billing",
+    credits: "credits",
+    invoices: "invoices",
+  };
+  const tab = settingsTabMap[settingsValue];
   if (tab) {
     set(setActiveTab$, tab);
     set(internalOrgManageDialogOpen$, true);

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
@@ -1,6 +1,8 @@
 import { command, computed, state } from "ccstate";
 import { clerk$ } from "../../auth.ts";
 import { onRef } from "../../utils.ts";
+import { searchParams$, updateSearchParams$ } from "../../route.ts";
+import { setActiveTab$, type OrgManageTab } from "./org-manage-tabs-state.ts";
 
 const internalOrgManageDialogOpen$ = state(false);
 
@@ -10,6 +12,38 @@ export const orgManageDialogOpen$ = computed((get) =>
 
 export const setOrgManageDialogOpen$ = command(({ set }, open: boolean) => {
   set(internalOrgManageDialogOpen$, open);
+});
+
+const SETTINGS_TAB_MAP: Record<string, OrgManageTab> = {
+  providers: "providers",
+  general: "general",
+  members: "members",
+  billing: "billing",
+  credits: "credits",
+  invoices: "invoices",
+};
+
+/**
+ * Check URL for `?settings=<tab>` param and auto-open the org manage dialog
+ * on the specified tab. Strips the param from the URL after consuming it.
+ */
+export const checkSettingsParam$ = command(({ get, set }) => {
+  const params = get(searchParams$);
+  const settingsValue = params.get("settings");
+  if (!settingsValue) {
+    return;
+  }
+
+  const tab = SETTINGS_TAB_MAP[settingsValue];
+  if (tab) {
+    set(setActiveTab$, tab);
+    set(internalOrgManageDialogOpen$, true);
+  }
+
+  // Strip the param so it doesn't re-trigger on navigation
+  const next = new URLSearchParams(params);
+  next.delete("settings");
+  set(updateSearchParams$, next);
 });
 
 const patchClerkOrgProfile$ = command(

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -17,6 +17,7 @@ import {
   updatePinnedAgentIds$,
 } from "./zero-pinned-agents.ts";
 import { syncModelPreference$ } from "./zero-model-preference.ts";
+import { checkSettingsParam$ } from "./settings/org-manage-dialog.ts";
 import { logger } from "../log.ts";
 import { pathname$ } from "../route.ts";
 import { Reason, detach } from "../utils.ts";
@@ -149,6 +150,9 @@ export const setupZeroPage$ = command(
     set(updatePage$, createElement(ZeroPage));
 
     await set(loadInitialData$, signal);
+
+    // Consume ?settings=<tab> param before resolveAndSwitchAgent replaces the URL
+    set(checkSettingsParam$);
 
     await resolveAndSwitchAgent(get, set, signal);
 

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -49,6 +49,7 @@ import {
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { Link, SimpleLink } from "../router/link.tsx";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
+import { setActiveTab$ } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import zeroAvatarImg from "./assets/zero-avatar.png";
 
 // ---------------------------------------------------------------------------
@@ -565,6 +566,7 @@ interface AssistantMessageProps {
 
 function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
   const setOrgManageOpen = useSet(setOrgManageDialogOpen$);
+  const setTab = useSet(setActiveTab$);
   const avatar = (
     <div className="h-9 w-9 shrink-0 mt-0.5 overflow-hidden rounded-xl">
       <img
@@ -670,7 +672,10 @@ function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
                   <button
                     type="button"
                     className="inline-flex items-center gap-1 text-amber-500 underline underline-offset-2 hover:text-amber-400"
-                    onClick={() => setOrgManageOpen(true)}
+                    onClick={() => {
+                      setTab("providers");
+                      setOrgManageOpen(true);
+                    }}
                   >
                     Set one up in Organization Settings
                   </button>{" "}

--- a/turbo/apps/web/src/lib/__tests__/deep-links.test.ts
+++ b/turbo/apps/web/src/lib/__tests__/deep-links.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { buildModelProviderLink, detectDeepLinks } from "../deep-links";
+
+describe("buildModelProviderLink", () => {
+  it("should return a deep link to the providers settings page", () => {
+    const link = buildModelProviderLink("https://app.vm0.ai");
+
+    expect(link).toEqual({
+      emoji: "🔑",
+      label: "Configure model providers",
+      url: "https://app.vm0.ai/?settings=providers",
+    });
+  });
+});
+
+describe("detectDeepLinks", () => {
+  const appUrl = "https://app.vm0.ai";
+
+  it("should not detect model provider keywords", () => {
+    const links = detectDeepLinks(
+      "The model provider is not configured",
+      appUrl,
+    );
+    expect(links).toEqual([]);
+  });
+
+  it("should still detect connector keywords", () => {
+    const links = detectDeepLinks(
+      "missing variable DATABASE_URL",
+      appUrl,
+      "my-agent",
+    );
+    expect(links).toHaveLength(1);
+    expect(links[0]?.label).toBe("Configure connectors");
+  });
+});

--- a/turbo/apps/web/src/lib/deep-links.ts
+++ b/turbo/apps/web/src/lib/deep-links.ts
@@ -2,7 +2,7 @@
 // Keyword detection for deep links (shared across Slack and Telegram)
 // ---------------------------------------------------------------------------
 
-type KeywordCategory = "provider" | "connector";
+type KeywordCategory = "connector";
 
 interface KeywordLinkMapping {
   keywords: string[];
@@ -18,12 +18,6 @@ export interface DeepLink {
 }
 
 const KEYWORD_LINK_MAPPINGS: readonly KeywordLinkMapping[] = Object.freeze([
-  {
-    keywords: ["model provider", "provider not configured"],
-    label: "Configure model providers",
-    category: "provider",
-    emoji: "🔑",
-  },
   {
     keywords: [
       "secret",
@@ -46,14 +40,23 @@ const KEYWORD_LINK_MAPPINGS: readonly KeywordLinkMapping[] = Object.freeze([
 ]);
 
 function buildPath(category: KeywordCategory, agentName?: string): string {
-  if (category === "provider") {
-    return "/settings";
-  }
   // Connector links route to the agent's team page with connectors tab
-  if (agentName) {
+  if (category === "connector" && agentName) {
     return `/team/${encodeURIComponent(agentName)}?tab=connectors`;
   }
   return "/team";
+}
+
+/**
+ * Build the deep link URL for configuring model providers.
+ * Opens the org manage dialog directly on the providers tab.
+ */
+export function buildModelProviderLink(appUrl: string): DeepLink {
+  return {
+    emoji: "🔑",
+    label: "Configure model providers",
+    url: `${appUrl}/?settings=providers`,
+  };
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/__tests__/extract-run-output.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/extract-run-output.test.ts
@@ -54,7 +54,6 @@ describe("extractRunOutput", () => {
     expect(output).toEqual({
       result: null,
       askUserDenials: [],
-      modelProviderIssue: false,
       connectorIssue: false,
       error: null,
     });
@@ -80,7 +79,7 @@ describe("extractRunOutput", () => {
     expect(output.result).toBeNull();
   });
 
-  it("detects model provider issues in result text", async () => {
+  it("does not flag model provider issues (handled via error code)", async () => {
     mockQuery.mockResolvedValue(
       axiomResponse([
         { eventData: { result: "model provider not configured" } },
@@ -89,7 +88,6 @@ describe("extractRunOutput", () => {
 
     const output = await extractRunOutput("run-1");
 
-    expect(output.modelProviderIssue).toBe(true);
     expect(output.connectorIssue).toBe(false);
   });
 
@@ -311,7 +309,6 @@ describe("buildDeepLinksFromFlags", () => {
   const baseOutput: RunOutput = {
     result: null,
     askUserDenials: [],
-    modelProviderIssue: false,
     connectorIssue: false,
     error: null,
   };
@@ -320,16 +317,6 @@ describe("buildDeepLinksFromFlags", () => {
     expect(buildDeepLinksFromFlags(baseOutput, "https://app.vm0.ai")).toEqual(
       [],
     );
-  });
-
-  it("returns provider link when modelProviderIssue is true", () => {
-    const links = buildDeepLinksFromFlags(
-      { ...baseOutput, modelProviderIssue: true },
-      "https://app.vm0.ai",
-    );
-
-    expect(links).toHaveLength(1);
-    expect(links[0]!.url).toBe("https://app.vm0.ai/settings");
   });
 
   it("returns connector link with agent name", () => {
@@ -343,12 +330,13 @@ describe("buildDeepLinksFromFlags", () => {
     expect(links[0]!.url).toContain("/team/my-agent?tab=connectors");
   });
 
-  it("returns both links when both issues present", () => {
+  it("returns connector link without agent name", () => {
     const links = buildDeepLinksFromFlags(
-      { ...baseOutput, modelProviderIssue: true, connectorIssue: true },
+      { ...baseOutput, connectorIssue: true },
       "https://app.vm0.ai",
     );
 
-    expect(links).toHaveLength(2);
+    expect(links).toHaveLength(1);
+    expect(links[0]!.url).toBe("https://app.vm0.ai/team");
   });
 });

--- a/turbo/apps/web/src/lib/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/run/extract-run-output.ts
@@ -86,7 +86,6 @@ export async function extractRunOutput(
     return {
       result: null,
       askUserDenials: [],
-
       connectorIssue: false,
       error: error ?? null,
     };
@@ -113,7 +112,6 @@ export async function extractAllRunOutputs(
       {
         result: null,
         askUserDenials: [],
-
         connectorIssue: false,
         error: error ?? null,
       },

--- a/turbo/apps/web/src/lib/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/run/extract-run-output.ts
@@ -22,8 +22,6 @@ export interface RunOutput {
   result: string | null;
   /** AskUserQuestion permission denials */
   askUserDenials: PermissionDenial[];
-  /** Whether model provider keywords were detected in the result */
-  modelProviderIssue: boolean;
   /** Whether connector/secret keywords were detected in the result */
   connectorIssue: boolean;
   /** Run error message (if failed) */
@@ -88,7 +86,7 @@ export async function extractRunOutput(
     return {
       result: null,
       askUserDenials: [],
-      modelProviderIssue: false,
+
       connectorIssue: false,
       error: error ?? null,
     };
@@ -115,7 +113,7 @@ export async function extractAllRunOutputs(
       {
         result: null,
         askUserDenials: [],
-        modelProviderIssue: false,
+
         connectorIssue: false,
         error: error ?? null,
       },
@@ -142,7 +140,6 @@ function buildRunOutput(event: ResultEvent, error?: string | null): RunOutput {
   return {
     result,
     askUserDenials,
-    modelProviderIssue: categories.has("provider"),
     connectorIssue: categories.has("connector"),
     error: error ?? null,
   };
@@ -186,14 +183,6 @@ export function buildDeepLinksFromFlags(
   agentName?: string,
 ): DeepLink[] {
   const links: DeepLink[] = [];
-
-  if (output.modelProviderIssue) {
-    links.push({
-      emoji: "🔑",
-      label: "Configure model providers",
-      url: `${appUrl}/settings`,
-    });
-  }
 
   if (output.connectorIssue) {
     const path = agentName

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -10,6 +10,7 @@ import {
   buildLoginPromptMessage,
   detectDeepLinks,
 } from "../../slack/blocks";
+import { buildModelProviderLink } from "../../deep-links";
 import type { SlackFile } from "../../slack/context";
 import { runAgentForSlackOrg } from "./run-agent";
 import type { SlackOrgCallbackContext } from "./run-agent";
@@ -174,7 +175,7 @@ export async function handleOrgDirectMessage(
     existingSessionId,
   };
 
-  const { status, response, runId } = await runAgentForSlackOrg({
+  const { status, response, runId, errorCode } = await runAgentForSlackOrg({
     composeId,
     agentName,
     sessionId: existingSessionId,
@@ -222,6 +223,9 @@ export async function handleOrgDirectMessage(
         response ?? "Sorry, an error occurred. Please try again.";
       const logsUrl = buildAgentLogsUrl();
       const deepLinks = detectDeepLinks(errorText, getAppUrl(), agentName);
+      if (errorCode === "NO_MODEL_PROVIDER") {
+        deepLinks.push(buildModelProviderLink(getAppUrl()));
+      }
       await postMessage(client, context.channelId, errorText, {
         threadTs,
         blocks: buildAgentResponseMessage(errorText, logsUrl, deepLinks),

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -6,6 +6,7 @@ import {
   buildLoginPromptMessage,
   detectDeepLinks,
 } from "../../slack/blocks";
+import { buildModelProviderLink } from "../../deep-links";
 import type { SlackFile } from "../../slack/context";
 import { runAgentForSlackOrg } from "./run-agent";
 import type { SlackOrgCallbackContext } from "./run-agent";
@@ -172,7 +173,7 @@ export async function handleOrgMention(
     existingSessionId,
   };
 
-  const { status, response, runId } = await runAgentForSlackOrg({
+  const { status, response, runId, errorCode } = await runAgentForSlackOrg({
     composeId,
     agentName,
     sessionId: existingSessionId,
@@ -220,6 +221,9 @@ export async function handleOrgMention(
         response ?? "Sorry, an error occurred. Please try again.";
       const logsUrl = buildAgentLogsUrl();
       const deepLinks = detectDeepLinks(errorText, getAppUrl(), agentName);
+      if (errorCode === "NO_MODEL_PROVIDER") {
+        deepLinks.push(buildModelProviderLink(getAppUrl()));
+      }
       await client.chat.postMessage({
         channel: context.channelId,
         thread_ts: threadTs,

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -43,6 +43,7 @@ interface RunAgentResult {
   status: "dispatched" | "queued" | "failed";
   response?: string;
   runId: string | undefined;
+  errorCode?: string;
 }
 
 /**
@@ -118,7 +119,12 @@ export async function runAgentForSlackOrg(
         agentName,
         userId,
       });
-      return { status: "failed", response, runId: undefined };
+      return {
+        status: "failed",
+        response,
+        runId: undefined,
+        errorCode: error.code,
+      };
     }
     const runId = isRunDispatchError(error) ? error.runId : undefined;
     log.error("Error running agent for Slack org:", error);

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -207,17 +207,12 @@ describe("detectDeepLinks", () => {
     expect(links).toEqual([]);
   });
 
-  it("should detect provider-related keywords", () => {
+  it("should not detect provider-related keywords (handled via error code)", () => {
     const links = detectDeepLinks(
       "The model provider is not configured",
       appUrl,
     );
-    expect(links).toHaveLength(1);
-    expect(links[0]).toEqual({
-      emoji: "\u{1F511}",
-      label: "Configure model providers",
-      url: `${appUrl}/settings`,
-    });
+    expect(links).toEqual([]);
   });
 
   it("should route connector links to team page with agent name", () => {
@@ -264,16 +259,14 @@ describe("detectDeepLinks", () => {
     expect(links[0]?.url).toBe(`${appUrl}/team/my-agent?tab=connectors`);
   });
 
-  it("should return multiple links for different destinations", () => {
+  it("should only return connector link when both provider and connector keywords present", () => {
     const links = detectDeepLinks(
       "The model provider is missing. Also the api key is not set and the MCP server is down.",
       appUrl,
       "my-agent",
     );
-    expect(links).toHaveLength(2);
-    const urls = links.map((l) => l.url);
-    expect(urls).toContain(`${appUrl}/settings`);
-    expect(urls).toContain(`${appUrl}/team/my-agent?tab=connectors`);
+    expect(links).toHaveLength(1);
+    expect(links[0]?.url).toBe(`${appUrl}/team/my-agent?tab=connectors`);
   });
 
   it("should encode special characters in agent name", () => {


### PR DESCRIPTION
## Summary
- Remove model provider keywords from `detectDeepLinks()` text scanning — provider errors are now handled via error code instead of keyword matching
- Add `buildModelProviderLink()` that generates a deep link to `/?settings=providers`, which auto-opens the org manage dialog on the Model Providers tab
- Add `errorCode` field to `RunAgentResult` so Slack handlers can detect `NO_MODEL_PROVIDER` errors and show the dedicated configuration link
- Add `checkSettingsParam$` to consume `?settings=<tab>` URL param on the platform, wired before `resolveAndSwitchAgent` to prevent param loss during URL redirect
- Update platform chat page "Set one up" link to navigate directly to the providers tab

## Test plan
- [x] `org-manage-dialog.test.ts` — tests `checkSettingsParam$` opens dialog on correct tab, strips param, handles unknown values, preserves other params
- [x] `deep-links.test.ts` — tests `buildModelProviderLink()` returns correct structure, `detectDeepLinks()` no longer matches provider keywords
- [x] `blocks.test.ts` — updated to reflect provider keywords removal
- [x] `extract-run-output.test.ts` — updated to remove `modelProviderIssue` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)