### PR TITLE
refactor: replace infra-client proxy with direct service calls in connector and org zero routes

### DIFF
--- a/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { DELETE } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zcdel");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function deleteUrl(slug: string, type: string): string {
+  return `http://localhost:3000/api/zero/connectors/${type}?org=${slug}`;
+}
+
+describe("DELETE /api/zero/connectors/:type", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should delete a connector and return 204", async () => {
+    const userId = uniqueId("zcdel-ok");
+    const { slug, orgId } = await setupOrg(userId);
+    await context.createConnector(orgId, { userId, type: "github" });
+
+    const response = await DELETE(
+      createTestRequest(deleteUrl(slug, "github"), { method: "DELETE" }),
+    );
+    expect(response.status).toBe(204);
+  });
+
+  it("should return 404 when connector not found", async () => {
+    const userId = uniqueId("zcdel-nf");
+    const { slug } = await setupOrg(userId);
+
+    const response = await DELETE(
+      createTestRequest(deleteUrl(slug, "github"), { method: "DELETE" }),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await DELETE(
+      createTestRequest(deleteUrl("test", "github"), { method: "DELETE" }),
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
@@ -3,7 +3,7 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../../src/lib/ts-rest-handler";
-import { zeroConnectorsByTypeContract } from "@vm0/core";
+import { zeroConnectorsByTypeContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -32,12 +32,7 @@ const router = tsr.router(zeroConnectorsByTypeContract, {
       };
     } catch (error) {
       if (isNotFound(error)) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Connector not found", code: "NOT_FOUND" },
-          },
-        };
+        return createErrorResponse("NOT_FOUND", "Connector not found");
       }
       throw error;
     }

--- a/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
@@ -3,40 +3,44 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../../src/lib/ts-rest-handler";
-import {
-  zeroConnectorsByTypeContract,
-  connectorsByTypeContract,
-  type ApiErrorResponse,
-} from "@vm0/core";
+import { zeroConnectorsByTypeContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { createInfraClient } from "../../../../../src/lib/infra-client";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { deleteConnector } from "../../../../../src/lib/connector/connector-service";
+import { isNotFound } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroConnectorsByTypeContract, {
   delete: async ({ params, headers }, { request }) => {
     initServices();
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const client = createInfraClient(
-      connectorsByTypeContract,
-      headers.authorization,
-      orgSlug ? { query: { org: orgSlug } } : undefined,
-    );
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
 
-    const result = await client.delete({ params: { type: params.type } });
+    try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const { org } = await resolveOrg(authCtx, orgSlug);
+      await deleteConnector(org.orgId, userId, params.type);
 
-    if (result.status === 204) {
-      return { status: 204 as const, body: undefined };
-    }
-    if (result.status === 401) {
       return {
-        status: 401 as const,
-        body: result.body as ApiErrorResponse,
+        status: 204 as const,
+        body: undefined,
       };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Connector not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      throw error;
     }
-    return {
-      status: 404 as const,
-      body: result.body as ApiErrorResponse,
-    };
   },
 });
 

--- a/turbo/apps/web/app/api/zero/connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/__tests__/route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zcon");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function connectorsUrl(slug: string): string {
+  return `http://localhost:3000/api/zero/connectors?org=${slug}`;
+}
+
+describe("GET /api/zero/connectors", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return empty connectors list", async () => {
+    const userId = uniqueId("zcon-list");
+    const { slug } = await setupOrg(userId);
+
+    const response = await GET(createTestRequest(connectorsUrl(slug)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.connectors).toEqual([]);
+    expect(Array.isArray(data.configuredTypes)).toBe(true);
+    expect(Array.isArray(data.connectorProvidedSecretNames)).toBe(true);
+  });
+
+  it("should return connectors when present", async () => {
+    const userId = uniqueId("zcon-has");
+    const { slug, orgId } = await setupOrg(userId);
+    await context.createConnector(orgId, { userId, type: "github" });
+
+    const response = await GET(createTestRequest(connectorsUrl(slug)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.connectors.length).toBeGreaterThanOrEqual(1);
+    expect(
+      data.connectors.some((c: { type: string }) => c.type === "github"),
+    ).toBe(true);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/connectors?org=test"),
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/route.ts
@@ -3,26 +3,45 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../src/lib/ts-rest-handler";
-import { zeroConnectorsMainContract, connectorsMainContract } from "@vm0/core";
+import {
+  zeroConnectorsMainContract,
+  getConnectorProvidedSecretNames,
+} from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
-  createInfraClient,
-  forwardInfra,
-} from "../../../../src/lib/infra-client";
+  requireAuth,
+  isAuthError,
+} from "../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import { listConnectors } from "../../../../src/lib/connector/connector-service";
+import { getConfiguredConnectorTypes } from "../../../../src/lib/connector/provider-registry";
 
 const router = tsr.router(zeroConnectorsMainContract, {
   list: async ({ headers }, { request }) => {
     initServices();
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const client = createInfraClient(
-      connectorsMainContract,
-      headers.authorization,
-      orgSlug ? { query: { org: orgSlug } } : undefined,
-    );
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
 
-    const result = await client.list({ headers: {} });
-    return forwardInfra(result);
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+    const connectorList = await listConnectors(org.orgId, userId);
+    const configuredTypes = getConfiguredConnectorTypes(
+      globalThis.services.env,
+    );
+    const connectorProvidedSecretNames = [
+      ...getConnectorProvidedSecretNames(connectorList.map((c) => c.type)),
+    ];
+
+    return {
+      status: 200 as const,
+      body: {
+        connectors: connectorList,
+        configuredTypes,
+        connectorProvidedSecretNames,
+      },
+    };
   },
 });
 

--- a/turbo/apps/web/app/api/zero/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET, PUT } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zorg");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function orgUrl(slug: string): string {
+  return `http://localhost:3000/api/zero/org?org=${slug}`;
+}
+
+describe("GET /api/zero/org", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return org info", async () => {
+    const userId = uniqueId("zorg-get");
+    const { slug } = await setupOrg(userId);
+
+    const response = await GET(createTestRequest(orgUrl(slug)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.id).toBeDefined();
+    expect(data.slug).toBe(slug);
+    expect(data.name).toBeDefined();
+  });
+
+  it("should return 404 when org not found", async () => {
+    const userId = uniqueId("zorg-nf");
+    mockClerk({ userId, orgId: `org_mock_${userId}`, orgRole: "org:admin" });
+
+    const response = await GET(
+      createTestRequest(orgUrl("nonexistent-org-slug")),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/org?org=test"),
+    );
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("PUT /api/zero/org", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should update org name and return 200", async () => {
+    const userId = uniqueId("zorg-upd");
+    const { slug } = await setupOrg(userId);
+
+    const response = await PUT(
+      createTestRequest(orgUrl(slug), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Updated Org Name" }),
+      }),
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.id).toBeDefined();
+    expect(data.slug).toBeDefined();
+    expect(data.name).toBeDefined();
+  });
+
+  it("should return 400 when changing slug without force", async () => {
+    const userId = uniqueId("zorg-noforce");
+    const { slug } = await setupOrg(userId);
+
+    const response = await PUT(
+      createTestRequest(orgUrl(slug), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: "new-slug-name" }),
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await PUT(
+      createTestRequest("http://localhost:3000/api/zero/org?org=test", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Test" }),
+      }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 404 when org not found", async () => {
+    const userId = uniqueId("zorg-upd-nf");
+    mockClerk({ userId, orgId: `org_mock_${userId}`, orgRole: "org:admin" });
+
+    const response = await PUT(
+      createTestRequest(orgUrl("nonexistent-org-slug"), {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Test" }),
+      }),
+    );
+    expect(response.status).toBe(404);
+  });
+});

