### PR TITLE
fix: use file_type() in walk_dir to avoid following symlinks

### DIFF
--- a/crates/guest-agent/src/artifact.rs
+++ b/crates/guest-agent/src/artifact.rs
@@ -300,6 +300,18 @@ fn walk_dir(current: &str, relative: &str, out: &mut Vec<FileEntry>) {
         if name_str == ".git" || name_str == ".vm0" {
             continue;
         }
+
+        // Use file_type() which does NOT follow symlinks (uses d_type from getdents64
+        // on Linux, no extra syscall). This avoids the manifest/archive mismatch where
+        // is_file()/is_dir() follow symlinks but tar stores them as symlink entries.
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if ft.is_symlink() {
+            continue; // Skip symlinks — v1 manifest cannot represent them
+        }
+
         let full = entry.path();
         let rel = if relative.is_empty() {
             name_str.to_string()
@@ -307,11 +319,11 @@ fn walk_dir(current: &str, relative: &str, out: &mut Vec<FileEntry>) {
             format!("{relative}/{name_str}")
         };
 
-        if full.is_dir() {
+        if ft.is_dir() {
             if let Some(s) = full.to_str() {
                 walk_dir(s, &rel, out);
             }
-        } else if full.is_file() {
+        } else if ft.is_file() {
             match compute_file_hash(&full) {
                 Ok((hash, size)) => out.push(FileEntry {
                     path: rel,
@@ -348,6 +360,7 @@ fn compute_file_hash(path: &Path) -> Result<(String, u64), std::io::Error> {
 fn create_archive(dir_path: &str, tar_path: &Path) -> bool {
     let output = std::process::Command::new("tar")
         .args([
+            "--hard-dereference",
             "-czf",
             &tar_path.to_string_lossy(),
             "--exclude=.git",

--- a/crates/guest-agent/src/artifact.rs
+++ b/crates/guest-agent/src/artifact.rs
@@ -388,3 +388,66 @@ fn create_archive(dir_path: &str, tar_path: &Path) -> bool {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs as unix_fs;
+
+    #[test]
+    fn walk_dir_skips_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // Regular file
+        std::fs::write(root.join("real.txt"), "hello").unwrap();
+
+        // Symlink to file
+        unix_fs::symlink(root.join("real.txt"), root.join("link.txt")).unwrap();
+
+        // Symlink to directory outside
+        std::fs::create_dir(root.join("subdir")).unwrap();
+        std::fs::write(root.join("subdir/inner.txt"), "inner").unwrap();
+        unix_fs::symlink(root.join("subdir"), root.join("link_dir")).unwrap();
+
+        // Dangling symlink
+        unix_fs::symlink("/nonexistent", root.join("dangling")).unwrap();
+
+        let files = collect_file_metadata(root.to_str().unwrap());
+        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+
+        // Regular files should be included
+        assert!(paths.contains(&"real.txt"));
+        assert!(paths.contains(&"subdir/inner.txt"));
+
+        // Symlinks should NOT be included
+        assert!(!paths.contains(&"link.txt"));
+        assert!(!paths.contains(&"link_dir"));
+        assert!(!paths.contains(&"dangling"));
+
+        // link_dir contents should NOT appear (symlink dir skipped, not followed)
+        assert!(!paths.iter().any(|p| p.starts_with("link_dir/")));
+    }
+
+    #[test]
+    fn walk_dir_handles_hardlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        std::fs::write(root.join("original.txt"), "content").unwrap();
+        std::fs::hard_link(root.join("original.txt"), root.join("hardlink.txt")).unwrap();
+
+        let files = collect_file_metadata(root.to_str().unwrap());
+        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+
+        // Both original and hardlink should be recorded as independent files
+        assert!(paths.contains(&"original.txt"));
+        assert!(paths.contains(&"hardlink.txt"));
+
+        // Both should have the same hash
+        let original = files.iter().find(|f| f.path == "original.txt").unwrap();
+        let hardlink = files.iter().find(|f| f.path == "hardlink.txt").unwrap();
+        assert_eq!(original.hash, hardlink.hash);
+        assert_eq!(original.size, hardlink.size);
+    }
+}


### PR DESCRIPTION
## Summary

- Switch `walk_dir` from `is_file()`/`is_dir()` (stat, follows symlinks) to `DirEntry::file_type()` (lstat, does not follow symlinks)
- Skip symlinks entirely in v1 manifest (cannot represent them)
- Add `--hard-dereference` to tar command to expand hardlinks into independent files
- Fixes #6147, related to #3934

## Problem

`walk_dir` and `create_archive` had inconsistent symlink/hardlink handling:

| Type | walk_dir (manifest) | tar (archive) | Result |
|---|---|---|---|
| Symlink → file | Followed, recorded target's hash | Stored as symlink entry | Hash mismatch |
| Symlink → dir | Followed, recursed into target | Stored as symlink entry | Extra files in manifest |
| Hardlink | Independent file with hash | Deduplicated by tar | File count mismatch |

This caused incorrect dedup hashes and incremental upload diffs.

## Fix

- **walk_dir**: `DirEntry::file_type()` uses `d_type` from `getdents64` on Linux (zero extra syscalls). Symlinks detected and skipped.
- **tar**: `--hard-dereference` expands hardlinks to independent files, matching walk_dir behavior.

## Test plan

- [x] `cargo clippy` clean
- [x] `cargo check` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)