### PR TITLE
refactor: remove ccstate-react/experimental from zero-chat-page.tsx

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -1,0 +1,112 @@
+import { command, computed, state } from "ccstate";
+
+// ---------------------------------------------------------------------------
+// Demo / landing page local UI state for ZeroChatPage
+// ---------------------------------------------------------------------------
+
+const INITIAL_TAGLINE_INDEX = Math.floor(Math.random() * 18);
+
+const internalInput$ = state("");
+export const chatPageInput$ = computed((get) => get(internalInput$));
+export const setChatPageInput$ = command(({ set }, value: string) => {
+  set(internalInput$, value);
+});
+
+const internalConversationActive$ = state(false);
+export const chatPageConversationActive$ = computed((get) =>
+  get(internalConversationActive$),
+);
+export const setChatPageConversationActive$ = command(
+  ({ set }, value: boolean) => {
+    set(internalConversationActive$, value);
+  },
+);
+
+const internalStreamedCount$ = state(0);
+export const chatPageStreamedCount$ = computed((get) =>
+  get(internalStreamedCount$),
+);
+
+const internalConversationEndEl$ = state<HTMLDivElement | null>(null);
+export const setChatPageConversationEndEl$ = command(
+  ({ set }, el: HTMLDivElement | null) => {
+    set(internalConversationEndEl$, el);
+  },
+);
+
+const internalSubAgentListEl$ = state<HTMLDivElement | null>(null);
+export const setChatPageSubAgentListEl$ = command(
+  ({ set }, el: HTMLDivElement | null) => {
+    set(internalSubAgentListEl$, el);
+  },
+);
+
+const internalApproveDone$ = state(false);
+export const chatPageApproveDone$ = computed((get) =>
+  get(internalApproveDone$),
+);
+export const setChatPageApproveDone$ = command(({ set }, value: boolean) => {
+  set(internalApproveDone$, value);
+});
+
+const internalSelectedOption$ = state<string | null>(null);
+export const chatPageSelectedOption$ = computed((get) =>
+  get(internalSelectedOption$),
+);
+export const setChatPageSelectedOption$ = command(
+  ({ set }, value: string | null) => {
+    set(internalSelectedOption$, value);
+  },
+);
+
+const internalTeamPersonalChoice$ = state<"team" | "personal" | null>(null);
+export const chatPageTeamPersonalChoice$ = computed((get) =>
+  get(internalTeamPersonalChoice$),
+);
+export const setChatPageTeamPersonalChoice$ = command(
+  ({ set }, value: "team" | "personal" | null) => {
+    set(internalTeamPersonalChoice$, value);
+  },
+);
+
+const internalConnectorConnected$ = state(false);
+export const chatPageConnectorConnected$ = computed((get) =>
+  get(internalConnectorConnected$),
+);
+export const setChatPageConnectorConnected$ = command(
+  ({ set }, value: boolean) => {
+    set(internalConnectorConnected$, value);
+  },
+);
+
+const internalCommandAllowed$ = state(false);
+export const chatPageCommandAllowed$ = computed((get) =>
+  get(internalCommandAllowed$),
+);
+export const setChatPageCommandAllowed$ = command(({ set }, value: boolean) => {
+  set(internalCommandAllowed$, value);
+});
+
+const internalShowSubAgentList$ = state(false);
+export const chatPageShowSubAgentList$ = computed((get) =>
+  get(internalShowSubAgentList$),
+);
+
+const internalTaglineIndex$ = state(INITIAL_TAGLINE_INDEX);
+export const chatPageTaglineIndex$ = computed((get) =>
+  get(internalTaglineIndex$),
+);
+
+/** Toggle sub-agent list visibility with auto-scroll when opening. */
+export const toggleChatPageSubAgentList$ = command(({ get, set }) => {
+  const current = get(internalShowSubAgentList$);
+  set(internalShowSubAgentList$, !current);
+  if (!current) {
+    window.requestAnimationFrame(() => {
+      const el = get(internalSubAgentListEl$);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth" });
+      }
+    });
+  }
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable ccstate/no-use-ccstate-in-views */
 import { Component } from "react";
-import { useCCState, useCommand } from "ccstate-react/experimental";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import { user$ } from "../../signals/auth.ts";
 import {
@@ -18,6 +16,28 @@ import { ZERO_TEAM_JOBS } from "./zero-mock-data";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { Link } from "../router/link.tsx";
+import {
+  chatPageInput$,
+  setChatPageInput$,
+  chatPageConversationActive$,
+  setChatPageConversationActive$,
+  chatPageStreamedCount$,
+  setChatPageConversationEndEl$,
+  setChatPageSubAgentListEl$,
+  chatPageApproveDone$,
+  setChatPageApproveDone$,
+  chatPageSelectedOption$,
+  setChatPageSelectedOption$,
+  chatPageTeamPersonalChoice$,
+  setChatPageTeamPersonalChoice$,
+  chatPageConnectorConnected$,
+  setChatPageConnectorConnected$,
+  chatPageCommandAllowed$,
+  setChatPageCommandAllowed$,
+  chatPageShowSubAgentList$,
+  chatPageTaglineIndex$,
+  toggleChatPageSubAgentList$,
+} from "../../signals/zero-page/zero-chat-page.ts";
 import chatFolderImg from "./assets/chat-folder.png";
 import chatCoffeeImg from "./assets/chat-coffee.png";
 import chatMacImg from "./assets/chat-mac.png";
@@ -104,8 +124,6 @@ function getStreamedScenarios(agentName: string): readonly Readonly<{
     },
   ];
 }
