### PR TITLE
feat(cli): add vm0 zero org secret, variable, and model-provider commands

### DIFF
--- a/turbo/apps/cli/src/commands/zero/org/index.ts
+++ b/turbo/apps/cli/src/commands/zero/org/index.ts
@@ -8,6 +8,9 @@ import { inviteCommand } from "./invite";
 import { removeCommand } from "./remove";
 import { leaveCommand } from "./leave";
 import { deleteCommand } from "./delete";
+import { zeroOrgSecretCommand } from "./secret";
+import { zeroOrgVariableCommand } from "./variable";
+import { zeroOrgModelProviderCommand } from "./model-provider";
 
 export const zeroOrgCommand = new Command()
   .name("org")
@@ -20,4 +23,7 @@ export const zeroOrgCommand = new Command()
   .addCommand(inviteCommand)
   .addCommand(removeCommand)
   .addCommand(leaveCommand)
-  .addCommand(deleteCommand);
+  .addCommand(deleteCommand)
+  .addCommand(zeroOrgSecretCommand)
+  .addCommand(zeroOrgVariableCommand)
+  .addCommand(zeroOrgModelProviderCommand);

--- a/turbo/apps/cli/src/commands/zero/org/model-provider/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/model-provider/__tests__/list.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for zero org model-provider list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+describe("zero org model-provider list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful list", () => {
+    it("should list org model providers grouped by framework", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/model-providers", () => {
+          return HttpResponse.json({
+            modelProviders: [
+              {
+                id: "1",
+                type: "anthropic-api-key",
+                framework: "claude-code",
+                selectedModel: "claude-sonnet-4-5-20250514",
+                isDefault: true,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                id: "2",
+                type: "openai-api-key",
+                framework: "claude-code",
+                selectedModel: "gpt-4",
+                isDefault: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Org Model Providers");
+      expect(logCalls).toContain("claude-code");
+      expect(logCalls).toContain("anthropic-api-key");
+      expect(logCalls).toContain("openai-api-key");
+      expect(logCalls).toContain("(default)");
+      expect(logCalls).toContain("claude-sonnet-4-5-20250514");
+      expect(logCalls).toContain("gpt-4");
+      expect(logCalls).toContain("2 provider(s)");
+    });
+
+    it("should show empty state when no org providers configured", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/model-providers", () => {
+          return HttpResponse.json({ modelProviders: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No org-level model providers configured");
+      expect(logCalls).toContain("vm0 zero org model-provider setup");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/model-providers", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/model-providers", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("alias", () => {
+    it("should have ls alias", () => {
+      expect(listCommand.alias()).toBe("ls");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/model-provider/__tests__/remove.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/model-provider/__tests__/remove.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for zero org model-provider remove command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../mocks/server";
+import { removeCommand } from "../remove";
+
+describe("zero org model-provider remove command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful removal", () => {
+    it("should show success message on successful removal", async () => {
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/zero/model-providers/:type",
+          () => {
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+      );
+
+      await removeCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Org model provider "anthropic-api-key" removed',
+        ),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("input validation", () => {
+    it("should reject invalid provider type", async () => {
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "invalid-type"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid type "invalid-type"'),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Valid types:"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/zero/model-providers/:type",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Model provider not found",
+                  code: "NOT_FOUND",
+                },
+              },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle forbidden error for non-admin", async () => {
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/zero/model-providers/:type",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Admin access required",
+                  code: "FORBIDDEN",
+                },
+              },
+              { status: 403 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Admin access required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/zero/model-providers/:type",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Not authenticated",
+                  code: "UNAUTHORIZED",
+                },
+              },
+              { status: 401 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/model-provider/__tests__/set-default.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/model-provider/__tests__/set-default.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for zero org model-provider set-default command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../mocks/server";
+import { setDefaultCommand } from "../set-default";
+
+describe("zero org model-provider set-default command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful set-default", () => {
+    it("should show success message with framework", async () => {
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/model-providers/:type/default",
+          () => {
+            return HttpResponse.json({
+              id: "1",
+              type: "anthropic-api-key",
+              framework: "claude-code",
+              isDefault: true,
+              selectedModel: null,
+              createdAt: "2025-01-01T00:00:00Z",
+              updatedAt: "2025-01-01T00:00:00Z",
+            });
+          },
+        ),
+      );
+
+      await setDefaultCommand.parseAsync(["node", "cli", "anthropic-api-key"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Default for claude-code set to "anthropic-api-key"',
+        ),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("input validation", () => {
+    it("should reject invalid provider type", async () => {
+      await expect(async () => {
+        await setDefaultCommand.parseAsync(["node", "cli", "invalid-type"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid type "invalid-type"'),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Valid types:"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/model-providers/:type/default",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Model provider not found",
+                  code: "NOT_FOUND",
+                },
+              },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await setDefaultCommand.parseAsync([
+          "node",
+          "cli",
+          "anthropic-api-key",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle forbidden error for non-admin", async () => {
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/model-providers/:type/default",
+          () => {
+            return HttpResponse.json(
+              {
+                error: {
+                  message: "Admin access required",
+                  code: "FORBIDDEN",
+                },
+              },
+              { status: 403 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await setDefaultCommand.parseAsync([
+          "node",
+          "cli",
+          "anthropic-api-key",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Admin access required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/model-provider/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/model-provider/__tests__/setup.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for zero org model-provider setup command (non-interactive mode)
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ *
+ * Interactive mode helpers are tested via model-provider/setup.test.ts
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../mocks/server";
+import { setupCommand } from "../setup";
+
+describe("zero org model-provider setup command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("non-interactive mode", () => {
+    it("should create single-secret provider", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/model-providers", () => {
+          return HttpResponse.json(
+            {
+              provider: {
+                id: "1",
+                type: "anthropic-api-key",
+                framework: "claude-code",
+                isDefault: true,
+                selectedModel: null,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              created: true,
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "--type",
+        "anthropic-api-key",
+        "--secret",
+        "sk-ant-test123",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Org model provider "anthropic-api-key" created',
+        ),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+
+    it("should create provider with model selection", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/model-providers", () => {
+          return HttpResponse.json(
+            {
+              provider: {
+                id: "1",
+                type: "moonshot-api-key",
+                framework: "claude-code",
+                isDefault: true,
+                selectedModel: "kimi-k2.5",
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              created: true,
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "--type",
+        "moonshot-api-key",
+        "--secret",
+        "sk-test",
+        "--model",
+        "kimi-k2.5",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Org model provider "moonshot-api-key" created',
+        ),
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("kimi-k2.5"),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+
+    it("should update existing provider", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/model-providers", () => {
+          return HttpResponse.json({
+            provider: {
+              id: "1",
+              type: "anthropic-api-key",
+              framework: "claude-code",
+              isDefault: false,
+              selectedModel: null,
+              createdAt: "2025-01-01T00:00:00Z",
+              updatedAt: "2025-01-01T00:00:00Z",
+            },
+            created: false,
+          });
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "--type",
+        "anthropic-api-key",
+        "--secret",
+        "sk-ant-updated",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Org model provider "anthropic-api-key" updated',
+        ),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("input validation", () => {
+    it("should require both --type and --secret", async () => {
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "anthropic-api-key",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Both --type and --secret are required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should reject invalid provider type", async () => {
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "invalid-type",
+          "--secret",
+          "sk-test",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid type "invalid-type"'),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle forbidden error for non-admin", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/model-providers", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Admin access required",
+                code: "FORBIDDEN",
+              },
+            },
+            { status: 403 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "anthropic-api-key",
+          "--secret",
+          "sk-ant-test",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Admin access required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/model-providers", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "--type",
+          "anthropic-api-key",
+          "--secret",
+          "sk-ant-test",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/model-provider/index.ts
+++ b/turbo/apps/cli/src/commands/zero/org/model-provider/index.ts
@@ -1,0 +1,13 @@
+import { Command } from "commander";
+import { listCommand } from "./list";
+import { setupCommand } from "./setup";
+import { removeCommand } from "./remove";
+import { setDefaultCommand } from "./set-default";
+
+export const zeroOrgModelProviderCommand = new Command()
+  .name("model-provider")
+  .description("Manage org-level model providers")
+  .addCommand(listCommand)
+  .addCommand(setupCommand)
+  .addCommand(removeCommand)
+  .addCommand(setDefaultCommand);

--- a/turbo/apps/cli/src/commands/zero/org/model-provider/list.ts
+++ b/turbo/apps/cli/src/commands/zero/org/model-provider/list.ts
@@ -1,0 +1,61 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listZeroOrgModelProviders } from "../../../../lib/api";
+import { withErrorHandler } from "../../../../lib/command";
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all org-level model providers")
+  .action(
+    withErrorHandler(async () => {
+      const result = await listZeroOrgModelProviders();
+
+      if (result.modelProviders.length === 0) {
+        console.log(chalk.dim("No org-level model providers configured"));
+        console.log();
+        console.log("To add an org-level model provider:");
+        console.log(chalk.cyan("  vm0 zero org model-provider setup"));
+        return;
+      }
+
+      // Group by framework
+      const byFramework = result.modelProviders.reduce(
+        (acc, p) => {
+          const fw = p.framework;
+          if (!acc[fw]) {
+            acc[fw] = [];
+          }
+          acc[fw].push(p);
+          return acc;
+        },
+        {} as Record<string, typeof result.modelProviders>,
+      );
+
+      console.log(chalk.bold("Org Model Providers:"));
+      console.log();
+
+      for (const [framework, providers] of Object.entries(byFramework)) {
+        console.log(`  ${chalk.cyan(framework)}:`);
+        for (const provider of providers) {
+          const defaultTag = provider.isDefault
+            ? chalk.green(" (default)")
+            : "";
+          const modelTag = provider.selectedModel
+            ? chalk.dim(` [${provider.selectedModel}]`)
+            : "";
+          console.log(`    ${provider.type}${defaultTag}${modelTag}`);
+          console.log(
+            chalk.dim(
+              `      Updated: ${new Date(provider.updatedAt).toLocaleString()}`,
+            ),
+          );
+        }
+        console.log();
+      }
+
+      console.log(
+        chalk.dim(`Total: ${result.modelProviders.length} provider(s)`),
+      );
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/model-provider/remove.ts
+++ b/turbo/apps/cli/src/commands/zero/org/model-provider/remove.ts
@@ -1,0 +1,23 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { deleteZeroOrgModelProvider } from "../../../../lib/api";
+import { withErrorHandler } from "../../../../lib/command";
+import { MODEL_PROVIDER_TYPES, type ModelProviderType } from "@vm0/core";
+
+export const removeCommand = new Command()
+  .name("remove")
+  .description("Remove an org-level model provider")
+  .argument("<type>", "Model provider type to remove")
+  .action(
+    withErrorHandler(async (type: string) => {
+      if (!Object.keys(MODEL_PROVIDER_TYPES).includes(type)) {
+        const validTypes = Object.keys(MODEL_PROVIDER_TYPES).join(", ");
+        throw new Error(`Invalid type "${type}"`, {
+          cause: new Error(`Valid types: ${validTypes}`),
+        });
+      }
+
+      await deleteZeroOrgModelProvider(type as ModelProviderType);
+      console.log(chalk.green(`✓ Org model provider "${type}" removed`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/model-provider/set-default.ts
+++ b/turbo/apps/cli/src/commands/zero/org/model-provider/set-default.ts
@@ -1,0 +1,29 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { setZeroOrgModelProviderDefault } from "../../../../lib/api";
+import { withErrorHandler } from "../../../../lib/command";
+import { MODEL_PROVIDER_TYPES, type ModelProviderType } from "@vm0/core";
+
+export const setDefaultCommand = new Command()
+  .name("set-default")
+  .description("Set an org-level model provider as default for its framework")
+  .argument("<type>", "Model provider type to set as default")
+  .action(
+    withErrorHandler(async (type: string) => {
+      if (!Object.keys(MODEL_PROVIDER_TYPES).includes(type)) {
+        const validTypes = Object.keys(MODEL_PROVIDER_TYPES).join(", ");
+        throw new Error(`Invalid type "${type}"`, {
+          cause: new Error(`Valid types: ${validTypes}`),
+        });
+      }
+
+      const provider = await setZeroOrgModelProviderDefault(
+        type as ModelProviderType,
+      );
+      console.log(
+        chalk.green(
+          `✓ Default for ${provider.framework} set to "${provider.type}"`,
+        ),
+      );
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/model-provider/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/org/model-provider/setup.ts
@@ -1,0 +1,280 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import prompts from "prompts";
+import {
+  listZeroOrgModelProviders,
+  upsertZeroOrgModelProvider,
+  updateZeroOrgModelProviderModel,
+  setZeroOrgModelProviderDefault,
+} from "../../../../lib/api";
+import {
+  MODEL_PROVIDER_TYPES,
+  hasModelSelection,
+  hasAuthMethods,
+  getSelectableProviderTypes,
+  type ModelProviderType,
+} from "@vm0/core";
+import { isInteractive } from "../../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../../lib/command";
+import {
+  type SetupInput,
+  handleNonInteractiveMode,
+  promptForModelSelection,
+  promptForAuthMethod,
+  promptForSecrets,
+  collectSecrets,
+} from "../../../../lib/domain/model-provider/shared";
+
+async function handleInteractiveMode(): Promise<SetupInput | null> {
+  if (!isInteractive()) {
+    throw new Error("Interactive mode requires a TTY", {
+      cause: new Error(
+        'Use non-interactive mode: vm0 zero org model-provider setup --type <type> --secret "<value>"',
+      ),
+    });
+  }
+
+  // Fetch configured org providers to annotate choices
+  const { modelProviders: configuredProviders } =
+    await listZeroOrgModelProviders();
+  const configuredTypes = new Set(configuredProviders.map((p) => p.type));
+
+  // Build provider choices with configuration status (only selectable providers)
+  const annotatedChoices = getSelectableProviderTypes().map((type) => {
+    const config = MODEL_PROVIDER_TYPES[type];
+    const isConfigured = configuredTypes.has(type);
+    const isExperimental = hasAuthMethods(type);
+    let title: string = config.label;
+    if (isConfigured) {
+      title = `${title} ✓`;
+    }
+    if (isExperimental) {
+      title = `${title} ${chalk.dim("(experimental)")}`;
+    }
+    return {
+      title,
+      value: type,
+    };
+  });
+
+  const typeResponse = await prompts(
+    {
+      type: "select",
+      name: "type",
+      message: "Select provider type:",
+      choices: annotatedChoices,
+    },
+    { onCancel: () => process.exit(0) },
+  );
+
+  const type = typeResponse.type as ModelProviderType;
+
+  // Check if provider is already configured using the list we already fetched
+  const existingProvider = configuredProviders.find((p) => p.type === type);
+
+  if (existingProvider) {
+    console.log();
+    console.log(`"${type}" is already configured`);
+    console.log();
+
+    const actionResponse = await prompts(
+      {
+        type: "select",
+        name: "action",
+        message: "",
+        choices: [
+          { title: "Keep existing secret", value: "keep" },
+          { title: "Update secret", value: "update" },
+        ],
+      },
+      { onCancel: () => process.exit(0) },
+    );
+
+    if (actionResponse.action === "keep") {
+      const selectedModel = await promptForModelSelection(type);
+      return {
+        type,
+        keepExistingSecret: true,
+        selectedModel,
+        isInteractiveMode: true,
+      };
+    }
+    // Fall through to secret prompt for "update"
+  }
+
+  const config = MODEL_PROVIDER_TYPES[type];
+
+  console.log();
+  if ("helpText" in config) {
+    console.log(chalk.dim(config.helpText));
+  }
+  console.log();
+
+  // Handle multi-auth providers
+  if (hasAuthMethods(type)) {
+    const authMethod = await promptForAuthMethod(type);
+    const secrets = await promptForSecrets(type, authMethod);
+    const selectedModel = await promptForModelSelection(type);
+
+    return {
+      type,
+      authMethod,
+      secrets,
+      selectedModel,
+      isInteractiveMode: true,
+    };
+  }
+
+  // Single-secret provider (legacy)
+  const secretLabel = "secretLabel" in config ? config.secretLabel : "secret";
+
+  const secretResponse = await prompts(
+    {
+      type: "password",
+      name: "secret",
+      message: `Enter your ${secretLabel}:`,
+      validate: (value: string) =>
+        value.length > 0 || `${secretLabel} is required`,
+    },
+    { onCancel: () => process.exit(0) },
+  );
+
+  const secret = secretResponse.secret as string;
+  const selectedModel = await promptForModelSelection(type);
+
+  return { type, secret, selectedModel, isInteractiveMode: true };
+}
+
+async function promptSetAsDefault(
+  type: ModelProviderType,
+  framework: string,
+  isDefault: boolean,
+): Promise<void> {
+  if (isDefault) return;
+
+  const response = await prompts(
+    {
+      type: "confirm",
+      name: "setDefault",
+      message: "Set this provider as default?",
+      initial: false,
+    },
+    { onCancel: () => process.exit(0) },
+  );
+
+  if (response.setDefault) {
+    await setZeroOrgModelProviderDefault(type);
+    console.log(chalk.green(`✓ Default for ${framework} set to "${type}"`));
+  }
+}
+
+export const setupCommand = new Command()
+  .name("setup")
+  .description("Configure an org-level model provider")
+  .option("-t, --type <type>", "Provider type (for non-interactive mode)")
+  .option(
+    "-s, --secret <value>",
+    "Secret value (can be used multiple times, supports VALUE or KEY=VALUE format)",
+    collectSecrets,
+    [],
+  )
+  .option(
+    "-a, --auth-method <method>",
+    "Auth method (required for multi-auth providers like aws-bedrock)",
+  )
+  .option("-m, --model <model>", "Model selection (for non-interactive mode)")
+  .action(
+    withErrorHandler(
+      async (options: {
+        type?: string;
+        secret?: string[];
+        authMethod?: string;
+        model?: string;
+      }) => {
+        let input: SetupInput;
+        const secretArgs = options.secret ?? [];
+
+        if (options.type && secretArgs.length > 0) {
+          input = handleNonInteractiveMode({
+            type: options.type,
+            secret: secretArgs,
+            authMethod: options.authMethod,
+            model: options.model,
+            commandPrefix: "vm0 zero org model-provider setup",
+          });
+        } else if (options.type || secretArgs.length > 0) {
+          throw new Error("Both --type and --secret are required");
+        } else {
+          const result = await handleInteractiveMode();
+          if (result === null) {
+            return;
+          }
+          input = result;
+        }
+
+        // Handle "keep existing secret" flow
+        if (input.keepExistingSecret) {
+          const provider = await updateZeroOrgModelProviderModel(
+            input.type,
+            input.selectedModel,
+          );
+
+          const defaultNote = provider.isDefault
+            ? ` (default for ${provider.framework})`
+            : "";
+          const modelNote = provider.selectedModel
+            ? ` with model: ${provider.selectedModel}`
+            : "";
+
+          if (!hasModelSelection(input.type)) {
+            console.log(
+              chalk.green(`✓ Org model provider "${input.type}" unchanged`),
+            );
+          } else {
+            console.log(
+              chalk.green(
+                `✓ Org model provider "${input.type}" updated${defaultNote}${modelNote}`,
+              ),
+            );
+          }
+          if (input.isInteractiveMode) {
+            await promptSetAsDefault(
+              input.type,
+              provider.framework,
+              provider.isDefault,
+            );
+          }
+          return;
+        }
+
+        // Standard upsert flow with secret
+        const { provider, created } = await upsertZeroOrgModelProvider({
+          type: input.type,
+          secret: input.secret,
+          authMethod: input.authMethod,
+          secrets: input.secrets,
+          selectedModel: input.selectedModel,
+        });
+
+        const action = created ? "created" : "updated";
+        const defaultNote = provider.isDefault
+          ? ` (default for ${provider.framework})`
+          : "";
+        const modelNote = provider.selectedModel
+          ? ` with model: ${provider.selectedModel}`
+          : "";
+        console.log(
+          chalk.green(
+            `✓ Org model provider "${input.type}" ${action}${defaultNote}${modelNote}`,
+          ),
+        );
+        if (input.isInteractiveMode) {
+          await promptSetAsDefault(
+            input.type,
+            provider.framework,
+            provider.isDefault,
+          );
+        }
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/secret/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/secret/__tests__/list.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for zero org secret list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+describe("zero org secret list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful list", () => {
+    it("should list org secrets with metadata", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({
+            secrets: [
+              {
+                name: "MY_API_KEY",
+                description: "API key for service",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                name: "DB_PASSWORD",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Org Secrets");
+      expect(logCalls).toContain("MY_API_KEY");
+      expect(logCalls).toContain("API key for service");
+      expect(logCalls).toContain("DB_PASSWORD");
+      expect(logCalls).toContain("2 secret(s)");
+    });
+
+    it("should show empty state when no secrets exist", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({ secrets: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No org secrets found");
+      expect(logCalls).toContain("vm0 zero org secret set");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("alias", () => {
+    it("should have ls alias", () => {
+      expect(listCommand.alias()).toBe("ls");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/secret/__tests__/remove.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/secret/__tests__/remove.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for zero org secret remove command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../mocks/server";
+import { removeCommand } from "../remove";
+
+describe("zero org secret remove command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful removal", () => {
+    it("should remove a secret with --yes flag", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/secrets/:name", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await removeCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Org secret "MY_API_KEY" deleted'),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("non-interactive mode", () => {
+    it("should require --yes flag in non-interactive mode", async () => {
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_API_KEY"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--yes flag is required in non-interactive mode",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/secrets/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Secret not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/secrets/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/secrets/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/secret/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/secret/__tests__/set.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for zero org secret set command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../mocks/server";
+import { setCommand } from "../set";
+import chalk from "chalk";
+
+describe("zero org secret set command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful set", () => {
+    it("should set a secret with --body flag", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              name: "MY_API_KEY",
+              updatedAt: "2025-01-01T00:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "MY_API_KEY",
+        "--body",
+        "secret-value",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('Org secret "MY_API_KEY" saved');
+      expect(logCalls).toContain("secrets.MY_API_KEY");
+    });
+
+    it("should set a secret with --body and --description", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/secrets",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              {
+                name: "MY_API_KEY",
+                description: "API key for external service",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "MY_API_KEY",
+        "--body",
+        "secret-value",
+        "--description",
+        "API key for external service",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        name: "MY_API_KEY",
+        value: "secret-value",
+        description: "API key for external service",
+      });
+    });
+  });
+
+  describe("non-interactive mode", () => {
+    it("should require --body flag in non-interactive mode", async () => {
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_API_KEY"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("required in non-interactive mode"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("input validation", () => {
+    it("should show helpful hint for invalid secret name", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message:
+                  "Name must contain only uppercase letters, digits, and underscores",
+                code: "BAD_REQUEST",
+              },
+            },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "my-invalid-key",
+          "--body",
+          "value",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("must contain only uppercase"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("MY_API_KEY"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "MY_API_KEY",
+          "--body",
+          "value",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "MY_API_KEY",
+          "--body",
+          "value",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/secret/index.ts
+++ b/turbo/apps/cli/src/commands/zero/org/secret/index.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+import { listCommand } from "./list";
+import { setCommand } from "./set";
+import { removeCommand } from "./remove";
+
+export const zeroOrgSecretCommand = new Command()
+  .name("secret")
+  .description("Manage org-level secrets (admin)")
+  .addCommand(listCommand)
+  .addCommand(setCommand)
+  .addCommand(removeCommand);

--- a/turbo/apps/cli/src/commands/zero/org/secret/list.ts
+++ b/turbo/apps/cli/src/commands/zero/org/secret/list.ts
@@ -1,0 +1,40 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listZeroOrgSecrets } from "../../../../lib/api";
+import { withErrorHandler } from "../../../../lib/command";
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all org-level secrets")
+  .action(
+    withErrorHandler(async () => {
+      const result = await listZeroOrgSecrets();
+
+      if (result.secrets.length === 0) {
+        console.log(chalk.dim("No org secrets found"));
+        console.log();
+        console.log("To add an org secret:");
+        console.log(
+          chalk.cyan("  vm0 zero org secret set MY_API_KEY --body <value>"),
+        );
+        return;
+      }
+
+      console.log(chalk.bold("Org Secrets:"));
+      console.log();
+
+      for (const secret of result.secrets) {
+        console.log(`  ${chalk.cyan(secret.name)}`);
+        if (secret.description) {
+          console.log(`    ${chalk.dim(secret.description)}`);
+        }
+        console.log(
+          `    ${chalk.dim(`Updated: ${new Date(secret.updatedAt).toLocaleString()}`)}`,
+        );
+        console.log();
+      }
+
+      console.log(chalk.dim(`Total: ${result.secrets.length} secret(s)`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/secret/remove.ts
+++ b/turbo/apps/cli/src/commands/zero/org/secret/remove.ts
@@ -1,0 +1,36 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { deleteZeroOrgSecret } from "../../../../lib/api";
+import {
+  isInteractive,
+  promptConfirm,
+} from "../../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../../lib/command";
+
+export const removeCommand = new Command()
+  .name("remove")
+  .description("Delete an org-level secret (admin only)")
+  .argument("<name>", "Secret name to delete")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
+      if (!options.yes) {
+        if (!isInteractive()) {
+          throw new Error("--yes flag is required in non-interactive mode");
+        }
+
+        const confirmed = await promptConfirm(
+          `Are you sure you want to delete org secret "${name}"?`,
+          false,
+        );
+
+        if (!confirmed) {
+          console.log(chalk.dim("Cancelled"));
+          return;
+        }
+      }
+
+      await deleteZeroOrgSecret(name);
+      console.log(chalk.green(`✓ Org secret "${name}" deleted`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/secret/set.ts
+++ b/turbo/apps/cli/src/commands/zero/org/secret/set.ts
@@ -1,0 +1,71 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { setZeroOrgSecret } from "../../../../lib/api";
+import {
+  isInteractive,
+  promptPassword,
+} from "../../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../../lib/command";
+
+export const setCommand = new Command()
+  .name("set")
+  .description("Create or update an org-level secret (admin only)")
+  .argument("<name>", "Secret name (uppercase, e.g., MY_API_KEY)")
+  .option(
+    "-b, --body <value>",
+    "Secret value (required in non-interactive mode)",
+  )
+  .option("-d, --description <description>", "Optional description")
+  .action(
+    withErrorHandler(
+      async (
+        name: string,
+        options: { body?: string; description?: string },
+      ) => {
+        let value: string;
+
+        if (options.body !== undefined) {
+          value = options.body;
+        } else if (isInteractive()) {
+          const prompted = await promptPassword("Enter secret value:");
+          if (prompted === undefined) {
+            process.exit(0);
+          }
+          value = prompted;
+        } else {
+          throw new Error("--body is required in non-interactive mode", {
+            cause: new Error(
+              `Usage: vm0 zero org secret set ${name} --body "your-secret-value"`,
+            ),
+          });
+        }
+
+        let secret;
+        try {
+          secret = await setZeroOrgSecret({
+            name,
+            value,
+            description: options.description,
+          });
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes("must contain only uppercase")
+          ) {
+            throw new Error(error.message, {
+              cause: new Error(
+                "Examples of valid secret names: MY_API_KEY, GITHUB_TOKEN, AWS_ACCESS_KEY_ID",
+              ),
+            });
+          }
+          throw error;
+        }
+
+        console.log(chalk.green(`✓ Org secret "${secret.name}" saved`));
+        console.log();
+        console.log("Use in vm0.yaml:");
+        console.log(chalk.cyan(`  environment:`));
+        console.log(chalk.cyan(`    ${name}: \${{ secrets.${name} }}`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/variable/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/variable/__tests__/list.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for zero org variable list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+describe("zero org variable list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful list", () => {
+    it("should list org variables with values", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json({
+            variables: [
+              {
+                name: "API_URL",
+                value: "https://api.example.com",
+                description: "External API endpoint",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                name: "DEBUG_MODE",
+                value: "true",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Org Variables");
+      expect(logCalls).toContain("API_URL");
+      expect(logCalls).toContain("https://api.example.com");
+      expect(logCalls).toContain("External API endpoint");
+      expect(logCalls).toContain("DEBUG_MODE");
+      expect(logCalls).toContain("2 variable(s)");
+    });
+
+    it("should show empty state when no variables exist", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json({ variables: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No org variables found");
+      expect(logCalls).toContain("vm0 zero org variable set");
+    });
+
+    it("should truncate long values", async () => {
+      const longValue = "a".repeat(100);
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json({
+            variables: [
+              {
+                name: "LONG_VAR",
+                value: longValue,
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("... [truncated]");
+      expect(logCalls).not.toContain(longValue);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("alias", () => {
+    it("should have ls alias", () => {
+      expect(listCommand.alias()).toBe("ls");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/variable/__tests__/remove.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/variable/__tests__/remove.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for zero org variable remove command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../mocks/server";
+import { removeCommand } from "../remove";
+
+describe("zero org variable remove command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful removal", () => {
+    it("should remove a variable with --yes flag", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/variables/:name", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await removeCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Org variable "MY_VAR" deleted'),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("non-interactive mode", () => {
+    it("should require --yes flag in non-interactive mode", async () => {
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_VAR"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--yes flag is required in non-interactive mode",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/variables/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Variable not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/variables/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/variables/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await removeCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/variable/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/variable/__tests__/set.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for zero org variable set command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../mocks/server";
+import { setCommand } from "../set";
+import chalk from "chalk";
+
+describe("zero org variable set command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful set", () => {
+    it("should set a variable with name and value", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              name: "API_URL",
+              value: "https://api.example.com",
+              updatedAt: "2025-01-01T00:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "API_URL",
+        "https://api.example.com",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('Org variable "API_URL" saved');
+      expect(logCalls).toContain("vars.API_URL");
+    });
+
+    it("should set a variable with --description", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/variables",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              {
+                name: "API_URL",
+                value: "https://api.example.com",
+                description: "External API endpoint",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "API_URL",
+        "https://api.example.com",
+        "--description",
+        "External API endpoint",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        name: "API_URL",
+        value: "https://api.example.com",
+        description: "External API endpoint",
+      });
+    });
+  });
+
+  describe("input validation", () => {
+    it("should show helpful hint for invalid variable name", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message:
+                  "Name must contain only uppercase letters, digits, and underscores",
+                code: "BAD_REQUEST",
+              },
+            },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "my-invalid-var", "value"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("must contain only uppercase"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("MY_VAR"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_VAR", "value"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_VAR", "value"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/org/variable/index.ts
+++ b/turbo/apps/cli/src/commands/zero/org/variable/index.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+import { listCommand } from "./list";
+import { setCommand } from "./set";
+import { removeCommand } from "./remove";
+
+export const zeroOrgVariableCommand = new Command()
+  .name("variable")
+  .description("Manage org-level variables (admin)")
+  .addCommand(listCommand)
+  .addCommand(setCommand)
+  .addCommand(removeCommand);

--- a/turbo/apps/cli/src/commands/zero/org/variable/list.ts
+++ b/turbo/apps/cli/src/commands/zero/org/variable/list.ts
@@ -1,0 +1,49 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listZeroOrgVariables } from "../../../../lib/api";
+import { withErrorHandler } from "../../../../lib/command";
+
+/**
+ * Truncate value for display if too long
+ */
+function truncateValue(value: string, maxLength: number = 60): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(0, maxLength - 15) + "... [truncated]";
+}
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all org-level variables")
+  .action(
+    withErrorHandler(async () => {
+      const result = await listZeroOrgVariables();
+
+      if (result.variables.length === 0) {
+        console.log(chalk.dim("No org variables found"));
+        console.log();
+        console.log("To add an org variable:");
+        console.log(chalk.cyan("  vm0 zero org variable set MY_VAR <value>"));
+        return;
+      }
+
+      console.log(chalk.bold("Org Variables:"));
+      console.log();
+
+      for (const variable of result.variables) {
+        const displayValue = truncateValue(variable.value);
+        console.log(`  ${chalk.cyan(variable.name)} = ${displayValue}`);
+        if (variable.description) {
+          console.log(`    ${chalk.dim(variable.description)}`);
+        }
+        console.log(
+          `    ${chalk.dim(`Updated: ${new Date(variable.updatedAt).toLocaleString()}`)}`,
+        );
+        console.log();
+      }
+
+      console.log(chalk.dim(`Total: ${result.variables.length} variable(s)`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/variable/remove.ts
+++ b/turbo/apps/cli/src/commands/zero/org/variable/remove.ts
@@ -1,0 +1,36 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { deleteZeroOrgVariable } from "../../../../lib/api";
+import {
+  isInteractive,
+  promptConfirm,
+} from "../../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../../lib/command";
+
+export const removeCommand = new Command()
+  .name("remove")
+  .description("Delete an org-level variable (admin only)")
+  .argument("<name>", "Variable name to delete")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
+      if (!options.yes) {
+        if (!isInteractive()) {
+          throw new Error("--yes flag is required in non-interactive mode");
+        }
+
+        const confirmed = await promptConfirm(
+          `Are you sure you want to delete org variable "${name}"?`,
+          false,
+        );
+
+        if (!confirmed) {
+          console.log(chalk.dim("Cancelled"));
+          return;
+        }
+      }
+
+      await deleteZeroOrgVariable(name);
+      console.log(chalk.green(`✓ Org variable "${name}" deleted`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/org/variable/set.ts
+++ b/turbo/apps/cli/src/commands/zero/org/variable/set.ts
@@ -1,0 +1,47 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { setZeroOrgVariable } from "../../../../lib/api";
+import { withErrorHandler } from "../../../../lib/command";
+
+export const setCommand = new Command()
+  .name("set")
+  .description("Create or update an org-level variable (admin only)")
+  .argument("<name>", "Variable name (uppercase, e.g., MY_VAR)")
+  .argument("<value>", "Variable value")
+  .option("-d, --description <description>", "Optional description")
+  .action(
+    withErrorHandler(
+      async (
+        name: string,
+        value: string,
+        options: { description?: string },
+      ) => {
+        let variable;
+        try {
+          variable = await setZeroOrgVariable({
+            name,
+            value,
+            description: options.description,
+          });
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes("must contain only uppercase")
+          ) {
+            throw new Error(error.message, {
+              cause: new Error(
+                "Examples of valid variable names: MY_VAR, API_URL, DEBUG_MODE",
+              ),
+            });
+          }
+          throw error;
+        }
+
+        console.log(chalk.green(`✓ Org variable "${variable.name}" saved`));
+        console.log();
+        console.log("Use in vm0.yaml:");
+        console.log(chalk.cyan(`  environment:`));
+        console.log(chalk.cyan(`    ${name}: \${{ vars.${name} }}`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-org-model-providers.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-org-model-providers.ts
@@ -1,0 +1,112 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroModelProvidersMainContract,
+  zeroModelProvidersByTypeContract,
+  zeroModelProvidersDefaultContract,
+  zeroModelProvidersUpdateModelContract,
+  type ModelProviderType,
+  type ModelProviderListResponse,
+  type ModelProviderResponse,
+  type UpsertModelProviderResponse,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+/**
+ * List all org-level model providers via zero API
+ */
+export async function listZeroOrgModelProviders(): Promise<ModelProviderListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroModelProvidersMainContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list org model providers");
+}
+
+/**
+ * Create or update an org-level model provider via zero API (admin only)
+ */
+export async function upsertZeroOrgModelProvider(body: {
+  type: ModelProviderType;
+  secret?: string;
+  authMethod?: string;
+  secrets?: Record<string, string>;
+  selectedModel?: string;
+}): Promise<UpsertModelProviderResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroModelProvidersMainContract, config);
+
+  const result = await client.upsert({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set org model provider");
+}
+
+/**
+ * Delete an org-level model provider via zero API (admin only)
+ */
+export async function deleteZeroOrgModelProvider(
+  type: ModelProviderType,
+): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroModelProvidersByTypeContract, config);
+
+  const result = await client.delete({
+    params: { type },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Org model provider "${type}" not found`);
+}
+
+/**
+ * Set an org-level model provider as default for its framework via zero API (admin only)
+ */
+export async function setZeroOrgModelProviderDefault(
+  type: ModelProviderType,
+): Promise<ModelProviderResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroModelProvidersDefaultContract, config);
+
+  const result = await client.setDefault({
+    params: { type },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set default org model provider");
+}
+
+/**
+ * Update model selection for an existing org-level provider via zero API (admin only)
+ */
+export async function updateZeroOrgModelProviderModel(
+  type: ModelProviderType,
+  selectedModel?: string,
+): Promise<ModelProviderResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroModelProvidersUpdateModelContract, config);
+
+  const result = await client.updateModel({
+    params: { type },
+    body: { selectedModel },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to update org model provider");
+}

--- a/turbo/apps/cli/src/lib/api/domains/zero-org-secrets.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-org-secrets.ts
@@ -1,0 +1,58 @@
+import { initClient } from "@ts-rest/core";
+import { zeroSecretsContract, zeroSecretsByNameContract } from "@vm0/core";
+import type { SecretResponse, SecretListResponse } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+/**
+ * List org-level secrets via zero API (metadata only, no values)
+ */
+export async function listZeroOrgSecrets(): Promise<SecretListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSecretsContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list org secrets");
+}
+
+/**
+ * Set (create or update) an org-level secret via zero API
+ */
+export async function setZeroOrgSecret(body: {
+  name: string;
+  value: string;
+  description?: string;
+}): Promise<SecretResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSecretsContract, config);
+
+  const result = await client.set({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set org secret");
+}
+
+/**
+ * Delete an org-level secret by name via zero API
+ */
+export async function deleteZeroOrgSecret(name: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSecretsByNameContract, config);
+
+  const result = await client.delete({
+    params: { name },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Org secret "${name}" not found`);
+}

--- a/turbo/apps/cli/src/lib/api/domains/zero-org-variables.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-org-variables.ts
@@ -1,0 +1,58 @@
+import { initClient } from "@ts-rest/core";
+import { zeroVariablesContract, zeroVariablesByNameContract } from "@vm0/core";
+import type { VariableResponse, VariableListResponse } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+/**
+ * List org-level variables via zero API (includes values)
+ */
+export async function listZeroOrgVariables(): Promise<VariableListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVariablesContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list org variables");
+}
+
+/**
+ * Set (create or update) an org-level variable via zero API
+ */
+export async function setZeroOrgVariable(body: {
+  name: string;
+  value: string;
+  description?: string;
+}): Promise<VariableResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVariablesContract, config);
+
+  const result = await client.set({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set org variable");
+}
+
+/**
+ * Delete an org-level variable by name via zero API
+ */
+export async function deleteZeroOrgVariable(name: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVariablesByNameContract, config);
+
+  const result = await client.delete({
+    params: { name },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Org variable "${name}" not found`);
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -124,3 +124,26 @@ export {
   leaveZeroOrg,
   deleteZeroOrg,
 } from "./domains/zero-orgs";
+
+// Domain modules - Zero Org Secrets
+export {
+  listZeroOrgSecrets,
+  setZeroOrgSecret,
+  deleteZeroOrgSecret,
+} from "./domains/zero-org-secrets";
+
+// Domain modules - Zero Org Variables
+export {
+  listZeroOrgVariables,
+  setZeroOrgVariable,
+  deleteZeroOrgVariable,
+} from "./domains/zero-org-variables";
+
+// Domain modules - Zero Org Model Providers
+export {
+  listZeroOrgModelProviders,
+  upsertZeroOrgModelProvider,
+  deleteZeroOrgModelProvider,
+  setZeroOrgModelProviderDefault,
+  updateZeroOrgModelProviderModel,
+} from "./domains/zero-org-model-providers";


### PR DESCRIPTION
## Summary

- Add `vm0 zero org secret` command group (list, set, remove) using zero API contracts
- Add `vm0 zero org variable` command group (list, set, remove) using zero API contracts
- Add `vm0 zero org model-provider` command group (list, setup, remove, set-default) using zero API contracts
- Create zero API domain modules for org-secrets, org-variables, and org-model-providers
- Integration tests for all 13 new commands (53 test cases)

## Details

These commands replace the legacy `vm0 org secret`, `vm0 org variable`, and `vm0 org model-provider` commands by routing through `/api/zero/*` endpoints. All backend routes and contracts already exist — this is CLI-only work.

**Files created (26):**
- 3 API domain modules (`zero-org-secrets.ts`, `zero-org-variables.ts`, `zero-org-model-providers.ts`)
- 13 command files (4 secret + 4 variable + 5 model-provider)
- 10 test files (3 secret + 3 variable + 4 model-provider)

**Files modified (2):**
- `commands/zero/org/index.ts` — register 3 new command groups
- `lib/api/index.ts` — export new domain functions

## Test plan

- [x] All 53 new integration tests pass
- [x] TypeScript type check passes
- [x] Lint passes (oxlint + eslint, 0 warnings)
- [x] Knip passes (no unused exports/dependencies)
- [x] Format passes (prettier)
- [x] Pre-commit hooks pass (commitlint)
- [ ] CI pipeline passes

Closes #6200

🤖 Generated with [Claude Code](https://claude.com/claude-code)