### PR TITLE
feat(cli): add vm0 zero org core commands

### DIFF
--- a/turbo/apps/cli/src/commands/zero/index.ts
+++ b/turbo/apps/cli/src/commands/zero/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
+import { zeroOrgCommand } from "./org";
 
-export const zeroCommand = new Command("zero").description(
-  "Zero platform commands",
-);
+export const zeroCommand = new Command("zero")
+  .description("Zero platform commands")
+  .addCommand(zeroOrgCommand);

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/delete.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { deleteCommand } from "../delete";
+import chalk from "chalk";
+
+describe("zero org delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  it("should delete organization with slug confirmation", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/org/delete", () => {
+        return HttpResponse.json({
+          message: "Organization deleted",
+        });
+      }),
+    );
+
+    await deleteCommand.parseAsync(["node", "cli", "my-org"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("my-org");
+    expect(logCalls).toContain("has been deleted");
+  });
+
+  it("should handle forbidden error (non-admin)", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/org/delete", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Only admins can delete organizations",
+              code: "FORBIDDEN",
+            },
+          },
+          { status: 403 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await deleteCommand.parseAsync(["node", "cli", "my-org"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Only admins can delete"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should handle slug mismatch error", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/org/delete", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Slug does not match current organization",
+              code: "BAD_REQUEST",
+            },
+          },
+          { status: 400 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await deleteCommand.parseAsync(["node", "cli", "wrong-slug"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Slug does not match"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/invite.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/invite.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { inviteCommand } from "../invite";
+import chalk from "chalk";
+
+describe("zero org invite command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  it("should invite member and show success", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/org/invite", () => {
+        return HttpResponse.json({
+          message: "Invitation sent to member@example.com",
+        });
+      }),
+    );
+
+    await inviteCommand.parseAsync([
+      "node",
+      "cli",
+      "--email",
+      "member@example.com",
+    ]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("member@example.com");
+    expect(logCalls).toContain("Invitation sent");
+  });
+
+  it("should handle forbidden error (non-admin)", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/org/invite", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Only admins can invite members",
+              code: "FORBIDDEN",
+            },
+          },
+          { status: 403 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await inviteCommand.parseAsync([
+        "node",
+        "cli",
+        "--email",
+        "member@example.com",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Only admins can invite"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/leave.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/leave.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { leaveCommand } from "../leave";
+import { mkdtempSync } from "fs";
+import * as path from "path";
+import * as os from "os";
+import chalk from "chalk";
+
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-zero-org-leave-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return { ...original, homedir: () => TEST_HOME };
+});
+
+describe("zero org leave command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  it("should leave org and auto-switch to remaining org", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/org/leave", () => {
+        return HttpResponse.json({
+          message: "Left organization",
+        });
+      }),
+      http.get("http://localhost:3000/api/zero/org/list", () => {
+        return HttpResponse.json({
+          orgs: [
+            { slug: "other-org", role: "member" },
+            { slug: "another-org", role: "admin" },
+          ],
+          active: undefined,
+        });
+      }),
+    );
+
+    await leaveCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Left organization");
+    expect(logCalls).toContain("Switched to: other-org");
+  });
+
+  it("should handle no remaining organizations after leaving", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/org/leave", () => {
+        return HttpResponse.json({
+          message: "Left organization",
+        });
+      }),
+      http.get("http://localhost:3000/api/zero/org/list", () => {
+        return HttpResponse.json({
+          orgs: [],
+          active: undefined,
+        });
+      }),
+    );
+
+    await leaveCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Left organization");
+    expect(logCalls).toContain("No remaining organizations");
+  });
+
+  it("should handle admin-cannot-leave error", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/org/leave", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Admin cannot leave the organization",
+              code: "FORBIDDEN",
+            },
+          },
+          { status: 403 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await leaveCommand.parseAsync(["node", "cli"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Admin cannot leave"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/list.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { listCommand } from "../list";
+import { mkdtempSync } from "fs";
+import { mkdir, writeFile, rm } from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import chalk from "chalk";
+
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-zero-org-list-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return { ...original, homedir: () => TEST_HOME };
+});
+
+describe("zero org list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(async () => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    vi.stubEnv("VM0_ACTIVE_ORG", "my-org");
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      path.join(configDir, "config.json"),
+      JSON.stringify({ activeOrg: "my-org" }),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(path.join(TEST_HOME, ".vm0"), { recursive: true, force: true });
+  });
+
+  it("should display organizations with roles", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org/list", () => {
+        return HttpResponse.json({
+          orgs: [
+            { slug: "personal-user", role: "admin" },
+            { slug: "my-org", role: "admin" },
+          ],
+          active: undefined,
+        });
+      }),
+    );
+
+    await listCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("personal-user");
+    expect(logCalls).toContain("admin");
+    expect(logCalls).toContain("my-org");
+  });
+
+  it("should mark current organization", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org/list", () => {
+        return HttpResponse.json({
+          orgs: [
+            { slug: "personal-user", role: "admin" },
+            { slug: "my-org", role: "admin" },
+          ],
+          active: undefined,
+        });
+      }),
+    );
+
+    await listCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("current");
+  });
+
+  it("should handle API error", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org/list", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Internal server error",
+              code: "SERVER_ERROR",
+            },
+          },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await listCommand.parseAsync(["node", "cli"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Internal server error"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/members.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/members.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { membersCommand } from "../members";
+import chalk from "chalk";
+
+describe("zero org members command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  it("should display organization members", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org/members", () => {
+        return HttpResponse.json({
+          slug: "my-org",
+          role: "admin",
+          createdAt: "2024-01-01T00:00:00Z",
+          members: [
+            { email: "admin@example.com", role: "admin" },
+            { email: "member@example.com", role: "member" },
+          ],
+          pendingInvitations: [],
+        });
+      }),
+    );
+
+    await membersCommand.parseAsync(["node", "cli"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("my-org");
+    expect(logCalls).toContain("admin@example.com");
+    expect(logCalls).toContain("member@example.com");
+  });
+
+  it("should handle forbidden error", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org/members", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Not authorized to view members",
+              code: "FORBIDDEN",
+            },
+          },
+          { status: 403 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await membersCommand.parseAsync(["node", "cli"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Not authorized"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/remove.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/remove.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { removeCommand } from "../remove";
+import chalk from "chalk";
+
+describe("zero org remove command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  it("should remove member and show success", async () => {
+    server.use(
+      http.delete("http://localhost:3000/api/zero/org/members", () => {
+        return HttpResponse.json({
+          message: "Member removed",
+        });
+      }),
+    );
+
+    await removeCommand.parseAsync(["node", "cli", "member@example.com"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Removed member@example.com from organization");
+  });
+
+  it("should handle forbidden error (non-admin)", async () => {
+    server.use(
+      http.delete("http://localhost:3000/api/zero/org/members", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Only admins can remove members",
+              code: "FORBIDDEN",
+            },
+          },
+          { status: 403 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await removeCommand.parseAsync(["node", "cli", "member@example.com"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Only admins can remove"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/set.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { setCommand } from "../set";
+
+describe("zero org set command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  it("should require --force to update existing organization", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "test-id",
+          slug: "oldslug",
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+    );
+
+    await expect(async () => {
+      await setCommand.parseAsync(["node", "cli", "newslug"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("already have an organization: oldslug"),
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("--force"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should update organization with --force", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "test-id",
+          slug: "oldslug",
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+      http.put("http://localhost:3000/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "test-id",
+          slug: "newslug",
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+    );
+
+    await setCommand.parseAsync(["node", "cli", "newslug", "--force"]);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Organization updated to newslug"),
+    );
+  });
+
+  it("should handle slug already taken", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "test-id",
+          slug: "oldslug",
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+      http.put("http://localhost:3000/api/zero/org", () => {
+        return HttpResponse.json(
+          { error: { message: "Org already exists", code: "CONFLICT" } },
+          { status: 409 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await setCommand.parseAsync(["node", "cli", "takenslug", "--force"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("already taken"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/status.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { statusCommand } from "../status";
+
+describe("zero org status command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  it("should display organization information", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "test-id",
+          slug: "testuser",
+          createdAt: "2024-01-01T00:00:00Z",
+          updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+    );
+
+    await statusCommand.parseAsync(["node", "cli"]);
+
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("Organization Information"),
+    );
+    expect(mockConsoleLog).toHaveBeenCalledWith(
+      expect.stringContaining("testuser"),
+    );
+  });
+
+  it("should show helpful message when user has no organization", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org", () => {
+        return HttpResponse.json(
+          { error: { message: "No org configured", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await statusCommand.parseAsync(["node", "cli"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("No organization configured"),
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("vm0 zero org set"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  it("should handle server errors", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org", () => {
+        return HttpResponse.json(
+          { error: { message: "Server error", code: "SERVER_ERROR" } },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await expect(async () => {
+      await statusCommand.parseAsync(["node", "cli"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Server error"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/use.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { useCommand } from "../use";
+import { mkdtempSync } from "fs";
+import * as path from "path";
+import * as os from "os";
+import chalk from "chalk";
+
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-zero-org-use-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return { ...original, homedir: () => TEST_HOME };
+});
+
+describe("zero org use command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  it("should switch to a valid organization", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org/list", () => {
+        return HttpResponse.json({
+          orgs: [
+            { slug: "org-a", role: "admin" },
+            { slug: "org-b", role: "member" },
+          ],
+          active: undefined,
+        });
+      }),
+    );
+
+    await useCommand.parseAsync(["node", "cli", "org-b"]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("Switched to organization: org-b");
+  });
+
+  it("should error when organization not found", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/zero/org/list", () => {
+        return HttpResponse.json({
+          orgs: [{ slug: "org-a", role: "admin" }],
+          active: undefined,
+        });
+      }),
+    );
+
+    await expect(async () => {
+      await useCommand.parseAsync(["node", "cli", "nonexistent"]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining("not found or not accessible"),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/org/delete.ts
@@ -1,0 +1,15 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { deleteZeroOrg } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const deleteCommand = new Command()
+  .name("delete")
+  .description("Delete the current organization (admin only)")
+  .argument("<slug>", "Organization slug to confirm deletion")
+  .action(
+    withErrorHandler(async (slug: string) => {
+      await deleteZeroOrg(slug);
+      console.log(chalk.green(`✓ Organization '${slug}' has been deleted.`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/index.ts
+++ b/turbo/apps/cli/src/commands/zero/org/index.ts
@@ -1,0 +1,23 @@
+import { Command } from "commander";
+import { statusCommand } from "./status";
+import { setCommand } from "./set";
+import { listCommand } from "./list";
+import { useCommand } from "./use";
+import { membersCommand } from "./members";
+import { inviteCommand } from "./invite";
+import { removeCommand } from "./remove";
+import { leaveCommand } from "./leave";
+import { deleteCommand } from "./delete";
+
+export const zeroOrgCommand = new Command()
+  .name("org")
+  .description("Manage your organization")
+  .addCommand(statusCommand)
+  .addCommand(setCommand)
+  .addCommand(listCommand)
+  .addCommand(useCommand)
+  .addCommand(membersCommand)
+  .addCommand(inviteCommand)
+  .addCommand(removeCommand)
+  .addCommand(leaveCommand)
+  .addCommand(deleteCommand);

--- a/turbo/apps/cli/src/commands/zero/org/invite.ts
+++ b/turbo/apps/cli/src/commands/zero/org/invite.ts
@@ -1,0 +1,15 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { inviteZeroOrgMember } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const inviteCommand = new Command()
+  .name("invite")
+  .description("Invite a member to the current organization")
+  .requiredOption("--email <email>", "Email address of the member to invite")
+  .action(
+    withErrorHandler(async (options: { email: string }) => {
+      await inviteZeroOrgMember(options.email);
+      console.log(chalk.green(`✓ Invitation sent to ${options.email}`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/leave.ts
+++ b/turbo/apps/cli/src/commands/zero/org/leave.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { leaveZeroOrg, listZeroOrgs } from "../../../lib/api";
+import { saveConfig } from "../../../lib/api/config";
+import { withErrorHandler } from "../../../lib/command";
+
+export const leaveCommand = new Command()
+  .name("leave")
+  .description("Leave the current organization")
+  .action(
+    withErrorHandler(async () => {
+      await leaveZeroOrg();
+
+      const { orgs } = await listZeroOrgs();
+      if (orgs.length === 0) {
+        await saveConfig({ activeOrg: undefined });
+        console.log(chalk.green("✓ Left organization."));
+        console.log(
+          chalk.yellow("No remaining organizations. Run: vm0 auth login"),
+        );
+        return;
+      }
+
+      const nextOrg = orgs[0]!.slug;
+      await saveConfig({ activeOrg: nextOrg });
+      console.log(chalk.green(`✓ Left organization. Switched to: ${nextOrg}`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/list.ts
+++ b/turbo/apps/cli/src/commands/zero/org/list.ts
@@ -1,0 +1,24 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listZeroOrgs } from "../../../lib/api";
+import { getActiveOrg } from "../../../lib/api/config";
+import { withErrorHandler } from "../../../lib/command";
+
+export const listCommand = new Command()
+  .name("list")
+  .description("List all accessible organizations")
+  .action(
+    withErrorHandler(async () => {
+      const result = await listZeroOrgs();
+      const activeOrg = await getActiveOrg();
+
+      console.log(chalk.bold("Available organizations:"));
+      for (const org of result.orgs) {
+        const isCurrent = org.slug === activeOrg;
+        const marker = isCurrent ? chalk.green("* ") : "  ";
+        const roleLabel = org.role ? ` (${org.role})` : "";
+        const currentLabel = isCurrent ? chalk.dim(" ← current") : "";
+        console.log(`${marker}${org.slug}${roleLabel}${currentLabel}`);
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/members.ts
+++ b/turbo/apps/cli/src/commands/zero/org/members.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getZeroOrgMembers } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const membersCommand = new Command()
+  .name("members")
+  .description("View organization members")
+  .action(
+    withErrorHandler(async () => {
+      const status = await getZeroOrgMembers();
+
+      console.log(chalk.bold(`Organization: ${status.slug}`));
+      console.log(`  Role: ${status.role}`);
+      console.log(
+        `  Created: ${new Date(status.createdAt).toLocaleDateString()}`,
+      );
+      console.log();
+      console.log(chalk.bold("Members:"));
+      for (const member of status.members) {
+        const roleTag =
+          member.role === "admin"
+            ? chalk.yellow(` (${member.role})`)
+            : chalk.dim(` (${member.role})`);
+        console.log(`  ${member.email}${roleTag}`);
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/remove.ts
+++ b/turbo/apps/cli/src/commands/zero/org/remove.ts
@@ -1,0 +1,15 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { removeZeroOrgMember } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const removeCommand = new Command()
+  .name("remove")
+  .description("Remove a member from the current organization")
+  .argument("<email>", "Email address of the member to remove")
+  .action(
+    withErrorHandler(async (email: string) => {
+      await removeZeroOrgMember(email);
+      console.log(chalk.green(`✓ Removed ${email} from organization`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/set.ts
+++ b/turbo/apps/cli/src/commands/zero/org/set.ts
@@ -1,0 +1,49 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getZeroOrg, updateZeroOrg } from "../../../lib/api";
+import { saveConfig } from "../../../lib/api/config";
+import { withErrorHandler } from "../../../lib/command";
+
+export const setCommand = new Command()
+  .name("set")
+  .description("Rename your organization slug")
+  .argument("<slug>", "The new organization slug")
+  .option(
+    "--force",
+    "Force change existing organization (may break references)",
+  )
+  .action(
+    withErrorHandler(async (slug: string, options: { force?: boolean }) => {
+      try {
+        const existingOrg = await getZeroOrg();
+
+        if (!options.force) {
+          throw new Error(
+            `You already have an organization: ${existingOrg.slug}`,
+            {
+              cause: new Error(
+                `To change, use: vm0 zero org set ${slug} --force`,
+              ),
+            },
+          );
+        }
+
+        const org = await updateZeroOrg({ slug, force: true });
+        await saveConfig({ activeOrg: org.slug });
+        console.log(chalk.green(`✓ Organization updated to ${org.slug}`));
+        console.log();
+        console.log("Your agents will now be namespaced as:");
+        console.log(chalk.cyan(`  ${org.slug}/<agent-name>`));
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("already exists")
+        ) {
+          throw new Error(
+            `Organization "${slug}" is already taken. Please choose a different slug.`,
+          );
+        }
+        throw error;
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/status.ts
+++ b/turbo/apps/cli/src/commands/zero/org/status.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getZeroOrg } from "../../../lib/api";
+import { ApiRequestError } from "../../../lib/api/core/client-factory";
+import { withErrorHandler } from "../../../lib/command";
+
+export const statusCommand = new Command()
+  .name("status")
+  .description("View current organization status")
+  .action(
+    withErrorHandler(async () => {
+      try {
+        const org = await getZeroOrg();
+
+        console.log(chalk.bold("Organization Information:"));
+        console.log(`  Slug: ${chalk.green(org.slug)}`);
+      } catch (error) {
+        if (error instanceof ApiRequestError && error.status === 404) {
+          throw new Error("No organization configured", {
+            cause: new Error(
+              "Set your organization with: vm0 zero org set <slug>",
+            ),
+          });
+        }
+        throw error;
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/use.ts
+++ b/turbo/apps/cli/src/commands/zero/org/use.ts
@@ -1,0 +1,22 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listZeroOrgs } from "../../../lib/api";
+import { saveConfig } from "../../../lib/api/config";
+import { withErrorHandler } from "../../../lib/command";
+
+export const useCommand = new Command()
+  .name("use")
+  .description("Switch to a different organization")
+  .argument("<slug>", "Organization slug to switch to")
+  .action(
+    withErrorHandler(async (slug: string) => {
+      const orgList = await listZeroOrgs();
+      const target = orgList.orgs.find((s) => s.slug === slug);
+      if (!target) {
+        throw new Error(`Organization '${slug}' not found or not accessible.`);
+      }
+
+      await saveConfig({ activeOrg: slug });
+      console.log(chalk.green(`✓ Switched to organization: ${slug}`));
+    }),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-orgs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-orgs.ts
@@ -1,0 +1,181 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroOrgContract,
+  zeroOrgListContract,
+  zeroOrgMembersContract,
+  zeroOrgInviteContract,
+  zeroOrgLeaveContract,
+  zeroOrgDeleteContract,
+  type OrgResponse,
+  type OrgMembersResponse,
+  type OrgListResponse,
+} from "@vm0/core";
+import {
+  getClientConfig,
+  getBaseUrl,
+  handleError,
+} from "../core/client-factory";
+import { getToken } from "../config";
+
+/**
+ * Get client config that always uses the user token (vm0_live_),
+ * not the org token. Used for org list operations.
+ */
+async function getUserTokenClientConfig(): Promise<{
+  baseUrl: string;
+  baseHeaders: Record<string, string>;
+  jsonQuery: false;
+}> {
+  const baseUrl = await getBaseUrl();
+  const token = await getToken();
+  if (!token) {
+    throw new Error("Not authenticated. Run: vm0 auth login");
+  }
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  if (bypassSecret) {
+    headers["x-vercel-protection-bypass"] = bypassSecret;
+  }
+  return { baseUrl, baseHeaders: headers, jsonQuery: false };
+}
+
+/**
+ * Get current org info via zero API
+ */
+export async function getZeroOrg(): Promise<OrgResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroOrgContract, config);
+
+  const result = await client.get({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to get organization");
+}
+
+/**
+ * Update org slug via zero API
+ */
+export async function updateZeroOrg(body: {
+  slug: string;
+  force?: boolean;
+}): Promise<OrgResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroOrgContract, config);
+
+  const result = await client.update({ body });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to update organization");
+}
+
+/**
+ * List all accessible orgs (always uses user token)
+ */
+export async function listZeroOrgs(): Promise<OrgListResponse> {
+  const config = await getUserTokenClientConfig();
+  const client = initClient(zeroOrgListContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list organizations");
+}
+
+/**
+ * Get org members via zero API
+ */
+export async function getZeroOrgMembers(): Promise<OrgMembersResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroOrgMembersContract, config);
+
+  const result = await client.members({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to get organization members");
+}
+
+/**
+ * Invite a member to the org via zero API
+ */
+export async function inviteZeroOrgMember(email: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroOrgInviteContract, config);
+
+  const result = await client.invite({
+    body: { email },
+  });
+
+  if (result.status === 200) {
+    return;
+  }
+
+  handleError(result, "Failed to invite member");
+}
+
+/**
+ * Remove a member from the org via zero API
+ */
+export async function removeZeroOrgMember(email: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroOrgMembersContract, config);
+
+  const result = await client.removeMember({
+    body: { email },
+  });
+
+  if (result.status === 200) {
+    return;
+  }
+
+  handleError(result, "Failed to remove member");
+}
+
+/**
+ * Leave the current org via zero API
+ */
+export async function leaveZeroOrg(): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroOrgLeaveContract, config);
+
+  const result = await client.leave({
+    body: {},
+  });
+
+  if (result.status === 200) {
+    return;
+  }
+
+  handleError(result, "Failed to leave organization");
+}
+
+/**
+ * Delete the current org via zero API
+ */
+export async function deleteZeroOrg(slug: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroOrgDeleteContract, config);
+
+  const result = await client.delete({
+    body: { slug },
+  });
+
+  if (result.status === 200) {
+    return;
+  }
+
+  handleError(result, "Failed to delete organization");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -112,3 +112,15 @@ export {
 
 // Domain modules - Skills
 export { resolveSkills } from "./domains/skills";
+
+// Domain modules - Zero Organizations
+export {
+  getZeroOrg,
+  updateZeroOrg,
+  listZeroOrgs,
+  getZeroOrgMembers,
+  inviteZeroOrgMember,
+  removeZeroOrgMember,
+  leaveZeroOrg,
+  deleteZeroOrg,
+} from "./domains/zero-orgs";


### PR DESCRIPTION
## Summary
- Add `vm0 zero org` command group with 9 subcommands: status, set, list, use, members, invite, remove, leave, delete
- Create zero-orgs.ts API domain module with 8 client functions using zero contracts (`/api/zero/org/*`)
- Add integration tests for all subcommands using MSW
- New `delete` command (admin-only, requires slug confirmation) not present in legacy `vm0 org`

## Test plan
- [x] All 908 CLI tests pass (91 test files)
- [x] TypeScript type-check clean
- [x] Lint passes (0 warnings, 0 errors)
- [x] Knip passes (no unused exports/dependencies)
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

Closes #6182

🤖 Generated with [Claude Code](https://claude.com/claude-code)