### PR TITLE
refactor: migrate remaining non-zero api calls to /api/zero/ and add lint rule

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-non-zero-api.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-non-zero-api.test.ts
@@ -1,0 +1,57 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-non-zero-api.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-non-zero-api", rule, {
+  valid: [
+    // Zero API paths are allowed
+    {
+      code: 'const url = "/api/zero/billing/status"',
+    },
+    {
+      code: 'fetchFn("/api/zero/agents")',
+    },
+    // Non-API strings are fine
+    {
+      code: 'const msg = "hello world"',
+    },
+    {
+      code: 'const path = "/dashboard/settings"',
+    },
+    // Partial path that doesn't contain /api/
+    {
+      code: 'const doc = "See the API docs at /docs/api"',
+    },
+    // External URLs with /api/ are allowed (e.g. Slack, Stripe)
+    {
+      code: 'const url = "https://slack.com/api/chat.postMessage"',
+    },
+    {
+      code: 'const url = "http://example.com/api/something"',
+    },
+  ],
+  invalid: [
+    {
+      code: 'fetchFn("/api/billing/status")',
+      errors: [{ messageId: "nonZeroApi" }],
+    },
+    {
+      code: 'const url = "/api/usage/members"',
+      errors: [{ messageId: "nonZeroApi" }],
+    },
+    {
+      code: 'window.open("/api/connectors/github/authorize")',
+      errors: [{ messageId: "nonZeroApi" }],
+    },
+    {
+      code: 'const path = "/api/agent/composes/123/instructions"',
+      errors: [{ messageId: "nonZeroApi" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -14,6 +14,7 @@
  * - no-store-in-params: Prevent Store type in function params
  * - no-side-effect-in-render: Prevent side-effect calls (set, detach) directly in render
  * - no-use-ccstate-in-views: Disallow useCCState() in views/ — signals must be in signals/
+ * - no-non-zero-api: Enforce that platform app only calls /api/zero/ endpoints
  */
 
 import signalDollarSuffix from "./rules/signal-dollar-suffix.ts";
@@ -29,6 +30,7 @@ import noStoreInParams from "./rules/no-store-in-params.ts";
 import setupPageRender from "./rules/setup-page-render.ts";
 import noSideEffectInRender from "./rules/no-side-effect-in-render.ts";
 import noUseCCStateInViews from "./rules/no-use-ccstate-in-views.ts";
+import noNonZeroApi from "./rules/no-non-zero-api.ts";
 
 const plugin = {
   meta: {
@@ -49,6 +51,7 @@ const plugin = {
     "setup-page-render": setupPageRender,
     "no-side-effect-in-render": noSideEffectInRender,
     "no-use-ccstate-in-views": noUseCCStateInViews,
+    "no-non-zero-api": noNonZeroApi,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/no-non-zero-api.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-non-zero-api.ts
@@ -1,0 +1,80 @@
+/**
+ * ESLint rule: no-non-zero-api
+ *
+ * Enforces that the platform app only calls /api/zero/ endpoints.
+ * Catches string literals and template literals containing /api/ paths
+ * that do not start with /api/zero/.
+ *
+ * Good: "/api/zero/billing/status"
+ * Bad: "/api/billing/status"
+ */
+
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/anthropics/vm0/blob/main/docs/eslint/${name}.md`,
+);
+
+type MessageIds = "nonZeroApi";
+
+/**
+ * Check if a string contains a non-zero API path.
+ * Matches /api/ followed by anything that is NOT zero/.
+ * Ignores external URLs (e.g. https://slack.com/api/...).
+ */
+function containsNonZeroApiPath(value: string): boolean {
+  // Skip external URLs — only flag paths starting with /api/ or relative paths
+  // that look like our API (not full URLs to third-party services)
+  if (/https?:\/\/[^/]+\/api\//.test(value)) {
+    return false;
+  }
+  // Match /api/ that is NOT followed by zero/
+  return /\/api\/(?!zero\/)/.test(value);
+}
+
+export default createRule<[], MessageIds>({
+  name: "no-non-zero-api",
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Enforce that platform app only calls /api/zero/ endpoints",
+    },
+    schema: [],
+    messages: {
+      nonZeroApi:
+        "Platform app must only call /api/zero/ endpoints. Found non-zero API path: '{{path}}'. Use a zero contract + route instead.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      Literal(node) {
+        if (typeof node.value !== "string") {
+          return;
+        }
+        if (containsNonZeroApiPath(node.value)) {
+          context.report({
+            node,
+            messageId: "nonZeroApi",
+            data: { path: node.value },
+          });
+        }
+      },
+      TemplateLiteral(node) {
+        // Check the static parts of template literals
+        for (const quasi of node.quasis) {
+          const value = quasi.value.raw;
+          if (containsNonZeroApiPath(value)) {
+            context.report({
+              node,
+              messageId: "nonZeroApi",
+              data: { path: value },
+            });
+            return;
+          }
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -35,6 +35,7 @@ export default [
       "ccstate/setup-page-render": "error",
       "ccstate/no-side-effect-in-render": "error",
       "ccstate/no-use-ccstate-in-views": "error",
+      "ccstate/no-non-zero-api": "error",
     },
   },
   // Type-aware rules (only for TypeScript files)

--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -59,8 +59,8 @@ export const apiAgentsHandlers = [
     });
   }),
 
-  // GET /api/agent/composes/:id/instructions
-  http.get("/api/agent/composes/:id/instructions", () => {
+  // GET /api/zero/agents/:name/instructions
+  http.get("/api/zero/agents/:name/instructions", () => {
     return HttpResponse.json({
       content: null,
       filename: null,
@@ -70,10 +70,5 @@ export const apiAgentsHandlers = [
   // GET /api/zero/schedules
   http.get("/api/zero/schedules", () => {
     return HttpResponse.json({ schedules: [] });
-  }),
-
-  // GET /api/agent/required-env
-  http.get("/api/agent/required-env", () => {
-    return HttpResponse.json({ agents: [] });
   }),
 ];

--- a/turbo/apps/platform/src/mocks/handlers/api-billing.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-billing.ts
@@ -1,7 +1,7 @@
 /**
  * Billing API Handlers
  *
- * Mock handlers for /api/billing endpoints.
+ * Mock handlers for /api/zero/billing endpoints.
  */
 
 import { http, HttpResponse } from "msw";
@@ -32,11 +32,11 @@ export function resetMockBilling(): void {
 }
 
 export const apiBillingHandlers = [
-  http.get("*/api/billing/status", () => {
+  http.get("*/api/zero/billing/status", () => {
     return HttpResponse.json(mockBillingStatus);
   }),
 
-  http.post("*/api/billing/checkout", async ({ request }) => {
+  http.post("*/api/zero/billing/checkout", async ({ request }) => {
     const body = (await request.json()) as {
       tier: string;
       successUrl: string;
@@ -47,17 +47,17 @@ export const apiBillingHandlers = [
     });
   }),
 
-  http.post("*/api/billing/portal", () => {
+  http.post("*/api/zero/billing/portal", () => {
     return HttpResponse.json({
       url: "https://billing.stripe.com/test-portal",
     });
   }),
 
-  http.get("*/api/billing/auto-recharge", () => {
+  http.get("*/api/zero/billing/auto-recharge", () => {
     return HttpResponse.json(mockBillingStatus.autoRecharge);
   }),
 
-  http.put("*/api/billing/auto-recharge", async ({ request }) => {
+  http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
     const body = (await request.json()) as {
       enabled: boolean;
       threshold?: number;

--- a/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/fetch.test.ts
@@ -223,15 +223,19 @@ describe("url handling", () => {
     const captured: { request: CapturedRequest | null } = { request: null };
 
     server.use(
-      createCaptureHandler("get", "http://localhost:3000/api/users", captured),
+      createCaptureHandler(
+        "get",
+        "http://localhost:3000/api/zero/users",
+        captured,
+      ),
     );
 
     const fch = context.store.get(fetch$);
-    await fch("/api/users?page=1&size=10");
+    await fch("/api/zero/users?page=1&size=10");
 
     expect(captured.request).not.toBeNull();
     expect(captured.request?.url).toBe(
-      "http://localhost:3000/api/users?page=1&size=10",
+      "http://localhost:3000/api/zero/users?page=1&size=10",
     );
   });
 });
@@ -311,14 +315,18 @@ describe("other fetch parameters", () => {
     const captured: { request: CapturedRequest | null } = { request: null };
 
     server.use(
-      createCaptureHandler("post", "http://localhost:3000/api/users", captured),
+      createCaptureHandler(
+        "post",
+        "http://localhost:3000/api/zero/users",
+        captured,
+      ),
     );
 
     const fch = context.store.get(fetch$);
-    await fch(new Request("/api/users", { method: "POST" }));
+    await fch(new Request("/api/zero/users", { method: "POST" }));
 
     expect(captured.request).not.toBeNull();
-    expect(captured.request?.url).toBe("http://localhost:3000/api/users");
+    expect(captured.request?.url).toBe("http://localhost:3000/api/zero/users");
     expect(captured.request?.method).toBe("POST");
   });
 });

--- a/turbo/apps/platform/src/signals/usage-page/usage-signals.ts
+++ b/turbo/apps/platform/src/signals/usage-page/usage-signals.ts
@@ -2,21 +2,6 @@ import { computed } from "ccstate";
 import { zeroUsageMembersContract } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 
-interface MemberUsage {
-  userId: string;
-  email: string;
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadInputTokens: number;
-  cacheCreationInputTokens: number;
-  creditsCharged: number;
-}
-
-interface UsageMembersResponse {
-  period: { start: string; end: string } | null;
-  members: MemberUsage[];
-}
-
 /**
  * Async computed signal that fetches per-member usage data.
  * Throws on non-OK responses so useLoadable enters hasError state.
@@ -28,5 +13,5 @@ export const usageMembersAsync$ = computed(async (get) => {
   if (result.status !== 200) {
     throw new Error(`Failed to fetch usage data: ${result.status}`);
   }
-  return result.body as UsageMembersResponse;
+  return result.body;
 });

--- a/turbo/apps/platform/src/signals/usage-page/usage-signals.ts
+++ b/turbo/apps/platform/src/signals/usage-page/usage-signals.ts
@@ -1,5 +1,6 @@
 import { computed } from "ccstate";
-import { fetch$ } from "../fetch.ts";
+import { zeroUsageMembersContract } from "@vm0/core";
+import { zeroClient$ } from "../api-client.ts";
 
 interface MemberUsage {
   userId: string;
@@ -21,11 +22,11 @@ interface UsageMembersResponse {
  * Throws on non-OK responses so useLoadable enters hasError state.
  */
 export const usageMembersAsync$ = computed(async (get) => {
-  const fetchFn = await get(fetch$);
-  const response = await fetchFn("/api/usage/members");
-  if (!response.ok) {
-    throw new Error(`Failed to fetch usage data: ${response.status}`);
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroUsageMembersContract);
+  const result = await client.get();
+  if (result.status !== 200) {
+    throw new Error(`Failed to fetch usage data: ${result.status}`);
   }
-  const data = (await response.json()) as UsageMembersResponse;
-  return data;
+  return result.body as UsageMembersResponse;
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -200,7 +200,7 @@ describe("zero-chat signals", () => {
             statusText: "Not Found",
           });
         }),
-        http.get("*/api/agent/sessions/:id", () => {
+        http.get("*/api/zero/sessions/:id", () => {
           return new HttpResponse(null, {
             status: 404,
             statusText: "Not Found",
@@ -1204,7 +1204,7 @@ describe("zero-chat signals", () => {
         http.get("*/api/zero/chat-threads", () => {
           return HttpResponse.json({ threads: [] });
         }),
-        http.post("*/api/agent/uploads", async () => {
+        http.post("*/api/zero/uploads", async () => {
           if (delayMs > 0) {
             await delay(delayMs);
           }
@@ -1281,7 +1281,7 @@ describe("zero-chat signals", () => {
         http.get("*/api/zero/chat-threads", () => {
           return HttpResponse.json({ threads: [] });
         }),
-        http.post("*/api/agent/uploads", async () => {
+        http.post("*/api/zero/uploads", async () => {
           requestCount++;
           const currentCount = requestCount;
           await delay(300);

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -108,7 +108,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(agentResponse);
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -176,7 +176,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(
               { error: "Internal Server Error" },
@@ -210,7 +210,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -251,7 +251,7 @@ describe("zero-job-detail signals", () => {
           });
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -276,7 +276,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -405,7 +405,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -446,7 +446,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -483,7 +483,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -525,7 +525,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -565,7 +565,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -606,7 +606,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -752,7 +752,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },
@@ -850,7 +850,7 @@ describe("zero-job-detail signals", () => {
           return HttpResponse.json(mockAgentResponse());
         }),
         http.get(
-          "http://localhost:3000/api/agent/composes/compose-1/instructions",
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
             return HttpResponse.json(mockInstructions());
           },

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -4,6 +4,7 @@ import {
   zeroBillingCheckoutContract,
   zeroBillingPortalContract,
   zeroBillingAutoRechargeContract,
+  type BillingStatusResponse,
 } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { logger } from "../log.ts";
@@ -20,19 +21,27 @@ const log = logger("billing");
 
 export type BillingTier = "free" | "pro" | "team";
 
-interface AutoRechargeConfig {
-  enabled: boolean;
-  threshold: number | null;
-  amount: number | null;
+export type BillingStatus = BillingStatusResponse;
+
+function isBillingTier(tier: string): tier is BillingTier {
+  return tier === "free" || tier === "pro" || tier === "team";
 }
 
-export interface BillingStatus {
-  tier: BillingTier;
-  credits: number;
-  subscriptionStatus: string | null;
-  currentPeriodEnd: string | null;
-  hasSubscription: boolean;
-  autoRecharge: AutoRechargeConfig;
+function toBillingTier(tier: string): BillingTier {
+  return isBillingTier(tier) ? tier : "free";
+}
+
+/** Extract error message from a ts-rest error response body. */
+function getErrorMessage(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null || !("error" in body)) {
+    return undefined;
+  }
+  const { error } = body;
+  if (typeof error !== "object" || error === null || !("message" in error)) {
+    return undefined;
+  }
+  const { message } = error;
+  return typeof message === "string" ? message : undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -62,10 +71,9 @@ export const billingStatusAsync$ = computed(async (get) => {
   const client = createClient(zeroBillingStatusContract);
   const result = await client.get();
   if (result.status !== 200) {
-    log.error("Failed to fetch billing status", result.status);
-    return null;
+    throw new Error(`Failed to fetch billing status: ${result.status}`);
   }
-  return result.body as BillingStatus;
+  return result.body;
 });
 
 // ---------------------------------------------------------------------------
@@ -74,16 +82,9 @@ export const billingStatusAsync$ = computed(async (get) => {
 
 export const openBillingDialog$ = command(async ({ get, set }) => {
   const status = await get(billingStatusAsync$);
-  const currentTier = (status?.tier as BillingTier) ?? "free";
+  const currentTier = toBillingTier(status.tier);
   set(setSelectedPlanTier$, currentTier);
-  set(
-    syncAutoRechargeForm$,
-    status?.autoRecharge ?? {
-      enabled: false,
-      threshold: null,
-      amount: null,
-    },
-  );
+  set(syncAutoRechargeForm$, status.autoRecharge);
   set(internalDialogOpen$, true);
 });
 
@@ -111,12 +112,11 @@ export const startCheckout$ = command(
       },
     });
 
-    if (result.status === 200 && result.body.url) {
+    if (result.status === 200) {
       window.location.href = result.body.url;
       // Don't reset loading — page is navigating away
     } else {
-      const errorBody = result.body as { error?: { message?: string } };
-      log.error("Checkout failed", errorBody.error?.message);
+      log.error("Checkout failed", getErrorMessage(result.body));
       set(internalDialogLoading$, false);
     }
   },
@@ -131,11 +131,10 @@ export const startDowngrade$ = command(async ({ get, set }) => {
     body: { returnUrl: window.location.href },
   });
 
-  if (result.status === 200 && result.body.url) {
+  if (result.status === 200) {
     window.location.href = result.body.url;
   } else {
-    const errorBody = result.body as { error?: { message?: string } };
-    log.error("Portal redirect failed", errorBody.error?.message);
+    log.error("Portal redirect failed", getErrorMessage(result.body));
     set(internalDialogLoading$, false);
   }
 });
@@ -158,9 +157,9 @@ export const saveAutoRecharge$ = command(
     set(internalDialogLoading$, false);
 
     if (result.status !== 200) {
-      const errorBody = result.body as { error?: { message?: string } };
-      log.error("Auto-recharge save failed", errorBody.error?.message);
-      return { ok: false, error: errorBody.error?.message };
+      const message = getErrorMessage(result.body);
+      log.error("Auto-recharge save failed", message);
+      return { ok: false, error: message };
     }
 
     // Invalidate billing status cache so the dialog shows fresh data on re-open

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -1,5 +1,11 @@
 import { command, computed, state } from "ccstate";
-import { fetch$ } from "../fetch.ts";
+import {
+  zeroBillingStatusContract,
+  zeroBillingCheckoutContract,
+  zeroBillingPortalContract,
+  zeroBillingAutoRechargeContract,
+} from "@vm0/core";
+import { zeroClient$ } from "../api-client.ts";
 import { logger } from "../log.ts";
 import {
   setSelectedPlanTier$,
@@ -52,14 +58,14 @@ export const billingDialogLoading$ = computed((get) =>
  */
 export const billingStatusAsync$ = computed(async (get) => {
   get(billingReload$);
-  const fetchFn = await get(fetch$);
-  const response = await fetchFn("/api/billing/status");
-  if (!response.ok) {
-    log.error("Failed to fetch billing status", response.status);
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroBillingStatusContract);
+  const result = await client.get();
+  if (result.status !== 200) {
+    log.error("Failed to fetch billing status", result.status);
     return null;
   }
-  const data = (await response.json()) as BillingStatus;
-  return data;
+  return result.body as BillingStatus;
 });
 
 // ---------------------------------------------------------------------------
@@ -89,33 +95,28 @@ export const startCheckout$ = command(
   async ({ get, set }, tier: "pro" | "team") => {
     set(internalDialogLoading$, true);
 
-    const fetchFn = get(fetch$);
     const currentUrl = window.location.href;
     const successUrl = new URL(currentUrl);
     successUrl.searchParams.set("billing", "success");
     const cancelUrl = new URL(currentUrl);
     cancelUrl.searchParams.set("billing", "canceled");
 
-    const response = await fetchFn("/api/billing/checkout", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroBillingCheckoutContract);
+    const result = await client.create({
+      body: {
         tier,
         successUrl: successUrl.toString(),
         cancelUrl: cancelUrl.toString(),
-      }),
+      },
     });
 
-    const data = (await response.json()) as {
-      url?: string;
-      error?: string;
-    };
-
-    if (data.url) {
-      window.location.href = data.url;
+    if (result.status === 200 && result.body.url) {
+      window.location.href = result.body.url;
       // Don't reset loading — page is navigating away
     } else {
-      log.error("Checkout failed", data.error);
+      const errorBody = result.body as { error?: { message?: string } };
+      log.error("Checkout failed", errorBody.error?.message);
       set(internalDialogLoading$, false);
     }
   },
@@ -124,22 +125,17 @@ export const startCheckout$ = command(
 export const startDowngrade$ = command(async ({ get, set }) => {
   set(internalDialogLoading$, true);
 
-  const fetchFn = get(fetch$);
-  const response = await fetchFn("/api/billing/portal", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ returnUrl: window.location.href }),
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroBillingPortalContract);
+  const result = await client.create({
+    body: { returnUrl: window.location.href },
   });
 
-  const data = (await response.json()) as {
-    url?: string;
-    error?: string;
-  };
-
-  if (data.url) {
-    window.location.href = data.url;
+  if (result.status === 200 && result.body.url) {
+    window.location.href = result.body.url;
   } else {
-    log.error("Portal redirect failed", data.error);
+    const errorBody = result.body as { error?: { message?: string } };
+    log.error("Portal redirect failed", errorBody.error?.message);
     set(internalDialogLoading$, false);
   }
 });
@@ -155,23 +151,16 @@ export const saveAutoRecharge$ = command(
   ) => {
     set(internalDialogLoading$, true);
 
-    const fetchFn = get(fetch$);
-    const response = await fetchFn("/api/billing/auto-recharge", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(config),
-    });
-
-    const data = (await response.json()) as {
-      enabled?: boolean;
-      error?: string;
-    };
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroBillingAutoRechargeContract);
+    const result = await client.update({ body: config });
 
     set(internalDialogLoading$, false);
 
-    if (!response.ok) {
-      log.error("Auto-recharge save failed", data.error);
-      return { ok: false, error: data.error };
+    if (result.status !== 200) {
+      const errorBody = result.body as { error?: { message?: string } };
+      log.error("Auto-recharge save failed", errorBody.error?.message);
+      return { ok: false, error: errorBody.error?.message };
     }
 
     // Invalidate billing status cache so the dialog shows fresh data on re-open

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -340,7 +340,7 @@ export const connectConnector$ = command(
     set(internalPollingType$, type);
 
     const authWindow = window.open(
-      `${baseUrl}/api/connectors/${type}/authorize`,
+      `${baseUrl}/api/zero/connectors/${type}/authorize`,
       "_blank",
       "width=600,height=700",
     );

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -119,7 +119,7 @@ async function fetchQueuePosition(
   runId: string,
 ): Promise<number> {
   const resp = await fetchFn(
-    `/api/app/queue-position?runId=${encodeURIComponent(runId)}`,
+    `/api/zero/queue-position?runId=${encodeURIComponent(runId)}`,
   );
   if (!resp.ok) {
     return 0;
@@ -618,7 +618,7 @@ export const uploadZeroAttachment$ = command(
       const formData = new FormData();
       formData.append("file", file);
 
-      const res = await fetchFn("/api/agent/uploads", {
+      const res = await fetchFn("/api/zero/uploads", {
         method: "POST",
         body: formData,
         signal: controller.signal,
@@ -794,7 +794,7 @@ export const switchZeroSession$ = command(
       let res = await fetchFn(`/api/zero/chat-threads/${threadId}`);
       let isLegacySession = false;
       if (!res.ok) {
-        res = await fetchFn(`/api/agent/sessions/${threadId}`);
+        res = await fetchFn(`/api/zero/sessions/${threadId}`);
         isLegacySession = true;
       }
       if (!res.ok) {

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -159,7 +159,7 @@ const fetchZeroJobInstructions$ = command(async ({ get, set }) => {
   try {
     const fetchFn = get(fetch$);
     const response = await fetchFn(
-      `/api/agent/composes/${detail.id}/instructions`,
+      `/api/zero/agents/${encodeURIComponent(detail.name)}/instructions`,
     );
     if (!response.ok) {
       throw new Error(`Failed to fetch instructions: ${response.statusText}`);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog.test.tsx
@@ -347,7 +347,7 @@ describe("auto-recharge in billing dialog", () => {
   it("should send correct PUT body when enabling auto-recharge via Save", async () => {
     const requestBody = vi.fn();
     server.use(
-      http.put("*/api/billing/auto-recharge", async ({ request }) => {
+      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
         requestBody(await request.json());
         return HttpResponse.json({
           enabled: true,
@@ -398,7 +398,7 @@ describe("auto-recharge in billing dialog", () => {
   it("should send enabled:false when disabling auto-recharge via Save", async () => {
     const requestBody = vi.fn();
     server.use(
-      http.put("*/api/billing/auto-recharge", async ({ request }) => {
+      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
         requestBody(await request.json());
         return HttpResponse.json({
           enabled: false,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
@@ -197,7 +197,7 @@ describe("zero connector card button clicks", () => {
 
     await waitFor(() => {
       expect(mockedWindowOpen).toHaveBeenCalledWith(
-        expect.stringContaining("/api/connectors/github/authorize"),
+        expect.stringContaining("/api/zero/connectors/github/authorize"),
         "_blank",
         "width=600,height=700",
       );
@@ -223,7 +223,7 @@ describe("zero connector card button clicks", () => {
 
     await waitFor(() => {
       expect(mockedWindowOpen).toHaveBeenCalledWith(
-        expect.stringContaining("/api/connectors/github/authorize"),
+        expect.stringContaining("/api/zero/connectors/github/authorize"),
         "_blank",
         "width=600,height=700",
       );
@@ -324,7 +324,7 @@ describe("zero connector card scope review modal", () => {
 
     await waitFor(() => {
       expect(mockedWindowOpen).toHaveBeenCalledWith(
-        expect.stringContaining("/api/connectors/github/authorize"),
+        expect.stringContaining("/api/zero/connectors/github/authorize"),
         "_blank",
         "width=600,height=700",
       );

--- a/turbo/apps/web/app/api/billing/auto-recharge/route.ts
+++ b/turbo/apps/web/app/api/billing/auto-recharge/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
 import { initServices } from "../../../../src/lib/init-services";
 import {
   requireAuth,
   isAuthError,
 } from "../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
-import { orgMetadata } from "../../../../src/db/schema/org-metadata";
+import {
+  getAutoRechargeConfig,
+  updateAutoRechargeConfig,
+} from "../../../../src/lib/billing/billing-service";
 import { CREDITS_PER_DOLLAR } from "../../../../src/lib/billing/auto-recharge-service";
 
 const updateBodySchema = z.object({
@@ -35,22 +37,8 @@ export async function GET(request: Request) {
   const orgSlug = new URL(request.url).searchParams.get("org");
   const { org } = await resolveOrg(authResult, orgSlug);
 
-  const db = globalThis.services.db;
-  const [row] = await db
-    .select({
-      autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
-      autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
-      autoRechargeAmount: orgMetadata.autoRechargeAmount,
-    })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, org.orgId))
-    .limit(1);
-
-  return NextResponse.json({
-    enabled: row?.autoRechargeEnabled ?? false,
-    threshold: row?.autoRechargeThreshold ?? null,
-    amount: row?.autoRechargeAmount ?? null,
-  });
+  const config = await getAutoRechargeConfig(org.orgId);
+  return NextResponse.json(config);
 }
 
 /**
@@ -90,44 +78,15 @@ export async function PUT(request: Request) {
     );
   }
 
-  const { enabled, threshold, amount } = parsed.data;
+  const result = await updateAutoRechargeConfig(
+    org.orgId,
+    org.tier,
+    parsed.data,
+  );
 
-  // When enabling, threshold and amount are required, and org must be on a paid tier
-  if (enabled) {
-    if (org.tier === "free") {
-      return NextResponse.json(
-        { error: "Auto-recharge is only available for paid plans (Pro/Max)" },
-        { status: 400 },
-      );
-    }
-
-    if (threshold === undefined || amount === undefined) {
-      return NextResponse.json(
-        {
-          error:
-            "threshold and amount are required when enabling auto-recharge",
-        },
-        { status: 400 },
-      );
-    }
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
   }
 
-  const db = globalThis.services.db;
-  await db
-    .update(orgMetadata)
-    .set({
-      autoRechargeEnabled: enabled,
-      autoRechargeThreshold: enabled ? threshold : null,
-      autoRechargeAmount: enabled ? amount : null,
-      // Clear pending state when disabling
-      ...(!enabled ? { autoRechargePendingAt: null } : {}),
-      updatedAt: new Date(),
-    })
-    .where(eq(orgMetadata.orgId, org.orgId));
-
-  return NextResponse.json({
-    enabled,
-    threshold: enabled ? threshold : null,
-    amount: enabled ? amount : null,
-  });
+  return NextResponse.json(result.data);
 }

--- a/turbo/apps/web/app/api/usage/members/route.ts
+++ b/turbo/apps/web/app/api/usage/members/route.ts
@@ -1,30 +1,11 @@
 import { NextResponse } from "next/server";
-import { sql, and, eq, gte, lt, inArray } from "drizzle-orm";
 import { initServices } from "../../../../src/lib/init-services";
 import {
   requireAuth,
   isAuthError,
 } from "../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
-import { getOrgBillingPeriod } from "../../../../src/lib/org/org-cache-service";
-import { creditUsage } from "../../../../src/db/schema/credit-usage";
-import { userCache } from "../../../../src/db/schema/user-cache";
-import { clerkClient } from "@clerk/nextjs/server";
-
-interface MemberUsage {
-  userId: string;
-  email: string;
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadInputTokens: number;
-  cacheCreationInputTokens: number;
-  creditsCharged: number;
-}
-
-interface UsageMembersResponse {
-  period: { start: string; end: string } | null;
-  members: MemberUsage[];
-}
+import { getUsageMembers } from "../../../../src/lib/billing/usage-service";
 
 /**
  * GET /api/usage/members
@@ -46,119 +27,6 @@ export async function GET(request: Request) {
   const orgSlug = new URL(request.url).searchParams.get("org");
   const { org } = await resolveOrg(authResult, orgSlug);
 
-  const billingPeriod = await getOrgBillingPeriod(org.orgId);
-
-  if (!billingPeriod) {
-    const response: UsageMembersResponse = { period: null, members: [] };
-    return NextResponse.json(response);
-  }
-
-  const db = globalThis.services.db;
-
-  // Aggregate token usage per member for the billing period
-  const rows = await db
-    .select({
-      userId: creditUsage.userId,
-      inputTokens:
-        sql<number>`COALESCE(SUM(${creditUsage.inputTokens}), 0)::bigint`.as(
-          "input_tokens",
-        ),
-      outputTokens:
-        sql<number>`COALESCE(SUM(${creditUsage.outputTokens}), 0)::bigint`.as(
-          "output_tokens",
-        ),
-      cacheReadInputTokens:
-        sql<number>`COALESCE(SUM(${creditUsage.cacheReadInputTokens}), 0)::bigint`.as(
-          "cache_read_input_tokens",
-        ),
-      cacheCreationInputTokens:
-        sql<number>`COALESCE(SUM(${creditUsage.cacheCreationInputTokens}), 0)::bigint`.as(
-          "cache_creation_input_tokens",
-        ),
-      creditsCharged:
-        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
-          "credits_charged",
-        ),
-    })
-    .from(creditUsage)
-    .where(
-      and(
-        eq(creditUsage.orgId, org.orgId),
-        eq(creditUsage.status, "processed"),
-        gte(creditUsage.createdAt, billingPeriod.start),
-        lt(creditUsage.createdAt, billingPeriod.end),
-      ),
-    )
-    .groupBy(creditUsage.userId);
-
-  if (rows.length === 0) {
-    const response: UsageMembersResponse = {
-      period: {
-        start: billingPeriod.start.toISOString(),
-        end: billingPeriod.end.toISOString(),
-      },
-      members: [],
-    };
-    return NextResponse.json(response);
-  }
-
-  // Resolve user emails from user_cache
-  const userIds = rows.map((r) => r.userId);
-  const cachedUsers = await db
-    .select({ userId: userCache.userId, email: userCache.email })
-    .from(userCache)
-    .where(inArray(userCache.userId, userIds));
-
-  const emailMap = new Map(cachedUsers.map((u) => [u.userId, u.email]));
-
-  // Find missing users and fetch from Clerk
-  const missingIds = userIds.filter((id) => !emailMap.has(id));
-  if (missingIds.length > 0) {
-    const client = await clerkClient();
-    const clerkUsers = await client.users.getUserList({
-      userId: missingIds,
-      limit: missingIds.length,
-    });
-
-    const now = new Date();
-    for (const user of clerkUsers.data) {
-      const primaryEmail = user.emailAddresses.find(
-        (e) => e.id === user.primaryEmailAddressId,
-      );
-      const email = primaryEmail?.emailAddress ?? "unknown";
-      emailMap.set(user.id, email);
-
-      // Upsert into user_cache
-      await db
-        .insert(userCache)
-        .values({ userId: user.id, email, cachedAt: now })
-        .onConflictDoUpdate({
-          target: userCache.userId,
-          set: { email, cachedAt: now },
-        });
-    }
-  }
-
-  const members: MemberUsage[] = rows.map((row) => ({
-    userId: row.userId,
-    email: emailMap.get(row.userId) ?? "unknown",
-    inputTokens: Number(row.inputTokens),
-    outputTokens: Number(row.outputTokens),
-    cacheReadInputTokens: Number(row.cacheReadInputTokens),
-    cacheCreationInputTokens: Number(row.cacheCreationInputTokens),
-    creditsCharged: Number(row.creditsCharged),
-  }));
-
-  // Sort by credits charged descending
-  members.sort((a, b) => b.creditsCharged - a.creditsCharged);
-
-  const response: UsageMembersResponse = {
-    period: {
-      start: billingPeriod.start.toISOString(),
-      end: billingPeriod.end.toISOString(),
-    },
-    members,
-  };
-
+  const response = await getUsageMembers(org.orgId);
   return NextResponse.json(response);
 }

--- a/turbo/apps/web/app/api/zero/billing/auto-recharge/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/auto-recharge/__tests__/route.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  updateOrgTier,
+  updateOrgAutoRecharge,
+  getOrgAutoRechargeFields,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { reloadEnv } from "../../../../../../src/env";
+
+vi.mock("stripe", () => ({
+  default: function MockStripe() {
+    return {
+      invoices: {
+        create: vi.fn(),
+        finalizeInvoice: vi.fn(),
+        pay: vi.fn(),
+      },
+      invoiceItems: { create: vi.fn() },
+      subscriptions: { retrieve: vi.fn() },
+      customers: { create: vi.fn() },
+      checkout: { sessions: { create: vi.fn() } },
+      billingPortal: { sessions: { create: vi.fn() } },
+      webhooks: { constructEvent: vi.fn() },
+    };
+  },
+}));
+
+import { GET, PUT } from "../route";
+
+const context = testContext();
+
+const BASE_URL = "http://localhost:3000/api/zero/billing/auto-recharge";
+
+describe("/api/zero/billing/auto-recharge", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+    reloadEnv();
+  });
+
+  describe("GET", () => {
+    it("returns default config for new org", async () => {
+      const request = createTestRequest(BASE_URL);
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({
+        enabled: false,
+        threshold: null,
+        amount: null,
+      });
+    });
+
+    it("returns configured auto-recharge settings", async () => {
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 2000,
+        autoRechargeAmount: 10000,
+      });
+
+      const request = createTestRequest(BASE_URL);
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toEqual({
+        enabled: true,
+        threshold: 2000,
+        amount: 10000,
+      });
+    });
+  });
+
+  describe("PUT", () => {
+    it("enables auto-recharge for pro tier org", async () => {
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 1000,
+          amount: 5000,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data).toEqual({
+        enabled: true,
+        threshold: 1000,
+        amount: 5000,
+      });
+
+      const fields = await getOrgAutoRechargeFields(user.orgId);
+      expect(fields?.autoRechargeEnabled).toBe(true);
+      expect(fields?.autoRechargeThreshold).toBe(1000);
+      expect(fields?.autoRechargeAmount).toBe(5000);
+    });
+
+    it("disables auto-recharge and clears pending state", async () => {
+      await updateOrgTier(user.orgId, "pro");
+      await updateOrgAutoRecharge(user.orgId, {
+        autoRechargeEnabled: true,
+        autoRechargeThreshold: 1000,
+        autoRechargeAmount: 5000,
+        autoRechargePendingAt: new Date(),
+      });
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(200);
+
+      const fields = await getOrgAutoRechargeFields(user.orgId);
+      expect(fields?.autoRechargeEnabled).toBe(false);
+      expect(fields?.autoRechargePendingAt).toBeNull();
+    });
+
+    it("returns 400 when enabling on free tier", async () => {
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 1000,
+          amount: 5000,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when enabling without threshold and amount", async () => {
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when amount is below minimum", async () => {
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 1000,
+          amount: 500,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 403 for non-admin member", async () => {
+      mockClerk({
+        userId: user.userId,
+        orgId: user.orgId,
+        orgRole: "org:member",
+      });
+
+      await updateOrgTier(user.orgId, "pro");
+
+      const request = createTestRequest(BASE_URL, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          enabled: true,
+          threshold: 1000,
+          amount: 5000,
+        }),
+      });
+
+      const response = await PUT(request);
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/zero/billing/auto-recharge/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/auto-recharge/route.ts
@@ -1,0 +1,66 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import {
+  zeroBillingAutoRechargeContract,
+  createErrorResponse,
+} from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import {
+  getAutoRechargeConfig,
+  updateAutoRechargeConfig,
+} from "../../../../../src/lib/billing/billing-service";
+
+const router = tsr.router(zeroBillingAutoRechargeContract, {
+  get: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    const config = await getAutoRechargeConfig(org.orgId);
+
+    return { status: 200 as const, body: config };
+  },
+
+  update: async ({ body, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org, member } = await resolveOrg(authCtx, orgSlug);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only org admins can update auto-recharge settings",
+      );
+    }
+
+    const result = await updateAutoRechargeConfig(org.orgId, org.tier, body);
+
+    if (!result.ok) {
+      return createErrorResponse("BAD_REQUEST", result.error);
+    }
+
+    return { status: 200 as const, body: result.data };
+  },
+});
+
+const handler = createHandler(zeroBillingAutoRechargeContract, router, {
+  errorHandler: createSafeErrorHandler("zero-billing-auto-recharge"),
+});
+
+export { handler as GET, handler as PUT };

--- a/turbo/apps/web/app/api/zero/billing/checkout/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/checkout/__tests__/route.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock";
+import { reloadEnv } from "../../../../../../src/env";
+
+const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
+  subscriptionsRetrieve: vi.fn(),
+  invoicesRetrieve: vi.fn(),
+  customersCreate: vi.fn(),
+  checkoutSessionsCreate: vi.fn(),
+  billingPortalSessionsCreate: vi.fn(),
+  constructEvent: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: function MockStripe() {
+    return {
+      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      invoices: { retrieve: stripeMocks.invoicesRetrieve },
+      customers: { create: stripeMocks.customersCreate },
+      checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+      billingPortal: {
+        sessions: { create: stripeMocks.billingPortalSessionsCreate },
+      },
+      webhooks: { constructEvent: stripeMocks.constructEvent },
+    };
+  },
+}));
+
+import { POST } from "../route";
+
+const TEST_PRICE_PRO = "price_test_pro";
+const TEST_PRICE_TEAM = "price_test_team";
+
+const context = testContext();
+
+describe("POST /api/zero/billing/checkout", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+    vi.stubEnv("ZERO_PRO_PLAN_PRICE_ID", TEST_PRICE_PRO);
+    vi.stubEnv("ZERO_MAX_PLAN_PRICE_ID", TEST_PRICE_TEAM);
+    reloadEnv();
+
+    stripeMocks.checkoutSessionsCreate.mockReset();
+    stripeMocks.customersCreate.mockReset();
+  });
+
+  it("returns 503 when STRIPE_SECRET_KEY is not configured", async () => {
+    vi.stubEnv("STRIPE_SECRET_KEY", "");
+    reloadEnv();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/checkout",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tier: "pro",
+          successUrl: "https://app.vm7.ai/billing?billing=success",
+          cancelUrl: "https://app.vm7.ai/billing?billing=canceled",
+        }),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(503);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/checkout",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tier: "pro",
+          successUrl: "https://app.vm7.ai/billing?billing=success",
+          cancelUrl: "https://app.vm7.ai/billing?billing=canceled",
+        }),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 for invalid tier", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/checkout",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tier: "enterprise",
+          successUrl: "https://app.vm7.ai/?billing=success",
+          cancelUrl: "https://app.vm7.ai/?billing=canceled",
+        }),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns checkout URL on success", async () => {
+    stripeMocks.customersCreate.mockResolvedValue({
+      id: uniqueId("cus-checkout"),
+    });
+    stripeMocks.checkoutSessionsCreate.mockResolvedValue({
+      url: "https://checkout.stripe.com/session/test",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/checkout",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tier: "pro",
+          successUrl: "https://app.vm7.ai/billing?billing=success",
+          cancelUrl: "https://app.vm7.ai/billing?billing=canceled",
+        }),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.url).toBe("https://checkout.stripe.com/session/test");
+  });
+});

--- a/turbo/apps/web/app/api/zero/billing/checkout/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/checkout/route.ts
@@ -1,0 +1,64 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroBillingCheckoutContract, createErrorResponse } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { env } from "../../../../../src/env";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { createCheckoutSession } from "../../../../../src/lib/billing/billing-service";
+
+const router = tsr.router(zeroBillingCheckoutContract, {
+  create: async ({ body, headers }, { request }) => {
+    initServices();
+
+    const {
+      STRIPE_SECRET_KEY,
+      ZERO_PRO_PLAN_PRICE_ID,
+      ZERO_MAX_PLAN_PRICE_ID,
+    } = env();
+
+    if (!STRIPE_SECRET_KEY) {
+      return createErrorResponse(
+        "PROVIDER_UNAVAILABLE",
+        "Billing not configured",
+      );
+    }
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    const priceId =
+      body.tier === "pro" ? ZERO_PRO_PLAN_PRICE_ID : ZERO_MAX_PLAN_PRICE_ID;
+    if (!priceId) {
+      return createErrorResponse(
+        "BAD_REQUEST",
+        `Price not configured for ${body.tier} tier`,
+      );
+    }
+
+    const url = await createCheckoutSession(
+      org.orgId,
+      org.slug,
+      priceId,
+      body.successUrl,
+      body.cancelUrl,
+    );
+
+    return { status: 200 as const, body: { url } };
+  },
+});
+
+const handler = createHandler(zeroBillingCheckoutContract, router, {
+  errorHandler: createSafeErrorHandler("zero-billing-checkout"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/zero/billing/portal/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/portal/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  updateOrgStripeFields,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock";
+import { reloadEnv } from "../../../../../../src/env";
+
+const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
+  subscriptionsRetrieve: vi.fn(),
+  invoicesRetrieve: vi.fn(),
+  customersCreate: vi.fn(),
+  checkoutSessionsCreate: vi.fn(),
+  billingPortalSessionsCreate: vi.fn(),
+  constructEvent: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: function MockStripe() {
+    return {
+      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      invoices: { retrieve: stripeMocks.invoicesRetrieve },
+      customers: { create: stripeMocks.customersCreate },
+      checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+      billingPortal: {
+        sessions: { create: stripeMocks.billingPortalSessionsCreate },
+      },
+      webhooks: { constructEvent: stripeMocks.constructEvent },
+    };
+  },
+}));
+
+import { POST } from "../route";
+
+const context = testContext();
+
+describe("POST /api/zero/billing/portal", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+    reloadEnv();
+
+    stripeMocks.billingPortalSessionsCreate.mockReset();
+  });
+
+  it("returns 503 when STRIPE_SECRET_KEY is not configured", async () => {
+    vi.stubEnv("STRIPE_SECRET_KEY", "");
+    reloadEnv();
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/portal",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ returnUrl: "http://localhost/settings" }),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(503);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/portal",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ returnUrl: "http://localhost/settings" }),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when returnUrl is missing", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/portal",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns portal URL on success", async () => {
+    await updateOrgStripeFields(user.orgId, {
+      stripeCustomerId: uniqueId("cus-portal"),
+    });
+
+    stripeMocks.billingPortalSessionsCreate.mockResolvedValue({
+      url: "https://billing.stripe.com/session/test",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/portal",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          returnUrl: "http://localhost/settings/billing",
+        }),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.url).toBe("https://billing.stripe.com/session/test");
+  });
+});

--- a/turbo/apps/web/app/api/zero/billing/portal/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/portal/route.ts
@@ -1,0 +1,44 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroBillingPortalContract, createErrorResponse } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { env } from "../../../../../src/env";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { createBillingPortalSession } from "../../../../../src/lib/billing/billing-service";
+
+const router = tsr.router(zeroBillingPortalContract, {
+  create: async ({ body, headers }, { request }) => {
+    initServices();
+
+    const { STRIPE_SECRET_KEY } = env();
+    if (!STRIPE_SECRET_KEY) {
+      return createErrorResponse(
+        "PROVIDER_UNAVAILABLE",
+        "Billing not configured",
+      );
+    }
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    const url = await createBillingPortalSession(org.orgId, body.returnUrl);
+
+    return { status: 200 as const, body: { url } };
+  },
+});
+
+const handler = createHandler(zeroBillingPortalContract, router, {
+  errorHandler: createSafeErrorHandler("zero-billing-portal"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  updateOrgStripeFields,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock";
+
+const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
+  subscriptionsRetrieve: vi.fn(),
+  invoicesRetrieve: vi.fn(),
+  customersCreate: vi.fn(),
+  checkoutSessionsCreate: vi.fn(),
+  billingPortalSessionsCreate: vi.fn(),
+  constructEvent: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: function MockStripe() {
+    return {
+      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      invoices: { retrieve: stripeMocks.invoicesRetrieve },
+      customers: { create: stripeMocks.customersCreate },
+      checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+      billingPortal: {
+        sessions: { create: stripeMocks.billingPortalSessionsCreate },
+      },
+      webhooks: { constructEvent: stripeMocks.constructEvent },
+    };
+  },
+}));
+
+import { GET } from "../route";
+
+const context = testContext();
+
+describe("GET /api/zero/billing/status", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/status",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns billing status for authenticated user", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/status",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.tier).toBe("free");
+    expect(data.credits).toBe(10_000);
+    expect(data.hasSubscription).toBe(false);
+    expect(data.subscriptionStatus).toBeNull();
+    expect(data.currentPeriodEnd).toBeNull();
+  });
+
+  it("returns correct data for subscribed org", async () => {
+    const { orgId } = await context.setupUser({ prefix: "sub-user" });
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus-status"),
+      stripeSubscriptionId: uniqueId("sub-status"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      tier: "pro",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/status",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.tier).toBe("pro");
+    expect(data.credits).toBe(10_000);
+    expect(data.subscriptionStatus).toBe("active");
+    expect(data.currentPeriodEnd).toBe(periodEnd.toISOString());
+    expect(data.hasSubscription).toBe(true);
+  });
+
+  it("returns defaults when org row does not exist", async () => {
+    const newOrgId = uniqueId("org-nonexistent");
+    mockClerk({
+      userId: uniqueId("user"),
+      orgId: newOrgId,
+      orgSlug: "nonexistent-org",
+      orgRole: "org:admin",
+      clerkOrgs: [
+        { id: newOrgId, slug: "nonexistent-org", name: "Nonexistent" },
+      ],
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/status?org=nonexistent-org",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.tier).toBe("free");
+    expect(data.credits).toBe(0);
+    expect(data.hasSubscription).toBe(false);
+  });
+});

--- a/turbo/apps/web/app/api/zero/billing/status/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/route.ts
@@ -1,0 +1,41 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroBillingStatusContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { getBillingStatus } from "../../../../../src/lib/billing/billing-service";
+
+const router = tsr.router(zeroBillingStatusContract, {
+  get: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    const status = await getBillingStatus(org.orgId);
+
+    return {
+      status: 200 as const,
+      body: {
+        ...status,
+        currentPeriodEnd: status.currentPeriodEnd?.toISOString() ?? null,
+      },
+    };
+  },
+});
+
+const handler = createHandler(zeroBillingStatusContract, router, {
+  errorHandler: createSafeErrorHandler("zero-billing-status"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/connectors/[type]/authorize/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/authorize/route.ts
@@ -1,0 +1,7 @@
+/**
+ * Zero alias for connector OAuth authorize endpoint.
+ *
+ * Re-exports the handler from the original /api/connectors/[type]/authorize path.
+ * This is a browser redirect endpoint (not JSON API), so it doesn't use ts-rest contracts.
+ */
+export { GET } from "../../../../connectors/[type]/authorize/route";

--- a/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  insertTestCreditUsage,
+  updateOrgStripeFields,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock";
+
+const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
+  subscriptionsRetrieve: vi.fn(),
+  invoicesRetrieve: vi.fn(),
+  customersCreate: vi.fn(),
+  checkoutSessionsCreate: vi.fn(),
+  billingPortalSessionsCreate: vi.fn(),
+  constructEvent: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: function MockStripe() {
+    return {
+      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      invoices: { retrieve: stripeMocks.invoicesRetrieve },
+      customers: { create: stripeMocks.customersCreate },
+      checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+      billingPortal: {
+        sessions: { create: stripeMocks.billingPortalSessionsCreate },
+      },
+      webhooks: { constructEvent: stripeMocks.constructEvent },
+    };
+  },
+}));
+
+import { GET } from "../route";
+
+const context = testContext();
+
+describe("GET /api/zero/usage/members", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/members",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns empty result for free tier org (no billing period)", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/members",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.period).toBeNull();
+    expect(data.members).toEqual([]);
+  });
+
+  it("returns aggregated usage for single user with processed records", async () => {
+    const { userId, orgId } = await context.user;
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus"),
+      stripeSubscriptionId: uniqueId("sub"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      tier: "pro",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadInputTokens: 200,
+      cacheCreationInputTokens: 100,
+      creditsCharged: 50,
+      status: "processed",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      inputTokens: 2000,
+      outputTokens: 1000,
+      cacheReadInputTokens: 300,
+      cacheCreationInputTokens: 150,
+      creditsCharged: 100,
+      status: "processed",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/members",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.period).not.toBeNull();
+    expect(data.members).toHaveLength(1);
+    expect(data.members[0].inputTokens).toBe(3000);
+    expect(data.members[0].outputTokens).toBe(1500);
+    expect(data.members[0].cacheReadInputTokens).toBe(500);
+    expect(data.members[0].cacheCreationInputTokens).toBe(250);
+    expect(data.members[0].creditsCharged).toBe(150);
+  });
+
+  it("returns separate aggregation for multiple users", async () => {
+    const { orgId } = await context.user;
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus"),
+      stripeSubscriptionId: uniqueId("sub"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      tier: "pro",
+    });
+
+    const user1 = uniqueId("user-alpha");
+    const user2 = uniqueId("user-beta");
+
+    await insertTestCreditUsage(orgId, {
+      userId: user1,
+      inputTokens: 1000,
+      outputTokens: 500,
+      creditsCharged: 50,
+      status: "processed",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId: user2,
+      inputTokens: 3000,
+      outputTokens: 1500,
+      creditsCharged: 200,
+      status: "processed",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/members",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.members).toHaveLength(2);
+
+    // Sorted by creditsCharged descending
+    expect(data.members[0].creditsCharged).toBe(200);
+    expect(data.members[1].creditsCharged).toBe(50);
+  });
+
+  it("excludes pending records from aggregation", async () => {
+    const { userId, orgId } = await context.user;
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus"),
+      stripeSubscriptionId: uniqueId("sub"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      tier: "pro",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      inputTokens: 1000,
+      creditsCharged: 50,
+      status: "processed",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      inputTokens: 5000,
+      creditsCharged: 0,
+      status: "pending",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/members",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.members).toHaveLength(1);
+    expect(data.members[0].inputTokens).toBe(1000);
+    expect(data.members[0].creditsCharged).toBe(50);
+  });
+});

--- a/turbo/apps/web/app/api/zero/usage/members/route.ts
+++ b/turbo/apps/web/app/api/zero/usage/members/route.ts
@@ -1,0 +1,35 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroUsageMembersContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { getUsageMembers } from "../../../../../src/lib/billing/usage-service";
+
+const router = tsr.router(zeroUsageMembersContract, {
+  get: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    const response = await getUsageMembers(org.orgId);
+
+    return { status: 200 as const, body: response };
+  },
+});
+
+const handler = createHandler(zeroUsageMembersContract, router, {
+  errorHandler: createSafeErrorHandler("zero-usage-members"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/src/lib/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/billing/billing-service.ts
@@ -402,6 +402,90 @@ export async function createBillingPortalSession(
 }
 
 /**
+ * Get auto-recharge configuration for an org.
+ */
+export async function getAutoRechargeConfig(orgId: string): Promise<{
+  enabled: boolean;
+  threshold: number | null;
+  amount: number | null;
+}> {
+  const db = globalThis.services.db;
+  const [row] = await db
+    .select({
+      autoRechargeEnabled: orgMetadata.autoRechargeEnabled,
+      autoRechargeThreshold: orgMetadata.autoRechargeThreshold,
+      autoRechargeAmount: orgMetadata.autoRechargeAmount,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  return {
+    enabled: row?.autoRechargeEnabled ?? false,
+    threshold: row?.autoRechargeThreshold ?? null,
+    amount: row?.autoRechargeAmount ?? null,
+  };
+}
+
+/**
+ * Update auto-recharge configuration for an org.
+ * Validates tier and required fields when enabling.
+ */
+export async function updateAutoRechargeConfig(
+  orgId: string,
+  orgTier: string,
+  config: { enabled: boolean; threshold?: number; amount?: number },
+): Promise<
+  | {
+      ok: true;
+      data: {
+        enabled: boolean;
+        threshold: number | null;
+        amount: number | null;
+      };
+    }
+  | { ok: false; error: string }
+> {
+  const { enabled, threshold, amount } = config;
+
+  if (enabled) {
+    if (orgTier === "free") {
+      return {
+        ok: false,
+        error: "Auto-recharge is only available for paid plans (Pro/Max)",
+      };
+    }
+    if (threshold === undefined || amount === undefined) {
+      return {
+        ok: false,
+        error: "threshold and amount are required when enabling auto-recharge",
+      };
+    }
+  }
+
+  const db = globalThis.services.db;
+  await db
+    .update(orgMetadata)
+    .set({
+      autoRechargeEnabled: enabled,
+      autoRechargeThreshold: enabled ? threshold : null,
+      autoRechargeAmount: enabled ? amount : null,
+      ...(!enabled ? { autoRechargePendingAt: null } : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(orgMetadata.orgId, orgId));
+
+  return {
+    ok: true,
+    data: {
+      enabled,
+      threshold: enabled ? (threshold ?? null) : null,
+      amount: enabled ? (amount ?? null) : null,
+    },
+  };
+}
+
+/**
  * Get billing status for an org.
  */
 export async function getBillingStatus(orgId: string): Promise<{

--- a/turbo/apps/web/src/lib/billing/usage-service.ts
+++ b/turbo/apps/web/src/lib/billing/usage-service.ts
@@ -1,0 +1,141 @@
+import { sql, and, eq, gte, lt, inArray } from "drizzle-orm";
+import { getOrgBillingPeriod } from "../org/org-cache-service";
+import { creditUsage } from "../../db/schema/credit-usage";
+import { userCache } from "../../db/schema/user-cache";
+import { clerkClient } from "@clerk/nextjs/server";
+
+interface MemberUsage {
+  userId: string;
+  email: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  creditsCharged: number;
+}
+
+interface UsageMembersResponse {
+  period: { start: string; end: string } | null;
+  members: MemberUsage[];
+}
+
+/**
+ * Get per-member token usage aggregation for the current billing period.
+ * Only includes credit_usage records with status = 'processed'.
+ * Free tier orgs (no billing period) get { period: null, members: [] }.
+ */
+export async function getUsageMembers(
+  orgId: string,
+): Promise<UsageMembersResponse> {
+  const billingPeriod = await getOrgBillingPeriod(orgId);
+
+  if (!billingPeriod) {
+    return { period: null, members: [] };
+  }
+
+  const db = globalThis.services.db;
+
+  // Aggregate token usage per member for the billing period
+  const rows = await db
+    .select({
+      userId: creditUsage.userId,
+      inputTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.inputTokens}), 0)::bigint`.as(
+          "input_tokens",
+        ),
+      outputTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.outputTokens}), 0)::bigint`.as(
+          "output_tokens",
+        ),
+      cacheReadInputTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.cacheReadInputTokens}), 0)::bigint`.as(
+          "cache_read_input_tokens",
+        ),
+      cacheCreationInputTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.cacheCreationInputTokens}), 0)::bigint`.as(
+          "cache_creation_input_tokens",
+        ),
+      creditsCharged:
+        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
+          "credits_charged",
+        ),
+    })
+    .from(creditUsage)
+    .where(
+      and(
+        eq(creditUsage.orgId, orgId),
+        eq(creditUsage.status, "processed"),
+        gte(creditUsage.createdAt, billingPeriod.start),
+        lt(creditUsage.createdAt, billingPeriod.end),
+      ),
+    )
+    .groupBy(creditUsage.userId);
+
+  if (rows.length === 0) {
+    return {
+      period: {
+        start: billingPeriod.start.toISOString(),
+        end: billingPeriod.end.toISOString(),
+      },
+      members: [],
+    };
+  }
+
+  // Resolve user emails from user_cache
+  const userIds = rows.map((r) => r.userId);
+  const cachedUsers = await db
+    .select({ userId: userCache.userId, email: userCache.email })
+    .from(userCache)
+    .where(inArray(userCache.userId, userIds));
+
+  const emailMap = new Map(cachedUsers.map((u) => [u.userId, u.email]));
+
+  // Find missing users and fetch from Clerk
+  const missingIds = userIds.filter((id) => !emailMap.has(id));
+  if (missingIds.length > 0) {
+    const client = await clerkClient();
+    const clerkUsers = await client.users.getUserList({
+      userId: missingIds,
+      limit: missingIds.length,
+    });
+
+    const now = new Date();
+    for (const user of clerkUsers.data) {
+      const primaryEmail = user.emailAddresses.find(
+        (e) => e.id === user.primaryEmailAddressId,
+      );
+      const email = primaryEmail?.emailAddress ?? "unknown";
+      emailMap.set(user.id, email);
+
+      // Upsert into user_cache
+      await db
+        .insert(userCache)
+        .values({ userId: user.id, email, cachedAt: now })
+        .onConflictDoUpdate({
+          target: userCache.userId,
+          set: { email, cachedAt: now },
+        });
+    }
+  }
+
+  const members: MemberUsage[] = rows.map((row) => ({
+    userId: row.userId,
+    email: emailMap.get(row.userId) ?? "unknown",
+    inputTokens: Number(row.inputTokens),
+    outputTokens: Number(row.outputTokens),
+    cacheReadInputTokens: Number(row.cacheReadInputTokens),
+    cacheCreationInputTokens: Number(row.cacheCreationInputTokens),
+    creditsCharged: Number(row.creditsCharged),
+  }));
+
+  // Sort by credits charged descending
+  members.sort((a, b) => b.creditsCharged - a.creditsCharged);
+
+  return {
+    period: {
+      start: billingPeriod.start.toISOString(),
+      end: billingPeriod.end.toISOString(),
+    },
+    members,
+  };
+}

--- a/turbo/apps/web/src/lib/billing/usage-service.ts
+++ b/turbo/apps/web/src/lib/billing/usage-service.ts
@@ -1,23 +1,9 @@
 import { sql, and, eq, gte, lt, inArray } from "drizzle-orm";
+import { type MemberUsage, type UsageMembersResponse } from "@vm0/core";
 import { getOrgBillingPeriod } from "../org/org-cache-service";
 import { creditUsage } from "../../db/schema/credit-usage";
 import { userCache } from "../../db/schema/user-cache";
 import { clerkClient } from "@clerk/nextjs/server";
-
-interface MemberUsage {
-  userId: string;
-  email: string;
-  inputTokens: number;
-  outputTokens: number;
-  cacheReadInputTokens: number;
-  cacheCreationInputTokens: number;
-  creditsCharged: number;
-}
-
-interface UsageMembersResponse {
-  period: { start: string; end: string } | null;
-  members: MemberUsage[];
-}
 
 /**
  * Get per-member token usage aggregation for the current billing period.

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -647,8 +647,16 @@ export {
   type ZeroBillingCheckoutContract,
   type ZeroBillingPortalContract,
   type ZeroBillingAutoRechargeContract,
+  // Inferred types
+  type BillingStatusResponse,
+  type AutoRechargeConfig,
+  type CheckoutResponse,
+  type PortalResponse,
 } from "./zero-billing";
 export {
   zeroUsageMembersContract,
   type ZeroUsageMembersContract,
+  // Inferred types
+  type MemberUsage,
+  type UsageMembersResponse,
 } from "./zero-usage";

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -638,3 +638,17 @@ export {
   integrationsSlackMessageContract,
   type IntegrationsSlackMessageContract,
 } from "./integrations";
+export {
+  zeroBillingStatusContract,
+  zeroBillingCheckoutContract,
+  zeroBillingPortalContract,
+  zeroBillingAutoRechargeContract,
+  type ZeroBillingStatusContract,
+  type ZeroBillingCheckoutContract,
+  type ZeroBillingPortalContract,
+  type ZeroBillingAutoRechargeContract,
+} from "./zero-billing";
+export {
+  zeroUsageMembersContract,
+  type ZeroUsageMembersContract,
+} from "./zero-usage";

--- a/turbo/packages/core/src/contracts/zero-billing.ts
+++ b/turbo/packages/core/src/contracts/zero-billing.ts
@@ -151,3 +151,9 @@ export const zeroBillingAutoRechargeContract = c.router({
 
 export type ZeroBillingAutoRechargeContract =
   typeof zeroBillingAutoRechargeContract;
+
+// Inferred types from Zod schemas
+export type BillingStatusResponse = z.infer<typeof billingStatusResponseSchema>;
+export type AutoRechargeConfig = z.infer<typeof autoRechargeSchema>;
+export type CheckoutResponse = z.infer<typeof checkoutResponseSchema>;
+export type PortalResponse = z.infer<typeof portalResponseSchema>;

--- a/turbo/packages/core/src/contracts/zero-billing.ts
+++ b/turbo/packages/core/src/contracts/zero-billing.ts
@@ -1,0 +1,153 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+const autoRechargeSchema = z.object({
+  enabled: z.boolean(),
+  threshold: z.number().nullable(),
+  amount: z.number().nullable(),
+});
+
+const billingStatusResponseSchema = z.object({
+  tier: z.string(),
+  credits: z.number(),
+  subscriptionStatus: z.string().nullable(),
+  currentPeriodEnd: z.string().nullable(),
+  hasSubscription: z.boolean(),
+  autoRecharge: autoRechargeSchema,
+});
+
+const checkoutResponseSchema = z.object({
+  url: z.string(),
+});
+
+const portalResponseSchema = z.object({
+  url: z.string(),
+});
+
+// ---------------------------------------------------------------------------
+// Request schemas
+// ---------------------------------------------------------------------------
+
+const checkoutRequestSchema = z.object({
+  tier: z.enum(["pro", "team"]),
+  successUrl: z.string().url(),
+  cancelUrl: z.string().url(),
+});
+
+const portalRequestSchema = z.object({
+  returnUrl: z.string().min(1),
+});
+
+const autoRechargeUpdateRequestSchema = z.object({
+  enabled: z.boolean(),
+  threshold: z.number().int().positive().optional(),
+  amount: z.number().int().min(1000).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Contracts
+// ---------------------------------------------------------------------------
+
+/**
+ * Zero contract for GET /api/zero/billing/status
+ */
+export const zeroBillingStatusContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/billing/status",
+    headers: authHeadersSchema,
+    responses: {
+      200: billingStatusResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get billing status for current org",
+  },
+});
+
+export type ZeroBillingStatusContract = typeof zeroBillingStatusContract;
+
+/**
+ * Zero contract for POST /api/zero/billing/checkout
+ */
+export const zeroBillingCheckoutContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/zero/billing/checkout",
+    headers: authHeadersSchema,
+    body: checkoutRequestSchema,
+    responses: {
+      200: checkoutResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Create Stripe checkout session",
+  },
+});
+
+export type ZeroBillingCheckoutContract = typeof zeroBillingCheckoutContract;
+
+/**
+ * Zero contract for POST /api/zero/billing/portal
+ */
+export const zeroBillingPortalContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/zero/billing/portal",
+    headers: authHeadersSchema,
+    body: portalRequestSchema,
+    responses: {
+      200: portalResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Create Stripe billing portal session",
+  },
+});
+
+export type ZeroBillingPortalContract = typeof zeroBillingPortalContract;
+
+/**
+ * Zero contract for /api/zero/billing/auto-recharge
+ */
+export const zeroBillingAutoRechargeContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/billing/auto-recharge",
+    headers: authHeadersSchema,
+    responses: {
+      200: autoRechargeSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get auto-recharge configuration",
+  },
+  update: {
+    method: "PUT",
+    path: "/api/zero/billing/auto-recharge",
+    headers: authHeadersSchema,
+    body: autoRechargeUpdateRequestSchema,
+    responses: {
+      200: autoRechargeSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Update auto-recharge configuration",
+  },
+});
+
+export type ZeroBillingAutoRechargeContract =
+  typeof zeroBillingAutoRechargeContract;

--- a/turbo/packages/core/src/contracts/zero-usage.ts
+++ b/turbo/packages/core/src/contracts/zero-usage.ts
@@ -42,3 +42,7 @@ export const zeroUsageMembersContract = c.router({
 });
 
 export type ZeroUsageMembersContract = typeof zeroUsageMembersContract;
+
+// Inferred types from Zod schemas
+export type MemberUsage = z.infer<typeof memberUsageSchema>;
+export type UsageMembersResponse = z.infer<typeof usageMembersResponseSchema>;

--- a/turbo/packages/core/src/contracts/zero-usage.ts
+++ b/turbo/packages/core/src/contracts/zero-usage.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const memberUsageSchema = z.object({
+  userId: z.string(),
+  email: z.string(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  cacheReadInputTokens: z.number(),
+  cacheCreationInputTokens: z.number(),
+  creditsCharged: z.number(),
+});
+
+const usageMembersResponseSchema = z.object({
+  period: z
+    .object({
+      start: z.string(),
+      end: z.string(),
+    })
+    .nullable(),
+  members: z.array(memberUsageSchema),
+});
+
+/**
+ * Zero contract for GET /api/zero/usage/members
+ */
+export const zeroUsageMembersContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/usage/members",
+    headers: authHeadersSchema,
+    responses: {
+      200: usageMembersResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get per-member usage for current billing period",
+  },
+});
+
+export type ZeroUsageMembersContract = typeof zeroUsageMembersContract;


### PR DESCRIPTION
## Summary

- Migrate all 7 remaining non-zero API calls in the platform app to `/api/zero/` endpoints with ts-rest contracts
- Add `no-non-zero-api` ESLint rule to enforce that platform app only calls `/api/zero/` endpoints going forward
- Extract business logic from old route handlers into reusable service functions

### Backend
- New contracts: `zeroBillingStatusContract`, `zeroBillingCheckoutContract`, `zeroBillingPortalContract`, `zeroBillingAutoRechargeContract`, `zeroUsageMembersContract`
- New zero route handlers: billing (status/checkout/portal/auto-recharge), usage/members, connectors/[type]/authorize
- Extract `getAutoRechargeConfig`, `updateAutoRechargeConfig` into billing-service, `getUsageMembers` into usage-service

### Frontend
- Rewrite billing signals to use `zeroClient` + typed contracts instead of raw `fetch`
- Rewrite usage signals to use `zeroClient` + typed contract
- Update job detail instructions to use `/api/zero/agents/:name/instructions`
- Update connector authorize to use `/api/zero/connectors/:type/authorize`

### Lint Rule
- `no-non-zero-api` flags string literals containing `/api/` paths not under `/api/zero/`
- Excludes external URLs (e.g. `https://slack.com/api/...`)
- Enabled as `error` in platform eslint config

## Test plan

- [x] ESLint rule tests pass (11 test cases covering valid/invalid patterns)
- [x] Billing dialog tests pass (17 tests)
- [x] Connector card tests pass (12 tests)
- [x] Job detail tests pass (26 tests)
- [x] Fetch utility tests pass (13 tests)
- [x] Lint passes clean across core, web, and app packages
- [x] Type checking passes
- [x] Knip finds no unused exports

Closes #6109

🤖 Generated with [Claude Code](https://claude.com/claude-code)