### PR TITLE
fix: prevent symlink path traversal in guest-download tar extraction

### DIFF
--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -460,6 +460,9 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
             continue;
         }
 
+        // TOCTOU is not a concern here: entries are processed sequentially from a single
+        // archive stream, so no external actor can modify the filesystem between our checks
+        // and the extraction below.
         entry.unpack_in(&target).map_err(|e| DownloadError {
             message: format!("Failed to extract entry {}: {e}", entry_path.display()),
             retriable: false,

--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -8,9 +8,62 @@
 use guest_common::{log_error, log_info, log_warn, telemetry::record_sandbox_op};
 use serde::Deserialize;
 use std::fs;
+use std::path::{Component, Path, PathBuf};
 use std::sync::LazyLock;
 use std::thread;
 use std::time::{Duration, Instant};
+
+/// Lexically normalize a path by collapsing `.` and `..` components.
+/// Unlike `canonicalize()`, this does not touch the filesystem.
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut components: Vec<Component> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                // Only pop Normal components; don't pop RootDir or Prefix
+                if matches!(components.last(), Some(Component::Normal(_))) {
+                    components.pop();
+                }
+            }
+            Component::CurDir => {}
+            c => components.push(c),
+        }
+    }
+    components.iter().collect()
+}
+
+/// Check whether `path` stays within `target` after lexical normalization.
+fn is_within(path: &Path, target: &Path) -> bool {
+    normalize_path(path).starts_with(target)
+}
+
+/// Walk up from `path`'s parent toward `target`, find the deepest existing ancestor,
+/// canonicalize it, and verify it still resolves within `target`.
+/// Returns false if any ancestor resolves outside `target` (e.g., a symlink directory
+/// was planted earlier in the archive to redirect writes outside the target).
+fn ancestors_within_target(path: &Path, target: &Path) -> bool {
+    // Start from parent — path itself is the entry being extracted (doesn't exist yet).
+    let Some(mut ancestor) = path.parent() else {
+        return true;
+    };
+    loop {
+        if ancestor == target {
+            return true; // Reached target itself, which is already canonical
+        }
+        // Use symlink_metadata (lstat) instead of exists (stat) so we detect
+        // dangling symlinks — exists() follows symlinks and returns false for them.
+        if ancestor.symlink_metadata().is_ok() {
+            return match ancestor.canonicalize() {
+                Ok(canonical) => canonical.starts_with(target),
+                Err(_) => false, // dangling symlink or permission error
+            };
+        }
+        match ancestor.parent() {
+            Some(parent) => ancestor = parent,
+            None => return true,
+        }
+    }
+}
 
 const LOG_TAG: &str = "sandbox:download";
 
@@ -299,13 +352,120 @@ fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadErro
     let decoder = flate2::read::GzDecoder::new(reader);
     let mut archive = tar::Archive::new(decoder);
 
