### PR TITLE
refactor: downgrade zerochat thread-loading logs from info to debug

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -790,7 +790,7 @@ export const switchZeroSession$ = command(
       const fetchFn = get(fetch$);
 
       // Try chat-threads API first; fall back to legacy sessions API
-      L.info("loading thread:", threadId);
+      L.debug("loading thread:", threadId);
       let res = await fetchFn(`/api/zero/chat-threads/${threadId}`);
       let isLegacySession = false;
       if (!res.ok) {
@@ -821,7 +821,7 @@ export const switchZeroSession$ = command(
         }[];
       };
 
-      L.info("loaded:", {
+      L.debug("loaded:", {
         isLegacySession,
         agentComposeId: data.agentComposeId,
         latestSessionId: data.latestSessionId,


### PR DESCRIPTION
## Summary
- Downgrade two `L.info` calls to `L.debug` in zero-chat.ts thread loading logic
- These are internal diagnostics that clutter the console at info level

Closes #6175

## Test plan
- [ ] Verify thread loading still works correctly
- [ ] Confirm logs appear at debug level only

🤖 Generated with [Claude Code](https://claude.com/claude-code)