### PR TITLE
feat(platform): polish zero sidebar and talk-to dialog

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -84,15 +84,15 @@
     0 16px 40px hsl(220 12% 20% / 0.05);
 }
 
-/* Search bar / text input */
+/* Search bar / text input (matches form inputs: white surface in light theme) */
 .zero-app .zero-search-input {
-  background-color: hsl(var(--gray-50));
+  background-color: hsl(var(--input));
   border-color: hsl(var(--border));
 }
 .zero-app .zero-search-input::placeholder {
   color: hsl(var(--muted-foreground));
 }
-.zero-app .zero-search-input:focus {
+.zero-app .zero-search-input:focus-within {
   border-color: hsl(var(--primary));
   outline: none;
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -331,7 +331,7 @@ export function ZeroActivityDetailPage() {
                   </span>
                 </div>
                 <div className="flex items-center gap-2 sm:gap-3">
-                  <div className="zero-search-input relative flex h-9 flex-1 sm:flex-none items-center rounded-lg border transition-colors focus-within:border-primary focus-within:ring-[3px] focus-within:ring-primary/10">
+                  <div className="zero-search-input relative flex h-9 flex-1 sm:flex-none items-center rounded-lg border transition-colors focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
                     <div className="pl-2">
                       <IconSearch className="h-4 w-4 text-muted-foreground" />
                     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -3,7 +3,8 @@ import { useGet, useSet } from "ccstate-react";
 import {
   IconSearch,
   IconX,
-  IconGripVertical,
+  IconArrowsMove,
+  IconPin,
   IconLoader2,
   IconCrown,
 } from "@tabler/icons-react";
@@ -60,30 +61,33 @@ function SortablePinnedAgent({
       style={style}
       className="flex items-center gap-2 px-1 py-2 rounded-lg hover:bg-accent transition-colors group"
     >
-      <button
-        type="button"
-        className="shrink-0 flex items-center justify-center cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground transition-colors touch-none"
-        {...attributes}
-        {...listeners}
-      >
-        <IconGripVertical size={14} />
-      </button>
       <AgentAvatarImg
         name={agent.name}
         alt={agent.displayName ?? agent.name}
         className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
       />
-      <span className="text-sm text-foreground flex-1 truncate">
+      <span className="text-sm text-foreground min-w-0 flex-1 truncate">
         {agent.displayName ?? agent.name}
       </span>
-      <button
-        type="button"
-        className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-md transition-colors p-1"
-        onClick={onUnpin}
-        aria-label={`Unpin ${agent.displayName ?? agent.name}`}
-      >
-        <IconX size={14} />
-      </button>
+      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+        <button
+          type="button"
+          className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg cursor-grab active:cursor-grabbing touch-none text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18"
+          aria-label={`Reorder ${agent.displayName ?? agent.name}`}
+          {...attributes}
+          {...listeners}
+        >
+          <IconArrowsMove size={16} stroke={2} />
+        </button>
+        <button
+          type="button"
+          className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18"
+          onClick={onUnpin}
+          aria-label={`Unpin ${agent.displayName ?? agent.name}`}
+        >
+          <IconX size={16} stroke={2} />
+        </button>
+      </div>
     </div>
   );
 }
@@ -228,7 +232,7 @@ export function ManagePinnedAgentsDialog({
               {unpinned.map((agent) => (
                 <div
                   key={agent.id}
-                  className="flex items-center gap-2 px-1 py-2 rounded-lg hover:bg-accent transition-colors"
+                  className="group flex items-center gap-2 px-1 py-2 rounded-lg hover:bg-accent transition-colors"
                 >
                   <AgentAvatarImg
                     name={agent.name}
@@ -238,13 +242,23 @@ export function ManagePinnedAgentsDialog({
                   <span className="text-sm text-muted-foreground flex-1 truncate">
                     {agent.displayName ?? agent.name}
                   </span>
-                  <button
-                    type="button"
-                    className="transition-colors px-2 py-0.5 rounded-md text-xs font-medium text-primary hover:text-primary/80 hover:bg-primary/10"
-                    onClick={() => togglePin(agent.id)}
-                  >
-                    Pin
-                  </button>
+                  <TooltipProvider delayDuration={200}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18"
+                          onClick={() => togglePin(agent.id)}
+                          aria-label="Pin to sidebar"
+                        >
+                          <IconPin size={16} stroke={2} />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="right">
+                        <p className="text-xs">Pin to sidebar</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 </div>
               ))}
             </div>
@@ -361,7 +375,7 @@ export function ChatListDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[400px] p-0 gap-0">
+      <DialogContent className="zero-app sm:max-w-xl w-[calc(100vw-2rem)] p-0 gap-0">
         <DialogHeader className="px-5 pt-5 pb-3">
           <DialogTitle className="text-base font-semibold">Talk to</DialogTitle>
           <p className="text-sm text-muted-foreground mt-1">
@@ -369,37 +383,37 @@ export function ChatListDialog({
           </p>
         </DialogHeader>
 
-        {/* Search */}
+        {/* Search — same pattern as zero-activity-detail-page (zero-search-input) */}
         <div className="px-5 pb-3">
-          <div
-            className="flex items-center gap-2 h-8 rounded-lg pl-2 pr-1 bg-sidebar-accent/60"
-            style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-          >
-            <IconSearch
-              size={15}
-              stroke={2.5}
-              className="shrink-0 text-muted-foreground/50"
-            />
+          <div className="zero-search-input relative flex h-10 w-full items-center rounded-lg border transition-colors focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
+            <div className="pl-2.5 shrink-0">
+              <IconSearch
+                size={16}
+                stroke={2}
+                className="text-muted-foreground"
+              />
+            </div>
             <input
               type="text"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search agents..."
-              className="flex-1 min-w-0 bg-transparent text-sm leading-5 text-foreground placeholder:text-muted-foreground/50 focus:outline-none"
+              className="h-full min-w-0 flex-1 border-0 bg-transparent py-2 pl-2 pr-2 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-0"
             />
             {query && (
               <button
                 type="button"
                 onClick={() => setQuery("")}
-                className="shrink-0 flex h-5 w-5 items-center justify-center rounded text-muted-foreground/50 hover:text-foreground transition-colors"
+                className="mr-1.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                aria-label="Clear search"
               >
-                <IconX size={12} stroke={2} />
+                <IconX size={14} stroke={2} />
               </button>
             )}
           </div>
         </div>
 
-        <div className="max-h-[400px] overflow-y-auto">
+        <div className="max-h-[min(520px,65vh)] overflow-y-auto">
           {/* Lead agent */}
           {showLead && (
             <div className="px-5 pb-2">
@@ -490,10 +504,11 @@ export function ChatListDialog({
                         <TooltipTrigger asChild>
                           <button
                             type="button"
-                            className="opacity-0 group-hover:opacity-100 transition-opacity duration-150 px-2 py-0.5 rounded-md text-xs font-medium text-primary hover:text-primary/80 hover:bg-primary/10"
+                            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18"
                             onClick={() => togglePin(agent.id)}
+                            aria-label="Pin to sidebar"
                           >
-                            Pin to sidebar
+                            <IconPin size={16} stroke={2} />
                           </button>
                         </TooltipTrigger>
                         <TooltipContent side="right">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -265,10 +265,10 @@ function AccountDropdown({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className={`flex items-center rounded-lg transition-colors duration-200 ${
+          className={`rounded-lg transition-colors duration-200 ${
             collapsed
-              ? "justify-center p-2 h-10 w-10"
-              : "w-full gap-2 p-2 text-left hover:bg-sidebar-accent/50"
+              ? "inline-flex h-8 w-8 shrink-0 items-center justify-center p-0 hover:bg-sidebar-accent/50"
+              : "flex w-full items-center gap-2 p-2 text-left hover:bg-sidebar-accent/50"
           }`}
         >
           <AccountAvatar
@@ -507,7 +507,7 @@ function RecentChatSection({
     <div className="mt-4 flex flex-col min-h-0 flex-1">
       {searchOpen ? (
         <div
-          className="shrink-0 flex items-center gap-2 h-8 rounded-lg pl-2 pr-1 bg-sidebar-accent/60"
+          className="shrink-0 flex h-8 items-center gap-2 rounded-lg bg-sidebar-accent/60 pl-2 pr-2"
           style={{ border: "0.7px solid hsl(var(--gray-400))" }}
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget)) {
@@ -542,7 +542,7 @@ function RecentChatSection({
           </div>
         </div>
       ) : (
-        <div className="shrink-0 zero-nav-recent-label h-8 flex items-center justify-between pl-2 pr-1">
+        <div className="zero-nav-recent-label flex h-8 shrink-0 items-center justify-between pl-2 pr-0">
           <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium truncate">
             Chats with {agentLabel}
           </span>
@@ -649,8 +649,8 @@ function TalkToSection({
 
   return (
     <div className="shrink-0 mt-4">
-      <div className="h-8 flex items-center pl-2 pr-1">
-        <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium truncate flex-1">
+      <div className="flex h-8 items-center justify-between pl-2 pr-0">
+        <span className="flex-1 truncate text-[13px] font-medium leading-4 text-sidebar-foreground/50">
           Pinned
         </span>
         <TooltipProvider delayDuration={200}>
@@ -718,7 +718,7 @@ function TalkToSection({
               <Link
                 pathname="/talk/:name"
                 options={{ pathParams: { name: agent.name } }}
-                className={`flex w-full h-8 shrink-0 items-center gap-2 rounded-lg px-2 pr-8 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
+                className={`flex w-full h-8 shrink-0 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
                   isPrimarySelected
                     ? "bg-sidebar-active text-sidebar-primary font-medium"
                     : isFromChat
@@ -735,7 +735,7 @@ function TalkToSection({
                   {agent.displayName ?? agent.name}
                 </span>
               </Link>
-              <div className="absolute right-1 top-0 flex h-8 items-center">
+              <div className="absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
                 <TooltipProvider delayDuration={200}>
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -748,7 +748,7 @@ function TalkToSection({
                             pinnedIds.filter((id) => id !== agent.id),
                           );
                         }}
-                        className={`flex h-5 w-5 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 ${
+                        className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 ${
                           isPrimarySelected
                             ? "text-sidebar-primary/80 hover:text-white hover:bg-white/20"
                             : "text-sidebar-foreground/80 hover:text-foreground hover:bg-sidebar-foreground/10"
@@ -906,12 +906,12 @@ export function ZeroSidebar() {
   if (collapsed) {
     return (
       <VM0ClerkProvider>
-        <aside className="zero-nav flex h-full w-16 shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar transition-all duration-300">
-          {/* Expand button */}
-          <div className="shrink-0 flex items-center justify-center pt-3 pb-1">
+        <aside className="zero-nav box-border flex h-full w-16 shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar px-2 transition-all duration-300">
+          {/* Expand — same row pattern as every nav icon (centered in content column) */}
+          <div className="flex w-full shrink-0 justify-center pt-3 pb-1">
             <button
               type="button"
-              className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
               onClick={onCollapse}
               aria-label="Expand sidebar"
             >
@@ -919,52 +919,57 @@ export function ZeroSidebar() {
             </button>
           </div>
 
-          {/* Icon-only nav */}
-          <nav className="flex-1 flex flex-col items-center gap-1 p-2">
+          {/* Icon-only nav: one centered column; inline-flex links never stretch */}
+          <nav className="flex min-h-0 w-full min-w-0 flex-1 flex-col items-center gap-1 pb-2 pt-0">
             <TooltipProvider delayDuration={100}>
               {allNavItems.map(({ id, label, icon: Icon }) => (
-                <Tooltip key={id}>
-                  <TooltipTrigger asChild>
-                    <Link
-                      pathname={
-                        id === "chat" ? "/" : id === "team" ? "/team" : "/:tab"
-                      }
-                      options={
-                        id === "chat" || id === "team"
-                          ? undefined
-                          : { pathParams: { tab: id } }
-                      }
-                      onClick={(e) => {
-                        if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                          return;
+                <div key={id} className="flex w-full shrink-0 justify-center">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Link
+                        pathname={
+                          id === "chat"
+                            ? "/"
+                            : id === "team"
+                              ? "/team"
+                              : "/:tab"
                         }
-                        e.preventDefault();
-                        if (id === "chat") {
-                          onSelect("chat");
-                          onNewChat?.(null);
-                        } else {
-                          onSelect(id);
+                        options={
+                          id === "chat" || id === "team"
+                            ? undefined
+                            : { pathParams: { tab: id } }
                         }
-                      }}
-                      className={`flex h-8 w-8 items-center justify-center rounded-lg transition-colors duration-200 ${
-                        activeId === id
-                          ? "bg-sidebar-active text-sidebar-primary"
-                          : "text-sidebar-foreground hover:bg-sidebar-accent"
-                      }`}
-                    >
-                      <Icon size={16} className="shrink-0" />
-                    </Link>
-                  </TooltipTrigger>
-                  <TooltipContent side="right">
-                    <p className="text-xs">{label}</p>
-                  </TooltipContent>
-                </Tooltip>
+                        onClick={(e) => {
+                          if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                            return;
+                          }
+                          e.preventDefault();
+                          if (id === "chat") {
+                            onSelect("chat");
+                            onNewChat?.(null);
+                          } else {
+                            onSelect(id);
+                          }
+                        }}
+                        className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
+                          activeId === id
+                            ? "bg-sidebar-active text-sidebar-primary"
+                            : "text-sidebar-foreground hover:bg-sidebar-accent"
+                        }`}
+                      >
+                        <Icon size={16} className="shrink-0" />
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">
+                      <p className="text-xs">{label}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
               ))}
             </TooltipProvider>
           </nav>
 
-          {/* Account avatar */}
-          <div className="p-2 flex justify-center">
+          <div className="flex w-full shrink-0 justify-center pb-2 pt-1">
             <AccountDropdown onAccountAction={onAccountAction} collapsed />
           </div>
         </aside>
@@ -977,13 +982,13 @@ export function ZeroSidebar() {
       <aside className="zero-nav flex h-full w-[300px] shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar transition-all duration-300 max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-40 max-md:shadow-xl">
         {/* Organization switcher */}
         <div className="shrink-0 px-2 pt-1.5 pb-0">
-          <div className="flex items-center justify-between rounded-lg pr-0 py-0.5">
-            <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2 rounded-lg py-0.5">
+            <div className="min-w-0 flex-1">
               <ClerkOrgSwitcher />
             </div>
             <button
               type="button"
-              className="flex h-7 w-7 -mr-[3px] shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
               onClick={onCollapse}
               aria-label="Collapse sidebar"
             >
@@ -995,7 +1000,7 @@ export function ZeroSidebar() {
         <nav className="flex-1 flex flex-col min-h-0 overflow-hidden p-2 pt-1">
           {/* Manage section */}
           <div className="shrink-0">
-            <div className="h-8 flex items-center pl-2">
+            <div className="flex h-8 items-center pl-2 pr-0">
               <span className="text-[13px] leading-4 text-sidebar-foreground/50 font-medium">
                 Manage
               </span>


### PR DESCRIPTION
## Summary
- Zero sidebar: align Manage/Pinned labels, pin/remove icon placement and hover states, collapsed rail layout tweaks.
- Talk-to / manage pinned dialogs: icon actions (reorder, unpin, pin), shared muted hover treatment, larger Talk-to dialog.
- Search: `zero-search-input` pattern for agent search; white input surface; primary border + `ring-2 ring-primary/20` focus (CSS `:focus-within` on wrapper).

## Test plan
- [ ] Open Zero app sidebar: labels align; pin rows show actions on row hover; remove/move icons behave as before.
- [ ] Open Talk to: search bar height, white bg, primary focus ring; Lead/Pinned/Others lists unchanged functionally.

Made with [Cursor](https://cursor.com)