### PR TITLE
feat(platform): add delete confirmation dialog for schedules

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
@@ -151,3 +151,166 @@ describe("zero job detail page", () => {
     });
   });
 });
+
+function mockAPIsWithSchedules() {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json({
+        composes: [
+          {
+            id: "mock-compose-id",
+            name: "zero",
+            displayName: null,
+            description: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+            isOwner: true,
+          },
+          {
+            id: "agent-detail-id",
+            name: "my-agent",
+            displayName: "My Agent",
+            description: "A helpful agent",
+            headVersionId: "version_2",
+            updatedAt: "2024-01-02T00:00:00Z",
+            isOwner: false,
+          },
+        ],
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    http.get("*/api/zero/composes", () => {
+      return HttpResponse.json({
+        id: "agent-detail-id",
+        name: "my-agent",
+        content: {
+          agents: {
+            "my-agent": {
+              description: "A helpful agent",
+              framework: null,
+            },
+          },
+        },
+      });
+    }),
+    http.get("*/api/zero/agents/:name/instructions", () => {
+      return HttpResponse.json({ instructions: null });
+    }),
+    http.get("*/api/zero/schedules", () => {
+      return HttpResponse.json({
+        schedules: [
+          {
+            id: "sched-1",
+            composeId: "agent-detail-id",
+            composeName: "my-agent",
+            orgSlug: "test",
+            name: "morning-briefing",
+            triggerType: "cron",
+            cronExpression: "0 9 * * 1-5",
+            atTime: null,
+            intervalSeconds: null,
+            timezone: "UTC",
+            prompt: "Summarize yesterday's threads",
+            description: null,
+            enabled: true,
+            notifyEmail: false,
+            notifySlack: false,
+            nextRunAt: null,
+            lastRunAt: null,
+            createdAt: "2026-03-01T00:00:00Z",
+            updatedAt: "2026-03-01T00:00:00Z",
+          },
+        ],
+      });
+    }),
+  );
+}
+
+describe("zero job detail page - schedule card delete confirmation", () => {
+  it("should show confirmation dialog when delete button is clicked in card view", async () => {
+    mockAPIsWithSchedules();
+    await setupPage({ context, path: "/team/my-agent?tab=schedule" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Delete Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Delete Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    });
+    expect(screen.getByText("morning-briefing")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  it("should close dialog without deleting when Cancel is clicked in card view", async () => {
+    let deleteCalled = false;
+
+    mockAPIsWithSchedules();
+    server.use(
+      http.delete("*/api/zero/schedules/:name", () => {
+        deleteCalled = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await setupPage({ context, path: "/team/my-agent?tab=schedule" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Delete Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Delete Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Delete schedule?")).not.toBeInTheDocument();
+    });
+    expect(deleteCalled).toBeFalsy();
+  });
+
+  it("should call delete API when Delete is confirmed in card view", async () => {
+    let deletedName: string | null = null;
+
+    mockAPIsWithSchedules();
+    server.use(
+      http.delete("*/api/zero/schedules/:name", ({ params }) => {
+        deletedName = params["name"] as string;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await setupPage({ context, path: "/team/my-agent?tab=schedule" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Delete Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Delete Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(deletedName).toBe("morning-briefing");
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -332,7 +332,7 @@ describe("zero schedule page - delete confirmation", () => {
     await waitFor(() => {
       expect(screen.queryByText("Delete schedule?")).not.toBeInTheDocument();
     });
-    expect(deleteCalled).toBe(false);
+    expect(deleteCalled).toBeFalsy();
   });
 
   it("should call delete API when Delete is confirmed", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -276,6 +276,103 @@ describe("zero schedule page - toggle enabled", () => {
   });
 });
 
+describe("zero schedule page - delete confirmation", () => {
+  it("should show confirmation dialog when delete button is clicked", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Delete Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Delete Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    });
+    expect(screen.getByText("morning-briefing")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  it("should close dialog without deleting when Cancel is clicked", async () => {
+    let deleteCalled = false;
+
+    server.use(
+      http.get("*/api/zero/schedules", () => {
+        return HttpResponse.json({ schedules: createMockSchedules() });
+      }),
+      http.delete("*/api/zero/schedules/:name", () => {
+        deleteCalled = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Delete Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Delete Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Delete schedule?")).not.toBeInTheDocument();
+    });
+    expect(deleteCalled).toBe(false);
+  });
+
+  it("should call delete API when Delete is confirmed", async () => {
+    let deletedName: string | null = null;
+
+    server.use(
+      http.get("*/api/zero/schedules", () => {
+        return HttpResponse.json({ schedules: createMockSchedules() });
+      }),
+      http.delete("*/api/zero/schedules/:name", ({ params }) => {
+        deletedName = params["name"] as string;
+        return new HttpResponse(null, { status: 204 });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Delete Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Delete Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(deletedName).toBe("morning-briefing");
+    });
+  });
+});
+
 describe("zero schedule page - view modes", () => {
   it("should render list and calendar view tabs", async () => {
     mockScheduleAPI();

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useGet, useSet } from "ccstate-react";
 import {
   scheduleViewMode$,
@@ -151,15 +152,44 @@ function DeleteButton({
   label: string;
   onDelete: (name: string) => Promise<void>;
 }) {
+  const [open, setOpen] = useState(false);
   return (
-    <button
-      type="button"
-      onClick={() => void onDelete(name)}
-      className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive focus:outline-none focus-visible:ring-2 focus-visible:ring-ring shrink-0"
-      aria-label={`Delete ${label}`}
-    >
-      <IconTrash size={14} stroke={1.5} />
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-destructive focus:outline-none focus-visible:ring-2 focus-visible:ring-ring shrink-0"
+        aria-label={`Delete ${label}`}
+      >
+        <IconTrash size={14} stroke={1.5} />
+      </button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete schedule?</DialogTitle>
+            <p className="text-sm text-muted-foreground mt-1">
+              This will permanently delete the schedule{" "}
+              <span className="font-medium text-foreground">{name}</span>. This
+              action cannot be undone.
+            </p>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setOpen(false);
+                detach(onDelete(name), Reason.DomCallback);
+              }}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -1113,6 +1113,9 @@ export function ZeroSchedulePage() {
   const [editingEntry, setEditingEntry] = useState<CombinedEntry | null>(null);
   const [saving, setSaving] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<CombinedEntry | null>(
+    null,
+  );
 
   const combinedSchedule = buildCombinedSchedule(
     entries,
@@ -1176,10 +1179,21 @@ export function ZeroSchedulePage() {
     if (entry.name === undefined) {
       return;
     }
+    setPendingDelete(entry);
+  };
+
+  const confirmDelete = () => {
+    if (pendingDelete?.name === undefined) {
+      return;
+    }
     detach(
-      deleteSchedule({ name: entry.name, composeId: entry.composeId }),
+      deleteSchedule({
+        name: pendingDelete.name,
+        composeId: pendingDelete.composeId,
+      }),
       Reason.DomCallback,
     );
+    setPendingDelete(null);
   };
 
   return (
@@ -1276,6 +1290,35 @@ export function ZeroSchedulePage() {
         agents={agents}
         defaultComposeId={defaultComposeId}
       />
+      <Dialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingDelete(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete schedule?</DialogTitle>
+            <p className="text-sm text-muted-foreground mt-1">
+              This will permanently delete the schedule{" "}
+              <span className="font-medium text-foreground">
+                {pendingDelete?.name}
+              </span>
+              . This action cannot be undone.
+            </p>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingDelete(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add confirmation dialog before deleting schedules in both `zero-schedule-card.tsx` and `zero-schedule-page.tsx`
- Prevents accidental deletion by requiring explicit user confirmation
- Uses the same `Dialog` + `Button variant="destructive"` pattern as existing confirmation dialogs in the codebase

## Test plan
- [ ] Open schedule card view, click delete on a schedule → confirmation dialog appears
- [ ] Click Cancel → dialog closes, schedule is not deleted
- [ ] Click Delete → dialog closes, schedule is deleted
- [ ] Open schedule page (calendar/list view), click delete → same confirmation flow
- [ ] Verify dialog shows the correct schedule name

🤖 Generated with [Claude Code](https://claude.com/claude-code)