### PR TITLE
feat: wire org deletion cleanup into clerk webhook handler

### DIFF
--- a/turbo/apps/web/app/api/webhooks/clerk/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/clerk/__tests__/route.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import * as externalCleanup from "../../../../../src/lib/org/org-external-cleanup";
+import * as s3Cleanup from "../../../../../src/lib/org/org-s3-cleanup";
+import * as dbCleanup from "../../../../../src/lib/org/org-deletion-service";
 
 // Mock @clerk/nextjs/webhooks (external dependency)
 const mockVerifyWebhook = vi.hoisted(() => vi.fn());
@@ -9,6 +13,8 @@ vi.mock("@clerk/nextjs/webhooks", () => ({
 
 // Import route handler AFTER mocks are set up
 import { POST } from "../route";
+
+const context = testContext();
 
 /** Helper to send a webhook request through the route */
 function createWebhookRequest(): NextRequest {
@@ -20,6 +26,23 @@ function createWebhookRequest(): NextRequest {
 }
 
 describe("POST /api/webhooks/clerk", () => {
+  let spyCleanupExternal: ReturnType<typeof vi.spyOn>;
+  let spyDeleteS3: ReturnType<typeof vi.spyOn>;
+  let spyDeleteOrgData: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    context.setupMocks();
+    spyCleanupExternal = vi
+      .spyOn(externalCleanup, "cleanupOrgExternalServices")
+      .mockResolvedValue(undefined);
+    spyDeleteS3 = vi
+      .spyOn(s3Cleanup, "deleteOrgS3Data")
+      .mockResolvedValue(undefined);
+    spyDeleteOrgData = vi
+      .spyOn(dbCleanup, "deleteOrgData")
+      .mockResolvedValue(undefined);
+  });
+
   it("returns 401 when signature verification fails", async () => {
     mockVerifyWebhook.mockRejectedValue(new Error("Invalid signature"));
 
@@ -28,18 +51,6 @@ describe("POST /api/webhooks/clerk", () => {
     expect(response.status).toBe(401);
     const data = await response.json();
     expect(data.error).toContain("Invalid webhook signature");
-  });
-
-  it("returns 200 for organization.deleted event", async () => {
-    mockVerifyWebhook.mockResolvedValue({
-      type: "organization.deleted",
-      data: { object: "organization", id: "org_test123", deleted: true },
-    });
-
-    const response = await POST(createWebhookRequest());
-
-    expect(response.status).toBe(200);
-    expect(await response.text()).toBe("OK");
   });
 
   it("returns 200 for unhandled event types", async () => {
@@ -64,5 +75,87 @@ describe("POST /api/webhooks/clerk", () => {
     await POST(request);
 
     expect(mockVerifyWebhook).toHaveBeenCalledWith(request);
+  });
+
+  describe("organization.deleted cleanup", () => {
+    it("calls all cleanup functions in correct order", async () => {
+      mockVerifyWebhook.mockResolvedValue({
+        type: "organization.deleted",
+        data: { object: "organization", id: "org_test123", deleted: true },
+      });
+
+      const callOrder: string[] = [];
+      spyCleanupExternal.mockImplementation(async () => {
+        callOrder.push("external");
+      });
+      spyDeleteS3.mockImplementation(async () => {
+        callOrder.push("s3");
+      });
+      spyDeleteOrgData.mockImplementation(async () => {
+        callOrder.push("db");
+      });
+
+      const response = await POST(createWebhookRequest());
+      expect(response.status).toBe(200);
+
+      await context.mocks.flushAfter();
+
+      expect(spyCleanupExternal).toHaveBeenCalledWith("org_test123");
+      expect(spyDeleteS3).toHaveBeenCalledWith("org_test123");
+      expect(spyDeleteOrgData).toHaveBeenCalledWith("org_test123");
+      expect(callOrder).toEqual(["external", "s3", "db"]);
+    });
+
+    it("handles missing org ID gracefully", async () => {
+      mockVerifyWebhook.mockResolvedValue({
+        type: "organization.deleted",
+        data: { object: "organization", id: undefined, deleted: true },
+      });
+
+      const response = await POST(createWebhookRequest());
+      expect(response.status).toBe(200);
+
+      await context.mocks.flushAfter();
+
+      expect(spyCleanupExternal).not.toHaveBeenCalled();
+      expect(spyDeleteS3).not.toHaveBeenCalled();
+      expect(spyDeleteOrgData).not.toHaveBeenCalled();
+    });
+
+    it("catches cleanup errors without affecting response", async () => {
+      mockVerifyWebhook.mockResolvedValue({
+        type: "organization.deleted",
+        data: { object: "organization", id: "org_fail", deleted: true },
+      });
+      spyCleanupExternal.mockRejectedValue(new Error("external failed"));
+
+      const response = await POST(createWebhookRequest());
+      expect(response.status).toBe(200);
+
+      // flushAfter should not throw — error is caught inside the after() callback
+      await expect(context.mocks.flushAfter()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("organizationMembership.deleted", () => {
+    it("returns 200 without calling cleanup functions", async () => {
+      mockVerifyWebhook.mockResolvedValue({
+        type: "organizationMembership.deleted",
+        data: {
+          object: "organization_membership",
+          organization: { id: "org_test123" },
+          public_user_data: { user_id: "user_test456" },
+        },
+      });
+
+      const response = await POST(createWebhookRequest());
+      expect(response.status).toBe(200);
+
+      await context.mocks.flushAfter();
+
+      expect(spyCleanupExternal).not.toHaveBeenCalled();
+      expect(spyDeleteS3).not.toHaveBeenCalled();
+      expect(spyDeleteOrgData).not.toHaveBeenCalled();
+    });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/clerk/route.ts
+++ b/turbo/apps/web/app/api/webhooks/clerk/route.ts
@@ -1,7 +1,10 @@
-import { type NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse, after } from "next/server";
 import { verifyWebhook } from "@clerk/nextjs/webhooks";
 import { initServices } from "../../../../src/lib/init-services";
 import { logger } from "../../../../src/lib/logger";
+import { cleanupOrgExternalServices } from "../../../../src/lib/org/org-external-cleanup";
+import { deleteOrgS3Data } from "../../../../src/lib/org/org-s3-cleanup";
+import { deleteOrgData } from "../../../../src/lib/org/org-deletion-service";
 
 const log = logger("webhook:clerk");
 
@@ -11,8 +14,9 @@ const log = logger("webhook:clerk");
  * POST /api/webhooks/clerk
  *
  * Handles incoming Clerk webhook events with Svix signature verification.
- * Currently handles:
- * - organization.deleted — placeholder for cascade cleanup (wired in later sub-issue)
+ * Handles:
+ * - organization.deleted — cascade cleanup of all org-scoped data
+ * - organizationMembership.deleted — intentional no-op (handled by org deletion)
  */
 export async function POST(request: NextRequest) {
   initServices();
@@ -30,10 +34,49 @@ export async function POST(request: NextRequest) {
   log.info("clerk webhook received", { type: evt.type });
 
   switch (evt.type) {
-    case "organization.deleted":
-      log.info("organization.deleted received", { orgId: evt.data.id });
-      // Cleanup logic will be wired in a subsequent sub-issue
+    case "organization.deleted": {
+      const orgId = evt.data.id;
+      if (!orgId) {
+        log.error("organization.deleted event missing org ID", {
+          data: evt.data,
+        });
+        break;
+      }
+
+      log.info("organization.deleted — starting cleanup", { orgId });
+
+      // Use after() to run cleanup after returning 200 to Clerk.
+      // This prevents Clerk from retrying due to timeout on large orgs.
+      after(async () => {
+        try {
+          // Phase 1: External services (needs DB data — must run first)
+          await cleanupOrgExternalServices(orgId);
+
+          // Phase 2: S3 cleanup (needs DB data — must run before DB deletion)
+          await deleteOrgS3Data(orgId);
+
+          // Phase 3: Database cleanup (deletes all org-scoped rows)
+          await deleteOrgData(orgId);
+
+          log.info("organization.deleted — cleanup complete", { orgId });
+        } catch (error) {
+          log.error("organization.deleted — cleanup failed", { orgId, error });
+        }
+      });
+
       break;
+    }
+
+    case "organizationMembership.deleted":
+      // When Clerk deletes an org, it may also fire organizationMembership.deleted
+      // for each member. We handle all member cleanup in organization.deleted,
+      // so this is intentionally a no-op to avoid conflicting with org deletion.
+      log.debug("organizationMembership.deleted received (no-op)", {
+        orgId: evt.data.organization?.id,
+        userId: evt.data.public_user_data?.user_id,
+      });
+      break;
+
     default:
       log.debug("ignoring unhandled Clerk event", { type: evt.type });
   }


### PR DESCRIPTION
## Summary

- Wire `cleanupOrgExternalServices`, `deleteOrgS3Data`, and `deleteOrgData` into the `organization.deleted` Clerk webhook handler using `after()` for non-blocking execution
- Add `organizationMembership.deleted` as intentional no-op (member cleanup handled by org deletion)
- Add integration tests verifying cleanup ordering, missing org ID handling, error resilience, and no-op behavior

Closes #5981

## Test plan

- [x] All 7 tests pass (3 existing + 4 new)
- [x] Cleanup functions called in correct order: external → S3 → DB
- [x] Missing org ID handled gracefully (no crash, no cleanup calls)
- [x] Cleanup errors caught without affecting webhook response
- [x] `organizationMembership.deleted` returns 200 without triggering cleanup
- [x] Lint, format, knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)