### PR TITLE
feat(cli): add vm0 zero command group skeleton

### DIFF
--- a/turbo/apps/cli/src/commands/zero/index.ts
+++ b/turbo/apps/cli/src/commands/zero/index.ts
@@ -1,0 +1,5 @@
+import { Command } from "commander";
+
+export const zeroCommand = new Command("zero").description(
+  "Zero platform commands",
+);

--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -25,6 +25,7 @@ import { connectorCommand } from "./commands/connector";
 import { preferenceCommand } from "./commands/preference";
 import { upgradeCommand } from "./commands/upgrade";
 import { whoamiCommand } from "./commands/whoami";
+import { zeroCommand } from "./commands/zero";
 
 const program = new Command();
 
@@ -57,6 +58,7 @@ program.addCommand(connectorCommand);
 program.addCommand(preferenceCommand);
 program.addCommand(upgradeCommand);
 program.addCommand(whoamiCommand);
+program.addCommand(zeroCommand);
 
 export { program };
 


### PR DESCRIPTION
## Summary
- Register an empty `zero` subcommand group in the CLI as the foundation for all future `vm0 zero *` commands
- `vm0 zero` / `vm0 zero --help` shows help with description "Zero platform commands"
- No subcommands yet — future sub-issues will add: schedule, org, secret, variable, connector, preference

Closes #6118
Part of #6074

## Test plan
- [x] `pnpm turbo run lint` passes
- [x] `pnpm check-types` passes
- [x] `pnpm format` — no changes needed
- [x] `pnpm knip` — no unused exports
- [x] `pnpm vitest --run` — all tests pass (3 pre-existing billing test failures on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)