### PR TITLE
fix: clean up generator types and error handling

### DIFF
--- a/turbo/packages/firewalls-generator/src/confluence.ts
+++ b/turbo/packages/firewalls-generator/src/confluence.ts
@@ -38,7 +38,7 @@ interface OpenApiOperation {
   security?: Array<Record<string, string[]>>;
 }
 
-type OpenApiPathItem = Record<string, OpenApiOperation | unknown>;
+type OpenApiPathItem = Record<string, unknown>;
 
 interface OpenApiSpec {
   info?: { version?: string };

--- a/turbo/packages/firewalls-generator/src/jira.ts
+++ b/turbo/packages/firewalls-generator/src/jira.ts
@@ -38,7 +38,7 @@ interface OpenApiOperation {
   security?: Array<Record<string, string[]>>;
 }
 
-type OpenApiPathItem = Record<string, OpenApiOperation | unknown>;
+type OpenApiPathItem = Record<string, unknown>;
 
 interface OpenApiSpec {
   info?: { version?: string };

--- a/turbo/packages/firewalls-generator/src/notion.ts
+++ b/turbo/packages/firewalls-generator/src/notion.ts
@@ -28,7 +28,7 @@ interface OpenApiOperation {
   tags?: string[];
 }
 
-type OpenApiPathItem = Record<string, OpenApiOperation | unknown>;
+type OpenApiPathItem = Record<string, unknown>;
 
 interface OpenApiSpec {
   info?: { version?: string };
@@ -190,11 +190,17 @@ function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
   return [...groups.entries()]
     .filter(([, ruleSet]) => ruleSet.size > 0)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([name, ruleSet]) => ({
-      name,
-      description: CAPABILITY_DESCRIPTIONS[name] ?? "",
-      rules: sortRules([...ruleSet]),
-    }));
+    .map(([name, ruleSet]) => {
+      const description = CAPABILITY_DESCRIPTIONS[name];
+      if (!description) {
+        throw new Error(`Unknown capability: ${name}`);
+      }
+      return {
+        name,
+        description,
+        rules: sortRules([...ruleSet]),
+      };
+    });
 }
 
 // ── TypeScript generation ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Remove misleading `OpenApiOperation | unknown` type union (collapses to `unknown`) in confluence, jira, and notion generators — replaced with `Record<string, unknown>`
- Throw on unknown capability in notion generator instead of silently falling back to empty description (notion capabilities are a fixed set of 6, unlike OAuth scopes from external specs)

## Test plan
- [ ] `pnpm -F @vm0/firewalls-generator check-types` passes
- [ ] Generated output unchanged (type-only refactor + unreachable error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)