### PR TITLE
feat(api): add zero org list endpoint

### DIFF
--- a/turbo/apps/web/app/api/zero/org/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/list/__tests__/route.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { GET } from "../route";
+
+const context = testContext();
+
+describe("GET /api/zero/org/list", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/org/list",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns list of user orgs", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/org/list",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.orgs).toBeInstanceOf(Array);
+    expect(data.orgs.length).toBeGreaterThanOrEqual(1);
+    expect(data.orgs[0]).toHaveProperty("slug");
+    expect(data.orgs[0]).toHaveProperty("role");
+  });
+
+  it("returns multiple orgs when user belongs to several", async () => {
+    const userId = uniqueId("multi-org");
+    mockClerk({
+      userId,
+      clerkOrgs: [
+        {
+          id: "org_1",
+          slug: "team-alpha",
+          name: "Team Alpha",
+          role: "org:admin",
+        },
+        {
+          id: "org_2",
+          slug: "team-beta",
+          name: "Team Beta",
+          role: "org:member",
+        },
+      ],
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/org/list",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.orgs).toHaveLength(2);
+    expect(data.orgs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ slug: "team-alpha", role: "admin" }),
+        expect.objectContaining({ slug: "team-beta", role: "member" }),
+      ]),
+    );
+  });
+});

--- a/turbo/apps/web/app/api/zero/org/list/route.ts
+++ b/turbo/apps/web/app/api/zero/org/list/route.ts
@@ -1,0 +1,34 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroOrgListContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { getUserAccessibleOrgs } from "../../../../../src/lib/org/org-member-service";
+
+const router = tsr.router(zeroOrgListContract, {
+  list: async ({ headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgs = await getUserAccessibleOrgs(authCtx.userId);
+
+    return {
+      status: 200 as const,
+      body: { orgs, active: undefined },
+    };
+  },
+});
+
+const handler = createHandler(zeroOrgListContract, router, {
+  errorHandler: createSafeErrorHandler("zero-org-list"),
+});
+
+export { handler as GET };

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -576,6 +576,7 @@ export {
   type ZeroOrgLeaveContract,
   type ZeroOrgDeleteContract,
 } from "./zero-org";
+export { zeroOrgListContract, type ZeroOrgListContract } from "./zero-org-list";
 export {
   zeroOrgMembersContract,
   zeroOrgInviteContract,

--- a/turbo/packages/core/src/contracts/zero-org-list.ts
+++ b/turbo/packages/core/src/contracts/zero-org-list.ts
@@ -1,0 +1,25 @@
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import { orgListResponseSchema } from "./org-list";
+
+const c = initContract();
+
+/**
+ * Zero contract for GET /api/zero/org/list
+ * Lists all accessible orgs for the authenticated user.
+ */
+export const zeroOrgListContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/org/list",
+    headers: authHeadersSchema,
+    responses: {
+      200: orgListResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List all accessible orgs for the authenticated user",
+  },
+});
+
+export type ZeroOrgListContract = typeof zeroOrgListContract;


### PR DESCRIPTION
## Summary

- Add `GET /api/zero/org/list` endpoint that lists all accessible organizations for the authenticated user
- Create `zeroOrgListContract` in `@vm0/core`, reusing `orgListResponseSchema` for consistency with legacy endpoint
- Implement route handler using `requireAuth()` + `getUserAccessibleOrgs()` (no org-scoped resolution needed)
- Add integration tests covering authentication, single org, and multi-org scenarios

Closes #6139
Part of Epic #6129

## Test plan

- [x] Integration test: returns 401 for unauthenticated requests
- [x] Integration test: returns org list with slug and role fields
- [x] Integration test: returns multiple orgs with correct admin/member role mapping
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)