### PR TITLE
fix(runner): scope doctor health check to deployed version only

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -88,7 +88,7 @@
     # Phase 4: Health check
     # ========================================
     - name: Verify runner health
-      command: "{{ bin_dir }}/runner doctor"
+      command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"
 
     # ========================================
     # Phase 5: Drain old runners + Cleanup
@@ -115,4 +115,4 @@
     # Phase 6: Final health check
     # ========================================
     - name: Verify runner health after cleanup
-      command: "{{ bin_dir }}/runner doctor"
+      command: "{{ bin_dir }}/runner doctor --name {{ runner_name }}"


### PR DESCRIPTION
## Summary

- Pass `--name` to `runner doctor` in deploy playbook so it only checks the version being deployed
- Stopped old-version runners without mitmproxy are expected during drain and should not fail the deploy health check

Fixes #6198

## Test plan

- [ ] Deploy to dev runner and verify doctor only reports on the new version
- [ ] Old stopped runners no longer cause exit code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)