### PR TITLE
refactor(api): use zero agent id instead of compose id for run creation

### DIFF
--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -72,10 +72,19 @@ const router = tsr.router(zeroRunsMainContract, {
         .where(eq(agentComposes.id, composeId))
         .limit(1);
 
+      if (!agent) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent not found", code: "NOT_FOUND" as const },
+          },
+        };
+      }
+
       const result = await createZeroRun({
         userId: authCtx.userId,
         prompt: body.prompt,
-        zeroAgentId: agent?.id ?? "",
+        zeroAgentId: agent.id,
         sessionId: body.sessionId,
         appendSystemPrompt: body.appendSystemPrompt,
         modelProvider: body.modelProvider,

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -1,3 +1,4 @@
+import { eq, and } from "drizzle-orm";
 import {
   createHandler,
   createSafeErrorHandler,
@@ -12,6 +13,8 @@ import {
 import { createZeroRun } from "../../../../src/lib/zero/zero-run-service";
 import { isApiError } from "../../../../src/lib/errors";
 import { isRunDispatchError } from "../../../../src/lib/run";
+import { agentComposes } from "../../../../src/db/schema/agent-compose";
+import { zeroAgents } from "../../../../src/db/schema/zero-agent";
 
 /**
  * Translate createZeroRun() errors into API response format.
@@ -54,10 +57,25 @@ const router = tsr.router(zeroRunsMainContract, {
     if (isAuthError(authCtx)) return authCtx;
 
     try {
+      // Resolve zeroAgentId from agentComposeId
+      const composeId = body.agentComposeId ?? "";
+      const [agent] = await globalThis.services.db
+        .select({ id: zeroAgents.id })
+        .from(agentComposes)
+        .innerJoin(
+          zeroAgents,
+          and(
+            eq(zeroAgents.orgId, agentComposes.orgId),
+            eq(zeroAgents.name, agentComposes.name),
+          ),
+        )
+        .where(eq(agentComposes.id, composeId))
+        .limit(1);
+
       const result = await createZeroRun({
         userId: authCtx.userId,
         prompt: body.prompt,
-        composeId: body.agentComposeId ?? "",
+        zeroAgentId: agent?.id ?? "",
         sessionId: body.sessionId,
         appendSystemPrompt: body.appendSystemPrompt,
         modelProvider: body.modelProvider,

--- a/turbo/apps/web/app/api/zero/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/route.ts
@@ -559,6 +559,7 @@ async function finishSubmit(
 
   await runAgentForSlackOrg({
     composeId: claimed.composeId,
+    zeroAgentId: agentInfo?.zeroAgentId ?? "",
     agentName: claimed.agentName,
     sessionId: claimed.sessionId ?? undefined,
     prompt: answerPrompt,

--- a/turbo/apps/web/app/api/zero/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/route.ts
@@ -557,9 +557,22 @@ async function finishSubmit(
     existingSessionId: claimed.sessionId ?? undefined,
   };
 
+  if (!agentInfo) {
+    log.error("Zero agent not found for compose", {
+      composeId: claimed.composeId,
+    });
+    await updateCardWithError(
+      claimed.slackChannelId,
+      claimed.slackMessageTs,
+      claimed.slackWorkspaceId,
+      "The agent could not be found. Please contact your org admin.",
+    );
+    return;
+  }
+
   await runAgentForSlackOrg({
     composeId: claimed.composeId,
-    zeroAgentId: agentInfo?.zeroAgentId ?? "",
+    zeroAgentId: agentInfo.zeroAgentId,
     agentName: claimed.agentName,
     sessionId: claimed.sessionId ?? undefined,
     prompt: answerPrompt,

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3933,6 +3933,13 @@ export async function seedTestCompose(opts: {
   if (!row) {
     throw new Error("Failed to seed agent compose");
   }
+
+  // Ensure a matching zero_agents row exists so handlers can resolve zeroAgentId
+  await globalThis.services.db
+    .insert(zeroAgents)
+    .values({ orgId: opts.orgId, name: opts.name })
+    .onConflictDoNothing();
+
   return { composeId: row.id };
 }
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -372,7 +372,24 @@ export async function createTestCompose(
       `Failed to create compose: ${error.error?.message || response.status}`,
     );
   }
-  return response.json();
+  const result: { composeId: string; versionId: string; name: string } =
+    await response.json();
+
+  // Ensure a matching zero_agents row exists so callers can resolve zeroAgentId
+  initServices();
+  const [compose] = await globalThis.services.db
+    .select({ orgId: agentComposes.orgId })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, result.composeId))
+    .limit(1);
+  if (compose) {
+    await globalThis.services.db
+      .insert(zeroAgents)
+      .values({ orgId: compose.orgId, name: result.name })
+      .onConflictDoNothing();
+  }
+
+  return result;
 }
 
 /**
@@ -392,13 +409,23 @@ export async function createTestZeroAgent(
   },
 ): Promise<void> {
   initServices();
-  await globalThis.services.db.insert(zeroAgents).values({
-    orgId,
-    name,
-    displayName: metadata.displayName ?? null,
-    description: metadata.description ?? null,
-    sound: metadata.sound ?? null,
-  });
+  await globalThis.services.db
+    .insert(zeroAgents)
+    .values({
+      orgId,
+      name,
+      displayName: metadata.displayName ?? null,
+      description: metadata.description ?? null,
+      sound: metadata.sound ?? null,
+    })
+    .onConflictDoUpdate({
+      target: [zeroAgents.orgId, zeroAgents.name],
+      set: {
+        displayName: metadata.displayName ?? null,
+        description: metadata.description ?? null,
+        sound: metadata.sound ?? null,
+      },
+    });
 }
 
 /**

--- a/turbo/apps/web/src/__tests__/github/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/github/api-helpers.ts
@@ -17,6 +17,7 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../db/schema/agent-compose";
+import { zeroAgents } from "../../db/schema/zero-agent";
 import { githubInstallations } from "../../db/schema/github-installation";
 import { githubUserLinks } from "../../db/schema/github-user-link";
 
@@ -81,6 +82,12 @@ export async function givenGitHubInstallation(
       name: uniqueId("gh-agent"),
     })
     .returning();
+
+  // Create zero agent so handler can resolve zeroAgentId
+  await globalThis.services.db
+    .insert(zeroAgents)
+    .values({ orgId, name: compose!.name })
+    .onConflictDoNothing();
 
   // Create compose version (content-addressed: id is SHA-256 hash)
   const versionContent = {

--- a/turbo/apps/web/src/lib/agent-identity.ts
+++ b/turbo/apps/web/src/lib/agent-identity.ts
@@ -1,7 +1,3 @@
-import { eq, and } from "drizzle-orm";
-import { agentComposes } from "../db/schema/agent-compose";
-import { zeroAgents } from "../db/schema/zero-agent";
-
 interface AgentIdentity {
   displayName: string | null;
   description: string | null;
@@ -23,7 +19,7 @@ const TONE_INSTRUCTIONS: Readonly<Record<string, string>> = {
  * Format agent identity metadata into a system prompt fragment.
  * Returns empty string if all fields are null/undefined.
  */
-function formatAgentIdentityPrompt(identity: AgentIdentity): string {
+export function formatAgentIdentityPrompt(identity: AgentIdentity): string {
   const parts: string[] = [];
 
   if (identity.displayName) {
@@ -42,36 +38,4 @@ function formatAgentIdentityPrompt(identity: AgentIdentity): string {
   }
 
   return `# Agent Identity\n${parts.join("\n")}`;
-}
-
-/**
- * Build a system prompt fragment with the agent's identity metadata.
- *
- * Queries zeroAgents by joining through agentComposes to resolve the
- * (orgId, name) key from a composeId. Returns empty string if the
- * compose or metadata is not found.
- */
-export async function buildAgentIdentityPrompt(
-  composeId: string,
-): Promise<string> {
-  const [row] = await globalThis.services.db
-    .select({
-      displayName: zeroAgents.displayName,
-      description: zeroAgents.description,
-      sound: zeroAgents.sound,
-    })
-    .from(agentComposes)
-    .innerJoin(
-      zeroAgents,
-      and(
-        eq(zeroAgents.orgId, agentComposes.orgId),
-        eq(zeroAgents.name, agentComposes.name),
-      ),
-    )
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
-
-  if (!row) return "";
-
-  return formatAgentIdentityPrompt(row);
 }

--- a/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
@@ -2,6 +2,7 @@ import { getReceivedEmail } from "../client";
 import { processEmailAttachments } from "../attachment";
 import { extractEmailBody } from "../content-extract";
 import { verifySenderAuthenticity } from "../sender-auth";
+import { eq, and } from "drizzle-orm";
 import {
   verifyReplyToken,
   lookupEmailThreadSession,
@@ -13,6 +14,8 @@ import { createZeroRun } from "../../zero/zero-run-service";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
+import { agentComposes } from "../../../db/schema/agent-compose";
+import { zeroAgents } from "../../../db/schema/zero-agent";
 import { logger } from "../../logger";
 
 const log = logger("email:inbound-reply");
@@ -175,13 +178,37 @@ export async function handleInboundEmailReply(
     },
   ];
 
-  // 11. Create run with integration context as system prompt
+  // 11. Resolve zeroAgentId from session's composeId
+  const [agent] = await globalThis.services.db
+    .select({ id: zeroAgents.id })
+    .from(agentComposes)
+    .innerJoin(
+      zeroAgents,
+      and(
+        eq(zeroAgents.orgId, agentComposes.orgId),
+        eq(zeroAgents.name, agentComposes.name),
+      ),
+    )
+    .where(eq(agentComposes.id, session.composeId))
+    .limit(1);
+
+  if (!agent) {
+    log.warn("No zero agent found for session compose", {
+      composeId: session.composeId,
+    });
+    return {
+      ok: false,
+      errorMessage: "The agent for this conversation could not be found.",
+    };
+  }
+
+  // 12. Create run with integration context as system prompt
   const appendSystemPrompt = buildIntegrationContext("Email");
   const result = await createZeroRun({
     userId: session.userId,
     prompt: replyContent,
     appendSystemPrompt,
-    composeId: session.composeId,
+    zeroAgentId: agent.id,
     sessionId: session.agentSessionId,
     triggerSource: "email",
     callbacks,

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -280,7 +280,7 @@ export async function handleInboundEmailTrigger(
     userId,
     prompt,
     appendSystemPrompt,
-    composeId: compose.composeId,
+    zeroAgentId: compose.zeroAgentId,
     triggerSource: "email",
     callbacks,
   });

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import { eq, and } from "drizzle-orm";
 import { emailThreadSessions } from "../../../db/schema/email-thread-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
+import { zeroAgents } from "../../../db/schema/zero-agent";
 import { getOrgBySlug } from "../../org/org-cache-service";
 import { env } from "../../../env";
 import { getAppUrl } from "../../url";
@@ -251,6 +252,7 @@ export function computeReplyRecipients(opts: {
 
 interface ResolvedAgent {
   composeId: string;
+  zeroAgentId: string;
   userId: string;
   orgId: string;
   orgSlug: string;
@@ -291,8 +293,20 @@ export async function resolveAgentByAddress(
   // Compose must have a published version to be triggerable
   if (!compose.headVersionId) return null;
 
+  // 3. Resolve zeroAgentId by (orgId, name)
+  const [agent] = await globalThis.services.db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(eq(zeroAgents.orgId, orgData.orgId), eq(zeroAgents.name, agentName)),
+    )
+    .limit(1);
+
+  if (!agent) return null;
+
   return {
     composeId: compose.id,
+    zeroAgentId: agent.id,
     userId: compose.userId,
     orgId: compose.orgId,
     orgSlug,

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -4,6 +4,7 @@ import { githubInstallations } from "../../../db/schema/github-installation";
 import { githubUserLinks } from "../../../db/schema/github-user-link";
 import { githubIssueSessions } from "../../../db/schema/github-issue-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
+import { zeroAgents } from "../../../db/schema/zero-agent";
 import { validateAgentSession } from "../../run";
 import { createZeroRun } from "../../zero/zero-run-service";
 import { buildIntegrationContext } from "../../integration-context";
@@ -426,6 +427,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     .select({
       id: agentComposes.id,
       name: agentComposes.name,
+      orgId: agentComposes.orgId,
     })
     .from(agentComposes)
     .where(eq(agentComposes.id, installation.defaultComposeId))
@@ -434,6 +436,24 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
   if (!compose) {
     throw new Error(
       `Agent compose not found: composeId=${installation.defaultComposeId}`,
+    );
+  }
+
+  // 3b. Resolve zeroAgentId from compose
+  const [zeroAgent] = await globalThis.services.db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.orgId, compose.orgId),
+        eq(zeroAgents.name, compose.name),
+      ),
+    )
+    .limit(1);
+
+  if (!zeroAgent) {
+    throw new Error(
+      `Zero agent not found for compose: composeId=${compose.id}`,
     );
   }
 
@@ -492,7 +512,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
       userId: vm0UserId,
       prompt: resolvedPrompt,
       appendSystemPrompt,
-      composeId: compose.id,
+      zeroAgentId: zeroAgent.id,
       sessionId: existingSessionId,
       triggerSource: "github",
       callbacks: [

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -1023,7 +1023,7 @@ async function executeSchedule(
       userId: schedule.userId,
       prompt: schedule.prompt,
       appendSystemPrompt: schedule.appendSystemPrompt ?? undefined,
-      composeId: compose.id,
+      zeroAgentId: schedule.zeroAgentId,
       scheduleId: schedule.id,
       triggerSource: "schedule",
       callbacks,

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -177,7 +177,7 @@ export async function handleOrgDirectMessage(
 
   const { status, response, runId, errorCode } = await runAgentForSlackOrg({
     composeId,
-    zeroAgentId: agent.zeroAgentId!,
+    zeroAgentId: agent.zeroAgentId,
     agentName,
     sessionId: existingSessionId,
     prompt: messageContent,

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -177,6 +177,7 @@ export async function handleOrgDirectMessage(
 
   const { status, response, runId, errorCode } = await runAgentForSlackOrg({
     composeId,
+    zeroAgentId: agent.zeroAgentId!,
     agentName,
     sessionId: existingSessionId,
     prompt: messageContent,

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -175,6 +175,7 @@ export async function handleOrgMention(
 
   const { status, response, runId, errorCode } = await runAgentForSlackOrg({
     composeId,
+    zeroAgentId: agent.zeroAgentId!,
     agentName,
     sessionId: existingSessionId,
     prompt: messageContent,

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -175,7 +175,7 @@ export async function handleOrgMention(
 
   const { status, response, runId, errorCode } = await runAgentForSlackOrg({
     composeId,
-    zeroAgentId: agent.zeroAgentId!,
+    zeroAgentId: agent.zeroAgentId,
     agentName,
     sessionId: existingSessionId,
     prompt: messageContent,

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -15,6 +15,7 @@ const log = logger("slack-org:run-agent");
 
 interface RunAgentParams {
   composeId: string;
+  zeroAgentId: string;
   agentName: string;
   sessionId: string | undefined;
   prompt: string;
@@ -47,6 +48,7 @@ export async function runAgentForSlackOrg(
 ): Promise<RunAgentResult> {
   const {
     composeId,
+    zeroAgentId,
     agentName,
     sessionId,
     prompt,
@@ -75,7 +77,7 @@ export async function runAgentForSlackOrg(
 
     const result = await createZeroRun({
       userId,
-      composeId,
+      zeroAgentId,
       prompt,
       appendSystemPrompt,
       sessionId,

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -327,10 +327,14 @@ export async function fetchConversationContexts(
  * Resolve workspace agent from composeId.
  * Returns id, name, and displayName from the zero_agents table.
  */
-export async function getWorkspaceAgent(
-  composeId: string,
-): Promise<
-  { id: string; name: string; displayName: string | null } | undefined
+export async function getWorkspaceAgent(composeId: string): Promise<
+  | {
+      id: string;
+      name: string;
+      displayName: string | null;
+      zeroAgentId: string | null;
+    }
+  | undefined
 > {
   const db = globalThis.services.db;
   const [compose] = await db
@@ -346,7 +350,10 @@ export async function getWorkspaceAgent(
   if (!compose) return undefined;
 
   const [agent] = await db
-    .select({ displayName: zeroAgents.displayName })
+    .select({
+      zeroAgentId: zeroAgents.id,
+      displayName: zeroAgents.displayName,
+    })
     .from(zeroAgents)
     .where(
       and(
@@ -360,6 +367,7 @@ export async function getWorkspaceAgent(
     id: compose.id,
     name: compose.name,
     displayName: agent?.displayName ?? null,
+    zeroAgentId: agent?.zeroAgentId ?? null,
   };
 }
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -332,7 +332,7 @@ export async function getWorkspaceAgent(composeId: string): Promise<
       id: string;
       name: string;
       displayName: string | null;
-      zeroAgentId: string | null;
+      zeroAgentId: string;
     }
   | undefined
 > {
@@ -363,11 +363,13 @@ export async function getWorkspaceAgent(composeId: string): Promise<
     )
     .limit(1);
 
+  if (!agent) return undefined;
+
   return {
     id: compose.id,
     name: compose.name,
-    displayName: agent?.displayName ?? null,
-    zeroAgentId: agent?.zeroAgentId ?? null,
+    displayName: agent.displayName,
+    zeroAgentId: agent.zeroAgentId,
   };
 }
 

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -160,7 +160,7 @@ export async function handleTelegramDirectMessage(
 
   const { status, response, runId } = await runAgentForTelegram({
     composeId,
-    zeroAgentId: defaultAgent.zeroAgentId!,
+    zeroAgentId: defaultAgent.zeroAgentId,
     agentName,
     sessionId: existingSessionId,
     prompt: enrichedPrompt,

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -160,6 +160,7 @@ export async function handleTelegramDirectMessage(
 
   const { status, response, runId } = await runAgentForTelegram({
     composeId,
+    zeroAgentId: defaultAgent.zeroAgentId!,
     agentName,
     sessionId: existingSessionId,
     prompt: enrichedPrompt,

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -147,6 +147,7 @@ export async function handleTelegramMention(
   );
   const { status, response, runId } = await runAgentForTelegram({
     composeId,
+    zeroAgentId: defaultAgent.zeroAgentId!,
     agentName,
     sessionId: existingSessionId,
     prompt: enrichedPrompt,

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -147,7 +147,7 @@ export async function handleTelegramMention(
   );
   const { status, response, runId } = await runAgentForTelegram({
     composeId,
-    zeroAgentId: defaultAgent.zeroAgentId!,
+    zeroAgentId: defaultAgent.zeroAgentId,
     agentName,
     sessionId: existingSessionId,
     prompt: enrichedPrompt,

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -11,6 +11,7 @@ const log = logger("telegram:run-agent");
 
 interface RunAgentParams {
   composeId: string;
+  zeroAgentId: string;
   agentName: string;
   sessionId: string | undefined;
   prompt: string;
@@ -36,6 +37,7 @@ export async function runAgentForTelegram(
 ): Promise<RunAgentResult> {
   const {
     composeId,
+    zeroAgentId,
     agentName,
     sessionId,
     prompt,
@@ -57,7 +59,7 @@ export async function runAgentForTelegram(
   try {
     const result = await createZeroRun({
       userId,
-      composeId,
+      zeroAgentId,
       prompt,
       appendSystemPrompt,
       sessionId,

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -260,9 +260,7 @@ export async function ensureOrgAndArtifact(vm0UserId: string): Promise<void> {
  */
 export async function getWorkspaceAgent(
   composeId: string,
-): Promise<
-  { id: string; name: string; zeroAgentId: string | null } | undefined
-> {
+): Promise<{ id: string; name: string; zeroAgentId: string } | undefined> {
   const db = globalThis.services.db;
   const [compose] = await db
     .select({
@@ -287,10 +285,12 @@ export async function getWorkspaceAgent(
     )
     .limit(1);
 
+  if (!agent) return undefined;
+
   return {
     id: compose.id,
     name: compose.name,
-    zeroAgentId: agent?.zeroAgentId ?? null,
+    zeroAgentId: agent.zeroAgentId,
   };
 }
 

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -3,6 +3,7 @@ import { telegramThreadSessions } from "../../../db/schema/telegram-thread-sessi
 import { telegramMessages } from "../../../db/schema/telegram-message";
 import { telegramUserLinks } from "../../../db/schema/telegram-user-link";
 import { agentComposes } from "../../../db/schema/agent-compose";
+import { zeroAgents } from "../../../db/schema/zero-agent";
 import { getAppUrl } from "../../url";
 import { resolveOrgOrNull } from "../../org/resolve-org";
 import { validateAgentSession } from "../../run";
@@ -259,13 +260,38 @@ export async function ensureOrgAndArtifact(vm0UserId: string): Promise<void> {
  */
 export async function getWorkspaceAgent(
   composeId: string,
-): Promise<{ id: string; name: string } | undefined> {
-  const [compose] = await globalThis.services.db
-    .select({ id: agentComposes.id, name: agentComposes.name })
+): Promise<
+  { id: string; name: string; zeroAgentId: string | null } | undefined
+> {
+  const db = globalThis.services.db;
+  const [compose] = await db
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      orgId: agentComposes.orgId,
+    })
     .from(agentComposes)
     .where(eq(agentComposes.id, composeId))
     .limit(1);
-  return compose ?? undefined;
+
+  if (!compose) return undefined;
+
+  const [agent] = await db
+    .select({ zeroAgentId: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(
+        eq(zeroAgents.orgId, compose.orgId),
+        eq(zeroAgents.name, compose.name),
+      ),
+    )
+    .limit(1);
+
+  return {
+    id: compose.id,
+    name: compose.name,
+    zeroAgentId: agent?.zeroAgentId ?? null,
+  };
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -8,6 +8,7 @@ import {
   createTestCompose,
   createTestSchedule,
   createTestZeroAgent,
+  getTestZeroAgentId,
   findTestRunRecord,
   findTestRunCallbacks,
   findTestRunnerJobEntry,
@@ -20,13 +21,14 @@ const context = testContext();
 
 describe("createZeroRun()", () => {
   let user: UserContext;
-  let composeId: string;
+  let zeroAgentId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
-    const compose = await createTestCompose(uniqueId("agent"));
-    composeId = compose.composeId;
+    const agentName = uniqueId("agent");
+    await createTestCompose(agentName);
+    zeroAgentId = await getTestZeroAgentId(user.orgId, agentName);
     vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
     reloadEnv();
   });
@@ -37,7 +39,7 @@ describe("createZeroRun()", () => {
     return {
       userId: user.userId,
       prompt: "Hello, world!",
-      composeId,
+      zeroAgentId,
       triggerSource: "web" as TriggerSource,
       ...overrides,
     };
@@ -72,16 +74,15 @@ describe("createZeroRun()", () => {
 
     it("should inject agent identity into appendSystemPrompt", async () => {
       const agentName = uniqueId("identity-agent");
-      const compose = await createTestCompose(agentName);
+      await createTestCompose(agentName);
       await createTestZeroAgent(user.orgId, agentName, {
         displayName: "My Agent",
         description: "A helpful assistant",
         sound: "friendly",
       });
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
 
-      const result = await createZeroRun(
-        baseParams({ composeId: compose.composeId }),
-      );
+      const result = await createZeroRun(baseParams({ zeroAgentId: agentId }));
 
       const run = await findTestRunRecord(result.runId);
       expect(run).toBeDefined();
@@ -91,14 +92,15 @@ describe("createZeroRun()", () => {
 
     it("should prepend identity before existing appendSystemPrompt", async () => {
       const agentName = uniqueId("prepend-agent");
-      const compose = await createTestCompose(agentName);
+      await createTestCompose(agentName);
       await createTestZeroAgent(user.orgId, agentName, {
         displayName: "Bot",
       });
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
 
       const result = await createZeroRun(
         baseParams({
-          composeId: compose.composeId,
+          zeroAgentId: agentId,
           appendSystemPrompt: "Custom instructions",
         }),
       );
@@ -153,12 +155,17 @@ describe("createZeroRun()", () => {
       const agentName = uniqueId("sched-agent");
       const compose = await createTestCompose(agentName);
       await createTestZeroAgent(user.orgId, agentName, {});
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
       const schedule = await createTestSchedule(
         compose.composeId,
         uniqueId("sched"),
       );
       const result = await createZeroRun(
-        baseParams({ scheduleId: schedule.id, triggerSource: "schedule" }),
+        baseParams({
+          zeroAgentId: agentId,
+          scheduleId: schedule.id,
+          triggerSource: "schedule",
+        }),
       );
 
       const run = await findTestRunRecord(result.runId);

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -1,8 +1,50 @@
+import { eq, and } from "drizzle-orm";
 import type { TriggerSource } from "@vm0/core";
 import { startRun, type CreateRunResult } from "../run";
 import { DISALLOWED_CRON_TOOLS } from "../integration-context";
-import { buildAgentIdentityPrompt } from "../agent-identity";
+import { formatAgentIdentityPrompt } from "../agent-identity";
 import type { CallbackPayload } from "../callback/callback-payloads";
+import { zeroAgents } from "../../db/schema/zero-agent";
+import { agentComposes } from "../../db/schema/agent-compose";
+
+/**
+ * Resolve agent identity metadata and the corresponding composeId
+ * from a zeroAgentId. Uses leftJoin so it works even if no matching
+ * agentComposes row exists (forward-compatible).
+ */
+async function resolveZeroAgent(zeroAgentId: string): Promise<{
+  displayName: string | null;
+  description: string | null;
+  sound: string | null;
+  composeId: string | null;
+}> {
+  const [row] = await globalThis.services.db
+    .select({
+      displayName: zeroAgents.displayName,
+      description: zeroAgents.description,
+      sound: zeroAgents.sound,
+      composeId: agentComposes.id,
+    })
+    .from(zeroAgents)
+    .leftJoin(
+      agentComposes,
+      and(
+        eq(agentComposes.orgId, zeroAgents.orgId),
+        eq(agentComposes.name, zeroAgents.name),
+      ),
+    )
+    .where(eq(zeroAgents.id, zeroAgentId))
+    .limit(1);
+
+  return (
+    row ?? {
+      displayName: null,
+      description: null,
+      sound: null,
+      composeId: null,
+    }
+  );
+}
 
 /**
  * Parameters accepted by createZeroRun().
@@ -12,7 +54,7 @@ import type { CallbackPayload } from "../callback/callback-payloads";
 interface ZeroRunParams {
   userId: string;
   prompt: string;
-  composeId: string;
+  zeroAgentId: string;
   triggerSource: TriggerSource;
   sessionId?: string;
   appendSystemPrompt?: string;
@@ -24,28 +66,29 @@ interface ZeroRunParams {
 /**
  * Create an agent run with zero-layer defaults.
  *
- * Injects agent identity, memoryName, artifactName, and disallowedTools
- * so that every zero trigger path gets consistent identity, memory
- * persistence, artifact storage, and cron-tool restrictions.
+ * Resolves the agent's composeId internally from zeroAgentId, then injects
+ * agent identity, memoryName, artifactName, and disallowedTools so that
+ * every zero trigger path gets consistent identity, memory persistence,
+ * artifact storage, and cron-tool restrictions.
  */
 export async function createZeroRun(
   params: ZeroRunParams,
 ): Promise<CreateRunResult> {
+  const agent = await resolveZeroAgent(params.zeroAgentId);
+
   // Inject agent identity into appendSystemPrompt
   let { appendSystemPrompt } = params;
-  if (params.composeId) {
-    const identity = await buildAgentIdentityPrompt(params.composeId);
-    if (identity) {
-      appendSystemPrompt = appendSystemPrompt
-        ? `${identity}\n\n${appendSystemPrompt}`
-        : identity;
-    }
+  if (agent.displayName || agent.description || agent.sound) {
+    const identity = formatAgentIdentityPrompt(agent);
+    appendSystemPrompt = appendSystemPrompt
+      ? `${identity}\n\n${appendSystemPrompt}`
+      : identity;
   }
 
   return startRun({
     userId: params.userId,
     prompt: params.prompt,
-    composeId: params.composeId,
+    composeId: agent.composeId ?? undefined,
     triggerSource: params.triggerSource,
     sessionId: params.sessionId,
     appendSystemPrompt,


### PR DESCRIPTION
## Summary

- Change `ZeroRunParams` to accept `zeroAgentId` instead of `composeId`, with `createZeroRun()` resolving `composeId` internally via new `resolveZeroAgent()` helper
- Update all 8 callers (email trigger/reply, slack DM/mention, telegram DM/mention, github issues, schedule, web API, slack interactive) to pass `zeroAgentId`
- Remove `buildAgentIdentityPrompt()` in favor of direct `formatAgentIdentityPrompt()` call with data from `resolveZeroAgent()`
- Update `createTestCompose()` to auto-create `zeroAgents` row and `createTestZeroAgent()` to handle conflicts

## Test plan

- [x] All 4326 tests pass (424 test files)
- [x] TypeScript type check passes
- [x] Lint passes (0 warnings, 0 errors)
- [x] Format check passes
- [x] Knip passes (no unused exports)
- [x] Verified `composeId` only appears in `resolveZeroAgent()` for `startRun()` passthrough
- [x] Verified `buildAgentIdentityPrompt` is fully removed from zero directory

Closes #6231

🤖 Generated with [Claude Code](https://claude.com/claude-code)