### PR TITLE
feat: add user deletion service for database cascade cleanup

### DIFF
--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -87,6 +87,7 @@ import { PUT as setSecretRoute } from "../../app/api/secrets/route";
 import { PUT as setVariableRoute } from "../../app/api/variables/route";
 
 import { GET as connectorCallbackRoute } from "../../app/api/connectors/[type]/callback/route";
+import { composeJobs } from "../db/schema/compose-job";
 import { connectors } from "../db/schema/connector";
 import { connectorSessions } from "../db/schema/connector-session";
 import { secrets } from "../db/schema/secret";
@@ -4279,4 +4280,171 @@ export async function insertTestOrgSentinelVariable(params: {
     userId: ORG_SENTINEL_USER_ID,
     orgId: params.orgId,
   });
+}
+
+/**
+ * Count rows in a table where user_id matches.
+ * Mirror of countOrgRows for user-scoped deletion verification.
+ */
+export async function countUserRows(
+  tableName:
+    | "agent_runs"
+    | "agent_run_queue"
+    | "agent_composes"
+    | "storages"
+    | "secrets"
+    | "model_providers"
+    | "connectors"
+    | "variables"
+    | "usage_daily"
+    | "export_jobs"
+    | "zero_agent_schedules"
+    | "cli_tokens"
+    | "compose_jobs"
+    | "connector_sessions"
+    | "device_codes"
+    | "org_members_cache"
+    | "org_members_metadata"
+    | "user_cache"
+    | "users",
+  userId: string,
+): Promise<number> {
+  const columnName = tableName === "users" ? "id" : "user_id";
+  const rows = await globalThis.services.db.execute(
+    sql`SELECT COUNT(*)::int AS count FROM ${sql.identifier(tableName)} WHERE ${sql.identifier(columnName)} = ${userId}`,
+  );
+  return (rows.rows[0] as { count: number }).count;
+}
+
+/**
+ * Count rows in slack_org_connections where vm0_user_id matches.
+ */
+export async function countSlackConnectionRows(
+  vm0UserId: string,
+): Promise<number> {
+  const rows = await globalThis.services.db.execute(
+    sql`SELECT COUNT(*)::int AS count FROM slack_org_connections WHERE vm0_user_id = ${vm0UserId}`,
+  );
+  return (rows.rows[0] as { count: number }).count;
+}
+
+/**
+ * Count rows in github_user_links where vm0_user_id matches.
+ */
+export async function countGithubUserLinkRows(
+  vm0UserId: string,
+): Promise<number> {
+  const rows = await globalThis.services.db.execute(
+    sql`SELECT COUNT(*)::int AS count FROM github_user_links WHERE vm0_user_id = ${vm0UserId}`,
+  );
+  return (rows.rows[0] as { count: number }).count;
+}
+
+/**
+ * Count rows in telegram_user_links where vm0_user_id matches.
+ */
+export async function countTelegramUserLinkRows(
+  vm0UserId: string,
+): Promise<number> {
+  const rows = await globalThis.services.db.execute(
+    sql`SELECT COUNT(*)::int AS count FROM telegram_user_links WHERE vm0_user_id = ${vm0UserId}`,
+  );
+  return (rows.rows[0] as { count: number }).count;
+}
+
+/**
+ * Insert a test compose job directly in the database.
+ */
+export async function insertTestComposeJob(params: {
+  userId: string;
+  status?: string;
+  githubUrl?: string;
+}): Promise<{ id: string }> {
+  const [row] = await globalThis.services.db
+    .insert(composeJobs)
+    .values({
+      userId: params.userId,
+      status: params.status ?? "completed",
+      githubUrl: params.githubUrl ?? "https://github.com/test/repo",
+    })
+    .returning({ id: composeJobs.id });
+  return row!;
+}
+
+/**
+ * Insert a test GitHub installation for a compose.
+ */
+export async function insertTestGithubInstallation(params: {
+  composeId: string;
+  installationId?: string;
+}): Promise<{ id: string }> {
+  const [row] = await globalThis.services.db
+    .insert(githubInstallations)
+    .values({
+      defaultComposeId: params.composeId,
+      installationId: params.installationId ?? `gh-inst-${Date.now()}`,
+    })
+    .returning({ id: githubInstallations.id });
+  return row!;
+}
+
+/**
+ * Insert a test GitHub user link.
+ */
+export async function insertTestGithubUserLink(params: {
+  installationId: string;
+  githubUserId: string;
+  vm0UserId: string;
+}): Promise<{ id: string }> {
+  const [row] = await globalThis.services.db
+    .insert(githubUserLinks)
+    .values({
+      installationId: params.installationId,
+      githubUserId: params.githubUserId,
+      vm0UserId: params.vm0UserId,
+    })
+    .returning({ id: githubUserLinks.id });
+  return row!;
+}
+
+/**
+ * Insert a test Telegram installation for a compose.
+ */
+export async function insertTestTelegramInstallation(params: {
+  composeId: string;
+  adminUserId: string;
+  botUsername?: string;
+}): Promise<{ id: string }> {
+  const botId = `tg-bot-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+  const [row] = await globalThis.services.db
+    .insert(telegramInstallations)
+    .values({
+      defaultComposeId: params.composeId,
+      telegramBotId: botId,
+      encryptedBotToken: `encrypted-test-token-${botId}`,
+      webhookSecret: `webhook-secret-${botId}`,
+      botUsername: params.botUsername ?? `test_bot_${Date.now()}`,
+      adminUserId: params.adminUserId,
+    })
+    .returning({ id: telegramInstallations.id });
+  return row!;
+}
+
+/**
+ * Insert a test Telegram user link.
+ */
+export async function insertTestTelegramUserLink(params: {
+  installationId: string;
+  telegramUserId: string;
+  vm0UserId: string;
+}): Promise<{ id: string }> {
+  const [row] = await globalThis.services.db
+    .insert(telegramUserLinks)
+    .values({
+      installationId: params.installationId,
+      telegramUserId: params.telegramUserId,
+      vm0UserId: params.vm0UserId,
+    })
+    .returning({ id: telegramUserLinks.id });
+  return row!;
 }

--- a/turbo/apps/web/src/lib/user/__tests__/user-deletion-service.test.ts
+++ b/turbo/apps/web/src/lib/user/__tests__/user-deletion-service.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect } from "vitest";
+import { testContext, uniqueId } from "../../../__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestRunInDb,
+  createTestSecret,
+  createTestVariable,
+  createTestAgentSession,
+  createTestEmailThreadSession,
+  createTestCliToken,
+  createTestDeviceCode,
+  createTestConnectorSession,
+  findTestRunRecord,
+  findTestQueueEntry,
+  insertTestQueueEntry,
+  insertTestSlackOrgInstallation,
+  insertTestSlackOrgConnection,
+  insertTestSlackOrgPendingQuestion,
+  insertTestSlackOrgThreadSession,
+  insertTestCreditUsageForRun,
+  insertTestConversation,
+  insertTestStorage,
+  insertTestStorageVersion,
+  insertTestUsageDaily,
+  insertTestExportJob,
+  insertOrgMembersCacheEntry,
+  insertOrgMembersEntry,
+  insertUserCacheEntry,
+  countUserRows,
+  countSlackConnectionRows,
+  countGithubUserLinkRows,
+  countTelegramUserLinkRows,
+  insertTestComposeJob,
+  insertTestGithubInstallation,
+  insertTestGithubUserLink,
+  insertTestTelegramInstallation,
+  insertTestTelegramUserLink,
+} from "../../../__tests__/api-test-helpers";
+import { deleteUserData } from "../user-deletion-service";
+
+const context = testContext();
+
+describe("deleteUserData", () => {
+  it("should complete without error for a nonexistent user (idempotency)", async () => {
+    context.setupMocks();
+    await context.setupUser();
+
+    await expect(
+      deleteUserData("user_nonexistent_test"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("should cancel running runs and delete queue entries", async () => {
+    context.setupMocks();
+    const { userId } = await context.setupUser();
+
+    const { composeId } = await createTestCompose("cancel-test");
+    const { runId: queuedRunId } = await createTestRunInDb(userId, composeId, {
+      status: "queued",
+    });
+    const { runId: pendingRunId } = await createTestRunInDb(userId, composeId, {
+      status: "pending",
+    });
+    const { runId: runningRunId } = await createTestRunInDb(userId, composeId, {
+      status: "running",
+      startedAt: new Date(),
+    });
+    await createTestRunInDb(userId, composeId, {
+      status: "completed",
+      completedAt: new Date(),
+    });
+
+    await insertTestQueueEntry(queuedRunId);
+
+    await deleteUserData(userId);
+
+    expect(await findTestRunRecord(queuedRunId)).toBeUndefined();
+    expect(await findTestRunRecord(pendingRunId)).toBeUndefined();
+    expect(await findTestRunRecord(runningRunId)).toBeUndefined();
+    expect(await findTestQueueEntry(queuedRunId)).toBeUndefined();
+  });
+
+  it("should cascade delete agent composes and children", async () => {
+    context.setupMocks();
+    const { userId } = await context.setupUser();
+
+    const { composeId } = await createTestCompose("cascade-compose-test");
+    await createTestAgentSession(userId, composeId);
+
+    await deleteUserData(userId);
+
+    expect(await countUserRows("agent_composes", userId)).toBe(0);
+  });
+
+  it("should cascade delete agent runs and children", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+
+    const { composeId } = await createTestCompose("cascade-run-test");
+    const { runId } = await createTestRunInDb(userId, composeId, {
+      status: "completed",
+      completedAt: new Date(),
+    });
+
+    await insertTestCreditUsageForRun({ runId, orgId, userId });
+    await insertTestConversation({ runId });
+
+    await deleteUserData(userId);
+
+    expect(await countUserRows("agent_runs", userId)).toBe(0);
+  });
+
+  it("should cascade delete storages and versions", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+
+    const storage = await insertTestStorage({
+      userId,
+      orgId,
+      name: "test-volume",
+    });
+    await insertTestStorageVersion({
+      storageId: storage.id,
+      createdBy: userId,
+    });
+
+    await deleteUserData(userId);
+
+    expect(await countUserRows("storages", userId)).toBe(0);
+  });
+
+  it("should cascade delete secrets and model providers", async () => {
+    context.setupMocks();
+    const { userId } = await context.setupUser();
+
+    await createTestSecret("TEST_KEY", "test-value");
+
+    await deleteUserData(userId);
+
+    expect(await countUserRows("secrets", userId)).toBe(0);
+    expect(await countUserRows("model_providers", userId)).toBe(0);
+  });
+
+  it("should delete independent tables", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+
+    await createTestVariable("TEST_VAR", "test-value");
+    await insertTestUsageDaily({ userId, orgId, date: "2026-01-01" });
+    await insertTestExportJob(orgId, { userId, status: "completed" });
+
+    await deleteUserData(userId);
+
+    expect(await countUserRows("variables", userId)).toBe(0);
+    expect(await countUserRows("usage_daily", userId)).toBe(0);
+    expect(await countUserRows("export_jobs", userId)).toBe(0);
+  });
+
+  it("should clean up Slack connections and pending questions", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+
+    const workspaceId = uniqueId("ws");
+
+    await insertTestSlackOrgInstallation({
+      slackWorkspaceId: workspaceId,
+      slackWorkspaceName: "Test Workspace",
+      orgId,
+      installedByUserId: userId,
+    });
+
+    const connection = await insertTestSlackOrgConnection({
+      slackUserId: uniqueId("slack-user"),
+      slackWorkspaceId: workspaceId,
+      vm0UserId: userId,
+    });
+
+    const { composeId } = await createTestCompose("slack-test");
+    const session = await createTestAgentSession(userId, composeId);
+
+    await insertTestSlackOrgPendingQuestion({
+      connectionId: connection.id,
+      composeId,
+      sessionId: session.id,
+      runId: uniqueId("run"),
+      slackWorkspaceId: workspaceId,
+    });
+
+    await insertTestSlackOrgThreadSession({ connectionId: connection.id });
+
+    await deleteUserData(userId);
+
+    expect(await countSlackConnectionRows(userId)).toBe(0);
+  });
+
+  it("should delete external service links (GitHub and Telegram)", async () => {
+    context.setupMocks();
+    const { userId } = await context.setupUser();
+
+    const { composeId } = await createTestCompose("external-links-test");
+
+    // GitHub: compose → installation → user link
+    const ghInstallation = await insertTestGithubInstallation({ composeId });
+    await insertTestGithubUserLink({
+      installationId: ghInstallation.id,
+      githubUserId: uniqueId("gh-user"),
+      vm0UserId: userId,
+    });
+
+    // Telegram: compose → installation → user link
+    const tgInstallation = await insertTestTelegramInstallation({
+      composeId,
+      adminUserId: userId,
+    });
+    await insertTestTelegramUserLink({
+      installationId: tgInstallation.id,
+      telegramUserId: uniqueId("tg-user"),
+      vm0UserId: userId,
+    });
+
+    await deleteUserData(userId);
+
+    expect(await countGithubUserLinkRows(userId)).toBe(0);
+    expect(await countTelegramUserLinkRows(userId)).toBe(0);
+  });
+
+  it("should delete user-only tables (cli_tokens, compose_jobs, connector_sessions, device_codes)", async () => {
+    context.setupMocks();
+    const { userId } = await context.setupUser();
+
+    await createTestCliToken(userId);
+    await createTestDeviceCode({ userId, status: "authenticated" });
+    await createTestConnectorSession(userId, "github");
+    await insertTestComposeJob({ userId });
+
+    await deleteUserData(userId);
+
+    expect(await countUserRows("cli_tokens", userId)).toBe(0);
+    expect(await countUserRows("device_codes", userId)).toBe(0);
+    expect(await countUserRows("connector_sessions", userId)).toBe(0);
+    expect(await countUserRows("compose_jobs", userId)).toBe(0);
+  });
+
+  it("should delete membership across multiple orgs", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+
+    await insertOrgMembersCacheEntry({ orgId, userId, role: "admin" });
+    await insertOrgMembersEntry({ orgId, userId });
+
+    await deleteUserData(userId);
+
+    expect(await countUserRows("org_members_cache", userId)).toBe(0);
+    expect(await countUserRows("org_members_metadata", userId)).toBe(0);
+  });
+
+  it("should delete user identity (user_cache, users)", async () => {
+    context.setupMocks();
+    const { userId } = await context.setupUser();
+
+    await insertUserCacheEntry({ userId, email: "test@example.com" });
+
+    await deleteUserData(userId);
+
+    expect(await countUserRows("user_cache", userId)).toBe(0);
+    expect(await countUserRows("users", userId)).toBe(0);
+  });
+
+  it("should delete all data in a fully populated user", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+
+    // Composes, sessions, runs
+    const { composeId } = await createTestCompose("full-user-test");
+    const session = await createTestAgentSession(userId, composeId);
+    const { runId } = await createTestRunInDb(userId, composeId, {
+      status: "running",
+      startedAt: new Date(),
+    });
+
+    await insertTestCreditUsageForRun({ runId, orgId, userId });
+    await insertTestConversation({ runId });
+    await insertTestQueueEntry(runId);
+
+    // Storage
+    const storage = await insertTestStorage({
+      userId,
+      orgId,
+      name: "full-test-volume",
+    });
+    await insertTestStorageVersion({
+      storageId: storage.id,
+      createdBy: userId,
+    });
+
+    // Secrets
+    await createTestSecret("FULL_TEST_KEY", "value");
+
+    // Variables, usage, exports
+    await createTestVariable("FULL_TEST_VAR", "value");
+    await insertTestUsageDaily({ userId, orgId, date: "2026-03-01" });
+    await insertTestExportJob(orgId, { userId, status: "completed" });
+
+    // Email thread session
+    await createTestEmailThreadSession({
+      userId,
+      composeId,
+      agentSessionId: session.id,
+      replyToToken: uniqueId("reply"),
+    });
+
+    // Slack
+    const workspaceId = uniqueId("ws");
+    await insertTestSlackOrgInstallation({
+      slackWorkspaceId: workspaceId,
+      slackWorkspaceName: "Full Test Workspace",
+      orgId,
+      installedByUserId: userId,
+    });
+    const connection = await insertTestSlackOrgConnection({
+      slackUserId: uniqueId("slack-user"),
+      slackWorkspaceId: workspaceId,
+      vm0UserId: userId,
+    });
+    await insertTestSlackOrgPendingQuestion({
+      connectionId: connection.id,
+      composeId,
+      sessionId: session.id,
+      runId: uniqueId("run"),
+      slackWorkspaceId: workspaceId,
+    });
+
+    // User-only tables
+    await createTestCliToken(userId);
+    await createTestDeviceCode({ userId, status: "authenticated" });
+    await createTestConnectorSession(userId, "github");
+    await insertTestComposeJob({ userId });
+
+    // Membership
+    await insertOrgMembersCacheEntry({ orgId, userId, role: "admin" });
+    await insertOrgMembersEntry({ orgId, userId });
+
+    // User identity
+    await insertUserCacheEntry({ userId, email: "full-test@example.com" });
+
+    // Execute deletion
+    await deleteUserData(userId);
+
+    // Verify ALL user-scoped tables are empty
+    const userIdTables = [
+      "agent_runs",
+      "agent_run_queue",
+      "agent_composes",
+      "storages",
+      "secrets",
+      "model_providers",
+      "connectors",
+      "variables",
+      "usage_daily",
+      "export_jobs",
+      "zero_agent_schedules",
+      "cli_tokens",
+      "compose_jobs",
+      "connector_sessions",
+      "device_codes",
+      "org_members_cache",
+      "org_members_metadata",
+      "user_cache",
+      "users",
+    ] as const;
+
+    for (const table of userIdTables) {
+      expect(
+        await countUserRows(table, userId),
+        `Expected 0 rows in ${table}`,
+      ).toBe(0);
+    }
+
+    // vm0UserId-based tables
+    expect(await countSlackConnectionRows(userId)).toBe(0);
+  });
+
+  it("should be idempotent — calling twice produces no errors", async () => {
+    context.setupMocks();
+    const { userId } = await context.setupUser();
+
+    const { composeId } = await createTestCompose("idempotent-test");
+    await createTestRunInDb(userId, composeId, {
+      status: "running",
+      startedAt: new Date(),
+    });
+    await createTestSecret("IDEM_KEY", "value");
+
+    await deleteUserData(userId);
+    await expect(deleteUserData(userId)).resolves.toBeUndefined();
+  });
+});

--- a/turbo/apps/web/src/lib/user/user-deletion-service.ts
+++ b/turbo/apps/web/src/lib/user/user-deletion-service.ts
@@ -1,0 +1,132 @@
+import { eq, and, inArray } from "drizzle-orm";
+import { logger } from "../logger";
+import { agentRuns } from "../../db/schema/agent-run";
+import { agentRunQueue } from "../../db/schema/agent-run-queue";
+import { agentComposes } from "../../db/schema/agent-compose";
+import { storages } from "../../db/schema/storage";
+import { secrets } from "../../db/schema/secret";
+import { modelProviders } from "../../db/schema/model-provider";
+import { connectors } from "../../db/schema/connector";
+import { variables } from "../../db/schema/variable";
+import { usageDaily } from "../../db/schema/usage-daily";
+import { exportJobs } from "../../db/schema/export-job";
+import { zeroAgentSchedules } from "../../db/schema/zero-agent-schedule";
+import { slackOrgConnections } from "../../db/schema/slack-org-connection";
+import { slackOrgPendingQuestions } from "../../db/schema/slack-org-pending-question";
+import { githubUserLinks } from "../../db/schema/github-user-link";
+import { telegramUserLinks } from "../../db/schema/telegram-user-link";
+import { cliTokens } from "../../db/schema/cli-tokens";
+import { composeJobs } from "../../db/schema/compose-job";
+import { connectorSessions } from "../../db/schema/connector-session";
+import { deviceCodes } from "../../db/schema/device-codes";
+import { orgMembersCache } from "../../db/schema/org-members-cache";
+import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
+import { userCache } from "../../db/schema/user-cache";
+import { users } from "../../db/schema/user";
+
+const log = logger("service:user-deletion");
+
+/**
+ * Cancel all pending/running/queued agent runs for a user.
+ * Bulk cancel only updates status — no side effects needed since the
+ * entire user is being deleted.
+ */
+async function cancelUserRuns(userId: string): Promise<void> {
+  const db = globalThis.services.db;
+
+  const result = await db
+    .update(agentRuns)
+    .set({ status: "cancelled", completedAt: new Date() })
+    .where(
+      and(
+        eq(agentRuns.userId, userId),
+        inArray(agentRuns.status, ["queued", "pending", "running"]),
+      ),
+    );
+
+  await db.delete(agentRunQueue).where(eq(agentRunQueue.userId, userId));
+
+  log.info("user runs cancelled", { userId, count: result.rowCount });
+}
+
+/**
+ * Delete all user-scoped data from the database.
+ *
+ * Idempotent: safe to call multiple times for the same userId.
+ */
+export async function deleteUserData(userId: string): Promise<void> {
+  const db = globalThis.services.db;
+
+  log.info("deleting user data", { userId });
+
+  // Phase 0: Cancel all running work
+  await cancelUserRuns(userId);
+
+  // Step 1: Slack cleanup (pending_questions FK blocks connection deletion)
+  const connections = await db
+    .select({ id: slackOrgConnections.id })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.vm0UserId, userId));
+
+  if (connections.length > 0) {
+    const connectionIds = connections.map((c) => c.id);
+    await db
+      .delete(slackOrgPendingQuestions)
+      .where(inArray(slackOrgPendingQuestions.connectionId, connectionIds));
+  }
+
+  // Delete connections (cascades slack_org_thread_sessions)
+  await db
+    .delete(slackOrgConnections)
+    .where(eq(slackOrgConnections.vm0UserId, userId));
+
+  // Step 2: External service links
+  await db.delete(githubUserLinks).where(eq(githubUserLinks.vm0UserId, userId));
+  await db
+    .delete(telegramUserLinks)
+    .where(eq(telegramUserLinks.vm0UserId, userId));
+
+  // Step 3: Aggregate roots with CASCADE (handles ~15 child tables)
+  // Delete runs first (references compose_versions with SET NULL)
+  await db.delete(agentRuns).where(eq(agentRuns.userId, userId));
+  // Then composes (cascades: compose_versions, sessions, chat_threads,
+  // email_thread_sessions, github_installations, telegram_installations,
+  // slack_org_pending_questions)
+  await db.delete(agentComposes).where(eq(agentComposes.userId, userId));
+  // Storages (cascades: storage_versions, storage_version_lineage)
+  await db.delete(storages).where(eq(storages.userId, userId));
+  // Model providers (some have null secretId, so won't cascade from secrets)
+  await db.delete(modelProviders).where(eq(modelProviders.userId, userId));
+  // Secrets (cascades remaining model_providers with secretId)
+  await db.delete(secrets).where(eq(secrets.userId, userId));
+
+  // Step 4: Tables without CASCADE
+  await db.delete(connectors).where(eq(connectors.userId, userId));
+  await db.delete(variables).where(eq(variables.userId, userId));
+  await db.delete(usageDaily).where(eq(usageDaily.userId, userId));
+  await db.delete(exportJobs).where(eq(exportJobs.userId, userId));
+  // Cross-org schedules: deleted by userId (not only via compose CASCADE)
+  await db
+    .delete(zeroAgentSchedules)
+    .where(eq(zeroAgentSchedules.userId, userId));
+
+  // Step 5: User-only tables (no orgId)
+  await db.delete(cliTokens).where(eq(cliTokens.userId, userId));
+  await db.delete(composeJobs).where(eq(composeJobs.userId, userId));
+  await db
+    .delete(connectorSessions)
+    .where(eq(connectorSessions.userId, userId));
+  await db.delete(deviceCodes).where(eq(deviceCodes.userId, userId));
+
+  // Step 6: Membership cleanup (all orgs)
+  await db.delete(orgMembersCache).where(eq(orgMembersCache.userId, userId));
+  await db
+    .delete(orgMembersMetadata)
+    .where(eq(orgMembersMetadata.userId, userId));
+
+  // Step 7: User identity (LAST)
+  await db.delete(userCache).where(eq(userCache.userId, userId));
+  await db.delete(users).where(eq(users.id, userId));
+
+  log.info("user data deleted", { userId });
+}


### PR DESCRIPTION
## Summary

- Add `deleteUserData(userId)` service that cascade-deletes all user-scoped database rows across all orgs
- Follow the same proven pattern as `deleteOrgData(orgId)` in `org-deletion-service.ts`
- Add test helpers (`countUserRows`, `insertTestComposeJob`, GitHub/Telegram installation and user link helpers)
- 14 integration tests covering FK ordering, cascade deletion, cross-org cleanup, and idempotency

Closes #6169

## Test plan

- [x] `pnpm vitest run src/lib/user/__tests__/user-deletion-service.test.ts` — 14/14 tests pass
- [x] `pnpm check-types` — no type errors
- [x] `pnpm turbo run lint` — no lint errors
- [x] `pnpm format` — all formatted
- [x] `pnpm knip` — no unused exports
- [x] Full test suite — 373/374 pass (1 pre-existing flaky test unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)