### PR TITLE
refactor: generalize slack file handling to support all file types

### DIFF
--- a/turbo/apps/platform/src/mocks/mock-log-detail-data.ts
+++ b/turbo/apps/platform/src/mocks/mock-log-detail-data.ts
@@ -51,7 +51,7 @@ export const mockLogDetail: LogDetail = {
     "<@UMOCK_MENTION01> Take a look at the content of this image I sent you and draft a blog post outline",
     "[file]: IMG_8408.png (PNG)",
     "   Dimensions: 1206x2622",
-    "   Image URL: https://mock-r2-storage.example.com/slack-images/CMOCK_CHAN01-1770813781.383159/FMOCK_FILE01-IMG_8408.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=FAKE_ACCESS_KEY_ID%2F20260211%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260211T125301Z&X-Amz-Expires=3600&X-Amz-Signature=0000000000000000000000000000000000000000000000000000000000000000&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject",
+    '   Download: curl -sS -o /tmp/FMOCK_FILE01.png "https://mock-r2-storage.example.com/slack-files/CMOCK_CHAN01-1770813781.383159/FMOCK_FILE01-IMG_8408.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=FAKE_ACCESS_KEY_ID%2F20260211%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260211T125301Z&X-Amz-Expires=3600&X-Amz-Signature=0000000000000000000000000000000000000000000000000000000000000000&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject"',
     "",
     "---",
     "",

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -462,6 +462,7 @@ describe("Feature: Format Context With Image Upload", () => {
               id: "F123",
               name: "screenshot.png",
               mimetype: "image/png",
+              filetype: "png",
               original_w: "1920",
               original_h: "1080",
               url_private_download:
@@ -482,7 +483,7 @@ describe("Feature: Format Context With Image Upload", () => {
       expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalled();
       expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledWith(
         "test-bucket",
-        expect.stringContaining("slack-images/test-session-123/"),
+        expect.stringContaining("slack-files/test-session-123/"),
         expect.any(Buffer),
         "image/png",
       );
@@ -490,7 +491,7 @@ describe("Feature: Format Context With Image Upload", () => {
       expect(result).toContain("[file]: screenshot.png (image/png)");
       expect(result).toContain("Dimensions: 1920x1080");
       expect(result).toContain(
-        'View: curl -sS -o /tmp/F123.png "https://mock-presigned-url"',
+        'Download: curl -sS -o /tmp/F123.png "https://mock-presigned-url"',
       );
       expect(result).toContain("- SENDER: {id: U123}");
     });
@@ -523,6 +524,7 @@ describe("Feature: Format Context With Image Upload", () => {
               id: "F456",
               name: "photo.jpg",
               mimetype: "image/jpeg",
+              filetype: "jpg",
               url_private_download:
                 "https://files.slack.com/download/photo.jpg",
             },
@@ -537,19 +539,31 @@ describe("Feature: Format Context With Image Upload", () => {
       );
 
       expect(result).toContain(
-        'View: curl -sS -o /tmp/F456.png "https://mock-presigned-url"',
+        'Download: curl -sS -o /tmp/F456.jpg "https://mock-presigned-url"',
       );
       expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledWith(
         "test-bucket",
-        expect.stringContaining("slack-images/test-session-123/"),
+        expect.stringContaining("slack-files/test-session-123/"),
         expect.any(Buffer),
         "image/jpeg",
       );
     });
   });
 
-  describe("Scenario: Fall back to URL for unsupported types", () => {
-    it("should not upload PDF files, use URL fallback", async () => {
+  describe("Scenario: Upload non-image file types to R2", () => {
+    it("should upload PDF files to R2 with presigned URL", async () => {
+      const pdfContent = Buffer.from("%PDF-1.4 fake pdf content");
+
+      const downloadHandler = http.get(
+        "https://files.slack.com/download/report.pdf",
+        () => {
+          return new HttpResponse(pdfContent, {
+            headers: { "content-type": "application/pdf" },
+          });
+        },
+      );
+      server.use(downloadHandler.handler);
+
       const messages = [
         {
           user: "U123",
@@ -557,8 +571,10 @@ describe("Feature: Format Context With Image Upload", () => {
           ts: "1234567890.001",
           files: [
             {
+              id: "F789",
               name: "report.pdf",
               mimetype: "application/pdf",
+              filetype: "pdf",
               url_private_download:
                 "https://files.slack.com/download/report.pdf",
               permalink: "https://slack.com/files/report.pdf",
@@ -573,10 +589,16 @@ describe("Feature: Format Context With Image Upload", () => {
         "test-session-123",
       );
 
-      expect(context.mocks.s3.uploadS3Buffer).not.toHaveBeenCalled();
+      expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledWith(
+        "test-bucket",
+        expect.stringContaining("slack-files/test-session-123/"),
+        expect.any(Buffer),
+        "application/pdf",
+      );
       expect(result).toContain("[file]: report.pdf (application/pdf)");
-      expect(result).toContain("URL: https://slack.com/files/report.pdf");
-      expect(result).not.toContain("Image URL:");
+      expect(result).toContain(
+        'Download: curl -sS -o /tmp/F789.pdf "https://mock-presigned-url"',
+      );
     });
   });
 
@@ -697,12 +719,12 @@ describe("Feature: Format Context With Image Upload", () => {
       expect(result).not.toContain("Image URL:");
     });
 
-    it("should fall back to URL when content has invalid image magic bytes", async () => {
-      const invalidContent = Buffer.from("Not an image file content");
+    it("should upload content regardless of magic bytes since all file types are supported", async () => {
+      const arbitraryContent = Buffer.from("Not an image file content");
       const downloadHandler = http.get(
         "https://files.slack.com/download/screenshot.png",
         () => {
-          return new HttpResponse(invalidContent, {
+          return new HttpResponse(arbitraryContent, {
             headers: { "content-type": "image/png" },
           });
         },
@@ -719,6 +741,7 @@ describe("Feature: Format Context With Image Upload", () => {
               id: "F123",
               name: "screenshot.png",
               mimetype: "image/png",
+              filetype: "png",
               url_private_download:
                 "https://files.slack.com/download/screenshot.png",
               permalink: "https://slack.com/files/screenshot.png",
@@ -733,27 +756,28 @@ describe("Feature: Format Context With Image Upload", () => {
         "test-session-123",
       );
 
-      expect(context.mocks.s3.uploadS3Buffer).not.toHaveBeenCalled();
-      expect(result).toContain("URL: https://slack.com/files/screenshot.png");
-      expect(result).not.toContain("Image URL:");
+      expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalled();
+      expect(result).toContain(
+        'Download: curl -sS -o /tmp/F123.png "https://mock-presigned-url"',
+      );
     });
   });
 
   describe("Scenario: Respect file size limits", () => {
-    it("should not upload files larger than 10MB", async () => {
+    it("should not upload files larger than 100MB", async () => {
       const messages = [
         {
           user: "U123",
-          text: "Large image",
+          text: "Large file",
           ts: "1234567890.001",
           files: [
             {
-              name: "large.png",
-              mimetype: "image/png",
-              size: 15 * 1024 * 1024, // 15MB (exceeds 10MB limit)
+              name: "large.zip",
+              mimetype: "application/zip",
+              size: 150 * 1024 * 1024, // 150MB (exceeds 100MB limit)
               url_private_download:
-                "https://files.slack.com/download/large.png",
-              permalink: "https://slack.com/files/large.png",
+                "https://files.slack.com/download/large.zip",
+              permalink: "https://slack.com/files/large.zip",
             },
           ],
         },
@@ -766,8 +790,7 @@ describe("Feature: Format Context With Image Upload", () => {
       );
 
       expect(context.mocks.s3.uploadS3Buffer).not.toHaveBeenCalled();
-      expect(result).toContain("URL: https://slack.com/files/large.png");
-      expect(result).not.toContain("Image URL:");
+      expect(result).toContain("URL: https://slack.com/files/large.zip");
     });
   });
 
@@ -855,7 +878,7 @@ describe("Feature: Format Context With Image Upload", () => {
       expect(result).toContain("[file]: img1.png");
       expect(result).toContain("[file]: img2.png");
       // Both should have presigned URLs
-      expect((result.match(/View: curl/g) || []).length).toBe(2);
+      expect((result.match(/Download: curl/g) || []).length).toBe(2);
     });
   });
 
@@ -1476,7 +1499,7 @@ describe("Feature: Format Current Message Files", () => {
 
     expect(result).toContain("[file]: photo.png (image/png)");
     expect(result).toContain("[file]: readme.txt (text/plain)");
-    expect(result).toContain("View: curl");
+    expect(result).toContain("Download: curl");
     expect(result).toContain("URL: https://slack.com/files/readme.txt");
     expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledTimes(1);
   });
@@ -1511,7 +1534,7 @@ describe("Feature: Format Current Message Files", () => {
 
       expect(context.mocks.s3.uploadS3Buffer).not.toHaveBeenCalled();
       expect(result).toContain("URL: https://slack.com/files/malicious.png");
-      expect(result).not.toContain("View: curl");
+      expect(result).not.toContain("Download: curl");
     });
 
     it("should reject private IP address URL", async () => {
@@ -1533,7 +1556,7 @@ describe("Feature: Format Current Message Files", () => {
 
       expect(context.mocks.s3.uploadS3Buffer).not.toHaveBeenCalled();
       expect(result).toContain("URL: https://slack.com/files/internal.png");
-      expect(result).not.toContain("View: curl");
+      expect(result).not.toContain("Download: curl");
     });
 
     it("should reject non-HTTPS Slack URL", async () => {
@@ -1555,7 +1578,7 @@ describe("Feature: Format Current Message Files", () => {
 
       expect(context.mocks.s3.uploadS3Buffer).not.toHaveBeenCalled();
       expect(result).toContain("URL: https://slack.com/files/file.png");
-      expect(result).not.toContain("View: curl");
+      expect(result).not.toContain("Download: curl");
     });
 
     it("should reject cloud metadata URL", async () => {
@@ -1577,7 +1600,7 @@ describe("Feature: Format Current Message Files", () => {
 
       expect(context.mocks.s3.uploadS3Buffer).not.toHaveBeenCalled();
       expect(result).toContain("URL: https://slack.com/files/metadata.png");
-      expect(result).not.toContain("View: curl");
+      expect(result).not.toContain("Download: curl");
     });
 
     it("should reject invalid URL string", async () => {
@@ -1599,7 +1622,7 @@ describe("Feature: Format Current Message Files", () => {
 
       expect(context.mocks.s3.uploadS3Buffer).not.toHaveBeenCalled();
       expect(result).toContain("URL: https://slack.com/files/bad.png");
-      expect(result).not.toContain("View: curl");
+      expect(result).not.toContain("Download: curl");
     });
   });
 });

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -20,28 +20,8 @@ function isValidSlackDownloadUrl(url: string): boolean {
   }
 }
 
-/**
- * Check if a buffer starts with known image magic bytes.
- */
-function hasImageMagicBytes(buffer: Buffer): boolean {
-  const isPng = buffer[0] === 0x89 && buffer[1] === 0x50;
-  const isJpeg = buffer[0] === 0xff && buffer[1] === 0xd8;
-  const isGif = buffer[0] === 0x47 && buffer[1] === 0x49;
-  const isWebp = buffer[0] === 0x52 && buffer[1] === 0x49;
-  return isPng || isJpeg || isGif || isWebp;
-}
-
-/** Maximum file size to download and upload (10MB) */
-const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-
-/** Image MIME types that can be uploaded for agent access */
-const SUPPORTED_IMAGE_TYPES = [
-  "image/png",
-  "image/jpeg",
-  "image/jpg",
-  "image/gif",
-  "image/webp",
-];
+/** Maximum file size to download and upload (100MB) */
+const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
 
 export interface SlackFile {
   id?: string;
@@ -154,14 +134,6 @@ export async function fetchChannelContext(
 
   // Reverse to get chronological order (oldest first)
   return ((result.messages ?? []) as SlackMessage[]).reverse();
-}
-
-/**
- * Check if a file is a supported image type
- */
-function isSupportedImageType(file: SlackFile): boolean {
-  const mimetype = file.mimetype?.toLowerCase();
-  return mimetype !== undefined && SUPPORTED_IMAGE_TYPES.includes(mimetype);
 }
 
 /**
@@ -332,32 +304,13 @@ async function downloadAndUploadSlackFile(
       return null;
     }
 
-    // Verify the response content type is an image
-    const responseContentType = response.headers.get("content-type");
-    if (!responseContentType || !responseContentType.startsWith("image/")) {
-      log.debug("Slack returned non-image content", {
-        fileId: file.id,
-        contentType: responseContentType,
-      });
-      return null;
-    }
-
     const arrayBuffer = await response.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
 
-    // Verify the content is actually an image (check magic bytes)
-    if (!hasImageMagicBytes(buffer)) {
-      log.debug("Downloaded content is not a valid image", {
-        fileId: file.id,
-        firstBytes: buffer.slice(0, 10).toString("hex"),
-      });
-      return null;
-    }
-
     // Upload to R2 temporary storage with correct MIME type
     const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
-    const filename = file.name || file.id || "image";
-    const s3Key = `slack-images/${sessionId}/${file.id || Date.now()}-${filename}`;
+    const filename = file.name || file.id || "file";
+    const s3Key = `slack-files/${sessionId}/${file.id || Date.now()}-${filename}`;
     const contentType = file.mimetype || "application/octet-stream";
 
     await uploadS3Buffer(bucketName, s3Key, buffer, contentType);
@@ -365,7 +318,7 @@ async function downloadAndUploadSlackFile(
     // Generate presigned URL (valid for 1 hour)
     const presignedUrl = await generatePresignedUrl(bucketName, s3Key, 3600);
 
-    log.debug("Uploaded Slack image to R2", {
+    log.debug("Uploaded Slack file to R2", {
       fileId: file.id,
       name: filename,
       size: buffer.length,
@@ -407,10 +360,10 @@ function formatFileInfo(file: SlackFile): string {
 }
 
 /**
- * Format file information for context with image upload to R2
- * Uploads supported image types to R2 and provides presigned URLs
+ * Format file information for context with file upload to R2
+ * Uploads files to R2 and provides presigned URLs for agent access
  */
-async function formatFileInfoWithImage(
+async function formatFileInfoWithUpload(
   file: SlackFile,
   botToken: string | undefined,
   sessionId: string,
@@ -425,18 +378,16 @@ async function formatFileInfoWithImage(
     parts.push(`   Dimensions: ${file.original_w}x${file.original_h}`);
   }
 
-  // Try to upload image to R2 and get presigned URL
-  if (botToken && isSupportedImageType(file)) {
+  // Try to upload file to R2 and get presigned URL
+  if (botToken) {
     const presignedUrl = await downloadAndUploadSlackFile(
       file,
       botToken,
       sessionId,
     );
     if (presignedUrl) {
-      const filename = `${file.id || "image"}.${file.filetype || "png"}`;
-      parts.push(
-        `   View: curl -sS -o /tmp/${filename} "${presignedUrl}" && read /tmp/${filename}`,
-      );
+      const filename = `${file.id || "file"}.${file.filetype || "bin"}`;
+      parts.push(`   Download: curl -sS -o /tmp/${filename} "${presignedUrl}"`);
       return parts.join("\n");
     }
   }
@@ -619,7 +570,7 @@ export async function formatContextForAgentWithImages(
       // Format files with image upload
       if (msg.files && msg.files.length > 0) {
         for (const file of msg.files) {
-          const fileInfo = await formatFileInfoWithImage(
+          const fileInfo = await formatFileInfoWithUpload(
             file,
             botToken,
             sessionId,
@@ -672,7 +623,7 @@ export async function formatCurrentMessageFiles(
 ): Promise<string> {
   const parts: string[] = [];
   for (const file of files) {
-    const fileInfo = await formatFileInfoWithImage(file, botToken, sessionId);
+    const fileInfo = await formatFileInfoWithUpload(file, botToken, sessionId);
     parts.push(fileInfo);
   }
   return parts.join("\n");

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -304,6 +304,16 @@ async function downloadAndUploadSlackFile(
       return null;
     }
 
+    // Reject HTML responses — Slack returns login pages when bot tokens expire
+    const responseContentType = response.headers.get("content-type") || "";
+    if (responseContentType.includes("text/html")) {
+      log.debug("Rejected HTML response from Slack (likely expired token)", {
+        fileId: file.id,
+        contentType: responseContentType,
+      });
+      return null;
+    }
+
     const arrayBuffer = await response.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
 
@@ -535,8 +545,8 @@ export function formatContextForAgent(
 }
 
 /**
- * Format messages into context for agent prompt with image upload
- * Uploads supported image types to R2 and provides presigned URLs
+ * Format messages into context for agent prompt with file upload
+ * Uploads files to R2 and provides presigned URLs for agent access
  *
  * @param messages - Array of Slack messages
  * @param botToken - Bot token for downloading private files
@@ -614,7 +624,7 @@ export async function formatContextForAgentWithImages(
 
 /**
  * Format files attached to the current message for inclusion in the prompt.
- * Uploads supported images to R2 and returns formatted file descriptions.
+ * Uploads files to R2 and returns formatted file descriptions.
  */
 export async function formatCurrentMessageFiles(
   files: SlackFile[],


### PR DESCRIPTION
## Summary
- Remove image-only restrictions from Slack file upload pipeline (magic byte checks, image MIME type validation, supported image types list)
- Increase max file size from 10MB to 100MB to accommodate larger file types
- Rename image-specific paths and functions to generic file terminology (`slack-images/` -> `slack-files/`, `formatFileInfoWithImage` -> `formatFileInfoWithUpload`)

## Test plan
- [ ] Upload an image file via Slack and verify it is still downloaded, uploaded to R2, and accessible via presigned URL
- [ ] Upload a non-image file (e.g., PDF, CSV) via Slack and verify it is now handled the same way
- [ ] Verify files larger than 10MB but under 100MB are accepted
- [ ] Verify files over 100MB are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)