### PR TITLE
chore: update devcontainer image to 20260323

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:c456944",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260323",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"


### PR DESCRIPTION
## Summary
- Update `vm0-dev` devcontainer image tag from `c456944` to `20260323` (latest build from main)

## Test plan
- [ ] Verify devcontainer rebuilds successfully with new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)