### PR TITLE
refactor: extract run service functions and replace infra-client proxy in run routes

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -79,7 +79,7 @@ const router = tsr.router(runsCancelContract, {
         return {
           status: 404 as const,
           body: {
-            error: { message: (error as Error).message, code: "NOT_FOUND" },
+            error: { message: error.message, code: "NOT_FOUND" },
           },
         };
       }
@@ -87,7 +87,7 @@ const router = tsr.router(runsCancelContract, {
         return {
           status: 400 as const,
           body: {
-            error: { message: (error as Error).message, code: "BAD_REQUEST" },
+            error: { message: error.message, code: "BAD_REQUEST" },
           },
         };
       }

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -1,9 +1,6 @@
 import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { runsCancelContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../../src/db/schema/agent-run";
-import { agentRunQueue } from "../../../../../../src/db/schema/agent-run-queue";
-import { eq, and } from "drizzle-orm";
 import {
   requireAuth,
   isAuthError,
@@ -11,15 +8,14 @@ import {
 import { isSandboxAuth } from "../../../../../../src/lib/auth/capability-check";
 import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 import { getOrgData } from "../../../../../../src/lib/org/org-cache-service";
-import { logger } from "../../../../../../src/lib/logger";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { eq, and } from "drizzle-orm";
 import {
-  transitionRunStatus,
-  dispatchTerminalSideEffects,
-} from "../../../../../../src/lib/run/run-status";
-import { drainOrgQueue } from "../../../../../../src/lib/run/run-queue-service";
-import { dispatchQueuedRun } from "../../../../../../src/lib/run/run-service";
-import { processOrgCredits } from "../../../../../../src/lib/credit/credit-service";
-import { publishCancelNotification } from "../../../../../../src/lib/realtime/client";
+  cancelRun,
+  dispatchCancelSideEffects,
+} from "../../../../../../src/lib/run/run-service";
+import { isNotFound, isBadRequest } from "../../../../../../src/lib/errors";
+import { logger } from "../../../../../../src/lib/logger";
 import { after } from "next/server";
 
 const log = logger("api:runs:cancel");
@@ -61,117 +57,42 @@ const router = tsr.router(runsCancelContract, {
       orgId = org.orgId;
     }
 
-    // Find the run - filter by userId and orgId for security
-    const [run] = await globalThis.services.db
-      .select()
-      .from(agentRuns)
-      .where(
-        and(
-          eq(agentRuns.id, runId),
-          eq(agentRuns.userId, userId),
-          eq(agentRuns.orgId, orgId),
-        ),
-      )
-      .limit(1);
+    try {
+      const result = await cancelRun(runId, userId, orgId);
 
-    if (!run) {
-      return {
-        status: 404 as const,
-        body: {
-          error: { message: `No such run: '${runId}'`, code: "NOT_FOUND" },
-        },
-      };
-    }
+      after(() => dispatchCancelSideEffects(result));
 
-    // Check if run can be cancelled
-    if (
-      run.status !== "queued" &&
-      run.status !== "pending" &&
-      run.status !== "running"
-    ) {
-      return {
-        status: 400 as const,
-        body: {
-          error: {
-            message: `Run cannot be cancelled: current status is '${run.status}'`,
-            code: "BAD_REQUEST",
-          },
-        },
-      };
-    }
-
-    // Atomically delete queue entry (if present) and transition status.
-    // The transaction prevents a concurrent drainOrgQueue from dequeuing
-    // the run between the queue delete and the status update.
-    const cancelled = await globalThis.services.db.transaction(async (tx) => {
-      await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, runId));
-
-      return transitionRunStatus(
-        runId,
-        { status: "cancelled", completedAt: new Date() },
-        ["queued", "pending", "running"],
-        tx,
+      log.debug(
+        `Run ${runId} cancelled by user ${userId}, sandbox: ${result.sandboxId ?? "none"}`,
       );
-    });
 
-    if (!cancelled) {
       return {
-        status: 400 as const,
+        status: 200 as const,
         body: {
-          error: {
-            message: `Run cannot be cancelled: status has already changed`,
-            code: "BAD_REQUEST",
-          },
+          id: runId,
+          status: "cancelled" as const,
+          message: "Run cancelled successfully",
         },
       };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: (error as Error).message, code: "NOT_FOUND" },
+          },
+        };
+      }
+      if (isBadRequest(error)) {
+        return {
+          status: 400 as const,
+          body: {
+            error: { message: (error as Error).message, code: "BAD_REQUEST" },
+          },
+        };
+      }
+      throw error;
     }
-
-    // Dispatch side effects after the response is sent:
-    // - Ably cancel notification (best-effort, DB status is already "cancelled")
-    // - Terminal callbacks (e.g., loop schedule advancement)
-    // - Queue drain + credit processing
-    after(async () => {
-      // Notify runner via Ably so it can kill the VM.
-      // Only needed for running jobs with a runner group — queued/pending
-      // runs are handled by the DB status change alone.
-      if (run.status === "running" && run.runnerGroup) {
-        const published = await publishCancelNotification(
-          run.runnerGroup,
-          runId,
-        );
-        if (!published) {
-          log.warn(
-            `Ably cancel notification failed for run ${runId}, VM will run until natural completion`,
-          );
-        }
-      }
-
-      const shouldDrain = run.status === "running" || run.status === "pending";
-      await dispatchTerminalSideEffects(
-        runId,
-        "cancelled",
-        "Run cancelled",
-        shouldDrain
-          ? () => drainOrgQueue(run.orgId, dispatchQueuedRun)
-          : undefined,
-      );
-      if (shouldDrain) {
-        await processOrgCredits(run.orgId);
-      }
-    });
-
-    log.debug(
-      `Run ${runId} cancelled by user ${userId}, sandbox: ${run.sandboxId ?? "none"}`,
-    );
-
-    return {
-      status: 200 as const,
-      body: {
-        id: runId,
-        status: "cancelled" as const,
-        message: "Run cancelled successfully",
-      },
-    };
   },
 });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/route.ts
