### PR TITLE
feat: deduplicate auto-generated firewalls against compose-declared firewalls

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/firewall-dedup.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/firewall-dedup.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { baseUrlCoveredBy, deduplicateAutoFirewalls } from "../build-context";
+
+describe("baseUrlCoveredBy", () => {
+  it("returns true for exact match", () => {
+    expect(
+      baseUrlCoveredBy("https://api.github.com", "https://api.github.com"),
+    ).toBe(true);
+  });
+
+  it("returns true when compose is a prefix at path boundary", () => {
+    expect(
+      baseUrlCoveredBy(
+        "https://www.googleapis.com/drive",
+        "https://www.googleapis.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when compose has trailing slash", () => {
+    expect(
+      baseUrlCoveredBy(
+        "https://api.github.com/repos",
+        "https://api.github.com/",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when compose has trailing slash and auto does not", () => {
+    expect(
+      baseUrlCoveredBy("https://api.github.com", "https://api.github.com/"),
+    ).toBe(true);
+  });
+
+  it("returns true when both have trailing slashes", () => {
+    expect(
+      baseUrlCoveredBy("https://api.github.com/", "https://api.github.com/"),
+    ).toBe(true);
+  });
+
+  it("returns false when auto is a prefix of compose", () => {
+    expect(
+      baseUrlCoveredBy(
+        "https://www.googleapis.com",
+        "https://www.googleapis.com/drive",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for partial segment match", () => {
+    expect(
+      baseUrlCoveredBy(
+        "https://api.github.com-evil.com",
+        "https://api.github.com",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for completely different URLs", () => {
+    expect(
+      baseUrlCoveredBy("https://api.anthropic.com", "https://slack.com/api"),
+    ).toBe(false);
+  });
+});
+
+describe("deduplicateAutoFirewalls", () => {
+  const mkFw = (name: string, bases: string[]) => ({
+    name,
+    apis: bases.map((base) => ({ base })),
+  });
+
+  it("returns all auto firewalls when no compose firewalls", () => {
+    const auto = [
+      mkFw("model-provider:anthropic", ["https://api.anthropic.com"]),
+    ];
+    expect(deduplicateAutoFirewalls(auto, [])).toEqual(auto);
+  });
+
+  it("drops auto firewall when compose covers same base URL", () => {
+    const auto = [
+      mkFw("model-provider:anthropic", ["https://api.anthropic.com"]),
+    ];
+    const compose = [mkFw("custom", ["https://api.anthropic.com"])];
+    expect(deduplicateAutoFirewalls(auto, compose)).toEqual([]);
+  });
+
+  it("drops auto firewall when compose covers base URL via prefix", () => {
+    const auto = [mkFw("auto:drive", ["https://www.googleapis.com/drive"])];
+    const compose = [mkFw("google", ["https://www.googleapis.com"])];
+    expect(deduplicateAutoFirewalls(auto, compose)).toEqual([]);
+  });
+
+  it("drops entire auto firewall when any base URL overlaps", () => {
+    const auto = [
+      mkFw("connector:github", [
+        "https://api.github.com",
+        "https://uploads.github.com",
+      ]),
+    ];
+    const compose = [mkFw("custom", ["https://api.github.com"])];
+    expect(deduplicateAutoFirewalls(auto, compose)).toEqual([]);
+  });
+
+  it("drops entire auto firewall when all base URLs overlap", () => {
+    const auto = [
+      mkFw("connector:github", [
+        "https://api.github.com",
+        "https://uploads.github.com",
+      ]),
+    ];
+    const compose = [
+      mkFw("gh-api", ["https://api.github.com"]),
+      mkFw("gh-uploads", ["https://uploads.github.com"]),
+    ];
+    expect(deduplicateAutoFirewalls(auto, compose)).toEqual([]);
+  });
+
+  it("keeps unrelated auto firewalls", () => {
+    const auto = [
+      mkFw("model-provider:anthropic", ["https://api.anthropic.com"]),
+      mkFw("connector:slack", ["https://slack.com/api"]),
+    ];
+    const compose = [mkFw("custom", ["https://api.anthropic.com"])];
+    expect(deduplicateAutoFirewalls(auto, compose)).toEqual([
+      mkFw("connector:slack", ["https://slack.com/api"]),
+    ]);
+  });
+});

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -892,6 +892,54 @@ interface BuildContextResult {
 }
 
 /**
+ * Check if a compose base URL covers an auto-generated base URL.
+ * A compose URL covers an auto URL when the auto URL starts with the compose URL
+ * (with a path-boundary check so "https://a.com/x" covers "https://a.com/x/y"
+ * but not "https://a.com/xy").
+ *
+ * @internal Exported for testing.
+ */
+export function baseUrlCoveredBy(
+  autoBase: string,
+  composeBase: string,
+): boolean {
+  // Strip trailing slashes for consistent comparison
+  const a = autoBase.replace(/\/+$/, "");
+  const c = composeBase.replace(/\/+$/, "");
+  if (a === c) return true;
+  return a.startsWith(c + "/");
+}
+
+/**
+ * Drop auto-generated firewalls when ANY of their API base URLs overlap with
+ * a compose-declared firewall. A single overlapping base URL means the user
+ * is managing that service's firewall — the entire auto firewall is dropped.
+ *
+ * @internal Exported for testing.
+ */
+export function deduplicateAutoFirewalls<
+  T extends { name: string; apis: { base: string }[] },
+>(autoFirewalls: T[], composeFirewalls: { apis: { base: string }[] }[]): T[] {
+  if (composeFirewalls.length === 0) return autoFirewalls;
+
+  const composeBases = composeFirewalls.flatMap((fw) =>
+    fw.apis.map((api) => api.base),
+  );
+
+  return autoFirewalls.filter((autoFw) => {
+    const covered = autoFw.apis.some((api) =>
+      composeBases.some((cb) => baseUrlCoveredBy(api.base, cb)),
+    );
+    if (covered) {
+      log.debug(
+        `Skipping auto-generated firewall "${autoFw.name}" — base URL overlaps with compose firewalls`,
+      );
+    }
+    return !covered;
+  });
+}
+
+/**
  * Build ExperimentalFirewalls manifest from agent compose's expanded experimental_firewalls.
  * Returns null if no firewall configs are declared.
  *
@@ -1073,10 +1121,14 @@ export async function buildExecutionContext(
 
   // Build experimental firewall manifest (base + auth entries for the runner).
   // Merge compose-declared firewalls with auto-generated model provider firewall.
+  // Auto-generated firewalls are skipped when compose already covers the same
+  // base URLs (prefix match — compose "https://api.x.com" covers auto
+  // "https://api.x.com/v1" but not vice versa).
   const composeFirewalls = buildExperimentalFirewalls(agentCompose);
+  const autoFirewalls = modelProviderFirewall ? [modelProviderFirewall] : [];
   const allFirewalls = [
     ...(composeFirewalls ?? []),
-    ...(modelProviderFirewall ? [modelProviderFirewall] : []),
+    ...deduplicateAutoFirewalls(autoFirewalls, composeFirewalls ?? []),
   ];
   const experimentalFirewalls =
     allFirewalls.length > 0 ? allFirewalls : undefined;


### PR DESCRIPTION
## Summary
- Add `deduplicateAutoFirewalls()` to drop auto-generated firewall entries when any of their API base URLs overlap with compose-declared firewalls
- Prevents duplicate proxy rules when users explicitly manage a service's firewall in `vm0.yaml`
- `baseUrlCoveredBy()` uses path-prefix matching with boundary checks (compose `https://a.com` covers auto `https://a.com/v1`, but `https://a.com/x` does not cover `https://a.com/xy`)
- Prepares for connector auto-firewall (#6107) — the dedup function is generic and handles both model provider and connector firewalls

## Test plan
- [x] 14 unit tests covering: exact match, prefix match, trailing slash normalization, partial segment defense, any-overlap drop, selective filtering
- [x] All 145 existing tests pass with no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)