### PR TITLE
feat: add user deletion s3 and external service cleanup

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -4466,3 +4466,59 @@ export async function insertTestTelegramUserLink(params: {
     .returning({ id: telegramUserLinks.id });
   return row!;
 }
+
+// ============================================================================
+// User Deletion Test Helpers (find/query)
+// ============================================================================
+
+export async function findTestGitHubUserLinksByVm0UserId(vm0UserId: string) {
+  return globalThis.services.db
+    .select()
+    .from(githubUserLinks)
+    .where(eq(githubUserLinks.vm0UserId, vm0UserId));
+}
+
+export async function findTestTelegramUserLinksByVm0UserId(vm0UserId: string) {
+  return globalThis.services.db
+    .select()
+    .from(telegramUserLinks)
+    .where(eq(telegramUserLinks.vm0UserId, vm0UserId));
+}
+
+export async function findTestSlackOrgConnectionsByVm0UserId(
+  vm0UserId: string,
+) {
+  return globalThis.services.db
+    .select()
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.vm0UserId, vm0UserId));
+}
+
+export async function findTestSlackOrgPendingQuestionsByConnectionId(
+  connectionId: string,
+) {
+  return globalThis.services.db
+    .select()
+    .from(slackOrgPendingQuestions)
+    .where(eq(slackOrgPendingQuestions.connectionId, connectionId));
+}
+
+export async function insertTestSlackOrgPendingQuestionNoSession(params: {
+  connectionId: string;
+  composeId: string;
+  runId: string;
+  slackWorkspaceId: string;
+}): Promise<void> {
+  await globalThis.services.db.insert(slackOrgPendingQuestions).values({
+    connectionId: params.connectionId,
+    composeId: params.composeId,
+    runId: params.runId,
+    slackWorkspaceId: params.slackWorkspaceId,
+    slackChannelId: "C-test",
+    slackThreadTs: "1234.5678",
+    slackMessageTs: "1234.5679",
+    agentName: "test-agent",
+    questions: [{ question: "test?" }],
+    expiresAt: new Date(Date.now() + 3600000),
+  });
+}

