### PR TITLE
refactor: unify zero trigger params — typed callbacks and prompt standardization

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
@@ -15,20 +15,12 @@ import {
   buildUnsubscribeUrl,
   buildUnsubscribeHeaders,
 } from "../../../../../../src/lib/email/handlers/shared";
+import type { EmailReplyCallbackPayload } from "../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("callback:email:reply");
 
-interface CallbackPayload {
-  emailThreadSessionId: string;
-  inboundEmailId: string;
-  inboundMessageId?: string;
-  inboundReferences?: string;
-  replyRecipientTo?: string[];
-  replyRecipientCc?: string[];
-}
-
-function parsePayload(payload: unknown): CallbackPayload | null {
+function parsePayload(payload: unknown): EmailReplyCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
   if (
@@ -37,7 +29,7 @@ function parsePayload(payload: unknown): CallbackPayload | null {
   ) {
     return null;
   }
-  return p as unknown as CallbackPayload;
+  return p as unknown as EmailReplyCallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -69,7 +61,7 @@ function formatOutput(
 }
 
 function buildThreadingHeaders(
-  payload: CallbackPayload,
+  payload: EmailReplyCallbackPayload,
   lastEmailMessageId: string | null,
 ): Record<string, string> {
   const headers: Record<string, string> = {};
@@ -98,7 +90,7 @@ function buildThreadingHeaders(
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
 
-  const result = await verifyCallback<CallbackPayload>(request, log);
+  const result = await verifyCallback<EmailReplyCallbackPayload>(request, log);
   if (!result.ok) return result.response;
 
   const { runId, status, error } = result.data;

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
@@ -16,18 +16,12 @@ import {
 } from "../../../../../../src/lib/email/handlers/shared";
 import { isUserUnsubscribed } from "../../../../../../src/lib/email/unsubscribe-service";
 import { env } from "../../../../../../src/env";
+import type { EmailScheduleCallbackPayload } from "../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("callback:email:schedule");
 
-interface CallbackPayload {
-  scheduleId: string;
-  composeId: string;
-  composeName: string;
-  userId: string;
-}
-
-function parsePayload(payload: unknown): CallbackPayload | null {
+function parsePayload(payload: unknown): EmailScheduleCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
   if (
@@ -38,7 +32,7 @@ function parsePayload(payload: unknown): CallbackPayload | null {
   ) {
     return null;
   }
-  return p as unknown as CallbackPayload;
+  return p as unknown as EmailScheduleCallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -53,7 +47,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true, skipped: true });
   }
 
-  const result = await verifyCallback<CallbackPayload>(request, log);
+  const result = await verifyCallback<EmailScheduleCallbackPayload>(
+    request,
+    log,
+  );
   if (!result.ok) return result.response;
 
   const { runId, status, error } = result.data;

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -14,26 +14,12 @@ import {
   buildUnsubscribeHeaders,
 } from "../../../../../../src/lib/email/handlers/shared";
 import { env } from "../../../../../../src/env";
+import type { EmailTriggerCallbackPayload } from "../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("callback:email:trigger");
 
-interface CallbackPayload {
-  senderEmail: string;
-  composeId: string;
-  userId: string;
-  inboundEmailId: string;
-  replyToken: string;
-  inboundMessageId?: string;
-  inboundReferences?: string;
-  subject?: string;
-  triggerLocalPart?: string;
-  runtimeOrgId?: string;
-  replyRecipientTo?: string[];
-  replyRecipientCc?: string[];
-}
-
-function parsePayload(payload: unknown): CallbackPayload | null {
+function parsePayload(payload: unknown): EmailTriggerCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
   if (
@@ -45,7 +31,7 @@ function parsePayload(payload: unknown): CallbackPayload | null {
   ) {
     return null;
   }
-  return p as unknown as CallbackPayload;
+  return p as unknown as EmailTriggerCallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -120,7 +106,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ success: true, skipped: true });
   }
 
-  const result = await verifyCallback<CallbackPayload>(request, log);
+  const result = await verifyCallback<EmailTriggerCallbackPayload>(
+    request,
+    log,
+  );
   if (!result.ok) return result.response;
 
   const { runId, status, error } = result.data;

--- a/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/github/issues/route.ts
@@ -17,23 +17,12 @@ import {
 } from "../../../../../../src/lib/run/extract-run-output";
 import { getAppUrl } from "../../../../../../src/lib/url";
 import { env } from "../../../../../../src/env";
+import type { GitHubIssuesCallbackPayload } from "../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("callback:github-issues");
 
-interface CallbackPayload {
-  installationId: string; // GitHub App installation ID (DB primary key)
-  repo: string; // "owner/repo"
-  issueNumber: number;
-  composeId: string;
-  agentName: string;
-  existingSessionId?: string;
-  triggerCommentId?: string;
-  triggerCommentBody?: string;
-  triggerReactionId?: string;
-}
-
-function parsePayload(payload: unknown): CallbackPayload | null {
+function parsePayload(payload: unknown): GitHubIssuesCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
   if (
@@ -45,7 +34,7 @@ function parsePayload(payload: unknown): CallbackPayload | null {
   ) {
     return null;
   }
-  return p as unknown as CallbackPayload;
+  return p as unknown as GitHubIssuesCallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -128,7 +117,10 @@ function formatGitHubComment(opts: {
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
 
-  const result = await verifyCallback<CallbackPayload>(request, log);
+  const result = await verifyCallback<GitHubIssuesCallbackPayload>(
+    request,
+    log,
+  );
   if (!result.ok) return result.response;
 
   const { runId, status, error } = result.data;

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../../src/lib/callback";
 import { agentSchedules } from "../../../../../../src/db/schema/agent-schedule";
+import type { ScheduleLoopCallbackPayload } from "../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("callback:schedule:loop");
@@ -10,12 +11,7 @@ const log = logger("callback:schedule:loop");
 // Auto-disable after this many consecutive failures
 const MAX_CONSECUTIVE_FAILURES = 3;
 
-interface CallbackPayload {
-  scheduleId: string;
-  intervalSeconds: number;
-}
-
-function parsePayload(payload: unknown): CallbackPayload | null {
+function parsePayload(payload: unknown): ScheduleLoopCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
   if (
@@ -24,7 +20,7 @@ function parsePayload(payload: unknown): CallbackPayload | null {
   ) {
     return null;
   }
-  return p as unknown as CallbackPayload;
+  return p as unknown as ScheduleLoopCallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -34,7 +30,10 @@ function errorResponse(message: string, status: number): NextResponse {
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
 
-  const result = await verifyCallback<CallbackPayload>(request, log);
+  const result = await verifyCallback<ScheduleLoopCallbackPayload>(
+    request,
+    log,
+  );
   if (!result.ok) return result.response;
 
   const { status, payload: rawPayload } = result.data;

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -28,6 +28,7 @@ import {
 } from "../../../../../../src/lib/slack-org/handlers/shared";
 import { getAppUrl } from "../../../../../../src/lib/url";
 import { env } from "../../../../../../src/env";
+import type { SlackOrgCallbackPayload } from "../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/logger";
 import type { WebClient } from "@slack/web-api";
 import type {
@@ -37,18 +38,7 @@ import type {
 
 const log = logger("callback:slack-org");
 
-interface CallbackPayload {
-  workspaceId: string;
-  channelId: string;
-  threadTs: string;
-  messageTs: string;
-  connectionId: string;
-  agentName: string;
-  composeId: string;
-  existingSessionId?: string;
-}
-
-function parsePayload(payload: unknown): CallbackPayload | null {
+function parsePayload(payload: unknown): SlackOrgCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
   if (
@@ -62,7 +52,7 @@ function parsePayload(payload: unknown): CallbackPayload | null {
   ) {
     return null;
   }
-  return p as unknown as CallbackPayload;
+  return p as unknown as SlackOrgCallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -95,7 +85,7 @@ async function findNewSessionId(
 async function postAskUserInteractiveCard(
   client: WebClient,
   resultData: { askUserDenials: PermissionDenial[] },
-  payload: CallbackPayload,
+  payload: SlackOrgCallbackPayload,
   runId: string,
   resolvedSessionId: string | undefined,
 ): Promise<void> {
@@ -169,7 +159,7 @@ function buildResponseText(
  * Returns the resolved session ID.
  */
 async function saveOrgThreadSession(
-  payload: CallbackPayload,
+  payload: SlackOrgCallbackPayload,
   runId: string,
   status: string,
 ): Promise<string | undefined> {
@@ -217,7 +207,7 @@ async function saveOrgThreadSession(
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
 
-  const result = await verifyCallback<CallbackPayload>(request, log);
+  const result = await verifyCallback<SlackOrgCallbackPayload>(request, log);
   if (!result.ok) return result.response;
 
   const { runId, status, error } = result.data;

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
@@ -18,19 +18,12 @@ import {
   getWorkspaceAgent,
 } from "../../../../../../../src/lib/slack-org/handlers/shared";
 import { env } from "../../../../../../../src/env";
+import type { SlackScheduleCallbackPayload } from "../../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../../src/lib/logger";
 
 const log = logger("callback:slack-org:schedule");
 
-interface CallbackPayload {
-  scheduleId: string;
-  composeId: string;
-  composeName: string;
-  userId: string;
-  orgId: string;
-}
-
-function parsePayload(payload: unknown): CallbackPayload | null {
+function parsePayload(payload: unknown): SlackScheduleCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
   if (
@@ -42,7 +35,7 @@ function parsePayload(payload: unknown): CallbackPayload | null {
   ) {
     return null;
   }
-  return p as unknown as CallbackPayload;
+  return p as unknown as SlackScheduleCallbackPayload;
 }
 
 function errorResponse(message: string, status: number): NextResponse {
@@ -144,7 +137,10 @@ async function postScheduleResults(
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
 
-  const result = await verifyCallback<CallbackPayload>(request, log);
+  const result = await verifyCallback<SlackScheduleCallbackPayload>(
+    request,
+    log,
+  );
   if (!result.ok) return result.response;
 
   const { runId, status, error } = result.data;

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -32,24 +32,12 @@ import {
   buildLogsUrl,
 } from "../../../../../src/lib/telegram/handlers/shared";
 import { env } from "../../../../../src/env";
+import type { TelegramCallbackPayload } from "../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../src/lib/logger";
 
 const log = logger("callback:telegram");
 
-interface CallbackPayload {
-  installationId: string;
-  chatId: string;
-  messageId: string;
-  rootMessageId: string | null;
-  userLinkId: string;
-  agentName: string;
-  composeId: string;
-  existingSessionId: string | null;
-  isDM: boolean;
-  thinkingMessageId: string | null;
-}
-
-function parsePayload(payload: unknown): CallbackPayload | null {
+function parsePayload(payload: unknown): TelegramCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
   if (
@@ -121,7 +109,7 @@ interface CompletionContext {
   runId: string;
   status: "completed" | "failed";
   error: string | undefined;
-  payload: CallbackPayload;
+  payload: TelegramCallbackPayload;
 }
 
 async function handleCompletion(ctx: CompletionContext): Promise<void> {
@@ -243,7 +231,7 @@ async function handleCompletion(ctx: CompletionContext): Promise<void> {
 export async function POST(request: NextRequest): Promise<NextResponse> {
   initServices();
 
-  const result = await verifyCallback<CallbackPayload>(request, log);
+  const result = await verifyCallback<TelegramCallbackPayload>(request, log);
   if (!result.ok) return result.response;
 
   const { runId, status, error } = result.data;

--- a/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/github/__tests__/route.test.ts
@@ -263,10 +263,14 @@ describe("POST /api/webhooks/github", () => {
       expect(startRunSpy).toHaveBeenCalledTimes(1);
       const callArgs = startRunSpy.mock.calls[0]![0] as {
         prompt: string;
+        appendSystemPrompt: string;
         callbacks: Array<{ payload: { issueNumber: number } }>;
       };
-      expect(callArgs.prompt).toContain("This is a test issue body");
-      expect(callArgs.prompt).toContain(
+      // Issue body and integration context are now in appendSystemPrompt
+      expect(callArgs.appendSystemPrompt).toContain(
+        "This is a test issue body",
+      );
+      expect(callArgs.appendSystemPrompt).toContain(
         "You are currently running inside: GitHub",
       );
       expect(callArgs.callbacks[0]!.payload.issueNumber).toBe(42);
@@ -385,10 +389,13 @@ describe("POST /api/webhooks/github", () => {
       await flushAfterCallbacks();
 
       expect(startRunSpy).toHaveBeenCalledTimes(1);
-      const callArgs = startRunSpy.mock.calls[0]![0] as { prompt: string };
-      // When body is null, falls back to issue title
-      expect(callArgs.prompt).toContain("Test Issue");
-      expect(callArgs.prompt).toContain(
+      const callArgs = startRunSpy.mock.calls[0]![0] as {
+        prompt: string;
+        appendSystemPrompt: string;
+      };
+      // When body is null, falls back to issue title in appendSystemPrompt
+      expect(callArgs.appendSystemPrompt).toContain("Test Issue");
+      expect(callArgs.appendSystemPrompt).toContain(
         "You are currently running inside: GitHub",
       );
     });

--- a/turbo/apps/web/app/api/zero/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/route.ts
@@ -22,7 +22,7 @@ import {
 } from "../../../../../src/lib/slack/blocks";
 import type { AskUserQuestion } from "../../../../../src/lib/slack/blocks";
 import { runAgentForSlackOrg } from "../../../../../src/lib/slack-org/handlers/run-agent";
-import type { SlackOrgCallbackContext } from "../../../../../src/lib/slack-org/handlers/run-agent";
+import type { SlackOrgCallbackPayload } from "../../../../../src/lib/callback/callback-payloads";
 import { getWorkspaceAgent } from "../../../../../src/lib/slack-org/handlers/shared";
 import { refreshOrgAppHome } from "../../../../../src/lib/slack-org/handlers/app-home";
 import { disconnect } from "../../../../../src/lib/slack-org/connect-service";
@@ -546,7 +546,7 @@ async function finishSubmit(
   }
 
   // Dispatch new agent run with the user's answer
-  const callbackContext: SlackOrgCallbackContext = {
+  const callbackContext: SlackOrgCallbackPayload = {
     workspaceId: claimed.slackWorkspaceId,
     channelId: claimed.slackChannelId,
     threadTs: claimed.slackThreadTs,

--- a/turbo/apps/web/src/lib/callback/callback-payloads.ts
+++ b/turbo/apps/web/src/lib/callback/callback-payloads.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared callback payload types for all zero-layer channels.
+ *
+ * Each interface defines the payload shape passed from the registration handler
+ * to the callback consumer route. These types provide compile-time safety while
+ * the parsePayload() functions in each route provide runtime validation.
+ */
+
+export interface TelegramCallbackPayload {
+  installationId: string;
+  chatId: string;
+  messageId: string;
+  rootMessageId: string | null;
+  userLinkId: string;
+  agentName: string;
+  composeId: string;
+  existingSessionId: string | null;
+  isDM: boolean;
+  thinkingMessageId: string | null;
+}
+
+export interface SlackOrgCallbackPayload {
+  workspaceId: string;
+  channelId: string;
+  threadTs: string;
+  messageTs: string;
+  connectionId: string;
+  agentName: string;
+  composeId: string;
+  existingSessionId?: string;
+}
+
+export interface EmailTriggerCallbackPayload {
+  senderEmail: string;
+  composeId: string;
+  userId: string;
+  inboundEmailId: string;
+  replyToken: string;
+  inboundMessageId?: string;
+  inboundReferences?: string;
+  subject?: string;
+  triggerLocalPart?: string;
+  runtimeOrgId?: string;
+  replyRecipientTo?: string[];
+  replyRecipientCc?: string[];
+}
+
+export interface EmailReplyCallbackPayload {
+  emailThreadSessionId: string;
+  inboundEmailId: string;
+  inboundMessageId?: string;
+  inboundReferences?: string;
+  replyRecipientTo?: string[];
+  replyRecipientCc?: string[];
+}
+
+export interface EmailScheduleCallbackPayload {
+  scheduleId: string;
+  composeId: string;
+  composeName: string;
+  userId: string;
+}
+
+export interface SlackScheduleCallbackPayload {
+  scheduleId: string;
+  composeId: string;
+  composeName: string;
+  userId: string;
+  orgId: string;
+}
+
+export interface ScheduleLoopCallbackPayload {
+  scheduleId: string;
+  intervalSeconds: number;
+}
+
+export interface GitHubIssuesCallbackPayload {
+  installationId: string;
+  repo: string;
+  issueNumber: number;
+  agentName: string;
+  composeId: string;
+  existingSessionId?: string;
+  triggerCommentId?: string;
+  triggerCommentBody?: string;
+  triggerReactionId?: string;
+}
+
+export type CallbackPayload =
+  | TelegramCallbackPayload
+  | SlackOrgCallbackPayload
+  | EmailTriggerCallbackPayload
+  | EmailReplyCallbackPayload
+  | EmailScheduleCallbackPayload
+  | SlackScheduleCallbackPayload
+  | ScheduleLoopCallbackPayload
+  | GitHubIssuesCallbackPayload;

--- a/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
@@ -175,12 +175,12 @@ export async function handleInboundEmailReply(
     },
   ];
 
-  // 11. Inject integration context and create run
-  // startRun resolves compose version + org internally
-  const fullPrompt = `${buildIntegrationContext("Email")}\n\n# User Prompt\n\n${replyContent}`;
+  // 11. Create run with integration context as system prompt
+  const appendSystemPrompt = buildIntegrationContext("Email");
   const result = await createZeroRun({
     userId: session.userId,
-    prompt: fullPrompt,
+    prompt: replyContent,
+    appendSystemPrompt,
     composeId: session.composeId,
     sessionId: session.agentSessionId,
     triggerSource: "email",

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -274,11 +274,12 @@ export async function handleInboundEmailTrigger(
     },
   ];
 
-  // 12. Inject integration context and create run
-  const fullPrompt = `${buildIntegrationContext("Email")}\n\n# User Prompt\n\n${prompt}`;
+  // 12. Create run with integration context as system prompt
+  const appendSystemPrompt = buildIntegrationContext("Email");
   const result = await createZeroRun({
     userId,
-    prompt: fullPrompt,
+    prompt,
+    appendSystemPrompt,
     composeId: compose.composeId,
     triggerSource: "email",
     callbacks,

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -8,6 +8,7 @@ import { validateAgentSession } from "../../run";
 import { createZeroRun } from "../../zero/zero-run-service";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
+import type { GitHubIssuesCallbackPayload } from "../../callback/callback-payloads";
 import { getInstallationAccessToken } from "../github-app";
 import {
   type IssueComment,
@@ -80,21 +81,6 @@ type GitHubIssuesEvent = z.infer<typeof gitHubIssuesEventSchema>;
 type GitHubIssueCommentEvent = z.infer<typeof gitHubIssueCommentEventSchema>;
 type GitHubIssue = z.infer<typeof gitHubIssueSchema>;
 type GitHubComment = z.infer<typeof gitHubCommentSchema>;
-
-// ─── Callback Context ──────────────────────────────────────────────
-
-interface GitHubCallbackContext {
-  installationId: string;
-  repo: string;
-  issueNumber: number;
-  userId: string;
-  agentName: string;
-  composeId: string;
-  existingSessionId?: string;
-  triggerCommentId?: string;
-  triggerCommentBody?: string;
-  triggerReactionId?: string;
-}
 
 // ─── Event Handlers ────────────────────────────────────────────────
 
@@ -311,23 +297,27 @@ async function validateSessionAgent(
 }
 
 /**
- * Build a full prompt with issue context.
+ * Build prompt and system context from issue context.
+ * Integration context and issue context go to appendSystemPrompt;
+ * only the user message remains in prompt.
  */
-function buildFullPrompt(
+function buildPromptParts(
   prompt: string,
   issueContext: string,
   isCommentTrigger: boolean,
-): string {
+): { prompt: string; appendSystemPrompt: string | undefined } {
   const integrationContext = buildIntegrationContext("GitHub");
+  const contextParts = [integrationContext, issueContext].filter(Boolean);
+  const appendSystemPrompt =
+    contextParts.length > 0 ? contextParts.join("\n\n") : undefined;
 
-  if (!issueContext) {
-    return `${integrationContext}\n\n# User Prompt\n\n${prompt}`;
-  }
+  const userPrompt = isCommentTrigger
+    ? prompt
+    : issueContext
+      ? "Based on the GitHub issue above and its discussion, analyze the request and decide on the appropriate action."
+      : prompt;
 
-  if (isCommentTrigger) {
-    return `${integrationContext}\n\n${issueContext}\n\n# User Prompt\n\n${prompt}`;
-  }
-  return `${integrationContext}\n\n${issueContext}\n\nBased on the GitHub issue above and its discussion, analyze the request and decide on the appropriate action.`;
+  return { prompt: userPrompt, appendSystemPrompt };
 }
 
 /**
@@ -476,16 +466,19 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
       commentId,
     );
   }
-  const fullPrompt = buildFullPrompt(prompt, issueContext, !!commentId);
+  const { prompt: resolvedPrompt, appendSystemPrompt } = buildPromptParts(
+    prompt,
+    issueContext,
+    !!commentId,
+  );
 
   // 6. Create agent run with callback
   const callbackUrl = `${getApiUrl()}/api/internal/callbacks/github/issues`;
   const callbackSecret = generateCallbackSecret();
-  const callbackContext: GitHubCallbackContext = {
+  const callbackContext: GitHubIssuesCallbackPayload = {
     installationId: installation.id,
     repo,
     issueNumber,
-    userId: vm0UserId,
     agentName: compose.name,
     composeId: compose.id,
     existingSessionId,
@@ -497,7 +490,8 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
   try {
     const result = await createZeroRun({
       userId: vm0UserId,
-      prompt: fullPrompt,
+      prompt: resolvedPrompt,
+      appendSystemPrompt,
       composeId: compose.id,
       sessionId: existingSessionId,
       triggerSource: "github",

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -10,6 +10,11 @@ import { logger } from "../logger";
 import { createZeroRun } from "../zero/zero-run-service";
 import { getUserPreferences } from "../user/user-preferences-service";
 import { generateCallbackSecret, getApiUrl } from "../callback";
+import type {
+  EmailScheduleCallbackPayload,
+  SlackScheduleCallbackPayload,
+  ScheduleLoopCallbackPayload,
+} from "../callback/callback-payloads";
 
 const log = logger("service:schedule");
 
@@ -797,14 +802,14 @@ async function executeSchedule(
   const orgData = await getOrgData(schedule.orgId);
 
   // Build callbacks for run completion notifications
-  const callbacks: Array<{ url: string; secret: string; payload: unknown }> =
-    [];
-  const callbackPayload = {
-    scheduleId: schedule.id,
-    composeId: schedule.composeId,
-    composeName: compose.name,
-    userId: schedule.userId,
-  };
+  const callbacks: Array<{
+    url: string;
+    secret: string;
+    payload:
+      | EmailScheduleCallbackPayload
+      | SlackScheduleCallbackPayload
+      | ScheduleLoopCallbackPayload;
+  }> = [];
 
   const prefs = await getUserPreferences(orgData.orgId, schedule.userId);
 
@@ -814,31 +819,45 @@ async function executeSchedule(
     prefs.notifyEmail &&
     schedule.notifyEmail
   ) {
+    const emailPayload: EmailScheduleCallbackPayload = {
+      scheduleId: schedule.id,
+      composeId: schedule.composeId,
+      composeName: compose.name,
+      userId: schedule.userId,
+    };
     callbacks.push({
       url: `${getApiUrl()}/api/internal/callbacks/email/schedule`,
       secret: generateCallbackSecret(),
-      payload: callbackPayload,
+      payload: emailPayload,
     });
   }
 
   // Slack schedule DM notification callback (only if user + schedule opted in)
   if (prefs.notifySlack && schedule.notifySlack) {
+    const slackPayload: SlackScheduleCallbackPayload = {
+      scheduleId: schedule.id,
+      composeId: schedule.composeId,
+      composeName: compose.name,
+      userId: schedule.userId,
+      orgId: schedule.orgId,
+    };
     callbacks.push({
       url: `${getApiUrl()}/api/internal/callbacks/slack/schedule`,
       secret: generateCallbackSecret(),
-      payload: callbackPayload,
+      payload: slackPayload,
     });
   }
 
   // Loop schedule advancement callback (triggers next iteration on completion)
   if (schedule.triggerType === "loop") {
+    const loopPayload: ScheduleLoopCallbackPayload = {
+      scheduleId: schedule.id,
+      intervalSeconds: schedule.intervalSeconds!,
+    };
     callbacks.push({
       url: `${getApiUrl()}/api/internal/callbacks/schedule/loop`,
       secret: generateCallbackSecret(),
-      payload: {
-        scheduleId: schedule.id,
-        intervalSeconds: schedule.intervalSeconds,
-      },
+      payload: loopPayload,
     });
   }
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -13,7 +13,7 @@ import {
 import { buildModelProviderLink } from "../../deep-links";
 import type { SlackFile } from "../../slack/context";
 import { runAgentForSlackOrg } from "./run-agent";
-import type { SlackOrgCallbackContext } from "./run-agent";
+import type { SlackOrgCallbackPayload } from "../../callback/callback-payloads";
 import {
   resolveOrgFromWorkspace,
   resolveConnectionFromSlackUser,
@@ -164,7 +164,7 @@ export async function handleOrgDirectMessage(
   );
 
   // 8. Dispatch agent run
-  const callbackContext: SlackOrgCallbackContext = {
+  const callbackContext: SlackOrgCallbackPayload = {
     workspaceId: context.workspaceId,
     channelId: context.channelId,
     threadTs,

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -9,7 +9,7 @@ import {
 import { buildModelProviderLink } from "../../deep-links";
 import type { SlackFile } from "../../slack/context";
 import { runAgentForSlackOrg } from "./run-agent";
-import type { SlackOrgCallbackContext } from "./run-agent";
+import type { SlackOrgCallbackPayload } from "../../callback/callback-payloads";
 import {
   resolveOrgFromWorkspace,
   resolveConnectionFromSlackUser,
@@ -162,7 +162,7 @@ export async function handleOrgMention(
   );
 
   // 8. Dispatch agent run
-  const callbackContext: SlackOrgCallbackContext = {
+  const callbackContext: SlackOrgCallbackPayload = {
     workspaceId: context.workspaceId,
     channelId: context.channelId,
     threadTs,

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -9,23 +9,9 @@ import { isApiError } from "../../errors";
 import { RUN_ERROR_GUIDANCE } from "@vm0/core";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { logger } from "../../logger";
+import type { SlackOrgCallbackPayload } from "../../callback/callback-payloads";
 
 const log = logger("slack-org:run-agent");
-
-/**
- * Org-aware callback context for Slack.
- * orgId is derived from composeId -> agentComposes.orgId at dispatch time.
- */
-export interface SlackOrgCallbackContext {
-  workspaceId: string;
-  channelId: string;
-  threadTs: string;
-  messageTs: string;
-  connectionId: string;
-  agentName: string;
-  composeId: string;
-  existingSessionId?: string;
-}
 
 interface RunAgentParams {
   composeId: string;
@@ -36,7 +22,7 @@ interface RunAgentParams {
   userContext: string;
   userId: string;
   botUserId: string;
-  callbackContext: SlackOrgCallbackContext;
+  callbackContext: SlackOrgCallbackPayload;
 }
 
 interface RunAgentResult {

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -5,24 +5,9 @@ import { isApiError } from "../../errors";
 import { RUN_ERROR_GUIDANCE } from "@vm0/core";
 import { logger } from "../../logger";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
+import type { TelegramCallbackPayload } from "../../callback/callback-payloads";
 
 const log = logger("telegram:run-agent");
-
-/**
- * Telegram-specific context to include in the callback payload
- */
-interface TelegramCallbackContext {
-  installationId: string;
-  chatId: string;
-  messageId: string;
-  rootMessageId: string | null;
-  userLinkId: string;
-  agentName: string;
-  composeId: string;
-  existingSessionId: string | null;
-  isDM: boolean;
-  thinkingMessageId: string | null;
-}
 
 interface RunAgentParams {
   composeId: string;
@@ -31,7 +16,7 @@ interface RunAgentParams {
   prompt: string;
   threadContext: string;
   userId: string;
-  callbackContext: TelegramCallbackContext;
+  callbackContext: TelegramCallbackPayload;
 }
 
 interface RunAgentResult {
@@ -59,10 +44,12 @@ export async function runAgentForTelegram(
     callbackContext,
   } = params;
 
-  const integrationContext = buildIntegrationContext("Telegram");
-  const fullPrompt = threadContext
-    ? `${integrationContext}\n\n${threadContext}\n\n# User Prompt\n\n${prompt}`
-    : `${integrationContext}\n\n# User Prompt\n\n${prompt}`;
+  const contextParts = [
+    buildIntegrationContext("Telegram"),
+    threadContext,
+  ].filter(Boolean);
+  const appendSystemPrompt =
+    contextParts.length > 0 ? contextParts.join("\n\n") : undefined;
 
   const callbackUrl = `${getApiUrl()}/api/internal/callbacks/telegram`;
   const callbackSecret = generateCallbackSecret();
@@ -71,7 +58,8 @@ export async function runAgentForTelegram(
     const result = await createZeroRun({
       userId,
       composeId,
-      prompt: fullPrompt,
+      prompt,
+      appendSystemPrompt,
       sessionId,
       triggerSource: "telegram",
       callbacks: [

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -167,7 +167,7 @@ describe("createZeroRun()", () => {
             {
               url: "https://example.com/callback",
               secret: "test-secret",
-              payload: { key: "value" },
+              payload: { scheduleId: "test-schedule", intervalSeconds: 300 },
             },
           ],
         }),

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -2,6 +2,7 @@ import type { TriggerSource } from "@vm0/core";
 import { startRun, type CreateRunResult } from "../run";
 import { DISALLOWED_CRON_TOOLS } from "../integration-context";
 import { buildAgentIdentityPrompt } from "../agent-identity";
+import type { CallbackPayload } from "../callback/callback-payloads";
 
 /**
  * Parameters accepted by createZeroRun().
@@ -16,7 +17,7 @@ interface ZeroRunParams {
   sessionId?: string;
   appendSystemPrompt?: string;
   modelProvider?: string;
-  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
+  callbacks?: Array<{ url: string; secret: string; payload: CallbackPayload }>;
   scheduleId?: string;
 }
 


### PR DESCRIPTION
## Summary

- Add shared callback payload types in `callback-payloads.ts` for compile-time safety across all 8 zero-layer callback channels
- Change `ZeroRunParams.callbacks.payload` from `unknown` to `CallbackPayload` union type
- Replace local interface definitions in handlers and callback routes with shared types
- Fix slack schedule callback missing `orgId` bug in `schedule-service.ts`
- Remove `userId` from `GitHubIssuesCallbackPayload` (consistent with consumer that queries from `agent_runs`)
- Standardize `prompt`/`appendSystemPrompt` across telegram, email, and github channels to match slack's pattern

## Test plan

- [x] TypeScript type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Format passes (`pnpm format`)
- [x] All 17 zero-run-service tests pass (`pnpm vitest`)
- [x] Knip finds no unused exports (`pnpm knip`)

Closes #6072

🤖 Generated with [Claude Code](https://claude.com/claude-code)