### PR TITLE
fix: use cell-scoped popover ids to prevent duplicate schedule entry conflicts

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -454,15 +454,18 @@ export function getEntriesInCell(
 
 function CalendarEntryPopover({
   entry,
+  cellKey,
   onEdit,
 }: {
   entry: ScheduleEntry;
+  cellKey: string;
   onEdit: (entry: ScheduleEntry) => void;
 }) {
   const hoveredId = useGet(calendarPopoverEntryId$);
   const setHoveredId = useSet(setCalendarPopoverEntryId$);
-  const open = hoveredId === entry.id;
-  const setOpen = (v: boolean) => setHoveredId(v ? entry.id : null);
+  const popoverId = `${entry.id}-${cellKey}`;
+  const open = hoveredId === popoverId;
+  const setOpen = (v: boolean) => setHoveredId(v ? popoverId : null);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -895,6 +898,7 @@ export function ZeroScheduleCard({
                                       <CalendarEntryPopover
                                         key={entry.id}
                                         entry={entry}
+                                        cellKey={`${dayIndex}-${timeLabel}`}
                                         onEdit={openEditSchedule}
                                       />
                                     ))}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -117,22 +117,30 @@ function getAgentCellClasses(
 
 function CalendarEntryPopover({
   entry,
+  cellKey,
   agentOrder,
   onEdit,
+  hoveredId,
+  setHoveredId,
 }: {
   entry: CombinedEntry;
+  cellKey: string;
   agentOrder: readonly string[];
   onEdit: (entry: CombinedEntry) => void;
+  hoveredId: string | null;
+  setHoveredId: (id: string | null) => void;
 }) {
-  const [open, setOpen] = useState(false);
+  const popoverId = `${entry.id}-${cellKey}`;
+  const open = hoveredId === popoverId;
+  const setOpen = (v: boolean) => setHoveredId(v ? popoverId : null);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
           type="button"
-          onMouseEnter={() => setOpen(true)}
-          onMouseLeave={() => setOpen(false)}
+          onMouseEnter={() => setHoveredId(popoverId)}
+          onMouseLeave={() => setHoveredId(null)}
           onDoubleClick={() => onEdit(entry)}
           className={cn(
             "w-full min-h-0 rounded px-1.5 py-0.5 text-[11px] leading-tight line-clamp-2 break-words border text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
@@ -190,6 +198,7 @@ function ScheduleCalendarView({
   agentOrder: readonly string[];
   onEdit: (entry: CombinedEntry) => void;
 }) {
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
   const enabledEntries = combinedSchedule.filter((e) => e.enabled !== false);
   const calendarSlots = buildCalendarTimeSlots(enabledEntries);
   const [selectedDay, setSelectedDay] = useState(
@@ -284,8 +293,11 @@ function ScheduleCalendarView({
                           <CalendarEntryPopover
                             key={entry.id}
                             entry={entry}
+                            cellKey={`${selectedDay}-${timeLabel}`}
                             agentOrder={agentOrder}
                             onEdit={onEdit}
+                            hoveredId={hoveredId}
+                            setHoveredId={setHoveredId}
                           />
                         ))}
                       </div>
@@ -351,8 +363,11 @@ function ScheduleCalendarView({
                               <CalendarEntryPopover
                                 key={entry.id}
                                 entry={entry}
+                                cellKey={`${dayIndex}-${timeLabel}`}
                                 agentOrder={agentOrder}
                                 onEdit={onEdit}
+                                hoveredId={hoveredId}
+                                setHoveredId={setHoveredId}
                               />
                             ))}
                           </div>


### PR DESCRIPTION
## Summary
- Fix calendar entry popovers conflicting when the same schedule entry spans multiple time slots
- Generate unique popover IDs by combining entry ID with cell key (day + time label) so each cell's popover opens independently
- Lift hover state to parent component in `zero-schedule-page.tsx` to ensure only one popover is open at a time across all cells

## Test plan
- [ ] Open the Zero schedule calendar view
- [ ] Hover over a schedule entry that spans multiple time slots
- [ ] Verify only the hovered cell's popover opens, not duplicates in other slots
- [ ] Verify double-click to edit still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)