### PR TITLE
fix: rename reserved "all" permission to "unrestricted" in model provider firewalls

### DIFF
--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -374,7 +374,7 @@ function mpFirewall(
       {
         base: getFirewallBaseUrl(type),
         auth: { headers: authHeaders },
-        permissions: [{ name: "all", rules: ["ANY /{path*}"] }],
+        permissions: [{ name: "unrestricted", rules: ["ANY /{path*}"] }],
       },
     ],
     placeholders,


### PR DESCRIPTION
## Summary
- Rename permission name from `"all"` to `"unrestricted"` in `mpFirewall()` helper
- `"all"` is a reserved keyword in `collectAndValidatePermissions()` — model provider firewalls bypassed this validation but used the reserved name
- Aligns naming for upcoming connector firewall auto-config (#6107)

## Test plan
- [ ] Verify `pnpm check-types` passes
- [ ] Verify no tests reference the old `"all"` permission name

🤖 Generated with [Claude Code](https://claude.com/claude-code)