--- a/turbo/apps/web/src/lib/user/__tests__/user-external-cleanup.test.ts
+++ b/turbo/apps/web/src/lib/user/__tests__/user-external-cleanup.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { testContext, uniqueId } from "../../../__tests__/test-helpers";
+import {
+  insertTestGitHubUserLink,
+  insertTestGitHubInstallation,
+  createTestTelegramInstallation,
+  insertTestSlackOrgInstallation,
+  insertTestSlackOrgConnection,
+  insertTestSlackOrgThreadSession,
+  insertTestSlackOrgPendingQuestionNoSession,
+  findTestGitHubUserLinksByVm0UserId,
+  findTestTelegramUserLinksByVm0UserId,
+  findTestSlackOrgConnectionsByVm0UserId,
+  findTestSlackOrgPendingQuestionsByConnectionId,
+} from "../../../__tests__/api-test-helpers";
+import { cleanupUserExternalServices } from "../user-external-cleanup";
+
+const context = testContext();
+
+describe("cleanupUserExternalServices", () => {
+  let userId: string;
+  let orgId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    userId = user.userId;
+    orgId = user.orgId;
+  });
+
+  it("completes without error when user has no external services", async () => {
+    await cleanupUserExternalServices(userId);
+  });
+
+  it("revokes connector tokens for user connectors across orgs", async () => {
+    // revokeConnectorToken will skip gracefully since OAuth credentials
+    // are not configured in the test environment — best-effort by design
+    await context.createConnector(orgId, { userId, type: "github" });
+
+    // Should complete without error even with no OAuth creds configured
+    await cleanupUserExternalServices(userId);
+  });
+
+  it("deletes github user links", async () => {
+    const compose = await context.createAgentCompose(userId);
+    const installation = await insertTestGitHubInstallation(compose.id);
+
+    await insertTestGitHubUserLink(
+      uniqueId("gh-user"),
+      installation.id,
+      userId,
+    );
+
+    await cleanupUserExternalServices(userId);
+
+    const remaining = await findTestGitHubUserLinksByVm0UserId(userId);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("deletes telegram user links", async () => {
+    await createTestTelegramInstallation({
+      adminUserId: userId,
+      vm0UserId: userId,
+    });
+
+    // Verify link exists before cleanup
+    const before = await findTestTelegramUserLinksByVm0UserId(userId);
+    expect(before.length).toBeGreaterThan(0);
+
+    await cleanupUserExternalServices(userId);
+
+    const after = await findTestTelegramUserLinksByVm0UserId(userId);
+    expect(after).toHaveLength(0);
+  });
+
+  it("deletes slack connections with pending questions (FK ordering)", async () => {
+    const workspaceId = uniqueId("W");
+    await insertTestSlackOrgInstallation({
+      slackWorkspaceId: workspaceId,
+      slackWorkspaceName: "Test Workspace",
+      orgId,
+      installedByUserId: userId,
+    });
+
+    const connection = await insertTestSlackOrgConnection({
+      slackUserId: uniqueId("slack-user"),
+      slackWorkspaceId: workspaceId,
+      vm0UserId: userId,
+    });
+
+    // Insert a pending question that references this connection
+    const compose = await context.createAgentCompose(userId);
+    await insertTestSlackOrgPendingQuestionNoSession({
+      connectionId: connection.id,
+      composeId: compose.id,
+      runId: uniqueId("run"),
+      slackWorkspaceId: workspaceId,
+    });
+
+    await cleanupUserExternalServices(userId);
+
+    // Pending questions should be deleted
+    const remainingQuestions =
+      await findTestSlackOrgPendingQuestionsByConnectionId(connection.id);
+    expect(remainingQuestions).toHaveLength(0);
+
+    // Connections should be deleted
+    const remainingConnections =
+      await findTestSlackOrgConnectionsByVm0UserId(userId);
+    expect(remainingConnections).toHaveLength(0);
+  });
+
+  it("deletes slack connections with thread sessions (cascade)", async () => {
+    const workspaceId = uniqueId("W");
+    await insertTestSlackOrgInstallation({
+      slackWorkspaceId: workspaceId,
+      slackWorkspaceName: "Test Workspace",
+      orgId,
+      installedByUserId: userId,
+    });
+
+    const connection = await insertTestSlackOrgConnection({
+      slackUserId: uniqueId("slack-user"),
+      slackWorkspaceId: workspaceId,
+      vm0UserId: userId,
+    });
+
+    // Thread sessions have cascade delete on connectionId
+    await insertTestSlackOrgThreadSession({ connectionId: connection.id });
+
+    await cleanupUserExternalServices(userId);
+
+    // Connections should be deleted (thread sessions cascade automatically)
+    const remainingConnections =
+      await findTestSlackOrgConnectionsByVm0UserId(userId);
+    expect(remainingConnections).toHaveLength(0);
+  });
+
+  it("continues cleanup when one step fails (best-effort)", async () => {
+    // Create a telegram user link that should be cleaned up
+    await createTestTelegramInstallation({
+      adminUserId: userId,
+      vm0UserId: userId,
+    });
+
+    // Create a connector that will fail during revocation attempt
+    // (OAuth credentials not configured — but step should not block other steps)
+    await context.createConnector(orgId, { userId, type: "github" });
+
+    await cleanupUserExternalServices(userId);
+
+    // Telegram links should still be cleaned up even if connector revocation had issues
+    const remainingTelegramLinks =
+      await findTestTelegramUserLinksByVm0UserId(userId);
+    expect(remainingTelegramLinks).toHaveLength(0);
+  });
+
+  it("is idempotent - calling twice produces no errors", async () => {
+    await createTestTelegramInstallation({
+      adminUserId: userId,
+      vm0UserId: userId,
+    });
+
+    await cleanupUserExternalServices(userId);
+    await cleanupUserExternalServices(userId);
+
+    const remaining = await findTestTelegramUserLinksByVm0UserId(userId);
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/turbo/apps/web/src/lib/user/__tests__/user-s3-cleanup.test.ts
+++ b/turbo/apps/web/src/lib/user/__tests__/user-s3-cleanup.test.ts
@@ -149,6 +149,43 @@ describe("deleteUserS3Data", () => {
     expect(context.mocks.s3.deleteS3Objects).not.toHaveBeenCalled();
   });
 
+  it("continues cleanup when one storage fails (best-effort)", async () => {
+    const name1 = uniqueId("storage");
+    const name2 = uniqueId("storage");
+    const exportKey = `exports/${userId}/${uniqueId("job")}.zip`;
+
+    await insertTestStorage({ userId, orgId, name: name1, type: "artifact" });
+    await insertTestStorage({ userId, orgId, name: name2, type: "memory" });
+    await insertTestExportJob(orgId, {
+      userId,
+      status: "completed",
+      s3Key: exportKey,
+    });
+
+    const prefix2 = `storages/${orgId}/${name2}/`;
+
+    // First storage listing throws an error
+    context.mocks.s3.listS3Objects
+      .mockRejectedValueOnce(new Error("S3 unavailable"))
+      .mockResolvedValueOnce([{ key: `${prefix2}v1/data.bin`, size: 2048 }]);
+
+    // Should complete without throwing despite first storage failure
+    await deleteUserS3Data(userId);
+
+    // Second storage should still be cleaned up
+    expect(context.mocks.s3.listS3Objects).toHaveBeenCalledTimes(2);
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [`${prefix2}v1/data.bin`],
+    );
+
+    // Export jobs should still be cleaned up
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [exportKey],
+    );
+  });
+
   it("is idempotent - calling twice produces no errors", async () => {
     const storageName = uniqueId("storage");
     await insertTestStorage({

--- a/turbo/apps/web/src/lib/user/__tests__/user-s3-cleanup.test.ts
+++ b/turbo/apps/web/src/lib/user/__tests__/user-s3-cleanup.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { testContext, uniqueId } from "../../../__tests__/test-helpers";
+import {
+  insertTestStorage,
+  insertTestExportJob,
+} from "../../../__tests__/api-test-helpers";
+import { deleteUserS3Data } from "../user-s3-cleanup";
+
+const context = testContext();
+
+describe("deleteUserS3Data", () => {
+  let userId: string;
+  let orgId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    userId = user.userId;
+    orgId = user.orgId;
+  });
+
+  it("should complete without error when user has no data", async () => {
+    await deleteUserS3Data(userId);
+
+    expect(context.mocks.s3.listS3Objects).not.toHaveBeenCalled();
+    expect(context.mocks.s3.deleteS3Objects).not.toHaveBeenCalled();
+  });
+
+  it("should delete S3 objects for user storages", async () => {
+    const name1 = uniqueId("storage");
+    const name2 = uniqueId("storage");
+
+    await insertTestStorage({ userId, orgId, name: name1, type: "artifact" });
+    await insertTestStorage({ userId, orgId, name: name2, type: "memory" });
+
+    const prefix1 = `storages/${orgId}/${name1}/`;
+    const prefix2 = `storages/${orgId}/${name2}/`;
+
+    context.mocks.s3.listS3Objects
+      .mockResolvedValueOnce([
+        { key: `${prefix1}v1/archive.tar.gz`, size: 1024 },
+        { key: `${prefix1}v1/manifest.json`, size: 256 },
+      ])
+      .mockResolvedValueOnce([{ key: `${prefix2}v1/data.bin`, size: 2048 }]);
+
+    await deleteUserS3Data(userId);
+
+    expect(context.mocks.s3.listS3Objects).toHaveBeenCalledTimes(2);
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledTimes(2);
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [`${prefix1}v1/archive.tar.gz`, `${prefix1}v1/manifest.json`],
+    );
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [`${prefix2}v1/data.bin`],
+    );
+  });
+
+  it("should delete export job ZIPs with s3Key", async () => {
+    const key1 = `exports/${userId}/${uniqueId("job")}.zip`;
+    const key2 = `exports/${userId}/${uniqueId("job")}.zip`;
+
+    await insertTestExportJob(orgId, {
+      userId,
+      status: "completed",
+      s3Key: key1,
+    });
+    await insertTestExportJob(orgId, {
+      userId,
+      status: "completed",
+      s3Key: key2,
+    });
+
+    await deleteUserS3Data(userId);
+
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [key1, key2],
+    );
+  });
+
+  it("should skip export jobs with null s3Key", async () => {
+    await insertTestExportJob(orgId, {
+      userId,
+      status: "pending",
+    });
+    await insertTestExportJob(orgId, {
+      userId,
+      status: "failed",
+    });
+
+    await deleteUserS3Data(userId);
+
+    expect(context.mocks.s3.deleteS3Objects).not.toHaveBeenCalled();
+  });
+
+  it("should clean up both storages and export jobs", async () => {
+    const storageName = uniqueId("storage");
+    await insertTestStorage({
+      userId,
+      orgId,
+      name: storageName,
+      type: "artifact",
+    });
+    const prefix = `storages/${orgId}/${storageName}/`;
+
+    const exportKey = `exports/${userId}/${uniqueId("job")}.zip`;
+    await insertTestExportJob(orgId, {
+      userId,
+      status: "completed",
+      s3Key: exportKey,
+    });
+
+    context.mocks.s3.listS3Objects.mockResolvedValueOnce([
+      { key: `${prefix}v1/archive.tar.gz`, size: 512 },
+    ]);
+
+    await deleteUserS3Data(userId);
+
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [`${prefix}v1/archive.tar.gz`],
+    );
+    expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      [exportKey],
+    );
+  });
+
+  it("should not call deleteS3Objects when storage prefix has no objects", async () => {
+    const storageName = uniqueId("storage");
+    await insertTestStorage({
+      userId,
+      orgId,
+      name: storageName,
+      type: "artifact",
+    });
+    const prefix = `storages/${orgId}/${storageName}/`;
+
+    // listS3Objects returns empty array (default mock behavior)
+
+    await deleteUserS3Data(userId);
+
+    expect(context.mocks.s3.listS3Objects).toHaveBeenCalledWith(
+      "test-bucket",
+      prefix,
+    );
+    expect(context.mocks.s3.deleteS3Objects).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent - calling twice produces no errors", async () => {
+    const storageName = uniqueId("storage");
+    await insertTestStorage({
+      userId,
+      orgId,
+      name: storageName,
+      type: "artifact",
+    });
+
+    // First call: no objects found (default mock)
+    await deleteUserS3Data(userId);
+    // Second call: same result
+    await deleteUserS3Data(userId);
+
+    expect(context.mocks.s3.listS3Objects).toHaveBeenCalledTimes(2);
+  });
+});