--- a/turbo/apps/web/app/api/zero/org/route.ts
+++ b/turbo/apps/web/app/api/zero/org/route.ts
@@ -3,40 +3,134 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../src/lib/ts-rest-handler";
-import { zeroOrgContract, orgContract } from "@vm0/core";
+import { zeroOrgContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
-  createInfraClient,
-  forwardInfra,
-} from "../../../../src/lib/infra-client";
+  requireAuth,
+  isAuthError,
+} from "../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import { updateOrg } from "../../../../src/lib/org/org-service";
+import {
+  isBadRequest,
+  isForbidden,
+  isNotFound,
+} from "../../../../src/lib/errors";
 
 const router = tsr.router(zeroOrgContract, {
   get: async ({ headers }, { request }) => {
     initServices();
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const client = createInfraClient(
-      orgContract,
-      headers.authorization,
-      orgSlug ? { query: { org: orgSlug } } : undefined,
-    );
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
 
-    const result = await client.get({ headers: {} });
-    return forwardInfra(result);
+    const orgSlug = new URL(request.url).searchParams.get("org");
+
+    try {
+      const { org: resolvedOrg, member } = await resolveOrg(authCtx, orgSlug);
+
+      return {
+        status: 200 as const,
+        body: {
+          id: resolvedOrg.orgId,
+          slug: resolvedOrg.slug,
+          name: resolvedOrg.name,
+          tier: resolvedOrg.tier,
+          role: member.role,
+        },
+      };
+    } catch (error) {
+      if (isNotFound(error) || isBadRequest(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Resource not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      throw error;
+    }
   },
 
   update: async ({ body, headers }, { request }) => {
     initServices();
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const client = createInfraClient(
-      orgContract,
-      headers.authorization,
-      orgSlug ? { query: { org: orgSlug } } : undefined,
-    );
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
 
-    const result = await client.update({ body });
-    return forwardInfra(result);
+    const orgSlug = new URL(request.url).searchParams.get("org");
+
+    let resolvedOrg;
+    try {
+      ({ org: resolvedOrg } = await resolveOrg(authCtx, orgSlug));
+    } catch (error) {
+      if (isNotFound(error) || isBadRequest(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: {
+              message:
+                "No org configured. Set your org with: vm0 org set <slug>",
+              code: "NOT_FOUND",
+            },
+          },
+        };
+      }
+      throw error;
+    }
+
+    try {
+      const updatedOrg = await updateOrg(resolvedOrg.orgId, userId, {
+        slug: body.slug,
+        name: body.name,
+        force: body.force,
+      });
+
+      return {
+        status: 200 as const,
+        body: {
+          id: updatedOrg.orgId,
+          slug: updatedOrg.slug,
+          name: updatedOrg.name,
+          tier: updatedOrg.tier,
+        },
+      };
+    } catch (error) {
+      if (isBadRequest(error)) {
+        if (error.message.includes("already exists")) {
+          return {
+            status: 409 as const,
+            body: {
+              error: { message: "Resource conflict", code: "CONFLICT" },
+            },
+          };
+        }
+        return {
+          status: 400 as const,
+          body: {
+            error: { message: "Invalid request", code: "BAD_REQUEST" },
+          },
+        };
+      }
+      if (isForbidden(error)) {
+        return {
+          status: 403 as const,
+          body: {
+            error: { message: "Access denied", code: "FORBIDDEN" },
+          },
+        };
+      }
+      if (isNotFound(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Resource not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      throw error;
+    }
   },
 });
 

--- a/turbo/apps/web/app/api/zero/org/route.ts
+++ b/turbo/apps/web/app/api/zero/org/route.ts
@@ -3,7 +3,7 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../src/lib/ts-rest-handler";
-import { zeroOrgContract } from "@vm0/core";
+import { zeroOrgContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -41,12 +41,7 @@ const router = tsr.router(zeroOrgContract, {
       };
     } catch (error) {
       if (isNotFound(error) || isBadRequest(error)) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Resource not found", code: "NOT_FOUND" },
-          },
-        };
+        return createErrorResponse("NOT_FOUND", "Resource not found");
       }
       throw error;
     }
@@ -61,26 +56,8 @@ const router = tsr.router(zeroOrgContract, {
 
     const orgSlug = new URL(request.url).searchParams.get("org");
 
-    let resolvedOrg;
     try {
-      ({ org: resolvedOrg } = await resolveOrg(authCtx, orgSlug));
-    } catch (error) {
-      if (isNotFound(error) || isBadRequest(error)) {
-        return {
-          status: 404 as const,
-          body: {
-            error: {
-              message:
-                "No org configured. Set your org with: vm0 org set <slug>",
-              code: "NOT_FOUND",
-            },
-          },
-        };
-      }
-      throw error;
-    }
-
-    try {
+      const { org: resolvedOrg } = await resolveOrg(authCtx, orgSlug);
       const updatedOrg = await updateOrg(resolvedOrg.orgId, userId, {
         slug: body.slug,
         name: body.name,
@@ -99,35 +76,18 @@ const router = tsr.router(zeroOrgContract, {
     } catch (error) {
       if (isBadRequest(error)) {
         if (error.message.includes("already exists")) {
-          return {
-            status: 409 as const,
-            body: {
-              error: { message: "Resource conflict", code: "CONFLICT" },
-            },
-          };
+          return createErrorResponse("CONFLICT", "Resource conflict");
         }
-        return {
-          status: 400 as const,
-          body: {
-            error: { message: "Invalid request", code: "BAD_REQUEST" },
-          },
-        };
+        return createErrorResponse("BAD_REQUEST", "Invalid request");
       }
       if (isForbidden(error)) {
-        return {
-          status: 403 as const,
-          body: {
-            error: { message: "Access denied", code: "FORBIDDEN" },
-          },
-        };
+        return createErrorResponse("FORBIDDEN", "Access denied");
       }
       if (isNotFound(error)) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Resource not found", code: "NOT_FOUND" },
-          },
-        };
+        return createErrorResponse(
+          "NOT_FOUND",
+          "No org configured. Set your org with: vm0 org set <slug>",
+        );
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

- Remove `createInfraClient` HTTP self-call pattern from `zero/connectors` and `zero/org` routes
- Routes now call core service functions directly (same functions used by agent/infra routes)
- Add 13 integration tests covering all endpoints (list, delete, get, update)

**Part of #6051** (PR 2/7: Connectors + Org domain)

### Routes changed
| Route | Before | After |
|-------|--------|-------|
| `GET /api/zero/connectors` | `createInfraClient` → `/api/connectors` | `listConnectors()` + `getConfiguredConnectorTypes()` + `getConnectorProvidedSecretNames()` |
| `DELETE /api/zero/connectors/:type` | `createInfraClient` → `/api/connectors/:type` | `deleteConnector()` |
| `GET /api/zero/org` | `createInfraClient` → `/api/org` | `resolveOrg()` |
| `PUT /api/zero/org` | `createInfraClient` → `/api/org` | `resolveOrg()` + `updateOrg()` |

### Layering strategy
No custom zero logic → call core service directly (same service functions used by agent routes).

## Test plan
- [x] 3 tests for connector list (empty, with connector, unauth)
- [x] 3 tests for connector delete (success 204, not found 404, unauth 401)
- [x] 7 tests for org get/put (get 200, get 404, get 401, update 200, update no-force 400, update 401, update 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)