### PR TITLE
feat: replace reddit brand monitor example with x (twitter)

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -599,12 +599,12 @@ const categories: readonly Category[] = [
         connectors: ["discord", "notion", "slack"],
       },
       {
-        title: "Reddit brand monitor",
+        title: "X brand monitor",
         description:
-          "Watch Reddit for brand mentions, save relevant threads to Notion, and alert the team",
+          "Watch X for brand mentions, save relevant posts to Notion, and alert the team",
         prompt:
-          "Set up a Reddit brand monitor that watches for mentions of our product, saves relevant threads to Notion, and sends Slack alerts for high-engagement posts",
-        connectors: ["reddit", "notion", "slack"],
+          "Set up an X brand monitor that watches for mentions of our product, saves relevant posts to Notion, and sends Slack alerts for high-engagement posts",
+        connectors: ["x", "notion", "slack"],
       },
       {
         title: "Mercury cash flow monitor",


### PR DESCRIPTION
## Summary

- Replace the Reddit brand monitor template with an X (Twitter) brand monitor in the ideation gallery
- Reddit is not a supported integration (locked behind feature flag), while X is fully available
- Updates title, description, prompt, and connectors fields in a single template entry

Closes #6214

## Test plan

- [x] Lint passes
- [x] Type check passes
- [x] Knip finds no issues
- [ ] Verify template gallery shows "X brand monitor" instead of "Reddit brand monitor"

🤖 Generated with [Claude Code](https://claude.com/claude-code)