--- a/turbo/apps/web/src/lib/user/user-external-cleanup.ts
+++ b/turbo/apps/web/src/lib/user/user-external-cleanup.ts
@@ -1,0 +1,128 @@
+import { eq } from "drizzle-orm";
+import { connectorTypeSchema } from "@vm0/core";
+import { logger } from "../logger";
+import { revokeConnectorToken } from "../connector/connector-service";
+import { connectors } from "../../db/schema/connector";
+import { githubUserLinks } from "../../db/schema/github-user-link";
+import { telegramUserLinks } from "../../db/schema/telegram-user-link";
+import { slackOrgConnections } from "../../db/schema/slack-org-connection";
+import { slackOrgPendingQuestions } from "../../db/schema/slack-org-pending-question";
+
+const log = logger("service:user-external-cleanup");
+
+/**
+ * Best-effort cleanup of external services for a deleted user.
+ * Must be called BEFORE database deletion — reads tokens/IDs from DB.
+ * All operations are best-effort: failures are logged but do not throw.
+ * Idempotent: safe to call multiple times.
+ */
+export async function cleanupUserExternalServices(
+  userId: string,
+): Promise<void> {
+  const steps = [
+    { name: "connector tokens", fn: () => revokeUserConnectorTokens(userId) },
+    { name: "github links", fn: () => deleteGitHubUserLinks(userId) },
+    { name: "telegram links", fn: () => deleteTelegramUserLinks(userId) },
+    {
+      name: "slack connections",
+      fn: () => deleteUserSlackConnections(userId),
+    },
+  ];
+
+  for (const step of steps) {
+    try {
+      await step.fn();
+    } catch (error) {
+      log.error(`failed to cleanup ${step.name} (best-effort)`, {
+        userId,
+        error,
+      });
+    }
+  }
+}
+
+async function revokeUserConnectorTokens(userId: string): Promise<void> {
+  const db = globalThis.services.db;
+  const userConnectors = await db
+    .select({ orgId: connectors.orgId, type: connectors.type })
+    .from(connectors)
+    .where(eq(connectors.userId, userId));
+
+  for (const conn of userConnectors) {
+    try {
+      const parsed = connectorTypeSchema.safeParse(conn.type);
+      if (!parsed.success) {
+        log.warn("unknown connector type, skipping revocation", {
+          userId,
+          type: conn.type,
+        });
+        continue;
+      }
+      await revokeConnectorToken(conn.orgId, userId, parsed.data);
+    } catch (error) {
+      log.error("failed to revoke connector token (best-effort)", {
+        userId,
+        orgId: conn.orgId,
+        type: conn.type,
+        error,
+      });
+    }
+  }
+}
+
+async function deleteGitHubUserLinks(userId: string): Promise<void> {
+  const db = globalThis.services.db;
+  const result = await db
+    .delete(githubUserLinks)
+    .where(eq(githubUserLinks.vm0UserId, userId));
+  if (result.rowCount && result.rowCount > 0) {
+    log.debug("deleted github user links", {
+      userId,
+      count: result.rowCount,
+    });
+  }
+}
+
+async function deleteTelegramUserLinks(userId: string): Promise<void> {
+  const db = globalThis.services.db;
+  const result = await db
+    .delete(telegramUserLinks)
+    .where(eq(telegramUserLinks.vm0UserId, userId));
+  if (result.rowCount && result.rowCount > 0) {
+    log.debug("deleted telegram user links", {
+      userId,
+      count: result.rowCount,
+    });
+  }
+}
+
+async function deleteUserSlackConnections(userId: string): Promise<void> {
+  const db = globalThis.services.db;
+
+  // Find all connections for this user
+  const connections = await db
+    .select({ id: slackOrgConnections.id })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.vm0UserId, userId));
+
+  if (connections.length === 0) return;
+
+  const connectionIds = connections.map((c) => c.id);
+
+  // Delete pending questions first (FK constraint: connectionId references slack_org_connections)
+  for (const connectionId of connectionIds) {
+    await db
+      .delete(slackOrgPendingQuestions)
+      .where(eq(slackOrgPendingQuestions.connectionId, connectionId));
+  }
+
+  // Delete connections (cascades slack_org_thread_sessions)
+  await db
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.vm0UserId, userId));
+
+  log.debug("deleted slack connections", {
+    userId,
+    count: connections.length,
+  });
+}

