### PR TITLE
chore: pass clerk webhook signing secret to production deployment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -316,6 +316,7 @@ jobs:
             STRIPE_OAUTH_CLIENT_SECRET=${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
             STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }}
             STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }}
+            CLERK_WEBHOOK_SIGNING_SECRET=${{ secrets.CLERK_WEBHOOK_SIGNING_SECRET }}
             ZERO_PRO_PLAN_PRICE_ID=${{ secrets.ZERO_PRO_PLAN_PRICE_ID }}
             ZERO_MAX_PLAN_PRICE_ID=${{ secrets.ZERO_MAX_PLAN_PRICE_ID }}
             NGROK_API_KEY=${{ secrets.NGROK_API_KEY }}


### PR DESCRIPTION
## Summary
- Add `CLERK_WEBHOOK_SIGNING_SECRET` to `deploy-web-production` environment variables in `release-please.yml`
- Secret already configured in GitHub `production` environment
- Required for the org deletion webhook handler (#5969) to verify Svix signatures in production

## Test plan
- [ ] Verify `release-please.yml` diff only adds one line in the production deploy section
- [ ] Next production release will pick up the new env var automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)