### PR TITLE
fix: use add column if not exists in migration 0178 to prevent duplicate column error

### DIFF
--- a/turbo/apps/web/src/db/migrations/0178_jittery_moondragon.sql
+++ b/turbo/apps/web/src/db/migrations/0178_jittery_moondragon.sql
@@ -1,4 +1,4 @@
-ALTER TABLE "org_cache" ADD COLUMN "name" text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE "org_cache" ADD COLUMN IF NOT EXISTS "name" text DEFAULT '' NOT NULL;--> statement-breakpoint
 ALTER TABLE "org_cache" ADD COLUMN "current_period_start" timestamp;--> statement-breakpoint
 ALTER TABLE "org_cache" ADD COLUMN "current_period_end" timestamp;--> statement-breakpoint
 ALTER TABLE "org_cache" ADD COLUMN "billing_cached_at" timestamp;


### PR DESCRIPTION
## Summary

- Update migration `0178_jittery_moondragon.sql` to use `ADD COLUMN IF NOT EXISTS` instead of `ADD COLUMN` for the `name` column on `org_cache` table
- This prevents an error if the column already exists in the database (e.g., when migration is re-applied or column was added manually)

## Test plan

- [ ] Verify migration runs without error on a fresh database
- [ ] Verify migration runs without error when `name` column already exists on `org_cache`