### PR TITLE
fix: use fake model names in vm0-provider test to avoid polluting dev database

### DIFF
--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -97,22 +97,22 @@ describe("VM0 managed model provider", () => {
     it("should return a random key for a vendor with keys", async () => {
       await insertVm0ApiKeys([
         {
-          vendor: "anthropic",
-          model: "claude-sonnet-4.6",
+          vendor: "test-vendor",
+          model: "test-model",
           apiKey: "sk-test-anthropic-1",
           label: "test key 1",
         },
         {
-          vendor: "anthropic",
-          model: "claude-sonnet-4.6",
+          vendor: "test-vendor",
+          model: "test-model",
           apiKey: "sk-test-anthropic-2",
           label: "test key 2",
         },
       ]);
 
-      const result = await getTestVm0ApiKey("anthropic");
+      const result = await getTestVm0ApiKey("test-vendor");
       expect(result).not.toBeNull();
-      expect(result!.model).toBe("claude-sonnet-4.6");
+      expect(result!.model).toBe("test-model");
       expect(["sk-test-anthropic-1", "sk-test-anthropic-2"]).toContain(
         result!.apiKey,
       );


### PR DESCRIPTION
## Summary
- Replace real vendor/model names (`anthropic`, `claude-sonnet-4.6`) with fake names (`test-vendor`, `test-model`) in the "key pool service" test block
- Prevents test data from mixing with real API keys in the dev database, which caused "Invalid API key" errors in real flows

Closes #6243

## Test plan
- [x] All 8 tests in `vm0-provider.test.ts` pass
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)