### PR TITLE
fix(platform): simplify job detail skeleton condition

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -27,7 +27,6 @@ import { TONE_OPTIONS, type Tone } from "./zero-tone-constants.ts";
 import type { ScheduleEntry } from "./zero-schedule-card.tsx";
 import {
   zeroJobDetail$,
-  zeroJobDetailLoading$,
   zeroJobDetailError$,
   zeroJobInstructions$,
   zeroJobInstructionsLoading$,
@@ -305,7 +304,6 @@ export function ZeroJobDetailPage({
   onCycleAvatar,
 }: ZeroJobDetailPageProps) {
   const detail = useGet(zeroJobDetail$);
-  const loading = useGet(zeroJobDetailLoading$);
   const error = useGet(zeroJobDetailError$);
   const agents = useGet(agentsList$);
   const listItem = agents.find((a) => a.name === agentName);
@@ -353,7 +351,7 @@ export function ZeroJobDetailPage({
       setAgentAvatarCmd(agentName, next);
     });
 
-  if (loading && !detail) {
+  if (!detail && !error) {
     return <DetailSkeleton />;
   }
 


### PR DESCRIPTION
## Summary
- Remove dependency on `zeroJobDetailLoading$` signal from the job detail page component
- Simplify the skeleton display condition from `loading && !detail` to `!detail && !error`, which correctly shows the skeleton whenever detail data hasn't loaded yet and there's no error
- This fixes a case where the loading signal could become stale, causing the skeleton to not display when navigating between job details

## Test plan
- [ ] Navigate between different job detail pages and verify the skeleton loader appears during transitions
- [ ] Verify that error states still display correctly when job detail fetch fails
- [ ] Verify that the detail page renders correctly once data loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)