### PR TITLE
feat(api): add zero agent list and delete endpoints

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[name]/route.ts
@@ -241,17 +241,21 @@ const router = tsr.router(zeroAgentsByNameContract, {
       };
     }
 
-    // Delete compose (cascades to zero_agent_schedules via composeId FK)
-    await globalThis.services.db
-      .delete(agentComposes)
-      .where(eq(agentComposes.id, compose.id));
+    // Delete compose and metadata atomically
+    await globalThis.services.db.transaction(async (tx) => {
+      // Delete compose (cascades to zero_agent_schedules via composeId FK)
+      await tx.delete(agentComposes).where(eq(agentComposes.id, compose.id));
 
-    // Delete zero_agents metadata record
-    await globalThis.services.db
-      .delete(zeroAgents)
-      .where(
-        and(eq(zeroAgents.orgId, org.orgId), eq(zeroAgents.name, params.name)),
-      );
+      // Delete zero_agents metadata record
+      await tx
+        .delete(zeroAgents)
+        .where(
+          and(
+            eq(zeroAgents.orgId, org.orgId),
+            eq(zeroAgents.name, params.name),
+          ),
+        );
+    });
 
     log.info(`Deleted zero agent: ${params.name}`);
 

--- a/turbo/apps/web/app/api/zero/agents/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[name]/route.ts
@@ -79,8 +79,7 @@ const router = tsr.router(zeroAgentsByNameContract, {
       .limit(1);
 
     // Extract connector short names from compose content
-    const content = (compose.content ?? {}) as Record<string, unknown>;
-    const connectors = extractConnectors(content);
+    const connectors = extractConnectors(compose.content);
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/app/api/zero/agents/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[name]/route.ts
@@ -206,10 +206,62 @@ const router = tsr.router(zeroAgentsByNameContract, {
       },
     };
   },
+
+  delete: async ({ params, headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent:write",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    // Find compose by (orgId, name)
+    const [compose] = await globalThis.services.db
+      .select({ id: agentComposes.id })
+      .from(agentComposes)
+      .where(
+        and(
+          eq(agentComposes.orgId, org.orgId),
+          eq(agentComposes.name, params.name),
+        ),
+      )
+      .limit(1);
+
+    if (!compose) {
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            message: `Agent not found: ${params.name}`,
+            code: "NOT_FOUND",
+          },
+        },
+      };
+    }
+
+    // Delete compose (cascades to zero_agent_schedules via composeId FK)
+    await globalThis.services.db
+      .delete(agentComposes)
+      .where(eq(agentComposes.id, compose.id));
+
+    // Delete zero_agents metadata record
+    await globalThis.services.db
+      .delete(zeroAgents)
+      .where(
+        and(eq(zeroAgents.orgId, org.orgId), eq(zeroAgents.name, params.name)),
+      );
+
+    log.info(`Deleted zero agent: ${params.name}`);
+
+    return { status: 204 as const, body: undefined };
+  },
 });
 
 const handler = createHandler(zeroAgentsByNameContract, router, {
   errorHandler: createSafeErrorHandler("zero-agents:name"),
 });
 
