### PR TITLE
feat(cli): implement vm0 zero agent commands (create/edit/view/list/delete)

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -69,26 +69,31 @@ describe("zero agent create command", () => {
       expect(logCalls).toContain("github");
     });
 
-    it("should create agent and upload instructions from file", async () => {
-      const instructionsPath = join(tmpdir(), "test-instructions.md");
-      writeFileSync(instructionsPath, "You are a helpful agent.");
+    describe("with instructions file", () => {
+      let instructionsPath: string;
 
-      const instructionsUpdateMock = vi.fn();
-      server.use(
-        http.post("http://localhost:3000/api/zero/agents", () => {
-          return HttpResponse.json(mockAgent, { status: 201 });
-        }),
-        http.put(
-          "http://localhost:3000/api/zero/agents/new-agent/instructions",
-          async ({ request }) => {
-            const body = await request.json();
-            instructionsUpdateMock(body);
-            return HttpResponse.json(mockAgent);
-          },
-        ),
-      );
+      beforeEach(() => {
+        instructionsPath = join(tmpdir(), "test-instructions.md");
+        writeFileSync(instructionsPath, "You are a helpful agent.");
+      });
 
-      try {
+      afterEach(() => {
+        unlinkSync(instructionsPath);
+      });
+
+      it("should create agent and upload instructions from file", async () => {
+        server.use(
+          http.post("http://localhost:3000/api/zero/agents", () => {
+            return HttpResponse.json(mockAgent, { status: 201 });
+          }),
+          http.put(
+            "http://localhost:3000/api/zero/agents/new-agent/instructions",
+            () => {
+              return HttpResponse.json(mockAgent);
+            },
+          ),
+        );
+
         await createCommand.parseAsync([
           "node",
           "cli",
@@ -98,15 +103,10 @@ describe("zero agent create command", () => {
           instructionsPath,
         ]);
 
-        expect(instructionsUpdateMock).toHaveBeenCalledWith({
-          content: "You are a helpful agent.",
-        });
-
         const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
         expect(logCalls).toContain("new-agent");
-      } finally {
-        unlinkSync(instructionsPath);
-      }
+        expect(logCalls).toContain("created");
+      });
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for zero agent create command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { server } from "../../../../mocks/server";
+import { createCommand } from "../create";
+import chalk from "chalk";
+
+const mockAgent = {
+  name: "new-agent",
+  agentComposeId: "comp_xyz789",
+  displayName: "New Agent",
+  description: null,
+  sound: null,
+  connectors: ["github"],
+};
+
+describe("zero agent create command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful create", () => {
+    it("should create agent with required connectors", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/agents", () => {
+          return HttpResponse.json(mockAgent, { status: 201 });
+        }),
+      );
+
+      await createCommand.parseAsync([
+        "node",
+        "cli",
+        "--connectors",
+        "github",
+        "--display-name",
+        "New Agent",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("new-agent");
+      expect(logCalls).toContain("comp_xyz789");
+      expect(logCalls).toContain("github");
+    });
+
+    it("should create agent and upload instructions from file", async () => {
+      const instructionsPath = join(tmpdir(), "test-instructions.md");
+      writeFileSync(instructionsPath, "You are a helpful agent.");
+
+      const instructionsUpdateMock = vi.fn();
+      server.use(
+        http.post("http://localhost:3000/api/zero/agents", () => {
+          return HttpResponse.json(mockAgent, { status: 201 });
+        }),
+        http.put(
+          "http://localhost:3000/api/zero/agents/new-agent/instructions",
+          async ({ request }) => {
+            const body = await request.json();
+            instructionsUpdateMock(body);
+            return HttpResponse.json(mockAgent);
+          },
+        ),
+      );
+
+      try {
+        await createCommand.parseAsync([
+          "node",
+          "cli",
+          "--connectors",
+          "github",
+          "--instructions-file",
+          instructionsPath,
+        ]);
+
+        expect(instructionsUpdateMock).toHaveBeenCalledWith({
+          content: "You are a helpful agent.",
+        });
+
+        const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+        expect(logCalls).toContain("new-agent");
+      } finally {
+        unlinkSync(instructionsPath);
+      }
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/agents", () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await createCommand.parseAsync([
+          "node",
+          "cli",
+          "--connectors",
+          "github",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -81,14 +81,17 @@ describe("zero agent create command", () => {
         unlinkSync(instructionsPath);
       });
 
-      it("should create agent and upload instructions from file", async () => {
+      it("should create agent and upload instructions content from file", async () => {
+        let capturedInstructionsContent: string | undefined;
         server.use(
           http.post("http://localhost:3000/api/zero/agents", () => {
             return HttpResponse.json(mockAgent, { status: 201 });
           }),
           http.put(
             "http://localhost:3000/api/zero/agents/new-agent/instructions",
-            () => {
+            async ({ request }) => {
+              const body = (await request.json()) as { content: string };
+              capturedInstructionsContent = body.content;
               return HttpResponse.json(mockAgent);
             },
           ),
@@ -103,6 +106,7 @@ describe("zero agent create command", () => {
           instructionsPath,
         ]);
 
+        expect(capturedInstructionsContent).toBe("You are a helpful agent.");
         const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
         expect(logCalls).toContain("new-agent");
         expect(logCalls).toContain("created");

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/delete.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for zero agent delete command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { deleteCommand } from "../delete";
+import chalk from "chalk";
+
+const mockAgent = {
+  name: "my-agent",
+  agentComposeId: "comp_abc123",
+  displayName: "My Agent",
+  description: null,
+  sound: null,
+  connectors: ["github"],
+};
+
+describe("zero agent delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful delete", () => {
+    it("should delete with --yes flag without prompting", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.delete("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", "my-agent", "--yes"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("deleted");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/missing", () => {
+          return HttpResponse.json(
+            { error: { message: "Agent not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "missing", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --yes in non-interactive mode", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+      );
+
+      // process.stdout.isTTY is undefined in test environment (non-interactive)
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "my-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--yes flag is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for zero agent edit command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { server } from "../../../../mocks/server";
+import { editCommand } from "../edit";
+import chalk from "chalk";
+
+const mockAgent = {
+  name: "my-agent",
+  agentComposeId: "comp_abc123",
+  displayName: "My Agent",
+  description: null,
+  sound: null,
+  connectors: ["github"],
+};
+
+describe("zero agent edit command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful edit", () => {
+    it("should update display name using existing connectors", async () => {
+      const updateMock = vi.fn();
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.put(
+          "http://localhost:3000/api/zero/agents/my-agent",
+          async ({ request }) => {
+            const body = await request.json();
+            updateMock(body);
+            return HttpResponse.json({ ...mockAgent, displayName: "Updated" });
+          },
+        ),
+      );
+
+      await editCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--display-name",
+        "Updated",
+      ]);
+
+      // Should pass existing connectors since --connectors was not provided
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({ connectors: ["github"] }),
+      );
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("updated");
+    });
+
+    it("should update instructions only without fetching agent", async () => {
+      const instructionsPath = join(tmpdir(), "new-instructions.md");
+      writeFileSync(instructionsPath, "New instructions");
+
+      const agentGetMock = vi.fn();
+      const instructionsMock = vi.fn();
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          agentGetMock();
+          return HttpResponse.json(mockAgent);
+        }),
+        http.put(
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
+          async ({ request }) => {
+            const body = await request.json();
+            instructionsMock(body);
+            return HttpResponse.json(mockAgent);
+          },
+        ),
+      );
+
+      try {
+        await editCommand.parseAsync([
+          "node",
+          "cli",
+          "my-agent",
+          "--instructions-file",
+          instructionsPath,
+        ]);
+
+        // Should NOT fetch existing agent when only updating instructions
+        expect(agentGetMock).not.toHaveBeenCalled();
+        expect(instructionsMock).toHaveBeenCalledWith({
+          content: "New instructions",
+        });
+      } finally {
+        unlinkSync(instructionsPath);
+      }
+    });
+  });
+
+  describe("validation", () => {
+    it("should fail when no options provided", async () => {
+      await expect(async () => {
+        await editCommand.parseAsync(["node", "cli", "my-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("At least one option is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/missing", () => {
+          return HttpResponse.json(
+            { error: { message: "Agent not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await editCommand.parseAsync([
+          "node",
+          "cli",
+          "missing",
+          "--display-name",
+          "x",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
@@ -47,14 +47,19 @@ describe("zero agent edit command", () => {
   });
 
   describe("successful edit", () => {
-    it("should update display name and show success message", async () => {
+    it("should preserve existing connectors when --connectors not provided", async () => {
+      let capturedBody: { connectors?: string[] } | undefined;
       server.use(
         http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
           return HttpResponse.json(mockAgent);
         }),
-        http.put("http://localhost:3000/api/zero/agents/my-agent", () => {
-          return HttpResponse.json({ ...mockAgent, displayName: "Updated" });
-        }),
+        http.put(
+          "http://localhost:3000/api/zero/agents/my-agent",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as { connectors?: string[] };
+            return HttpResponse.json({ ...mockAgent, displayName: "Updated" });
+          },
+        ),
       );
 
       await editCommand.parseAsync([
@@ -65,6 +70,7 @@ describe("zero agent edit command", () => {
         "Updated",
       ]);
 
+      expect(capturedBody?.connectors).toEqual(["github"]);
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("updated");
     });
@@ -81,14 +87,17 @@ describe("zero agent edit command", () => {
         unlinkSync(instructionsPath);
       });
 
-      it("should update instructions and show success message", async () => {
+      it("should upload instructions content from file and show success message", async () => {
+        let capturedInstructionsContent: string | undefined;
         server.use(
           http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
             return HttpResponse.json(mockAgent);
           }),
           http.put(
             "http://localhost:3000/api/zero/agents/my-agent/instructions",
-            () => {
+            async ({ request }) => {
+              const body = (await request.json()) as { content: string };
+              capturedInstructionsContent = body.content;
               return HttpResponse.json(mockAgent);
             },
           ),
@@ -102,6 +111,7 @@ describe("zero agent edit command", () => {
           instructionsPath,
         ]);
 
+        expect(capturedInstructionsContent).toBe("New instructions");
         const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
         expect(logCalls).toContain("updated");
       });

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
@@ -47,20 +47,14 @@ describe("zero agent edit command", () => {
   });
 
   describe("successful edit", () => {
-    it("should update display name using existing connectors", async () => {
-      const updateMock = vi.fn();
+    it("should update display name and show success message", async () => {
       server.use(
         http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
           return HttpResponse.json(mockAgent);
         }),
-        http.put(
-          "http://localhost:3000/api/zero/agents/my-agent",
-          async ({ request }) => {
-            const body = await request.json();
-            updateMock(body);
-            return HttpResponse.json({ ...mockAgent, displayName: "Updated" });
-          },
-        ),
+        http.put("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json({ ...mockAgent, displayName: "Updated" });
+        }),
       );
 
       await editCommand.parseAsync([
@@ -71,37 +65,35 @@ describe("zero agent edit command", () => {
         "Updated",
       ]);
 
-      // Should pass existing connectors since --connectors was not provided
-      expect(updateMock).toHaveBeenCalledWith(
-        expect.objectContaining({ connectors: ["github"] }),
-      );
-
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("updated");
     });
 
-    it("should update instructions only without fetching agent", async () => {
-      const instructionsPath = join(tmpdir(), "new-instructions.md");
-      writeFileSync(instructionsPath, "New instructions");
+    describe("with instructions file", () => {
+      let instructionsPath: string;
 
-      const agentGetMock = vi.fn();
-      const instructionsMock = vi.fn();
-      server.use(
-        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
-          agentGetMock();
-          return HttpResponse.json(mockAgent);
-        }),
-        http.put(
-          "http://localhost:3000/api/zero/agents/my-agent/instructions",
-          async ({ request }) => {
-            const body = await request.json();
-            instructionsMock(body);
+      beforeEach(() => {
+        instructionsPath = join(tmpdir(), "new-instructions.md");
+        writeFileSync(instructionsPath, "New instructions");
+      });
+
+      afterEach(() => {
+        unlinkSync(instructionsPath);
+      });
+
+      it("should update instructions and show success message", async () => {
+        server.use(
+          http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
             return HttpResponse.json(mockAgent);
-          },
-        ),
-      );
+          }),
+          http.put(
+            "http://localhost:3000/api/zero/agents/my-agent/instructions",
+            () => {
+              return HttpResponse.json(mockAgent);
+            },
+          ),
+        );
 
-      try {
         await editCommand.parseAsync([
           "node",
           "cli",
@@ -110,14 +102,9 @@ describe("zero agent edit command", () => {
           instructionsPath,
         ]);
 
-        // Should NOT fetch existing agent when only updating instructions
-        expect(agentGetMock).not.toHaveBeenCalled();
-        expect(instructionsMock).toHaveBeenCalledWith({
-          content: "New instructions",
-        });
-      } finally {
-        unlinkSync(instructionsPath);
-      }
+        const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+        expect(logCalls).toContain("updated");
+      });
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/list.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for zero agent list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+const mockAgent = {
+  name: "my-agent",
+  agentComposeId: "comp_abc123",
+  displayName: "My Agent",
+  description: null,
+  sound: null,
+  connectors: ["github", "linear"],
+};
+
+describe("zero agent list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful list", () => {
+    it("should display agents in table format", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents", () => {
+          return HttpResponse.json([mockAgent]);
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("My Agent");
+      expect(logCalls).toContain("github, linear");
+    });
+
+    it("should display empty state message when no agents", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents", () => {
+          return HttpResponse.json([]);
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No zero agents found");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents", () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for zero agent view command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { viewCommand } from "../view";
+import chalk from "chalk";
+
+const mockAgent = {
+  name: "my-agent",
+  agentComposeId: "comp_abc123",
+  displayName: "My Agent",
+  description: "A test agent",
+  sound: "professional",
+  connectors: ["github"],
+};
+
+describe("zero agent view command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful view", () => {
+    it("should display agent info", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+      );
+
+      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("comp_abc123");
+      expect(logCalls).toContain("github");
+      expect(logCalls).toContain("A test agent");
+      expect(logCalls).toContain("professional");
+    });
+
+    it("should show instructions content with --instructions flag", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
+          () => {
+            return HttpResponse.json({
+              content: "Do the thing",
+              filename: "CLAUDE.md",
+            });
+          },
+        ),
+      );
+
+      await viewCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--instructions",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Do the thing");
+    });
+
+    it("should show empty instructions message when no instructions set", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/instructions",
+          () => {
+            return HttpResponse.json({ content: null, filename: null });
+          },
+        ),
+      );
+
+      await viewCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--instructions",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No instructions set");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/missing", () => {
+          return HttpResponse.json(
+            { error: { message: "Agent not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await viewCommand.parseAsync(["node", "cli", "missing"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -1,0 +1,52 @@
+import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import chalk from "chalk";
+import { createZeroAgent, updateZeroAgentInstructions } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const createCommand = new Command()
+  .name("create")
+  .description("Create a new zero agent")
+  .requiredOption(
+    "--connectors <items>",
+    "Comma-separated connector short names (e.g. github,linear)",
+  )
+  .option("--display-name <name>", "Agent display name")
+  .option("--description <text>", "Agent description")
+  .option(
+    "--sound <tone>",
+    "Agent tone: professional, friendly, direct, supportive",
+  )
+  .option("--instructions-file <path>", "Path to instructions file")
+  .action(
+    withErrorHandler(
+      async (options: {
+        connectors: string;
+        displayName?: string;
+        description?: string;
+        sound?: string;
+        instructionsFile?: string;
+      }) => {
+        const connectors = options.connectors.split(",").map((s) => s.trim());
+
+        const agent = await createZeroAgent({
+          connectors,
+          displayName: options.displayName,
+          description: options.description,
+          sound: options.sound,
+        });
+
+        if (options.instructionsFile) {
+          const content = readFileSync(options.instructionsFile, "utf-8");
+          await updateZeroAgentInstructions(agent.name, content);
+        }
+
+        console.log(chalk.green(`✓ Zero agent '${agent.name}' created`));
+        console.log(`  Compose ID:   ${agent.agentComposeId}`);
+        console.log(`  Connectors:   ${agent.connectors.join(", ")}`);
+        if (agent.displayName) {
+          console.log(`  Display Name: ${agent.displayName}`);
+        }
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/agent/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/delete.ts
@@ -1,0 +1,34 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getZeroAgent, deleteZeroAgent } from "../../../lib/api";
+import { isInteractive, promptConfirm } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const deleteCommand = new Command()
+  .name("delete")
+  .alias("rm")
+  .description("Delete a zero agent")
+  .argument("<name>", "Agent name")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
+      await getZeroAgent(name);
+
+      if (!options.yes) {
+        if (!isInteractive()) {
+          throw new Error("--yes flag is required in non-interactive mode");
+        }
+        const confirmed = await promptConfirm(
+          `Delete zero agent '${name}'?`,
+          false,
+        );
+        if (!confirmed) {
+          console.log(chalk.dim("Cancelled"));
+          return;
+        }
+      }
+
+      await deleteZeroAgent(name);
+      console.log(chalk.green(`✓ Zero agent '${name}' deleted`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -1,0 +1,81 @@
+import { Command } from "commander";
+import { readFileSync } from "node:fs";
+import chalk from "chalk";
+import {
+  getZeroAgent,
+  updateZeroAgent,
+  updateZeroAgentInstructions,
+} from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const editCommand = new Command()
+  .name("edit")
+  .description("Edit a zero agent")
+  .argument("<name>", "Agent name")
+  .option(
+    "--connectors <items>",
+    "Comma-separated connector short names (e.g. github,linear)",
+  )
+  .option("--display-name <name>", "New display name")
+  .option("--description <text>", "New description")
+  .option(
+    "--sound <tone>",
+    "New tone: professional, friendly, direct, supportive",
+  )
+  .option("--instructions-file <path>", "Path to new instructions file")
+  .action(
+    withErrorHandler(
+      async (
+        name: string,
+        options: {
+          connectors?: string;
+          displayName?: string;
+          description?: string;
+          sound?: string;
+          instructionsFile?: string;
+        },
+      ) => {
+        const hasAgentUpdate =
+          options.connectors !== undefined ||
+          options.displayName !== undefined ||
+          options.description !== undefined ||
+          options.sound !== undefined;
+
+        if (!hasAgentUpdate && !options.instructionsFile) {
+          throw new Error(
+            "At least one option is required (--connectors, --display-name, --description, --sound, --instructions-file)",
+          );
+        }
+
+        if (hasAgentUpdate) {
+          const current = await getZeroAgent(name);
+          const connectors = options.connectors
+            ? options.connectors.split(",").map((s) => s.trim())
+            : current.connectors;
+
+          await updateZeroAgent(name, {
+            connectors,
+            displayName:
+              options.displayName !== undefined
+                ? options.displayName
+                : (current.displayName ?? undefined),
+            description:
+              options.description !== undefined
+                ? options.description
+                : (current.description ?? undefined),
+            sound:
+              options.sound !== undefined
+                ? options.sound
+                : (current.sound ?? undefined),
+          });
+        }
+
+        if (options.instructionsFile) {
+          const content = readFileSync(options.instructionsFile, "utf-8");
+          await updateZeroAgentInstructions(name, content);
+        }
+
+        console.log(chalk.green(`✓ Zero agent '${name}' updated`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/agent/index.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/index.ts
@@ -1,0 +1,14 @@
+import { Command } from "commander";
+import { createCommand } from "./create";
+import { editCommand } from "./edit";
+import { viewCommand } from "./view";
+import { listCommand } from "./list";
+import { deleteCommand } from "./delete";
+
+export const agentCommand = new Command("agent")
+  .description("Manage zero agents")
+  .addCommand(createCommand)
+  .addCommand(editCommand)
+  .addCommand(viewCommand)
+  .addCommand(listCommand)
+  .addCommand(deleteCommand);

--- a/turbo/apps/cli/src/commands/zero/agent/list.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/list.ts
@@ -1,0 +1,46 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listZeroAgents } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all zero agents")
+  .action(
+    withErrorHandler(async () => {
+      const agents = await listZeroAgents();
+
+      if (agents.length === 0) {
+        console.log(chalk.dim("No zero agents found"));
+        console.log(
+          chalk.dim(
+            '  Create one with: vm0 zero agent create --connectors github --display-name "My Agent"',
+          ),
+        );
+        return;
+      }
+
+      const nameWidth = Math.max(4, ...agents.map((a) => a.name.length));
+      const displayWidth = Math.max(
+        12,
+        ...agents.map((a) => (a.displayName ?? "").length),
+      );
+
+      const header = [
+        "NAME".padEnd(nameWidth),
+        "DISPLAY NAME".padEnd(displayWidth),
+        "CONNECTORS",
+      ].join("  ");
+      console.log(chalk.dim(header));
+
+      for (const agent of agents) {
+        const row = [
+          agent.name.padEnd(nameWidth),
+          (agent.displayName ?? "-").padEnd(displayWidth),
+          agent.connectors.join(", ") || "-",
+        ].join("  ");
+        console.log(row);
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -1,0 +1,37 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getZeroAgent, getZeroAgentInstructions } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const viewCommand = new Command()
+  .name("view")
+  .description("View a zero agent")
+  .argument("<name>", "Agent name")
+  .option("--instructions", "Also show instructions content")
+  .action(
+    withErrorHandler(
+      async (name: string, options: { instructions?: boolean }) => {
+        const agent = await getZeroAgent(name);
+
+        console.log(chalk.bold(agent.name));
+        if (agent.displayName) console.log(chalk.dim(agent.displayName));
+        console.log();
+        console.log(`Compose ID:   ${agent.agentComposeId}`);
+        console.log(`Connectors:   ${agent.connectors.join(", ") || "-"}`);
+        if (agent.description)
+          console.log(`Description:  ${agent.description}`);
+        if (agent.sound) console.log(`Sound:        ${agent.sound}`);
+
+        if (options.instructions) {
+          console.log();
+          const result = await getZeroAgentInstructions(name);
+          if (result.content) {
+            console.log(chalk.dim("── Instructions ──"));
+            console.log(result.content);
+          } else {
+            console.log(chalk.dim("No instructions set"));
+          }
+        }
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/index.ts
+++ b/turbo/apps/cli/src/commands/zero/index.ts
@@ -1,6 +1,8 @@
 import { Command } from "commander";
 import { zeroOrgCommand } from "./org";
+import { agentCommand } from "./agent";
 
 export const zeroCommand = new Command("zero")
   .description("Zero platform commands")
-  .addCommand(zeroOrgCommand);
+  .addCommand(zeroOrgCommand)
+  .addCommand(agentCommand);

--- a/turbo/apps/cli/src/lib/api/domains/zero-agents.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-agents.ts
@@ -1,0 +1,79 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroAgentsMainContract,
+  zeroAgentsByNameContract,
+  zeroAgentInstructionsContract,
+  type ZeroAgentResponse,
+  type ZeroAgentRequest,
+  type ZeroAgentInstructionsResponse,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function createZeroAgent(
+  body: ZeroAgentRequest,
+): Promise<ZeroAgentResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentsMainContract, config);
+  const result = await client.create({ body });
+  if (result.status === 201) return result.body;
+  handleError(result, "Failed to create zero agent");
+}
+
+export async function listZeroAgents(): Promise<ZeroAgentResponse[]> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentsMainContract, config);
+  const result = await client.list({ headers: {} });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to list zero agents");
+}
+
+export async function getZeroAgent(name: string): Promise<ZeroAgentResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentsByNameContract, config);
+  const result = await client.get({ params: { name } });
+  if (result.status === 200) return result.body;
+  handleError(result, `Zero agent "${name}" not found`);
+}
+
+export async function updateZeroAgent(
+  name: string,
+  body: ZeroAgentRequest,
+): Promise<ZeroAgentResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentsByNameContract, config);
+  const result = await client.update({ params: { name }, body });
+  if (result.status === 200) return result.body;
+  handleError(result, `Failed to update zero agent "${name}"`);
+}
+
+export async function deleteZeroAgent(name: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentsByNameContract, config);
+  const result = await client.delete({ params: { name } });
+  if (result.status === 204) return;
+  handleError(result, `Zero agent "${name}" not found`);
+}
+
+export async function getZeroAgentInstructions(
+  name: string,
+): Promise<ZeroAgentInstructionsResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentInstructionsContract, config);
+  const result = await client.get({ params: { name } });
+  if (result.status === 200) return result.body;
+  handleError(result, `Failed to get instructions for zero agent "${name}"`);
+}
+
+export async function updateZeroAgentInstructions(
+  name: string,
+  content: string,
+): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentInstructionsContract, config);
+  const result = await client.update({
+    params: { name },
+    body: { content },
+  });
+  if (result.status === 200) return;
+  handleError(result, `Failed to update instructions for zero agent "${name}"`);
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -147,3 +147,14 @@ export {
   setZeroOrgModelProviderDefault,
   updateZeroOrgModelProviderModel,
 } from "./domains/zero-org-model-providers";
+
+// Domain modules - Zero Agents
+export {
+  createZeroAgent,
+  listZeroAgents,
+  getZeroAgent,
+  updateZeroAgent,
+  deleteZeroAgent,
+  getZeroAgentInstructions,
+  updateZeroAgentInstructions,
+} from "./domains/zero-agents";


### PR DESCRIPTION
## Summary

- Implements 5 CLI subcommands under `vm0 zero agent`: `create`, `edit`, `view`, `list`, `delete`
- Creates `zero-agents.ts` API domain module wrapping all zero agent contracts
- Uses fetch-merge pattern on `edit` so user doesn't need to re-specify unchanged connectors
- Closes #6166

## Commands

```bash
vm0 zero agent create --connectors github,linear --display-name "My Agent" [--instructions-file ./CLAUDE.md]
vm0 zero agent edit <name> [--connectors ...] [--display-name ...] [--instructions-file ...]
vm0 zero agent view <name> [--instructions]
vm0 zero agent list
vm0 zero agent delete <name> [--yes]
```

## Test plan

- [x] 17 unit tests across all 5 commands (list, view, create, edit, delete)
- [x] Happy path + error cases + edge cases (empty list, `--yes` flag, `--instructions` flag)
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Format passes (`pnpm format`)
- [x] Knip passes (no unused exports/deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)