### PR TITLE
test: add sandbox token e2e test for zero agent flow

### DIFF
--- a/turbo/apps/web/app/api/zero/__tests__/zero-agent.test.ts
+++ b/turbo/apps/web/app/api/zero/__tests__/zero-agent.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST as createAgentRoute } from "../agents/route";
+import { GET as getAgentRoute } from "../agents/[name]/route";
+import { PUT as updateInstructionsRoute } from "../agents/[name]/instructions/route";
+import { POST as upsertModelProviderRoute } from "../model-providers/route";
+import { POST as createRunRoute } from "../runs/route";
+import { POST as claimJobRoute } from "../../runners/jobs/[id]/claim/route";
+import {
+  createTestRequest,
+  createTestCliToken,
+  seedSeedSkills,
+  seedSeedSkillStorages,
+  clearSkillsData,
+} from "../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+/**
+ * End-to-end zero agent flow:
+ *   onboarding (model provider) → create agent → run agent → claim job → use sandbox token
+ *
+ * Every step goes through real API route handlers.
+ * The only test helpers used are infrastructure (auth mock, request construction, skill seeding).
+ */
+describe("Zero Agent E2E: create → run → sandbox token access", () => {
+  let user: UserContext;
+  let cliToken: string;
+  let orgSlug: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    await clearSkillsData();
+    await seedSeedSkills();
+    await seedSeedSkillStorages();
+    user = await context.setupUser();
+    cliToken = await createTestCliToken(user.userId);
+    orgSlug = `org-${user.userId.slice(-8)}`;
+  });
+
+  it("should allow sandbox token from claimed run to read agent details", async () => {
+    // ── 1. Onboarding: set up model provider via API ──
+    const providerRes = await upsertModelProviderRoute(
+      createTestRequest(
+        `http://localhost:3000/api/zero/model-providers?org=${orgSlug}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${cliToken}`,
+          },
+          body: JSON.stringify({
+            type: "anthropic-api-key",
+            secret: "sk-ant-test-key",
+          }),
+        },
+      ),
+    );
+    expect(providerRes.status).toBe(201);
+
+    // ── 2. Create agent via API ──
+    const agentRes = await createAgentRoute(
+      createTestRequest(
+        `http://localhost:3000/api/zero/agents?org=${orgSlug}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${cliToken}`,
+          },
+          body: JSON.stringify({
+            connectors: [],
+            displayName: "E2E Agent",
+            description: "Created for sandbox token test",
+          }),
+        },
+      ),
+    );
+    expect(agentRes.status).toBe(201);
+    const agent = await agentRes.json();
+    expect(agent.name).toBeTruthy();
+    expect(agent.agentComposeId).toBeTruthy();
+
+    // ── 3. Upload instructions (creates agent-instructions storage) ──
+    const instructionsRes = await updateInstructionsRoute(
+      createTestRequest(
+        `http://localhost:3000/api/zero/agents/${agent.name}/instructions?org=${orgSlug}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${cliToken}`,
+          },
+          body: JSON.stringify({
+            content: "# Agent Instructions\nBe helpful.",
+          }),
+        },
+      ),
+    );
+    expect(instructionsRes.status).toBe(200);
+
+    // ── 4. Run agent via API ──
+    const runRes = await createRunRoute(
+      createTestRequest("http://localhost:3000/api/zero/runs", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${cliToken}`,
+        },
+        body: JSON.stringify({
+          agentComposeId: agent.agentComposeId,
+          prompt: "Hello agent",
+        }),
+      }),
+    );
+    expect(runRes.status).toBe(201);
+    const run = await runRes.json();
+    expect(run.runId).toBeTruthy();
+
+    // ── 5. Claim job as official runner via API ──
+    // The run was dispatched to runner_job_queue (RUNNER_DEFAULT_GROUP=vm0/default).
+    // Official runner token = vm0_official_<OFFICIAL_RUNNER_SECRET>
+    const officialRunnerToken = `vm0_official_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef`;
+    const claimRes = await claimJobRoute(
+      createTestRequest(
+        `http://localhost:3000/api/runners/jobs/${run.runId}/claim`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${officialRunnerToken}`,
+          },
+          body: JSON.stringify({}),
+        },
+      ),
+    );
+    expect(claimRes.status).toBe(200);
+    const executionContext = await claimRes.json();
+
+    // Verify the execution context contains a sandbox token and capabilities
+    expect(executionContext.sandboxToken).toBeTruthy();
+    expect(executionContext.sandboxToken).toMatch(/^vm0_sandbox_/);
+    expect(executionContext.experimentalCapabilities).toEqual(
+      expect.arrayContaining(["agent:read"]),
+    );
+
+    // ── 6. Use sandbox token to read agent details ──
+    // This is what happens inside the sandbox: the runner injects
+    // sandboxToken as VM0_TOKEN and VM0_ACTIVE_ORG, and the agent CLI
+    // uses them to call the API with ?org=<slug>.
+    mockClerk({ userId: null });
+
+    // 6a. Without ?org= → sandbox token has no orgId, request fails
+    // (in production, runner also injects VM0_ACTIVE_ORG for this reason)
+    const noOrgRes = await getAgentRoute(
+      createTestRequest(`http://localhost:3000/api/zero/agents/${agent.name}`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${executionContext.sandboxToken}`,
+        },
+      }),
+    );
+    expect(noOrgRes.ok).toBe(false);
+
+    // 6b. With ?org= (simulating VM0_ACTIVE_ORG) → should succeed
+    const getRes = await getAgentRoute(
+      createTestRequest(
+        `http://localhost:3000/api/zero/agents/${agent.name}?org=${orgSlug}`,
+        {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${executionContext.sandboxToken}`,
+          },
+        },
+      ),
+    );
+    expect(getRes.status).toBe(200);
+    const fetched = await getRes.json();
+    expect(fetched.name).toBe(agent.name);
+    expect(fetched.agentComposeId).toBe(agent.agentComposeId);
+    expect(fetched.displayName).toBe("E2E Agent");
+    expect(fetched.description).toBe("Created for sandbox token test");
+  });
+});

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -9,16 +9,23 @@ import {
 import {
   createTestRequest,
   createTestCliToken,
+  createTestRun,
+  createTestOrgModelProvider,
+  createTestSandboxToken,
   seedTestSkill,
   seedSeedSkills,
   clearSkillsData,
 } from "../../../../../src/__tests__/api-test-helpers";
-import { testContext } from "../../../../../src/__tests__/test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { createSingleFileTar } from "../../../../../src/lib/tar";
 
 const context = testContext();
 
+let user: UserContext;
 let testCliToken: string;
 let testOrgSlug: string;
 
@@ -160,7 +167,7 @@ describe("Zero Agents API", () => {
     context.setupMocks();
     await clearSkillsData();
     await seedSeedSkills();
-    const user = await context.setupUser();
+    user = await context.setupUser();
     testCliToken = await createTestCliToken(user.userId);
     testOrgSlug = `org-${user.userId.slice(-8)}`;
   });
@@ -555,6 +562,51 @@ describe("Zero Agents API", () => {
       const fetched = await getRes.json();
 
       expect(fetched.content).toBe(instructionsContent);
+    });
+  });
+
+  describe("sandbox token (VM0_TOKEN) access", () => {
+    it("should allow GET /api/zero/agents/:name with sandbox token from a run", async () => {
+      // Given — create an agent via POST
+      const createResponse = await postAgent(
+        {
+          connectors: [],
+          displayName: "Sandbox Access Agent",
+          description: "Agent accessible via sandbox token",
+          sound: "professional",
+        },
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(createResponse.status).toBe(201);
+      const created = await createResponse.json();
+
+      // When — create a run for this agent, then generate a sandbox token
+      // (VM0_TOKEN) with agent:read capability (simulating runner injection)
+      await createTestOrgModelProvider("anthropic-api-key", "test-key");
+      const { runId } = await createTestRun(
+        created.agentComposeId,
+        "test prompt",
+      );
+
+      // Reset Clerk so sandbox token is the only auth path
+      mockClerk({ userId: null });
+
+      const sandboxToken = await createTestSandboxToken(user.userId, runId, [
+        "agent:read",
+      ]);
+
+      // Use the sandbox token (VM0_TOKEN) to GET the agent
+      const response = await getAgent(created.name, sandboxToken, testOrgSlug);
+
+      // Then — should return agent details
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.name).toBe(created.name);
+      expect(data.agentComposeId).toBe(created.agentComposeId);
+      expect(data.displayName).toBe("Sandbox Access Agent");
+      expect(data.description).toBe("Agent accessible via sandbox token");
+      expect(data.sound).toBe("professional");
     });
   });
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -194,8 +194,9 @@ export function createDefaultComposeConfig(
 export async function createTestSandboxToken(
   userId: string,
   runId: string,
+  capabilities?: Parameters<typeof generateSandboxToken>[2],
 ): Promise<string> {
-  return generateSandboxToken(userId, runId);
+  return generateSandboxToken(userId, runId, capabilities);
 }
 
 // ============================================================================
@@ -3470,6 +3471,20 @@ export async function seedSeedSkills(): Promise<void> {
     .insert(skills)
     .values(values)
     .onConflictDoNothing();
+}
+
+/**
+ * Seed storage volumes for all SEED_SKILLS under SYSTEM_ORG_ID.
+ * Required for tests that dispatch runs with zero-agent composes,
+ * because skill volumes must exist at runtime for storage manifest resolution.
+ */
+export async function seedSeedSkillStorages(): Promise<void> {
+  const { SEED_SKILLS } = await import("../lib/zero/seed-skills");
+  for (const name of SEED_SKILLS) {
+    const fullPath = `vm0-ai/vm0-skills/tree/main/${name}`;
+    const storageName = `agent-skills@${fullPath}`;
+    await createTestVolumeForOrg(SYSTEM_ORG_ID, storageName);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add a new E2E integration test (`zero-agent.test.ts`) that exercises the full zero agent lifecycle: onboarding (model provider) -> create agent -> upload instructions -> run agent -> claim job -> use sandbox token to read agent details
- Extend the existing agents route tests with a sandbox token access test case using `createTestSandboxToken` with explicit capabilities
- Add `seedSeedSkillStorages` helper and expose `capabilities` parameter on `createTestSandboxToken` in `api-test-helpers.ts`

## Test plan
- [ ] CI passes all existing and new tests
- [ ] New E2E test validates sandbox token flow end-to-end through real API route handlers
- [ ] No regressions in existing zero agent tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)