### PR TITLE
refactor: introduce startZeroRun to separate platform/integration run creation from CLI

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -90,7 +90,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const data = await createTestRun(composeId, "Hello");
       const run = await getTestRun(data.runId);
 
-      // CLI path (startRun) does not inject agent identity — that's done by startZeroRun
+      // CLI path (startCliRun) does not inject agent identity — that's done by startZeroRun
       expect(run.appendSystemPrompt).toBeNull();
     });
 

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -78,7 +78,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.status).toBe("pending");
     });
 
-    it("should inject agent identity into appendSystemPrompt", async () => {
+    it("should not inject agent identity for CLI callers", async () => {
       const agentName = uniqueId("identity-agent");
       const { composeId } = await createTestCompose(agentName);
       await createTestZeroAgent(user.orgId, agentName, {
@@ -90,9 +90,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const data = await createTestRun(composeId, "Hello");
       const run = await getTestRun(data.runId);
 
-      expect(run.appendSystemPrompt).toContain("My Agent");
-      expect(run.appendSystemPrompt).toContain("A helpful assistant");
-      expect(run.appendSystemPrompt).toContain("warm, approachable");
+      // CLI path (startRun) does not inject agent identity — that's done by startZeroRun
+      expect(run.appendSystemPrompt).toBeNull();
     });
 
     it("should not inject identity when no metadata exists", async () => {
@@ -102,7 +101,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(run.appendSystemPrompt).toBeNull();
     });
 
-    it("should prepend identity before existing appendSystemPrompt", async () => {
+    it("should pass through appendSystemPrompt without identity for CLI callers", async () => {
       const agentName = uniqueId("prepend-agent");
       const { composeId } = await createTestCompose(agentName);
       await createTestZeroAgent(user.orgId, agentName, {
@@ -114,7 +113,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       });
       const run = await getTestRun(data.runId);
 
-      expect(run.appendSystemPrompt).toMatch(/Bot[\s\S]*Custom instructions/);
+      // CLI path passes appendSystemPrompt through without prepending identity
+      expect(run.appendSystemPrompt).toBe("Custom instructions");
     });
   });
 

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
 import { and, eq, inArray, desc, gte, lte } from "drizzle-orm";
-import { startRun, type RunDispatchError } from "../../../../src/lib/run";
+import { startCliRun, type RunDispatchError } from "../../../../src/lib/run";
 import {
   requireAuth,
   isAuthError,
@@ -211,9 +211,9 @@ const router = tsr.router(runsMainContract, {
       `Creating run - mode: ${body.checkpointId ? "checkpoint" : body.sessionId ? "session" : "new"}`,
     );
 
-    // Delegate all resolution, validation, and dispatch to startRun()
+    // Delegate all resolution, validation, and dispatch to startCliRun()
     try {
-      const result = await startRun({
+      const result = await startCliRun({
         userId,
         prompt: body.prompt,
         appendSystemPrompt: body.appendSystemPrompt,

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -544,7 +544,7 @@ describe("Telegram bot commands", () => {
       const editMsg = telegramEditMessageText();
       server.use(sendMsg.handler, editMsg.handler);
 
-      vi.spyOn(runModule, "startRun").mockResolvedValue({
+      vi.spyOn(runModule, "startZeroRun").mockResolvedValue({
         runId: "mock-run-id",
         status: "queued",
         createdAt: new Date(),
@@ -579,7 +579,7 @@ describe("Telegram bot commands", () => {
       const editMsg = telegramEditMessageText();
       server.use(sendMsg.handler, editMsg.handler);
 
-      vi.spyOn(runModule, "startRun").mockResolvedValue({
+      vi.spyOn(runModule, "startZeroRun").mockResolvedValue({
         runId: "mock-run-id",
         status: "queued",
         createdAt: new Date(),

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -18,7 +18,7 @@ import { POST } from "../route";
 import * as runModule from "../../../../../src/lib/run";
 import { reloadEnv } from "../../../../../src/env";
 
-// Note: startRun is spied on (rather than exercised with real DB + executor)
+// Note: startZeroRun is spied on (rather than exercised with real DB + executor)
 // because this test file focuses on the webhook routing layer: signature
 // verification, event routing, trigger conditions, and callback context
 // construction.  Real run creation integration is covered by its own dedicated
@@ -153,7 +153,7 @@ function buildIssueCommentPayload(overrides?: CommentPayloadOverrides) {
 }
 
 describe("POST /api/webhooks/github", () => {
-  let startRunSpy: ReturnType<typeof vi.spyOn>;
+  let startZeroRunSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     afterPromises.length = 0;
@@ -182,8 +182,8 @@ describe("POST /api/webhooks/github", () => {
       ),
     );
 
-    // Mock startRun to prevent actual sandbox dispatch
-    startRunSpy = vi.spyOn(runModule, "startRun").mockResolvedValue({
+    // Mock startZeroRun to prevent actual sandbox dispatch
+    startZeroRunSpy = vi.spyOn(runModule, "startZeroRun").mockResolvedValue({
       runId: "test-run-id",
       status: "running",
       createdAt: new Date(),
@@ -260,8 +260,8 @@ describe("POST /api/webhooks/github", () => {
       await flushAfterCallbacks();
 
       // Then createRun should have been called
-      expect(startRunSpy).toHaveBeenCalledTimes(1);
-      const callArgs = startRunSpy.mock.calls[0]![0] as {
+      expect(startZeroRunSpy).toHaveBeenCalledTimes(1);
+      const callArgs = startZeroRunSpy.mock.calls[0]![0] as {
         prompt: string;
         callbacks: Array<{ payload: { issueNumber: number } }>;
       };
@@ -291,7 +291,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(startRunSpy).toHaveBeenCalledTimes(1);
+      expect(startZeroRunSpy).toHaveBeenCalledTimes(1);
     });
 
     it("should NOT trigger agent for opened issue without app slug label", async () => {
@@ -312,7 +312,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(startRunSpy).not.toHaveBeenCalled();
+      expect(startZeroRunSpy).not.toHaveBeenCalled();
     });
 
     it("should NOT trigger agent when a non-app slug label is added", async () => {
@@ -337,7 +337,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(startRunSpy).not.toHaveBeenCalled();
+      expect(startZeroRunSpy).not.toHaveBeenCalled();
     });
 
     it("should ignore closed/edited/other issue actions", async () => {
@@ -345,7 +345,7 @@ describe("POST /api/webhooks/github", () => {
         await givenGitHubInstallation();
 
       for (const action of ["closed", "edited", "reopened", "deleted"]) {
-        startRunSpy.mockClear();
+        startZeroRunSpy.mockClear();
 
         const request = createGitHubWebhookRequest(
           "issues",
@@ -361,7 +361,7 @@ describe("POST /api/webhooks/github", () => {
 
         await flushAfterCallbacks();
 
-        expect(startRunSpy).not.toHaveBeenCalled();
+        expect(startZeroRunSpy).not.toHaveBeenCalled();
       }
     });
 
@@ -384,8 +384,8 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(startRunSpy).toHaveBeenCalledTimes(1);
-      const callArgs = startRunSpy.mock.calls[0]![0] as { prompt: string };
+      expect(startZeroRunSpy).toHaveBeenCalledTimes(1);
+      const callArgs = startZeroRunSpy.mock.calls[0]![0] as { prompt: string };
       // When body is null, falls back to issue title
       expect(callArgs.prompt).toContain("Test Issue");
       expect(callArgs.prompt).toContain(
@@ -414,7 +414,7 @@ describe("POST /api/webhooks/github", () => {
       await flushAfterCallbacks();
 
       // Label alone should NOT trigger — bot mention is required
-      expect(startRunSpy).not.toHaveBeenCalled();
+      expect(startZeroRunSpy).not.toHaveBeenCalled();
     });
 
     it("should trigger agent for comment mentioning @bot", async () => {
@@ -435,7 +435,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(startRunSpy).toHaveBeenCalledTimes(1);
+      expect(startZeroRunSpy).toHaveBeenCalledTimes(1);
     });
 
     it("should NOT trigger for comment without label or mention", async () => {
@@ -456,7 +456,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(startRunSpy).not.toHaveBeenCalled();
+      expect(startZeroRunSpy).not.toHaveBeenCalled();
     });
 
     it("should prevent self-triggering from bot comments", async () => {
@@ -479,7 +479,7 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(startRunSpy).not.toHaveBeenCalled();
+      expect(startZeroRunSpy).not.toHaveBeenCalled();
     });
 
     it("should ignore non-created comment actions", async () => {
@@ -487,7 +487,7 @@ describe("POST /api/webhooks/github", () => {
         await givenGitHubInstallation();
 
       for (const action of ["edited", "deleted"]) {
-        startRunSpy.mockClear();
+        startZeroRunSpy.mockClear();
 
         const request = createGitHubWebhookRequest(
           "issue_comment",
@@ -503,7 +503,7 @@ describe("POST /api/webhooks/github", () => {
 
         await flushAfterCallbacks();
 
-        expect(startRunSpy).not.toHaveBeenCalled();
+        expect(startZeroRunSpy).not.toHaveBeenCalled();
       }
     });
   });
@@ -524,7 +524,7 @@ describe("POST /api/webhooks/github", () => {
       // The error thrown in dispatchAgentRun is caught by the .catch() in route.ts
       await flushAfterCallbacks();
 
-      expect(startRunSpy).not.toHaveBeenCalled();
+      expect(startZeroRunSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -685,8 +685,8 @@ describe("POST /api/webhooks/github", () => {
 
       await flushAfterCallbacks();
 
-      expect(startRunSpy).toHaveBeenCalledTimes(1);
-      const callArgs = startRunSpy.mock.calls[0]![0] as {
+      expect(startZeroRunSpy).toHaveBeenCalledTimes(1);
+      const callArgs = startZeroRunSpy.mock.calls[0]![0] as {
         callbacks: Array<{
           url: string;
           secret: string;

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -5,11 +5,7 @@ import {
 } from "../../../../src/lib/ts-rest-handler";
 import { zeroRunsMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import {
-  startZeroRun,
-  isRunDispatchError,
-  type RunDispatchError,
-} from "../../../../src/lib/run";
+import { startZeroRun, isRunDispatchError } from "../../../../src/lib/run";
 import {
   requireAuth,
   isAuthError,
@@ -21,21 +17,23 @@ import { isApiError } from "../../../../src/lib/errors";
  * Mirrors handleCreateRunError in /api/agent/runs/route.ts.
  */
 function handleStartZeroRunError(error: unknown) {
-  if (isApiError(error)) {
-    const dispatchError = error as RunDispatchError;
-    const runId = dispatchError.runId;
-    if (runId) {
-      return {
-        status: 201 as const,
-        body: {
-          runId,
-          status: "failed" as const,
-          error: error.message,
-          createdAt: dispatchError.createdAt?.toISOString() ?? "",
-        },
-      };
-    }
+  // Post-INSERT errors have runId attached by markRunFailed().
+  // Return 201 with failed status so the client can track the run.
+  if (isRunDispatchError(error) && error.runId) {
+    return {
+      status: 201 as const,
+      body: {
+        runId: error.runId,
+        status: "failed" as const,
+        error: error.message,
+        createdAt: error.createdAt?.toISOString() ?? "",
+      },
+    };
+  }
 
+  // Pre-INSERT errors — return proper HTTP error with structured code.
+  // Map UNAUTHORIZED → NOT_FOUND for security (don't leak resource existence).
+  if (isApiError(error)) {
     const status = error.code === "UNAUTHORIZED" ? 404 : error.statusCode;
     const code = error.code === "UNAUTHORIZED" ? "NOT_FOUND" : error.code;
     const message =
@@ -43,18 +41,6 @@ function handleStartZeroRunError(error: unknown) {
     return {
       status: status as 400 | 401 | 403 | 404,
       body: { error: { message, code } },
-    };
-  }
-
-  if (isRunDispatchError(error)) {
-    return {
-      status: 201 as const,
-      body: {
-        runId: error.runId!,
-        status: "failed" as const,
-        error: "Run failed",
-        createdAt: error.createdAt?.toISOString() ?? "",
-      },
     };
   }
 

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -3,21 +3,129 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../src/lib/ts-rest-handler";
-import { zeroRunsMainContract, runsMainContract } from "@vm0/core";
+import { zeroRunsMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
-  createInfraClient,
-  forwardInfra,
-} from "../../../../src/lib/infra-client";
+  startZeroRun,
+  isRunDispatchError,
+  type RunDispatchError,
+} from "../../../../src/lib/run";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../src/lib/auth/require-auth";
+import { isApiError } from "../../../../src/lib/errors";
+
+/**
+ * Translate startZeroRun() errors into API response format.
+ * Mirrors handleCreateRunError in /api/agent/runs/route.ts.
+ */
+function handleStartZeroRunError(error: unknown) {
+  if (isApiError(error)) {
+    const dispatchError = error as RunDispatchError;
+    const runId = dispatchError.runId;
+    if (runId) {
+      return {
+        status: 201 as const,
+        body: {
+          runId,
+          status: "failed" as const,
+          error: error.message,
+          createdAt: dispatchError.createdAt?.toISOString() ?? "",
+        },
+      };
+    }
+
+    const status = error.code === "UNAUTHORIZED" ? 404 : error.statusCode;
+    const code = error.code === "UNAUTHORIZED" ? "NOT_FOUND" : error.code;
+    const message =
+      error.code === "UNAUTHORIZED" ? "Resource not found" : error.message;
+    return {
+      status: status as 400 | 401 | 403 | 404,
+      body: { error: { message, code } },
+    };
+  }
+
+  if (isRunDispatchError(error)) {
+    return {
+      status: 201 as const,
+      body: {
+        runId: error.runId!,
+        status: "failed" as const,
+        error: "Run failed",
+        createdAt: error.createdAt?.toISOString() ?? "",
+      },
+    };
+  }
+
+  return null;
+}
 
 const router = tsr.router(zeroRunsMainContract, {
   create: async ({ body, headers }) => {
     initServices();
-    const client = createInfraClient(runsMainContract, headers.authorization);
-    const result = await client.create({
-      body: { ...body, triggerSource: "web" },
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:write",
     });
-    return forwardInfra(result);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    if (!body.agentComposeId) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "agentComposeId is required",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
+    }
+
+    try {
+      const result = await startZeroRun({
+        userId,
+        prompt: body.prompt,
+        composeId: body.agentComposeId,
+        sessionId: body.sessionId,
+        appendSystemPrompt: body.appendSystemPrompt,
+        disallowedTools: body.disallowedTools,
+        tools: body.tools,
+        settings: body.settings,
+        conversationId: body.conversationId,
+        vars: body.vars,
+        secrets: body.secrets,
+        artifactName: body.artifactName,
+        artifactVersion: body.artifactVersion,
+        memoryName: body.memoryName,
+        volumeVersions: body.volumeVersions,
+        modelProvider: body.modelProvider,
+        triggerSource: "web",
+        debugNoMockClaude: body.debugNoMockClaude,
+        checkEnv: body.checkEnv,
+      });
+
+      return {
+        status: 201 as const,
+        body: {
+          runId: result.runId,
+          status: result.status as
+            | "queued"
+            | "pending"
+            | "running"
+            | "completed"
+            | "failed"
+            | "timeout",
+          sandboxId: result.sandboxId,
+          createdAt: result.createdAt.toISOString(),
+        },
+      };
+    } catch (error) {
+      const errorResponse = handleStartZeroRunError(error);
+      if (errorResponse) return errorResponse;
+      throw error;
+    }
   },
 });
 

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -149,7 +149,7 @@ describe("POST /api/zero/slack/events", () => {
     });
 
     it("posts error when run was not created (no callback)", async () => {
-      // Set up a compose WITHOUT a version → startRun fails before creating the run
+      // Set up a compose WITHOUT a version → startZeroRun fails before creating the run
       const { composeId } = await seedTestCompose({
         userId: user.userId,
         name: uniqueId("agent"),
@@ -178,7 +178,7 @@ describe("POST /api/zero/slack/events", () => {
 
       await context.mocks.flushAfter();
 
-      // startRun failed before creating a run → no callback → handler posts error
+      // startZeroRun failed before creating a run → no callback → handler posts error
       const { WebClient } = await import("@slack/web-api");
       const mockClient = new WebClient();
       expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();

--- a/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
@@ -176,7 +176,7 @@ export async function handleInboundEmailReply(
   ];
 
   // 11. Inject integration context and create run
-  // startRun resolves compose version + org internally
+  // startZeroRun resolves compose version + org internally
   const fullPrompt = `${buildIntegrationContext("Email")}\n\n# User Prompt\n\n${replyContent}`;
   const result = await startZeroRun({
     userId: session.userId,

--- a/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
@@ -9,7 +9,7 @@ import {
   getFromDomain,
   type HandlerResult,
 } from "./shared";
-import { startRun } from "../../run";
+import { startZeroRun } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
@@ -178,7 +178,7 @@ export async function handleInboundEmailReply(
   // 11. Inject integration context and create run
   // startRun resolves compose version + org internally
   const fullPrompt = `${buildIntegrationContext("Email")}\n\n# User Prompt\n\n${replyContent}`;
-  const result = await startRun({
+  const result = await startZeroRun({
     userId: session.userId,
     prompt: fullPrompt,
     composeId: session.composeId,

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -10,7 +10,7 @@ import {
   getFromDomain,
   type HandlerResult,
 } from "./shared";
-import { startRun } from "../../run";
+import { startZeroRun } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
@@ -276,7 +276,7 @@ export async function handleInboundEmailTrigger(
 
   // 12. Inject integration context and create run
   const fullPrompt = `${buildIntegrationContext("Email")}\n\n# User Prompt\n\n${prompt}`;
-  const result = await startRun({
+  const result = await startZeroRun({
     userId,
     prompt: fullPrompt,
     composeId: compose.composeId,

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -4,7 +4,7 @@ import { githubInstallations } from "../../../db/schema/github-installation";
 import { githubUserLinks } from "../../../db/schema/github-user-link";
 import { githubIssueSessions } from "../../../db/schema/github-issue-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
-import { startRun, validateAgentSession } from "../../run";
+import { startZeroRun, validateAgentSession } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getInstallationAccessToken } from "../github-app";
@@ -494,7 +494,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
   };
 
   try {
-    const result = await startRun({
+    const result = await startZeroRun({
       userId: vm0UserId,
       prompt: fullPrompt,
       composeId: compose.id,

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -430,7 +430,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
 
   const vm0UserId = userLink.vm0UserId;
 
-  // 3. Resolve agent compose (version + org resolved by startRun)
+  // 3. Resolve agent compose (version + org resolved by startZeroRun)
   const [compose] = await globalThis.services.db
     .select({
       id: agentComposes.id,

--- a/turbo/apps/web/src/lib/run/index.ts
+++ b/turbo/apps/web/src/lib/run/index.ts
@@ -7,9 +7,9 @@ export {
   validateCheckpoint,
   validateAgentSession,
   startRun,
-  startZeroRun,
   isRunDispatchError,
   type RunDispatchError,
   type StartRunParams,
-  type StartZeroRunParams,
 } from "./run-service";
+
+export { startZeroRun, type StartZeroRunParams } from "./zero-run-service";

--- a/turbo/apps/web/src/lib/run/index.ts
+++ b/turbo/apps/web/src/lib/run/index.ts
@@ -7,7 +7,9 @@ export {
   validateCheckpoint,
   validateAgentSession,
   startRun,
+  startZeroRun,
   isRunDispatchError,
   type RunDispatchError,
   type StartRunParams,
+  type StartZeroRunParams,
 } from "./run-service";

--- a/turbo/apps/web/src/lib/run/index.ts
+++ b/turbo/apps/web/src/lib/run/index.ts
@@ -6,10 +6,10 @@
 export {
   validateCheckpoint,
   validateAgentSession,
-  startRun,
+  startCliRun,
   isRunDispatchError,
   type RunDispatchError,
-  type StartRunParams,
+  type StartCliRunParams,
 } from "./run-service";
 
 export { startZeroRun, type StartZeroRunParams } from "./zero-run-service";

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -488,6 +488,42 @@ export interface StartRunParams {
   checkEnv?: boolean;
 }
 
+/**
+ * Params for non-CLI callers (platform UI + integrations).
+ *
+ * Key differences from StartRunParams:
+ * - composeId is always required (all non-CLI callers know the compose)
+ * - Only supports composeId + sessionId resolution (no checkpointId, agentComposeVersionId)
+ * - No callerOrgId cross-org check (non-CLI callers are already org-scoped)
+ */
+export interface StartZeroRunParams {
+  userId: string;
+  prompt: string;
+  composeId: string;
+
+  // Optional — compose resolution
+  sessionId?: string;
+
+  // Optional — forwarded to createRun
+  appendSystemPrompt?: string;
+  disallowedTools?: string[];
+  tools?: string[];
+  settings?: string;
+  conversationId?: string;
+  vars?: Record<string, string>;
+  secrets?: Record<string, string>;
+  artifactName?: string;
+  artifactVersion?: string;
+  memoryName?: string;
+  volumeVersions?: Record<string, string>;
+  scheduleId?: string;
+  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
+  modelProvider?: string;
+  triggerSource?: TriggerSource;
+  debugNoMockClaude?: boolean;
+  checkEnv?: boolean;
+}
+
 export interface CreateRunResult {
   runId: string;
   status: string;
@@ -996,11 +1032,87 @@ async function resolveStartRunCompose(
 }
 
 /**
- * High-level run entry point — the single public API for all run creation.
+ * Run entry point for platform UI and integrations (non-CLI callers).
+ *
+ * Simpler than startRun(): only supports composeId + sessionId resolution,
+ * no cross-org check. Resolves compose version + org context internally,
+ * injects agent identity, then delegates to createRun().
+ *
+ * @throws NotFoundError - compose/session not found
+ * @throws BadRequestError - compose has no versions
+ * @throws ForbiddenError - user cannot access compose
+ * @throws Error - dispatch failure
+ */
+export async function startZeroRun(
+  params: StartZeroRunParams,
+): Promise<CreateRunResult> {
+  // 1. Resolve compose version: sessionId → resolveBySession, else composeId
+  let resolved: ResolvedStartRunCompose;
+  if (params.sessionId) {
+    const sessionData = await validateAgentSession(
+      params.sessionId,
+      params.userId,
+    );
+    resolved = await resolveByComposeId(sessionData.agentComposeId);
+  } else {
+    resolved = await resolveByComposeId(params.composeId);
+  }
+
+  // 2. Resolve org context
+  const orgData = await getOrgData(resolved.orgId);
+  const orgTier = orgTierSchema.parse(orgData.tier);
+
+  // 3. Inject agent identity into appendSystemPrompt
+  let { appendSystemPrompt } = params;
+  if (resolved.composeId) {
+    const identity = await buildAgentIdentityPrompt(resolved.composeId);
+    if (identity) {
+      appendSystemPrompt = appendSystemPrompt
+        ? `${identity}\n\n${appendSystemPrompt}`
+        : identity;
+    }
+  }
+
+  // 4. Delegate to createRun with fully resolved params
+  return createRun({
+    userId: params.userId,
+    agentComposeVersionId: resolved.agentComposeVersionId,
+    prompt: params.prompt,
+    appendSystemPrompt,
+    disallowedTools: params.disallowedTools,
+    tools: params.tools,
+    settings: params.settings,
+    composeId: resolved.composeId,
+    sessionId: params.sessionId,
+    conversationId: params.conversationId,
+    vars: params.vars,
+    secrets: params.secrets,
+    artifactName: params.artifactName,
+    artifactVersion: params.artifactVersion,
+    memoryName: params.memoryName,
+    volumeVersions: params.volumeVersions,
+    scheduleId: params.scheduleId,
+    callbacks: params.callbacks,
+    agentName: resolved.agentName,
+    modelProvider: params.modelProvider,
+    triggerSource: params.triggerSource,
+    debugNoMockClaude: params.debugNoMockClaude,
+    checkEnv: params.checkEnv,
+    orgSlug: orgData.slug,
+    orgId: resolved.orgId,
+    orgTier,
+  });
+}
+
+/**
+ * High-level run entry point for CLI callers.
+ *
+ * Supports all 4 compose resolution modes (composeId, agentComposeVersionId,
+ * checkpointId, sessionId) and cross-org access checks via callerOrgId.
  *
  * Resolves compose version + org context internally, then delegates to
- * createRun(). Callers only need a compose identifier (composeId, versionId,
- * checkpointId, or sessionId) — no manual DB queries or org resolution.
+ * createRun(). Callers only need a compose identifier — no manual DB queries
+ * or org resolution.
  *
  * @throws NotFoundError - compose/version/checkpoint/session not found
  * @throws BadRequestError - compose has no versions, or missing identifier

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -22,7 +22,6 @@ import { orgMetadata } from "../../db/schema/org-metadata";
 import { modelProviders } from "../../db/schema/model-provider";
 import { enqueueRun, drainOrgQueue } from "./run-queue-service";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
-import { buildAgentIdentityPrompt } from "../agent-identity";
 import { logger } from "../logger";
 import type { Database } from "../../types/global";
 import type { AgentComposeSnapshot } from "../checkpoint/types";
@@ -488,42 +487,6 @@ export interface StartRunParams {
   checkEnv?: boolean;
 }
 
-/**
- * Params for non-CLI callers (platform UI + integrations).
- *
- * Key differences from StartRunParams:
- * - composeId is always required (all non-CLI callers know the compose)
- * - Only supports composeId + sessionId resolution (no checkpointId, agentComposeVersionId)
- * - No callerOrgId cross-org check (non-CLI callers are already org-scoped)
- */
-export interface StartZeroRunParams {
-  userId: string;
-  prompt: string;
-  composeId: string;
-
-  // Optional — compose resolution
-  sessionId?: string;
-
-  // Optional — forwarded to createRun
-  appendSystemPrompt?: string;
-  disallowedTools?: string[];
-  tools?: string[];
-  settings?: string;
-  conversationId?: string;
-  vars?: Record<string, string>;
-  secrets?: Record<string, string>;
-  artifactName?: string;
-  artifactVersion?: string;
-  memoryName?: string;
-  volumeVersions?: Record<string, string>;
-  scheduleId?: string;
-  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
-  modelProvider?: string;
-  triggerSource?: TriggerSource;
-  debugNoMockClaude?: boolean;
-  checkEnv?: boolean;
-}
-
 export interface CreateRunResult {
   runId: string;
   status: string;
@@ -938,7 +901,7 @@ async function lookupComposeByVersion(
 /**
  * Resolve compose by composeId → headVersionId.
  */
-async function resolveByComposeId(
+export async function resolveByComposeId(
   composeId: string,
 ): Promise<ResolvedStartRunCompose> {
   const [compose] = await globalThis.services.db
@@ -1032,79 +995,6 @@ async function resolveStartRunCompose(
 }
 
 /**
- * Run entry point for platform UI and integrations (non-CLI callers).
- *
- * Simpler than startRun(): only supports composeId + sessionId resolution,
- * no cross-org check. Resolves compose version + org context internally,
- * injects agent identity, then delegates to createRun().
- *
- * @throws NotFoundError - compose/session not found
- * @throws BadRequestError - compose has no versions
- * @throws ForbiddenError - user cannot access compose
- * @throws Error - dispatch failure
- */
-export async function startZeroRun(
-  params: StartZeroRunParams,
-): Promise<CreateRunResult> {
-  // 1. Resolve compose version: sessionId → resolveBySession, else composeId
-  let resolved: ResolvedStartRunCompose;
-  if (params.sessionId) {
-    const sessionData = await validateAgentSession(
-      params.sessionId,
-      params.userId,
-    );
-    resolved = await resolveByComposeId(sessionData.agentComposeId);
-  } else {
-    resolved = await resolveByComposeId(params.composeId);
-  }
-
-  // 2. Resolve org context
-  const orgData = await getOrgData(resolved.orgId);
-  const orgTier = orgTierSchema.parse(orgData.tier);
-
-  // 3. Inject agent identity into appendSystemPrompt
-  let { appendSystemPrompt } = params;
-  if (resolved.composeId) {
-    const identity = await buildAgentIdentityPrompt(resolved.composeId);
-    if (identity) {
-      appendSystemPrompt = appendSystemPrompt
-        ? `${identity}\n\n${appendSystemPrompt}`
-        : identity;
-    }
-  }
-
-  // 4. Delegate to createRun with fully resolved params
-  return createRun({
-    userId: params.userId,
-    agentComposeVersionId: resolved.agentComposeVersionId,
-    prompt: params.prompt,
-    appendSystemPrompt,
-    disallowedTools: params.disallowedTools,
-    tools: params.tools,
-    settings: params.settings,
-    composeId: resolved.composeId,
-    sessionId: params.sessionId,
-    conversationId: params.conversationId,
-    vars: params.vars,
-    secrets: params.secrets,
-    artifactName: params.artifactName,
-    artifactVersion: params.artifactVersion,
-    memoryName: params.memoryName,
-    volumeVersions: params.volumeVersions,
-    scheduleId: params.scheduleId,
-    callbacks: params.callbacks,
-    agentName: resolved.agentName,
-    modelProvider: params.modelProvider,
-    triggerSource: params.triggerSource,
-    debugNoMockClaude: params.debugNoMockClaude,
-    checkEnv: params.checkEnv,
-    orgSlug: orgData.slug,
-    orgId: resolved.orgId,
-    orgTier,
-  });
-}
-
-/**
  * High-level run entry point for CLI callers.
  *
  * Supports all 4 compose resolution modes (composeId, agentComposeVersionId,
@@ -1137,23 +1027,12 @@ export async function startRun(
   const orgData = await getOrgData(authOrgId);
   const orgTier = orgTierSchema.parse(orgData.tier);
 
-  // 4. Inject agent identity metadata into appendSystemPrompt
-  let { appendSystemPrompt } = params;
-  if (resolved.composeId) {
-    const identity = await buildAgentIdentityPrompt(resolved.composeId);
-    if (identity) {
-      appendSystemPrompt = appendSystemPrompt
-        ? `${identity}\n\n${appendSystemPrompt}`
-        : identity;
-    }
-  }
-
-  // 5. Delegate to createRun with fully resolved params
+  // 4. Delegate to createRun with fully resolved params
   return createRun({
     userId: params.userId,
     agentComposeVersionId: resolved.agentComposeVersionId,
     prompt: params.prompt,
-    appendSystemPrompt,
+    appendSystemPrompt: params.appendSystemPrompt,
     disallowedTools: params.disallowedTools,
     tools: params.tools,
     settings: params.settings,

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -442,7 +442,7 @@ export interface CreateRunParams {
 }
 
 /**
- * High-level run params — callers provide a compose identifier and startRun()
+ * High-level run params — callers provide a compose identifier and startCliRun()
  * resolves version + org internally.
  *
  * Compose resolution modes (mutually exclusive):
@@ -451,7 +451,7 @@ export interface CreateRunParams {
  * - checkpointId: resume from checkpoint (resolves version from checkpoint)
  * - sessionId: continue session (resolves version from session's compose)
  */
-export interface StartRunParams {
+export interface StartCliRunParams {
   userId: string;
   prompt: string;
 
@@ -462,7 +462,7 @@ export interface StartRunParams {
   sessionId?: string;
 
   // --- Caller-validated org (optional, for API routes with org membership) ---
-  // When provided, startRun() verifies the compose belongs to this org
+  // When provided, startCliRun() verifies the compose belongs to this org
   // and uses it for authorization. When omitted, org is auto-resolved
   // from the compose (used by integration callers that verify access upstream).
   callerOrgId?: string;
@@ -931,7 +931,7 @@ export async function resolveByComposeId(
 }
 
 /**
- * Resolve compose version + org ID from StartRunParams.
+ * Resolve compose version + org ID from StartCliRunParams.
  *
  * Handles 4 mutually exclusive resolution modes:
  * 1. checkpointId → validate checkpoint → get version, then look up compose
@@ -940,7 +940,7 @@ export async function resolveByComposeId(
  * 4. composeId → load compose → use headVersionId
  */
 async function resolveStartRunCompose(
-  params: StartRunParams,
+  params: StartCliRunParams,
 ): Promise<ResolvedStartRunCompose> {
   // Validate mutual exclusivity before resolution
   if (params.checkpointId && params.sessionId) {
@@ -1009,8 +1009,8 @@ async function resolveStartRunCompose(
  * @throws ForbiddenError - user cannot access compose
  * @throws Error - dispatch failure
  */
-export async function startRun(
-  params: StartRunParams,
+export async function startCliRun(
+  params: StartCliRunParams,
 ): Promise<CreateRunResult> {
   // 1. Resolve compose version
   const resolved = await resolveStartRunCompose(params);
@@ -1064,7 +1064,7 @@ export async function startRun(
  * Low-level run creation pipeline (requires pre-resolved version + org).
  *
  * Validates, creates, and dispatches a run in a single call.
- * Prefer startRun() unless you need checkpoint/session resume or custom params.
+ * Prefer startCliRun() unless you need checkpoint/session resume or custom params.
  *
  * Pipeline:
  * 1. Load compose version content + compose metadata

--- a/turbo/apps/web/src/lib/run/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/run/zero-run-service.ts
@@ -8,7 +8,7 @@ import type { CreateRunResult } from "./run-service";
 /**
  * Params for non-CLI callers (platform UI + integrations).
  *
- * Key differences from StartRunParams:
+ * Key differences from StartCliRunParams:
  * - composeId is always required (all non-CLI callers know the compose)
  * - Only supports composeId + sessionId resolution (no checkpointId, agentComposeVersionId)
  * - No callerOrgId cross-org check (non-CLI callers are already org-scoped)
@@ -44,7 +44,7 @@ export interface StartZeroRunParams {
 /**
  * Run entry point for platform UI and integrations (non-CLI callers).
  *
- * Simpler than startRun(): only supports composeId + sessionId resolution,
+ * Simpler than startCliRun(): only supports composeId + sessionId resolution,
  * no cross-org check. Resolves compose version + org context internally,
  * injects agent identity, then delegates to createRun().
  *

--- a/turbo/apps/web/src/lib/run/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/run/zero-run-service.ts
@@ -1,0 +1,118 @@
+import { type TriggerSource, orgTierSchema } from "@vm0/core";
+import { getOrgData } from "../org/org-cache-service";
+import { buildAgentIdentityPrompt } from "../agent-identity";
+import { validateAgentSession } from "./run-service";
+import { createRun, resolveByComposeId } from "./run-service";
+import type { CreateRunResult } from "./run-service";
+
+/**
+ * Params for non-CLI callers (platform UI + integrations).
+ *
+ * Key differences from StartRunParams:
+ * - composeId is always required (all non-CLI callers know the compose)
+ * - Only supports composeId + sessionId resolution (no checkpointId, agentComposeVersionId)
+ * - No callerOrgId cross-org check (non-CLI callers are already org-scoped)
+ */
+export interface StartZeroRunParams {
+  userId: string;
+  prompt: string;
+  composeId: string;
+
+  // Optional — compose resolution
+  sessionId?: string;
+
+  // Optional — forwarded to createRun
+  appendSystemPrompt?: string;
+  disallowedTools?: string[];
+  tools?: string[];
+  settings?: string;
+  conversationId?: string;
+  vars?: Record<string, string>;
+  secrets?: Record<string, string>;
+  artifactName?: string;
+  artifactVersion?: string;
+  memoryName?: string;
+  volumeVersions?: Record<string, string>;
+  scheduleId?: string;
+  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
+  modelProvider?: string;
+  triggerSource?: TriggerSource;
+  debugNoMockClaude?: boolean;
+  checkEnv?: boolean;
+}
+
+/**
+ * Run entry point for platform UI and integrations (non-CLI callers).
+ *
+ * Simpler than startRun(): only supports composeId + sessionId resolution,
+ * no cross-org check. Resolves compose version + org context internally,
+ * injects agent identity, then delegates to createRun().
+ *
+ * Defaults artifactName to "artifact" when not provided (integration callers
+ * always use the default artifact).
+ *
+ * @throws NotFoundError - compose/session not found
+ * @throws BadRequestError - compose has no versions
+ * @throws ForbiddenError - user cannot access compose
+ * @throws Error - dispatch failure
+ */
+export async function startZeroRun(
+  params: StartZeroRunParams,
+): Promise<CreateRunResult> {
+  // 1. Resolve compose version: sessionId → resolveBySession, else composeId
+  let resolved;
+  if (params.sessionId) {
+    const sessionData = await validateAgentSession(
+      params.sessionId,
+      params.userId,
+    );
+    resolved = await resolveByComposeId(sessionData.agentComposeId);
+  } else {
+    resolved = await resolveByComposeId(params.composeId);
+  }
+
+  // 2. Resolve org context
+  const orgData = await getOrgData(resolved.orgId);
+  const orgTier = orgTierSchema.parse(orgData.tier);
+
+  // 3. Inject agent identity into appendSystemPrompt
+  let { appendSystemPrompt } = params;
+  if (resolved.composeId) {
+    const identity = await buildAgentIdentityPrompt(resolved.composeId);
+    if (identity) {
+      appendSystemPrompt = appendSystemPrompt
+        ? `${identity}\n\n${appendSystemPrompt}`
+        : identity;
+    }
+  }
+
+  // 4. Delegate to createRun with fully resolved params
+  return createRun({
+    userId: params.userId,
+    agentComposeVersionId: resolved.agentComposeVersionId,
+    prompt: params.prompt,
+    appendSystemPrompt,
+    disallowedTools: params.disallowedTools,
+    tools: params.tools,
+    settings: params.settings,
+    composeId: resolved.composeId,
+    sessionId: params.sessionId,
+    conversationId: params.conversationId,
+    vars: params.vars,
+    secrets: params.secrets,
+    artifactName: params.artifactName ?? "artifact",
+    artifactVersion: params.artifactVersion,
+    memoryName: params.memoryName,
+    volumeVersions: params.volumeVersions,
+    scheduleId: params.scheduleId,
+    callbacks: params.callbacks,
+    agentName: resolved.agentName,
+    modelProvider: params.modelProvider,
+    triggerSource: params.triggerSource,
+    debugNoMockClaude: params.debugNoMockClaude,
+    checkEnv: params.checkEnv,
+    orgSlug: orgData.slug,
+    orgId: resolved.orgId,
+    orgTier,
+  });
+}

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -7,7 +7,7 @@ import { decryptSecretsMap } from "../crypto";
 import { getOrgData } from "../org/org-cache-service";
 import { notFound, badRequest, schedulePast } from "../errors";
 import { logger } from "../logger";
-import { startZeroRun } from "../run/run-service";
+import { startZeroRun } from "../run/zero-run-service";
 import { getUserPreferences } from "../user/user-preferences-service";
 import { generateCallbackSecret, getApiUrl } from "../callback";
 

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -7,7 +7,7 @@ import { decryptSecretsMap } from "../crypto";
 import { getOrgData } from "../org/org-cache-service";
 import { notFound, badRequest, schedulePast } from "../errors";
 import { logger } from "../logger";
-import { startRun } from "../run/run-service";
+import { startZeroRun } from "../run/run-service";
 import { getUserPreferences } from "../user/user-preferences-service";
 import { generateCallbackSecret, getApiUrl } from "../callback";
 
@@ -845,7 +845,7 @@ async function executeSchedule(
   // Delegate run creation, validation, and dispatch to startRun()
   let runId: string;
   try {
-    const result = await startRun({
+    const result = await startZeroRun({
       userId: schedule.userId,
       prompt: schedule.prompt,
       appendSystemPrompt: schedule.appendSystemPrompt ?? undefined,

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -842,7 +842,7 @@ async function executeSchedule(
     });
   }
 
-  // Delegate run creation, validation, and dispatch to startRun()
+  // Delegate run creation, validation, and dispatch to startZeroRun()
   let runId: string;
   try {
     const result = await startZeroRun({

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -1,4 +1,4 @@
-import { startRun, isRunDispatchError } from "../../run";
+import { startZeroRun, isRunDispatchError } from "../../run";
 import {
   buildIntegrationContext,
   buildScheduleGuidance,
@@ -86,7 +86,7 @@ export async function runAgentForSlackOrg(
     const callbackUrl = `${getApiUrl()}/api/internal/callbacks/slack/org`;
     const callbackSecret = generateCallbackSecret();
 
-    const result = await startRun({
+    const result = await startZeroRun({
       userId,
       composeId,
       prompt,

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -48,12 +48,12 @@ interface RunAgentResult {
 /**
  * Execute an agent run for org-aware Slack integration.
  *
- * Uses the unified startRun() entry point which handles compose/org resolution.
+ * Uses the unified startZeroRun() entry point which handles compose/org resolution.
  * This function only handles Slack-specific concerns: prompt construction and callbacks.
  *
  * Context (integration header, thread history, user metadata) is passed via
  * appendSystemPrompt so Claude sees it as system-level instructions rather than
- * user input. startRun() prepends agent identity to appendSystemPrompt.
+ * user input. startZeroRun() prepends agent identity to appendSystemPrompt.
  */
 export async function runAgentForSlackOrg(
   params: RunAgentParams,
@@ -71,7 +71,7 @@ export async function runAgentForSlackOrg(
   } = params;
 
   try {
-    // Build system prompt from context parts (agent identity is prepended by startRun)
+    // Build system prompt from context parts (agent identity is prepended by startZeroRun)
     const contextParts = [
       buildIntegrationContext("Slack", { botUserId }),
       threadContext,

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -1,4 +1,4 @@
-import { startRun, isRunDispatchError } from "../../run";
+import { startZeroRun, isRunDispatchError } from "../../run";
 import { buildIntegrationContext } from "../../integration-context";
 import { isApiError } from "../../errors";
 import { RUN_ERROR_GUIDANCE } from "@vm0/core";
@@ -67,7 +67,7 @@ export async function runAgentForTelegram(
   const callbackSecret = generateCallbackSecret();
 
   try {
-    const result = await startRun({
+    const result = await startZeroRun({
       userId,
       composeId,
       prompt: fullPrompt,


### PR DESCRIPTION
## Summary

- Add `startZeroRun()` as a dedicated run entry point for **non-CLI callers** (platform UI + integrations), separate from `startRun()` which remains CLI-only
- Replace the `/api/zero/runs` HTTP proxy (`createInfraClient` → `/api/agent/runs`) with a direct `startZeroRun()` call, eliminating an unnecessary HTTP round-trip
- Migrate all integration callers (Slack, Telegram, GitHub, Email, Schedule) from `startRun()` to `startZeroRun()`

Key differences of `startZeroRun()` from `startRun()`:
- Only supports `composeId` + `sessionId` resolution (no `checkpointId`, `agentComposeVersionId`)
- No `callerOrgId` cross-org check (non-CLI callers are already org-scoped)
- Simpler compose resolution path

Closes #6024

## Test plan

- [x] All existing tests pass (3975/3975)
- [x] TypeScript type check passes
- [x] Lint passes (zero warnings)
- [x] Knip passes (no unused exports)
- [ ] Verify platform UI run creation works end-to-end
- [ ] Verify Slack/Telegram/GitHub/Email integrations trigger runs correctly
- [ ] Verify scheduled runs execute normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)