### PR TITLE
fix: kill entire process tree on e2e test timeout

### DIFF
--- a/e2e/helpers/trace-cli.sh
+++ b/e2e/helpers/trace-cli.sh
@@ -5,10 +5,16 @@
 # and duration to /tmp/e2e-trace.log. The log file is printed by CI in
 # an always-run step so that timeouts leave a trail showing which
 # command was last executed and how long completed commands took.
+#
+# Uses GNU timeout to ensure the entire process tree is killed on
+# timeout (timeout creates a process group and sends SIGTERM to the
+# whole group). CLI_TIMEOUT defaults to 55s, leaving headroom for
+# BATS_TEST_TIMEOUT (typically 60s) to handle cleanup.
+CLI_TIMEOUT="${CLI_TIMEOUT:-55}"
 TAG="[${BATS_TEST_FILENAME##*/}] ${BATS_TEST_NAME}"
 echo "$(date +%T) $TAG: START vm0 $*" >> /tmp/e2e-trace.log 2>/dev/null
 START=$SECONDS
-vm0 "$@"
+timeout --kill-after=5 "$CLI_TIMEOUT" vm0 "$@"
 RC=$?
 echo "$(date +%T) $TAG: END(${RC}) $((SECONDS - START))s vm0 $*" >> /tmp/e2e-trace.log 2>/dev/null
 exit $RC

--- a/e2e/tests/03-experimental-runner/t27-real-claude-smoke.bats
+++ b/e2e/tests/03-experimental-runner/t27-real-claude-smoke.bats
@@ -105,7 +105,7 @@ teardown_file() {
     fi
 
     # Run claude --version inside the sandbox to confirm which binary is installed
-    run timeout 60 $CLI_COMMAND run "$AGENT_NAME" \
+    run $CLI_COMMAND run "$AGENT_NAME" \
         --model-provider "anthropic-api-key" \
         --debug-no-mock-claude \
         "Run 'claude --version' with the Bash tool and include the exact output"
@@ -122,7 +122,7 @@ teardown_file() {
         skip "ANTHROPIC_API_KEY not set"
     fi
 
-    run timeout 120 $CLI_COMMAND run "$AGENT_NAME" \
+    run $CLI_COMMAND run "$AGENT_NAME" \
         --model-provider "anthropic-api-key" \
         --debug-no-mock-claude \
         "Compute 123+456 and reply with exactly: RESULT=<answer>"
@@ -144,7 +144,7 @@ teardown_file() {
 
     # "--" separates variadic --disallowed-tools from the prompt
     # (Commander.js <tools...> would otherwise swallow subsequent args)
-    run timeout 120 $CLI_COMMAND run "${AGENT_NAME}-flags" \
+    run $CLI_COMMAND run "${AGENT_NAME}-flags" \
         --model-provider "anthropic-api-key" \
         --debug-no-mock-claude \
         --append-system-prompt "Always end your final response with SIGNATURE=smoke-test" \
@@ -172,7 +172,7 @@ teardown_file() {
     # Claude will read this file to prove the hook fired inside the sandbox.
     local settings='{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo SETTINGS_HOOK_OK > /tmp/hook_sentinel.txt"}]}]}}'
 
-    run timeout 120 $CLI_COMMAND run "${AGENT_NAME}-settings" \
+    run $CLI_COMMAND run "${AGENT_NAME}-settings" \
         --model-provider "anthropic-api-key" \
         --debug-no-mock-claude \
         --settings "$settings" \

--- a/e2e/tests/03-experimental-runner/t43-stuck-tool-watchdog.bats
+++ b/e2e/tests/03-experimental-runner/t43-stuck-tool-watchdog.bats
@@ -46,7 +46,7 @@ EOF
     echo "# Step 2: Run with @stuck-tool prompt and 3s timeout..."
     # VM0_STUCK_TOOL_TIMEOUT_SECS=3 makes the watchdog trigger in ~3-8s
     # instead of 60s, keeping the test fast.
-    run timeout 60 $CLI_COMMAND run "$AGENT_NAME" --no-auto-update "@stuck-tool"
+    run $CLI_COMMAND run "$AGENT_NAME" --no-auto-update "@stuck-tool"
 
     echo "# Step 3: Verify run failed..."
     assert_failure


### PR DESCRIPTION
## Summary
- Wrap `vm0` calls in `trace-cli.sh` with `timeout --kill-after=5 $CLI_TIMEOUT` (default 55s)
- GNU `timeout` creates a process group and kills all descendants on timeout, preventing orphaned processes
- Remove redundant per-test `timeout` wrappers from `t27-real-claude-smoke.bats` (4 places) and `t43-stuck-tool-watchdog.bats` (1 place)

## Root Cause
`BATS_TEST_TIMEOUT` uses `pkill -P` which only kills direct children. Grandchild processes (e.g. `node` spawned by `vm0 run`) survive and block the test, causing 8-minute GitHub Actions job cancellation.

## Test plan
- [ ] Runner E2E tests pass without job-level timeouts
- [ ] Verify `CLI_TIMEOUT` can be overridden via env var for special cases

Closes #5994

🤖 Generated with [Claude Code](https://claude.com/claude-code)