### PR TITLE
refactor: replace http proxy with direct service calls in zero schedule routes

### DIFF
--- a/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
@@ -5,7 +5,6 @@ import {
   createTestCompose,
   createTestOrg,
   createTestSchedule,
-  getTestSchedule,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,

--- a/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { DELETE } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestOrg,
+  createTestSchedule,
+  getTestSchedule,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zsdel");
+  const orgId = `org_mock_${userId}`;
+
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+
+  return { slug, orgId };
+}
+
+describe("DELETE /api/zero/schedules/:name", () => {
+  let slug: string;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    const org = await setupOrg(user.userId);
+    slug = org.slug;
+
+    const { composeId } = await createTestCompose(
+      `zero-sched-del-${Date.now()}`,
+    );
+    testComposeId = composeId;
+  });
+
+  it("should delete schedule and return 204", async () => {
+    await createTestSchedule(testComposeId, "to-delete", {
+      cronExpression: "0 9 * * *",
+      prompt: "Will be deleted",
+    });
+
+    const response = await DELETE(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/to-delete?composeId=${testComposeId}&org=${slug}`,
+        { method: "DELETE" },
+      ),
+    );
+
+    expect(response.status).toBe(204);
+  });
+
+  it("should return 404 for non-existent schedule", async () => {
+    const response = await DELETE(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/non-existent?composeId=${testComposeId}&org=${slug}`,
+        { method: "DELETE" },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should reject unauthenticated request", async () => {
+    mockClerk({ userId: null });
+
+    const response = await DELETE(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/any?composeId=${testComposeId}&org=${slug}`,
+        { method: "DELETE" },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestOrg,
+  createTestSchedule,
+  enableTestSchedule,
+  getTestSchedule,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zsdis");
+  const orgId = `org_mock_${userId}`;
+
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+
+  return { slug, orgId };
+}
+
+describe("POST /api/zero/schedules/:name/disable", () => {
+  let slug: string;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    const org = await setupOrg(user.userId);
+    slug = org.slug;
+
+    const { composeId } = await createTestCompose(
+      `zero-sched-disable-${Date.now()}`,
+    );
+    testComposeId = composeId;
+  });
+
+  it("should disable an enabled schedule", async () => {
+    await createTestSchedule(testComposeId, "to-disable", {
+      cronExpression: "0 9 * * *",
+      prompt: "Disable test",
+    });
+    await enableTestSchedule(testComposeId, "to-disable");
+
+    const before = await getTestSchedule(testComposeId, "to-disable");
+    expect(before.enabled).toBe(true);
+
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/to-disable/disable?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ composeId: testComposeId }),
+        },
+      ),
+      { params: Promise.resolve({ name: "to-disable" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.enabled).toBe(false);
+  });
+
+  it("should return 404 for non-existent schedule", async () => {
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/non-existent/disable?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ composeId: testComposeId }),
+        },
+      ),
+      { params: Promise.resolve({ name: "non-existent" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 400 for invalid body", async () => {
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/any/disable?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      ),
+      { params: Promise.resolve({ name: "any" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should reject unauthenticated request", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/any/disable?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ composeId: testComposeId }),
+        },
+      ),
+      { params: Promise.resolve({ name: "any" }) },
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
@@ -1,16 +1,61 @@
-/**
- * POST /api/zero/schedules/:name/disable
- * Proxies to /api/agent/schedules/:name/disable
- */
-import { proxyToInfra } from "../../../../../../src/lib/infra-client";
+import { z } from "zod";
+import { initServices } from "../../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { disableSchedule } from "../../../../../../src/lib/schedule";
+import { isNotFound } from "../../../../../../src/lib/errors";
+
+const bodySchema = z.object({ composeId: z.string() });
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ name: string }> },
 ) {
+  initServices();
+
   const { name } = await params;
-  return proxyToInfra(
-    `/api/agent/schedules/${encodeURIComponent(name)}/disable`,
-    request,
-  );
+  const authorization = request.headers.get("authorization") ?? undefined;
+
+  const authCtx = await requireAuth(authorization, {
+    requiredCapability: "schedule:write",
+  });
+  if (isAuthError(authCtx)) {
+    return Response.json(authCtx.body, { status: authCtx.status });
+  }
+  const { userId } = authCtx;
+
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const {
+    org: { orgId },
+  } = await resolveOrg(authCtx, orgSlug);
+
+  const parsed = bodySchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: { message: "Invalid request body", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const schedule = await disableSchedule(
+      userId,
+      orgId,
+      parsed.data.composeId,
+      name,
+    );
+
+    return Response.json(schedule, { status: 200 });
+  } catch (error) {
+    if (isNotFound(error)) {
+      return Response.json(
+        { error: { message: "Resource not found", code: "NOT_FOUND" } },
+        { status: 404 },
+      );
+    }
+    throw error;
+  }
 }

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/__tests__/route.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestOrg,
+  createTestSchedule,
+  getTestSchedule,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zsen");
+  const orgId = `org_mock_${userId}`;
+
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+
+  return { slug, orgId };
+}
+
+describe("POST /api/zero/schedules/:name/enable", () => {
+  let slug: string;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    const org = await setupOrg(user.userId);
+    slug = org.slug;
+
+    const { composeId } = await createTestCompose(
+      `zero-sched-enable-${Date.now()}`,
+    );
+    testComposeId = composeId;
+  });
+
+  it("should enable a disabled schedule", async () => {
+    await createTestSchedule(testComposeId, "to-enable", {
+      cronExpression: "0 9 * * *",
+      prompt: "Enable test",
+    });
+
+    const before = await getTestSchedule(testComposeId, "to-enable");
+    expect(before.enabled).toBe(false);
+
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/to-enable/enable?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ composeId: testComposeId }),
+        },
+      ),
+      { params: Promise.resolve({ name: "to-enable" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.enabled).toBe(true);
+  });
+
+  it("should return 404 for non-existent schedule", async () => {
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/non-existent/enable?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ composeId: testComposeId }),
+        },
+      ),
+      { params: Promise.resolve({ name: "non-existent" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 400 for invalid body", async () => {
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/any/enable?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      ),
+      { params: Promise.resolve({ name: "any" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should reject unauthenticated request", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/any/enable?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ composeId: testComposeId }),
+        },
+      ),
+      { params: Promise.resolve({ name: "any" }) },
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
@@ -1,16 +1,72 @@
-/**
- * POST /api/zero/schedules/:name/enable
- * Proxies to /api/agent/schedules/:name/enable
- */
-import { proxyToInfra } from "../../../../../../src/lib/infra-client";
+import { z } from "zod";
+import { initServices } from "../../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { enableSchedule } from "../../../../../../src/lib/schedule";
+import { isNotFound, isSchedulePast } from "../../../../../../src/lib/errors";
+
+const bodySchema = z.object({ composeId: z.string() });
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ name: string }> },
 ) {
+  initServices();
+
   const { name } = await params;
-  return proxyToInfra(
-    `/api/agent/schedules/${encodeURIComponent(name)}/enable`,
-    request,
-  );
+  const authorization = request.headers.get("authorization") ?? undefined;
+
+  const authCtx = await requireAuth(authorization, {
+    requiredCapability: "schedule:write",
+  });
+  if (isAuthError(authCtx)) {
+    return Response.json(authCtx.body, { status: authCtx.status });
+  }
+  const { userId } = authCtx;
+
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const {
+    org: { orgId },
+  } = await resolveOrg(authCtx, orgSlug);
+
+  const parsed = bodySchema.safeParse(await request.json());
+  if (!parsed.success) {
+    return Response.json(
+      { error: { message: "Invalid request body", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const schedule = await enableSchedule(
+      userId,
+      orgId,
+      parsed.data.composeId,
+      name,
+    );
+
+    return Response.json(schedule, { status: 200 });
+  } catch (error) {
+    if (isNotFound(error)) {
+      return Response.json(
+        { error: { message: "Resource not found", code: "NOT_FOUND" } },
+        { status: 404 },
+      );
+    }
+    if (isSchedulePast(error)) {
+      return Response.json(
+        {
+          error: {
+            message: "Schedule time has already passed",
+            code: "SCHEDULE_PAST",
+          },
+        },
+        { status: 400 },
+      );
+    }
+    throw error;
+  }
 }

--- a/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
@@ -3,25 +3,49 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../../src/lib/ts-rest-handler";
-import {
-  zeroSchedulesByNameContract,
-  schedulesByNameContract,
-} from "@vm0/core";
+import { zeroSchedulesByNameContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
-  createInfraClient,
-  forwardInfra,
-} from "../../../../../src/lib/infra-client";
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { deleteSchedule } from "../../../../../src/lib/schedule";
+import { isNotFound } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroSchedulesByNameContract, {
-  delete: async ({ params, query, headers }) => {
+  delete: async ({ params, query, headers }, { request }) => {
     initServices();
-    const client = createInfraClient(
-      schedulesByNameContract,
-      headers.authorization,
-    );
-    const result = await client.delete({ params, query });
-    return forwardInfra(result);
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "schedule:write",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const {
+        org: { orgId },
+      } = await resolveOrg(authCtx, orgSlug);
+
+      await deleteSchedule(userId, orgId, query.composeId, params.name);
+
+      return {
+        status: 204 as const,
+        body: undefined,
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Resource not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      throw error;
+    }
   },
 });
 

--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST, GET } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestOrg,
+  createTestSchedule,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zsched");
+  const orgId = `org_mock_${userId}`;
+
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+
+  return { slug, orgId };
+}
+
+describe("POST /api/zero/schedules - Deploy Schedule", () => {
+  let slug: string;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    const org = await setupOrg(user.userId);
+    slug = org.slug;
+
+    const { composeId } = await createTestCompose(
+      `zero-sched-deploy-${Date.now()}`,
+    );
+    testComposeId = composeId;
+  });
+
+  it("should create schedule and return 201", async () => {
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            composeId: testComposeId,
+            name: "daily-zero",
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+            prompt: "Run daily",
+          }),
+        },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.created).toBe(true);
+    expect(data.schedule.name).toBe("daily-zero");
+    expect(data.schedule.cronExpression).toBe("0 9 * * *");
+  });
+
+  it("should update existing schedule and return 200", async () => {
+    await createTestSchedule(testComposeId, "update-zero", {
+      cronExpression: "0 9 * * *",
+      prompt: "Original",
+    });
+
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            composeId: testComposeId,
+            name: "update-zero",
+            cronExpression: "0 10 * * *",
+            timezone: "UTC",
+            prompt: "Updated",
+          }),
+        },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.created).toBe(false);
+    expect(data.schedule.cronExpression).toBe("0 10 * * *");
+  });
+
+  it("should return 400 for non-existent compose", async () => {
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            composeId: "non-existent-compose-id",
+            name: "will-fail",
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+            prompt: "Test",
+          }),
+        },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should reject unauthenticated request", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            composeId: testComposeId,
+            name: "unauth",
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+            prompt: "Test",
+          }),
+        },
+      ),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("GET /api/zero/schedules - List Schedules", () => {
+  let slug: string;
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    const org = await setupOrg(user.userId);
+    slug = org.slug;
+
+    const { composeId } = await createTestCompose(
+      `zero-sched-list-${Date.now()}`,
+    );
+    testComposeId = composeId;
+  });
+
+  it("should return list of schedules", async () => {
+    await createTestSchedule(testComposeId, "list-test-1", {
+      cronExpression: "0 9 * * *",
+      prompt: "First",
+    });
+    await createTestSchedule(testComposeId, "list-test-2", {
+      cronExpression: "0 10 * * *",
+      prompt: "Second",
+    });
+
+    const response = await GET(
+      createTestRequest(`http://localhost:3000/api/zero/schedules?org=${slug}`),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.schedules.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should return empty array for invalid org", async () => {
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules?org=non-existent-org`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.schedules).toEqual([]);
+  });
+
+  it("should reject unauthenticated request", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest(`http://localhost:3000/api/zero/schedules?org=${slug}`),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/schedules/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/route.ts
@@ -3,31 +3,120 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../src/lib/ts-rest-handler";
-import { zeroSchedulesMainContract, schedulesMainContract } from "@vm0/core";
+import { zeroSchedulesMainContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
-  createInfraClient,
-  forwardInfra,
-} from "../../../../src/lib/infra-client";
+  requireAuth,
+  isAuthError,
+} from "../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import { deploySchedule, listSchedules } from "../../../../src/lib/schedule";
+import {
+  isNotFound,
+  isBadRequest,
+  isForbidden,
+  isSchedulePast,
+} from "../../../../src/lib/errors";
 
 const router = tsr.router(zeroSchedulesMainContract, {
-  deploy: async ({ body, headers }) => {
+  deploy: async ({ body, headers }, { request }) => {
     initServices();
-    const client = createInfraClient(
-      schedulesMainContract,
-      headers.authorization,
-    );
-    const result = await client.deploy({ body });
-    return forwardInfra(result);
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "schedule:write",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const {
+        org: { orgId },
+      } = await resolveOrg(authCtx, orgSlug);
+
+      const result = await deploySchedule(userId, orgId, {
+        name: body.name,
+        composeId: body.composeId,
+        cronExpression: body.cronExpression,
+        atTime: body.atTime,
+        intervalSeconds: body.intervalSeconds,
+        timezone: body.timezone,
+        prompt: body.prompt,
+        appendSystemPrompt: body.appendSystemPrompt,
+        enabled: body.enabled,
+        notifyEmail: body.notifyEmail,
+        notifySlack: body.notifySlack,
+        artifactName: body.artifactName,
+        artifactVersion: body.artifactVersion,
+        volumeVersions: body.volumeVersions,
+      });
+
+      return {
+        status: (result.created ? 201 : 200) as 201 | 200,
+        body: result,
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: error.message, code: "NOT_FOUND" },
+          },
+        };
+      }
+      if (isBadRequest(error)) {
+        return {
+          status: 400 as const,
+          body: {
+            error: { message: error.message, code: "BAD_REQUEST" },
+          },
+        };
+      }
+      if (isSchedulePast(error)) {
+        return {
+          status: 400 as const,
+          body: {
+            error: {
+              message: error.message,
+              code: "SCHEDULE_PAST",
+            },
+          },
+        };
+      }
+      throw error;
+    }
   },
-  list: async ({ headers }) => {
+
+  list: async ({ headers }, { request }) => {
     initServices();
-    const client = createInfraClient(
-      schedulesMainContract,
-      headers.authorization,
-    );
-    const result = await client.list({ headers: {} });
-    return forwardInfra(result);
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "schedule:read",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    let orgId: string;
+    try {
+      const { org } = await resolveOrg(authCtx, orgSlug);
+      orgId = org.orgId;
+    } catch (error) {
+      if (isNotFound(error) || isForbidden(error) || isBadRequest(error)) {
+        return {
+          status: 200 as const,
+          body: { schedules: [] },
+        };
+      }
+      throw error;
+    }
+
+    const schedules = await listSchedules(userId, orgId);
+
+    return {
+      status: 200 as const,
+      body: { schedules },
+    };
   },
 });
 


### PR DESCRIPTION
## Summary

Rewrites 4 zero schedule routes to call core service functions directly, removing `createInfraClient`/`proxyToInfra` HTTP self-calls.

**Layering strategy**: Schedules have no zero-specific logic (no defaults to inject, no transformations), so zero routes call core services directly — same as agent routes. See #6051 for full strategy.

| Route | Before | After |
|-------|--------|-------|
| `zero/schedules/route.ts` (deploy + list) | `createInfraClient` → HTTP to agent | `deploySchedule()` / `listSchedules()` |
| `zero/schedules/[name]/route.ts` (delete) | `createInfraClient` → HTTP to agent | `deleteSchedule()` |
| `zero/schedules/[name]/enable/route.ts` | `proxyToInfra` → HTTP to agent | `enableSchedule()` |
| `zero/schedules/[name]/disable/route.ts` | `proxyToInfra` → HTTP to agent | `disableSchedule()` |

**Note**: enable/disable use raw Next.js handlers instead of ts-rest because `zeroSchedulesEnableContract` bundles both endpoints but they live in separate route files, and `tsr.router()` requires all contract endpoints to be implemented.

Part of #6051

## Test plan

- [x] All 4000 existing tests pass (`pnpm vitest run`)
- [x] `pnpm turbo run lint` passes
- [x] `pnpm check-types` passes
- [x] `pnpm knip` shows no new issues
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)