### PR TITLE
chore: integrate pr-check into pr-review-loop workflow

### DIFF
--- a/.claude/skills/issue-action/SKILL.md
+++ b/.claude/skills/issue-action/SKILL.md
@@ -92,21 +92,18 @@ Review new comments for:
 
 2. Run `/pr-review-loop` skill to perform a full code review and fix cycle
    - The pr-review-loop skill will review the PR, post comments, fix issues, and re-review until LGTM
+   - After the review loop completes, it automatically invokes `/pr-check` to monitor and fix CI pipeline
 
-3. Run `/pr-check` skill to monitor and fix CI pipeline
-   - The pr-check skill will auto-fix lint/format issues
-   - If type or test errors occur, pr-check will exit with details for manual intervention
-
-4. **If both pr-review-loop and pr-check complete successfully**: Post comment to issue:
+3. **If pr-review-loop completes successfully (including CI check)**: Post comment to issue:
    ```bash
    gh issue comment {issue-id} --body "Work completed. PR created: {pr-url}
 
    Code review passed and all CI checks passing."
    ```
 
-5. **If pr-review-loop or pr-check exits with manual intervention required**: Add "pending" label and exit
+4. **If pr-review-loop exits with manual intervention required**: Add "pending" label and exit
 
-6. Keep issue open (user will close it after merging PR)
+5. Keep issue open (user will close it after merging PR)
 
 ## Label Management
 

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -328,3 +328,13 @@ Remaining issues need manual intervention:
 
 All review comments posted to PR.
 ```
+
+---
+
+## Phase 4: CI Check
+
+After the review loop completes, invoke `/pr-check` to monitor CI pipeline and auto-fix any remaining CI issues (lint/format failures from the fix commits, etc.):
+
+invoke skill /pr-check ${PR_NUMBER}
+
+This ensures that all fix commits pushed during the review loop pass CI before the PR is ready for merge.


### PR DESCRIPTION
## Summary
- Moves the `/pr-check` CI monitoring step from a separate phase in `issue-action` into the end of the `pr-review-loop` skill as Phase 4
- Simplifies the `issue-action` workflow by reducing steps from 6 to 5, since pr-review-loop now handles CI checking automatically after the review loop completes

## Test plan
- [ ] Verify `issue-action` skill correctly invokes `pr-review-loop` and expects CI check to be handled within it
- [ ] Verify `pr-review-loop` skill invokes `/pr-check` after completing the review loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)