### PR TITLE
refactor: remove non-anthropic vm0 model providers

### DIFF
--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -54,65 +54,6 @@ const MODEL_PRICING: ModelPricing[] = [
     cacheReadTokenPrice: usd(1.5),
     cacheCreationTokenPrice: usd(18.75),
   },
-  // Moonshot
-  {
-    model: "kimi-k2.5",
-    modelProvider: "vm0",
-    inputTokenPrice: usd(0.5),
-    outputTokenPrice: usd(2),
-    cacheReadTokenPrice: 0,
-    cacheCreationTokenPrice: 0,
-  },
-  {
-    model: "kimi-k2-thinking-turbo",
-    modelProvider: "vm0",
-    inputTokenPrice: usd(0.5),
-    outputTokenPrice: usd(2),
-    cacheReadTokenPrice: 0,
-    cacheCreationTokenPrice: 0,
-  },
-  {
-    model: "kimi-k2-thinking",
-    modelProvider: "vm0",
-    inputTokenPrice: usd(1),
-    outputTokenPrice: usd(4),
-    cacheReadTokenPrice: 0,
-    cacheCreationTokenPrice: 0,
-  },
-  // Z.AI (GLM)
-  {
-    model: "glm-5",
-    modelProvider: "vm0",
-    inputTokenPrice: usd(1),
-    outputTokenPrice: usd(4),
-    cacheReadTokenPrice: 0,
-    cacheCreationTokenPrice: 0,
-  },
-  {
-    model: "glm-4.7",
-    modelProvider: "vm0",
-    inputTokenPrice: usd(0.5),
-    outputTokenPrice: usd(2),
-    cacheReadTokenPrice: 0,
-    cacheCreationTokenPrice: 0,
-  },
-  {
-    model: "glm-4.5-air",
-    modelProvider: "vm0",
-    inputTokenPrice: usd(0.2),
-    outputTokenPrice: usd(0.8),
-    cacheReadTokenPrice: 0,
-    cacheCreationTokenPrice: 0,
-  },
-  // MiniMax
-  {
-    model: "MiniMax-M2.1",
-    modelProvider: "vm0",
-    inputTokenPrice: usd(1),
-    outputTokenPrice: usd(4),
-    cacheReadTokenPrice: 0,
-    cacheCreationTokenPrice: 0,
-  },
 ];
 
 /**
@@ -124,18 +65,6 @@ function buildVm0ApiKeys(): Vm0ApiKey[] {
     anthropic: {
       envVar: "DEV_MODEL_ANTHROPIC_KEY",
       models: ["claude-sonnet-4.6", "claude-opus-4.6"],
-    },
-    moonshot: {
-      envVar: "DEV_MODEL_MOONSHOT_KEY",
-      models: ["kimi-k2.5", "kimi-k2-thinking-turbo", "kimi-k2-thinking"],
-    },
-    zai: {
-      envVar: "DEV_MODEL_ZAI_KEY",
-      models: ["glm-5", "glm-4.7", "glm-4.5-air"],
-    },
-    minimax: {
-      envVar: "DEV_MODEL_MINIMAX_KEY",
-      models: ["MiniMax-M2.1"],
     },
   };
 

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -56,7 +56,7 @@ describe("VM0 managed model provider", () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             type: "vm0",
-            selectedModel: "kimi-k2.5",
+            selectedModel: "claude-sonnet-4.6",
           }),
         }),
       );
@@ -65,7 +65,7 @@ describe("VM0 managed model provider", () => {
       const data = await response.json();
       expect(data.provider.type).toBe("vm0");
       expect(data.provider.framework).toBe("claude-code");
-      expect(data.provider.selectedModel).toBe("kimi-k2.5");
+      expect(data.provider.selectedModel).toBe("claude-sonnet-4.6");
       expect(data.provider.isDefault).toBe(true);
       expect(data.created).toBe(true);
     });
@@ -80,7 +80,7 @@ describe("VM0 managed model provider", () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             type: "vm0",
-            selectedModel: "kimi-k2.5",
+            selectedModel: "claude-opus-4.6",
           }),
         }),
       );
@@ -88,7 +88,7 @@ describe("VM0 managed model provider", () => {
 
       const data = await response.json();
       expect(data.provider.type).toBe("vm0");
-      expect(data.provider.selectedModel).toBe("kimi-k2.5");
+      expect(data.provider.selectedModel).toBe("claude-opus-4.6");
       expect(data.created).toBe(true);
     });
   });
@@ -97,23 +97,23 @@ describe("VM0 managed model provider", () => {
     it("should return a random key for a vendor with keys", async () => {
       await insertVm0ApiKeys([
         {
-          vendor: "moonshot",
-          model: "kimi-k2.5",
-          apiKey: "sk-test-moonshot-1",
+          vendor: "anthropic",
+          model: "claude-sonnet-4.6",
+          apiKey: "sk-test-anthropic-1",
           label: "test key 1",
         },
         {
-          vendor: "moonshot",
-          model: "kimi-k2.5",
-          apiKey: "sk-test-moonshot-2",
+          vendor: "anthropic",
+          model: "claude-sonnet-4.6",
+          apiKey: "sk-test-anthropic-2",
           label: "test key 2",
         },
       ]);
 
-      const result = await getTestVm0ApiKey("moonshot");
+      const result = await getTestVm0ApiKey("anthropic");
       expect(result).not.toBeNull();
-      expect(result!.model).toBe("kimi-k2.5");
-      expect(["sk-test-moonshot-1", "sk-test-moonshot-2"]).toContain(
+      expect(result!.model).toBe("claude-sonnet-4.6");
+      expect(["sk-test-anthropic-1", "sk-test-anthropic-2"]).toContain(
         result!.apiKey,
       );
     });
@@ -125,28 +125,18 @@ describe("VM0 managed model provider", () => {
   });
 
   describe("model-to-provider mapping", () => {
-    it("should resolve moonshot models to moonshot-api-key", () => {
-      expect(getVm0ConcreteProviderType("kimi-k2.5")).toBe("moonshot-api-key");
-      expect(getVm0Vendor("kimi-k2.5")).toBe("moonshot");
-    });
-
-    it("should resolve anthropic models to anthropic-api-key", () => {
+    it("should resolve sonnet to anthropic-api-key", () => {
       expect(getVm0ConcreteProviderType("claude-sonnet-4.6")).toBe(
         "anthropic-api-key",
       );
       expect(getVm0Vendor("claude-sonnet-4.6")).toBe("anthropic");
     });
 
-    it("should resolve zai models to zai-api-key", () => {
-      expect(getVm0ConcreteProviderType("glm-5")).toBe("zai-api-key");
-      expect(getVm0Vendor("glm-5")).toBe("zai");
-    });
-
-    it("should resolve minimax models to minimax-api-key", () => {
-      expect(getVm0ConcreteProviderType("MiniMax-M2.1")).toBe(
-        "minimax-api-key",
+    it("should resolve opus to anthropic-api-key", () => {
+      expect(getVm0ConcreteProviderType("claude-opus-4.6")).toBe(
+        "anthropic-api-key",
       );
-      expect(getVm0Vendor("MiniMax-M2.1")).toBe("minimax");
+      expect(getVm0Vendor("claude-opus-4.6")).toBe("anthropic");
     });
 
     it("should throw for unknown models", () => {
@@ -156,20 +146,11 @@ describe("VM0 managed model provider", () => {
     });
 
     it("should have all VM0 provider models mapped", () => {
-      const vm0Models = [
-        "claude-sonnet-4.6",
-        "claude-opus-4.6",
-        "kimi-k2.5",
-        "kimi-k2-thinking-turbo",
-        "kimi-k2-thinking",
-        "glm-5",
-        "glm-4.7",
-        "glm-4.5-air",
-        "MiniMax-M2.1",
-      ];
+      const vm0Models = ["claude-sonnet-4.6", "claude-opus-4.6"];
       for (const model of vm0Models) {
         expect(VM0_MODEL_TO_PROVIDER[model]).toBeDefined();
       }
+      expect(Object.keys(VM0_MODEL_TO_PROVIDER)).toHaveLength(2);
     });
   });
 });

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -45,19 +45,6 @@ export const VM0_MODEL_TO_PROVIDER: Record<
     concreteType: "anthropic-api-key",
     vendor: "anthropic",
   },
-  "kimi-k2.5": { concreteType: "moonshot-api-key", vendor: "moonshot" },
-  "kimi-k2-thinking-turbo": {
-    concreteType: "moonshot-api-key",
-    vendor: "moonshot",
-  },
-  "kimi-k2-thinking": {
-    concreteType: "moonshot-api-key",
-    vendor: "moonshot",
-  },
-  "glm-5": { concreteType: "zai-api-key", vendor: "zai" },
-  "glm-4.7": { concreteType: "zai-api-key", vendor: "zai" },
-  "glm-4.5-air": { concreteType: "zai-api-key", vendor: "zai" },
-  "MiniMax-M2.1": { concreteType: "minimax-api-key", vendor: "minimax" },
 };
 
 /**


### PR DESCRIPTION
## Summary
- Remove Moonshot (kimi-k2.5, kimi-k2-thinking-turbo, kimi-k2-thinking), Z.AI (glm-5, glm-4.7, glm-4.5-air), and MiniMax (MiniMax-M2.1) from VM0 model provider mapping
- Clean up dev seed data and API key configuration for removed vendors
- Update VM0 provider tests to only cover Anthropic models (claude-sonnet-4.6, claude-opus-4.6)

## Test plan
- [ ] Verify VM0 provider tests pass with only Anthropic models
- [ ] Confirm dev seed script works without removed vendor configurations
- [ ] Check that model-to-provider mapping correctly resolves Anthropic models

🤖 Generated with [Claude Code](https://claude.com/claude-code)