### PR TITLE
fix(platform): refresh activity list on navigation

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-page-setup.ts
@@ -5,11 +5,12 @@ import { updatePage$ } from "../react-router.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
 import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
-import { initZeroActivity$ } from "./activity-signals.ts";
+import { initZeroActivity$, refreshZeroActivity$ } from "./activity-signals.ts";
 
 export const setupActivityPage$ = command(
   async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroActivityPageWrapper));
+    set(refreshZeroActivity$);
     await Promise.all([
       set(fetchAgentsList$),
       set(initZeroOnboarding$, signal),

--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -86,6 +86,7 @@ export const initZeroActivity$ = command(async ({ set }) => {
 export const {
   limit$: zeroActivityLimit$,
   data$: zeroActivityData$,
+  refresh$: refreshZeroActivity$,
   seedCursorHistory$: seedZeroActivityCursorHistory$,
   hasPrev$: zeroActivityHasPrev$,
   currentPage$: zeroActivityCurrentPage$,

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-refresh.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-refresh.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function makeLogsResponse(
+  data: {
+    id: string;
+    agentName: string;
+    displayName: string;
+    status: string;
+  }[],
+) {
+  return {
+    data: data.map((d) => ({
+      ...d,
+      sessionId: `session-${d.id}`,
+      orgSlug: "test",
+      framework: "claude-code",
+      triggerSource: "web",
+      createdAt: "2026-03-10T14:56:00Z",
+      startedAt: "2026-03-10T14:56:01Z",
+      completedAt: "2026-03-10T14:56:10Z",
+    })),
+    pagination: { hasMore: false, nextCursor: null, totalPages: 1 },
+    filters: { statuses: ["completed"], sources: ["web"], agents: ["zero"] },
+  };
+}
+
+function mockCommonAPIs() {
+  server.use(
+    http.get("*/api/zero/composes/list", () => {
+      return HttpResponse.json({
+        composes: [{ name: "zero", displayName: "Zero" }],
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("activity list refresh on navigation", () => {
+  it("should refresh data when navigating back to the activity page", async () => {
+    let fetchCount = 0;
+
+    mockCommonAPIs();
+
+    server.use(
+      http.get("*/api/zero/logs", () => {
+        fetchCount++;
+        return HttpResponse.json(
+          makeLogsResponse([
+            {
+              id: `run-${fetchCount}`,
+              agentName: "zero",
+              displayName: "Zero",
+              status: "completed",
+            },
+          ]),
+        );
+      }),
+    );
+
+    // Navigate to activity page
+    await setupPage({ context, path: "/activity" });
+
+    // Wait for the activity heading and list data to render
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("heading", { name: "Activity" }),
+        ).toBeInTheDocument();
+        expect(screen.getAllByText("Zero").length).toBeGreaterThanOrEqual(1);
+      },
+      { timeout: 5000 },
+    );
+
+    const initialFetchCount = fetchCount;
+
+    // Navigate to team page via sidebar
+    const teamLink = screen.getByText("Zero's team").closest("a");
+    expect(teamLink).not.toBeNull();
+    fireEvent.click(teamLink!);
+
+    // Wait for team page to render
+    await waitFor(
+      () => {
+        expect(
+          screen.queryByRole("heading", { name: "Activity" }),
+        ).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    // Navigate back to activity page
+    const activityLink = screen.getByText("Activity logs").closest("a");
+    expect(activityLink).not.toBeNull();
+    fireEvent.click(activityLink!);
+
+    // Wait for the list to render again
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("heading", { name: "Activity" }),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // Wait for data to be fetched again
+    await waitFor(
+      () => {
+        expect(screen.getAllByText("Zero").length).toBeGreaterThanOrEqual(1);
+      },
+      { timeout: 5000 },
+    );
+
+    // Verify that a new fetch was triggered after re-navigation
+    expect(fetchCount).toBeGreaterThan(initialFetchCount);
+  }, 20_000);
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -269,12 +269,17 @@ export function ZeroActivityPage() {
                   </div>
                 )}
                 {isLoading ? (
-                  <div className="flex items-center justify-center min-h-[20rem]">
-                    <IconLoader2
-                      size={20}
-                      stroke={1.5}
-                      className="animate-spin text-muted-foreground"
-                    />
+                  <div className="divide-y divide-border/40">
+                    {Array.from({ length: rowsPerPage }, (_, i) => (
+                      <div key={i} className={cn(ROW_GRID, "py-3")}>
+                        <div className="h-4 w-20 rounded bg-muted/50 animate-pulse" />
+                        <div className="h-4 w-12 rounded bg-muted/50 animate-pulse" />
+                        <div className="h-5 w-16 rounded-full bg-muted/50 animate-pulse" />
+                        <div className="h-4 w-24 rounded bg-muted/50 animate-pulse" />
+                        <div className="h-4 w-14 rounded bg-muted/50 animate-pulse" />
+                        <div />
+                      </div>
+                    ))}
                   </div>
                 ) : logs.length === 0 ? (
                   <div className="flex flex-col items-center justify-center min-h-[20rem] gap-4">


### PR DESCRIPTION
## Summary
- Activity list now re-fetches data when navigating back to the page via sidebar, instead of showing stale cached results
- Replace the loading spinner with skeleton rows that match the table layout for a smoother loading experience
- Export and call `refreshZeroActivity$` (bumps `refreshTick$`) in `setupActivityPage$` before async setup, so the data request starts immediately while the skeleton is visible

## Test plan
- [ ] Navigate to Activity logs → see skeleton → data loads
- [ ] Navigate away (e.g. Zero's team) → navigate back to Activity logs → list re-fetches with skeleton, not stale data
- [ ] `pnpm vitest run activity-refresh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)