### PR TITLE
fix: add missing libc dependency to runner crate

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1537,6 +1537,7 @@ dependencies = [
  "guest-download",
  "guest-init",
  "guest-mock-claude",
+ "libc",
  "nix",
  "reqeast",
  "sandbox",

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true, features = ["serde", "now"] }
 clap = { workspace = true, features = ["derive", "env"] }
+libc = { workspace = true }
 nix = { workspace = true, features = ["user", "signal", "fs"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary
- Add `libc = { workspace = true }` to `crates/runner/Cargo.toml`
- The dependency was added in #6060 but reverted by the subsequent release-please commit (`chore: release main` e5b9d22af) which regenerated Cargo.toml from a stale base
- Runner's `kmsg_log` module uses `libc::prctl` for `PR_SET_PDEATHSIG`

## Test plan
- [x] `cargo build --target aarch64-unknown-linux-musl -p runner --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)