### PR TITLE
perf: dynamically import @clerk/clerk-js to reduce initial bundle

### DIFF
--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -1,4 +1,3 @@
-import { Clerk } from "@clerk/clerk-js";
 import { command, computed, state } from "ccstate";
 import { clearSentryUser, setSentryUser } from "../lib/sentry.ts";
 
@@ -32,6 +31,11 @@ export const clerk$ = computed(async () => {
   if (!publishableKey) {
     throw new Error("Missing VITE_CLERK_PUBLISHABLE_KEY environment variable");
   }
+
+  // Dynamic import: @clerk/clerk-js is a 2.8MB webpack monolith (53%
+  // Web3/Solana/Coinbase code we don't use) that cannot be tree-shaken.
+  // Moving it to a separate async chunk avoids blocking initial JS parsing.
+  const { Clerk } = await import("@clerk/clerk-js");
 
   const webOrigin = resolveWebOrigin();
   const clerkInstance = new Clerk(publishableKey);


### PR DESCRIPTION
## Summary
- Convert static `import { Clerk } from "@clerk/clerk-js"` to dynamic `await import("@clerk/clerk-js")` inside the async `clerk$` computed signal
- Moves ~2.8MB of Clerk JS (including unused Web3/Solana/Coinbase code) into a separate async chunk
- No behavior changes -- `clerk$` is already async, so the dynamic import is transparent to all consumers

## Test plan
- [x] Existing auth signal tests pass (vi.mock intercepts dynamic imports identically)
- [x] Lint passes (oxlint + eslint)
- [x] Type check passes (tsc --noEmit)
- [x] Knip finds no unused exports/dependencies
- [ ] Verify in CI that build produces a separate chunk for @clerk/clerk-js

Closes #6087

🤖 Generated with [Claude Code](https://claude.com/claude-code)