### PR TITLE
fix(ci): resolve duplicate cd turbo in neon branch subshell

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -681,6 +681,7 @@ jobs:
         run: |
           # --- Start Neon branch creation in background ---
           (
+            set -e
             if ! command -v neonctl &> /dev/null; then
               npm install -g neonctl@2.15.0
             fi
@@ -711,8 +712,9 @@ jobs:
             fi
             echo "$DATABASE_URL" > /tmp/neon-database-url
 
-            cd turbo && DATABASE_URL="$DATABASE_URL" pnpm -F web db:migrate
-            cd turbo && DATABASE_URL="$DATABASE_URL" pnpm -F web db:dev-seed
+            cd turbo
+            DATABASE_URL="$DATABASE_URL" pnpm -F web db:migrate
+            DATABASE_URL="$DATABASE_URL" pnpm -F web db:dev-seed
             echo "Neon branch ready"
           ) > /tmp/neon-log 2>&1 &
           NEON_PID=$!


### PR DESCRIPTION
## Summary

- Fix duplicate `cd turbo` in Neon branch creation subshell that caused `db:dev-seed` to be silently skipped on every preview deployment
- Add `set -e` to the subshell so any command failure (neonctl, migrate, seed) propagates to the existing `wait $NEON_PID` error handler

Closes #6165

## Test plan

- [ ] Verify YAML syntax is valid (CI will check this)
- [ ] Confirm next preview deployment runs both `db:migrate` and `db:dev-seed` successfully
- [ ] Verify seed data is present in preview environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)