### PR TITLE
refactor(firewalls-generator): extract shared codegen utilities

### DIFF
--- a/turbo/packages/firewalls-generator/src/codegen.ts
+++ b/turbo/packages/firewalls-generator/src/codegen.ts
@@ -1,0 +1,181 @@
+/**
+ * Shared codegen utilities for firewall config generators.
+ *
+ * Provides common types, rule sorting, TypeScript rendering helpers,
+ * and file I/O used by all individual firewall generators.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface PermissionGroup {
+  name: string;
+  description?: string;
+  rules: string[];
+}
+
+// ── OpenAPI types ────────────────────────────────────────────────────────
+
+export interface OpenApiOperation {
+  security?: Array<Record<string, string[]>>;
+}
+
+type OpenApiPathItem = Record<string, unknown>;
+
+export interface OpenApiSpec {
+  info?: { version?: string };
+  paths?: Record<string, OpenApiPathItem>;
+  components?: {
+    securitySchemes?: {
+      [key: string]: {
+        flows?: {
+          authorizationCode?: {
+            scopes?: Record<string, string>;
+          };
+        };
+      };
+    };
+  };
+}
+
+export const ALL_METHODS = new Set([
+  "get",
+  "head",
+  "post",
+  "put",
+  "patch",
+  "delete",
+]);
+
+export const OPENAPI_PATH_KEYS = new Set([
+  "summary",
+  "description",
+  "servers",
+  "parameters",
+  "$ref",
+  "options",
+  "trace",
+]);
+
+// ── Rule sorting ─────────────────────────────────────────────────────────
+
+const METHOD_ORDER: Record<string, number> = {
+  GET: 0,
+  HEAD: 1,
+  POST: 2,
+  PUT: 3,
+  PATCH: 4,
+  DELETE: 5,
+};
+
+function ruleKey(rule: string): [string, number] {
+  const [method, rulePath] = rule.split(" ", 2) as [string, string];
+  return [rulePath, METHOD_ORDER[method] ?? 9];
+}
+
+export function sortRules(rules: string[]): string[] {
+  return [...rules].sort((a, b) => {
+    const [pathA, orderA] = ruleKey(a);
+    const [pathB, orderB] = ruleKey(b);
+    return pathA < pathB ? -1 : pathA > pathB ? 1 : orderA - orderB;
+  });
+}
+
+// ── String escaping ──────────────────────────────────────────────────────
+
+export function escapeString(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+// ── TypeScript rendering ─────────────────────────────────────────────────
+
+/**
+ * Render permission entries (unrestricted catch-all + all groups) as
+ * indented TypeScript source lines for embedding in an `apis[].permissions`
+ * array.
+ */
+export function renderPermissions(permissions: PermissionGroup[]): string[] {
+  const lines: string[] = [];
+
+  // Catch-all: allows all endpoints
+  lines.push("        {");
+  lines.push('          name: "unrestricted",');
+  lines.push('          description: "Allow all endpoints",');
+  lines.push("          rules: [");
+  lines.push('            "ANY /{path*}",');
+  lines.push("          ],");
+  lines.push("        },");
+
+  for (const perm of permissions) {
+    lines.push("        {");
+    lines.push(`          name: "${escapeString(perm.name)}",`);
+    if (perm.description) {
+      lines.push(`          description: "${escapeString(perm.description)}",`);
+    }
+    lines.push("          rules: [");
+    for (const rule of perm.rules) {
+      lines.push(`            "${escapeString(rule)}",`);
+    }
+    lines.push("          ],");
+    lines.push("        },");
+  }
+
+  return lines;
+}
+
+// ── File I/O ─────────────────────────────────────────────────────────────
+
+/**
+ * Write generated content to the output file and validate it's non-empty.
+ *
+ * @param serviceName - Used to derive the output filename
+ *   (e.g. "figma" → "figma.generated.ts")
+ * @param content - Generated TypeScript source
+ * @param dirname - `import.meta.dirname` of the calling module
+ */
+export function writeOutput(
+  serviceName: string,
+  content: string,
+  dirname: string,
+): void {
+  const outPath = path.resolve(
+    dirname,
+    `../../core/src/firewalls/${serviceName}.generated.ts`,
+  );
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, content);
+  console.error(`  Written to ${outPath}`);
+
+  const stat = fs.statSync(outPath);
+  if (stat.size === 0) {
+    throw new Error("Generated file is empty");
+  }
+  console.error(`  Validated (${(stat.size / 1024).toFixed(1)} KB)`);
+}
+
+// ── Logging ──────────────────────────────────────────────────────────────
+
+export function logStats(permissions: PermissionGroup[]): void {
+  const totalRules = permissions.reduce((sum, p) => sum + p.rules.length, 0);
+  console.error(
+    `  ${permissions.length} permission groups, ${totalRules} rules`,
+  );
+}
+
+// ── HTTP ─────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch a URL with error handling. Throws on non-OK responses.
+ */
+export async function fetchSpec(url: string, label: string): Promise<Response> {
+  console.error(`Downloading ${label}…`);
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch ${label}: ${res.status} ${res.statusText}`,
+    );
+  }
+  return res;
+}

--- a/turbo/packages/firewalls-generator/src/confluence.ts
+++ b/turbo/packages/firewalls-generator/src/confluence.ts
@@ -9,8 +9,16 @@
  * Endpoints without OAuth2 security are skipped.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
+import {
+  ALL_METHODS,
+  OPENAPI_PATH_KEYS,
+  fetchSpec,
+  logStats,
+  renderPermissions,
+  sortRules,
+  writeOutput,
+} from "./codegen";
+import type { OpenApiOperation, OpenApiSpec, PermissionGroup } from "./codegen";
 
 const OPENAPI_URL =
   "https://developer.atlassian.com/cloud/confluence/swagger.v3.json";
@@ -21,70 +29,8 @@ const PLACEHOLDER_VALUE =
   "ATATT3xVm0PlaceHolder000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
 const OAUTH_SCHEME_KEY = "oAuthDefinitions";
-const ALL_METHODS = new Set(["get", "head", "post", "put", "patch", "delete"]);
-const OPENAPI_PATH_KEYS = new Set([
-  "summary",
-  "description",
-  "servers",
-  "parameters",
-  "$ref",
-  "options",
-  "trace",
-]);
-
-// ── OpenAPI types ────────────────────────────────────────────────────────
-
-interface OpenApiOperation {
-  security?: Array<Record<string, string[]>>;
-}
-
-type OpenApiPathItem = Record<string, unknown>;
-
-interface OpenApiSpec {
-  info?: { version?: string };
-  paths?: Record<string, OpenApiPathItem>;
-  components?: {
-    securitySchemes?: {
-      [key: string]: {
-        flows?: {
-          authorizationCode?: {
-            scopes?: Record<string, string>;
-          };
-        };
-      };
-    };
-  };
-}
 
 // ── Grouping ─────────────────────────────────────────────────────────────
-
-interface PermissionGroup {
-  name: string;
-  description: string;
-  rules: string[];
-}
-
-const METHOD_ORDER: Record<string, number> = {
-  GET: 0,
-  HEAD: 1,
-  POST: 2,
-  PUT: 3,
-  PATCH: 4,
-  DELETE: 5,
-};
-
-function ruleKey(rule: string): [string, number] {
-  const [method, rulePath] = rule.split(" ", 2) as [string, string];
-  return [rulePath, METHOD_ORDER[method] ?? 9];
-}
-
-function sortRules(rules: string[]): string[] {
-  return [...rules].sort((a, b) => {
-    const [pathA, orderA] = ruleKey(a);
-    const [pathB, orderB] = ruleKey(b);
-    return pathA < pathB ? -1 : pathA > pathB ? 1 : orderA - orderB;
-  });
-}
 
 function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
   const groups = new Map<string, Set<string>>();
@@ -142,10 +88,6 @@ function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
 
 // ── TypeScript generation ────────────────────────────────────────────────
 
-function escapeString(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
 function generateTypeScript(permissions: PermissionGroup[]): string {
   const lines: string[] = [
     "// Auto-generated from Confluence Cloud's official OpenAPI spec.",
@@ -173,28 +115,7 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
     "      permissions: [",
   ];
 
-  // Catch-all: allows all endpoints
-  lines.push("        {");
-  lines.push('          name: "unrestricted",');
-  lines.push('          description: "Allow all endpoints",');
-  lines.push("          rules: [");
-  lines.push('            "ANY /{path*}",');
-  lines.push("          ],");
-  lines.push("        },");
-
-  for (const perm of permissions) {
-    lines.push("        {");
-    lines.push(`          name: "${escapeString(perm.name)}",`);
-    if (perm.description) {
-      lines.push(`          description: "${escapeString(perm.description)}",`);
-    }
-    lines.push("          rules: [");
-    for (const rule of perm.rules) {
-      lines.push(`            "${escapeString(rule)}",`);
-    }
-    lines.push("          ],");
-    lines.push("        },");
-  }
+  lines.push(...renderPermissions(permissions));
 
   lines.push("      ],");
   lines.push("    },");
@@ -208,35 +129,13 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
 // ── Main ─────────────────────────────────────────────────────────────────
 
 export async function generate(): Promise<void> {
-  console.error("Downloading Confluence OpenAPI spec…");
-  const res = await fetch(OPENAPI_URL);
-  if (!res.ok) {
-    throw new Error(
-      `Failed to fetch OpenAPI spec: ${res.status} ${res.statusText}`,
-    );
-  }
+  const res = await fetchSpec(OPENAPI_URL, "Confluence OpenAPI spec");
   const spec = (await res.json()) as OpenApiSpec;
   console.error(`  Spec version: ${spec.info?.version ?? "unknown"}`);
 
   const permissions = buildGroups(spec);
   const ts = generateTypeScript(permissions);
 
-  const totalRules = permissions.reduce((sum, p) => sum + p.rules.length, 0);
-  console.error(
-    `  ${permissions.length} permission groups, ${totalRules} rules`,
-  );
-
-  const outPath = path.resolve(
-    import.meta.dirname,
-    "../../core/src/firewalls/confluence.generated.ts",
-  );
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, ts);
-  console.error(`  Written to ${outPath}`);
-
-  const stat = fs.statSync(outPath);
-  if (stat.size === 0) {
-    throw new Error("Generated file is empty");
-  }
-  console.error(`  Validated (${(stat.size / 1024).toFixed(1)} KB)`);
+  logStats(permissions);
+  writeOutput("confluence", ts, import.meta.dirname);
 }

--- a/turbo/packages/firewalls-generator/src/figma.ts
+++ b/turbo/packages/firewalls-generator/src/figma.ts
@@ -9,9 +9,18 @@
  * Endpoints without OAuth2 security are skipped.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
 import { parse as parseYaml } from "yaml";
+
+import {
+  ALL_METHODS,
+  OPENAPI_PATH_KEYS,
+  fetchSpec,
+  logStats,
+  renderPermissions,
+  sortRules,
+  writeOutput,
+} from "./codegen";
+import type { OpenApiOperation, OpenApiSpec, PermissionGroup } from "./codegen";
 
 const OPENAPI_URL =
   "https://raw.githubusercontent.com/figma/rest-api-spec/main/openapi/openapi.yaml";
@@ -21,70 +30,8 @@ const OPENAPI_URL =
 const PLACEHOLDER_VALUE = "figd_Vm0PlaceHolder00000000000000000000000000";
 
 const OAUTH_SCHEME_KEYS = new Set(["OAuth2", "OrgOAuth2"]);
-const ALL_METHODS = new Set(["get", "head", "post", "put", "patch", "delete"]);
-const OPENAPI_PATH_KEYS = new Set([
-  "summary",
-  "description",
-  "servers",
-  "parameters",
-  "$ref",
-  "options",
-  "trace",
-]);
-
-// ── OpenAPI types ────────────────────────────────────────────────────────
-
-interface OpenApiOperation {
-  security?: Array<Record<string, string[]>>;
-}
-
-type OpenApiPathItem = Record<string, unknown>;
-
-interface OpenApiSpec {
-  info?: { version?: string };
-  paths?: Record<string, OpenApiPathItem>;
-  components?: {
-    securitySchemes?: {
-      [key: string]: {
-        flows?: {
-          authorizationCode?: {
-            scopes?: Record<string, string>;
-          };
-        };
-      };
-    };
-  };
-}
 
 // ── Grouping ─────────────────────────────────────────────────────────────
-
-interface PermissionGroup {
-  name: string;
-  description: string;
-  rules: string[];
-}
-
-const METHOD_ORDER: Record<string, number> = {
-  GET: 0,
-  HEAD: 1,
-  POST: 2,
-  PUT: 3,
-  PATCH: 4,
-  DELETE: 5,
-};
-
-function ruleKey(rule: string): [string, number] {
-  const [method, rulePath] = rule.split(" ", 2) as [string, string];
-  return [rulePath, METHOD_ORDER[method] ?? 9];
-}
-
-function sortRules(rules: string[]): string[] {
-  return [...rules].sort((a, b) => {
-    const [pathA, orderA] = ruleKey(a);
-    const [pathB, orderB] = ruleKey(b);
-    return pathA < pathB ? -1 : pathA > pathB ? 1 : orderA - orderB;
-  });
-}
 
 function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
   const groups = new Map<string, Set<string>>();
@@ -153,10 +100,6 @@ function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
 
 // ── TypeScript generation ────────────────────────────────────────────────
 
-function escapeString(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
 function generateTypeScript(permissions: PermissionGroup[]): string {
   const lines: string[] = [
     "// Auto-generated from Figma's official OpenAPI spec.",
@@ -184,28 +127,7 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
     "      permissions: [",
   ];
 
-  // Catch-all: allows all endpoints
-  lines.push("        {");
-  lines.push('          name: "unrestricted",');
-  lines.push('          description: "Allow all endpoints",');
-  lines.push("          rules: [");
-  lines.push('            "ANY /{path*}",');
-  lines.push("          ],");
-  lines.push("        },");
-
-  for (const perm of permissions) {
-    lines.push("        {");
-    lines.push(`          name: "${escapeString(perm.name)}",`);
-    if (perm.description) {
-      lines.push(`          description: "${escapeString(perm.description)}",`);
-    }
-    lines.push("          rules: [");
-    for (const rule of perm.rules) {
-      lines.push(`            "${escapeString(rule)}",`);
-    }
-    lines.push("          ],");
-    lines.push("        },");
-  }
+  lines.push(...renderPermissions(permissions));
 
   lines.push("      ],");
   lines.push("    },");
@@ -219,13 +141,7 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
 // ── Main ─────────────────────────────────────────────────────────────────
 
 export async function generate(): Promise<void> {
-  console.error("Downloading Figma OpenAPI spec…");
-  const res = await fetch(OPENAPI_URL);
-  if (!res.ok) {
-    throw new Error(
-      `Failed to fetch OpenAPI spec: ${res.status} ${res.statusText}`,
-    );
-  }
+  const res = await fetchSpec(OPENAPI_URL, "Figma OpenAPI spec");
   const text = await res.text();
   const spec = parseYaml(text) as OpenApiSpec;
   console.error(`  Spec version: ${spec.info?.version ?? "unknown"}`);
@@ -233,22 +149,6 @@ export async function generate(): Promise<void> {
   const permissions = buildGroups(spec);
   const ts = generateTypeScript(permissions);
 
-  const totalRules = permissions.reduce((sum, p) => sum + p.rules.length, 0);
-  console.error(
-    `  ${permissions.length} permission groups, ${totalRules} rules`,
-  );
-
-  const outPath = path.resolve(
-    import.meta.dirname,
-    "../../core/src/firewalls/figma.generated.ts",
-  );
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, ts);
-  console.error(`  Written to ${outPath}`);
-
-  const stat = fs.statSync(outPath);
-  if (stat.size === 0) {
-    throw new Error("Generated file is empty");
-  }
-  console.error(`  Validated (${(stat.size / 1024).toFixed(1)} KB)`);
+  logStats(permissions);
+  writeOutput("figma", ts, import.meta.dirname);
 }

--- a/turbo/packages/firewalls-generator/src/github.ts
+++ b/turbo/packages/firewalls-generator/src/github.ts
@@ -12,8 +12,14 @@
  * or manual mapping needed — the classification is entirely data-driven.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
+import {
+  fetchSpec,
+  logStats,
+  renderPermissions,
+  sortRules,
+  writeOutput,
+} from "./codegen";
+import type { PermissionGroup } from "./codegen";
 
 const PERMS_URL =
   "https://raw.githubusercontent.com/github/docs/main/src/github-apps/data/fpt-2026-03-10/server-to-server-permissions.json";
@@ -93,34 +99,6 @@ type PermsData = Record<string, PermEntry>;
 
 // ── Grouping ─────────────────────────────────────────────────────────────
 
-const METHOD_ORDER: Record<string, number> = {
-  GET: 0,
-  HEAD: 1,
-  POST: 2,
-  PUT: 3,
-  PATCH: 4,
-  DELETE: 5,
-};
-
-function ruleKey(rule: string): [string, number] {
-  const [method, rulePath] = rule.split(" ", 2) as [string, string];
-  return [rulePath, METHOD_ORDER[method] ?? 9];
-}
-
-function sortRules(rules: string[]): string[] {
-  return [...rules].sort((a, b) => {
-    const [pathA, orderA] = ruleKey(a);
-    const [pathB, orderB] = ruleKey(b);
-    return pathA < pathB ? -1 : pathA > pathB ? 1 : orderA - orderB;
-  });
-}
-
-interface PermissionGroup {
-  name: string;
-  description: string;
-  rules: string[];
-}
-
 function buildGroups(permsData: PermsData): PermissionGroup[] {
   const groups = new Map<string, Set<string>>();
   const descriptions = new Map<string, string>();
@@ -158,10 +136,6 @@ function buildGroups(permsData: PermsData): PermissionGroup[] {
 
 // ── TypeScript generation ────────────────────────────────────────────────
 
-function escapeString(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
 function generateTypeScript(permissions: PermissionGroup[]): string {
   const placeholder = makeGitHubPlaceholder();
 
@@ -192,28 +166,7 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
     "      permissions: [",
   ];
 
-  // Catch-all: allows all endpoints (for users who only need token injection)
-  lines.push("        {");
-  lines.push('          name: "unrestricted",');
-  lines.push('          description: "Allow all endpoints",');
-  lines.push("          rules: [");
-  lines.push('            "ANY /{path*}",');
-  lines.push("          ],");
-  lines.push("        },");
-
-  for (const perm of permissions) {
-    lines.push("        {");
-    lines.push(`          name: "${escapeString(perm.name)}",`);
-    if (perm.description) {
-      lines.push(`          description: "${escapeString(perm.description)}",`);
-    }
-    lines.push("          rules: [");
-    for (const rule of perm.rules) {
-      lines.push(`            "${escapeString(rule)}",`);
-    }
-    lines.push("          ],");
-    lines.push("        },");
-  }
+  lines.push(...renderPermissions(permissions));
 
   lines.push("      ],");
   lines.push("    },");
@@ -255,43 +208,13 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
 // ── Main ─────────────────────────────────────────────────────────────────
 
 export async function generate(): Promise<void> {
-  console.error("Downloading GitHub permissions data…");
-  const res = await fetch(PERMS_URL);
-  if (!res.ok) {
-    throw new Error(
-      `Failed to fetch permissions data: ${res.status} ${res.statusText}`,
-    );
-  }
+  const res = await fetchSpec(PERMS_URL, "GitHub permissions data");
   const permsData = (await res.json()) as PermsData;
   console.error(`  ${Object.keys(permsData).length} permissions`);
 
   const permissions = buildGroups(permsData);
   const ts = generateTypeScript(permissions);
 
-  const totalRules = permissions.reduce((sum, p) => sum + p.rules.length, 0);
-  console.error(
-    `  ${permissions.length} permission groups, ${totalRules} rules`,
-  );
-
-  const outPath = path.resolve(
-    import.meta.dirname,
-    "../../core/src/firewalls/github.generated.ts",
-  );
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, ts);
-  console.error(`  Written to ${outPath}`);
-
-  // Validate the generated config matches the schema
-  validateGeneratedConfig(outPath);
-}
-
-function validateGeneratedConfig(outPath: string): void {
-  // We can't dynamically import the generated TS at this point,
-  // but type-checking via tsc will catch schema mismatches.
-  // Just verify the file was written and is non-empty.
-  const stat = fs.statSync(outPath);
-  if (stat.size === 0) {
-    throw new Error("Generated file is empty");
-  }
-  console.error(`  Validated (${(stat.size / 1024).toFixed(1)} KB)`);
+  logStats(permissions);
+  writeOutput("github", ts, import.meta.dirname);
 }

--- a/turbo/packages/firewalls-generator/src/google.ts
+++ b/turbo/packages/firewalls-generator/src/google.ts
@@ -5,8 +5,15 @@
  * API format: resources → methods → {path, httpMethod, scopes}.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
+import {
+  escapeString,
+  fetchSpec,
+  logStats,
+  renderPermissions,
+  sortRules,
+  writeOutput,
+} from "./codegen";
+import type { PermissionGroup } from "./codegen";
 
 // Short scope names: strip the common prefix for readable permission names.
 const SCOPE_PREFIX = "https://www.googleapis.com/auth/";
@@ -68,34 +75,6 @@ function extractMethods(
 }
 
 // ── Grouping ─────────────────────────────────────────────────────────────
-
-interface PermissionGroup {
-  name: string;
-  description: string;
-  rules: string[];
-}
-
-const METHOD_ORDER: Record<string, number> = {
-  GET: 0,
-  HEAD: 1,
-  POST: 2,
-  PUT: 3,
-  PATCH: 4,
-  DELETE: 5,
-};
-
-function ruleKey(rule: string): [string, number] {
-  const [method, rulePath] = rule.split(" ", 2) as [string, string];
-  return [rulePath, METHOD_ORDER[method] ?? 9];
-}
-
-function sortRules(rules: string[]): string[] {
-  return [...rules].sort((a, b) => {
-    const [pathA, orderA] = ruleKey(a);
-    const [pathB, orderB] = ruleKey(b);
-    return pathA < pathB ? -1 : pathA > pathB ? 1 : orderA - orderB;
-  });
-}
 
 function buildGroups(
   discovery: DiscoveryDocument,
@@ -173,10 +152,6 @@ function buildGroups(
 
 // ── TypeScript generation ────────────────────────────────────────────────
 
-function escapeString(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
 function generateTypeScript(
   permissions: PermissionGroup[],
   config: GoogleFirewallConfig,
@@ -212,28 +187,7 @@ function generateTypeScript(
     "      permissions: [",
   ];
 
-  // Catch-all: allows all endpoints
-  lines.push("        {");
-  lines.push('          name: "unrestricted",');
-  lines.push('          description: "Allow all endpoints",');
-  lines.push("          rules: [");
-  lines.push('            "ANY /{path*}",');
-  lines.push("          ],");
-  lines.push("        },");
-
-  for (const perm of permissions) {
-    lines.push("        {");
-    lines.push(`          name: "${escapeString(perm.name)}",`);
-    if (perm.description) {
-      lines.push(`          description: "${escapeString(perm.description)}",`);
-    }
-    lines.push("          rules: [");
-    for (const rule of perm.rules) {
-      lines.push(`            "${escapeString(rule)}",`);
-    }
-    lines.push("          ],");
-    lines.push("        },");
-  }
+  lines.push(...renderPermissions(permissions));
 
   lines.push("      ],");
   lines.push("    },");
@@ -269,13 +223,10 @@ async function generateGoogleFirewall(
   const allPermissions: PermissionGroup[] = [];
 
   for (const discoveryUrl of config.discoveryUrls) {
-    console.error(`Downloading ${config.serviceName} discovery document…`);
-    const res = await fetch(discoveryUrl);
-    if (!res.ok) {
-      throw new Error(
-        `Failed to fetch discovery doc: ${res.status} ${res.statusText}`,
-      );
-    }
+    const res = await fetchSpec(
+      discoveryUrl,
+      `${config.serviceName} discovery document`,
+    );
     const discovery = (await res.json()) as DiscoveryDocument;
     console.error(`  API version: ${discovery.version ?? "unknown"}`);
 
@@ -302,24 +253,8 @@ async function generateGoogleFirewall(
 
   const ts = generateTypeScript(allPermissions, config);
 
-  const totalRules = allPermissions.reduce((sum, p) => sum + p.rules.length, 0);
-  console.error(
-    `  ${allPermissions.length} permission groups, ${totalRules} rules`,
-  );
-
-  const outPath = path.resolve(
-    import.meta.dirname,
-    `../../core/src/firewalls/${config.serviceName}.generated.ts`,
-  );
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, ts);
-  console.error(`  Written to ${outPath}`);
-
-  const stat = fs.statSync(outPath);
-  if (stat.size === 0) {
-    throw new Error("Generated file is empty");
-  }
-  console.error(`  Validated (${(stat.size / 1024).toFixed(1)} KB)`);
+  logStats(allPermissions);
+  writeOutput(config.serviceName, ts, import.meta.dirname);
 }
 
 // ── Service configs ──────────────────────────────────────────────────────

--- a/turbo/packages/firewalls-generator/src/jira.ts
+++ b/turbo/packages/firewalls-generator/src/jira.ts
@@ -9,8 +9,16 @@
  * Endpoints without OAuth2 security are skipped.
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
+import {
+  ALL_METHODS,
+  OPENAPI_PATH_KEYS,
+  fetchSpec,
+  logStats,
+  renderPermissions,
+  sortRules,
+  writeOutput,
+} from "./codegen";
+import type { OpenApiOperation, OpenApiSpec, PermissionGroup } from "./codegen";
 
 const OPENAPI_URL =
   "https://developer.atlassian.com/cloud/jira/platform/swagger-v3.v3.json";
@@ -21,70 +29,8 @@ const PLACEHOLDER_VALUE =
   "ATATT3xVm0PlaceHolder000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
 const OAUTH_SCHEME_KEY = "OAuth2";
-const ALL_METHODS = new Set(["get", "head", "post", "put", "patch", "delete"]);
-const OPENAPI_PATH_KEYS = new Set([
-  "summary",
-  "description",
-  "servers",
-  "parameters",
-  "$ref",
-  "options",
-  "trace",
-]);
-
-// ── OpenAPI types ────────────────────────────────────────────────────────
-
-interface OpenApiOperation {
-  security?: Array<Record<string, string[]>>;
-}
-
-type OpenApiPathItem = Record<string, unknown>;
-
-interface OpenApiSpec {
-  info?: { version?: string };
-  paths?: Record<string, OpenApiPathItem>;
-  components?: {
-    securitySchemes?: {
-      [key: string]: {
-        flows?: {
-          authorizationCode?: {
-            scopes?: Record<string, string>;
-          };
-        };
-      };
-    };
-  };
-}
 
 // ── Grouping ─────────────────────────────────────────────────────────────
-
-interface PermissionGroup {
-  name: string;
-  description: string;
-  rules: string[];
-}
-
-const METHOD_ORDER: Record<string, number> = {
-  GET: 0,
-  HEAD: 1,
-  POST: 2,
-  PUT: 3,
-  PATCH: 4,
-  DELETE: 5,
-};
-
-function ruleKey(rule: string): [string, number] {
-  const [method, rulePath] = rule.split(" ", 2) as [string, string];
-  return [rulePath, METHOD_ORDER[method] ?? 9];
-}
-
-function sortRules(rules: string[]): string[] {
-  return [...rules].sort((a, b) => {
-    const [pathA, orderA] = ruleKey(a);
-    const [pathB, orderB] = ruleKey(b);
-    return pathA < pathB ? -1 : pathA > pathB ? 1 : orderA - orderB;
-  });
-}
 
 function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
   const groups = new Map<string, Set<string>>();
@@ -142,10 +88,6 @@ function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
 
 // ── TypeScript generation ────────────────────────────────────────────────
 
-function escapeString(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
 function generateTypeScript(permissions: PermissionGroup[]): string {
   const lines: string[] = [
     "// Auto-generated from Jira Cloud's official OpenAPI spec.",
@@ -173,28 +115,7 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
     "      permissions: [",
   ];
 
-  // Catch-all: allows all endpoints
-  lines.push("        {");
-  lines.push('          name: "unrestricted",');
-  lines.push('          description: "Allow all endpoints",');
-  lines.push("          rules: [");
-  lines.push('            "ANY /{path*}",');
-  lines.push("          ],");
-  lines.push("        },");
-
-  for (const perm of permissions) {
-    lines.push("        {");
-    lines.push(`          name: "${escapeString(perm.name)}",`);
-    if (perm.description) {
-      lines.push(`          description: "${escapeString(perm.description)}",`);
-    }
-    lines.push("          rules: [");
-    for (const rule of perm.rules) {
-      lines.push(`            "${escapeString(rule)}",`);
-    }
-    lines.push("          ],");
-    lines.push("        },");
-  }
+  lines.push(...renderPermissions(permissions));
 
   lines.push("      ],");
   lines.push("    },");
@@ -208,35 +129,13 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
 // ── Main ─────────────────────────────────────────────────────────────────
 
 export async function generate(): Promise<void> {
-  console.error("Downloading Jira OpenAPI spec…");
-  const res = await fetch(OPENAPI_URL);
-  if (!res.ok) {
-    throw new Error(
-      `Failed to fetch OpenAPI spec: ${res.status} ${res.statusText}`,
-    );
-  }
+  const res = await fetchSpec(OPENAPI_URL, "Jira OpenAPI spec");
   const spec = (await res.json()) as OpenApiSpec;
   console.error(`  Spec version: ${spec.info?.version ?? "unknown"}`);
 
   const permissions = buildGroups(spec);
   const ts = generateTypeScript(permissions);
 
-  const totalRules = permissions.reduce((sum, p) => sum + p.rules.length, 0);
-  console.error(
-    `  ${permissions.length} permission groups, ${totalRules} rules`,
-  );
-
-  const outPath = path.resolve(
-    import.meta.dirname,
-    "../../core/src/firewalls/jira.generated.ts",
-  );
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, ts);
-  console.error(`  Written to ${outPath}`);
-
-  const stat = fs.statSync(outPath);
-  if (stat.size === 0) {
-    throw new Error("Generated file is empty");
-  }
-  console.error(`  Validated (${(stat.size / 1024).toFixed(1)} KB)`);
+  logStats(permissions);
+  writeOutput("jira", ts, import.meta.dirname);
 }

--- a/turbo/packages/firewalls-generator/src/notion.ts
+++ b/turbo/packages/firewalls-generator/src/notion.ts
@@ -13,8 +13,16 @@
  * are excluded (not behind capabilities).
  */
 
-import * as fs from "node:fs";
-import * as path from "node:path";
+import {
+  ALL_METHODS,
+  OPENAPI_PATH_KEYS,
+  fetchSpec,
+  logStats,
+  renderPermissions,
+  sortRules,
+  writeOutput,
+} from "./codegen";
+import type { OpenApiSpec, PermissionGroup } from "./codegen";
 
 const OPENAPI_URL = "https://developers.notion.com/openapi.json";
 
@@ -24,29 +32,11 @@ const PLACEHOLDER_VALUE = "ntn_00000000000Vm0PlaceHolder000000000000000000Aaa";
 
 // ── OpenAPI types ────────────────────────────────────────────────────────
 
-interface OpenApiOperation {
+interface NotionOperation {
   tags?: string[];
 }
 
-type OpenApiPathItem = Record<string, unknown>;
-
-interface OpenApiSpec {
-  info?: { version?: string };
-  paths?: Record<string, OpenApiPathItem>;
-}
-
 // ── Capability mapping ───────────────────────────────────────────────────
-
-const ALL_METHODS = new Set(["get", "head", "post", "put", "patch", "delete"]);
-const OPENAPI_PATH_KEYS = new Set([
-  "summary",
-  "description",
-  "servers",
-  "parameters",
-  "$ref",
-  "options",
-  "trace",
-]);
 
 // Tags to skip (OAuth endpoints are not behind capabilities).
 const SKIP_TAGS = new Set(["OAuth"]);
@@ -122,34 +112,6 @@ const CAPABILITY_DESCRIPTIONS: Record<string, string> = {
 
 // ── Grouping ─────────────────────────────────────────────────────────────
 
-interface PermissionGroup {
-  name: string;
-  description: string;
-  rules: string[];
-}
-
-const METHOD_ORDER: Record<string, number> = {
-  GET: 0,
-  HEAD: 1,
-  POST: 2,
-  PUT: 3,
-  PATCH: 4,
-  DELETE: 5,
-};
-
-function ruleKey(rule: string): [string, number] {
-  const [method, rulePath] = rule.split(" ", 2) as [string, string];
-  return [rulePath, METHOD_ORDER[method] ?? 9];
-}
-
-function sortRules(rules: string[]): string[] {
-  return [...rules].sort((a, b) => {
-    const [pathA, orderA] = ruleKey(a);
-    const [pathB, orderB] = ruleKey(b);
-    return pathA < pathB ? -1 : pathA > pathB ? 1 : orderA - orderB;
-  });
-}
-
 function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
   const groups = new Map<string, Set<string>>();
   if (!spec.paths) {
@@ -165,7 +127,7 @@ function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
         throw new Error(`Unexpected key '${methodLower}' on ${apiPath}`);
       }
 
-      const operation: OpenApiOperation = op;
+      const operation: NotionOperation = op;
       const tags = operation.tags ?? [];
       if (tags.length === 0) continue;
 
@@ -205,10 +167,6 @@ function buildGroups(spec: OpenApiSpec): PermissionGroup[] {
 
 // ── TypeScript generation ────────────────────────────────────────────────
 
-function escapeString(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
 function generateTypeScript(permissions: PermissionGroup[]): string {
   const lines: string[] = [
     "// Auto-generated from Notion's official OpenAPI spec.",
@@ -236,28 +194,7 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
     "      permissions: [",
   ];
 
-  // Catch-all: allows all endpoints
-  lines.push("        {");
-  lines.push('          name: "unrestricted",');
-  lines.push('          description: "Allow all endpoints",');
-  lines.push("          rules: [");
-  lines.push('            "ANY /{path*}",');
-  lines.push("          ],");
-  lines.push("        },");
-
-  for (const perm of permissions) {
-    lines.push("        {");
-    lines.push(`          name: "${escapeString(perm.name)}",`);
-    if (perm.description) {
-      lines.push(`          description: "${escapeString(perm.description)}",`);
-    }
-    lines.push("          rules: [");
-    for (const rule of perm.rules) {
-      lines.push(`            "${escapeString(rule)}",`);
-    }
-    lines.push("          ],");
-    lines.push("        },");
-  }
+  lines.push(...renderPermissions(permissions));
 
   lines.push("      ],");
   lines.push("    },");
@@ -271,35 +208,13 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
 // ── Main ─────────────────────────────────────────────────────────────────
 
 export async function generate(): Promise<void> {
-  console.error("Downloading Notion OpenAPI spec…");
-  const res = await fetch(OPENAPI_URL);
-  if (!res.ok) {
-    throw new Error(
-      `Failed to fetch OpenAPI spec: ${res.status} ${res.statusText}`,
-    );
-  }
+  const res = await fetchSpec(OPENAPI_URL, "Notion OpenAPI spec");
   const spec = (await res.json()) as OpenApiSpec;
   console.error(`  Spec version: ${spec.info?.version ?? "unknown"}`);
 
   const permissions = buildGroups(spec);
   const ts = generateTypeScript(permissions);
 
-  const totalRules = permissions.reduce((sum, p) => sum + p.rules.length, 0);
-  console.error(
-    `  ${permissions.length} permission groups, ${totalRules} rules`,
-  );
-
-  const outPath = path.resolve(
-    import.meta.dirname,
-    "../../core/src/firewalls/notion.generated.ts",
-  );
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, ts);
-  console.error(`  Written to ${outPath}`);
-
-  const stat = fs.statSync(outPath);
-  if (stat.size === 0) {
-    throw new Error("Generated file is empty");
-  }
-  console.error(`  Validated (${(stat.size / 1024).toFixed(1)} KB)`);
+  logStats(permissions);
+  writeOutput("notion", ts, import.meta.dirname);
 }

--- a/turbo/packages/firewalls-generator/src/slack.ts
+++ b/turbo/packages/firewalls-generator/src/slack.ts
@@ -21,6 +21,9 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { execSync } from "node:child_process";
 
+import { logStats, renderPermissions, sortRules, writeOutput } from "./codegen";
+import type { PermissionGroup } from "./codegen";
+
 const REPO_TARBALL_URL =
   "https://github.com/slack-ruby/slack-api-ref/archive/refs/heads/master.tar.gz";
 
@@ -68,34 +71,6 @@ async function downloadMethods(): Promise<Map<string, SlackMethodData>> {
 }
 
 // ── Grouping ─────────────────────────────────────────────────────────────
-
-interface PermissionGroup {
-  name: string;
-  description?: string;
-  rules: string[];
-}
-
-const METHOD_ORDER: Record<string, number> = {
-  GET: 0,
-  HEAD: 1,
-  POST: 2,
-  PUT: 3,
-  PATCH: 4,
-  DELETE: 5,
-};
-
-function ruleKey(rule: string): [string, number] {
-  const [method, rulePath] = rule.split(" ", 2) as [string, string];
-  return [rulePath, METHOD_ORDER[method] ?? 9];
-}
-
-function sortRules(rules: string[]): string[] {
-  return [...rules].sort((a, b) => {
-    const [pathA, orderA] = ruleKey(a);
-    const [pathB, orderB] = ruleKey(b);
-    return pathA < pathB ? -1 : pathA > pathB ? 1 : orderA - orderB;
-  });
-}
 
 function buildGroups(methods: Map<string, SlackMethodData>): PermissionGroup[] {
   const groups = new Map<string, Set<string>>();
@@ -161,10 +136,6 @@ function buildGroups(methods: Map<string, SlackMethodData>): PermissionGroup[] {
 
 // ── TypeScript generation ────────────────────────────────────────────────
 
-function escapeString(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
 function generateTypeScript(permissions: PermissionGroup[]): string {
   // Slack bot token format: xoxb-[0-9]{10,13}-[0-9]{10,13}[a-zA-Z0-9-]*
   const placeholder =
@@ -196,28 +167,7 @@ function generateTypeScript(permissions: PermissionGroup[]): string {
     "      permissions: [",
   ];
 
-  // Catch-all: allows all endpoints
-  lines.push("        {");
-  lines.push('          name: "unrestricted",');
-  lines.push('          description: "Allow all endpoints",');
-  lines.push("          rules: [");
-  lines.push('            "ANY /{path*}",');
-  lines.push("          ],");
-  lines.push("        },");
-
-  for (const perm of permissions) {
-    lines.push("        {");
-    lines.push(`          name: "${escapeString(perm.name)}",`);
-    if (perm.description) {
-      lines.push(`          description: "${escapeString(perm.description)}",`);
-    }
-    lines.push("          rules: [");
-    for (const rule of perm.rules) {
-      lines.push(`            "${escapeString(rule)}",`);
-    }
-    lines.push("          ],");
-    lines.push("        },");
-  }
+  lines.push(...renderPermissions(permissions));
 
   lines.push("      ],");
   lines.push("    },");
@@ -261,22 +211,6 @@ export async function generate(): Promise<void> {
   const permissions = buildGroups(methods);
   const ts = generateTypeScript(permissions);
 
-  const totalRules = permissions.reduce((sum, p) => sum + p.rules.length, 0);
-  console.error(
-    `  ${permissions.length} permission groups, ${totalRules} rules`,
-  );
-
-  const outPath = path.resolve(
-    import.meta.dirname,
-    "../../core/src/firewalls/slack.generated.ts",
-  );
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.writeFileSync(outPath, ts);
-  console.error(`  Written to ${outPath}`);
-
-  const stat = fs.statSync(outPath);
-  if (stat.size === 0) {
-    throw new Error("Generated file is empty");
-  }
-  console.error(`  Validated (${(stat.size / 1024).toFixed(1)} KB)`);
+  logStats(permissions);
+  writeOutput("slack", ts, import.meta.dirname);
 }


### PR DESCRIPTION
## Summary

- Extract duplicated code from 7 firewall generators into a shared `codegen.ts` module
- Reduces ~580 lines of repetition (274 added, 688 removed)
- Extracted: `PermissionGroup` type, OpenAPI types/constants, `sortRules`, `escapeString`, `renderPermissions`, `writeOutput`, `logStats`, `fetchSpec`

## Test plan

- [x] `tsc --noEmit` passes
- [x] `knip` reports no unused exports
- [ ] CI passes (lint, type-check, format)
- [ ] Regenerate one firewall to verify output is unchanged: `cd turbo && pnpm -F @vm0/firewalls-generator generate:figma`

🤖 Generated with [Claude Code](https://claude.com/claude-code)