@@ -1,13 +1,12 @@
 import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { runsByIdContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../src/db/schema/agent-run";
-import { eq, and } from "drizzle-orm";
 import {
   requireAuth,
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { getRunById } from "../../../../../src/lib/run/run-service";
 
 const router = tsr.router(runsByIdContract, {
   getById: async ({ params, headers }, { request }) => {
@@ -22,19 +21,7 @@ const router = tsr.router(runsByIdContract, {
     const orgSlug = new URL(request.url).searchParams.get("org");
     const { org } = await resolveOrg(authCtx, orgSlug);
 
-    // Query run from database - filter by userId and orgId for security
-    const [run] = await globalThis.services.db
-      .select()
-      .from(agentRuns)
-      .where(
-        and(
-          eq(agentRuns.id, params.id),
-          eq(agentRuns.userId, userId),
-          eq(agentRuns.orgId, org.orgId),
-        ),
-      )
-      .limit(1);
-
+    const run = await getRunById(params.id, userId, org.orgId);
     if (!run) {
       return {
         status: 404 as const,
@@ -44,28 +31,7 @@ const router = tsr.router(runsByIdContract, {
       };
     }
 
-    return {
-      status: 200 as const,
-      body: {
-        runId: run.id,
-        agentComposeVersionId: run.agentComposeVersionId,
-        status: run.status as
-          | "pending"
-          | "running"
-          | "completed"
-          | "failed"
-          | "timeout",
-        prompt: run.prompt,
-        appendSystemPrompt: run.appendSystemPrompt,
-        vars: run.vars as Record<string, string> | undefined,
-        sandboxId: run.sandboxId || undefined,
-        result: run.result as Record<string, unknown> | undefined,
-        error: run.error || undefined,
-        createdAt: run.createdAt.toISOString(),
-        startedAt: run.startedAt?.toISOString(),
-        completedAt: run.completedAt?.toISOString(),
-      },
-    };
+    return { status: 200 as const, body: run };
   },
 });
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
@@ -5,24 +5,10 @@ import {
 } from "../../../../../../../src/lib/ts-rest-handler";
 import { runAgentEventsContract } from "@vm0/core";
 import { initServices } from "../../../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
-import { agentComposeVersions } from "../../../../../../../src/db/schema/agent-compose";
-import { eq, and } from "drizzle-orm";
 import { getAuthContext } from "../../../../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../../../../src/lib/org/resolve-org";
-import {
-  queryAxiom,
-  getDatasetName,
-  DATASETS,
-} from "../../../../../../../src/lib/axiom";
-interface AxiomAgentEvent {
-  _time: string;
-  runId: string;
-  userId: string;
-  sequenceNumber: number;
-  eventType: string;
-  eventData: Record<string, unknown>;
-}
+import { getRunAgentEvents } from "../../../../../../../src/lib/run/run-telemetry-service";
+import { isNotFound } from "../../../../../../../src/lib/errors";
 
 const router = tsr.router(runAgentEventsContract, {
   getAgentEvents: async ({ params, query, headers }, { request }) => {
@@ -44,74 +30,25 @@ const router = tsr.router(runAgentEventsContract, {
     const orgSlug = new URL(request.url).searchParams.get("org");
     const { org } = await resolveOrg(authCtx, orgSlug);
 
-    // Verify run exists and belongs to user+org, join with compose version to get framework
-    const [runWithCompose] = await globalThis.services.db
-      .select({
-        id: agentRuns.id,
-        composeContent: agentComposeVersions.content,
-      })
-      .from(agentRuns)
-      .leftJoin(
-        agentComposeVersions,
-        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-      )
-      .where(
-        and(
-          eq(agentRuns.id, params.id),
-          eq(agentRuns.userId, userId),
-          eq(agentRuns.orgId, org.orgId),
-        ),
-      )
-      .limit(1);
-
-    if (!runWithCompose) {
-      return {
-        status: 404 as const,
-        body: {
-          error: { message: "Agent run not found", code: "NOT_FOUND" },
-        },
-      };
+    try {
+      const result = await getRunAgentEvents(
+        params.id,
+        userId,
+        org.orgId,
+        query,
+      );
+      return { status: 200 as const, body: result };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent run not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      throw error;
     }
-
-    // Extract framework from compose content
-    const composeContent = runWithCompose.composeContent as {
-      agent?: { framework?: string };
-    } | null;
-    const framework = composeContent?.agent?.framework ?? "claude-code";
-
-    const { since, limit, order } = query;
-
-    // Build APL query for Axiom
-    const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
-    const sinceFilter = since
-      ? `| where _time > datetime("${new Date(since).toISOString()}")`
-      : "";
-    const apl = `['${dataset}']
-| where runId == "${params.id}"
-${sinceFilter}
-| order by _time ${order}
-| limit ${limit + 1}`;
-
-    // Query Axiom for agent events
-    const events = await queryAxiom<AxiomAgentEvent>(apl);
-
-    // Check if there are more events
-    const hasMore = events.length > limit;
-    const resultEvents = hasMore ? events.slice(0, limit) : events;
-
-    return {
-      status: 200 as const,
-      body: {
-        events: resultEvents.map((e) => ({
-          sequenceNumber: e.sequenceNumber,
-          eventType: e.eventType,
-          eventData: e.eventData,
-          createdAt: e._time,
-        })),
-        hasMore,
-        framework,
-      },
-    };
   },
 });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { randomUUID } from "crypto";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+  createTestCompose,
+  createTestRunInDb,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zrun");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function runUrl(slug: string, runId: string): string {
+  return `http://localhost:3000/api/zero/runs/${runId}?org=${slug}`;
+}
+
+describe("GET /api/zero/runs/:id", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return run details", async () => {
+    const userId = uniqueId("zrun-get");
+    const { slug } = await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zrun")}`);
+    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+      status: "running",
+      prompt: "test prompt",
+    });
+
+    const response = await GET(createTestRequest(runUrl(slug, runId)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.runId).toBe(runId);
+    expect(data.status).toBe("running");
+    expect(data.prompt).toBe("test prompt");
+  });
+
+  it("should return 404 when run not found", async () => {
+    const userId = uniqueId("zrun-nf");
+    const { slug } = await setupOrg(userId);
+
+    const response = await GET(createTestRequest(runUrl(slug, randomUUID())));
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/runs/some-id?org=test"),
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { randomUUID } from "crypto";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+  createTestCompose,
+  createTestRunInDb,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zcanc");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function cancelUrl(slug: string, runId: string): string {
+  return `http://localhost:3000/api/zero/runs/${runId}/cancel?org=${slug}`;
+}
+
+describe("POST /api/zero/runs/:id/cancel", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should cancel a running run", async () => {
+    const userId = uniqueId("zcanc-ok");
+    const { slug } = await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
+    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+      status: "running",
+    });
+
+    const response = await POST(
+      createTestRequest(cancelUrl(slug, runId), { method: "POST" }),
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.id).toBe(runId);
+    expect(data.status).toBe("cancelled");
+  });
+
+  it("should return 400 when run already completed", async () => {
+    const userId = uniqueId("zcanc-done");
+    const { slug } = await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
+    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+      status: "completed",
+      completedAt: new Date(),
+    });
+
+    const response = await POST(
+      createTestRequest(cancelUrl(slug, runId), { method: "POST" }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("should return 404 when run not found", async () => {
+    const userId = uniqueId("zcanc-nf");
+    const { slug } = await setupOrg(userId);
+
+    const response = await POST(
+      createTestRequest(cancelUrl(slug, randomUUID()), {
+        method: "POST",
+      }),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/some-id/cancel?org=test",
+        { method: "POST" },
+      ),
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
@@ -3,19 +3,53 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../../../src/lib/ts-rest-handler";
-import { zeroRunsCancelContract, runsCancelContract } from "@vm0/core";
+import { zeroRunsCancelContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
-  createInfraClient,
-  forwardInfra,
-} from "../../../../../../src/lib/infra-client";
+  requireAuth,
+  isAuthError,
+} from "../../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import {
+  cancelRun,
+  dispatchCancelSideEffects,
+} from "../../../../../../src/lib/run/run-service";
+import { isNotFound, isBadRequest } from "../../../../../../src/lib/errors";
+import { after } from "next/server";
 
 const router = tsr.router(zeroRunsCancelContract, {
-  cancel: async ({ params, headers }) => {
+  cancel: async ({ params, headers }, { request }) => {
     initServices();
-    const client = createInfraClient(runsCancelContract, headers.authorization);
-    const result = await client.cancel({ params });
-    return forwardInfra(result);
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    try {
+      const result = await cancelRun(params.id, userId, org.orgId);
+
+      after(() => dispatchCancelSideEffects(result));
+
+      return {
+        status: 200 as const,
+        body: {
+          id: result.runId,
+          status: "cancelled" as const,
+          message: "Run cancelled successfully",
+        },
+      };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return createErrorResponse("NOT_FOUND", error.message);
+      }
+      if (isBadRequest(error)) {
+        return createErrorResponse("BAD_REQUEST", error.message);
+      }
+      throw error;
+    }
   },
 });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/route.ts
@@ -3,19 +3,37 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../../src/lib/ts-rest-handler";
-import { zeroRunsByIdContract, runsByIdContract } from "@vm0/core";
+import { zeroRunsByIdContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
-  createInfraClient,
-  forwardInfra,
-} from "../../../../../src/lib/infra-client";
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { getRunById } from "../../../../../src/lib/run/run-service";
 
 const router = tsr.router(zeroRunsByIdContract, {
-  getById: async ({ params, headers }) => {
+  getById: async ({ params, headers }, { request }) => {
     initServices();
-    const client = createInfraClient(runsByIdContract, headers.authorization);
-    const result = await client.getById({ params });
-    return forwardInfra(result);
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    const run = await getRunById(params.id, userId, org.orgId);
+    if (!run) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
+    }
+
+    return { status: 200 as const, body: run };
   },
 });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { randomUUID } from "crypto";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+  createTestCompose,
+  createTestRunInDb,
+} from "../../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("ztele");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function telemetryUrl(slug: string, runId: string): string {
+  return `http://localhost:3000/api/zero/runs/${runId}/telemetry/agent?org=${slug}&limit=10&order=desc`;
+}
+
+describe("GET /api/zero/runs/:id/telemetry/agent", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return agent events for a run", async () => {
+    const userId = uniqueId("ztele-get");
+    const { slug } = await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("ztele")}`);
+    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+      status: "running",
+    });
+
+    context.mocks.axiom.queryAxiom.mockResolvedValue([]);
+
+    const response = await GET(createTestRequest(telemetryUrl(slug, runId)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.events).toEqual([]);
+    expect(data.hasMore).toBe(false);
+    expect(data.framework).toBeDefined();
+  });
+
+  it("should return 404 when run not found", async () => {
+    const userId = uniqueId("ztele-nf");
+    const { slug } = await setupOrg(userId);
+
+    const response = await GET(
+      createTestRequest(telemetryUrl(slug, randomUUID())),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/runs/${randomUUID()}/telemetry/agent?org=test&limit=10&order=desc`,
+      ),
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
@@ -3,22 +3,46 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../../../../src/lib/ts-rest-handler";
-import { zeroRunAgentEventsContract, runAgentEventsContract } from "@vm0/core";
+import { zeroRunAgentEventsContract } from "@vm0/core";
 import { initServices } from "../../../../../../../src/lib/init-services";
 import {
-  createInfraClient,
-  forwardInfra,
-} from "../../../../../../../src/lib/infra-client";
+  requireAuth,
+  isAuthError,
+} from "../../../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../../../src/lib/org/resolve-org";
+import { getRunAgentEvents } from "../../../../../../../src/lib/run/run-telemetry-service";
+import { isNotFound } from "../../../../../../../src/lib/errors";
 
 const router = tsr.router(zeroRunAgentEventsContract, {
-  getAgentEvents: async ({ params, query, headers }) => {
+  getAgentEvents: async ({ params, query, headers }, { request }) => {
     initServices();
-    const client = createInfraClient(
-      runAgentEventsContract,
-      headers.authorization,
-    );
-    const result = await client.getAgentEvents({ params, query });
-    return forwardInfra(result);
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    try {
+      const result = await getRunAgentEvents(
+        params.id,
+        userId,
+        org.orgId,
+        query,
+      );
+      return { status: 200 as const, body: result };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent run not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      throw error;
+    }
   },
 });
 

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -45,9 +45,13 @@ import {
   type OrgTier,
   type RunStatus,
   type TriggerSource,
+  type GetRunResponse,
   orgTierSchema,
 } from "@vm0/core";
 import { getOrgData } from "../org/org-cache-service";
+import { agentRunQueue } from "../../db/schema/agent-run-queue";
+import { publishCancelNotification } from "../realtime/client";
+import { processOrgCredits } from "../credit/credit-service";
 
 const log = logger("service:run");
 
@@ -1252,4 +1256,157 @@ export async function dispatchQueuedRun(
     authorizeTime,
     transactionTime,
   });
+}
+
+/**
+ * Get a run by ID, scoped to user and org for security.
+ * Returns the run response object or null if not found.
+ */
+export async function getRunById(
+  runId: string,
+  userId: string,
+  orgId: string,
+): Promise<GetRunResponse | null> {
+  const [run] = await globalThis.services.db
+    .select()
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        eq(agentRuns.userId, userId),
+        eq(agentRuns.orgId, orgId),
+      ),
+    )
+    .limit(1);
+
+  if (!run) return null;
+
+  return {
+    runId: run.id,
+    agentComposeVersionId: run.agentComposeVersionId,
+    status: run.status as
+      | "pending"
+      | "running"
+      | "completed"
+      | "failed"
+      | "timeout",
+    prompt: run.prompt,
+    appendSystemPrompt: run.appendSystemPrompt,
+    vars: run.vars as Record<string, string> | undefined,
+    sandboxId: run.sandboxId || undefined,
+    result: run.result as Record<string, unknown> | undefined,
+    error: run.error || undefined,
+    createdAt: run.createdAt.toISOString(),
+    startedAt: run.startedAt?.toISOString(),
+    completedAt: run.completedAt?.toISOString(),
+  };
+}
+
+/**
+ * Result of a successful run cancellation, used to dispatch side effects.
+ */
+interface CancelRunResult {
+  runId: string;
+  previousStatus: string;
+  orgId: string;
+  sandboxId: string | null;
+  runnerGroup: string | null;
+}
+
+/**
+ * Cancel a run. Atomically deletes queue entry and transitions status.
+ * Throws NotFound if run doesn't exist, BadRequest if run can't be cancelled.
+ */
+export async function cancelRun(
+  runId: string,
+  userId: string,
+  orgId: string,
+): Promise<CancelRunResult> {
+  const db = globalThis.services.db;
+
+  const [run] = await db
+    .select()
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        eq(agentRuns.userId, userId),
+        eq(agentRuns.orgId, orgId),
+      ),
+    )
+    .limit(1);
+
+  if (!run) {
+    throw notFound(`No such run: '${runId}'`);
+  }
+
+  if (
+    run.status !== "queued" &&
+    run.status !== "pending" &&
+    run.status !== "running"
+  ) {
+    throw badRequest(
+      `Run cannot be cancelled: current status is '${run.status}'`,
+    );
+  }
+
+  const cancelled = await db.transaction(async (tx) => {
+    await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, runId));
+    return transitionRunStatus(
+      runId,
+      { status: "cancelled", completedAt: new Date() },
+      ["queued", "pending", "running"],
+      tx,
+    );
+  });
+
+  if (!cancelled) {
+    throw badRequest(`Run cannot be cancelled: status has already changed`);
+  }
+
+  return {
+    runId,
+    previousStatus: run.status,
+    orgId: run.orgId,
+    sandboxId: run.sandboxId,
+    runnerGroup: run.runnerGroup,
+  };
+}
+
+/**
+ * Dispatch post-cancellation side effects (Ably notification, callbacks, queue drain, credits).
+ * Designed to be called inside `after()` so it runs after the response is sent.
+ */
+export async function dispatchCancelSideEffects(
+  result: CancelRunResult,
+): Promise<void> {
+  const log = logger("service:run:cancel");
+
+  if (result.previousStatus === "running" && result.runnerGroup) {
+    const published = await publishCancelNotification(
+      result.runnerGroup,
+      result.runId,
+    );
+    if (!published) {
+      log.warn(
+        `Ably cancel notification failed for run ${result.runId}, VM will run until natural completion`,
+      );
+    }
+  }
+
+  const shouldDrain =
+    result.previousStatus === "running" || result.previousStatus === "pending";
+
+  await dispatchTerminalSideEffects(
+    result.runId,
+    "cancelled",
+    "Run cancelled",
+    shouldDrain
+      ? () => drainOrgQueue(result.orgId, dispatchQueuedRun)
+      : undefined,
+  );
+
+  if (shouldDrain) {
+    await processOrgCredits(result.orgId);
+  }
 }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -1284,12 +1284,7 @@ export async function getRunById(
   return {
     runId: run.id,
     agentComposeVersionId: run.agentComposeVersionId,
-    status: run.status as
-      | "pending"
-      | "running"
-      | "completed"
-      | "failed"
-      | "timeout",
+    status: run.status as RunStatus,
     prompt: run.prompt,
     appendSystemPrompt: run.appendSystemPrompt,
     vars: run.vars as Record<string, string> | undefined,

--- a/turbo/apps/web/src/lib/run/run-telemetry-service.ts
+++ b/turbo/apps/web/src/lib/run/run-telemetry-service.ts
@@ -1,0 +1,100 @@
+import { eq, and } from "drizzle-orm";
+import { agentRuns } from "../../db/schema/agent-run";
+import { agentComposeVersions } from "../../db/schema/agent-compose";
+import { queryAxiom, getDatasetName, DATASETS } from "../axiom";
+import { notFound } from "../errors";
+
+interface AxiomAgentEvent {
+  _time: string;
+  runId: string;
+  userId: string;
+  sequenceNumber: number;
+  eventType: string;
+  eventData: Record<string, unknown>;
+}
+
+interface AgentEventsQuery {
+  since?: number;
+  limit: number;
+  order: "asc" | "desc";
+}
+
+interface AgentEventsResult {
+  events: Array<{
+    sequenceNumber: number;
+    eventType: string;
+    eventData: Record<string, unknown>;
+    createdAt: string;
+  }>;
+  hasMore: boolean;
+  framework: string;
+}
+
+/**
+ * Get agent telemetry events for a run.
+ * Verifies run ownership, extracts framework from compose, queries Axiom.
+ */
+export async function getRunAgentEvents(
+  runId: string,
+  userId: string,
+  orgId: string,
+  query: AgentEventsQuery,
+): Promise<AgentEventsResult> {
+  const db = globalThis.services.db;
+
+  const [runWithCompose] = await db
+    .select({
+      id: agentRuns.id,
+      composeContent: agentComposeVersions.content,
+    })
+    .from(agentRuns)
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        eq(agentRuns.userId, userId),
+        eq(agentRuns.orgId, orgId),
+      ),
+    )
+    .limit(1);
+
+  if (!runWithCompose) {
+    throw notFound("Agent run not found");
+  }
+
+  const composeContent = runWithCompose.composeContent as {
+    agent?: { framework?: string };
+  } | null;
+  const framework = composeContent?.agent?.framework ?? "claude-code";
+
+  const { since, limit, order } = query;
+
+  const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
+  const sinceFilter = since
+    ? `| where _time > datetime("${new Date(since).toISOString()}")`
+    : "";
+  const apl = `['${dataset}']
+| where runId == "${runId}"
+${sinceFilter}
+| order by _time ${order}
+| limit ${limit + 1}`;
+
+  const events = await queryAxiom<AxiomAgentEvent>(apl);
+
+  const hasMore = events.length > limit;
+  const resultEvents = hasMore ? events.slice(0, limit) : events;
+
+  return {
+    events: resultEvents.map((e) => ({
+      sequenceNumber: e.sequenceNumber,
+      eventType: e.eventType,
+      eventData: e.eventData,
+      createdAt: e._time,
+    })),
+    hasMore,
+    framework,
+  };
+}


### PR DESCRIPTION
## Summary

- Extract `getRunById`, `cancelRun`, `dispatchCancelSideEffects` into `run-service.ts`
- Create `run-telemetry-service.ts` with `getRunAgentEvents` for Axiom telemetry queries
- Rewrite 3 zero routes (`runs/[id]`, `runs/[id]/cancel`, `runs/[id]/telemetry/agent`) to call service functions directly instead of proxying via `createInfraClient`
- Update 3 agent routes to reuse the same extracted service functions, removing duplicated inline logic
- Add 10 integration tests covering all 3 zero run endpoints (get, cancel, telemetry)

Part of #6051 — PR 3 of 7 (Runs: getById + cancel + telemetry)

## Test plan

- [x] 10 new integration tests added and passing
- [x] Pre-existing tests unaffected (9 failures in `credit-service.test.ts` pre-exist on main)
- [x] All pre-commit checks pass (format, lint, types, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)