### PR TITLE
feat(cli): add vm0 zero secret and variable commands — user-level

### DIFF
--- a/turbo/apps/cli/src/commands/zero/index.ts
+++ b/turbo/apps/cli/src/commands/zero/index.ts
@@ -1,8 +1,12 @@
 import { Command } from "commander";
 import { zeroOrgCommand } from "./org";
 import { agentCommand } from "./agent";
+import { zeroSecretCommand } from "./secret";
+import { zeroVariableCommand } from "./variable";
 
 export const zeroCommand = new Command("zero")
   .description("Zero platform commands")
   .addCommand(zeroOrgCommand)
-  .addCommand(agentCommand);
+  .addCommand(agentCommand)
+  .addCommand(zeroSecretCommand)
+  .addCommand(zeroVariableCommand);

--- a/turbo/apps/cli/src/commands/zero/secret/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/__tests__/delete.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for zero secret delete command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { deleteCommand } from "../delete";
+
+describe("zero secret delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful deletion", () => {
+    it("should delete a secret with --yes flag", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/secrets/:name", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Secret "MY_API_KEY" deleted'),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("non-interactive mode", () => {
+    it("should require --yes flag in non-interactive mode", async () => {
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "MY_API_KEY"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--yes flag is required in non-interactive mode",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/secrets/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Secret not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/secrets/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/secrets/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "MY_API_KEY", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/secret/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/__tests__/list.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Tests for zero secret list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators, getConnectorDerivedNames
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+describe("zero secret list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful list", () => {
+    it("should list secrets with metadata", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({
+            secrets: [
+              {
+                name: "MY_API_KEY",
+                description: "API key for service",
+                type: "user",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                name: "DB_PASSWORD",
+                type: "user",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Secrets");
+      expect(logCalls).toContain("MY_API_KEY");
+      expect(logCalls).toContain("API key for service");
+      expect(logCalls).toContain("DB_PASSWORD");
+      expect(logCalls).toContain("2 secret(s)");
+    });
+
+    it("should show empty state when no secrets exist", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({ secrets: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No secrets found");
+      expect(logCalls).toContain("vm0 zero secret set");
+    });
+  });
+
+  describe("connector secrets", () => {
+    it("should display connector secret with derived env var names", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({
+            secrets: [
+              {
+                name: "GITHUB_ACCESS_TOKEN",
+                type: "connector",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("GITHUB_ACCESS_TOKEN");
+      expect(logCalls).toContain("[GitHub connector]");
+      expect(logCalls).toContain("Available as: GH_TOKEN, GITHUB_TOKEN");
+    });
+
+    it("should display connector secret without derived names when no mapping found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({
+            secrets: [
+              {
+                name: "UNKNOWN_CONNECTOR_SECRET",
+                type: "connector",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("UNKNOWN_CONNECTOR_SECRET");
+      expect(logCalls).toContain("[connector]");
+      expect(logCalls).not.toContain("Available as:");
+    });
+
+    it("should display model-provider type indicator", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({
+            secrets: [
+              {
+                name: "ANTHROPIC_API_KEY",
+                type: "model-provider",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("ANTHROPIC_API_KEY");
+      expect(logCalls).toContain("[model-provider]");
+    });
+
+    it("should display mixed secret types correctly", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json({
+            secrets: [
+              {
+                name: "MY_API_KEY",
+                description: "User secret",
+                type: "user",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                name: "ANTHROPIC_API_KEY",
+                type: "model-provider",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                name: "GITHUB_ACCESS_TOKEN",
+                type: "connector",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("MY_API_KEY");
+      expect(logCalls).not.toContain("MY_API_KEY [");
+      expect(logCalls).toContain("[model-provider]");
+      expect(logCalls).toContain("[GitHub connector]");
+      expect(logCalls).toContain("Available as: GH_TOKEN, GITHUB_TOKEN");
+      expect(logCalls).toContain("Total: 3 secret(s)");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("alias", () => {
+    it("should have ls alias", () => {
+      expect(listCommand.alias()).toBe("ls");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/secret/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/__tests__/set.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for zero secret set command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { setCommand } from "../set";
+import chalk from "chalk";
+
+describe("zero secret set command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful set", () => {
+    it("should set a secret with --body flag", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              name: "MY_API_KEY",
+              updatedAt: "2025-01-01T00:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "MY_API_KEY",
+        "--body",
+        "secret-value",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('Secret "MY_API_KEY" saved');
+      expect(logCalls).toContain("secrets.MY_API_KEY");
+    });
+
+    it("should set a secret with --body and --description", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/secrets",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              {
+                name: "MY_API_KEY",
+                description: "API key for external service",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "MY_API_KEY",
+        "--body",
+        "secret-value",
+        "--description",
+        "API key for external service",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        name: "MY_API_KEY",
+        value: "secret-value",
+        description: "API key for external service",
+      });
+    });
+  });
+
+  describe("non-interactive mode", () => {
+    it("should require --body flag in non-interactive mode", async () => {
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_API_KEY"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("required in non-interactive mode"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("input validation", () => {
+    it("should show helpful hint for invalid secret name", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message:
+                  "Name must contain only uppercase letters, digits, and underscores",
+                code: "BAD_REQUEST",
+              },
+            },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "my-invalid-key",
+          "--body",
+          "value",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("must contain only uppercase"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("MY_API_KEY"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "MY_API_KEY",
+          "--body",
+          "value",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/secrets", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync([
+          "node",
+          "cli",
+          "MY_API_KEY",
+          "--body",
+          "value",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/secret/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/delete.ts
@@ -1,0 +1,33 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { deleteZeroSecret } from "../../../lib/api";
+import { isInteractive, promptConfirm } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const deleteCommand = new Command()
+  .name("delete")
+  .description("Delete a secret")
+  .argument("<name>", "Secret name to delete")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
+      if (!options.yes) {
+        if (!isInteractive()) {
+          throw new Error("--yes flag is required in non-interactive mode");
+        }
+
+        const confirmed = await promptConfirm(
+          `Are you sure you want to delete secret "${name}"?`,
+          false,
+        );
+
+        if (!confirmed) {
+          console.log(chalk.dim("Cancelled"));
+          return;
+        }
+      }
+
+      await deleteZeroSecret(name);
+      console.log(chalk.green(`✓ Secret "${name}" deleted`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/secret/index.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/index.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+import { listCommand } from "./list";
+import { setCommand } from "./set";
+import { deleteCommand } from "./delete";
+
+export const zeroSecretCommand = new Command()
+  .name("secret")
+  .description("Manage secrets")
+  .addCommand(listCommand)
+  .addCommand(setCommand)
+  .addCommand(deleteCommand);

--- a/turbo/apps/cli/src/commands/zero/secret/list.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/list.ts
@@ -1,0 +1,69 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getConnectorDerivedNames } from "@vm0/core";
+import { listZeroSecrets } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all secrets")
+  .action(
+    withErrorHandler(async () => {
+      const result = await listZeroSecrets();
+
+      if (result.secrets.length === 0) {
+        console.log(chalk.dim("No secrets found"));
+        console.log();
+        console.log("To add a secret:");
+        console.log(
+          chalk.cyan("  vm0 zero secret set MY_API_KEY --body <value>"),
+        );
+        return;
+      }
+
+      console.log(chalk.bold("Secrets:"));
+      console.log();
+
+      for (const secret of result.secrets) {
+        let typeIndicator = "";
+        let derivedLine: string | null = null;
+
+        if (secret.type === "model-provider") {
+          typeIndicator = chalk.dim(" [model-provider]");
+        } else if (secret.type === "connector") {
+          const derived = getConnectorDerivedNames(secret.name);
+          if (derived) {
+            typeIndicator = chalk.dim(` [${derived.connectorLabel} connector]`);
+            derivedLine = chalk.dim(
+              `Available as: ${derived.envVarNames.join(", ")}`,
+            );
+          } else {
+            typeIndicator = chalk.dim(" [connector]");
+          }
+        } else if (secret.type === "user") {
+          const derived = getConnectorDerivedNames(secret.name);
+          if (derived) {
+            typeIndicator = chalk.dim(` [${derived.connectorLabel} connector]`);
+            derivedLine = chalk.dim(
+              `Available as: ${derived.envVarNames.join(", ")}`,
+            );
+          }
+        }
+
+        console.log(`  ${chalk.cyan(secret.name)}${typeIndicator}`);
+        if (derivedLine) {
+          console.log(`    ${derivedLine}`);
+        }
+        if (secret.description) {
+          console.log(`    ${chalk.dim(secret.description)}`);
+        }
+        console.log(
+          `    ${chalk.dim(`Updated: ${new Date(secret.updatedAt).toLocaleString()}`)}`,
+        );
+        console.log();
+      }
+
+      console.log(chalk.dim(`Total: ${result.secrets.length} secret(s)`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/secret/set.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/set.ts
@@ -1,0 +1,68 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { setZeroSecret } from "../../../lib/api";
+import { isInteractive, promptPassword } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const setCommand = new Command()
+  .name("set")
+  .description("Create or update a secret")
+  .argument("<name>", "Secret name (uppercase, e.g., MY_API_KEY)")
+  .option(
+    "-b, --body <value>",
+    "Secret value (required in non-interactive mode)",
+  )
+  .option("-d, --description <description>", "Optional description")
+  .action(
+    withErrorHandler(
+      async (
+        name: string,
+        options: { body?: string; description?: string },
+      ) => {
+        let value: string;
+
+        if (options.body !== undefined) {
+          value = options.body;
+        } else if (isInteractive()) {
+          const prompted = await promptPassword("Enter secret value:");
+          if (prompted === undefined) {
+            process.exit(0);
+          }
+          value = prompted;
+        } else {
+          throw new Error("--body is required in non-interactive mode", {
+            cause: new Error(
+              `Usage: vm0 zero secret set ${name} --body "your-secret-value"`,
+            ),
+          });
+        }
+
+        let secret;
+        try {
+          secret = await setZeroSecret({
+            name,
+            value,
+            description: options.description,
+          });
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes("must contain only uppercase")
+          ) {
+            throw new Error(error.message, {
+              cause: new Error(
+                "Examples of valid secret names: MY_API_KEY, GITHUB_TOKEN, AWS_ACCESS_KEY_ID",
+              ),
+            });
+          }
+          throw error;
+        }
+
+        console.log(chalk.green(`✓ Secret "${secret.name}" saved`));
+        console.log();
+        console.log("Use in vm0.yaml:");
+        console.log(chalk.cyan(`  environment:`));
+        console.log(chalk.cyan(`    ${name}: \${{ secrets.${name} }}`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/variable/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/variable/__tests__/delete.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for zero variable delete command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { deleteCommand } from "../delete";
+
+describe("zero variable delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful deletion", () => {
+    it("should delete a variable with --yes flag", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/variables/:name", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Variable "MY_VAR" deleted'),
+      );
+      expect(mockExit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("non-interactive mode", () => {
+    it("should require --yes flag in non-interactive mode", async () => {
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "MY_VAR"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--yes flag is required in non-interactive mode",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/variables/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Variable not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/variables/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.delete("http://localhost:3000/api/zero/variables/:name", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "MY_VAR", "--yes"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/variable/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/variable/__tests__/list.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for zero variable list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+describe("zero variable list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful list", () => {
+    it("should list variables with values", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json({
+            variables: [
+              {
+                name: "API_URL",
+                value: "https://api.example.com",
+                description: "External API endpoint",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                name: "DEBUG_MODE",
+                value: "true",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Variables");
+      expect(logCalls).toContain("API_URL");
+      expect(logCalls).toContain("https://api.example.com");
+      expect(logCalls).toContain("External API endpoint");
+      expect(logCalls).toContain("DEBUG_MODE");
+      expect(logCalls).toContain("2 variable(s)");
+    });
+
+    it("should show empty state when no variables exist", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json({ variables: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No variables found");
+      expect(logCalls).toContain("vm0 zero variable set");
+    });
+
+    it("should truncate long values", async () => {
+      const longValue = "a".repeat(100);
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json({
+            variables: [
+              {
+                name: "LONG_VAR",
+                value: longValue,
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("... [truncated]");
+      expect(logCalls).not.toContain(longValue);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("alias", () => {
+    it("should have ls alias", () => {
+      expect(listCommand.alias()).toBe("ls");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/variable/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/variable/__tests__/set.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for zero variable set command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { setCommand } from "../set";
+import chalk from "chalk";
+
+describe("zero variable set command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful set", () => {
+    it("should set a variable with positional value", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              name: "MY_VAR",
+              value: "my-value",
+              updatedAt: "2025-01-01T00:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setCommand.parseAsync(["node", "cli", "MY_VAR", "my-value"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('Variable "MY_VAR" saved');
+      expect(logCalls).toContain("vars.MY_VAR");
+    });
+
+    it("should set a variable with --description", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/variables",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(
+              {
+                name: "API_URL",
+                value: "https://api.example.com",
+                description: "External API endpoint",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              { status: 201 },
+            );
+          },
+        ),
+      );
+
+      await setCommand.parseAsync([
+        "node",
+        "cli",
+        "API_URL",
+        "https://api.example.com",
+        "--description",
+        "External API endpoint",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        name: "API_URL",
+        value: "https://api.example.com",
+        description: "External API endpoint",
+      });
+    });
+  });
+
+  describe("input validation", () => {
+    it("should show helpful hint for invalid variable name", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message:
+                  "Name must contain only uppercase letters, digits, and underscores",
+                code: "BAD_REQUEST",
+              },
+            },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "my-invalid-var", "value"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("must contain only uppercase"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("MY_VAR"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_VAR", "value"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle generic API error", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/variables", () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Internal server error",
+                code: "SERVER_ERROR",
+              },
+            },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setCommand.parseAsync(["node", "cli", "MY_VAR", "value"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Internal server error"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/variable/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/variable/delete.ts
@@ -1,0 +1,33 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { deleteZeroVariable } from "../../../lib/api";
+import { isInteractive, promptConfirm } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const deleteCommand = new Command()
+  .name("delete")
+  .description("Delete a variable")
+  .argument("<name>", "Variable name to delete")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
+      if (!options.yes) {
+        if (!isInteractive()) {
+          throw new Error("--yes flag is required in non-interactive mode");
+        }
+
+        const confirmed = await promptConfirm(
+          `Are you sure you want to delete variable "${name}"?`,
+          false,
+        );
+
+        if (!confirmed) {
+          console.log(chalk.dim("Cancelled"));
+          return;
+        }
+      }
+
+      await deleteZeroVariable(name);
+      console.log(chalk.green(`✓ Variable "${name}" deleted`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/variable/index.ts
+++ b/turbo/apps/cli/src/commands/zero/variable/index.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+import { listCommand } from "./list";
+import { setCommand } from "./set";
+import { deleteCommand } from "./delete";
+
+export const zeroVariableCommand = new Command()
+  .name("variable")
+  .description("Manage variables")
+  .addCommand(listCommand)
+  .addCommand(setCommand)
+  .addCommand(deleteCommand);

--- a/turbo/apps/cli/src/commands/zero/variable/list.ts
+++ b/turbo/apps/cli/src/commands/zero/variable/list.ts
@@ -1,0 +1,49 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listZeroVariables } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+/**
+ * Truncate value for display if too long
+ */
+function truncateValue(value: string, maxLength: number = 60): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(0, maxLength - 15) + "... [truncated]";
+}
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all variables")
+  .action(
+    withErrorHandler(async () => {
+      const result = await listZeroVariables();
+
+      if (result.variables.length === 0) {
+        console.log(chalk.dim("No variables found"));
+        console.log();
+        console.log("To add a variable:");
+        console.log(chalk.cyan("  vm0 zero variable set MY_VAR <value>"));
+        return;
+      }
+
+      console.log(chalk.bold("Variables:"));
+      console.log();
+
+      for (const variable of result.variables) {
+        const displayValue = truncateValue(variable.value);
+        console.log(`  ${chalk.cyan(variable.name)} = ${displayValue}`);
+        if (variable.description) {
+          console.log(`    ${chalk.dim(variable.description)}`);
+        }
+        console.log(
+          `    ${chalk.dim(`Updated: ${new Date(variable.updatedAt).toLocaleString()}`)}`,
+        );
+        console.log();
+      }
+
+      console.log(chalk.dim(`Total: ${result.variables.length} variable(s)`));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/variable/set.ts
+++ b/turbo/apps/cli/src/commands/zero/variable/set.ts
@@ -1,0 +1,47 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { setZeroVariable } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const setCommand = new Command()
+  .name("set")
+  .description("Create or update a variable")
+  .argument("<name>", "Variable name (uppercase, e.g., MY_VAR)")
+  .argument("<value>", "Variable value")
+  .option("-d, --description <description>", "Optional description")
+  .action(
+    withErrorHandler(
+      async (
+        name: string,
+        value: string,
+        options: { description?: string },
+      ) => {
+        let variable;
+        try {
+          variable = await setZeroVariable({
+            name,
+            value,
+            description: options.description,
+          });
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes("must contain only uppercase")
+          ) {
+            throw new Error(error.message, {
+              cause: new Error(
+                "Examples of valid variable names: MY_VAR, API_URL, DEBUG_MODE",
+              ),
+            });
+          }
+          throw error;
+        }
+
+        console.log(chalk.green(`✓ Variable "${variable.name}" saved`));
+        console.log();
+        console.log("Use in vm0.yaml:");
+        console.log(chalk.cyan(`  environment:`));
+        console.log(chalk.cyan(`    ${name}: \${{ vars.${name} }}`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-secrets.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-secrets.ts
@@ -1,0 +1,58 @@
+import { initClient } from "@ts-rest/core";
+import { zeroSecretsContract, zeroSecretsByNameContract } from "@vm0/core";
+import type { SecretResponse, SecretListResponse } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+/**
+ * List user-level secrets via zero API (metadata only, no values)
+ */
+export async function listZeroSecrets(): Promise<SecretListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSecretsContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list secrets");
+}
+
+/**
+ * Set (create or update) a user-level secret via zero API
+ */
+export async function setZeroSecret(body: {
+  name: string;
+  value: string;
+  description?: string;
+}): Promise<SecretResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSecretsContract, config);
+
+  const result = await client.set({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set secret");
+}
+
+/**
+ * Delete a user-level secret by name via zero API
+ */
+export async function deleteZeroSecret(name: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSecretsByNameContract, config);
+
+  const result = await client.delete({
+    params: { name },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Secret "${name}" not found`);
+}

--- a/turbo/apps/cli/src/lib/api/domains/zero-variables.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-variables.ts
@@ -1,0 +1,58 @@
+import { initClient } from "@ts-rest/core";
+import { zeroVariablesContract, zeroVariablesByNameContract } from "@vm0/core";
+import type { VariableResponse, VariableListResponse } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+/**
+ * List user-level variables via zero API (includes values)
+ */
+export async function listZeroVariables(): Promise<VariableListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVariablesContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list variables");
+}
+
+/**
+ * Set (create or update) a user-level variable via zero API
+ */
+export async function setZeroVariable(body: {
+  name: string;
+  value: string;
+  description?: string;
+}): Promise<VariableResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVariablesContract, config);
+
+  const result = await client.set({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to set variable");
+}
+
+/**
+ * Delete a user-level variable by name via zero API
+ */
+export async function deleteZeroVariable(name: string): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVariablesByNameContract, config);
+
+  const result = await client.delete({
+    params: { name },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Variable "${name}" not found`);
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -125,6 +125,20 @@ export {
   deleteZeroOrg,
 } from "./domains/zero-orgs";
 
+// Domain modules - Zero Secrets
+export {
+  listZeroSecrets,
+  setZeroSecret,
+  deleteZeroSecret,
+} from "./domains/zero-secrets";
+
+// Domain modules - Zero Variables
+export {
+  listZeroVariables,
+  setZeroVariable,
+  deleteZeroVariable,
+} from "./domains/zero-variables";
+
 // Domain modules - Zero Org Secrets
 export {
   listZeroOrgSecrets,


### PR DESCRIPTION
## Summary

- Add `vm0 zero secret` command group (list, set, delete) for user-level secrets via zero API
- Add `vm0 zero variable` command group (list, set, delete) for user-level variables via zero API
- Secret list includes connector-derived name display (type indicators + available env var names)
- Delete commands handle 404 directly from API without pre-checking existence

## Changes

**New files (16):**
- API domain modules: `zero-secrets.ts`, `zero-variables.ts`
- Secret commands: `index.ts`, `list.ts`, `set.ts`, `delete.ts` + 3 test files
- Variable commands: `index.ts`, `list.ts`, `set.ts`, `delete.ts` + 3 test files

**Modified files (2):**
- `commands/zero/index.ts` — register new command groups
- `lib/api/index.ts` — export new domain functions

## Test plan

- [x] 36 new integration tests covering all commands (list, set, delete for both secret and variable)
- [x] Connector-derived names display tested (GitHub connector, unknown connector, model-provider, mixed types)
- [x] Error handling tested (401, 404, 500)
- [x] Non-interactive mode enforcement tested
- [x] All 997 existing CLI tests pass (no regressions)
- [x] Lint, type-check, format, knip all pass

Closes #6210

🤖 Generated with [Claude Code](https://claude.com/claude-code)