### PR TITLE
feat: confirm before closing schedule dialog with unsaved edits

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/schedule-card.ts
+++ b/turbo/apps/platform/src/signals/zero-page/schedule-card.ts
@@ -35,37 +35,6 @@ export const { get$: editingScheduleId$, set$: setEditingScheduleId$ } = cell<
   string | null
 >(null);
 
-export const { get$: newSchedulePrompt$, set$: setNewSchedulePrompt$ } =
-  cell("");
-
-export const { get$: scheduleFreq$, set$: setScheduleFreq$ } =
-  cell<string>("every_day");
-
-export const { get$: scheduleDate$, set$: setScheduleDate$ } = cell<string>(
-  new Date().toISOString().slice(0, 10),
-);
-
-export const { get$: scheduleHour$, set$: setScheduleHour$ } = cell(9);
-
-export const { get$: scheduleMinute$, set$: setScheduleMinute$ } = cell(0);
-
-export const { get$: scheduleTimezone$, set$: setScheduleTimezone$ } =
-  cell("UTC");
-
-export const { get$: scheduleIntervalStr$, set$: setScheduleIntervalStr$ } =
-  cell("300");
-
-export const { get$: scheduleDayOfWeek$, set$: setScheduleDayOfWeek$ } =
-  cell("1");
-
-export const { get$: scheduleDayOfMonth$, set$: setScheduleDayOfMonth$ } =
-  cell("1");
-
-export const {
-  get$: newScheduleDescription$,
-  set$: setNewScheduleDescription$,
-} = cell("");
-
 export const { get$: saveError$, set$: setSaveError$ } = cell<string | null>(
   null,
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -204,7 +204,7 @@ export const fetchZeroSchedules$ = command(async ({ get, set }) => {
 // Save schedule (create or update)
 // ---------------------------------------------------------------------------
 
-export interface ZeroScheduleSaveParams {
+interface ZeroScheduleSaveParams {
   prompt: string;
   description?: string;
   freq: string;

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -204,7 +204,7 @@ export const fetchZeroSchedules$ = command(async ({ get, set }) => {
 // Save schedule (create or update)
 // ---------------------------------------------------------------------------
 
-interface ZeroScheduleSaveParams {
+export interface ZeroScheduleSaveParams {
   prompt: string;
   description?: string;
   freq: string;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
@@ -417,6 +417,39 @@ describe("zero schedule page - edit dialog confirm close", () => {
     ).toBeInTheDocument();
   });
 
+  it("should show confirm overlay when ESC key is pressed with unsaved changes", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    const promptInput = screen.getByLabelText("Prompt");
+    fireEvent.change(promptInput, {
+      target: { value: "Changed prompt text" },
+    });
+
+    // Press ESC key on the dialog content
+    const dialogContent = screen
+      .getByText("Edit schedule")
+      .closest("[role=dialog]");
+    fireEvent.keyDown(dialogContent!, { key: "Escape" });
+
+    // Confirm overlay should appear
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+  });
+
   it("should close dialog directly when Cancel is clicked without changes", async () => {
     mockScheduleAPI();
     await renderSchedulePage();
@@ -734,13 +767,9 @@ describe("zero schedule page - schedule dialog fields", () => {
     });
 
     // Toggle email notification on
-    const emailSwitch = screen
-      .getByText("Email")
-      .closest("div")
-      ?.querySelector("[role=switch]");
-    if (emailSwitch) {
-      fireEvent.click(emailSwitch);
-    }
+    const emailRow = screen.getByText("Email").parentElement!;
+    const emailSwitch = within(emailRow).getByRole("switch");
+    fireEvent.click(emailSwitch);
 
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -186,7 +186,9 @@ describe("zero schedule page - create dialog", () => {
     fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("New schedule")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
     });
     expect(screen.getByLabelText("Prompt")).toBeInTheDocument();
   });
@@ -219,7 +221,9 @@ describe("zero schedule page - create dialog", () => {
     fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("New schedule")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
     });
 
     // Fill in prompt
@@ -370,6 +374,213 @@ describe("zero schedule page - delete confirmation", () => {
     await waitFor(() => {
       expect(deletedName).toBe("morning-briefing");
     });
+  });
+});
+
+describe("zero schedule page - edit dialog confirm close", () => {
+  it("should show confirm overlay when Cancel is clicked with unsaved changes", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    // Wait for schedule list
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    // Open edit dialog
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    // Modify the prompt
+    const promptInput = screen.getByLabelText("Prompt");
+    fireEvent.change(promptInput, {
+      target: { value: "Changed prompt text" },
+    });
+
+    // Click Cancel
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // Confirm overlay should appear
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: "Continue Editing" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Discard Changes" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should close dialog directly when Cancel is clicked without changes", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    // Click Cancel without making changes
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // Dialog should close immediately
+    await waitFor(() => {
+      expect(screen.queryByText("Edit schedule")).not.toBeInTheDocument();
+    });
+    // No confirm overlay
+    expect(
+      screen.queryByText("You have unsaved changes"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should return to editing when Continue Editing is clicked", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    const promptInput = screen.getByLabelText("Prompt");
+    fireEvent.change(promptInput, {
+      target: { value: "Changed prompt text" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+
+    // Click Continue Editing
+    fireEvent.click(screen.getByRole("button", { name: "Continue Editing" }));
+
+    // Confirm overlay dismissed, dialog still open with edits preserved
+    await waitFor(() => {
+      expect(
+        screen.queryByText("You have unsaved changes"),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+  });
+
+  it("should close dialog when Discard Changes is clicked", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    const promptInput = screen.getByLabelText("Prompt");
+    fireEvent.change(promptInput, {
+      target: { value: "Changed prompt text" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+
+    // Click Discard Changes
+    fireEvent.click(screen.getByRole("button", { name: "Discard Changes" }));
+
+    // Dialog should close
+    await waitFor(() => {
+      expect(screen.queryByText("Edit schedule")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero schedule page - create dialog confirm close", () => {
+  it("should show confirm overlay when Cancel is clicked with prompt text", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Add schedule/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    const promptInput = screen.getByLabelText("Prompt");
+    fireEvent.change(promptInput, {
+      target: { value: "Some new task" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+  });
+
+  it("should close create dialog directly when Cancel is clicked without changes", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Add schedule/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Add schedule" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("You have unsaved changes"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -584,6 +584,260 @@ describe("zero schedule page - create dialog confirm close", () => {
   });
 });
 
+describe("zero schedule page - schedule dialog fields", () => {
+  it("should show agent selector in create dialog", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Add schedule/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText("Agent")).toBeInTheDocument();
+  });
+
+  it("should show notification toggles in create dialog", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Add schedule/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+    expect(screen.getByText("Email")).toBeInTheDocument();
+    expect(screen.getByText("Slack")).toBeInTheDocument();
+  });
+
+  it("should show notification toggles in edit dialog", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+    expect(screen.getByText("Email")).toBeInTheDocument();
+    expect(screen.getByText("Slack")).toBeInTheDocument();
+  });
+
+  it("should disable Create button when prompt is empty", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Add schedule/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
+  });
+
+  it("should enable Create button when prompt is filled", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Add schedule/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Prompt"), {
+      target: { value: "Do something" },
+    });
+
+    expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
+  });
+
+  it("should include notification values in save request", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get("*/api/zero/schedules", () => {
+        return HttpResponse.json({ schedules: createMockSchedules() });
+      }),
+      http.post("*/api/zero/schedules", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ success: true });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Add schedule/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    // Fill prompt
+    fireEvent.change(screen.getByLabelText("Prompt"), {
+      target: { value: "Test with notifications" },
+    });
+
+    // Toggle email notification on
+    const emailSwitch = screen
+      .getByText("Email")
+      .closest("div")
+      ?.querySelector("[role=switch]");
+    if (emailSwitch) {
+      fireEvent.click(emailSwitch);
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(capturedBody).toBeTruthy();
+    });
+    expect(capturedBody).toHaveProperty("notifyEmail", true);
+    expect(capturedBody).toHaveProperty("notifySlack", false);
+  });
+
+  it("should show save error in dialog", async () => {
+    server.use(
+      http.get("*/api/zero/schedules", () => {
+        return HttpResponse.json({ schedules: createMockSchedules() });
+      }),
+      http.post("*/api/zero/schedules", () => {
+        return HttpResponse.json(
+          { error: { message: "Schedule limit reached" } },
+          { status: 400 },
+        );
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Add schedule/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add schedule/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Prompt"), {
+      target: { value: "Some task" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    // Dialog should stay open with error message
+    await waitFor(() => {
+      expect(screen.getByText(/Schedule limit reached/)).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("heading", { name: "Add schedule" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should pre-fill prompt when editing an existing schedule", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    const promptInput = screen.getByLabelText("Prompt") as HTMLTextAreaElement;
+    expect(promptInput.value).toBe("Summarize yesterday's threads");
+  });
+
+  it("should not show agent selector in edit dialog", async () => {
+    mockScheduleAPI();
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText("Agent")).not.toBeInTheDocument();
+  });
+});
+
 describe("zero schedule page - view modes", () => {
   it("should render list and calendar view tabs", async () => {
     mockScheduleAPI();

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -1,0 +1,741 @@
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { IconX } from "@tabler/icons-react";
+import {
+  Button,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui";
+import { Switch } from "@vm0/ui/components/ui/switch";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@vm0/ui/components/ui/dialog";
+import {
+  COMMON_TIMEZONES,
+  getTodayDateLocal,
+} from "../../signals/zero-page/cron.ts";
+
+// ---------------------------------------------------------------------------
+// Constants (moved from zero-schedule-card.tsx)
+// ---------------------------------------------------------------------------
+
+const SCHEDULE_FREQUENCY_OPTIONS = [
+  { value: "now", label: "Now" },
+  { value: "once", label: "Once" },
+  { value: "every_weekday", label: "Every weekday" },
+  { value: "every_day", label: "Every day" },
+  { value: "every_week", label: "Every week" },
+  { value: "every_month", label: "Every month" },
+  { value: "every_n_minutes", label: "Loop" },
+] as const;
+
+const SCHEDULE_LOOP_MINUTES = [5, 15, 30, 60] as const;
+
+const HOUR_OPTIONS: readonly number[] = Array.from({ length: 24 }, (_, i) => i);
+
+const MINUTE_OPTIONS: readonly number[] = Array.from(
+  { length: 12 },
+  (_, i) => i * 5,
+);
+
+/**
+ * Build the minute dropdown options, inserting a non-standard value (e.g. an
+ * existing schedule whose minute is not a multiple of 5) so the schedule
+ * remains editable.
+ */
+function getMinuteOptions(currentMinute?: number): readonly number[] {
+  if (currentMinute === undefined || MINUTE_OPTIONS.includes(currentMinute)) {
+    return MINUTE_OPTIONS;
+  }
+  return [...MINUTE_OPTIONS, currentMinute].sort((a, b) => a - b);
+}
+
+function isCronFreq(f: string): boolean {
+  return (
+    f === "once" ||
+    f === "every_weekday" ||
+    f === "every_day" ||
+    f === "every_week" ||
+    f === "every_month"
+  );
+}
+
+const DAY_OF_WEEK_OPTIONS = [
+  ["1", "Mon"],
+  ["2", "Tue"],
+  ["3", "Wed"],
+  ["4", "Thu"],
+  ["5", "Fri"],
+  ["6", "Sat"],
+  ["0", "Sun"],
+] as const;
+
+function getLoopMinuteOptions(current: number): readonly number[] {
+  if ((SCHEDULE_LOOP_MINUTES as readonly number[]).includes(current)) {
+    return SCHEDULE_LOOP_MINUTES;
+  }
+  return [...SCHEDULE_LOOP_MINUTES, current].sort((a, b) => a - b);
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ScheduleFormValues {
+  prompt: string;
+  description: string;
+  composeId: string;
+  freq: string;
+  date: string;
+  hour: number;
+  minute: number;
+  timezone: string;
+  loopMinutes: number;
+  dayOfWeek: string;
+  dayOfMonth: string;
+  notifyEmail: boolean;
+  notifySlack: boolean;
+}
+
+interface ScheduleFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (values: ScheduleFormValues) => void;
+  saving: boolean;
+  mode: "create" | "edit";
+  initialValues?: Partial<ScheduleFormValues>;
+  /** When provided, renders an agent selector dropdown. */
+  agents?: { id: string; name: string; displayName?: string | null }[];
+  /** Error message displayed above the footer. */
+  saveError?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Confirm-close overlay
+// ---------------------------------------------------------------------------
+
+function ConfirmCloseOverlay({
+  onDiscard,
+  onContinue,
+}: {
+  onDiscard: () => void;
+  onContinue: () => void;
+}) {
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ pointerEvents: "auto" }}
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="confirm-close-title"
+      aria-describedby="confirm-close-desc"
+    >
+      <div
+        className="fixed inset-0 bg-black/50 dark:bg-black/70"
+        onClick={onContinue}
+        role="presentation"
+      />
+      <div className="relative z-10 mx-4 max-w-sm rounded-lg border border-border bg-card p-6 shadow-xl">
+        <p
+          id="confirm-close-title"
+          className="text-sm font-medium text-foreground mb-1"
+        >
+          You have unsaved changes
+        </p>
+        <p
+          id="confirm-close-desc"
+          className="text-sm text-muted-foreground mb-4"
+        >
+          Are you sure you want to close? Your changes will be lost.
+        </p>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={onContinue}>
+            Continue Editing
+          </Button>
+          <Button variant="destructive" size="sm" onClick={onDiscard}>
+            Discard Changes
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Timing fields sub-component
+// ---------------------------------------------------------------------------
+
+function ScheduleTimingFields({
+  freq,
+  setFreq,
+  loopMinutes,
+  setLoopMinutes,
+  date,
+  setDate,
+  dayOfWeek,
+  setDayOfWeek,
+  dayOfMonth,
+  setDayOfMonth,
+  hour,
+  setHour,
+  minute,
+  setMinute,
+  timezone,
+  setTimezone,
+}: {
+  freq: string;
+  setFreq: (v: string) => void;
+  loopMinutes: number;
+  setLoopMinutes: (v: number) => void;
+  date: string;
+  setDate: (v: string) => void;
+  dayOfWeek: string;
+  setDayOfWeek: (v: string) => void;
+  dayOfMonth: string;
+  setDayOfMonth: (v: string) => void;
+  hour: number;
+  setHour: (v: number) => void;
+  minute: number;
+  setMinute: (v: number) => void;
+  timezone: string;
+  setTimezone: (v: string) => void;
+}) {
+  return (
+    <>
+      {/* Frequency */}
+      <div className="flex flex-col gap-2">
+        <label
+          htmlFor="schedule-dialog-freq"
+          className="text-sm font-medium text-foreground"
+        >
+          Time
+        </label>
+        <Select value={freq} onValueChange={setFreq}>
+          <SelectTrigger id="schedule-dialog-freq" className="h-9">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {SCHEDULE_FREQUENCY_OPTIONS.map((opt) => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Loop interval */}
+      {freq === "every_n_minutes" && (
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="schedule-dialog-loop"
+            className="text-sm font-medium text-foreground"
+          >
+            Every
+          </label>
+          <Select
+            value={String(loopMinutes)}
+            onValueChange={(v) => setLoopMinutes(Number(v))}
+          >
+            <SelectTrigger id="schedule-dialog-loop" className="h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {getLoopMinuteOptions(loopMinutes).map((m) => (
+                <SelectItem key={m} value={String(m)}>
+                  {m} minutes
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Date (once) */}
+      {freq === "once" && (
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="schedule-dialog-date"
+            className="text-sm font-medium text-foreground"
+          >
+            Date
+          </label>
+          <Input
+            id="schedule-dialog-date"
+            type="date"
+            value={date}
+            min={getTodayDateLocal()}
+            onChange={(e) => setDate(e.target.value)}
+            className="h-9"
+          />
+        </div>
+      )}
+
+      {/* Day of week */}
+      {freq === "every_week" && (
+        <DayOfWeekPicker dayOfWeek={dayOfWeek} setDayOfWeek={setDayOfWeek} />
+      )}
+
+      {/* Day of month */}
+      {freq === "every_month" && (
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-foreground">
+            Day of month
+          </label>
+          <Select value={dayOfMonth} onValueChange={setDayOfMonth}>
+            <SelectTrigger className="h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Array.from({ length: 31 }, (_, i) => (
+                <SelectItem key={i + 1} value={String(i + 1)}>
+                  {i + 1}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Hour / minute */}
+      {freq !== "now" && freq !== "every_n_minutes" && (
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-foreground">Time</label>
+          <div className="flex items-center gap-2">
+            <Select
+              value={String(hour)}
+              onValueChange={(v) => setHour(Number(v))}
+            >
+              <SelectTrigger className="h-9 w-20">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {HOUR_OPTIONS.map((h) => (
+                  <SelectItem key={h} value={String(h)}>
+                    {h.toString().padStart(2, "0")}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <span className="text-muted-foreground">:</span>
+            <Select
+              value={String(minute)}
+              onValueChange={(v) => setMinute(Number(v))}
+            >
+              <SelectTrigger className="h-9 w-20">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {getMinuteOptions(minute).map((m) => (
+                  <SelectItem key={m} value={String(m)}>
+                    {m.toString().padStart(2, "0")}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      )}
+
+      {/* Timezone */}
+      {isCronFreq(freq) && (
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="schedule-dialog-tz"
+            className="text-sm font-medium text-foreground"
+          >
+            Timezone
+          </label>
+          <Select value={timezone} onValueChange={setTimezone}>
+            <SelectTrigger id="schedule-dialog-tz" className="h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {COMMON_TIMEZONES.map((tz) => (
+                <SelectItem key={tz} value={tz}>
+                  {tz.replace(/_/g, " ")}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Day of week picker sub-component
+// ---------------------------------------------------------------------------
+
+function DayOfWeekPicker({
+  dayOfWeek,
+  setDayOfWeek,
+}: {
+  dayOfWeek: string;
+  setDayOfWeek: (v: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-medium text-foreground">Day of week</label>
+      <div className="flex gap-1">
+        {DAY_OF_WEEK_OPTIONS.map(([value, label]) => {
+          const selected = dayOfWeek.split(",").includes(value);
+          return (
+            <button
+              key={value}
+              type="button"
+              className={`h-8 min-w-[40px] rounded-lg border text-xs font-medium transition-colors ${
+                selected
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-input bg-background text-muted-foreground hover:bg-muted"
+              }`}
+              onClick={() => {
+                const current = dayOfWeek.split(",").filter(Boolean);
+                if (selected) {
+                  if (current.length > 1) {
+                    setDayOfWeek(current.filter((d) => d !== value).join(","));
+                  }
+                } else {
+                  setDayOfWeek([...current, value].join(","));
+                }
+              }}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Notification fields sub-component
+// ---------------------------------------------------------------------------
+
+function ScheduleNotificationFields({
+  notifyEmail,
+  setNotifyEmail,
+  notifySlack,
+  setNotifySlack,
+}: {
+  notifyEmail: boolean;
+  setNotifyEmail: (v: boolean) => void;
+  notifySlack: boolean;
+  setNotifySlack: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-medium text-foreground">
+        Notifications
+      </label>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-foreground">Email</span>
+        <Switch checked={notifyEmail} onCheckedChange={setNotifyEmail} />
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-foreground">Slack</span>
+        <Switch checked={notifySlack} onCheckedChange={setNotifySlack} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildDefaults(
+  agents: ScheduleFormDialogProps["agents"],
+  initialValues: Partial<ScheduleFormValues> | undefined,
+): ScheduleFormValues {
+  const defaults: ScheduleFormValues = {
+    prompt: "",
+    description: "",
+    composeId: agents?.[0]?.id ?? "",
+    freq: "every_day",
+    date: new Date().toISOString().slice(0, 10),
+    hour: 9,
+    minute: 0,
+    timezone: new Intl.DateTimeFormat().resolvedOptions().timeZone,
+    loopMinutes: 15,
+    dayOfWeek: "1",
+    dayOfMonth: "1",
+    notifyEmail: false,
+    notifySlack: false,
+  };
+  return { ...defaults, ...initialValues };
+}
+
+function checkDirty(
+  current: ScheduleFormValues,
+  init: ScheduleFormValues,
+  mode: "create" | "edit",
+  opts: { hasAgents: boolean },
+): boolean {
+  if (mode !== "edit") {
+    return current.prompt.trim() !== "" || current.description.trim() !== "";
+  }
+  return (
+    current.prompt !== init.prompt ||
+    current.description !== init.description ||
+    current.freq !== init.freq ||
+    current.date !== init.date ||
+    current.hour !== init.hour ||
+    current.minute !== init.minute ||
+    current.timezone !== init.timezone ||
+    current.loopMinutes !== init.loopMinutes ||
+    current.dayOfWeek !== init.dayOfWeek ||
+    current.dayOfMonth !== init.dayOfMonth ||
+    current.notifyEmail !== init.notifyEmail ||
+    current.notifySlack !== init.notifySlack ||
+    (opts.hasAgents && current.composeId !== init.composeId)
+  );
+}
+
+function getSaveLabel(mode: "create" | "edit", saving: boolean): string {
+  if (mode === "edit") {
+    return saving ? "Saving\u2026" : "Save";
+  }
+  return saving ? "Creating\u2026" : "Create";
+}
+
+// ---------------------------------------------------------------------------
+// Inner dialog (manages form state, mounted only when open)
+// ---------------------------------------------------------------------------
+
+function ScheduleFormDialogInner({
+  onClose,
+  onSave,
+  saving,
+  mode,
+  initialValues,
+  agents,
+  saveError,
+}: Omit<ScheduleFormDialogProps, "open">) {
+  const init = buildDefaults(agents, initialValues);
+
+  const [prompt, setPrompt] = useState(init.prompt);
+  const [description, setDescription] = useState(init.description);
+  const [composeId, setComposeId] = useState(init.composeId);
+  const [freq, setFreq] = useState(init.freq);
+  const [date, setDate] = useState(init.date);
+  const [hour, setHour] = useState(init.hour);
+  const [minute, setMinute] = useState(init.minute);
+  const [timezone, setTimezone] = useState(init.timezone);
+  const [loopMinutes, setLoopMinutes] = useState(init.loopMinutes);
+  const [dayOfWeek, setDayOfWeek] = useState(init.dayOfWeek);
+  const [dayOfMonth, setDayOfMonth] = useState(init.dayOfMonth);
+  const [notifyEmail, setNotifyEmail] = useState(init.notifyEmail);
+  const [notifySlack, setNotifySlack] = useState(init.notifySlack);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const current: ScheduleFormValues = {
+    prompt,
+    description,
+    composeId,
+    freq,
+    date,
+    hour,
+    minute,
+    timezone,
+    loopMinutes,
+    dayOfWeek,
+    dayOfMonth,
+    notifyEmail,
+    notifySlack,
+  };
+
+  const isDirty = checkDirty(current, init, mode, {
+    hasAgents: agents !== undefined,
+  });
+
+  const requestClose = () => {
+    if (isDirty) {
+      setShowConfirm(true);
+    } else {
+      onClose();
+    }
+  };
+
+  const handleSave = () => {
+    if (!prompt.trim()) {
+      return;
+    }
+    if (agents && !composeId) {
+      return;
+    }
+    onSave(current);
+  };
+
+  const title = mode === "edit" ? "Edit schedule" : "Add schedule";
+  const saveLabel = getSaveLabel(mode, saving);
+
+  return (
+    <>
+      <DialogContent
+        className="sm:max-w-lg gap-6 [&>button[aria-label=Close]:last-child]:hidden"
+        onEscapeKeyDown={(e) => {
+          e.preventDefault();
+          requestClose();
+        }}
+        onInteractOutside={(e) => {
+          e.preventDefault();
+          requestClose();
+        }}
+      >
+        <button
+          type="button"
+          className="absolute right-4 top-4 flex items-center justify-center size-9 rounded-lg transition-colors opacity-70 hover:opacity-100 hover:bg-accent focus:outline-none"
+          aria-label="Close"
+          onClick={requestClose}
+        >
+          <IconX size={20} className="text-foreground" />
+        </button>
+
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          {/* Agent selector (create-on-page only) */}
+          {agents && (
+            <div className="flex flex-col gap-2">
+              <label
+                htmlFor="schedule-dialog-agent"
+                className="text-sm font-medium text-foreground"
+              >
+                Agent
+              </label>
+              <Select value={composeId} onValueChange={setComposeId}>
+                <SelectTrigger id="schedule-dialog-agent" className="h-9">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {agents.map((a) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      {a.displayName ?? a.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {/* Prompt */}
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="schedule-dialog-prompt"
+              className="text-sm font-medium text-foreground"
+            >
+              Prompt
+            </label>
+            <textarea
+              id="schedule-dialog-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Describe your task and instruction"
+              rows={5}
+              className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
+            />
+          </div>
+
+          {/* Description */}
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="schedule-dialog-description"
+              className="text-sm font-medium text-foreground"
+            >
+              Description
+              <span className="text-muted-foreground font-normal ml-1">
+                (optional)
+              </span>
+            </label>
+            <Input
+              id="schedule-dialog-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Leave blank to auto-generate"
+              className="h-9"
+            />
+          </div>
+
+          <ScheduleTimingFields
+            freq={freq}
+            setFreq={setFreq}
+            loopMinutes={loopMinutes}
+            setLoopMinutes={setLoopMinutes}
+            date={date}
+            setDate={setDate}
+            dayOfWeek={dayOfWeek}
+            setDayOfWeek={setDayOfWeek}
+            dayOfMonth={dayOfMonth}
+            setDayOfMonth={setDayOfMonth}
+            hour={hour}
+            setHour={setHour}
+            minute={minute}
+            setMinute={setMinute}
+            timezone={timezone}
+            setTimezone={setTimezone}
+          />
+
+          <ScheduleNotificationFields
+            notifyEmail={notifyEmail}
+            setNotifyEmail={setNotifyEmail}
+            notifySlack={notifySlack}
+            setNotifySlack={setNotifySlack}
+          />
+        </div>
+
+        {saveError && <p className="text-sm text-destructive">{saveError}</p>}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            className="zero-btn-morandi"
+            onClick={requestClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={!prompt.trim() || (agents ? !composeId : false) || saving}
+          >
+            {saveLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+
+      {showConfirm && (
+        <ConfirmCloseOverlay
+          onDiscard={onClose}
+          onContinue={() => setShowConfirm(false)}
+        />
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public component
+// ---------------------------------------------------------------------------
+
+export function ScheduleFormDialog({ open, ...rest }: ScheduleFormDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={() => {}}>
+      {open && <ScheduleFormDialogInner {...rest} />}
+    </Dialog>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -11,26 +11,6 @@ import {
   setAddScheduleOpen$,
   editingScheduleId$,
   setEditingScheduleId$,
-  newSchedulePrompt$,
-  setNewSchedulePrompt$,
-  scheduleFreq$,
-  setScheduleFreq$,
-  scheduleDate$,
-  setScheduleDate$,
-  scheduleHour$,
-  setScheduleHour$,
-  scheduleMinute$,
-  setScheduleMinute$,
-  scheduleTimezone$,
-  setScheduleTimezone$,
-  scheduleIntervalStr$,
-  setScheduleIntervalStr$,
-  scheduleDayOfWeek$,
-  setScheduleDayOfWeek$,
-  scheduleDayOfMonth$,
-  setScheduleDayOfMonth$,
-  newScheduleDescription$,
-  setNewScheduleDescription$,
   saveError$,
   setSaveError$,
   togglingIds$,
@@ -53,12 +33,6 @@ import {
   Tabs,
   TabsList,
   TabsTrigger,
-  Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   cn,
 } from "@vm0/ui";
 import {
@@ -66,6 +40,12 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@vm0/ui/components/ui/popover";
+import { throwIfAbort, detach, Reason } from "../../signals/utils.ts";
+import {
+  ScheduleFormDialog,
+  type ScheduleFormValues,
+} from "./schedule-dialog.tsx";
+import emptyScheduleImg from "./assets/empty-schedule.webp";
 import {
   Dialog,
   DialogContent,
@@ -73,45 +53,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@vm0/ui/components/ui/dialog";
-import { throwIfAbort, detach, Reason } from "../../signals/utils.ts";
-import emptyScheduleImg from "./assets/empty-schedule.webp";
-import {
-  COMMON_TIMEZONES,
-  getTodayDateLocal,
-  getBrowserTimezone,
-} from "../../signals/zero-page/cron.ts";
-
-export const SCHEDULE_FREQUENCY_OPTIONS = [
-  { value: "now", label: "Now" },
-  { value: "once", label: "Once" },
-  { value: "every_weekday", label: "Every weekday" },
-  { value: "every_day", label: "Every day" },
-  { value: "every_week", label: "Every week" },
-  { value: "every_month", label: "Every month" },
-  { value: "every_n_minutes", label: "Loop" },
-] as const;
-
-export const SCHEDULE_LOOP_MINUTES = [5, 15, 30, 60] as const;
-export const HOUR_OPTIONS: readonly number[] = Array.from(
-  { length: 24 },
-  (_, i) => i,
-);
-const MINUTE_OPTIONS: readonly number[] = Array.from(
-  { length: 12 },
-  (_, i) => i * 5,
-);
-
-/**
- * Build the minute dropdown options, inserting a non-standard value (e.g. an
- * existing schedule whose minute is not a multiple of 5) so the schedule
- * remains editable.
- */
-export function getMinuteOptions(currentMinute?: number): readonly number[] {
-  if (currentMinute === undefined || MINUTE_OPTIONS.includes(currentMinute)) {
-    return MINUTE_OPTIONS;
-  }
-  return [...MINUTE_OPTIONS, currentMinute].sort((a, b) => a - b);
-}
+import { getBrowserTimezone } from "../../signals/zero-page/cron.ts";
 
 export const WEEKDAY_LABELS = [
   "Mon",
@@ -529,6 +471,8 @@ interface ZeroScheduleCardProps {
     dayOfWeek?: string;
     dayOfMonth?: string;
     editName?: string;
+    notifyEmail?: boolean;
+    notifySlack?: boolean;
   }) => Promise<void>;
   /** When provided, called to delete a schedule by name. */
   onDelete?: (name: string) => Promise<void>;
@@ -563,123 +507,105 @@ export function ZeroScheduleCard({
   const setAddScheduleOpen = useSet(setAddScheduleOpen$);
   const editingScheduleId = useGet(editingScheduleId$);
   const setEditingScheduleId = useSet(setEditingScheduleId$);
-  const newSchedulePrompt = useGet(newSchedulePrompt$);
-  const setNewSchedulePrompt = useSet(setNewSchedulePrompt$);
-  const scheduleFreq = useGet(scheduleFreq$);
-  const setScheduleFreq = useSet(setScheduleFreq$);
-  const scheduleDate = useGet(scheduleDate$);
-  const setScheduleDate = useSet(setScheduleDate$);
-  const scheduleHour = useGet(scheduleHour$);
-  const setScheduleHour = useSet(setScheduleHour$);
-  const scheduleMinute = useGet(scheduleMinute$);
-  const setScheduleMinute = useSet(setScheduleMinute$);
   const resolvedTimezone = defaultTimezone || getBrowserTimezone();
-  const scheduleTimezone = useGet(scheduleTimezone$);
-  const setScheduleTimezone = useSet(setScheduleTimezone$);
-  const scheduleIntervalStr = useGet(scheduleIntervalStr$);
-  const setScheduleIntervalStr = useSet(setScheduleIntervalStr$);
-  const scheduleDayOfWeek = useGet(scheduleDayOfWeek$);
-  const setScheduleDayOfWeek = useSet(setScheduleDayOfWeek$);
-  const scheduleDayOfMonth = useGet(scheduleDayOfMonth$);
-  const setScheduleDayOfMonth = useSet(setScheduleDayOfMonth$);
-  const newScheduleDescription = useGet(newScheduleDescription$);
-  const setNewScheduleDescription = useSet(setNewScheduleDescription$);
   const saveError = useGet(saveError$);
   const setSaveError = useSet(setSaveError$);
   const togglingIds = useGet(togglingIds$);
   const setTogglingIds = useSet(setTogglingIds$);
 
+  const [dialogMode, setDialogMode] = useState<"create" | "edit">("create");
+  const [dialogInitialValues, setDialogInitialValues] = useState<
+    Partial<ScheduleFormValues>
+  >({});
+
   const openAddSchedule = () => {
     setEditingScheduleId(null);
-    setNewSchedulePrompt("");
-    setNewScheduleDescription("");
-    setScheduleFreq("every_day");
-    setScheduleDate(new Date().toISOString().slice(0, 10));
-    setScheduleHour(9);
-    setScheduleMinute(0);
-    setScheduleTimezone(resolvedTimezone);
-    setScheduleIntervalStr("300");
-    setScheduleDayOfWeek("1");
-    setScheduleDayOfMonth("1");
+    setDialogMode("create");
+    setDialogInitialValues({ timezone: resolvedTimezone });
     setSaveError(null);
     setAddScheduleOpen(true);
   };
 
   const openEditSchedule = (entry: ScheduleEntry) => {
     setEditingScheduleId(entry.id);
-    setNewSchedulePrompt(entry.prompt);
-    setNewScheduleDescription(entry.description ?? "");
+    setDialogMode("edit");
     const parsed = parseScheduleTimeString(entry.time);
-    setScheduleFreq(parsed.freq);
-    setScheduleDate(parsed.date);
-    setScheduleHour(parsed.hour);
-    setScheduleMinute(parsed.minute);
-    setScheduleTimezone(parsed.timezone);
-    setScheduleIntervalStr(
-      String(entry.intervalSeconds ?? (parsed.loopMinutes ?? 5) * 60),
-    );
-    setScheduleDayOfWeek(parsed.dayOfWeek ?? "1");
-    setScheduleDayOfMonth(parsed.dayOfMonth ?? "1");
+    setDialogInitialValues({
+      prompt: entry.prompt,
+      description: entry.description ?? "",
+      freq: parsed.freq,
+      date: parsed.date,
+      hour: parsed.hour,
+      minute: parsed.minute,
+      timezone: parsed.timezone,
+      loopMinutes:
+        entry.intervalSeconds !== null && entry.intervalSeconds !== undefined
+          ? Math.round(entry.intervalSeconds / 60)
+          : parsed.loopMinutes,
+      dayOfWeek: parsed.dayOfWeek ?? "1",
+      dayOfMonth: parsed.dayOfMonth ?? "1",
+      notifyEmail: entry.notifyEmail ?? false,
+      notifySlack: entry.notifySlack ?? false,
+    });
     setSaveError(null);
     setAddScheduleOpen(true);
   };
 
-  const addScheduleEntry = async () => {
-    if (!newSchedulePrompt.trim()) {
-      return;
-    }
-
+  const handleDialogSave = (values: ScheduleFormValues) => {
     if (onSave) {
-      // Find the editing entry's name for API update
       const editingEntry = editingScheduleId
         ? scheduleList.find((e) => e.id === editingScheduleId)
         : null;
-      try {
-        setSaveError(null);
-        await onSave({
-          prompt: newSchedulePrompt.trim(),
-          description: newScheduleDescription.trim() || undefined,
-          freq: scheduleFreq,
-          date: scheduleDate,
-          hour: scheduleHour,
-          minute: scheduleMinute,
-          timezone: scheduleTimezone,
-          intervalSeconds: Number(scheduleIntervalStr) || 0,
+      setSaveError(null);
+      detach(
+        onSave({
+          prompt: values.prompt.trim(),
+          description: values.description.trim() || undefined,
+          freq: values.freq,
+          date: values.date,
+          hour: values.hour,
+          minute: values.minute,
+          timezone: values.timezone,
+          intervalSeconds: values.loopMinutes * 60,
           dayOfWeek:
-            scheduleFreq === "every_week" ? scheduleDayOfWeek : undefined,
+            values.freq === "every_week" ? values.dayOfWeek : undefined,
           dayOfMonth:
-            scheduleFreq === "every_month" ? scheduleDayOfMonth : undefined,
+            values.freq === "every_month" ? values.dayOfMonth : undefined,
           editName: editingEntry?.name,
-        });
-      } catch (error) {
-        throwIfAbort(error);
-        setSaveError(
-          error instanceof Error ? error.message : "Failed to save schedule",
-        );
-        return;
-      }
-      setNewSchedulePrompt("");
-      setEditingScheduleId(null);
-      setAddScheduleOpen(false);
+          notifyEmail: values.notifyEmail,
+          notifySlack: values.notifySlack,
+        })
+          .then(() => {
+            setEditingScheduleId(null);
+            setAddScheduleOpen(false);
+          })
+          .catch((error: unknown) => {
+            throwIfAbort(error);
+            setSaveError(
+              error instanceof Error
+                ? error.message
+                : "Failed to save schedule",
+            );
+          }),
+        Reason.DomCallback,
+      );
       return;
     }
 
     const timeStr = buildScheduleTimeString({
-      freq: scheduleFreq,
-      date: scheduleFreq === "once" ? scheduleDate : undefined,
-      hour: scheduleHour,
-      minute: scheduleMinute,
-      timezone: scheduleTimezone,
+      freq: values.freq,
+      date: values.freq === "once" ? values.date : undefined,
+      hour: values.hour,
+      minute: values.minute,
+      timezone: values.timezone,
       loopMinutes:
-        scheduleFreq === "every_n_minutes"
-          ? Math.round((Number(scheduleIntervalStr) || 0) / 60)
-          : undefined,
+        values.freq === "every_n_minutes" ? values.loopMinutes : undefined,
     });
     if (editingScheduleId) {
       setScheduleList((prev) =>
         prev.map((e) =>
           e.id === editingScheduleId
-            ? { ...e, time: timeStr, prompt: newSchedulePrompt.trim() }
+            ? { ...e, time: timeStr, prompt: values.prompt.trim() }
             : e,
         ),
       );
@@ -690,11 +616,10 @@ export function ZeroScheduleCard({
         {
           id: String(Date.now()),
           time: timeStr,
-          prompt: newSchedulePrompt.trim(),
+          prompt: values.prompt.trim(),
         },
       ]);
     }
-    setNewSchedulePrompt("");
     setAddScheduleOpen(false);
   };
 
@@ -982,276 +907,19 @@ export function ZeroScheduleCard({
           })()}
       </CardContent>
 
-      <Dialog
+      <ScheduleFormDialog
+        key={editingScheduleId ?? "new"}
         open={addScheduleOpen}
-        onOpenChange={(open) => {
-          setAddScheduleOpen(open);
-          if (!open) {
-            setEditingScheduleId(null);
-          }
+        mode={dialogMode}
+        onClose={() => {
+          setAddScheduleOpen(false);
+          setEditingScheduleId(null);
         }}
-      >
-        <DialogContent className="sm:max-w-lg gap-6">
-          <DialogHeader>
-            <DialogTitle>
-              {editingScheduleId ? "Edit schedule" : "Add schedule"}
-            </DialogTitle>
-          </DialogHeader>
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-2">
-              <label
-                htmlFor="schedule-dialog-prompt"
-                className="text-sm font-medium text-foreground"
-              >
-                Prompt
-              </label>
-              <textarea
-                id="schedule-dialog-prompt"
-                value={newSchedulePrompt}
-                onChange={(e) => setNewSchedulePrompt(e.target.value)}
-                placeholder="Describe your task and instruction"
-                rows={5}
-                className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
-              />
-            </div>
-            <div className="flex flex-col gap-2">
-              <label
-                htmlFor="schedule-dialog-description"
-                className="text-sm font-medium text-foreground"
-              >
-                Description
-                <span className="text-muted-foreground font-normal ml-1">
-                  (optional)
-                </span>
-              </label>
-              <Input
-                id="schedule-dialog-description"
-                value={newScheduleDescription}
-                onChange={(e) => setNewScheduleDescription(e.target.value)}
-                placeholder="Leave blank to auto-generate"
-                className="h-9"
-              />
-            </div>
-            <div className="flex flex-col gap-2">
-              <label
-                htmlFor="schedule-dialog-freq"
-                className="text-sm font-medium text-foreground"
-              >
-                Time
-              </label>
-              <Select value={scheduleFreq} onValueChange={setScheduleFreq}>
-                <SelectTrigger id="schedule-dialog-freq" className="h-9">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {SCHEDULE_FREQUENCY_OPTIONS.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {scheduleFreq === "every_n_minutes" && (
-              <div className="flex flex-col gap-2">
-                <label
-                  htmlFor="schedule-dialog-loop"
-                  className="text-sm font-medium text-foreground"
-                >
-                  Interval (seconds)
-                </label>
-                <Input
-                  id="schedule-dialog-loop"
-                  type="number"
-                  min={0}
-                  value={scheduleIntervalStr}
-                  onChange={(e) => setScheduleIntervalStr(e.target.value)}
-                  placeholder="300"
-                  className="h-9"
-                />
-                <p className="text-xs text-muted-foreground">
-                  Time between the end of one run and the start of the next. Use
-                  0 for immediate restart.
-                </p>
-              </div>
-            )}
-            {scheduleFreq === "once" && (
-              <div className="flex flex-col gap-2">
-                <label
-                  htmlFor="schedule-dialog-date"
-                  className="text-sm font-medium text-foreground"
-                >
-                  Date
-                </label>
-                <Input
-                  id="schedule-dialog-date"
-                  type="date"
-                  value={scheduleDate}
-                  min={getTodayDateLocal()}
-                  onChange={(e) => setScheduleDate(e.target.value)}
-                  className="h-9"
-                />
-              </div>
-            )}
-            {scheduleFreq === "every_week" && (
-              <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium text-foreground">
-                  Day of week
-                </label>
-                <div className="flex gap-1">
-                  {(
-                    [
-                      ["1", "Mon"],
-                      ["2", "Tue"],
-                      ["3", "Wed"],
-                      ["4", "Thu"],
-                      ["5", "Fri"],
-                      ["6", "Sat"],
-                      ["0", "Sun"],
-                    ] as const
-                  ).map(([value, label]) => {
-                    const selected = scheduleDayOfWeek
-                      .split(",")
-                      .includes(value);
-                    return (
-                      <button
-                        key={value}
-                        type="button"
-                        className={`h-8 min-w-[40px] rounded-lg border text-xs font-medium transition-colors ${
-                          selected
-                            ? "border-primary bg-primary text-primary-foreground"
-                            : "border-input bg-background text-muted-foreground hover:bg-muted"
-                        }`}
-                        onClick={() => {
-                          const current = scheduleDayOfWeek
-                            .split(",")
-                            .filter(Boolean);
-                          if (selected) {
-                            if (current.length > 1) {
-                              setScheduleDayOfWeek(
-                                current.filter((d) => d !== value).join(","),
-                              );
-                            }
-                          } else {
-                            setScheduleDayOfWeek([...current, value].join(","));
-                          }
-                        }}
-                      >
-                        {label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-            {scheduleFreq === "every_month" && (
-              <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium text-foreground">
-                  Day of month
-                </label>
-                <Select
-                  value={scheduleDayOfMonth}
-                  onValueChange={setScheduleDayOfMonth}
-                >
-                  <SelectTrigger className="h-9">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Array.from({ length: 31 }, (_, i) => (
-                      <SelectItem key={i + 1} value={String(i + 1)}>
-                        {i + 1}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-            {scheduleFreq !== "now" && scheduleFreq !== "every_n_minutes" && (
-              <div className="flex flex-col gap-2">
-                <label className="text-sm font-medium text-foreground">
-                  Time
-                </label>
-                <div className="flex items-center gap-2">
-                  <Select
-                    value={String(scheduleHour)}
-                    onValueChange={(v) => setScheduleHour(Number(v))}
-                  >
-                    <SelectTrigger className="h-9 w-20">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {HOUR_OPTIONS.map((h) => (
-                        <SelectItem key={h} value={String(h)}>
-                          {h.toString().padStart(2, "0")}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <span className="text-muted-foreground">:</span>
-                  <Select
-                    value={String(scheduleMinute)}
-                    onValueChange={(v) => setScheduleMinute(Number(v))}
-                  >
-                    <SelectTrigger className="h-9 w-20">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {getMinuteOptions(scheduleMinute).map((m) => (
-                        <SelectItem key={m} value={String(m)}>
-                          {m.toString().padStart(2, "0")}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            )}
-            {scheduleFreq !== "now" && scheduleFreq !== "every_n_minutes" && (
-              <div className="flex flex-col gap-2">
-                <label
-                  htmlFor="schedule-dialog-tz"
-                  className="text-sm font-medium text-foreground"
-                >
-                  Timezone
-                </label>
-                <Select
-                  value={scheduleTimezone}
-                  onValueChange={setScheduleTimezone}
-                >
-                  <SelectTrigger id="schedule-dialog-tz" className="h-9">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {COMMON_TIMEZONES.map((tz) => (
-                      <SelectItem key={tz} value={tz}>
-                        {tz.replace(/_/g, " ")}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-          </div>
-          {saveError && <p className="text-sm text-destructive">{saveError}</p>}
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              className="zero-btn-morandi"
-              onClick={() => setAddScheduleOpen(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              onClick={() => void addScheduleEntry()}
-              disabled={!newSchedulePrompt.trim() || saving}
-            >
-              {saving ? "Saving…" : editingScheduleId ? "Save" : "Add"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onSave={handleDialogSave}
+        saving={saving === true}
+        initialValues={dialogInitialValues}
+        saveError={saveError}
+      />
     </Card>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -602,24 +602,29 @@ function ConfirmCloseOverlay({
   onContinue: () => void;
 }) {
   return createPortal(
-    <div className="fixed inset-0 z-[60] flex items-center justify-center">
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="confirm-close-title"
+      aria-describedby="confirm-close-desc"
+    >
       <div
         className="fixed inset-0 bg-black/50 dark:bg-black/70"
         onClick={onContinue}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            onContinue();
-          }
-        }}
-        role="button"
-        tabIndex={-1}
-        aria-label="Continue editing"
+        role="presentation"
       />
       <div className="relative z-10 mx-4 max-w-sm rounded-lg border border-border bg-card p-6 shadow-xl">
-        <p className="text-sm font-medium text-foreground mb-1">
+        <p
+          id="confirm-close-title"
+          className="text-sm font-medium text-foreground mb-1"
+        >
           You have unsaved changes
         </p>
-        <p className="text-sm text-muted-foreground mb-4">
+        <p
+          id="confirm-close-desc"
+          className="text-sm text-muted-foreground mb-4"
+        >
           Are you sure you want to close? Your changes will be lost.
         </p>
         <div className="flex justify-end gap-2">

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
 import {
   IconPencil,
@@ -8,6 +9,7 @@ import {
   IconPlus,
   IconChevronLeft,
   IconChevronRight,
+  IconX,
 } from "@tabler/icons-react";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import {
@@ -68,7 +70,7 @@ import emptyScheduleImg from "./assets/empty-schedule.webp";
 
 type CombinedEntry = ScheduleEntry & {
   agentLabel: string;
-  zeroAgentId: string;
+  composeId: string;
 };
 
 function buildCombinedSchedule(
@@ -88,10 +90,10 @@ function buildCombinedSchedule(
     name: e.name,
     intervalSeconds: e.intervalSeconds,
     agentLabel:
-      e.zeroAgentId === defaultComposeId
+      e.composeId === defaultComposeId
         ? agentName
-        : (nameToDisplay.get(e.agentName) ?? e.agentName),
-    zeroAgentId: e.zeroAgentId,
+        : (nameToDisplay.get(e.composeName) ?? e.composeName),
+    composeId: e.composeId,
   }));
 }
 
@@ -589,13 +591,59 @@ function ScheduleEditFields({
 }
 
 // ---------------------------------------------------------------------------
+// Confirm close overlay
+// ---------------------------------------------------------------------------
+
+function ConfirmCloseOverlay({
+  onDiscard,
+  onContinue,
+}: {
+  onDiscard: () => void;
+  onContinue: () => void;
+}) {
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex items-center justify-center">
+      <div
+        className="fixed inset-0 bg-black/50 dark:bg-black/70"
+        onClick={onContinue}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            onContinue();
+          }
+        }}
+        role="button"
+        tabIndex={-1}
+        aria-label="Continue editing"
+      />
+      <div className="relative z-10 mx-4 max-w-sm rounded-lg border border-border bg-card p-6 shadow-xl">
+        <p className="text-sm font-medium text-foreground mb-1">
+          You have unsaved changes
+        </p>
+        <p className="text-sm text-muted-foreground mb-4">
+          Are you sure you want to close? Your changes will be lost.
+        </p>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={onContinue}>
+            Continue Editing
+          </Button>
+          <Button variant="destructive" size="sm" onClick={onDiscard}>
+            Discard Changes
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Edit dialog
 // ---------------------------------------------------------------------------
 
 interface ScheduleEditDialogProps {
   entry: CombinedEntry | null;
   onClose: () => void;
-  onSave: (params: ZeroScheduleSaveParams & { zeroAgentId: string }) => void;
+  onSave: (params: ZeroScheduleSaveParams & { composeId: string }) => void;
   saving: boolean;
 }
 
@@ -616,6 +664,27 @@ function ScheduleEditDialogInner({
   const [loopMinutes, setLoopMinutes] = useState(parsed.loopMinutes);
   const [notifyEmail, setNotifyEmail] = useState(entry.notifyEmail);
   const [notifySlack, setNotifySlack] = useState(entry.notifySlack);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const isDirty =
+    prompt !== entry.prompt ||
+    description !== (entry.description ?? "") ||
+    freq !== parsed.freq ||
+    date !== parsed.date ||
+    hour !== parsed.hour ||
+    minute !== parsed.minute ||
+    timezone !== parsed.timezone ||
+    loopMinutes !== parsed.loopMinutes ||
+    notifyEmail !== entry.notifyEmail ||
+    notifySlack !== entry.notifySlack;
+
+  const requestClose = () => {
+    if (isDirty) {
+      setShowConfirm(true);
+    } else {
+      onClose();
+    }
+  };
 
   const handleSave = () => {
     if (!prompt.trim()) {
@@ -631,112 +700,131 @@ function ScheduleEditDialogInner({
       timezone,
       intervalSeconds: loopMinutes * 60,
       editName: entry.name,
-      zeroAgentId: entry.zeroAgentId,
+      composeId: entry.composeId,
       notifyEmail,
       notifySlack,
     });
   };
 
   return (
-    <DialogContent className="sm:max-w-lg gap-6">
-      <DialogHeader>
-        <DialogTitle>Edit schedule</DialogTitle>
-      </DialogHeader>
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="schedule-dialog-prompt"
-            className="text-sm font-medium text-foreground"
-          >
-            Prompt
-          </label>
-          <textarea
-            id="schedule-dialog-prompt"
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            placeholder="Describe your task and instruction"
-            rows={5}
-            className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
+    <>
+      <DialogContent
+        className="sm:max-w-lg gap-6 [&>button[aria-label=Close]]:hidden"
+        onEscapeKeyDown={(e) => {
+          e.preventDefault();
+          requestClose();
+        }}
+        onInteractOutside={(e) => {
+          e.preventDefault();
+          requestClose();
+        }}
+      >
+        <button
+          type="button"
+          className="absolute right-4 top-4 icon-button opacity-70 hover:opacity-100 focus:outline-none"
+          aria-label="Close"
+          onClick={requestClose}
+        >
+          <IconX size={20} className="text-foreground" />
+        </button>
+        <DialogHeader>
+          <DialogTitle>Edit schedule</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="schedule-dialog-prompt"
+              className="text-sm font-medium text-foreground"
+            >
+              Prompt
+            </label>
+            <textarea
+              id="schedule-dialog-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Describe your task and instruction"
+              rows={5}
+              className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="schedule-edit-description"
+              className="text-sm font-medium text-foreground"
+            >
+              Description
+              <span className="text-muted-foreground font-normal ml-1">
+                (optional)
+              </span>
+            </label>
+            <Input
+              id="schedule-edit-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Leave blank to auto-generate"
+              className="h-9"
+            />
+          </div>
+          <ScheduleEditFields
+            freq={freq}
+            setFreq={setFreq}
+            loopMinutes={loopMinutes}
+            setLoopMinutes={setLoopMinutes}
+            date={date}
+            setDate={setDate}
+            hour={hour}
+            setHour={setHour}
+            minute={minute}
+            setMinute={setMinute}
+            timezone={timezone}
+            setTimezone={setTimezone}
           />
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium text-foreground">
+              Notifications
+            </label>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-foreground">Email</span>
+              <Switch checked={notifyEmail} onCheckedChange={setNotifyEmail} />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-foreground">Slack</span>
+              <Switch checked={notifySlack} onCheckedChange={setNotifySlack} />
+            </div>
+          </div>
         </div>
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="schedule-edit-description"
-            className="text-sm font-medium text-foreground"
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            className="zero-btn-morandi"
+            onClick={requestClose}
           >
-            Description
-            <span className="text-muted-foreground font-normal ml-1">
-              (optional)
-            </span>
-          </label>
-          <Input
-            id="schedule-edit-description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Leave blank to auto-generate"
-            className="h-9"
-          />
-        </div>
-        <ScheduleEditFields
-          freq={freq}
-          setFreq={setFreq}
-          loopMinutes={loopMinutes}
-          setLoopMinutes={setLoopMinutes}
-          date={date}
-          setDate={setDate}
-          hour={hour}
-          setHour={setHour}
-          minute={minute}
-          setMinute={setMinute}
-          timezone={timezone}
-          setTimezone={setTimezone}
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={!prompt.trim() || saving}
+          >
+            {saving ? "Saving\u2026" : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+      {showConfirm && (
+        <ConfirmCloseOverlay
+          onDiscard={onClose}
+          onContinue={() => setShowConfirm(false)}
         />
-        <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium text-foreground">
-            Notifications
-          </label>
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-foreground">Email</span>
-            <Switch checked={notifyEmail} onCheckedChange={setNotifyEmail} />
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-sm text-foreground">Slack</span>
-            <Switch checked={notifySlack} onCheckedChange={setNotifySlack} />
-          </div>
-        </div>
-      </div>
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          className="zero-btn-morandi"
-          onClick={onClose}
-        >
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          onClick={handleSave}
-          disabled={!prompt.trim() || saving}
-        >
-          {saving ? "Saving\u2026" : "Save"}
-        </Button>
-      </DialogFooter>
-    </DialogContent>
+      )}
+    </>
   );
 }
 
 function ScheduleEditDialog(props: ScheduleEditDialogProps) {
-  const { entry, onClose } = props;
+  const { entry } = props;
   return (
-    <Dialog
-      open={entry !== null}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={entry !== null} onOpenChange={() => {}}>
       {entry && (
         <ScheduleEditDialogInner key={entry.id} {...props} entry={entry} />
       )}
@@ -751,7 +839,7 @@ function ScheduleEditDialog(props: ScheduleEditDialogProps) {
 interface ScheduleCreateDialogProps {
   open: boolean;
   onClose: () => void;
-  onSave: (params: ZeroScheduleSaveParams & { zeroAgentId: string }) => void;
+  onSave: (params: ZeroScheduleSaveParams & { composeId: string }) => void;
   saving: boolean;
   agents: { id: string; name: string; displayName?: string | null }[];
   defaultComposeId: string | null;
@@ -766,7 +854,7 @@ function ScheduleCreateDialogInner({
 }: Omit<ScheduleCreateDialogProps, "open">) {
   const [prompt, setPrompt] = useState("");
   const [description, setDescription] = useState("");
-  const [zeroAgentId, setZeroAgentId] = useState(
+  const [composeId, setComposeId] = useState(
     defaultComposeId ?? agents[0]?.id ?? "",
   );
   const [freq, setFreq] = useState("every_day");
@@ -777,9 +865,20 @@ function ScheduleCreateDialogInner({
     new Intl.DateTimeFormat().resolvedOptions().timeZone,
   );
   const [loopMinutes, setLoopMinutes] = useState(15);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const isDirty = prompt.trim() !== "" || description.trim() !== "";
+
+  const requestClose = () => {
+    if (isDirty) {
+      setShowConfirm(true);
+    } else {
+      onClose();
+    }
+  };
 
   const handleSave = () => {
-    if (!prompt.trim() || !zeroAgentId) {
+    if (!prompt.trim() || !composeId) {
       return;
     }
     onSave({
@@ -791,103 +890,129 @@ function ScheduleCreateDialogInner({
       minute,
       timezone,
       intervalSeconds: loopMinutes * 60,
-      zeroAgentId,
+      composeId,
     });
   };
 
   return (
-    <DialogContent className="sm:max-w-lg gap-6">
-      <DialogHeader>
-        <DialogTitle>New schedule</DialogTitle>
-      </DialogHeader>
-      <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="schedule-create-agent"
-            className="text-sm font-medium text-foreground"
-          >
-            Agent
-          </label>
-          <Select value={zeroAgentId} onValueChange={setZeroAgentId}>
-            <SelectTrigger id="schedule-create-agent" className="h-9">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {agents.map((a) => (
-                <SelectItem key={a.id} value={a.id}>
-                  {a.displayName ?? a.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="schedule-create-prompt"
-            className="text-sm font-medium text-foreground"
-          >
-            Prompt
-          </label>
-          <textarea
-            id="schedule-create-prompt"
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            placeholder="Describe your task and instruction"
-            rows={5}
-            className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
+    <>
+      <DialogContent
+        className="sm:max-w-lg gap-6 [&>button[aria-label=Close]]:hidden"
+        onEscapeKeyDown={(e) => {
+          e.preventDefault();
+          requestClose();
+        }}
+        onInteractOutside={(e) => {
+          e.preventDefault();
+          requestClose();
+        }}
+      >
+        <button
+          type="button"
+          className="absolute right-4 top-4 icon-button opacity-70 hover:opacity-100 focus:outline-none"
+          aria-label="Close"
+          onClick={requestClose}
+        >
+          <IconX size={20} className="text-foreground" />
+        </button>
+        <DialogHeader>
+          <DialogTitle>New schedule</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="schedule-create-agent"
+              className="text-sm font-medium text-foreground"
+            >
+              Agent
+            </label>
+            <Select value={composeId} onValueChange={setComposeId}>
+              <SelectTrigger id="schedule-create-agent" className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {agents.map((a) => (
+                  <SelectItem key={a.id} value={a.id}>
+                    {a.displayName ?? a.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="schedule-create-prompt"
+              className="text-sm font-medium text-foreground"
+            >
+              Prompt
+            </label>
+            <textarea
+              id="schedule-create-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Describe your task and instruction"
+              rows={5}
+              className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="schedule-create-description"
+              className="text-sm font-medium text-foreground"
+            >
+              Description
+              <span className="text-muted-foreground font-normal ml-1">
+                (optional)
+              </span>
+            </label>
+            <Input
+              id="schedule-create-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Leave blank to auto-generate"
+              className="h-9"
+            />
+          </div>
+          <ScheduleEditFields
+            freq={freq}
+            setFreq={setFreq}
+            loopMinutes={loopMinutes}
+            setLoopMinutes={setLoopMinutes}
+            date={date}
+            setDate={setDate}
+            hour={hour}
+            setHour={setHour}
+            minute={minute}
+            setMinute={setMinute}
+            timezone={timezone}
+            setTimezone={setTimezone}
           />
         </div>
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="schedule-create-description"
-            className="text-sm font-medium text-foreground"
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            className="zero-btn-morandi"
+            onClick={requestClose}
           >
-            Description
-            <span className="text-muted-foreground font-normal ml-1">
-              (optional)
-            </span>
-          </label>
-          <Input
-            id="schedule-create-description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Leave blank to auto-generate"
-            className="h-9"
-          />
-        </div>
-        <ScheduleEditFields
-          freq={freq}
-          setFreq={setFreq}
-          loopMinutes={loopMinutes}
-          setLoopMinutes={setLoopMinutes}
-          date={date}
-          setDate={setDate}
-          hour={hour}
-          setHour={setHour}
-          minute={minute}
-          setMinute={setMinute}
-          timezone={timezone}
-          setTimezone={setTimezone}
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={!prompt.trim() || !composeId || saving}
+          >
+            {saving ? "Creating\u2026" : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+      {showConfirm && (
+        <ConfirmCloseOverlay
+          onDiscard={onClose}
+          onContinue={() => setShowConfirm(false)}
         />
-      </div>
-      <DialogFooter>
-        <Button
-          type="button"
-          variant="outline"
-          className="zero-btn-morandi"
-          onClick={onClose}
-        >
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          onClick={handleSave}
-          disabled={!prompt.trim() || !zeroAgentId || saving}
-        >
-          {saving ? "Creating\u2026" : "Create"}
-        </Button>
-      </DialogFooter>
-    </DialogContent>
+      )}
+    </>
   );
 }
 
@@ -897,14 +1022,7 @@ function ScheduleCreateDialog({
   ...rest
 }: ScheduleCreateDialogProps) {
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(isOpen) => {
-        if (!isOpen) {
-          onClose();
-        }
-      }}
-    >
+    <Dialog open={open} onOpenChange={() => {}}>
       {open && <ScheduleCreateDialogInner onClose={onClose} {...rest} />}
     </Dialog>
   );
@@ -1148,7 +1266,7 @@ export function ZeroSchedulePage() {
   };
 
   const handleCreateSave = (
-    params: ZeroScheduleSaveParams & { zeroAgentId: string },
+    params: ZeroScheduleSaveParams & { composeId: string },
   ) => {
     setSaving(true);
     detach(
@@ -1164,7 +1282,7 @@ export function ZeroSchedulePage() {
   };
 
   const handleDialogSave = (
-    params: ZeroScheduleSaveParams & { zeroAgentId: string },
+    params: ZeroScheduleSaveParams & { composeId: string },
   ) => {
     setSaving(true);
     detach(
@@ -1186,7 +1304,7 @@ export function ZeroSchedulePage() {
     await toggleEnabled({
       name: entry.name,
       enabled,
-      zeroAgentId: entry.zeroAgentId,
+      composeId: entry.composeId,
     });
   };
 
@@ -1204,7 +1322,7 @@ export function ZeroSchedulePage() {
     detach(
       deleteSchedule({
         name: pendingDelete.name,
-        zeroAgentId: pendingDelete.zeroAgentId,
+        composeId: pendingDelete.composeId,
       }),
       Reason.DomCallback,
     );

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { createPortal } from "react-dom";
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
 import {
   IconPencil,
@@ -9,7 +8,6 @@ import {
   IconPlus,
   IconChevronLeft,
   IconChevronRight,
-  IconX,
 } from "@tabler/icons-react";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
 import {
@@ -19,16 +17,9 @@ import {
   TabsList,
   TabsTrigger,
   Button,
-  Input,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   cn,
 } from "@vm0/ui";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
-import { Switch } from "@vm0/ui/components/ui/switch";
 import {
   Popover,
   PopoverContent,
@@ -46,16 +37,15 @@ import {
   buildCalendarTimeSlots,
   WEEKDAY_LABELS,
   parseScheduleTimeString,
-  SCHEDULE_FREQUENCY_OPTIONS,
-  SCHEDULE_LOOP_MINUTES,
-  HOUR_OPTIONS,
-  getMinuteOptions,
   type ScheduleEntry,
 } from "./zero-schedule-card";
+import {
+  ScheduleFormDialog,
+  type ScheduleFormValues,
+} from "./schedule-dialog.tsx";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import { agentsList$ } from "../../signals/zero-page/agents-list.ts";
-import { COMMON_TIMEZONES } from "../../signals/zero-page/cron.ts";
-import { detach, Reason } from "../../signals/utils.ts";
+import { detach, throwIfAbort, Reason } from "../../signals/utils.ts";
 import {
   allOrgScheduleEntries$,
   allOrgSchedulesLoaded$,
@@ -63,14 +53,13 @@ import {
   toggleOrgScheduleEnabled$,
   deleteOrgSchedule$,
   type OrgScheduleEntry,
-  type ZeroScheduleSaveParams,
 } from "../../signals/zero-page/zero-schedule.ts";
 import { zeroOnboardingStatus$ } from "../../signals/zero-page/zero-onboarding.ts";
 import emptyScheduleImg from "./assets/empty-schedule.webp";
 
 type CombinedEntry = ScheduleEntry & {
   agentLabel: string;
-  composeId: string;
+  zeroAgentId: string;
 };
 
 function buildCombinedSchedule(
@@ -90,10 +79,10 @@ function buildCombinedSchedule(
     name: e.name,
     intervalSeconds: e.intervalSeconds,
     agentLabel:
-      e.composeId === defaultComposeId
+      e.zeroAgentId === defaultComposeId
         ? agentName
-        : (nameToDisplay.get(e.composeName) ?? e.composeName),
-    composeId: e.composeId,
+        : (nameToDisplay.get(e.agentName) ?? e.agentName),
+    zeroAgentId: e.zeroAgentId,
   }));
 }
 
@@ -422,617 +411,6 @@ function ScheduleCalendarView({
 }
 
 // ---------------------------------------------------------------------------
-// Edit fields
-// ---------------------------------------------------------------------------
-
-function isCronFreq(f: string): boolean {
-  return (
-    f === "once" ||
-    f === "every_weekday" ||
-    f === "every_day" ||
-    f === "every_week" ||
-    f === "every_month"
-  );
-}
-
-function ScheduleEditFields({
-  freq,
-  setFreq,
-  loopMinutes,
-  setLoopMinutes,
-  date,
-  setDate,
-  hour,
-  setHour,
-  minute,
-  setMinute,
-  timezone,
-  setTimezone,
-}: {
-  freq: string;
-  setFreq: (v: string) => void;
-  loopMinutes: number;
-  setLoopMinutes: (v: number) => void;
-  date: string;
-  setDate: (v: string) => void;
-  hour: number;
-  setHour: (v: number) => void;
-  minute: number;
-  setMinute: (v: number) => void;
-  timezone: string;
-  setTimezone: (v: string) => void;
-}) {
-  return (
-    <>
-      <div className="flex flex-col gap-2">
-        <label
-          htmlFor="schedule-dialog-freq"
-          className="text-sm font-medium text-foreground"
-        >
-          Time
-        </label>
-        <Select value={freq} onValueChange={setFreq}>
-          <SelectTrigger id="schedule-dialog-freq" className="h-9">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {SCHEDULE_FREQUENCY_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-      {freq === "every_n_minutes" && (
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="schedule-dialog-loop"
-            className="text-sm font-medium text-foreground"
-          >
-            Every
-          </label>
-          <Select
-            value={String(loopMinutes)}
-            onValueChange={(v) => setLoopMinutes(Number(v))}
-          >
-            <SelectTrigger id="schedule-dialog-loop" className="h-9">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {SCHEDULE_LOOP_MINUTES.map((m) => (
-                <SelectItem key={m} value={String(m)}>
-                  {m} minutes
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      )}
-      {freq === "once" && (
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="schedule-dialog-date"
-            className="text-sm font-medium text-foreground"
-          >
-            Date
-          </label>
-          <Input
-            id="schedule-dialog-date"
-            type="date"
-            value={date}
-            onChange={(e) => setDate(e.target.value)}
-            className="h-9"
-          />
-        </div>
-      )}
-      {freq !== "now" && freq !== "every_n_minutes" && (
-        <div className="flex flex-col gap-2">
-          <label className="text-sm font-medium text-foreground">Time</label>
-          <div className="flex items-center gap-2">
-            <Select
-              value={String(hour)}
-              onValueChange={(v) => setHour(Number(v))}
-            >
-              <SelectTrigger className="h-9 w-20">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {HOUR_OPTIONS.map((h) => (
-                  <SelectItem key={h} value={String(h)}>
-                    {h.toString().padStart(2, "0")}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <span className="text-muted-foreground">:</span>
-            <Select
-              value={String(minute)}
-              onValueChange={(v) => setMinute(Number(v))}
-            >
-              <SelectTrigger className="h-9 w-20">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {getMinuteOptions(minute).map((m) => (
-                  <SelectItem key={m} value={String(m)}>
-                    {m.toString().padStart(2, "0")}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-      )}
-      {isCronFreq(freq) && (
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="schedule-dialog-tz"
-            className="text-sm font-medium text-foreground"
-          >
-            Timezone
-          </label>
-          <Select value={timezone} onValueChange={setTimezone}>
-            <SelectTrigger id="schedule-dialog-tz" className="h-9">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {COMMON_TIMEZONES.map((tz) => (
-                <SelectItem key={tz} value={tz}>
-                  {tz.replace(/_/g, " ")}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      )}
-    </>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Confirm close overlay
-// ---------------------------------------------------------------------------
-
-function ConfirmCloseOverlay({
-  onDiscard,
-  onContinue,
-}: {
-  onDiscard: () => void;
-  onContinue: () => void;
-}) {
-  return createPortal(
-    <div
-      className="fixed inset-0 z-[60] flex items-center justify-center"
-      role="alertdialog"
-      aria-modal="true"
-      aria-labelledby="confirm-close-title"
-      aria-describedby="confirm-close-desc"
-    >
-      <div
-        className="fixed inset-0 bg-black/50 dark:bg-black/70"
-        onClick={onContinue}
-        role="presentation"
-      />
-      <div className="relative z-10 mx-4 max-w-sm rounded-lg border border-border bg-card p-6 shadow-xl">
-        <p
-          id="confirm-close-title"
-          className="text-sm font-medium text-foreground mb-1"
-        >
-          You have unsaved changes
-        </p>
-        <p
-          id="confirm-close-desc"
-          className="text-sm text-muted-foreground mb-4"
-        >
-          Are you sure you want to close? Your changes will be lost.
-        </p>
-        <div className="flex justify-end gap-2">
-          <Button variant="outline" size="sm" onClick={onContinue}>
-            Continue Editing
-          </Button>
-          <Button variant="destructive" size="sm" onClick={onDiscard}>
-            Discard Changes
-          </Button>
-        </div>
-      </div>
-    </div>,
-    document.body,
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Edit dialog
-// ---------------------------------------------------------------------------
-
-interface ScheduleEditDialogProps {
-  entry: CombinedEntry | null;
-  onClose: () => void;
-  onSave: (params: ZeroScheduleSaveParams & { composeId: string }) => void;
-  saving: boolean;
-}
-
-function ScheduleEditDialogInner({
-  entry,
-  onClose,
-  onSave,
-  saving,
-}: ScheduleEditDialogProps & { entry: CombinedEntry }) {
-  const parsed = parseScheduleTimeString(entry.time);
-  const [prompt, setPrompt] = useState(entry.prompt);
-  const [description, setDescription] = useState(entry.description ?? "");
-  const [freq, setFreq] = useState(parsed.freq);
-  const [date, setDate] = useState(parsed.date);
-  const [hour, setHour] = useState(parsed.hour);
-  const [minute, setMinute] = useState(parsed.minute);
-  const [timezone, setTimezone] = useState(parsed.timezone);
-  const [loopMinutes, setLoopMinutes] = useState(parsed.loopMinutes);
-  const [notifyEmail, setNotifyEmail] = useState(entry.notifyEmail);
-  const [notifySlack, setNotifySlack] = useState(entry.notifySlack);
-  const [showConfirm, setShowConfirm] = useState(false);
-
-  const isDirty =
-    prompt !== entry.prompt ||
-    description !== (entry.description ?? "") ||
-    freq !== parsed.freq ||
-    date !== parsed.date ||
-    hour !== parsed.hour ||
-    minute !== parsed.minute ||
-    timezone !== parsed.timezone ||
-    loopMinutes !== parsed.loopMinutes ||
-    notifyEmail !== entry.notifyEmail ||
-    notifySlack !== entry.notifySlack;
-
-  const requestClose = () => {
-    if (isDirty) {
-      setShowConfirm(true);
-    } else {
-      onClose();
-    }
-  };
-
-  const handleSave = () => {
-    if (!prompt.trim()) {
-      return;
-    }
-    onSave({
-      prompt: prompt.trim(),
-      description: description.trim() || undefined,
-      freq,
-      date,
-      hour,
-      minute,
-      timezone,
-      intervalSeconds: loopMinutes * 60,
-      editName: entry.name,
-      composeId: entry.composeId,
-      notifyEmail,
-      notifySlack,
-    });
-  };
-
-  return (
-    <>
-      <DialogContent
-        className="sm:max-w-lg gap-6 [&>button[aria-label=Close]]:hidden"
-        onEscapeKeyDown={(e) => {
-          e.preventDefault();
-          requestClose();
-        }}
-        onInteractOutside={(e) => {
-          e.preventDefault();
-          requestClose();
-        }}
-      >
-        <button
-          type="button"
-          className="absolute right-4 top-4 icon-button opacity-70 hover:opacity-100 focus:outline-none"
-          aria-label="Close"
-          onClick={requestClose}
-        >
-          <IconX size={20} className="text-foreground" />
-        </button>
-        <DialogHeader>
-          <DialogTitle>Edit schedule</DialogTitle>
-        </DialogHeader>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <label
-              htmlFor="schedule-dialog-prompt"
-              className="text-sm font-medium text-foreground"
-            >
-              Prompt
-            </label>
-            <textarea
-              id="schedule-dialog-prompt"
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              placeholder="Describe your task and instruction"
-              rows={5}
-              className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <label
-              htmlFor="schedule-edit-description"
-              className="text-sm font-medium text-foreground"
-            >
-              Description
-              <span className="text-muted-foreground font-normal ml-1">
-                (optional)
-              </span>
-            </label>
-            <Input
-              id="schedule-edit-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Leave blank to auto-generate"
-              className="h-9"
-            />
-          </div>
-          <ScheduleEditFields
-            freq={freq}
-            setFreq={setFreq}
-            loopMinutes={loopMinutes}
-            setLoopMinutes={setLoopMinutes}
-            date={date}
-            setDate={setDate}
-            hour={hour}
-            setHour={setHour}
-            minute={minute}
-            setMinute={setMinute}
-            timezone={timezone}
-            setTimezone={setTimezone}
-          />
-          <div className="flex flex-col gap-2">
-            <label className="text-sm font-medium text-foreground">
-              Notifications
-            </label>
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-foreground">Email</span>
-              <Switch checked={notifyEmail} onCheckedChange={setNotifyEmail} />
-            </div>
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-foreground">Slack</span>
-              <Switch checked={notifySlack} onCheckedChange={setNotifySlack} />
-            </div>
-          </div>
-        </div>
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            className="zero-btn-morandi"
-            onClick={requestClose}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            onClick={handleSave}
-            disabled={!prompt.trim() || saving}
-          >
-            {saving ? "Saving\u2026" : "Save"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-      {showConfirm && (
-        <ConfirmCloseOverlay
-          onDiscard={onClose}
-          onContinue={() => setShowConfirm(false)}
-        />
-      )}
-    </>
-  );
-}
-
-function ScheduleEditDialog(props: ScheduleEditDialogProps) {
-  const { entry } = props;
-  return (
-    <Dialog open={entry !== null} onOpenChange={() => {}}>
-      {entry && (
-        <ScheduleEditDialogInner key={entry.id} {...props} entry={entry} />
-      )}
-    </Dialog>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Create dialog
-// ---------------------------------------------------------------------------
-
-interface ScheduleCreateDialogProps {
-  open: boolean;
-  onClose: () => void;
-  onSave: (params: ZeroScheduleSaveParams & { composeId: string }) => void;
-  saving: boolean;
-  agents: { id: string; name: string; displayName?: string | null }[];
-  defaultComposeId: string | null;
-}
-
-function ScheduleCreateDialogInner({
-  onClose,
-  onSave,
-  saving,
-  agents,
-  defaultComposeId,
-}: Omit<ScheduleCreateDialogProps, "open">) {
-  const [prompt, setPrompt] = useState("");
-  const [description, setDescription] = useState("");
-  const [composeId, setComposeId] = useState(
-    defaultComposeId ?? agents[0]?.id ?? "",
-  );
-  const [freq, setFreq] = useState("every_day");
-  const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
-  const [hour, setHour] = useState(9);
-  const [minute, setMinute] = useState(0);
-  const [timezone, setTimezone] = useState(
-    new Intl.DateTimeFormat().resolvedOptions().timeZone,
-  );
-  const [loopMinutes, setLoopMinutes] = useState(15);
-  const [showConfirm, setShowConfirm] = useState(false);
-
-  const isDirty = prompt.trim() !== "" || description.trim() !== "";
-
-  const requestClose = () => {
-    if (isDirty) {
-      setShowConfirm(true);
-    } else {
-      onClose();
-    }
-  };
-
-  const handleSave = () => {
-    if (!prompt.trim() || !composeId) {
-      return;
-    }
-    onSave({
-      prompt: prompt.trim(),
-      description: description.trim() || undefined,
-      freq,
-      date,
-      hour,
-      minute,
-      timezone,
-      intervalSeconds: loopMinutes * 60,
-      composeId,
-    });
-  };
-
-  return (
-    <>
-      <DialogContent
-        className="sm:max-w-lg gap-6 [&>button[aria-label=Close]]:hidden"
-        onEscapeKeyDown={(e) => {
-          e.preventDefault();
-          requestClose();
-        }}
-        onInteractOutside={(e) => {
-          e.preventDefault();
-          requestClose();
-        }}
-      >
-        <button
-          type="button"
-          className="absolute right-4 top-4 icon-button opacity-70 hover:opacity-100 focus:outline-none"
-          aria-label="Close"
-          onClick={requestClose}
-        >
-          <IconX size={20} className="text-foreground" />
-        </button>
-        <DialogHeader>
-          <DialogTitle>New schedule</DialogTitle>
-        </DialogHeader>
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <label
-              htmlFor="schedule-create-agent"
-              className="text-sm font-medium text-foreground"
-            >
-              Agent
-            </label>
-            <Select value={composeId} onValueChange={setComposeId}>
-              <SelectTrigger id="schedule-create-agent" className="h-9">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {agents.map((a) => (
-                  <SelectItem key={a.id} value={a.id}>
-                    {a.displayName ?? a.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="flex flex-col gap-2">
-            <label
-              htmlFor="schedule-create-prompt"
-              className="text-sm font-medium text-foreground"
-            >
-              Prompt
-            </label>
-            <textarea
-              id="schedule-create-prompt"
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              placeholder="Describe your task and instruction"
-              rows={5}
-              className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <label
-              htmlFor="schedule-create-description"
-              className="text-sm font-medium text-foreground"
-            >
-              Description
-              <span className="text-muted-foreground font-normal ml-1">
-                (optional)
-              </span>
-            </label>
-            <Input
-              id="schedule-create-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Leave blank to auto-generate"
-              className="h-9"
-            />
-          </div>
-          <ScheduleEditFields
-            freq={freq}
-            setFreq={setFreq}
-            loopMinutes={loopMinutes}
-            setLoopMinutes={setLoopMinutes}
-            date={date}
-            setDate={setDate}
-            hour={hour}
-            setHour={setHour}
-            minute={minute}
-            setMinute={setMinute}
-            timezone={timezone}
-            setTimezone={setTimezone}
-          />
-        </div>
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            className="zero-btn-morandi"
-            onClick={requestClose}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            onClick={handleSave}
-            disabled={!prompt.trim() || !composeId || saving}
-          >
-            {saving ? "Creating\u2026" : "Create"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-      {showConfirm && (
-        <ConfirmCloseOverlay
-          onDiscard={onClose}
-          onContinue={() => setShowConfirm(false)}
-        />
-      )}
-    </>
-  );
-}
-
-function ScheduleCreateDialog({
-  open,
-  onClose,
-  ...rest
-}: ScheduleCreateDialogProps) {
-  return (
-    <Dialog open={open} onOpenChange={() => {}}>
-      {open && <ScheduleCreateDialogInner onClose={onClose} {...rest} />}
-    </Dialog>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Skeleton
 // ---------------------------------------------------------------------------
@@ -1250,6 +628,7 @@ export function ZeroSchedulePage() {
   );
   const [editingEntry, setEditingEntry] = useState<CombinedEntry | null>(null);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<CombinedEntry | null>(
     null,
@@ -1270,14 +649,31 @@ export function ZeroSchedulePage() {
     setEditingEntry(entry);
   };
 
-  const handleCreateSave = (
-    params: ZeroScheduleSaveParams & { composeId: string },
-  ) => {
+  const handleCreateSave = (values: ScheduleFormValues) => {
     setSaving(true);
+    setSaveError(null);
     detach(
-      saveSchedule(params)
+      saveSchedule({
+        prompt: values.prompt.trim(),
+        description: values.description.trim() || undefined,
+        freq: values.freq,
+        date: values.date,
+        hour: values.hour,
+        minute: values.minute,
+        timezone: values.timezone,
+        intervalSeconds: values.loopMinutes * 60,
+        zeroAgentId: values.composeId,
+        notifyEmail: values.notifyEmail,
+        notifySlack: values.notifySlack,
+      })
         .then(() => {
           setCreateOpen(false);
+        })
+        .catch((error: unknown) => {
+          throwIfAbort(error);
+          setSaveError(
+            error instanceof Error ? error.message : "Failed to save schedule",
+          );
         })
         .finally(() => {
           setSaving(false);
@@ -1286,14 +682,35 @@ export function ZeroSchedulePage() {
     );
   };
 
-  const handleDialogSave = (
-    params: ZeroScheduleSaveParams & { composeId: string },
-  ) => {
+  const handleEditSave = (values: ScheduleFormValues) => {
+    if (!editingEntry) {
+      return;
+    }
     setSaving(true);
+    setSaveError(null);
     detach(
-      saveSchedule(params)
+      saveSchedule({
+        prompt: values.prompt.trim(),
+        description: values.description.trim() || undefined,
+        freq: values.freq,
+        date: values.date,
+        hour: values.hour,
+        minute: values.minute,
+        timezone: values.timezone,
+        intervalSeconds: values.loopMinutes * 60,
+        editName: editingEntry.name,
+        zeroAgentId: editingEntry.zeroAgentId,
+        notifyEmail: values.notifyEmail,
+        notifySlack: values.notifySlack,
+      })
         .then(() => {
           setEditingEntry(null);
+        })
+        .catch((error: unknown) => {
+          throwIfAbort(error);
+          setSaveError(
+            error instanceof Error ? error.message : "Failed to save schedule",
+          );
         })
         .finally(() => {
           setSaving(false);
@@ -1309,7 +726,7 @@ export function ZeroSchedulePage() {
     await toggleEnabled({
       name: entry.name,
       enabled,
-      composeId: entry.composeId,
+      zeroAgentId: entry.zeroAgentId,
     });
   };
 
@@ -1327,7 +744,7 @@ export function ZeroSchedulePage() {
     detach(
       deleteSchedule({
         name: pendingDelete.name,
-        composeId: pendingDelete.composeId,
+        zeroAgentId: pendingDelete.zeroAgentId,
       }),
       Reason.DomCallback,
     );
@@ -1414,19 +831,46 @@ export function ZeroSchedulePage() {
         </div>
       </main>
 
-      <ScheduleEditDialog
-        entry={editingEntry}
-        onClose={() => setEditingEntry(null)}
-        onSave={handleDialogSave}
-        saving={saving}
-      />
-      <ScheduleCreateDialog
+      {editingEntry &&
+        (() => {
+          const parsed = parseScheduleTimeString(editingEntry.time);
+          return (
+            <ScheduleFormDialog
+              key={editingEntry.id}
+              open
+              mode="edit"
+              onClose={() => setEditingEntry(null)}
+              onSave={handleEditSave}
+              saving={saving}
+              saveError={saveError}
+              initialValues={{
+                prompt: editingEntry.prompt,
+                description: editingEntry.description ?? "",
+                freq: parsed.freq,
+                date: parsed.date,
+                hour: parsed.hour,
+                minute: parsed.minute,
+                timezone: parsed.timezone,
+                loopMinutes: parsed.loopMinutes,
+                dayOfWeek: parsed.dayOfWeek ?? "1",
+                dayOfMonth: parsed.dayOfMonth ?? "1",
+                notifyEmail: editingEntry.notifyEmail ?? false,
+                notifySlack: editingEntry.notifySlack ?? false,
+              }}
+            />
+          );
+        })()}
+      <ScheduleFormDialog
         open={createOpen}
+        mode="create"
         onClose={() => setCreateOpen(false)}
         onSave={handleCreateSave}
         saving={saving}
+        saveError={saveError}
         agents={agents}
-        defaultComposeId={defaultComposeId}
+        initialValues={{
+          composeId: defaultComposeId ?? agents[0]?.id ?? "",
+        }}
       />
       <Dialog
         open={pendingDelete !== null}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
@@ -5,23 +5,8 @@ import { notificationPreferences$ } from "../../signals/zero-page/settings/notif
 import {
   scheduleTabSaving$,
   setScheduleTabSaving$,
+  type ZeroScheduleSaveParams,
 } from "../../signals/zero-page/zero-schedule.ts";
-
-interface ZeroScheduleSaveParams {
-  prompt: string;
-  description?: string;
-  freq: string;
-  date: string;
-  hour: number;
-  minute: number;
-  timezone: string;
-  intervalSeconds: number;
-  dayOfWeek?: string;
-  dayOfMonth?: string;
-  editName?: string;
-  notifyEmail?: boolean;
-  notifySlack?: boolean;
-}
 
 interface ZeroScheduleTabProps {
   agentName: string;

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
@@ -19,6 +19,8 @@ interface ZeroScheduleSaveParams {
   dayOfWeek?: string;
   dayOfMonth?: string;
   editName?: string;
+  notifyEmail?: boolean;
+  notifySlack?: boolean;
 }
 
 interface ZeroScheduleTabProps {


### PR DESCRIPTION
## Summary

- Adds unsaved changes detection to both schedule edit and create dialogs
- When dialog has dirty state, pressing ESC, clicking outside, clicking Cancel, or clicking X shows a confirmation overlay with "Continue Editing" and "Discard Changes" options
- If no edits have been made, the dialog closes immediately (no prompt)
- For edit dialog: dirty = any field differs from original values
- For create dialog: dirty = prompt or description has content

Closes #5703

## Test plan

- [ ] Open edit schedule dialog, make no changes, press ESC → dialog closes immediately
- [ ] Open edit schedule dialog, modify prompt text, press ESC → confirmation appears
- [ ] In confirmation, click "Continue Editing" → returns to dialog with edits preserved
- [ ] In confirmation, click "Discard Changes" → dialog closes, edits lost
- [ ] Same flows work with clicking outside the dialog
- [ ] Same flows work with clicking Cancel button
- [ ] Same flows work with clicking X button
- [ ] Create dialog: type prompt text, try to close → confirmation appears
- [ ] Create dialog: no edits, close → closes immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)