### PR TITLE
test(platform): cover missing navigation paths from refactor PR #6185

### DIFF
--- a/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function mockQueuePage() {
+  server.use(
+    http.get("*/api/zero/runs/queue", () => {
+      return HttpResponse.json({
+        concurrency: { tier: "free", limit: 2, active: 1, available: 1 },
+        runningTasks: [
+          {
+            runId: "run_link_1",
+            agentName: "link-agent",
+            agentDisplayName: "Link Agent",
+            userEmail: "me@test.com",
+            startedAt: new Date().toISOString(),
+            isOwner: true,
+          },
+        ],
+        queue: [],
+        estimatedTimePerRun: null,
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("link component new-tab behavior", () => {
+  it("should open new tab on ctrl+click instead of navigating via pushState", async () => {
+    mockQueuePage();
+
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    await setupPage({ context, path: "/queue" });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("Link Agent")).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // The "View logs" link is a Link component — ctrl+click should open new tab
+    const viewLogsLink = screen.getByText("View logs");
+    fireEvent.click(viewLogsLink, { ctrlKey: true });
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/activity/run_link_1"),
+        "_blank",
+      );
+    });
+
+    openSpy.mockRestore();
+  }, 15_000);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-session-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-session-navigation.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { pathname, search } from "../../../signals/location.ts";
+
+const context = testContext();
+
+function mockChatSessionAPIs() {
+  server.use(
+    http.get("*/api/zero/chat-threads/:id", () => {
+      return HttpResponse.json({
+        id: "session-thread-1",
+        title: "Session navigation test",
+        agentComposeId: "mock-compose-id",
+        chatMessages: [
+          {
+            role: "user",
+            content: "Run the task",
+            createdAt: "2026-03-10T00:00:00Z",
+          },
+          {
+            role: "assistant",
+            content: "Task is running.",
+            createdAt: "2026-03-10T00:00:01Z",
+          },
+        ],
+        latestSessionId: "session-wrapper-1",
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:01Z",
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("chat session page wrapper navigation", () => {
+  it("should navigate to agent schedule when clicking schedule button", async () => {
+    mockChatSessionAPIs();
+
+    await setupPage({ context, path: "/chat/session-thread-1" });
+
+    // Wait for chat messages to render
+    await waitFor(
+      () => {
+        expect(screen.getByText("Task is running.")).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // Click the schedule button in the session header
+    const scheduledButton = screen.getByLabelText("Scheduled");
+    fireEvent.click(scheduledButton);
+
+    // Verify navigation to /team/zero with tab=schedule
+    await waitFor(() => {
+      expect(pathname()).toBe("/team/zero");
+      expect(search()).toContain("tab=schedule");
+    });
+  }, 15_000);
+
+  it("should navigate to agent profile when clicking chat avatar", async () => {
+    mockChatSessionAPIs();
+
+    await setupPage({ context, path: "/chat/session-thread-1" });
+
+    // Wait for chat messages to render
+    await waitFor(
+      () => {
+        expect(screen.getByText("Task is running.")).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // Click the avatar button in the session header
+    const avatarButton = screen.getByLabelText("View agent profile");
+    fireEvent.click(avatarButton);
+
+    // Verify navigation to /team/zero (no tab param)
+    await waitFor(() => {
+      expect(pathname()).toBe("/team/zero");
+    });
+  }, 15_000);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-navigation.test.tsx
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+function mockOnboardingNeededAdmin() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: false,
+        defaultAgentName: null,
+        defaultAgentComposeId: null,
+        defaultAgentMetadata: null,
+        defaultAgentSkills: [],
+      });
+    }),
+    // Mock the agent creation endpoint
+    http.post("*/api/zero/agents", () => {
+      return HttpResponse.json({
+        name: "zero",
+        agentComposeId: "new-compose-id",
+      });
+    }),
+    // Mock instructions upload
+    http.put("*/api/zero/agents/:name/instructions", () => {
+      return HttpResponse.json({ success: true });
+    }),
+    // Mock setting default agent
+    http.put("*/api/zero/default-agent", () => {
+      return HttpResponse.json({ success: true });
+    }),
+    // Mock chat threads for the home page
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    // Mock chat send for the auto-intro message
+    http.post("*/api/zero/chat", () => {
+      return HttpResponse.json({ threadId: "new-thread-1" });
+    }),
+  );
+}
+
+function mockOnboardingNeededMember() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: false,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentName: "zero",
+        defaultAgentComposeId: "mock-compose-id",
+        defaultAgentMetadata: null,
+        defaultAgentSkills: [],
+      });
+    }),
+    // Mock complete member onboarding
+    http.post("*/api/zero/onboarding/complete", () => {
+      return HttpResponse.json({ success: true });
+    }),
+    // Mock chat threads for the home page
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    // Mock chat send for the auto-intro message
+    http.post("*/api/zero/chat", () => {
+      return HttpResponse.json({ threadId: "new-thread-1" });
+    }),
+  );
+}
+
+describe("onboarding navigation", () => {
+  it("should navigate to / after completing admin onboarding via web", async () => {
+    mockOnboardingNeededAdmin();
+
+    await setupPage({ context, path: "/" });
+
+    // Step 1: Wait for welcome screen
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(/Meet Zero, your new teammate/),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // Click Next to go to step 3 (connectors)
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Add connector")).toBeInTheDocument();
+    });
+
+    // Click Next to go to step 4 (where to work)
+    fireEvent.click(screen.getAllByRole("button", { name: "Next" })[0]!);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Where would you like to work with/),
+      ).toBeInTheDocument();
+    });
+
+    // Click "Chat with Zero" to trigger handleContinueWithWeb -> navigate("/")
+    const chatWithZeroButton = screen.getByRole("button", {
+      name: /Chat with Zero/,
+    });
+    fireEvent.click(chatWithZeroButton);
+
+    // Verify navigation to /
+    await waitFor(
+      () => {
+        expect(pathname()).toBe("/");
+      },
+      { timeout: 5000 },
+    );
+  }, 15_000);
+
+  it("should navigate to / after completing member onboarding via web", async () => {
+    mockOnboardingNeededMember();
+
+    await setupPage({ context, path: "/" });
+
+    // Step 1: Wait for member welcome screen
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText(/Meet .+, your new teammate/),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // With no defaultAgentSkills, Next goes directly to "where" step
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Where would you like to work with/),
+      ).toBeInTheDocument();
+    });
+
+    // Click "Chat with zero" to trigger handleContinueWeb -> navigate("/")
+    const chatButton = screen.getByRole("button", {
+      name: /Chat with zero/i,
+    });
+    fireEvent.click(chatButton);
+
+    // Verify navigation to /
+    await waitFor(
+      () => {
+        expect(pathname()).toBe("/");
+      },
+      { timeout: 5000 },
+    );
+  }, 15_000);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+function mockSubagentAPIs() {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json({
+        composes: [
+          {
+            id: "mock-compose-id",
+            name: "zero",
+            displayName: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+            isOwner: true,
+          },
+          {
+            id: "subagent-compose-id",
+            name: "helper",
+            displayName: "Helper Bot",
+            headVersionId: "version_2",
+            updatedAt: "2024-01-01T00:00:00Z",
+            isOwner: true,
+          },
+        ],
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({
+        threads: [
+          {
+            id: "thread-sub-1",
+            title: "Subagent thread",
+            preview: "Hello from subagent",
+            agentComposeId: "subagent-compose-id",
+            createdAt: "2026-03-10T00:00:00Z",
+            updatedAt: "2026-03-10T00:00:00Z",
+          },
+        ],
+      });
+    }),
+    http.get("*/api/zero/chat-threads/:id", () => {
+      return HttpResponse.json({
+        id: "thread-sub-1",
+        title: "Subagent thread",
+        agentComposeId: "subagent-compose-id",
+        chatMessages: [
+          {
+            role: "user",
+            content: "Hello from subagent",
+            createdAt: "2026-03-10T00:00:00Z",
+          },
+          {
+            role: "assistant",
+            content: "Hi, I am Helper Bot!",
+            createdAt: "2026-03-10T00:00:01Z",
+          },
+        ],
+        latestSessionId: "session-sub-1",
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:01Z",
+      });
+    }),
+  );
+}
+
+describe("sidebar new chat navigation", () => {
+  it("should navigate to / when clicking new chat for default agent", async () => {
+    mockSubagentAPIs();
+
+    // Start on /team so the "new chat" button navigates away
+    await setupPage({ context, path: "/team" });
+
+    // Wait for the sidebar to render with the new chat button
+    const newChatButton = await waitFor(
+      () => {
+        return screen.getByLabelText("New chat with Zero");
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(newChatButton);
+
+    // Verify navigation to /
+    await waitFor(() => {
+      expect(pathname()).toBe("/");
+    });
+  }, 15_000);
+
+  it("should navigate to /talk/:name when clicking new chat for a subagent", async () => {
+    mockSubagentAPIs();
+
+    await setupPage({ context, path: "/talk/helper" });
+
+    // Wait for the subagent chat to load — find the new chat button for the subagent
+    const newChatButton = await waitFor(
+      () => {
+        return screen.getByLabelText("New chat with Helper Bot");
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(newChatButton);
+
+    // Verify navigation to /talk/helper
+    await waitFor(() => {
+      expect(pathname()).toBe("/talk/helper");
+    });
+  }, 15_000);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-app-shell-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-app-shell-navigation.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+function mockChatAPIs() {
+  server.use(
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("zero-app-shell content navigation handlers", () => {
+  it("should navigate to agent profile when clicking chat avatar on landing page", async () => {
+    mockChatAPIs();
+
+    await setupPage({ context, path: "/" });
+
+    // On the landing page the avatar button triggers handleChatAvatarClick
+    const avatarButton = await waitFor(
+      () => {
+        return screen.getByLabelText("View agent profile");
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(avatarButton);
+
+    // handleChatAvatarClick -> navigateTo("/team/:name", { pathParams: { name: "zero" } })
+    await waitFor(() => {
+      expect(pathname()).toBe("/team/zero");
+    });
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary
- Add 5 integration test files covering uncovered `navigateTo$` call sites from the navigation refactor PR #6185
- Tests cover: avatar click navigation in `zero-app-shell`, schedule/avatar navigation in `zero-chat-session-page-wrapper`, admin/member onboarding web continuation in `zero-onboarding`, default/subagent new-chat in `zero-sidebar`, and ctrl+click new-tab behavior in `link.tsx`
- All 8 new test cases verify end-to-end navigation by rendering the full app and asserting pathname changes

## Test plan
- [x] All 501 platform tests pass (67 test files, 0 failures)
- [x] Lint passes (oxlint + eslint)
- [x] Type check passes (tsc --noEmit)
- [x] Format check passes (prettier)
- [x] Knip passes (no unused exports/dependencies)

Closes #6203

🤖 Generated with [Claude Code](https://claude.com/claude-code)