### PR TITLE
fix: neon branch cleanup naming mismatch causing endpoint exhaustion

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -46,7 +46,7 @@ jobs:
               continue
             fi
 
-            # Extract PR number from preview/pr-{number} or preview/pr-{number}-merge-queue
+            # Extract PR number from preview/pr-{number} or preview/pr-{number}-mq
             PR_NUMBER=$(echo "$branch" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [ -n "$PR_NUMBER" ]; then
 
@@ -161,8 +161,8 @@ jobs:
               let shouldDelete = false;
               let reason = '';
 
-              // Check if it's a PR-based deployment (pr-123 or pr-123-merge-queue format)
-              const prMatch = identifier.match(/^pr-(\d+)(-merge-queue)?$/);
+              // Check if it's a PR-based deployment (pr-123 or pr-123-mq format)
+              const prMatch = identifier.match(/^pr-(\d+)(-mq)?$/);
               if (prMatch) {
                 const prNumber = parseInt(prMatch[1]);
                 if (!openPRNumbers.has(prNumber)) {
@@ -277,17 +277,17 @@ jobs:
 
             if [ "$DRY_RUN" = "true" ]; then
               echo "[DRY-RUN] Would cleanup turbo runner pr-${PR_NUMBER}"
-              echo "[DRY-RUN] Would cleanup turbo runner pr-${PR_NUMBER}-merge-queue"
+              echo "[DRY-RUN] Would cleanup turbo runner pr-${PR_NUMBER}-mq"
               echo "[DRY-RUN] Would cleanup crates runner pr-${PR_NUMBER}-test"
-              echo "[DRY-RUN] Would cleanup crates runner pr-${PR_NUMBER}-merge-queue-test"
+              echo "[DRY-RUN] Would cleanup crates runner pr-${PR_NUMBER}-mq-test"
               CLEANED=$((CLEANED + 1))
               continue
             fi
 
             PR_FAILED=0
 
-            # Cleanup turbo runners (PR and merge-queue)
-            for JOB_REF in "pr-${PR_NUMBER}" "pr-${PR_NUMBER}-merge-queue"; do
+            # Cleanup turbo runners (PR and mq)
+            for JOB_REF in "pr-${PR_NUMBER}" "pr-${PR_NUMBER}-mq"; do
               if ! ansible-playbook \
                 -i "${METAL_HOSTS}," \
                 playbooks/cleanup-turbo-runner.yml \
@@ -299,8 +299,8 @@ jobs:
               fi
             done
 
-            # Cleanup crates runners (PR and merge-queue)
-            for JOB_REF in "pr-${PR_NUMBER}-test" "pr-${PR_NUMBER}-merge-queue-test"; do
+            # Cleanup crates runners (PR and mq)
+            for JOB_REF in "pr-${PR_NUMBER}-test" "pr-${PR_NUMBER}-mq-test"; do
               if ! ansible-playbook \
                 -i "${METAL_HOSTS}," \
                 playbooks/cleanup-crates-runner.yml \

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -49,7 +49,7 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
         run: |
           cd ansible
-          for JOB_REF in "pr-${PR_NUMBER}" "pr-${PR_NUMBER}-merge-queue"; do
+          for JOB_REF in "pr-${PR_NUMBER}" "pr-${PR_NUMBER}-mq"; do
             if ! ansible-playbook \
               -i "${METAL_HOSTS}," \
               playbooks/cleanup-turbo-runner.yml \
@@ -68,7 +68,7 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
         run: |
           cd ansible
-          for JOB_REF in "pr-${PR_NUMBER}-test" "pr-${PR_NUMBER}-merge-queue-test"; do
+          for JOB_REF in "pr-${PR_NUMBER}-test" "pr-${PR_NUMBER}-mq-test"; do
             if ! ansible-playbook \
               -i "${METAL_HOSTS}," \
               playbooks/cleanup-crates-runner.yml \
@@ -93,15 +93,15 @@ jobs:
         with:
           neon-api-key: ${{ secrets.NEON_API_KEY }}
           neon-project-id: ${{ vars.NEON_PROJECT_ID }}
-          branch-name: "${{ github.event.pull_request.head.ref }}"
+          branch-name: "pr-${{ github.event.pull_request.number }}"
           action: "cleanup"
 
-      - name: Delete Neon Branch (merge-queue)
+      - name: Delete Neon Branch (mq)
         uses: ./.github/actions/neon-branch
         with:
           neon-api-key: ${{ secrets.NEON_API_KEY }}
           neon-project-id: ${{ vars.NEON_PROJECT_ID }}
-          branch-name: "pr-${{ github.event.pull_request.number }}-merge-queue"
+          branch-name: "pr-${{ github.event.pull_request.number }}-mq"
           action: "cleanup"
 
   cleanup-deployments:
@@ -118,9 +118,9 @@ jobs:
             const branchName = context.payload.pull_request.head.ref;
             const sha = context.payload.pull_request.head.sha;
             const prNumber = context.payload.pull_request.number;
-            const mergeQueueJobRef = `pr-${prNumber}-merge-queue`;
+            const mergeQueueJobRef = `pr-${prNumber}-mq`;
 
-            console.log(`Cleaning up deployments for branch: ${branchName}, sha: ${sha}, merge-queue: ${mergeQueueJobRef}`);
+            console.log(`Cleaning up deployments for branch: ${branchName}, sha: ${sha}, mq: ${mergeQueueJobRef}`);
 
             // Get all deployments and filter by branch name
             const allDeployments = await github.rest.repos.listDeployments({
@@ -129,7 +129,7 @@ jobs:
               per_page: 100
             });
 
-            // Filter deployments that belong to this branch or its merge-queue run
+            // Filter deployments that belong to this branch or its mq run
             const branchDeployments = allDeployments.data.filter(deployment => {
               // Match by ref or environment name containing branch
               return deployment.ref === branchName ||

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -202,8 +202,8 @@ jobs:
             MQ_REF="${{ github.event.merge_group.head_ref }}"
             PR_NUM=$(echo "$MQ_REF" | grep -oE 'pr-[0-9]+' | head -1 | sed 's/pr-//')
             if [ -n "$PR_NUM" ]; then
-              echo "job-ref=pr-${PR_NUM}-mq-${GITHUB_RUN_ID}" >> "$GITHUB_OUTPUT"
-              echo "Job ref set to: pr-${PR_NUM}-mq-${GITHUB_RUN_ID}"
+              echo "job-ref=pr-${PR_NUM}-mq" >> "$GITHUB_OUTPUT"
+              echo "Job ref set to: pr-${PR_NUM}-mq"
             else
               echo "::error::Failed to extract PR number from merge_group head_ref: $MQ_REF"
               exit 1


### PR DESCRIPTION
## Summary
- Remove `GITHUB_RUN_ID` from merge queue job-ref in `turbo.yml` so MQ retries reuse the same Neon branch instead of creating orphans
- Fix PR cleanup in `cleanup.yml` to use `pr-{number}` (matching actual Neon branch name) instead of git branch name
- Update all `merge-queue` suffix references to `-mq` across `cleanup.yml` and `cleanup-stale.yml` for consistency

Closes #6071

## Test plan
- [ ] Static review: trace branch name from creation (`turbo.yml`) through cleanup (`cleanup.yml`) and stale cleanup (`cleanup-stale.yml`) to verify naming consistency
- [ ] Post-merge: trigger `cleanup-stale.yml` via `workflow_dispatch` to clean up existing orphaned `preview/pr-*-mq-*` branches
- [ ] Post-merge: open a test PR, let it go through MQ, close it, and verify cleanup deletes the Neon branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)