### PR TITLE
feat: allow canceling attachment upload before it completes

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -28,6 +28,10 @@ import {
   queueZeroChatMessage$,
   withdrawQueuedMessage$,
   cancelActiveRun$,
+  zeroChatAttachments$,
+  uploadZeroAttachment$,
+  removeZeroAttachment$,
+  cancelZeroAttachmentUpload$,
 } from "../zero-chat.ts";
 
 const context = testContext();
@@ -1020,7 +1024,7 @@ describe("zero-chat signals", () => {
       expect(context.store.get(zeroChatSending$)).toBeFalsy();
     });
 
-    it("should auto-send queued message after run cancellation", async () => {
+    it("should auto-send queued message after run cancellation (cancelActiveRun$)", async () => {
       let runCount = 0;
       let latestPrompt = "";
       server.use(
@@ -1102,6 +1106,138 @@ describe("zero-chat signals", () => {
       expect(runCount).toBe(2);
       expect(latestPrompt).toBe("after cancel");
       expect(context.store.get(zeroChatSending$)).toBeFalsy();
+    });
+  });
+
+  describe("attachment upload and cancel", () => {
+    function useUploadHandler(options?: { delayMs?: number }) {
+      const delayMs = options?.delayMs ?? 0;
+      server.use(
+        http.post("*/api/zero/uploads", async () => {
+          if (delayMs > 0) {
+            await delay(delayMs);
+          }
+          return HttpResponse.json({
+            id: "upload-1",
+            filename: "test.png",
+            contentType: "image/png",
+            size: 1024,
+            url: "https://example.com/test.png",
+          });
+        }),
+      );
+    }
+
+    function createTestFile(name = "test.png") {
+      return new File(["file-content"], name, { type: "image/png" });
+    }
+
+    it("should upload a file and update attachment state", async () => {
+      useUploadHandler();
+      await setup();
+
+      await context.store.set(uploadZeroAttachment$, createTestFile());
+
+      const attachments = context.store.get(zeroChatAttachments$);
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0]?.filename).toBe("test.png");
+      expect(attachments[0]?.uploading).toBeFalsy();
+      expect(attachments[0]?.url).toBe("https://example.com/test.png");
+    });
+
+    it("should cancel an in-flight upload and remove the attachment", async () => {
+      useUploadHandler({ delayMs: 500 });
+      await setup();
+
+      const uploadPromise = context.store
+        .set(uploadZeroAttachment$, createTestFile())
+        .catch(() => {});
+
+      // Wait for the placeholder to appear
+      await delay(10);
+      const before = context.store.get(zeroChatAttachments$);
+      expect(before).toHaveLength(1);
+      expect(before[0]?.uploading).toBeTruthy();
+      const attachmentId = before[0]!.id;
+
+      // Cancel the upload
+      context.store.set(cancelZeroAttachmentUpload$, attachmentId);
+
+      await uploadPromise;
+
+      const after = context.store.get(zeroChatAttachments$);
+      expect(after).toHaveLength(0);
+    });
+
+    it("should remove a completed attachment without aborting", async () => {
+      useUploadHandler();
+      await setup();
+
+      await context.store.set(uploadZeroAttachment$, createTestFile());
+
+      const attachments = context.store.get(zeroChatAttachments$);
+      expect(attachments).toHaveLength(1);
+      const attachmentId = attachments[0]!.id;
+
+      context.store.set(removeZeroAttachment$, attachmentId);
+
+      expect(context.store.get(zeroChatAttachments$)).toHaveLength(0);
+    });
+
+    it("should cancel one upload without affecting others", async () => {
+      let requestCount = 0;
+      server.use(
+        http.post("*/api/zero/uploads", async () => {
+          requestCount++;
+          const currentCount = requestCount;
+          await delay(300);
+          return HttpResponse.json({
+            id: `upload-${currentCount}`,
+            filename: `file-${currentCount}.png`,
+            contentType: "image/png",
+            size: 1024,
+            url: `https://example.com/file-${currentCount}.png`,
+          });
+        }),
+      );
+      await setup();
+
+      const promise1 = context.store
+        .set(uploadZeroAttachment$, createTestFile("file-a.png"))
+        .catch(() => {});
+      const promise2 = context.store
+        .set(uploadZeroAttachment$, createTestFile("file-b.png"))
+        .catch(() => {});
+
+      // Wait for both placeholders
+      await delay(10);
+      const before = context.store.get(zeroChatAttachments$);
+      expect(before).toHaveLength(2);
+
+      // Cancel the first upload
+      const firstId = before[0]!.id;
+      context.store.set(cancelZeroAttachmentUpload$, firstId);
+
+      await Promise.all([promise1, promise2]);
+
+      const after = context.store.get(zeroChatAttachments$);
+      // Only the second upload should remain, completed
+      expect(after).toHaveLength(1);
+      expect(after[0]?.uploading).toBeFalsy();
+      expect(after[0]?.url).toContain("example.com");
+    });
+
+    it("should remove placeholder on upload failure", async () => {
+      server.use(
+        http.post("*/api/zero/uploads", () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+      await setup();
+
+      await context.store.set(uploadZeroAttachment$, createTestFile());
+
+      expect(context.store.get(zeroChatAttachments$)).toHaveLength(0);
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -642,6 +642,9 @@ export const uploadZeroAttachment$ = command(
       // Remove the failed placeholder
       set(internalAttachments$, (prev) => prev.filter((a) => a.id !== id));
     } finally {
+      // Clean up the controller entry. When cancel triggers this path, the
+      // entry was already removed by cancelZeroAttachmentUpload$ — Map.delete
+      // on a missing key is a safe no-op.
       set(uploadAbortControllers$, (prev) => {
         const next = new Map(prev);
         next.delete(id);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -583,6 +583,8 @@ export const setZeroDragOver$ = command(({ set }, value: boolean) => {
   set(internalDragOver$, value);
 });
 
+const uploadAbortControllers$ = state(new Map<string, AbortController>());
+
 export const uploadZeroAttachment$ = command(
   async ({ get, set }, file: File) => {
     const id = crypto.randomUUID();
@@ -596,6 +598,9 @@ export const uploadZeroAttachment$ = command(
     };
     set(internalAttachments$, (prev) => [...prev, placeholder]);
 
+    const controller = new AbortController();
+    set(uploadAbortControllers$, (prev) => new Map(prev).set(id, controller));
+
     try {
       const fetchFn = get(fetch$);
       const formData = new FormData();
@@ -604,6 +609,7 @@ export const uploadZeroAttachment$ = command(
       const res = await fetchFn("/api/zero/uploads", {
         method: "POST",
         body: formData,
+        signal: controller.signal,
       });
 
       if (!res.ok) {
@@ -635,6 +641,12 @@ export const uploadZeroAttachment$ = command(
       L.error("Upload failed:", error);
       // Remove the failed placeholder
       set(internalAttachments$, (prev) => prev.filter((a) => a.id !== id));
+    } finally {
+      set(uploadAbortControllers$, (prev) => {
+        const next = new Map(prev);
+        next.delete(id);
+        return next;
+      });
     }
   },
 );
@@ -642,6 +654,22 @@ export const uploadZeroAttachment$ = command(
 export const removeZeroAttachment$ = command(({ set }, id: string) => {
   set(internalAttachments$, (prev) => prev.filter((a) => a.id !== id));
 });
+
+export const cancelZeroAttachmentUpload$ = command(
+  ({ get, set }, id: string) => {
+    const controllers = get(uploadAbortControllers$);
+    const controller = controllers.get(id);
+    if (controller) {
+      controller.abort();
+      set(uploadAbortControllers$, (prev) => {
+        const next = new Map(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+    set(internalAttachments$, (prev) => prev.filter((a) => a.id !== id));
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Commands: session list management

--- a/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-attachment-chips.tsx
@@ -170,23 +170,26 @@ function AttachmentChip({
         ) : (
           <IconFile size={28} stroke={1.5} className="text-muted-foreground" />
         )}
-        {attachment.uploading ? (
-          <span className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
+        {attachment.uploading && (
+          <span className="absolute -top-1 -left-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-background">
             <IconLoader2
               size={10}
               className="animate-spin text-muted-foreground"
             />
           </span>
-        ) : (
-          <button
-            type="button"
-            onClick={onRemove}
-            className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
-            aria-label={`Remove ${attachment.filename}`}
-          >
-            <IconX size={9} stroke={2.5} />
-          </button>
         )}
+        <button
+          type="button"
+          onClick={onRemove}
+          className="absolute -top-1 -right-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-muted hover:bg-destructive hover:text-destructive-foreground transition-colors"
+          aria-label={
+            attachment.uploading
+              ? `Cancel upload ${attachment.filename}`
+              : `Remove ${attachment.filename}`
+          }
+        >
+          <IconX size={9} stroke={2.5} />
+        </button>
       </div>
       {lightboxUrl && <ImageLightbox url={lightboxUrl} />}
     </>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -32,6 +32,7 @@ import {
   zeroChatAttachments$,
   uploadZeroAttachment$,
   removeZeroAttachment$,
+  cancelZeroAttachmentUpload$,
   composerFileInput$,
   setComposerFileInput$,
   composerAddDialogOpen$,
@@ -377,6 +378,7 @@ export function ZeroChatComposer({
   const attachments = useGet(zeroChatAttachments$);
   const uploadAttachment = useSet(uploadZeroAttachment$);
   const removeAttachment = useSet(removeZeroAttachment$);
+  const cancelUpload = useSet(cancelZeroAttachmentUpload$);
 
   // File picker
   const fileInputEl = useGet(composerFileInput$);
@@ -506,7 +508,14 @@ export function ZeroChatComposer({
             {attachments.length > 0 && (
               <AttachmentChips
                 attachments={attachments}
-                onRemove={removeAttachment}
+                onRemove={(id) => {
+                  const attachment = attachments.find((a) => a.id === id);
+                  if (attachment?.uploading) {
+                    cancelUpload(id);
+                  } else {
+                    removeAttachment(id);
+                  }
+                }}
               />
             )}
             {queuedMessage ? (


### PR DESCRIPTION
## Summary

- Add `AbortController`-based cancellation for in-flight attachment uploads
- Store per-upload `AbortController` in a state map (`uploadAbortControllers$`)
- Always show the X (cancel/remove) button on attachment chips, alongside the spinner during upload
- Clicking X during upload aborts the fetch and removes the attachment from state

Closes #5769

## Test plan

- [ ] Upload a large file → cancel button visible during upload → click cancel → upload aborted, attachment removed
- [ ] Upload a file → let it complete → X button removes completed attachment (regression)
- [ ] Upload multiple files → cancel one → others continue unaffected
- [ ] Paste/drag file → cancel during upload → clean state
- [ ] Existing upload API tests pass (`pnpm vitest run apps/web/app/api/zero/uploads`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)