### PR TITLE
fix(platform): preserve schedule timezone when editing

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -563,6 +563,7 @@ export const zeroJobScheduleEntries$ = computed((get) => {
         description: s.description,
         enabled: s.enabled,
         name: s.name,
+        timezone: s.timezone,
         intervalSeconds: s.intervalSeconds,
       }),
     );

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -140,10 +140,10 @@ interface ZeroScheduleEntry {
   notifySlack: boolean;
   /** Original schedule name for API operations */
   name: string;
+  /** IANA timezone stored on the server */
+  timezone: string;
   /** Raw interval in seconds for loop schedules */
   intervalSeconds: number | null;
-  /** IANA timezone identifier */
-  timezone: string;
 }
 
 export const zeroScheduleEntries$ = computed((get) => {
@@ -160,8 +160,8 @@ export const zeroScheduleEntries$ = computed((get) => {
         notifyEmail: s.notifyEmail,
         notifySlack: s.notifySlack,
         name: s.name,
-        intervalSeconds: s.intervalSeconds,
         timezone: s.timezone,
+        intervalSeconds: s.intervalSeconds,
       }),
     );
 });
@@ -394,11 +394,11 @@ export interface OrgScheduleEntry {
   notifyEmail: boolean;
   notifySlack: boolean;
   name: string;
+  /** IANA timezone stored on the server */
+  timezone: string;
   intervalSeconds: number | null;
   agentId: string;
   agentName: string;
-  /** IANA timezone identifier */
-  timezone: string;
 }
 
 const internalAllSchedules$ = state<ScheduleResponse[]>([]);
@@ -423,10 +423,10 @@ export const allOrgScheduleEntries$ = computed((get) => {
         notifyEmail: s.notifyEmail,
         notifySlack: s.notifySlack,
         name: s.name,
+        timezone: s.timezone,
         intervalSeconds: s.intervalSeconds,
         agentId: s.agentId,
         agentName: s.agentName,
-        timezone: s.timezone,
       }),
     );
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -55,12 +55,6 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import { getBrowserTimezone } from "../../signals/zero-page/cron.ts";
 
-/** Include the current value if it is not in the preset list (e.g. browser-detected TZ). */
-function timezonesForSelect(value: string): readonly string[] {
-  const preset = COMMON_TIMEZONES as readonly string[];
-  return preset.includes(value) ? preset : [...preset, value];
-}
-
 export const WEEKDAY_LABELS = [
   "Mon",
   "Tue",

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -55,6 +55,12 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import { getBrowserTimezone } from "../../signals/zero-page/cron.ts";
 
+/** Include the current value if it is not in the preset list (e.g. browser-detected TZ). */
+function timezonesForSelect(value: string): readonly string[] {
+  const preset = COMMON_TIMEZONES as readonly string[];
+  return preset.includes(value) ? preset : [...preset, value];
+}
+
 export const WEEKDAY_LABELS = [
   "Mon",
   "Tue",
@@ -81,6 +87,8 @@ export interface ScheduleEntry {
   enabled?: boolean;
   notifyEmail?: boolean;
   notifySlack?: boolean;
+  /** IANA timezone from the server (not derivable from `time` alone). */
+  timezone?: string;
   /** Raw interval in seconds for loop schedules */
   intervalSeconds?: number | null;
 }
@@ -537,7 +545,7 @@ export function ZeroScheduleCard({
       date: parsed.date,
       hour: parsed.hour,
       minute: parsed.minute,
-      timezone: parsed.timezone,
+      timezone: entry.timezone ?? parsed.timezone,
       loopMinutes:
         entry.intervalSeconds !== null && entry.intervalSeconds !== undefined
           ? Math.round(entry.intervalSeconds / 60)

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -78,7 +78,6 @@ function buildCombinedSchedule(
     notifyEmail: e.notifyEmail,
     notifySlack: e.notifySlack,
     name: e.name,
-    timezone: e.timezone,
     intervalSeconds: e.intervalSeconds,
     agentLabel:
       e.agentId === defaultComposeId

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -78,6 +78,7 @@ function buildCombinedSchedule(
     notifyEmail: e.notifyEmail,
     notifySlack: e.notifySlack,
     name: e.name,
+    timezone: e.timezone,
     intervalSeconds: e.intervalSeconds,
     agentLabel:
       e.agentId === defaultComposeId


### PR DESCRIPTION
## Summary

Schedule edit dialogs derived the timezone only from the human-readable `time` string via `parseScheduleTimeString`, which defaults to `UTC`. The API already returns the stored IANA timezone but it was not wired into UI entries.

## Changes

- Map `timezone` from schedule API responses into `ZeroScheduleEntry`, `OrgScheduleEntry`, and job-detail `ScheduleEntry` shapes.
- Initialize edit dialogs with `entry.timezone ?? parsed.timezone`.
- When the stored timezone is not in `COMMON_TIMEZONES`, append it to the select options so the control stays valid.

## Testing

- `pnpm turbo run check-types --filter=@vm0/app`
- `pnpm vitest run --project @vm0/app`

Made with [Cursor](https://cursor.com)