-    // Extract to target path
-    // Note: tar crate handles empty archives gracefully (returns Ok with 0 entries)
-    archive.unpack(target_path).map_err(|e| DownloadError {
-        message: format!("Failed to extract archive: {e}"),
+    // Extract entries one by one, validating paths to prevent symlink path traversal.
+    let target = Path::new(target_path)
+        .canonicalize()
+        .map_err(|e| DownloadError {
+            message: format!("Failed to canonicalize target path {target_path}: {e}"),
+            retriable: false,
+            status_code: None,
+        })?;
+
+    for entry in archive.entries().map_err(|e| DownloadError {
+        message: format!("Failed to read archive entries: {e}"),
         retriable: false,
         status_code: None,
-    })?;
+    })? {
+        let mut entry = entry.map_err(|e| DownloadError {
+            message: format!("Failed to read archive entry: {e}"),
+            retriable: false,
+            status_code: None,
+        })?;
+
+        let entry_path = entry
+            .path()
+            .map_err(|e| DownloadError {
+                message: format!("Failed to read entry path: {e}"),
+                retriable: false,
+                status_code: None,
+            })?
+            .into_owned();
+
+        let entry_type = entry.header().entry_type();
+
+        // Check that the entry path lexically stays within the target directory
+        // (normalize to collapse any .. components before checking)
+        let full_path = target.join(&entry_path);
+        if !is_within(&full_path, &target) {
+            log_warn!(
+                LOG_TAG,
+                "Skipping entry with path escaping target dir: {}",
+                entry_path.display()
+            );
+            continue;
+        }
+
+        // For symlinks, validate the resolved link target stays within the target directory
+        if entry_type.is_symlink() {
+            let link_target = match entry.link_name() {
+                Ok(Some(t)) => t,
+                _ => {
+                    log_warn!(
+                        LOG_TAG,
+                        "Skipping symlink with unreadable target: {}",
+                        entry_path.display()
+                    );
+                    continue;
+                }
+            };
+            let link_dir = full_path.parent().unwrap_or(&target);
+            let resolved = link_dir.join(&*link_target);
+            if !is_within(&resolved, &target) {
+                log_warn!(
+                    LOG_TAG,
+                    "Skipping symlink with target escaping dir: {} -> {}",
+                    entry_path.display(),
+                    link_target.display()
+                );
+                continue;
+            }
+        }
+
+        // For hardlinks, validate the link source stays within the target directory
+        if entry_type == tar::EntryType::Link {
+            let link_name = match entry.link_name() {
+                Ok(Some(t)) => t,
+                _ => {
+                    log_warn!(
+                        LOG_TAG,
+                        "Skipping hardlink with unreadable source: {}",
+                        entry_path.display()
+                    );
+                    continue;
+                }
+            };
+            let resolved = target.join(&*link_name);
+            if !is_within(&resolved, &target) {
+                log_warn!(
+                    LOG_TAG,
+                    "Skipping hardlink with source escaping dir: {} -> {}",
+                    entry_path.display(),
+                    link_name.display()
+                );
+                continue;
+            }
+        }
+
+        // Verify that parent directories haven't been replaced by symlinks pointing outside
+        // the target (two-step attack: first create a symlink dir, then write entries through
+        // it). Walk up to the deepest existing ancestor since the immediate parent may not
+        // exist yet. This applies to ALL entry types — a symlink/hardlink entry extracted
+        // through a malicious symlink directory is equally dangerous.
+        if !ancestors_within_target(&full_path, &target) {
+            log_warn!(
+                LOG_TAG,
+                "Skipping entry whose parent resolves outside target: {}",
+                entry_path.display()
+            );
+            continue;
+        }
+
+        entry.unpack_in(&target).map_err(|e| DownloadError {
+            message: format!("Failed to extract entry {}: {e}", entry_path.display()),
+            retriable: false,
+            status_code: None,
+        })?;
+    }
 
     Ok(())
 }

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -978,3 +978,159 @@ fn hardlink_relative_dotdot_escape_blocked() {
     );
     assert!(!mount.join("evil_hardlink").exists());
 }
