### PR TITLE
fix: persist dev server logs to file for context compaction resilience

### DIFF
--- a/.claude/skills/dev-logs/SKILL.md
+++ b/.claude/skills/dev-logs/SKILL.md
@@ -3,7 +3,7 @@ name: dev-logs
 description: View development server logs with optional filtering
 ---
 
-View development server output by reading the background task output via TaskOutput.
+View development server output. Uses a persistent log file as the primary source, with TaskOutput as fallback.
 
 ## Arguments Format
 
@@ -20,26 +20,35 @@ Your args are: `$ARGUMENTS`
 
 ## Workflow
 
-### Step 1: Find the Dev Server Task
+### Step 1: Read Logs from File (Primary)
 
-First, try to read the persisted task ID from the local file:
+The dev server writes logs to a persistent file via `tee`. Read from it:
+
+```bash
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+tail -n 200 "$PROJECT_ROOT/turbo/.dev-server.log" 2>/dev/null
+```
+
+If the file exists and has content, use this output — proceed to Step 3.
+
+If the file does not exist or is empty, fall back to Step 2.
+
+### Step 2: Fallback — TaskOutput
+
+Try to read the task ID from the persisted file:
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cat "$PROJECT_ROOT/turbo/.dev-task-id" 2>/dev/null
 ```
 
-If the file exists and contains a task ID, use that ID directly.
+If the file exists and contains a task ID, use **TaskOutput** with that ID (`block: false`) to read the dev server logs.
 
-If the file does not exist, fall back to **TaskList** to find the dev server background task. Look for a task whose command contains `pnpm dev` — this is the task created by `/dev-start`.
+If the file does not exist, fall back to **TaskList** to find a task whose command contains `pnpm dev`.
 
 If neither method finds a task, inform the user:
-- "No dev server task found. Please run `/dev-start` to start the server."
-
-### Step 2: Read Task Output
-
-Use **TaskOutput** with the task_id from Step 1 to read the dev server logs. Use `block: false` to avoid waiting.
+- "No dev server logs found. Please run `/dev-start` to start the server."
 
 ### Step 3: Display Output
 
-Show the output in readable format. If a filter pattern was provided, grep the output for matching lines.
+Show the output in readable format. If a filter pattern was provided in the arguments, filter the output for matching lines only.

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -67,21 +67,23 @@ cd "$PROJECT_ROOT" && bash scripts/prepare.sh
 
 After `prepare.sh` completes successfully, start the dev server using Bash tool with `run_in_background: true` parameter.
 
+**Important**: Use `tee` to write output to a persistent log file so `/dev-logs` works even after context compaction. The log file is the primary way `/dev-logs` reads output.
+
 If `--tunnel-hostname=<fqdn>` was provided in args, pass it as `TUNNEL_HOSTNAME` env var:
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/turbo" && TUNNEL_HOSTNAME=<fqdn> pnpm dev
+cd "$PROJECT_ROOT/turbo" && TUNNEL_HOSTNAME=<fqdn> pnpm dev 2>&1 | tee "$PROJECT_ROOT/turbo/.dev-server.log"
 ```
 
 Otherwise (default):
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/turbo" && pnpm dev
+cd "$PROJECT_ROOT/turbo" && pnpm dev 2>&1 | tee "$PROJECT_ROOT/turbo/.dev-server.log"
 ```
 
-**Save the dev server task_id** to a local file so `/dev-logs` can find it across conversation sessions:
+**Save the dev server task_id** to a local file for TaskOutput fallback:
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
@@ -315,10 +317,10 @@ cd "$PROJECT_ROOT/turbo" && pnpm build
 
 Use Bash tool with `run_in_background: true` for **both** commands in parallel (two separate Bash calls in the same message):
 
-**Dev server:**
+**Dev server** (use `tee` to persist logs for `/dev-logs` after context compaction):
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT/turbo" && pnpm dev
+cd "$PROJECT_ROOT/turbo" && pnpm dev 2>&1 | tee "$PROJECT_ROOT/turbo/.dev-server.log"
 ```
 
 **Runner:**

--- a/turbo/.gitignore
+++ b/turbo/.gitignore
@@ -48,8 +48,9 @@ yarn-error.log*
 *.pem
 .env*.local
 
-# Dev server task ID (written by /dev-start, read by /dev-logs)
+# Dev server files (written by /dev-start, read by /dev-logs)
 .dev-task-id
+.dev-server.log
 
 # SBOM
 sbom.json


### PR DESCRIPTION
## Summary
- Pipe dev server output through `tee` to write a persistent `.dev-server.log` file alongside the existing background task
- Update `/dev-logs` skill to read from the log file as primary source, falling back to TaskOutput
- Add `.dev-server.log` to `turbo/.gitignore`

This ensures dev server logs remain accessible after context compaction, when TaskOutput references may be lost.

## Test plan
- [ ] Run `/dev-start` and verify `.dev-server.log` is created in `turbo/`
- [ ] Run `/dev-logs` and verify it reads from the log file
- [ ] Verify log file is gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)