### PR TITLE
fix: pass schedule description through agent detail data flow

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -69,6 +69,7 @@ function mockSchedules() {
         intervalSeconds: null,
         timezone: "UTC",
         prompt: "Run the daily digest",
+        description: "Daily digest summary",
         createdAt: "2024-06-01T00:00:00Z",
       },
       {
@@ -83,6 +84,7 @@ function mockSchedules() {
         intervalSeconds: null,
         timezone: "UTC",
         prompt: "Something else",
+        description: null,
         createdAt: "2024-06-01T00:00:00Z",
       },
     ],
@@ -135,6 +137,7 @@ describe("zero-job-detail signals", () => {
       expect(entries).toHaveLength(1);
       expect(entries[0]!.name).toBe("daily-run");
       expect(entries[0]!.time).toBe("Every day at 9:00 AM");
+      expect(entries[0]!.description).toBe("Daily digest summary");
       expect(scheduleError).toBeNull();
     });
 
@@ -319,6 +322,76 @@ describe("zero-job-detail signals", () => {
         enabled: true,
         cronExpression: "30 9 * * *",
       });
+    });
+
+    it("should include description in save request when provided", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      await setupWithAgent();
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/schedules",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ id: "new-sched" });
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      const params: ZeroJobScheduleSaveParams = {
+        prompt: "Run daily task",
+        description: "  A daily task description  ",
+        freq: "every_day",
+        date: "2030-01-01",
+        hour: 9,
+        minute: 30,
+        timezone: "UTC",
+        intervalSeconds: 0,
+      };
+
+      await context.store.set(saveZeroJobSchedule$, params);
+
+      expect(capturedBody).toMatchObject({
+        prompt: "Run daily task",
+        description: "A daily task description",
+      });
+    });
+
+    it("should omit description from save request when not provided", async () => {
+      let capturedBody: Record<string, unknown> = {};
+
+      await setupWithAgent();
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/schedules",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ id: "new-sched" });
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      const params: ZeroJobScheduleSaveParams = {
+        prompt: "Run daily task",
+        freq: "every_day",
+        date: "2030-01-01",
+        hour: 9,
+        minute: 30,
+        timezone: "UTC",
+        intervalSeconds: 0,
+      };
+
+      await context.store.set(saveZeroJobSchedule$, params);
+
+      expect(capturedBody).not.toHaveProperty("description");
     });
 
     it("should save a loop schedule with intervalSeconds", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -423,6 +423,7 @@ interface ScheduleItem {
   intervalSeconds: number | null;
   timezone: string;
   prompt: string;
+  description: string | null;
   createdAt: string;
 }
 
@@ -514,6 +515,7 @@ export const zeroJobScheduleEntries$ = computed((get) => {
         id: s.id,
         time: scheduleToTimeString(s),
         prompt: s.prompt,
+        description: s.description,
         enabled: s.enabled,
         name: s.name,
         intervalSeconds: s.intervalSeconds,
@@ -560,6 +562,7 @@ const fetchZeroJobSchedule$ = command(async ({ get, set }) => {
 
 export interface ZeroJobScheduleSaveParams {
   prompt: string;
+  description?: string;
   freq: string;
   date: string;
   hour: number;
@@ -586,6 +589,7 @@ export const saveZeroJobSchedule$ = command(
       name: scheduleName,
       timezone: params.timezone,
       prompt: params.prompt.trim(),
+      ...(params.description && { description: params.description.trim() }),
       enabled: true,
     };
 

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
@@ -9,6 +9,7 @@ import {
 
 interface ZeroScheduleSaveParams {
   prompt: string;
+  description?: string;
   freq: string;
   date: string;
   hour: number;


### PR DESCRIPTION
## Summary
- Add missing `description` field to `ScheduleItem` interface, `ZeroJobScheduleSaveParams`, and `ZeroScheduleSaveParams` in the agent detail page data flow
- Wire `description` through `zeroJobScheduleEntries$` mapping so the edit dialog displays the auto-generated description
- Include `description` in the save request base object so user edits are persisted

The description field was added to the org schedule page in #6113 but the agent detail page (`zero-job-detail.ts`) and schedule tab (`zero-schedule-tab.tsx`) were not updated, causing the description to be missing in the edit dialog.

## Test plan
- [ ] Open an agent's Schedule tab, create a new schedule without filling description — verify description is auto-generated and visible in the edit dialog
- [ ] Edit an existing schedule's description — verify the change persists after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)