+
+// ---------------------------------------------------------------------------
+// Test 28: absolute path entry is blocked
+// ---------------------------------------------------------------------------
+#[test]
+fn absolute_path_entry_blocked() {
+    let server = MockServer::start();
+
+    // Build raw tar with /etc/passwd entry — tar crate builder rejects absolute paths
+    let tar_gz = {
+        let content = b"malicious";
+        let path_bytes = b"/etc/passwd";
+
+        let mut full_tar: Vec<u8> = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut full_tar);
+            let mut h = tar::Header::new_gnu();
+            h.set_size(4);
+            h.set_mode(0o644);
+            h.set_cksum();
+            builder
+                .append_data(&mut h, "legit.txt", b"safe" as &[u8])
+                .unwrap();
+            builder.into_inner().unwrap();
+        }
+        while full_tar.len() >= 512 && full_tar[full_tar.len() - 512..].iter().all(|&b| b == 0) {
+            full_tar.truncate(full_tar.len() - 512);
+        }
+
+        let mut header_block = [0u8; 512];
+        header_block[..path_bytes.len()].copy_from_slice(path_bytes);
+        header_block[100..108].copy_from_slice(b"0000644\0");
+        header_block[108..116].copy_from_slice(b"0000000\0");
+        header_block[116..124].copy_from_slice(b"0000000\0");
+        let size_str = format!("{:011o}\0", content.len());
+        header_block[124..136].copy_from_slice(size_str.as_bytes());
+        header_block[136..148].copy_from_slice(b"00000000000\0");
+        header_block[156] = b'0';
+        header_block[257..263].copy_from_slice(b"ustar\0");
+        header_block[263..265].copy_from_slice(b"00");
+        header_block[148..156].copy_from_slice(b"        ");
+        let cksum: u32 = header_block.iter().map(|&b| b as u32).sum();
+        let cksum_str = format!("{:06o}\0 ", cksum);
+        header_block[148..156].copy_from_slice(cksum_str.as_bytes());
+
+        full_tar.extend_from_slice(&header_block);
+        let mut data_block = [0u8; 512];
+        data_block[..content.len()].copy_from_slice(content);
+        full_tar.extend_from_slice(&data_block);
+        full_tar.extend_from_slice(&[0u8; 1024]);
+
+        let mut gz_data = Vec::new();
+        let mut encoder = GzEncoder::new(&mut gz_data, Compression::fast());
+        encoder.write_all(&full_tar).unwrap();
+        encoder.finish().unwrap();
+        gz_data
+    };
+
+    server.mock(|when, then| {
+        when.method(GET).path("/storage.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&tar_gz);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("mount");
+    let url = server.url("/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    assert_eq!(
+        std::fs::read_to_string(mount.join("legit.txt")).unwrap(),
+        "safe"
+    );
+    // Absolute path entry should NOT be extracted
+    assert!(!mount.join("etc/passwd").exists());
+}
+
+// ---------------------------------------------------------------------------
+// Test 29: symlink with missing link target is skipped
+// ---------------------------------------------------------------------------
+#[test]
+fn symlink_missing_link_target_skipped() {
+    let server = MockServer::start();
+
+    // Build raw tar with a symlink entry that has no link target in the header
+    let tar_gz = {
+        let mut full_tar: Vec<u8> = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut full_tar);
+            let mut h = tar::Header::new_gnu();
+            h.set_size(4);
+            h.set_mode(0o644);
+            h.set_cksum();
+            builder
+                .append_data(&mut h, "legit.txt", b"safe" as &[u8])
+                .unwrap();
+            builder.into_inner().unwrap();
+        }
+        while full_tar.len() >= 512 && full_tar[full_tar.len() - 512..].iter().all(|&b| b == 0) {
+            full_tar.truncate(full_tar.len() - 512);
+        }
+
+        // Symlink header with empty link target (linkname field at bytes 157-257 is all zeros)
+        let path_bytes = b"bad_symlink";
+        let mut header_block = [0u8; 512];
+        header_block[..path_bytes.len()].copy_from_slice(path_bytes);
+        header_block[100..108].copy_from_slice(b"0000777\0");
+        header_block[108..116].copy_from_slice(b"0000000\0");
+        header_block[116..124].copy_from_slice(b"0000000\0");
+        header_block[124..136].copy_from_slice(b"00000000000\0");
+        header_block[136..148].copy_from_slice(b"00000000000\0");
+        header_block[156] = b'2'; // symlink type
+        // linkname at 157..257 left as zeros (empty target)
+        header_block[257..263].copy_from_slice(b"ustar\0");
+        header_block[263..265].copy_from_slice(b"00");
+        header_block[148..156].copy_from_slice(b"        ");
+        let cksum: u32 = header_block.iter().map(|&b| b as u32).sum();
+        let cksum_str = format!("{:06o}\0 ", cksum);
+        header_block[148..156].copy_from_slice(cksum_str.as_bytes());
+
+        full_tar.extend_from_slice(&header_block);
+        full_tar.extend_from_slice(&[0u8; 1024]);
+
+        let mut gz_data = Vec::new();
+        let mut encoder = GzEncoder::new(&mut gz_data, Compression::fast());
+        encoder.write_all(&full_tar).unwrap();
+        encoder.finish().unwrap();
+        gz_data
+    };
+
+    server.mock(|when, then| {
+        when.method(GET).path("/storage.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&tar_gz);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("mount");
+    let url = server.url("/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    assert_eq!(
+        std::fs::read_to_string(mount.join("legit.txt")).unwrap(),
+        "safe"
+    );
+    // Malformed symlink should NOT be created
+    assert!(mount.join("bad_symlink").symlink_metadata().is_err());
+}

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -5,17 +5,49 @@ use std::io::Write;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
+enum TarEntry<'a> {
+    File(&'a str, &'a [u8]),
+    Symlink(&'a str, &'a str),
+    Hardlink(&'a str, &'a str),
+}
+
 /// Create a tar.gz archive in memory containing the given files.
 fn create_tar_gz(files: &[(&str, &[u8])]) -> std::io::Result<Vec<u8>> {
+    let entries: Vec<TarEntry> = files.iter().map(|(p, c)| TarEntry::File(p, c)).collect();
+    create_tar_gz_entries(&entries)
+}
+
+/// Create a tar.gz archive with mixed file and symlink entries.
+fn create_tar_gz_entries(entries: &[TarEntry]) -> std::io::Result<Vec<u8>> {
     let mut tar_data = Vec::new();
     {
         let mut builder = tar::Builder::new(&mut tar_data);
-        for (path, contents) in files {
-            let mut header = tar::Header::new_gnu();
-            header.set_size(contents.len() as u64);
-            header.set_mode(0o644);
-            header.set_cksum();
-            builder.append_data(&mut header, path, *contents)?;
+        for entry in entries {
+            match entry {
+                TarEntry::File(path, contents) => {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_size(contents.len() as u64);
+                    header.set_mode(0o644);
+                    header.set_cksum();
+                    builder.append_data(&mut header, path, *contents)?;
+                }
+                TarEntry::Symlink(path, target) => {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_size(0);
+                    header.set_mode(0o777);
+                    header.set_entry_type(tar::EntryType::Symlink);
+                    header.set_cksum();
+                    builder.append_link(&mut header, path, target)?;
+                }
+                TarEntry::Hardlink(path, target) => {
+                    let mut header = tar::Header::new_gnu();
+                    header.set_size(0);
+                    header.set_mode(0o644);
+                    header.set_entry_type(tar::EntryType::Link);
+                    header.set_cksum();
+                    builder.append_link(&mut header, path, target)?;
+                }
+            }
         }
         builder.finish()?;
     }
@@ -588,4 +620,361 @@ fn memory_null_url_skipped() {
         write_manifest_with_memory(&dir, &[], None, Some((mount.to_str().unwrap(), None))).unwrap();
     let result = guest_download::run(manifest.to_str().unwrap());
     assert!(result);
+}
+
+// ---------------------------------------------------------------------------
+// Test 20: symlink escaping target directory is skipped
+// ---------------------------------------------------------------------------
+#[test]
+fn symlink_path_traversal_blocked() {
+    let server = MockServer::start();
+    let tar_gz = create_tar_gz_entries(&[
+        TarEntry::File("legit.txt", b"safe content"),
+        TarEntry::Symlink("evil_link", "../../etc/passwd"),
+    ])
+    .unwrap();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/storage.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&tar_gz);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("mount");
+    let url = server.url("/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    // Legitimate file should be extracted
+    assert_eq!(
+        std::fs::read_to_string(mount.join("legit.txt")).unwrap(),
+        "safe content"
+    );
+    // Symlink escaping the target should NOT be created (use symlink_metadata to
+    // detect the symlink itself, since exists() follows symlinks and returns false for dangling)
+    assert!(mount.join("evil_link").symlink_metadata().is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Test 21: symlink within target directory is allowed
+// ---------------------------------------------------------------------------
+#[test]
+fn symlink_within_target_allowed() {
+    let server = MockServer::start();
+    let tar_gz = create_tar_gz_entries(&[
+        TarEntry::File("real.txt", b"real content"),
+        TarEntry::Symlink("link.txt", "real.txt"),
+    ])
+    .unwrap();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/storage.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&tar_gz);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("mount");
+    let url = server.url("/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    assert_eq!(
+        std::fs::read_to_string(mount.join("real.txt")).unwrap(),
+        "real content"
+    );
+    // Symlink within target should be created
+    assert!(
+        mount
+            .join("link.txt")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 22: entry path with .. components escaping target is skipped
+// ---------------------------------------------------------------------------
+#[test]
+fn path_traversal_via_dotdot_blocked() {
+    let server = MockServer::start();
+
+    // Build a raw tar with ../outside.txt — the tar crate builder rejects .. paths,
+    // so we construct the tar entry manually to simulate a malicious archive.
+    let tar_gz = {
+        let content = b"escaped";
+        let path_bytes = b"../outside.txt";
+
+        // Build legit entry via tar crate, then append raw malicious entry
+        let mut full_tar: Vec<u8> = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut full_tar);
+            let mut h = tar::Header::new_gnu();
+            h.set_size(4);
+            h.set_mode(0o644);
+            h.set_cksum();
+            builder
+                .append_data(&mut h, "legit.txt", b"safe" as &[u8])
+                .unwrap();
+            builder.into_inner().unwrap();
+        }
+        // Strip EOF markers (trailing 512-byte zero blocks)
+        while full_tar.len() >= 512 && full_tar[full_tar.len() - 512..].iter().all(|&b| b == 0) {
+            full_tar.truncate(full_tar.len() - 512);
+        }
+
+        // Raw tar header for ../outside.txt
+        let mut header_block = [0u8; 512];
+        header_block[..path_bytes.len()].copy_from_slice(path_bytes);
+        header_block[100..108].copy_from_slice(b"0000644\0"); // mode
+        header_block[108..116].copy_from_slice(b"0000000\0"); // uid
+        header_block[116..124].copy_from_slice(b"0000000\0"); // gid
+        let size_str = format!("{:011o}\0", content.len());
+        header_block[124..136].copy_from_slice(size_str.as_bytes());
+        header_block[136..148].copy_from_slice(b"00000000000\0"); // mtime
+        header_block[156] = b'0'; // regular file
+        header_block[257..263].copy_from_slice(b"ustar\0");
+        header_block[263..265].copy_from_slice(b"00");
+        // Checksum (with checksum field as spaces)
+        header_block[148..156].copy_from_slice(b"        ");
+        let cksum: u32 = header_block.iter().map(|&b| b as u32).sum();
+        let cksum_str = format!("{:06o}\0 ", cksum);
+        header_block[148..156].copy_from_slice(cksum_str.as_bytes());
+
+        full_tar.extend_from_slice(&header_block);
+        let mut data_block = [0u8; 512];
+        data_block[..content.len()].copy_from_slice(content);
+        full_tar.extend_from_slice(&data_block);
+        full_tar.extend_from_slice(&[0u8; 1024]); // EOF
+
+        let mut gz_data = Vec::new();
+        let mut encoder = GzEncoder::new(&mut gz_data, Compression::fast());
+        encoder.write_all(&full_tar).unwrap();
+        encoder.finish().unwrap();
+        gz_data
+    };
+
+    server.mock(|when, then| {
+        when.method(GET).path("/storage.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&tar_gz);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("mount");
+    let url = server.url("/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    // Legit file should be extracted
+    assert_eq!(
+        std::fs::read_to_string(mount.join("legit.txt")).unwrap(),
+        "safe"
+    );
+    // File should NOT be extracted outside the mount directory
+    assert!(!dir.path().join("outside.txt").exists());
+}
+
+// ---------------------------------------------------------------------------
+// Test 23: two-step symlink attack (symlink dir + file through it) is blocked
+// ---------------------------------------------------------------------------
+#[test]
+fn two_step_symlink_attack_blocked() {
+    let server = MockServer::start();
+
+    // Attack: create a symlink "subdir" pointing to /tmp/evil-target, then
+    // write a file "subdir/payload.txt" which would resolve through the symlink.
+    let evil_target = tempfile::tempdir().unwrap();
+    let evil_target_path = evil_target.path().to_str().unwrap();
+
+    let tar_gz = create_tar_gz_entries(&[
+        TarEntry::File("safe.txt", b"safe"),
+        TarEntry::Symlink("subdir", evil_target_path),
+        TarEntry::File("subdir/payload.txt", b"malicious"),
+    ])
+    .unwrap();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/storage.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&tar_gz);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("mount");
+    let url = server.url("/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    // Safe file should be extracted
+    assert_eq!(
+        std::fs::read_to_string(mount.join("safe.txt")).unwrap(),
+        "safe"
+    );
+    // Payload should NOT be written to the evil target directory
+    assert!(!evil_target.path().join("payload.txt").exists());
+}
+
+// ---------------------------------------------------------------------------
+// Test 24: hardlink escaping target directory is blocked
+// ---------------------------------------------------------------------------
+#[test]
+fn hardlink_escaping_target_blocked() {
+    let server = MockServer::start();
+    let tar_gz = create_tar_gz_entries(&[
+        TarEntry::File("legit.txt", b"safe"),
+        TarEntry::Hardlink("evil_hardlink", "/etc/passwd"),
+    ])
+    .unwrap();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/storage.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&tar_gz);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("mount");
+    let url = server.url("/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    assert_eq!(
+        std::fs::read_to_string(mount.join("legit.txt")).unwrap(),
+        "safe"
+    );
+    // Hardlink should NOT be created
+    assert!(!mount.join("evil_hardlink").exists());
+}
+
+// ---------------------------------------------------------------------------
+// Test 25: symlink with relative .. target escaping is blocked
+// ---------------------------------------------------------------------------
+#[test]
+fn symlink_relative_dotdot_escape_blocked() {
+    let server = MockServer::start();
+
+    // Create a file outside mount to verify the symlink can't reach it
+    let dir = tempfile::tempdir().unwrap();
+    let outside_file = dir.path().join("secret.txt");
+    std::fs::write(&outside_file, "secret data").unwrap();
+
+    // Symlink target uses .. to escape mount and reach the parent dir
+    let tar_gz = create_tar_gz_entries(&[
+        TarEntry::File("legit.txt", b"safe"),
+        TarEntry::Symlink("escape", "../secret.txt"),
+    ])
+    .unwrap();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/storage.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&tar_gz);
+    });
+
+    let mount = dir.path().join("mount");
+    let url = server.url("/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    assert_eq!(
+        std::fs::read_to_string(mount.join("legit.txt")).unwrap(),
+        "safe"
+    );
+    // Symlink should NOT be created (symlink_metadata detects even dangling symlinks)
+    assert!(mount.join("escape").symlink_metadata().is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Test 26: two-step attack via deeper nested path is blocked
+// ---------------------------------------------------------------------------
+#[test]
+fn two_step_attack_deep_nested_blocked() {
+    let server = MockServer::start();
+
+    // Attack: symlink "a" points outside, then file "a/b/c.txt" tries to
+    // write through it. The immediate parent "a/b" doesn't exist, but
+    // ancestor "a" is the escaping symlink.
+    let evil_target = tempfile::tempdir().unwrap();
+    let evil_target_path = evil_target.path().to_str().unwrap();
+
+    let tar_gz = create_tar_gz_entries(&[
+        TarEntry::Symlink("a", evil_target_path),
+        TarEntry::File("a/b/c.txt", b"payload"),
+    ])
+    .unwrap();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/storage.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&tar_gz);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("mount");
+    let url = server.url("/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    // Payload should NOT be written to the evil target
+    assert!(!evil_target.path().join("b").exists());
+    assert!(!evil_target.path().join("b/c.txt").exists());
+}
+
+// ---------------------------------------------------------------------------
+// Test 27: hardlink with relative .. escaping is blocked
+// ---------------------------------------------------------------------------
+#[test]
+fn hardlink_relative_dotdot_escape_blocked() {
+    let server = MockServer::start();
+    let tar_gz = create_tar_gz_entries(&[
+        TarEntry::File("legit.txt", b"safe"),
+        TarEntry::Hardlink("evil_hardlink", "../../../etc/passwd"),
+    ])
+    .unwrap();
+
+    server.mock(|when, then| {
+        when.method(GET).path("/storage.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&tar_gz);
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let mount = dir.path().join("mount");
+    let url = server.url("/storage.tar.gz");
+    let manifest = write_manifest(&dir, &[(mount.to_str().unwrap(), Some(&url))], None).unwrap();
+
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    assert_eq!(
+        std::fs::read_to_string(mount.join("legit.txt")).unwrap(),
+        "safe"
+    );
+    assert!(!mount.join("evil_hardlink").exists());
 }


### PR DESCRIPTION
## Summary

- Replace `archive.unpack()` with per-entry extraction that validates each path before writing
- Prevent symlink/hardlink-based directory escape attacks in tar archive restore
- Fixes #6146, related to #3934

## Defense layers

1. **Lexical path normalization** — collapse `..`/`.` components before `starts_with` check (fixes `Path::starts_with` not handling `..`)
2. **Symlink target validation** — reject symlinks pointing outside target directory
3. **Hardlink source validation** — reject hardlinks referencing files outside target directory
4. **Filesystem ancestor canonicalization** — walk up to deepest existing ancestor and `canonicalize()` to detect two-step attacks (symlink dir planted by earlier entry + file written through it)

## Attacks blocked

| Attack | Defense |
|---|---|
| Absolute path entry (`/etc/passwd`) | Lexical check |
| `..` path traversal (`../outside`) | Lexical normalization + check |
| Symlink to absolute target (`a → /etc`) | Symlink target check |
| Symlink with relative `..` escape (`a → ../../etc`) | Symlink target normalization |
| Two-step attack (symlink dir + file through it) | Ancestor canonicalization |
| Deep nested two-step (`symlink a + file a/b/c`) | Ancestor walk-up |
| Hardlink escape (absolute or relative `..`) | Hardlink source check |
| Dangling symlink directory bypass | `symlink_metadata` instead of `exists` |
| Malformed symlink/hardlink (unreadable target) | Reject on `link_name()` failure |

## Test plan

- [x] 8 new security tests (symlink escape, hardlink escape, `..` traversal, two-step attacks, relative `..` variants)
- [x] All 19 pre-existing tests pass (normal extraction unaffected)
- [x] clippy clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)