-
-const INITIAL_TAGLINE_INDEX = Math.floor(Math.random() * 18);
 
 function getTagline(
   agentName: string,
@@ -758,54 +776,27 @@ export function ZeroChatPage({
   const agentName = chatAgentName ?? defaultAgentName;
   const userName = useUserFirstName();
 
-  const input$ = useCCState("");
-  const input = useGet(input$);
-  const setInput = useSet(input$);
-  const conversationActive$ = useCCState(false);
-  const conversationActive = useGet(conversationActive$);
-  const setConversationActive = useSet(conversationActive$);
-  const streamedCount$ = useCCState(0);
-  const streamedCount = useGet(streamedCount$);
-  const conversationEndEl$ = useCCState<HTMLDivElement | null>(null);
-  const setConversationEndEl = useSet(conversationEndEl$);
-  const subAgentListEl$ = useCCState<HTMLDivElement | null>(null);
-  const setSubAgentListEl = useSet(subAgentListEl$);
-  const approveDone$ = useCCState(false);
-  const approveDone = useGet(approveDone$);
-  const setApproveDone = useSet(approveDone$);
-  const selectedOption$ = useCCState<string | null>(null);
-  const selectedOption = useGet(selectedOption$);
-  const setSelectedOption = useSet(selectedOption$);
-  const teamPersonalChoice$ = useCCState<"team" | "personal" | null>(null);
-  const teamPersonalChoice = useGet(teamPersonalChoice$);
-  const setTeamPersonalChoice = useSet(teamPersonalChoice$);
-  const connectorConnected$ = useCCState(false);
-  const connectorConnected = useGet(connectorConnected$);
-  const setConnectorConnected = useSet(connectorConnected$);
-  const commandAllowed$ = useCCState(false);
-  const commandAllowed = useGet(commandAllowed$);
-  const setCommandAllowed = useSet(commandAllowed$);
-  const showSubAgentList$ = useCCState(false);
-  const showSubAgentList = useGet(showSubAgentList$);
-  const taglineIndex$ = useCCState(INITIAL_TAGLINE_INDEX);
-  const taglineIndex = useGet(taglineIndex$);
+  const input = useGet(chatPageInput$);
+  const setInput = useSet(setChatPageInput$);
+  const conversationActive = useGet(chatPageConversationActive$);
+  const setConversationActive = useSet(setChatPageConversationActive$);
+  const streamedCount = useGet(chatPageStreamedCount$);
+  const setConversationEndEl = useSet(setChatPageConversationEndEl$);
+  const setSubAgentListEl = useSet(setChatPageSubAgentListEl$);
+  const approveDone = useGet(chatPageApproveDone$);
+  const setApproveDone = useSet(setChatPageApproveDone$);
+  const selectedOption = useGet(chatPageSelectedOption$);
+  const setSelectedOption = useSet(setChatPageSelectedOption$);
+  const teamPersonalChoice = useGet(chatPageTeamPersonalChoice$);
+  const setTeamPersonalChoice = useSet(setChatPageTeamPersonalChoice$);
+  const connectorConnected = useGet(chatPageConnectorConnected$);
+  const setConnectorConnected = useSet(setChatPageConnectorConnected$);
+  const commandAllowed = useGet(chatPageCommandAllowed$);
+  const setCommandAllowed = useSet(setChatPageCommandAllowed$);
+  const showSubAgentList = useGet(chatPageShowSubAgentList$);
+  const taglineIndex = useGet(chatPageTaglineIndex$);
   const tagline = getTagline(agentName, userName, taglineIndex);
-
-  // Toggle sub-agent list with auto-scroll when opening
-  const toggleSubAgentList$ = useCommand(({ get, set }) => {
-    const current = get(showSubAgentList$);
-    set(showSubAgentList$, !current);
-    if (!current) {
-      // Becoming visible — scroll into view after next paint
-      window.requestAnimationFrame(() => {
-        const el = get(subAgentListEl$);
-        if (el) {
-          el.scrollIntoView({ behavior: "smooth" });
-        }
-      });
-    }
-  });
-  const toggleSubAgentList = useSet(toggleSubAgentList$);
+  const toggleSubAgentList = useSet(toggleChatPageSubAgentList$);
 
   const handleSend = (text: string, opts?: { modelProvider: string }) => {
     setInput("");


### PR DESCRIPTION
## Summary

- Move all `useCCState` and `useCommand` usage from `zero-chat-page.tsx` into a new `signals/zero-page/zero-chat-page.ts` file
- All demo page local state (input, scenario interaction flags, sub-agent list toggle) is now declared as `state()`/`computed()`/`command()` in the signals layer
- Remove the `eslint-disable ccstate/no-use-ccstate-in-views` comment and the `ccstate-react/experimental` import

Closes #5797

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes (no warnings)
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no unused exports
- [x] Existing `zero-chat-page.test.tsx` tests pass (suggested prompts render and populate input)
- [x] Existing `zero-chat.test.ts` signal tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)