### PR TITLE
feat(cli): add vm0 zero schedule commands

### DIFF
--- a/turbo/apps/cli/src/commands/zero/index.ts
+++ b/turbo/apps/cli/src/commands/zero/index.ts
@@ -1,8 +1,10 @@
 import { Command } from "commander";
 import { zeroOrgCommand } from "./org";
 import { agentCommand } from "./agent";
+import { zeroScheduleCommand } from "./schedule";
 
 export const zeroCommand = new Command("zero")
   .description("Zero platform commands")
   .addCommand(zeroOrgCommand)
-  .addCommand(agentCommand);
+  .addCommand(agentCommand)
+  .addCommand(zeroScheduleCommand);

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/delete.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for zero schedule delete command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { deleteCommand } from "../delete";
+import chalk from "chalk";
+
+const mockSchedule = {
+  id: "sched-001",
+  composeId: "comp-001",
+  composeName: "my-agent",
+  zeroAgentId: "za-001",
+  agentName: "my-agent",
+  orgSlug: "my-org",
+  userId: "user-001",
+  name: "default",
+  triggerType: "cron",
+  cronExpression: "0 9 * * *",
+  atTime: null,
+  intervalSeconds: null,
+  timezone: "UTC",
+  prompt: "run daily check",
+  description: null,
+  appendSystemPrompt: null,
+  vars: null,
+  secretNames: null,
+  artifactName: null,
+  artifactVersion: null,
+  volumeVersions: null,
+  enabled: true,
+  notifyEmail: true,
+  notifySlack: true,
+  nextRunAt: "2026-03-24T09:00:00Z",
+  lastRunAt: null,
+  retryStartedAt: null,
+  consecutiveFailures: 0,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+describe("zero schedule delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful delete", () => {
+    it("should delete with --yes flag without prompting", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [mockSchedule] });
+        }),
+        http.delete("http://localhost:3000/api/zero/schedules/default", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", "my-agent", "--yes"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Deleted");
+      expect(logCalls).toContain("my-agent");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle no schedule found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync([
+          "node",
+          "cli",
+          "missing-agent",
+          "--yes",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No schedule found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --yes in non-interactive mode", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [mockSchedule] });
+        }),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync(["node", "cli", "my-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--yes flag is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/disable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/disable.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for zero schedule disable command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { disableCommand } from "../disable";
+import chalk from "chalk";
+
+const mockSchedule = {
+  id: "sched-001",
+  composeId: "comp-001",
+  composeName: "my-agent",
+  zeroAgentId: "za-001",
+  agentName: "my-agent",
+  orgSlug: "my-org",
+  userId: "user-001",
+  name: "default",
+  triggerType: "cron",
+  cronExpression: "0 9 * * *",
+  atTime: null,
+  intervalSeconds: null,
+  timezone: "UTC",
+  prompt: "run daily check",
+  description: null,
+  appendSystemPrompt: null,
+  vars: null,
+  secretNames: null,
+  artifactName: null,
+  artifactVersion: null,
+  volumeVersions: null,
+  enabled: false,
+  notifyEmail: true,
+  notifySlack: true,
+  nextRunAt: null,
+  lastRunAt: null,
+  retryStartedAt: null,
+  consecutiveFailures: 0,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+describe("zero schedule disable command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful disable", () => {
+    it("should disable a schedule", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({
+            schedules: [{ ...mockSchedule, enabled: true }],
+          });
+        }),
+        http.post(
+          "http://localhost:3000/api/zero/schedules/default/disable",
+          () => {
+            return HttpResponse.json(mockSchedule);
+          },
+        ),
+      );
+
+      await disableCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Disabled");
+      expect(logCalls).toContain("my-agent");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle no schedule found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await disableCommand.parseAsync(["node", "cli", "missing-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No schedule found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/enable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/enable.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for zero schedule enable command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { enableCommand } from "../enable";
+import chalk from "chalk";
+
+const mockSchedule = {
+  id: "sched-001",
+  composeId: "comp-001",
+  composeName: "my-agent",
+  zeroAgentId: "za-001",
+  agentName: "my-agent",
+  orgSlug: "my-org",
+  userId: "user-001",
+  name: "default",
+  triggerType: "cron",
+  cronExpression: "0 9 * * *",
+  atTime: null,
+  intervalSeconds: null,
+  timezone: "UTC",
+  prompt: "run daily check",
+  description: null,
+  appendSystemPrompt: null,
+  vars: null,
+  secretNames: null,
+  artifactName: null,
+  artifactVersion: null,
+  volumeVersions: null,
+  enabled: true,
+  notifyEmail: true,
+  notifySlack: true,
+  nextRunAt: "2026-03-24T09:00:00Z",
+  lastRunAt: null,
+  retryStartedAt: null,
+  consecutiveFailures: 0,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+describe("zero schedule enable command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful enable", () => {
+    it("should enable a schedule", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [mockSchedule] });
+        }),
+        http.post(
+          "http://localhost:3000/api/zero/schedules/default/enable",
+          () => {
+            return HttpResponse.json(mockSchedule);
+          },
+        ),
+      );
+
+      await enableCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Enabled");
+      expect(logCalls).toContain("my-agent");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle no schedule found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await enableCommand.parseAsync(["node", "cli", "missing-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No schedule found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/list.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for zero schedule list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+const mockSchedule = {
+  id: "sched-001",
+  composeId: "comp-001",
+  composeName: "my-agent",
+  zeroAgentId: "za-001",
+  agentName: "my-agent",
+  orgSlug: "my-org",
+  userId: "user-001",
+  name: "default",
+  triggerType: "cron",
+  cronExpression: "0 9 * * *",
+  atTime: null,
+  intervalSeconds: null,
+  timezone: "UTC",
+  prompt: "run daily check",
+  description: null,
+  appendSystemPrompt: null,
+  vars: null,
+  secretNames: null,
+  artifactName: null,
+  artifactVersion: null,
+  volumeVersions: null,
+  enabled: true,
+  notifyEmail: true,
+  notifySlack: true,
+  nextRunAt: "2026-03-24T09:00:00Z",
+  lastRunAt: null,
+  retryStartedAt: null,
+  consecutiveFailures: 0,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+describe("zero schedule list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful list", () => {
+    it("should display schedules in table format", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [mockSchedule] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("default");
+      expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain("enabled");
+    });
+
+    it("should display empty state message when no schedules", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await listCommand.parseAsync(["node", "cli"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No schedules found");
+      expect(logCalls).toContain("vm0 zero schedule setup");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for zero schedule setup command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { setupCommand } from "../setup";
+import chalk from "chalk";
+
+const mockAgent = {
+  name: "my-agent",
+  agentComposeId: "comp_abc123",
+  displayName: "My Agent",
+  description: null,
+  sound: null,
+  connectors: ["github"],
+};
+
+const mockDeployResponse = {
+  created: true,
+  schedule: {
+    id: "sched-001",
+    composeId: "comp-001",
+    composeName: "my-agent",
+    zeroAgentId: "za-001",
+    agentName: "my-agent",
+    orgSlug: "my-org",
+    userId: "user-001",
+    name: "default",
+    triggerType: "cron",
+    cronExpression: "0 9 * * *",
+    atTime: null,
+    intervalSeconds: null,
+    timezone: "UTC",
+    prompt: "run daily check",
+    description: null,
+    appendSystemPrompt: null,
+    vars: null,
+    secretNames: null,
+    artifactName: "artifact",
+    artifactVersion: null,
+    volumeVersions: null,
+    enabled: false,
+    notifyEmail: true,
+    notifySlack: true,
+    nextRunAt: "2026-03-24T09:00:00Z",
+    lastRunAt: null,
+    retryStartedAt: null,
+    consecutiveFailures: 0,
+    createdAt: "2026-03-23T00:00:00Z",
+    updatedAt: "2026-03-23T00:00:00Z",
+  },
+};
+
+describe("zero schedule setup command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful setup (non-interactive)", () => {
+    it("should create daily schedule with all flags", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+        http.post("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json(mockDeployResponse, { status: 201 });
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--frequency",
+        "daily",
+        "--time",
+        "09:00",
+        "--timezone",
+        "UTC",
+        "--prompt",
+        "run daily check",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Created schedule");
+      expect(logCalls).toContain("my-agent");
+    });
+
+    it("should create loop schedule with interval flag", async () => {
+      const loopResponse = {
+        ...mockDeployResponse,
+        schedule: {
+          ...mockDeployResponse.schedule,
+          triggerType: "loop",
+          cronExpression: null,
+          intervalSeconds: 300,
+          nextRunAt: null,
+        },
+      };
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+        http.post("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json(loopResponse, { status: 201 });
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--frequency",
+        "loop",
+        "--interval",
+        "300",
+        "--prompt",
+        "loop task",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Created schedule");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle agent not found", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/missing", () => {
+          return HttpResponse.json(
+            { error: { message: "Agent not found", code: "NOT_FOUND" } },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "missing",
+          "--frequency",
+          "daily",
+          "--time",
+          "09:00",
+          "--prompt",
+          "test",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --frequency in non-interactive mode", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await setupCommand.parseAsync([
+          "node",
+          "cli",
+          "my-agent",
+          "--prompt",
+          "test",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--frequency is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for zero schedule status command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { statusCommand } from "../status";
+import chalk from "chalk";
+
+const mockSchedule = {
+  id: "sched-001",
+  composeId: "comp-001",
+  composeName: "my-agent",
+  zeroAgentId: "za-001",
+  agentName: "my-agent",
+  orgSlug: "my-org",
+  userId: "user-001",
+  name: "default",
+  triggerType: "cron",
+  cronExpression: "0 9 * * *",
+  atTime: null,
+  intervalSeconds: null,
+  timezone: "UTC",
+  prompt: "run daily check",
+  description: null,
+  appendSystemPrompt: null,
+  vars: null,
+  secretNames: null,
+  artifactName: null,
+  artifactVersion: null,
+  volumeVersions: null,
+  enabled: true,
+  notifyEmail: true,
+  notifySlack: true,
+  nextRunAt: "2026-03-24T09:00:00Z",
+  lastRunAt: null,
+  retryStartedAt: null,
+  consecutiveFailures: 0,
+  createdAt: "2026-03-23T00:00:00Z",
+  updatedAt: "2026-03-23T00:00:00Z",
+};
+
+describe("zero schedule status command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful status", () => {
+    it("should display schedule details", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [mockSchedule] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("enabled");
+      expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain("run daily check");
+    });
+
+    it("should display schedule with --name option", async () => {
+      const secondSchedule = {
+        ...mockSchedule,
+        name: "weekly",
+        cronExpression: "0 9 * * 1",
+      };
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({
+            schedules: [mockSchedule, secondSchedule],
+          });
+        }),
+      );
+
+      await statusCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--name",
+        "weekly",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("0 9 * * 1");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle no schedule found for agent", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "missing-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No schedule found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --name when agent has multiple schedules", async () => {
+      const secondSchedule = { ...mockSchedule, name: "weekly" };
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({
+            schedules: [mockSchedule, secondSchedule],
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await statusCommand.parseAsync(["node", "cli", "my-agent"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("multiple schedules"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/schedule/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/delete.ts
@@ -1,0 +1,52 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  deleteZeroSchedule,
+  resolveZeroScheduleByAgent,
+} from "../../../lib/api";
+import { isInteractive, promptConfirm } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const deleteCommand = new Command()
+  .name("delete")
+  .alias("rm")
+  .description("Delete a zero schedule")
+  .argument("<agent-name>", "Agent name")
+  .option(
+    "-n, --name <schedule-name>",
+    "Schedule name (required when agent has multiple schedules)",
+  )
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    withErrorHandler(
+      async (agentName: string, options: { name?: string; yes?: boolean }) => {
+        const resolved = await resolveZeroScheduleByAgent(
+          agentName,
+          options.name,
+        );
+
+        if (!options.yes) {
+          if (!isInteractive()) {
+            throw new Error("--yes flag is required in non-interactive mode");
+          }
+          const confirmed = await promptConfirm(
+            `Delete schedule for agent ${chalk.cyan(agentName)}?`,
+            false,
+          );
+          if (!confirmed) {
+            console.log(chalk.dim("Cancelled"));
+            return;
+          }
+        }
+
+        await deleteZeroSchedule({
+          name: resolved.name,
+          zeroAgentId: resolved.zeroAgentId,
+        });
+
+        console.log(
+          chalk.green(`✓ Deleted schedule for agent ${chalk.cyan(agentName)}`),
+        );
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/schedule/disable.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/disable.ts
@@ -1,0 +1,33 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  disableZeroSchedule,
+  resolveZeroScheduleByAgent,
+} from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const disableCommand = new Command()
+  .name("disable")
+  .description("Disable a zero schedule")
+  .argument("<agent-name>", "Agent name")
+  .option(
+    "-n, --name <schedule-name>",
+    "Schedule name (required when agent has multiple schedules)",
+  )
+  .action(
+    withErrorHandler(async (agentName: string, options: { name?: string }) => {
+      const resolved = await resolveZeroScheduleByAgent(
+        agentName,
+        options.name,
+      );
+
+      await disableZeroSchedule({
+        name: resolved.name,
+        zeroAgentId: resolved.zeroAgentId,
+      });
+
+      console.log(
+        chalk.green(`✓ Disabled schedule for agent ${chalk.cyan(agentName)}`),
+      );
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/enable.ts
@@ -1,0 +1,33 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  enableZeroSchedule,
+  resolveZeroScheduleByAgent,
+} from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const enableCommand = new Command()
+  .name("enable")
+  .description("Enable a zero schedule")
+  .argument("<agent-name>", "Agent name")
+  .option(
+    "-n, --name <schedule-name>",
+    "Schedule name (required when agent has multiple schedules)",
+  )
+  .action(
+    withErrorHandler(async (agentName: string, options: { name?: string }) => {
+      const resolved = await resolveZeroScheduleByAgent(
+        agentName,
+        options.name,
+      );
+
+      await enableZeroSchedule({
+        name: resolved.name,
+        zeroAgentId: resolved.zeroAgentId,
+      });
+
+      console.log(
+        chalk.green(`✓ Enabled schedule for agent ${chalk.cyan(agentName)}`),
+      );
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/schedule/index.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/index.ts
@@ -1,0 +1,17 @@
+import { Command } from "commander";
+import { setupCommand } from "./setup";
+import { listCommand } from "./list";
+import { statusCommand } from "./status";
+import { deleteCommand } from "./delete";
+import { enableCommand } from "./enable";
+import { disableCommand } from "./disable";
+
+export const zeroScheduleCommand = new Command()
+  .name("schedule")
+  .description("Manage zero agent schedules")
+  .addCommand(setupCommand)
+  .addCommand(listCommand)
+  .addCommand(statusCommand)
+  .addCommand(deleteCommand)
+  .addCommand(enableCommand)
+  .addCommand(disableCommand);

--- a/turbo/apps/cli/src/commands/zero/schedule/list.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/list.ts
@@ -1,0 +1,72 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listZeroSchedules } from "../../../lib/api";
+import { formatRelativeTime } from "../../../lib/domain/schedule-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List all zero schedules")
+  .action(
+    withErrorHandler(async () => {
+      const result = await listZeroSchedules();
+
+      if (result.schedules.length === 0) {
+        console.log(chalk.dim("No schedules found"));
+        console.log(
+          chalk.dim("  Create one with: vm0 zero schedule setup <agent-name>"),
+        );
+        return;
+      }
+
+      const agentWidth = Math.max(
+        5,
+        ...result.schedules.map((s) => s.agentName.length),
+      );
+      const scheduleWidth = Math.max(
+        8,
+        ...result.schedules.map((s) => s.name.length),
+      );
+      const triggerWidth = Math.max(
+        7,
+        ...result.schedules.map((s) =>
+          s.cronExpression
+            ? s.cronExpression.length + s.timezone.length + 3
+            : s.atTime?.length || 0,
+        ),
+      );
+
+      const header = [
+        "AGENT".padEnd(agentWidth),
+        "SCHEDULE".padEnd(scheduleWidth),
+        "TRIGGER".padEnd(triggerWidth),
+        "STATUS".padEnd(8),
+        "NEXT RUN",
+      ].join("  ");
+      console.log(chalk.dim(header));
+
+      for (const schedule of result.schedules) {
+        const trigger = schedule.cronExpression
+          ? `${schedule.cronExpression} (${schedule.timezone})`
+          : schedule.atTime || "-";
+
+        const status = schedule.enabled
+          ? chalk.green("enabled")
+          : chalk.yellow("disabled");
+
+        const nextRun = schedule.enabled
+          ? formatRelativeTime(schedule.nextRunAt)
+          : "-";
+
+        const row = [
+          schedule.agentName.padEnd(agentWidth),
+          schedule.name.padEnd(scheduleWidth),
+          trigger.padEnd(triggerWidth),
+          status.padEnd(8 + (schedule.enabled ? 0 : 2)),
+          nextRun,
+        ].join("  ");
+        console.log(row);
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -1,0 +1,791 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import {
+  isInteractive,
+  promptText,
+  promptSelect,
+  promptConfirm,
+} from "../../../lib/utils/prompt-utils";
+import {
+  generateCronExpression,
+  detectTimezone,
+  validateTimeFormat,
+  validateDateFormat,
+  getTomorrowDateLocal,
+  getCurrentTimeLocal,
+  toISODateTime,
+  type ScheduleFrequency,
+} from "../../../lib/domain/schedule-utils";
+import {
+  getZeroAgent,
+  deployZeroSchedule,
+  listZeroSchedules,
+  enableZeroSchedule,
+  getUserPreferences,
+  ApiRequestError,
+} from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+const FREQUENCY_CHOICES = [
+  { title: "Daily", value: "daily" as const, description: "Run every day" },
+  {
+    title: "Weekly",
+    value: "weekly" as const,
+    description: "Run once per week",
+  },
+  {
+    title: "Monthly",
+    value: "monthly" as const,
+    description: "Run once per month",
+  },
+  {
+    title: "One-time",
+    value: "once" as const,
+    description: "Run once at specific time",
+  },
+  {
+    title: "Loop",
+    value: "loop" as const,
+    description: "Run repeatedly at fixed intervals",
+  },
+];
+
+const DAY_OF_WEEK_CHOICES = [
+  { title: "Monday", value: 1 },
+  { title: "Tuesday", value: 2 },
+  { title: "Wednesday", value: 3 },
+  { title: "Thursday", value: 4 },
+  { title: "Friday", value: 5 },
+  { title: "Saturday", value: 6 },
+  { title: "Sunday", value: 0 },
+];
+
+function parseDayOption(
+  day: string,
+  frequency: ScheduleFrequency,
+): number | undefined {
+  if (frequency === "weekly") {
+    const dayMap: Record<string, number> = {
+      sun: 0,
+      mon: 1,
+      tue: 2,
+      wed: 3,
+      thu: 4,
+      fri: 5,
+      sat: 6,
+    };
+    return dayMap[day.toLowerCase()];
+  } else if (frequency === "monthly") {
+    const num = parseInt(day, 10);
+    if (num >= 1 && num <= 31) {
+      return num;
+    }
+  }
+  return undefined;
+}
+
+function formatInTimezone(isoDate: string, timezone: string): string {
+  const date = new Date(isoDate);
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}`;
+}
+
+function parseFrequencyFromCron(
+  cron: string,
+): { frequency: ScheduleFrequency; day?: number; time: string } | null {
+  const parts = cron.split(" ");
+  if (parts.length !== 5) return null;
+
+  const [minute, hour, dayOfMonth, , dayOfWeek] = parts;
+  const time = `${hour!.padStart(2, "0")}:${minute!.padStart(2, "0")}`;
+
+  if (dayOfMonth === "*" && dayOfWeek === "*") {
+    return { frequency: "daily", time };
+  } else if (dayOfMonth === "*" && dayOfWeek !== "*") {
+    return { frequency: "weekly", day: parseInt(dayOfWeek!, 10), time };
+  } else if (dayOfMonth !== "*" && dayOfWeek === "*") {
+    return { frequency: "monthly", day: parseInt(dayOfMonth!, 10), time };
+  }
+
+  return null;
+}
+
+interface SetupOptions {
+  name?: string;
+  frequency?: string;
+  time?: string;
+  day?: string;
+  interval?: string;
+  timezone?: string;
+  prompt?: string;
+  artifactName: string;
+  enable?: boolean;
+  notifyEmail?: boolean;
+  notifySlack?: boolean;
+}
+
+interface ExistingScheduleDefaults {
+  frequency?: ScheduleFrequency;
+  day?: number;
+  time?: string;
+  intervalSeconds?: number;
+}
+
+interface ScheduleListItem {
+  name: string;
+  agentName: string;
+  triggerType?: "cron" | "once" | "loop";
+  cronExpression?: string | null;
+  atTime?: string | null;
+  intervalSeconds?: number | null;
+  timezone: string;
+  prompt: string;
+  enabled?: boolean;
+  notifyEmail?: boolean;
+  notifySlack?: boolean;
+}
+
+function getExistingDefaults(
+  existingSchedule: ScheduleListItem | undefined,
+): ExistingScheduleDefaults {
+  const defaults: ExistingScheduleDefaults = {};
+
+  if (existingSchedule?.triggerType === "loop") {
+    defaults.frequency = "loop";
+    defaults.intervalSeconds = existingSchedule.intervalSeconds ?? undefined;
+  } else if (existingSchedule?.cronExpression) {
+    const parsed = parseFrequencyFromCron(existingSchedule.cronExpression);
+    if (parsed) {
+      defaults.frequency = parsed.frequency;
+      defaults.day = parsed.day;
+      defaults.time = parsed.time;
+    }
+  } else if (existingSchedule?.atTime) {
+    defaults.frequency = "once";
+  }
+
+  return defaults;
+}
+
+async function gatherFrequency(
+  optionFrequency: string | undefined,
+  existingFrequency: ScheduleFrequency | undefined,
+): Promise<ScheduleFrequency | null> {
+  let frequency = optionFrequency as ScheduleFrequency | undefined;
+
+  if (
+    frequency &&
+    ["daily", "weekly", "monthly", "once", "loop"].includes(frequency)
+  ) {
+    return frequency;
+  }
+
+  if (!isInteractive()) {
+    throw new Error("--frequency is required (daily|weekly|monthly|once|loop)");
+  }
+
+  const defaultIndex = existingFrequency
+    ? FREQUENCY_CHOICES.findIndex((c) => c.value === existingFrequency)
+    : 0;
+
+  frequency = await promptSelect<ScheduleFrequency>(
+    "Schedule frequency",
+    FREQUENCY_CHOICES,
+    defaultIndex >= 0 ? defaultIndex : 0,
+  );
+
+  return frequency || null;
+}
+
+async function gatherDay(
+  frequency: ScheduleFrequency,
+  optionDay: string | undefined,
+  existingDay: number | undefined,
+): Promise<number | null> {
+  if (frequency !== "weekly" && frequency !== "monthly") {
+    return null;
+  }
+
+  if (optionDay) {
+    const day = parseDayOption(optionDay, frequency);
+    if (day === undefined) {
+      throw new Error(
+        `Invalid day: ${optionDay}. Use mon-sun for weekly or 1-31 for monthly.`,
+      );
+    }
+    return day;
+  }
+
+  if (!isInteractive()) {
+    throw new Error("--day is required for weekly/monthly");
+  }
+
+  if (frequency === "weekly") {
+    const defaultDayIndex =
+      existingDay !== undefined
+        ? DAY_OF_WEEK_CHOICES.findIndex((c) => c.value === existingDay)
+        : 0;
+    const day = await promptSelect(
+      "Day of week",
+      DAY_OF_WEEK_CHOICES,
+      defaultDayIndex >= 0 ? defaultDayIndex : 0,
+    );
+    return day ?? null;
+  }
+
+  const dayStr = await promptText(
+    "Day of month (1-31)",
+    existingDay?.toString() || "1",
+  );
+  if (!dayStr) return null;
+
+  const day = parseInt(dayStr, 10);
+  if (isNaN(day) || day < 1 || day > 31) {
+    throw new Error("Day must be between 1 and 31");
+  }
+  return day;
+}
+
+async function gatherRecurringTime(
+  optionTime: string | undefined,
+  existingTime: string | undefined,
+): Promise<string | undefined> {
+  if (optionTime) {
+    const validation = validateTimeFormat(optionTime);
+    if (validation !== true) {
+      throw new Error(`Invalid time: ${validation}`);
+    }
+    return optionTime;
+  }
+
+  if (!isInteractive()) {
+    throw new Error("--time is required (HH:MM format)");
+  }
+
+  return await promptText(
+    "Time (HH:MM)",
+    existingTime || "09:00",
+    validateTimeFormat,
+  );
+}
+
+async function gatherOneTimeSchedule(
+  optionDay: string | undefined,
+  optionTime: string | undefined,
+  existingTime: string | undefined,
+): Promise<string | null> {
+  if (optionDay && optionTime) {
+    if (!validateDateFormat(optionDay)) {
+      throw new Error(
+        `Invalid date format: ${optionDay}. Use YYYY-MM-DD format.`,
+      );
+    }
+    if (!validateTimeFormat(optionTime)) {
+      throw new Error(`Invalid time format: ${optionTime}. Use HH:MM format.`);
+    }
+    return `${optionDay} ${optionTime}`;
+  }
+
+  if (!isInteractive()) {
+    throw new Error("One-time schedules require interactive mode", {
+      cause: new Error(
+        "Or provide --day (YYYY-MM-DD) and --time (HH:MM) flags",
+      ),
+    });
+  }
+
+  const tomorrowDate = getTomorrowDateLocal();
+  const date = await promptText(
+    "Date (YYYY-MM-DD, default tomorrow)",
+    tomorrowDate,
+    validateDateFormat,
+  );
+  if (!date) return null;
+
+  const currentTime = getCurrentTimeLocal();
+  const time = await promptText(
+    "Time (HH:MM)",
+    existingTime || currentTime,
+    validateTimeFormat,
+  );
+  if (!time) return null;
+
+  return `${date} ${time}`;
+}
+
+async function gatherTimezone(
+  optionTimezone: string | undefined,
+  existingTimezone: string | undefined | null,
+): Promise<string | undefined> {
+  if (optionTimezone) return optionTimezone;
+
+  let userTimezone: string | null = null;
+  try {
+    const prefs = await getUserPreferences();
+    userTimezone = prefs.timezone;
+  } catch {
+    // Ignore error - fall back to detected timezone
+  }
+
+  const defaultTimezone = userTimezone || detectTimezone();
+
+  if (!isInteractive()) {
+    return defaultTimezone;
+  }
+
+  return await promptText("Timezone", existingTimezone || defaultTimezone);
+}
+
+async function gatherPromptText(
+  optionPrompt: string | undefined,
+  existingPrompt: string | undefined | null,
+): Promise<string | undefined> {
+  if (optionPrompt) return optionPrompt;
+
+  if (!isInteractive()) {
+    throw new Error("--prompt is required");
+  }
+
+  return await promptText(
+    "Prompt to run",
+    existingPrompt || "let's start working.",
+  );
+}
+
+async function gatherNotificationPreferences(
+  optionNotifyEmail: boolean | undefined,
+  optionNotifySlack: boolean | undefined,
+  existingSchedule: ScheduleListItem | undefined,
+): Promise<{ notifyEmail?: boolean; notifySlack?: boolean }> {
+  if (optionNotifyEmail !== undefined && optionNotifySlack !== undefined) {
+    return {
+      notifyEmail: optionNotifyEmail,
+      notifySlack: optionNotifySlack,
+    };
+  }
+
+  if (!isInteractive()) {
+    return {
+      notifyEmail: optionNotifyEmail,
+      notifySlack: optionNotifySlack,
+    };
+  }
+
+  const notifyEmail =
+    optionNotifyEmail ??
+    (await promptConfirm(
+      "Enable email notifications?",
+      existingSchedule?.notifyEmail ?? true,
+    ));
+
+  const notifySlack =
+    optionNotifySlack ??
+    (await promptConfirm(
+      "Enable Slack notifications?",
+      existingSchedule?.notifySlack ?? true,
+    ));
+
+  return { notifyEmail, notifySlack };
+}
+
+async function gatherInterval(
+  optionInterval: string | undefined,
+  existingInterval: number | undefined,
+): Promise<number | null> {
+  if (optionInterval) {
+    const val = parseInt(optionInterval, 10);
+    if (isNaN(val) || val < 0) {
+      throw new Error(
+        "Invalid interval. Must be a non-negative integer (seconds)",
+      );
+    }
+    return val;
+  }
+
+  if (!isInteractive()) {
+    throw new Error("--interval is required for loop schedules (seconds)");
+  }
+
+  const defaultVal =
+    existingInterval !== undefined ? String(existingInterval) : "300";
+  const result = await promptText(
+    "Interval in seconds (time between runs)",
+    defaultVal,
+    (v: string) => {
+      const n = parseInt(v, 10);
+      if (isNaN(n) || n < 0) return "Must be a non-negative integer";
+      return true;
+    },
+  );
+  if (!result) return null;
+  return parseInt(result, 10);
+}
+
+async function gatherTiming(
+  frequency: ScheduleFrequency,
+  options: SetupOptions,
+  defaults: ExistingScheduleDefaults,
+): Promise<{
+  day: number | undefined;
+  time: string | undefined;
+  atTime: string | undefined;
+  intervalSeconds: number | undefined;
+} | null> {
+  if (frequency === "loop") {
+    const intervalSeconds = await gatherInterval(
+      options.interval,
+      defaults.intervalSeconds,
+    );
+    if (intervalSeconds === null) return null;
+    return {
+      day: undefined,
+      time: undefined,
+      atTime: undefined,
+      intervalSeconds,
+    };
+  }
+
+  if (frequency === "once") {
+    const result = await gatherOneTimeSchedule(
+      options.day,
+      options.time,
+      defaults.time,
+    );
+    if (!result) return null;
+    return {
+      day: undefined,
+      time: undefined,
+      atTime: result,
+      intervalSeconds: undefined,
+    };
+  }
+
+  const day =
+    (await gatherDay(frequency, options.day, defaults.day)) ?? undefined;
+  if (day === null && (frequency === "weekly" || frequency === "monthly")) {
+    return null;
+  }
+
+  const time = await gatherRecurringTime(options.time, defaults.time);
+  if (!time) return null;
+
+  return { day, time, atTime: undefined, intervalSeconds: undefined };
+}
+
+async function findExistingSchedule(
+  agentName: string,
+  scheduleName: string,
+): Promise<ScheduleListItem | undefined> {
+  const { schedules } = await listZeroSchedules();
+  return schedules.find(
+    (s) => s.agentName === agentName && s.name === scheduleName,
+  );
+}
+
+interface DeployResult {
+  created: boolean;
+  schedule: {
+    triggerType?: "cron" | "once" | "loop";
+    timezone: string;
+    cronExpression?: string | null;
+    nextRunAt?: string | null;
+    atTime?: string | null;
+    intervalSeconds?: number | null;
+  };
+}
+
+async function buildAndDeploy(params: {
+  scheduleName: string;
+  zeroAgentId: string;
+  agentName: string;
+  frequency: ScheduleFrequency;
+  time: string | undefined;
+  day: number | undefined;
+  atTime: string | undefined;
+  intervalSeconds: number | undefined;
+  timezone: string;
+  prompt: string;
+  artifactName: string;
+  notifyEmail?: boolean;
+  notifySlack?: boolean;
+}): Promise<DeployResult> {
+  let cronExpression: string | undefined;
+  let atTimeISO: string | undefined;
+
+  if (params.frequency === "loop") {
+    // Loop mode: intervalSeconds is passed directly
+  } else if (params.atTime) {
+    atTimeISO = toISODateTime(params.atTime);
+  } else if (params.time && params.frequency !== "once") {
+    cronExpression = generateCronExpression(
+      params.frequency,
+      params.time,
+      params.day,
+    );
+  }
+
+  console.log(
+    `\nDeploying schedule for agent ${chalk.cyan(params.agentName)}...`,
+  );
+
+  const deployResult = await deployZeroSchedule({
+    name: params.scheduleName,
+    zeroAgentId: params.zeroAgentId,
+    cronExpression,
+    atTime: atTimeISO,
+    intervalSeconds: params.intervalSeconds,
+    timezone: params.timezone,
+    prompt: params.prompt,
+    artifactName: params.artifactName,
+    ...(params.notifyEmail !== undefined && {
+      notifyEmail: params.notifyEmail,
+    }),
+    ...(params.notifySlack !== undefined && {
+      notifySlack: params.notifySlack,
+    }),
+  });
+
+  return deployResult;
+}
+
+function displayDeployResult(
+  agentName: string,
+  deployResult: DeployResult,
+): void {
+  if (deployResult.created) {
+    console.log(
+      chalk.green(`✓ Created schedule for agent ${chalk.cyan(agentName)}`),
+    );
+  } else {
+    console.log(
+      chalk.green(`✓ Updated schedule for agent ${chalk.cyan(agentName)}`),
+    );
+  }
+
+  console.log(chalk.dim(`  Timezone: ${deployResult.schedule.timezone}`));
+
+  if (
+    deployResult.schedule.triggerType === "loop" &&
+    deployResult.schedule.intervalSeconds != null
+  ) {
+    console.log(
+      chalk.dim(
+        `  Mode: Loop (interval ${deployResult.schedule.intervalSeconds}s)`,
+      ),
+    );
+  } else if (deployResult.schedule.cronExpression) {
+    console.log(chalk.dim(`  Cron: ${deployResult.schedule.cronExpression}`));
+    if (deployResult.schedule.nextRunAt) {
+      const nextRun = formatInTimezone(
+        deployResult.schedule.nextRunAt,
+        deployResult.schedule.timezone,
+      );
+      console.log(chalk.dim(`  Next run: ${nextRun}`));
+    }
+  } else if (deployResult.schedule.atTime) {
+    const atTimeFormatted = formatInTimezone(
+      deployResult.schedule.atTime,
+      deployResult.schedule.timezone,
+    );
+    console.log(chalk.dim(`  At: ${atTimeFormatted}`));
+  }
+}
+
+async function tryEnableSchedule(
+  scheduleName: string,
+  zeroAgentId: string,
+  agentName: string,
+): Promise<void> {
+  try {
+    await enableZeroSchedule({ name: scheduleName, zeroAgentId });
+    console.log(
+      chalk.green(`✓ Enabled schedule for agent ${chalk.cyan(agentName)}`),
+    );
+  } catch (error) {
+    console.error(chalk.yellow("⚠ Failed to enable schedule"));
+    if (error instanceof ApiRequestError) {
+      if (error.code === "SCHEDULE_PAST") {
+        console.error(chalk.dim("  Scheduled time has already passed"));
+      } else {
+        console.error(chalk.dim(`  ${error.message}`));
+      }
+    } else if (error instanceof Error) {
+      console.error(chalk.dim(`  ${error.message}`));
+    }
+    console.log(
+      `  To enable manually: ${chalk.cyan(`vm0 zero schedule enable ${agentName}`)}`,
+    );
+  }
+}
+
+function showEnableHint(agentName: string): void {
+  console.log();
+  console.log(
+    `  To enable: ${chalk.cyan(`vm0 zero schedule enable ${agentName}`)}`,
+  );
+}
+
+async function handleScheduleEnabling(params: {
+  scheduleName: string;
+  zeroAgentId: string;
+  agentName: string;
+  enableFlag: boolean;
+  shouldPromptEnable: boolean;
+}): Promise<void> {
+  const {
+    scheduleName,
+    zeroAgentId,
+    agentName,
+    enableFlag,
+    shouldPromptEnable,
+  } = params;
+
+  if (enableFlag) {
+    await tryEnableSchedule(scheduleName, zeroAgentId, agentName);
+    return;
+  }
+
+  if (shouldPromptEnable && isInteractive()) {
+    const enableNow = await promptConfirm("Enable this schedule?", true);
+    if (enableNow) {
+      await tryEnableSchedule(scheduleName, zeroAgentId, agentName);
+    } else {
+      showEnableHint(agentName);
+    }
+    return;
+  }
+
+  if (shouldPromptEnable) {
+    showEnableHint(agentName);
+  }
+}
+
+export const setupCommand = new Command()
+  .name("setup")
+  .description("Create or edit a schedule for a zero agent")
+  .argument("<agent-name>", "Agent name to configure schedule for")
+  .option("-n, --name <schedule-name>", 'Schedule name (default: "default")')
+  .option("-f, --frequency <type>", "Frequency: daily|weekly|monthly|once|loop")
+  .option("-t, --time <HH:MM>", "Time to run (24-hour format)")
+  .option("-d, --day <day>", "Day of week (mon-sun) or day of month (1-31)")
+  .option("-i, --interval <seconds>", "Interval in seconds for loop mode")
+  .option("-z, --timezone <tz>", "IANA timezone")
+  .option("-p, --prompt <text>", "Prompt to run")
+  .option("--artifact-name <name>", "Artifact name", "artifact")
+  .option("-e, --enable", "Enable schedule immediately after creation")
+  .option("--notify-email", "Enable email notifications (default: true)")
+  .option("--no-notify-email", "Disable email notifications")
+  .option("--notify-slack", "Enable Slack notifications (default: true)")
+  .option("--no-notify-slack", "Disable Slack notifications")
+  .action(
+    withErrorHandler(async (agentName: string, options: SetupOptions) => {
+      // 1. Resolve agent to zeroAgentId (via agentComposeId — schedule service handles fallback)
+      const agent = await getZeroAgent(agentName);
+      const zeroAgentId = agent.agentComposeId;
+      const scheduleName = options.name || "default";
+
+      // 2. Check for existing schedule
+      const existingSchedule = await findExistingSchedule(
+        agentName,
+        scheduleName,
+      );
+
+      console.log(
+        chalk.dim(
+          existingSchedule
+            ? `Editing existing schedule for agent ${agentName}`
+            : `Creating new schedule for agent ${agentName}`,
+        ),
+      );
+
+      const defaults = getExistingDefaults(existingSchedule);
+
+      // 3. Gather frequency
+      const frequency = await gatherFrequency(
+        options.frequency,
+        defaults.frequency,
+      );
+      if (!frequency) {
+        console.log(chalk.dim("Cancelled"));
+        return;
+      }
+
+      // 4. Gather day and time
+      const timing = await gatherTiming(frequency, options, defaults);
+      if (!timing) {
+        console.log(chalk.dim("Cancelled"));
+        return;
+      }
+      const { day, time, atTime, intervalSeconds } = timing;
+
+      // 5. Gather timezone
+      const timezone = await gatherTimezone(
+        options.timezone,
+        existingSchedule?.timezone,
+      );
+      if (!timezone) {
+        console.log(chalk.dim("Cancelled"));
+        return;
+      }
+
+      // 6. Gather prompt
+      const promptText_ = await gatherPromptText(
+        options.prompt,
+        existingSchedule?.prompt,
+      );
+      if (!promptText_) {
+        console.log(chalk.dim("Cancelled"));
+        return;
+      }
+
+      // 7. Gather notification preferences
+      const { notifyEmail, notifySlack } = await gatherNotificationPreferences(
+        options.notifyEmail,
+        options.notifySlack,
+        existingSchedule,
+      );
+
+      // 8. Build trigger and deploy
+      const deployResult = await buildAndDeploy({
+        scheduleName,
+        zeroAgentId,
+        agentName,
+        frequency,
+        time,
+        day,
+        atTime,
+        intervalSeconds,
+        timezone,
+        prompt: promptText_,
+        artifactName: options.artifactName,
+        notifyEmail,
+        notifySlack,
+      });
+
+      // 9. Display deployment result
+      displayDeployResult(agentName, deployResult);
+
+      // 10. Handle schedule enabling
+      const shouldPromptEnable =
+        deployResult.created ||
+        (existingSchedule !== undefined && !existingSchedule.enabled);
+
+      await handleScheduleEnabling({
+        scheduleName,
+        zeroAgentId,
+        agentName,
+        enableFlag: options.enable ?? false,
+        shouldPromptEnable,
+      });
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -334,7 +334,9 @@ async function gatherTimezone(
     const prefs = await getUserPreferences();
     userTimezone = prefs.timezone;
   } catch {
-    // Ignore error - fall back to detected timezone
+    console.log(
+      chalk.dim("Could not fetch timezone preference, using detected timezone"),
+    );
   }
 
   const defaultTimezone = userTimezone || detectTimezone();

--- a/turbo/apps/cli/src/commands/zero/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/status.ts
@@ -1,0 +1,152 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listZeroSchedules } from "../../../lib/api";
+import {
+  formatDateTime,
+  detectTimezone,
+} from "../../../lib/domain/schedule-utils";
+import { withErrorHandler } from "../../../lib/command";
+import type { ScheduleResponse } from "@vm0/core";
+
+/**
+ * Format date with styled relative time (adds chalk formatting)
+ */
+function formatDateTimeStyled(dateStr: string | null): string {
+  if (!dateStr) return chalk.dim("-");
+  const formatted = formatDateTime(dateStr);
+  return formatted.replace(/\(([^)]+)\)$/, chalk.dim("($1)"));
+}
+
+/**
+ * Format trigger (cron or at) - timezone shown separately
+ */
+function formatTrigger(schedule: ScheduleResponse): string {
+  if (schedule.triggerType === "loop" && schedule.intervalSeconds !== null) {
+    return `interval ${schedule.intervalSeconds}s ${chalk.dim("(loop)")}`;
+  }
+  if (schedule.cronExpression) {
+    return schedule.cronExpression;
+  }
+  if (schedule.atTime) {
+    return `${schedule.atTime} ${chalk.dim("(one-time)")}`;
+  }
+  return chalk.dim("-");
+}
+
+/**
+ * Print run configuration section
+ */
+function printRunConfiguration(schedule: ScheduleResponse): void {
+  const statusText = schedule.enabled
+    ? chalk.green("enabled")
+    : chalk.yellow("disabled");
+  console.log(`${"Status:".padEnd(16)}${statusText}`);
+
+  console.log(
+    `${"Agent:".padEnd(16)}${schedule.agentName} ${chalk.dim(`(${schedule.orgSlug})`)}`,
+  );
+
+  const promptPreview =
+    schedule.prompt.length > 60
+      ? schedule.prompt.slice(0, 57) + "..."
+      : schedule.prompt;
+  console.log(`${"Prompt:".padEnd(16)}${chalk.dim(promptPreview)}`);
+
+  if (schedule.vars && Object.keys(schedule.vars).length > 0) {
+    console.log(
+      `${"Variables:".padEnd(16)}${Object.keys(schedule.vars).join(", ")}`,
+    );
+  }
+
+  if (schedule.secretNames && schedule.secretNames.length > 0) {
+    console.log(`${"Secrets:".padEnd(16)}${schedule.secretNames.join(", ")}`);
+  }
+
+  if (schedule.artifactName) {
+    const artifactInfo = schedule.artifactVersion
+      ? `${schedule.artifactName}:${schedule.artifactVersion}`
+      : schedule.artifactName;
+    console.log(`${"Artifact:".padEnd(16)}${artifactInfo}`);
+  }
+
+  if (
+    schedule.volumeVersions &&
+    Object.keys(schedule.volumeVersions).length > 0
+  ) {
+    console.log(
+      `${"Volumes:".padEnd(16)}${Object.keys(schedule.volumeVersions).join(", ")}`,
+    );
+  }
+}
+
+/**
+ * Print time schedule section
+ */
+function printTimeSchedule(schedule: ScheduleResponse): void {
+  console.log();
+  console.log(`${"Trigger:".padEnd(16)}${formatTrigger(schedule)}`);
+  console.log(`${"Timezone:".padEnd(16)}${detectTimezone()}`);
+
+  if (schedule.enabled) {
+    console.log(
+      `${"Next Run:".padEnd(16)}${formatDateTimeStyled(schedule.nextRunAt)}`,
+    );
+  }
+
+  if (schedule.triggerType === "loop") {
+    const failureText =
+      schedule.consecutiveFailures > 0
+        ? chalk.yellow(`${schedule.consecutiveFailures}/3`)
+        : chalk.dim("0/3");
+    console.log(`${"Failures:".padEnd(16)}${failureText}`);
+  }
+}
+
+export const statusCommand = new Command()
+  .name("status")
+  .description("Show detailed status of a zero schedule")
+  .argument("<agent-name>", "Agent name")
+  .option(
+    "-n, --name <schedule-name>",
+    "Schedule name (required when agent has multiple schedules)",
+  )
+  .action(
+    withErrorHandler(async (agentName: string, options: { name?: string }) => {
+      const { schedules } = await listZeroSchedules();
+
+      const agentSchedules = schedules.filter((s) => s.agentName === agentName);
+
+      if (agentSchedules.length === 0) {
+        throw new Error(`No schedule found for agent "${agentName}"`);
+      }
+
+      let schedule: ScheduleResponse;
+
+      if (options.name) {
+        const match = agentSchedules.find((s) => s.name === options.name);
+        if (!match) {
+          const available = agentSchedules.map((s) => s.name).join(", ");
+          throw new Error(
+            `Schedule "${options.name}" not found for agent "${agentName}". Available schedules: ${available}`,
+          );
+        }
+        schedule = match;
+      } else if (agentSchedules.length === 1) {
+        schedule = agentSchedules[0]!;
+      } else {
+        const available = agentSchedules.map((s) => s.name).join(", ");
+        throw new Error(
+          `Agent "${agentName}" has multiple schedules. Use --name to specify which one: ${available}`,
+        );
+      }
+
+      console.log();
+      console.log(`Schedule for agent: ${chalk.cyan(agentName)}`);
+      console.log(chalk.dim("━".repeat(50)));
+
+      printRunConfiguration(schedule);
+      printTimeSchedule(schedule);
+
+      console.log();
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/status.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { listZeroSchedules } from "../../../lib/api";
+import { resolveZeroScheduleByAgent } from "../../../lib/api";
 import {
   formatDateTime,
   detectTimezone,
@@ -112,33 +112,10 @@ export const statusCommand = new Command()
   )
   .action(
     withErrorHandler(async (agentName: string, options: { name?: string }) => {
-      const { schedules } = await listZeroSchedules();
-
-      const agentSchedules = schedules.filter((s) => s.agentName === agentName);
-
-      if (agentSchedules.length === 0) {
-        throw new Error(`No schedule found for agent "${agentName}"`);
-      }
-
-      let schedule: ScheduleResponse;
-
-      if (options.name) {
-        const match = agentSchedules.find((s) => s.name === options.name);
-        if (!match) {
-          const available = agentSchedules.map((s) => s.name).join(", ");
-          throw new Error(
-            `Schedule "${options.name}" not found for agent "${agentName}". Available schedules: ${available}`,
-          );
-        }
-        schedule = match;
-      } else if (agentSchedules.length === 1) {
-        schedule = agentSchedules[0]!;
-      } else {
-        const available = agentSchedules.map((s) => s.name).join(", ");
-        throw new Error(
-          `Agent "${agentName}" has multiple schedules. Use --name to specify which one: ${available}`,
-        );
-      }
+      const schedule = await resolveZeroScheduleByAgent(
+        agentName,
+        options.name,
+      );
 
       console.log();
       console.log(`Schedule for agent: ${chalk.cyan(agentName)}`);

--- a/turbo/apps/cli/src/lib/api/domains/zero-schedules.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-schedules.ts
@@ -126,18 +126,10 @@ export async function disableZeroSchedule(params: {
 }
 
 /**
- * Result of resolving a zero schedule by agent name
- */
-interface ResolveZeroScheduleResult {
-  name: string;
-  zeroAgentId: string;
-  agentName: string;
-}
-
-/**
  * Resolve a zero schedule by agent name using the list API.
  * Searches across all user's schedules and finds by agentName.
  *
+ * Returns the full ScheduleResponse so callers can access any field.
  * When an agent has multiple schedules, scheduleName is required for disambiguation.
  * When an agent has exactly one schedule, scheduleName is optional.
  *
@@ -146,7 +138,7 @@ interface ResolveZeroScheduleResult {
 export async function resolveZeroScheduleByAgent(
   agentName: string,
   scheduleName?: string,
-): Promise<ResolveZeroScheduleResult> {
+): Promise<ScheduleResponse> {
   const { schedules } = await listZeroSchedules();
 
   const agentSchedules = schedules.filter((s) => s.agentName === agentName);
@@ -163,19 +155,11 @@ export async function resolveZeroScheduleByAgent(
         `Schedule "${scheduleName}" not found for agent "${agentName}". Available schedules: ${available}`,
       );
     }
-    return {
-      name: match.name,
-      zeroAgentId: match.zeroAgentId,
-      agentName: match.agentName,
-    };
+    return match;
   }
 
   if (agentSchedules.length === 1) {
-    return {
-      name: agentSchedules[0]!.name,
-      zeroAgentId: agentSchedules[0]!.zeroAgentId,
-      agentName: agentSchedules[0]!.agentName,
-    };
+    return agentSchedules[0]!;
   }
 
   const available = agentSchedules.map((s) => s.name).join(", ");

--- a/turbo/apps/cli/src/lib/api/domains/zero-schedules.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-schedules.ts
@@ -1,0 +1,185 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroSchedulesMainContract,
+  zeroSchedulesByNameContract,
+  zeroSchedulesEnableContract,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+import type {
+  ScheduleResponse,
+  ScheduleListResponse,
+  DeployScheduleResponse,
+} from "../core/types";
+
+/**
+ * Deploy zero schedule (create or update)
+ */
+export async function deployZeroSchedule(body: {
+  name: string;
+  zeroAgentId: string;
+  cronExpression?: string;
+  atTime?: string;
+  intervalSeconds?: number;
+  timezone?: string;
+  prompt: string;
+  description?: string;
+  appendSystemPrompt?: string;
+  artifactName?: string;
+  artifactVersion?: string;
+  volumeVersions?: Record<string, string>;
+  enabled?: boolean;
+  notifyEmail?: boolean;
+  notifySlack?: boolean;
+}): Promise<DeployScheduleResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSchedulesMainContract, config);
+
+  const result = await client.deploy({ body });
+
+  if (result.status === 200 || result.status === 201) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to deploy schedule");
+}
+
+/**
+ * List all zero schedules
+ */
+export async function listZeroSchedules(): Promise<ScheduleListResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSchedulesMainContract, config);
+
+  const result = await client.list({ headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to list schedules");
+}
+
+/**
+ * Delete zero schedule by name
+ */
+export async function deleteZeroSchedule(params: {
+  name: string;
+  zeroAgentId: string;
+}): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSchedulesByNameContract, config);
+
+  const result = await client.delete({
+    params: { name: params.name },
+    query: { zeroAgentId: params.zeroAgentId },
+  });
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, `Schedule "${params.name}" not found on remote`);
+}
+
+/**
+ * Enable zero schedule
+ */
+export async function enableZeroSchedule(params: {
+  name: string;
+  zeroAgentId: string;
+}): Promise<ScheduleResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSchedulesEnableContract, config);
+
+  const result = await client.enable({
+    params: { name: params.name },
+    body: { zeroAgentId: params.zeroAgentId },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Failed to enable schedule "${params.name}"`);
+}
+
+/**
+ * Disable zero schedule
+ */
+export async function disableZeroSchedule(params: {
+  name: string;
+  zeroAgentId: string;
+}): Promise<ScheduleResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroSchedulesEnableContract, config);
+
+  const result = await client.disable({
+    params: { name: params.name },
+    body: { zeroAgentId: params.zeroAgentId },
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, `Failed to disable schedule "${params.name}"`);
+}
+
+/**
+ * Result of resolving a zero schedule by agent name
+ */
+interface ResolveZeroScheduleResult {
+  name: string;
+  zeroAgentId: string;
+  agentName: string;
+}
+
+/**
+ * Resolve a zero schedule by agent name using the list API.
+ * Searches across all user's schedules and finds by agentName.
+ *
+ * When an agent has multiple schedules, scheduleName is required for disambiguation.
+ * When an agent has exactly one schedule, scheduleName is optional.
+ *
+ * @throws Error if agent has no schedule or disambiguation is needed
+ */
+export async function resolveZeroScheduleByAgent(
+  agentName: string,
+  scheduleName?: string,
+): Promise<ResolveZeroScheduleResult> {
+  const { schedules } = await listZeroSchedules();
+
+  const agentSchedules = schedules.filter((s) => s.agentName === agentName);
+
+  if (agentSchedules.length === 0) {
+    throw new Error(`No schedule found for agent "${agentName}"`);
+  }
+
+  if (scheduleName) {
+    const match = agentSchedules.find((s) => s.name === scheduleName);
+    if (!match) {
+      const available = agentSchedules.map((s) => s.name).join(", ");
+      throw new Error(
+        `Schedule "${scheduleName}" not found for agent "${agentName}". Available schedules: ${available}`,
+      );
+    }
+    return {
+      name: match.name,
+      zeroAgentId: match.zeroAgentId,
+      agentName: match.agentName,
+    };
+  }
+
+  if (agentSchedules.length === 1) {
+    return {
+      name: agentSchedules[0]!.name,
+      zeroAgentId: agentSchedules[0]!.zeroAgentId,
+      agentName: agentSchedules[0]!.agentName,
+    };
+  }
+
+  const available = agentSchedules.map((s) => s.name).join(", ");
+  throw new Error(
+    `Agent "${agentName}" has multiple schedules. Use --name to specify which one: ${available}`,
+  );
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -158,3 +158,13 @@ export {
   getZeroAgentInstructions,
   updateZeroAgentInstructions,
 } from "./domains/zero-agents";
+
+// Domain modules - Zero Schedules
+export {
+  deployZeroSchedule,
+  listZeroSchedules,
+  deleteZeroSchedule,
+  enableZeroSchedule,
+  disableZeroSchedule,
+  resolveZeroScheduleByAgent,
+} from "./domains/zero-schedules";


### PR DESCRIPTION
## Summary
- Add `vm0 zero schedule` CLI subcommand group (setup/list/status/delete/enable/disable) that calls `/api/zero/schedules/*` endpoints using `zeroAgentId`
- Create zero schedule API client module with deploy, list, delete, enable, disable, and resolveByAgent functions
- Register schedule subcommand in the zero command group alongside org and agent

Closes #6217

## Key Implementation Details
- Mirrors existing `vm0 schedule` commands but uses zero API layer (`zeroAgentId` instead of `composeId`)
- Agent resolution: `getZeroAgent(name)` → `agentComposeId` (schedule service handles the fallback resolution)
- Schedule resolution for status/delete/enable/disable: list + client-side filter by `agentName`
- Status command omits "Recent Runs" section since no zero `scheduleRuns` endpoint exists (no server-side changes per issue scope)
- Setup command supports both interactive prompts and non-interactive CLI flags

## Test plan
- [x] All 6 test files pass (18 tests total): list, enable, disable, delete, status, setup
- [x] Full CLI test suite passes (112 files, 996 tests)
- [x] Type check passes
- [x] Lint passes (0 warnings, 0 errors)
- [x] Format passes
- [x] Knip passes (no unused code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)