### PR TITLE
feat: add migration immutability check to ci pipeline

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -402,7 +402,8 @@ jobs:
           # Check that migration SQL files and snapshots are only added, never modified or deleted
           CHANGED=$(git diff --diff-filter=MD --name-only "$BASE_REF" -- \
             'turbo/apps/web/src/db/migrations/*.sql' \
-            'turbo/apps/web/src/db/migrations/meta/*_snapshot.json')
+            'turbo/apps/web/src/db/migrations/meta/*_snapshot.json' \
+            'turbo/apps/web/src/db/migrations/meta/_journal.json')
 
           if [ -n "$CHANGED" ]; then
             echo "::error::Migration files must not be modified or deleted once on main:"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -408,11 +408,18 @@ jobs:
           DELETED_JOURNAL=$(git diff --diff-filter=D --name-only "$BASE_REF" -- \
             'turbo/apps/web/src/db/migrations/meta/_journal.json')
 
-          VIOLATIONS="${CHANGED}${DELETED_JOURNAL}"
-
-          if [ -n "$VIOLATIONS" ]; then
+          FAILED=0
+          if [ -n "$CHANGED" ]; then
             echo "::error::Migration files must not be modified or deleted once on main:"
-            echo "$VIOLATIONS"
+            echo "$CHANGED"
+            FAILED=1
+          fi
+          if [ -n "$DELETED_JOURNAL" ]; then
+            echo "::error::Migration journal must not be deleted:"
+            echo "$DELETED_JOURNAL"
+            FAILED=1
+          fi
+          if [ "$FAILED" -eq 1 ]; then
             echo ""
             echo "These files may already be deployed to production."
             echo "Create a NEW migration instead of modifying existing ones."

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -402,12 +402,17 @@ jobs:
           # Check that migration SQL files and snapshots are only added, never modified or deleted
           CHANGED=$(git diff --diff-filter=MD --name-only "$BASE_REF" -- \
             'turbo/apps/web/src/db/migrations/*.sql' \
-            'turbo/apps/web/src/db/migrations/meta/*_snapshot.json' \
+            'turbo/apps/web/src/db/migrations/meta/*_snapshot.json')
+
+          # _journal.json is modified on every new migration, so only flag deletion
+          DELETED_JOURNAL=$(git diff --diff-filter=D --name-only "$BASE_REF" -- \
             'turbo/apps/web/src/db/migrations/meta/_journal.json')
 
-          if [ -n "$CHANGED" ]; then
+          VIOLATIONS="${CHANGED}${DELETED_JOURNAL}"
+
+          if [ -n "$VIOLATIONS" ]; then
             echo "::error::Migration files must not be modified or deleted once on main:"
-            echo "$CHANGED"
+            echo "$VIOLATIONS"
             echo ""
             echo "These files may already be deployed to production."
             echo "Create a NEW migration instead of modifying existing ones."

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -81,6 +81,7 @@ jobs:
       crates-changed: ${{ steps.detect-crates.outputs.crates-changed }}
       ci-changed: ${{ steps.detect-ci.outputs.ci-changed }}
       e2e-changed: ${{ steps.detect-e2e.outputs.e2e-changed }}
+      base-ref: ${{ steps.detect.outputs.base-ref }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -392,7 +393,25 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/toolchain-init
+      - name: Check Migration Immutability
+        run: |
+          BASE_REF="${{ needs.prepare.outputs.base-ref }}"
+          # Check that migration SQL files and snapshots are only added, never modified or deleted
+          CHANGED=$(git diff --diff-filter=MD --name-only "$BASE_REF" -- \
+            'turbo/apps/web/src/db/migrations/*.sql' \
+            'turbo/apps/web/src/db/migrations/meta/*_snapshot.json')
+
+          if [ -n "$CHANGED" ]; then
+            echo "::error::Migration files must not be modified or deleted once on main:"
+            echo "$CHANGED"
+            echo ""
+            echo "These files may already be deployed to production."
+            echo "Create a NEW migration instead of modifying existing ones."
+            exit 1
+          fi
       - name: Test Migration Consistency
         working-directory: turbo/apps/web
         env:


### PR DESCRIPTION
## Summary

- Add a `Check Migration Immutability` step to the `test-migrate` CI job that blocks modification or deletion of deployed migration SQL files and snapshot JSON files
- Expose `base-ref` output from the `prepare` job and use it for accurate base comparison across PR, merge queue, and push events
- Add `fetch-depth: 0` to the `test-migrate` checkout to enable `git diff` against the base ref

Closes #6100

## Context

PR #6019 replaced an already-deployed migration file, causing Drizzle to re-execute it in production and produce a column conflict (`name` already exists on `org_cache`). This check prevents that class of error by failing CI when migration files are modified or deleted.

## Test plan

- [ ] Verify YAML is syntactically valid
- [ ] Confirm the new step is placed before "Test Migration Consistency"
- [ ] The check will be exercised on the first PR that modifies existing migration files

🤖 Generated with [Claude Code](https://claude.com/claude-code)