### PR TITLE
test: replace credit-service.test.ts with cron route test and cover member cap gaps

### DIFF
--- a/turbo/apps/web/app/api/cron/process-credits/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/process-credits/__tests__/route.test.ts
@@ -1,45 +1,72 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../route";
 import {
   testContext,
   uniqueId,
   type UserContext,
-} from "../../../__tests__/test-helpers";
+} from "../../../../../src/__tests__/test-helpers";
 import {
-  insertOrgCacheEntry,
   insertTestCreditPricing,
   insertTestCreditUsage,
   findTestCreditUsage,
   getOrgCredits,
-} from "../../../__tests__/api-test-helpers";
-import { processOrgCredits, processStaleCredits } from "../credit-service";
+  insertOrgCacheEntry,
+  insertOrgMembersEntry,
+  getOrgMembersEntry,
+  updateOrgStripeFields,
+} from "../../../../../src/__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../../src/env";
+
+vi.hoisted(() => {
+  vi.stubEnv("CRON_SECRET", "test-cron-secret");
+});
 
 const context = testContext();
 
-describe("credit-service", () => {
+function cronRequest(secret?: string) {
+  return new Request("http://localhost:3000/api/cron/process-credits", {
+    method: "GET",
+    headers: secret ? { authorization: `Bearer ${secret}` } : {},
+  });
+}
+
+describe("GET /api/cron/process-credits", () => {
   let user: UserContext;
 
   beforeEach(async () => {
     context.setupMocks();
+    vi.stubEnv("CRON_SECRET", "test-cron-secret");
+    reloadEnv();
     user = await context.setupUser();
   });
 
-  describe("processOrgCredits", () => {
-    it("no-ops when no pending records exist", async () => {
-      await processOrgCredits(user.orgId);
+  describe("auth", () => {
+    it("returns 401 with missing authorization header", async () => {
+      const response = await GET(cronRequest());
+      expect(response.status).toBe(401);
+    });
 
-      // Org row exists (from setupUser) with default credits (10000)
+    it("returns 401 with wrong cron secret", async () => {
+      const response = await GET(cronRequest("wrong-secret"));
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("credit processing", () => {
+    it("no-ops when no pending records exist", async () => {
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
+
       const credits = await getOrgCredits(user.orgId);
       expect(credits).toBe(10_000);
     });
 
     it("processes a single pending record with correct calculation", async () => {
-      // Set up pricing: input=100/M, output=200/M
       await insertTestCreditPricing("gpt-4", {
         inputTokenPrice: 100,
         outputTokenPrice: 200,
       });
 
-      // Insert usage: 1000 input, 500 output
       const usageId = await insertTestCreditUsage(user.orgId, {
         userId: user.userId,
         model: "gpt-4",
@@ -47,18 +74,17 @@ describe("credit-service", () => {
         outputTokens: 500,
       });
 
-      await processOrgCredits(user.orgId);
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
 
-      // Verify calculation (purely token-based):
-      // input: ceil(1000 * 100 / 1_000_000) = ceil(0.1) = 1
-      // output: ceil(500 * 200 / 1_000_000) = ceil(0.1) = 1
-      // total: 1 + 1 = 2
+      // input: ceil(1000 * 100 / 1_000_000) = 1
+      // output: ceil(500 * 200 / 1_000_000) = 1
+      // total: 2
       const record = await findTestCreditUsage(usageId);
       expect(record!.status).toBe("processed");
       expect(record!.creditsCharged).toBe(2);
       expect(record!.processedAt).toBeInstanceOf(Date);
 
-      // Verify credits were deducted in org table (10000 default - 2 = 9998)
       const credits = await getOrgCredits(user.orgId);
       expect(credits).toBe(9998);
     });
@@ -69,7 +95,6 @@ describe("credit-service", () => {
         outputTokenPrice: 1_000_000,
       });
 
-      // Insert two usage records
       const id1 = await insertTestCreditUsage(user.orgId, {
         userId: user.userId,
         model: "gpt-4",
@@ -83,19 +108,17 @@ describe("credit-service", () => {
         outputTokens: 200,
       });
 
-      await processOrgCredits(user.orgId);
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
 
-      // Record 1: ceil(100*1M/1M) + ceil(100*1M/1M) = 100 + 100 = 200
       const record1 = await findTestCreditUsage(id1);
       expect(record1!.status).toBe("processed");
       expect(record1!.creditsCharged).toBe(200);
 
-      // Record 2: ceil(200*1M/1M) + ceil(200*1M/1M) = 200 + 200 = 400
       const record2 = await findTestCreditUsage(id2);
       expect(record2!.status).toBe("processed");
       expect(record2!.creditsCharged).toBe(400);
 
-      // Total: 200 + 400 = 600, deducted from org (10000 default - 600 = 9400)
       const credits = await getOrgCredits(user.orgId);
       expect(credits).toBe(9400);
     });
@@ -103,7 +126,6 @@ describe("credit-service", () => {
     it("skips already-processed records", async () => {
       await insertTestCreditPricing("gpt-4");
 
-      // Insert a processed record
       const usageId = await insertTestCreditUsage(user.orgId, {
         userId: user.userId,
         model: "gpt-4",
@@ -111,28 +133,26 @@ describe("credit-service", () => {
         creditsCharged: 500,
       });
 
-      await processOrgCredits(user.orgId);
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
 
-      // Record should be unchanged
       const record = await findTestCreditUsage(usageId);
       expect(record!.status).toBe("processed");
       expect(record!.creditsCharged).toBe(500);
 
-      // Org row exists (from setupUser) with default credits (10000)
       const credits = await getOrgCredits(user.orgId);
       expect(credits).toBe(10_000);
     });
 
     it("marks records with no matching pricing as processed with zero charge", async () => {
-      // No pricing for "unknown-model" — simulates user's own provider
       const usageId = await insertTestCreditUsage(user.orgId, {
         userId: user.userId,
         model: "unknown-model",
       });
 
-      await processOrgCredits(user.orgId);
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
 
-      // Record should be processed with zero credits
       const record = await findTestCreditUsage(usageId);
       expect(record!.status).toBe("processed");
       expect(record!.creditsCharged).toBe(0);
@@ -140,7 +160,6 @@ describe("credit-service", () => {
     });
 
     it("includes cache tokens in credit calculation", async () => {
-      // Set up pricing with cache token prices
       await insertTestCreditPricing("gpt-4", {
         inputTokenPrice: 100,
         outputTokenPrice: 200,
@@ -148,7 +167,6 @@ describe("credit-service", () => {
         cacheCreationTokenPrice: 150,
       });
 
-      // Insert usage with cache tokens
       const usageId = await insertTestCreditUsage(user.orgId, {
         userId: user.userId,
         model: "gpt-4",
@@ -158,14 +176,14 @@ describe("credit-service", () => {
         cacheCreationInputTokens: 18000,
       });
 
-      await processOrgCredits(user.orgId);
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
 
-      // Verify calculation:
-      // input: ceil(1000 * 100 / 1_000_000) = ceil(0.1) = 1
-      // output: ceil(500 * 200 / 1_000_000) = ceil(0.1) = 1
-      // cacheRead: ceil(6000 * 10 / 1_000_000) = ceil(0.06) = 1
-      // cacheCreation: ceil(18000 * 150 / 1_000_000) = ceil(2.7) = 3
-      // total: 1 + 1 + 1 + 3 = 6
+      // input: ceil(1000 * 100 / 1_000_000) = 1
+      // output: ceil(500 * 200 / 1_000_000) = 1
+      // cacheRead: ceil(6000 * 10 / 1_000_000) = 1
+      // cacheCreation: ceil(18000 * 150 / 1_000_000) = 3
+      // total: 6
       const record = await findTestCreditUsage(usageId);
       expect(record!.status).toBe("processed");
       expect(record!.creditsCharged).toBe(6);
@@ -175,14 +193,12 @@ describe("credit-service", () => {
     });
 
     it("charges only when model+provider matches pricing", async () => {
-      // Set up pricing for gpt-4 with anthropic-api-key provider
       await insertTestCreditPricing("gpt-4", {
         inputTokenPrice: 1_000_000,
         outputTokenPrice: 1_000_000,
         modelProvider: "anthropic-api-key",
       });
 
-      // Insert usage with matching provider — should be charged
       const chargedId = await insertTestCreditUsage(user.orgId, {
         userId: user.userId,
         model: "gpt-4",
@@ -191,7 +207,6 @@ describe("credit-service", () => {
         outputTokens: 100,
       });
 
-      // Insert usage with different provider — no charge
       const freeId = await insertTestCreditUsage(user.orgId, {
         userId: user.userId,
         model: "gpt-4",
@@ -200,7 +215,8 @@ describe("credit-service", () => {
         outputTokens: 100,
       });
 
-      await processOrgCredits(user.orgId);
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
 
       const charged = await findTestCreditUsage(chargedId);
       expect(charged!.status).toBe("processed");
@@ -210,7 +226,6 @@ describe("credit-service", () => {
       expect(free!.status).toBe("processed");
       expect(free!.creditsCharged).toBe(0);
 
-      // Only charged record (200 credits) should be deducted
       const credits = await getOrgCredits(user.orgId);
       expect(credits).toBe(9800);
     });
@@ -228,35 +243,28 @@ describe("credit-service", () => {
         outputTokens: 100,
       });
 
-      // Run two concurrent calls
       await Promise.all([
-        processOrgCredits(user.orgId),
-        processOrgCredits(user.orgId),
+        GET(cronRequest("test-cron-secret")),
+        GET(cronRequest("test-cron-secret")),
       ]);
 
-      // Record should be processed exactly once
       const record = await findTestCreditUsage(usageId);
       expect(record!.status).toBe("processed");
       expect(record!.creditsCharged).toBe(200);
 
-      // Credits should be deducted exactly once
       const credits = await getOrgCredits(user.orgId);
       expect(credits).toBe(9800);
     });
-  });
 
-  describe("processStaleCredits", () => {
     it("finds and processes all orgs with pending records", async () => {
       await insertTestCreditPricing("gpt-4", {
         inputTokenPrice: 1_000_000,
         outputTokenPrice: 1_000_000,
       });
 
-      // Create a second org
       const org2Id = uniqueId("org");
       await insertOrgCacheEntry({ orgId: org2Id, slug: uniqueId("slug") });
 
-      // Insert records for both orgs
       const id1 = await insertTestCreditUsage(user.orgId, {
         userId: user.userId,
         model: "gpt-4",
@@ -270,16 +278,81 @@ describe("credit-service", () => {
         outputTokens: 0,
       });
 
-      const count = await processStaleCredits();
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
 
-      // At least 2 orgs processed (may include leftover records from other tests)
-      expect(count).toBeGreaterThanOrEqual(2);
+      const data = await response.json();
+      expect(data.processed).toBeGreaterThanOrEqual(2);
 
       const record1 = await findTestCreditUsage(id1);
       expect(record1!.status).toBe("processed");
 
       const record2 = await findTestCreditUsage(id2);
       expect(record2!.status).toBe("processed");
+    });
+  });
+
+  describe("member cap evaluation", () => {
+    it("disables member when usage exceeds cap after credit processing", async () => {
+      const periodEnd = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000);
+      await updateOrgStripeFields(user.orgId, { currentPeriodEnd: periodEnd });
+
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: true,
+      });
+
+      // Set up pricing so the usage will exceed the 100-credit cap
+      await insertTestCreditPricing("gpt-4", {
+        inputTokenPrice: 1_000_000,
+        outputTokenPrice: 1_000_000,
+      });
+
+      // 200 input + 200 output = 400 credits, exceeding the 100 cap
+      await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "gpt-4",
+        inputTokens: 200,
+        outputTokens: 200,
+      });
+
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
+
+      const member = await getOrgMembersEntry(user.orgId, user.userId);
+      expect(member?.creditEnabled).toBe(false);
+    });
+
+    it("skips already-disabled members", async () => {
+      const periodEnd = new Date(Date.now() + 15 * 24 * 60 * 60 * 1000);
+      await updateOrgStripeFields(user.orgId, { currentPeriodEnd: periodEnd });
+
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: false,
+      });
+
+      await insertTestCreditPricing("gpt-4", {
+        inputTokenPrice: 1_000_000,
+        outputTokenPrice: 1_000_000,
+      });
+
+      await insertTestCreditUsage(user.orgId, {
+        userId: user.userId,
+        model: "gpt-4",
+        inputTokens: 200,
+        outputTokens: 200,
+      });
+
+      const response = await GET(cronRequest("test-cron-secret"));
+      expect(response.status).toBe(200);
+
+      const member = await getOrgMembersEntry(user.orgId, user.userId);
+      expect(member?.creditEnabled).toBe(false);
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -11,6 +11,8 @@ import {
   grantCreditsToOrg,
   updateOrgAutoRecharge,
   getOrgAutoRechargeFields,
+  insertOrgMembersEntry,
+  getOrgMembersEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
 import type { StripeMockFns } from "../../../../../src/__tests__/stripe-mock";
 import { reloadEnv } from "../../../../../src/env";
@@ -368,6 +370,42 @@ describe("POST /api/webhooks/stripe", () => {
       // Pending flag should be cleared
       const autoRecharge = await getOrgAutoRechargeFields(user.orgId);
       expect(autoRecharge?.autoRechargePendingAt).toBeNull();
+    });
+
+    it("resets disabled member credit flags on invoice.paid", async () => {
+      const cusId = uniqueId("cus-reset");
+      const subId = uniqueId("sub-reset");
+      const invId = uniqueId("inv-reset");
+
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+        stripeSubscriptionId: subId,
+      });
+
+      // Insert a disabled member
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: false,
+      });
+
+      stripeMocks.subscriptionsRetrieve.mockResolvedValue({
+        id: subId,
+        items: { data: [{ price: { id: TEST_PRICE_PRO } }] },
+      });
+
+      const response = await sendWebhookEvent("invoice.paid", {
+        id: invId,
+        customer: cusId,
+        parent: { subscription_details: { subscription: subId } },
+      });
+
+      expect(response.status).toBe(200);
+
+      // Member should be re-enabled after invoice.paid
+      const member = await getOrgMembersEntry(user.orgId, user.userId);
+      expect(member?.creditEnabled).toBe(true);
     });
   });
 

--- a/turbo/apps/web/app/api/zero/org/members/credit-cap/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/members/credit-cap/__tests__/route.test.ts
@@ -42,6 +42,13 @@ describe("/api/zero/org/members/credit-cap", () => {
   }
 
   describe("GET", () => {
+    it("returns 401 for unauthenticated request", async () => {
+      mockClerk({ userId: null });
+      const request = createTestRequest(`${BASE_URL}?userId=${user.userId}`);
+      const response = await GET(request);
+      expect(response.status).toBe(401);
+    });
+
     it("returns default cap state (null cap, enabled)", async () => {
       const request = createTestRequest(`${BASE_URL}?userId=${user.userId}`);
       const response = await GET(request);


### PR DESCRIPTION
## Summary
- Migrate all 9 credit-service tests from service-level (`processOrgCredits`/`processStaleCredits`) to route-level integration tests via `GET /api/cron/process-credits`
- Add 2 new tests for `evaluateMemberCaps` coverage (disables member over cap, skips already-disabled)
- Add 2 cron auth tests (missing/wrong secret returns 401)
- Add 1 auth test to `credit-cap/route.test.ts` for the `isAuthError` branch
- Add 1 Stripe webhook test for `resetMemberCreditFlags` in `invoice.paid` flow
- Delete old `credit-service.test.ts`

## Test plan
- [x] All 13 cron route tests pass
- [x] All 9 credit-cap route tests pass (including new auth test)
- [x] All 15 Stripe webhook tests pass (including new reset test)
- [x] Full test suite passes (389 files, 4168 tests)
- [x] Lint, type-check, format, knip all pass

Closes #6196

🤖 Generated with [Claude Code](https://claude.com/claude-code)