-export { handler as GET, handler as PUT };
+export { handler as GET, handler as PUT, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -215,9 +215,6 @@ describe("Zero Agents API", () => {
     });
 
     it("should return 401 without auth", async () => {
-      const { mockClerk } = await import(
-        "../../../../../src/__tests__/clerk-mock"
-      );
       mockClerk({ userId: null });
 
       const response = await postAgent({ connectors: [] }, "no-token");

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -13,6 +13,7 @@ import {
   clearSkillsData,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { createSingleFileTar } from "../../../../../src/lib/tar";
 
 const context = testContext();
@@ -571,9 +572,6 @@ describe("Zero Agents API", () => {
     });
 
     it("should return 401 without auth", async () => {
-      const { mockClerk } = await import(
-        "../../../../../src/__tests__/clerk-mock"
-      );
       mockClerk({ userId: null });
       const response = await listAgentsReq("no-token");
       expect(response.status).toBe(401);
@@ -621,9 +619,6 @@ describe("Zero Agents API", () => {
     });
 
     it("should return 401 without auth", async () => {
-      const { mockClerk } = await import(
-        "../../../../../src/__tests__/clerk-mock"
-      );
       mockClerk({ userId: null });
       const response = await deleteAgent("some-agent", "no-token");
       expect(response.status).toBe(401);

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { gzipSync } from "node:zlib";
-import { POST } from "../route";
-import { GET, PUT } from "../[name]/route";
+import { POST, GET as listAgents } from "../route";
+import { GET, PUT, DELETE } from "../[name]/route";
 import {
   GET as getInstructions,
   PUT as putInstructions,
@@ -68,6 +68,29 @@ function putAgent(
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(body),
+      },
+    ),
+  );
+}
+
+function listAgentsReq(token: string, orgSlug?: string) {
+  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+  return listAgents(
+    createTestRequest(`http://localhost:3000/api/zero/agents${orgParam}`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+  );
+}
+
+function deleteAgent(name: string, token: string, orgSlug?: string) {
+  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+  return DELETE(
+    createTestRequest(
+      `http://localhost:3000/api/zero/agents/${name}${orgParam}`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
       },
     ),
   );
@@ -446,6 +469,24 @@ describe("Zero Agents API", () => {
       expect(fetched.sound).toBe("casual");
     });
 
+    it("should reflect deleted agent in list", async () => {
+      const created = await (
+        await postAgent(
+          { connectors: [], displayName: "To Delete" },
+          testCliToken,
+          testOrgSlug,
+        )
+      ).json();
+
+      await deleteAgent(created.name, testCliToken, testOrgSlug);
+
+      const listResponse = await listAgentsReq(testCliToken, testOrgSlug);
+      const data = await listResponse.json();
+      expect(
+        data.find((a: { name: string }) => a.name === created.name),
+      ).toBeUndefined();
+    });
+
     it("should read back instructions content after PUT via GET", async () => {
       const created = await (
         await postAgent({ connectors: [] }, testCliToken, testOrgSlug)
@@ -492,6 +533,100 @@ describe("Zero Agents API", () => {
       const fetched = await getRes.json();
 
       expect(fetched.content).toBe(instructionsContent);
+    });
+  });
+
+  describe("GET /api/zero/agents", () => {
+    it("should return empty array when no agents exist", async () => {
+      const response = await listAgentsReq(testCliToken, testOrgSlug);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toStrictEqual([]);
+    });
+
+    it("should return list with created agent", async () => {
+      const created = await (
+        await postAgent(
+          {
+            connectors: [],
+            displayName: "Listed Agent",
+            description: "desc",
+            sound: "friendly",
+          },
+          testCliToken,
+          testOrgSlug,
+        )
+      ).json();
+
+      const response = await listAgentsReq(testCliToken, testOrgSlug);
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toHaveLength(1);
+      expect(data[0].name).toBe(created.name);
+      expect(data[0].agentComposeId).toBe(created.agentComposeId);
+      expect(data[0].displayName).toBe("Listed Agent");
+      expect(data[0].description).toBe("desc");
+      expect(data[0].sound).toBe("friendly");
+      expect(data[0].connectors).toStrictEqual([]);
+    });
+
+    it("should return 401 without auth", async () => {
+      const { mockClerk } = await import(
+        "../../../../../src/__tests__/clerk-mock"
+      );
+      mockClerk({ userId: null });
+      const response = await listAgentsReq("no-token");
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("DELETE /api/zero/agents/:name", () => {
+    it("should delete an agent and return 204", async () => {
+      const created = await (
+        await postAgent({ connectors: [] }, testCliToken, testOrgSlug)
+      ).json();
+
+      const response = await deleteAgent(
+        created.name,
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(204);
+    });
+
+    it("should return 404 on GET after delete", async () => {
+      const created = await (
+        await postAgent({ connectors: [] }, testCliToken, testOrgSlug)
+      ).json();
+
+      await deleteAgent(created.name, testCliToken, testOrgSlug);
+
+      const getResponse = await getAgent(
+        created.name,
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(getResponse.status).toBe(404);
+    });
+
+    it("should return 404 for nonexistent agent", async () => {
+      const response = await deleteAgent(
+        "nonexistent-agent",
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("should return 401 without auth", async () => {
+      const { mockClerk } = await import(
+        "../../../../../src/__tests__/clerk-mock"
+      );
+      mockClerk({ userId: null });
+      const response = await deleteAgent("some-agent", "no-token");
+      expect(response.status).toBe(401);
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/agents/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/route.ts
@@ -13,6 +13,11 @@ import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { serverSideCompose } from "../../../../src/lib/compose/server-side-compose";
 import { zeroAgents } from "../../../../src/db/schema/zero-agent";
 import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../src/db/schema/agent-compose";
+import { eq, and, desc } from "drizzle-orm";
+import {
   buildComposeContent,
   extractConnectors,
 } from "../../../../src/lib/zero/build-compose-content";
@@ -94,10 +99,60 @@ const router = tsr.router(zeroAgentsMainContract, {
       },
     };
   },
+
+  list: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent:read",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    const rows = await globalThis.services.db
+      .select({
+        name: zeroAgents.name,
+        agentComposeId: agentComposes.id,
+        displayName: zeroAgents.displayName,
+        description: zeroAgents.description,
+        sound: zeroAgents.sound,
+        content: agentComposeVersions.content,
+      })
+      .from(zeroAgents)
+      .innerJoin(
+        agentComposes,
+        and(
+          eq(zeroAgents.orgId, agentComposes.orgId),
+          eq(zeroAgents.name, agentComposes.name),
+        ),
+      )
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentComposes.headVersionId, agentComposeVersions.id),
+      )
+      .where(eq(zeroAgents.orgId, org.orgId))
+      .orderBy(desc(zeroAgents.updatedAt));
+
+    return {
+      status: 200 as const,
+      body: rows.map((row) => ({
+        name: row.name,
+        agentComposeId: row.agentComposeId,
+        displayName: row.displayName ?? null,
+        description: row.description ?? null,
+        sound: row.sound ?? null,
+        connectors: extractConnectors(
+          (row.content ?? {}) as Record<string, unknown>,
+        ),
+      })),
+    };
+  },
 });
 
 const handler = createHandler(zeroAgentsMainContract, router, {
   errorHandler: createSafeErrorHandler("zero-agents"),
 });
 
-export { handler as POST };
+export { handler as POST, handler as GET };

--- a/turbo/apps/web/app/api/zero/agents/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/route.ts
@@ -143,9 +143,7 @@ const router = tsr.router(zeroAgentsMainContract, {
         displayName: row.displayName ?? null,
         description: row.description ?? null,
         sound: row.sound ?? null,
-        connectors: extractConnectors(
-          (row.content ?? {}) as Record<string, unknown>,
-        ),
+        connectors: extractConnectors(row.content),
       })),
     };
   },

--- a/turbo/apps/web/src/lib/zero/build-compose-content.ts
+++ b/turbo/apps/web/src/lib/zero/build-compose-content.ts
@@ -45,8 +45,9 @@ export function buildComposeContent(
  * Reverses the skill URL mapping: extracts the bare name from
  * GitHub URLs matching the vm0-skills pattern.
  */
-export function extractConnectors(content: Record<string, unknown>): string[] {
-  const agents = content.agents as
+export function extractConnectors(content: unknown): string[] {
+  const obj = typeof content === "object" && content !== null ? content : {};
+  const agents = (obj as Record<string, unknown>).agents as
     | Record<string, Record<string, unknown>>
     | undefined;
   if (!agents) return [];

--- a/turbo/packages/core/src/contracts/zero-agents.ts
+++ b/turbo/packages/core/src/contracts/zero-agents.ts
@@ -42,7 +42,7 @@ export const zeroAgentInstructionsRequestSchema = z.object({
 });
 
 /**
- * Contract for POST /api/zero/agents (create agent)
+ * Contract for GET/POST /api/zero/agents (list/create agents)
  */
 export const zeroAgentsMainContract = c.router({
   create: {
@@ -58,10 +58,20 @@ export const zeroAgentsMainContract = c.router({
     },
     summary: "Create zero agent",
   },
+  list: {
+    method: "GET",
+    path: "/api/zero/agents",
+    headers: authHeadersSchema,
+    responses: {
+      200: z.array(zeroAgentResponseSchema),
+      401: apiErrorSchema,
+    },
+    summary: "List zero agents",
+  },
 });
 
 /**
- * Contract for GET/PUT /api/zero/agents/:name
+ * Contract for GET/PUT/DELETE /api/zero/agents/:name
  */
 export const zeroAgentsByNameContract = c.router({
   get: {
@@ -90,6 +100,19 @@ export const zeroAgentsByNameContract = c.router({
       422: apiErrorSchema,
     },
     summary: "Update zero agent",
+  },
+  delete: {
+    method: "DELETE",
+    path: "/api/zero/agents/:name",
+    headers: authHeadersSchema,
+    pathParams: z.object({ name: z.string() }),
+    body: c.noBody(),
+    responses: {
+      204: c.noBody(),
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Delete zero agent by name",
   },
 });
 


### PR DESCRIPTION
## Summary

- Add `GET /api/zero/agents` to list all zero agents for an org
- Add `DELETE /api/zero/agents/:name` to delete a zero agent by name
- Extend `zeroAgentsMainContract` with a `list` entry (GET on same path as create POST)
- Extend `zeroAgentsByNameContract` with a `delete` entry (DELETE on same path as get/update)

## Implementation Details

**List endpoint**: Queries `zero_agents` INNER JOIN `agent_composes` + LEFT JOIN `agent_compose_versions` to get compose content, then extracts connectors — identical query shape to the existing single-agent GET.

**Delete endpoint**: Deletes from `agent_composes` first (which cascades to `zero_agent_schedules` via FK), then deletes from `zero_agents`. Returns 204 on success, 404 if agent not found.

## Test plan

- [x] `GET /api/zero/agents` returns empty array when no agents exist
- [x] `GET /api/zero/agents` returns correct agent data after create
- [x] `GET /api/zero/agents` returns 401 without auth
- [x] `DELETE /api/zero/agents/:name` returns 204 and removes agent
- [x] `DELETE /api/zero/agents/:name` returns 404 after deletion (agent no longer gettable)
- [x] `DELETE /api/zero/agents/:name` returns 404 for nonexistent agent
- [x] `DELETE /api/zero/agents/:name` returns 401 without auth
- [x] Deleted agent no longer appears in list
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)

Closes #6163

🤖 Generated with [Claude Code](https://claude.com/claude-code)