--- a/turbo/apps/web/src/lib/user/user-s3-cleanup.ts
+++ b/turbo/apps/web/src/lib/user/user-s3-cleanup.ts
@@ -9,6 +9,7 @@ const log = logger("service:user-s3-cleanup");
 /**
  * Delete all S3 objects belonging to a user.
  * Must be called BEFORE database deletion — reads s3Prefix/s3Key from DB.
+ * All operations are best-effort: individual failures are logged but do not stop other steps.
  * Idempotent: deleting non-existent S3 objects is a no-op.
  */
 export async function deleteUserS3Data(userId: string): Promise<void> {
@@ -22,15 +23,23 @@ export async function deleteUserS3Data(userId: string): Promise<void> {
     .where(eq(storages.userId, userId));
 
   for (const storage of userStorages) {
-    const objects = await listS3Objects(bucket, storage.s3Prefix);
-    if (objects.length > 0) {
-      await deleteS3Objects(
-        bucket,
-        objects.map((o) => o.key),
-      );
-      log.debug("deleted storage objects", {
+    try {
+      const objects = await listS3Objects(bucket, storage.s3Prefix);
+      if (objects.length > 0) {
+        await deleteS3Objects(
+          bucket,
+          objects.map((o) => o.key),
+        );
+        log.debug("deleted storage objects", {
+          prefix: storage.s3Prefix,
+          count: objects.length,
+        });
+      }
+    } catch (error) {
+      log.error("failed to delete storage objects (best-effort)", {
+        userId,
         prefix: storage.s3Prefix,
-        count: objects.length,
+        error,
       });
     }
   }
@@ -46,8 +55,16 @@ export async function deleteUserS3Data(userId: string): Promise<void> {
     .filter((k): k is string => k !== null);
 
   if (exportKeys.length > 0) {
-    await deleteS3Objects(bucket, exportKeys);
-    log.debug("deleted export objects", { count: exportKeys.length });
+    try {
+      await deleteS3Objects(bucket, exportKeys);
+      log.debug("deleted export objects", { count: exportKeys.length });
+    } catch (error) {
+      log.error("failed to delete export objects (best-effort)", {
+        userId,
+        count: exportKeys.length,
+        error,
+      });
+    }
   }
 
   log.info("user S3 data deleted", {

--- a/turbo/apps/web/src/lib/user/user-s3-cleanup.ts
+++ b/turbo/apps/web/src/lib/user/user-s3-cleanup.ts
@@ -1,0 +1,58 @@
+import { eq, and, isNotNull } from "drizzle-orm";
+import { storages } from "../../db/schema/storage";
+import { exportJobs } from "../../db/schema/export-job";
+import { listS3Objects, deleteS3Objects } from "../s3/s3-client";
+import { logger } from "../logger";
+
+const log = logger("service:user-s3-cleanup");
+
+/**
+ * Delete all S3 objects belonging to a user.
+ * Must be called BEFORE database deletion — reads s3Prefix/s3Key from DB.
+ * Idempotent: deleting non-existent S3 objects is a no-op.
+ */
+export async function deleteUserS3Data(userId: string): Promise<void> {
+  const db = globalThis.services.db;
+  const bucket = globalThis.services.env.R2_USER_STORAGES_BUCKET_NAME;
+
+  // 1. Delete user's storage objects (artifacts, memory — NOT volumes which use __org__)
+  const userStorages = await db
+    .select({ s3Prefix: storages.s3Prefix })
+    .from(storages)
+    .where(eq(storages.userId, userId));
+
+  for (const storage of userStorages) {
+    const objects = await listS3Objects(bucket, storage.s3Prefix);
+    if (objects.length > 0) {
+      await deleteS3Objects(
+        bucket,
+        objects.map((o) => o.key),
+      );
+      log.debug("deleted storage objects", {
+        prefix: storage.s3Prefix,
+        count: objects.length,
+      });
+    }
+  }
+
+  // 2. Delete user's export job ZIPs
+  const userExports = await db
+    .select({ s3Key: exportJobs.s3Key })
+    .from(exportJobs)
+    .where(and(eq(exportJobs.userId, userId), isNotNull(exportJobs.s3Key)));
+
+  const exportKeys = userExports
+    .map((e) => e.s3Key)
+    .filter((k): k is string => k !== null);
+
+  if (exportKeys.length > 0) {
+    await deleteS3Objects(bucket, exportKeys);
+    log.debug("deleted export objects", { count: exportKeys.length });
+  }
+
+  log.info("user S3 data deleted", {
+    userId,
+    storageCount: userStorages.length,
+    exportCount: exportKeys.length,
+  });
+}


### PR DESCRIPTION
## Summary

Closes #6170

- Add `deleteUserS3Data(userId)` — deletes all S3 objects for user's storages and export jobs
- Add `cleanupUserExternalServices(userId)` — best-effort cleanup of connector tokens, GitHub/Telegram user links, and Slack connections with proper FK ordering
- Add test helpers for user deletion verification queries

## Details

**Phase 1-2 of user deletion cascade** (parent epic: #6162). These services run before database deletion since they need to read data from DB.

### `user-s3-cleanup.ts`
- Queries storages by `userId` (not orgId) — automatically excludes volumes which use `__org__`
- Deletes export job ZIPs filtering by `userId` with non-null `s3Key`

### `user-external-cleanup.ts`
- Revokes connector tokens across all orgs for the user
- Deletes GitHub user links, Telegram user links
- Deletes Slack connections with correct FK ordering (pending questions before connections; thread sessions cascade automatically)
- All operations are best-effort: individual failures logged but don't stop other steps

### Rollback
Revert the PR. Purely additive — no existing functionality modified. The webhook handler does not call these services yet (separate sub-issue).

## Test plan

- [x] `pnpm vitest user-s3-cleanup user-external-cleanup` — 15 tests pass
- [x] S3 cleanup queries storages by userId (not orgId)
- [x] External cleanup is best-effort (individual failures don't stop other steps)
- [x] Slack connection cleanup respects FK ordering (pending_questions before connections)
- [x] Both services are idempotent
- [x] Lint, type-check, format, knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)