### PR TITLE
fix: migrate platform schedule frontend from composeId to zeroAgentId

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -59,8 +59,8 @@ function mockSchedules() {
     schedules: [
       {
         id: "sched-1",
-        composeId: "compose-1",
-        composeName: "my-agent",
+        zeroAgentId: "compose-1",
+        agentName: "my-agent",
         name: "daily-run",
         enabled: true,
         triggerType: "cron",
@@ -69,12 +69,13 @@ function mockSchedules() {
         intervalSeconds: null,
         timezone: "UTC",
         prompt: "Run the daily digest",
+        description: "Daily digest summary",
         createdAt: "2024-06-01T00:00:00Z",
       },
       {
         id: "sched-2",
-        composeId: "compose-2",
-        composeName: "other-agent",
+        zeroAgentId: "compose-2",
+        agentName: "other-agent",
         name: "other-run",
         enabled: true,
         triggerType: "cron",
@@ -83,6 +84,7 @@ function mockSchedules() {
         intervalSeconds: null,
         timezone: "UTC",
         prompt: "Something else",
+        description: null,
         createdAt: "2024-06-01T00:00:00Z",
       },
     ],
@@ -135,6 +137,7 @@ describe("zero-job-detail signals", () => {
       expect(entries).toHaveLength(1);
       expect(entries[0]!.name).toBe("daily-run");
       expect(entries[0]!.time).toBe("Every day at 9:00 AM");
+      expect(entries[0]!.description).toBe("Daily digest summary");
       expect(scheduleError).toBeNull();
     });
 
@@ -313,12 +316,13 @@ describe("zero-job-detail signals", () => {
       await context.store.set(saveZeroJobSchedule$, params);
 
       expect(capturedBody).toMatchObject({
-        composeId: "compose-1",
+        zeroAgentId: "compose-1",
         timezone: "UTC",
         prompt: "Run daily task",
         enabled: true,
         cronExpression: "30 9 * * *",
       });
+      expect(capturedBody).not.toHaveProperty("composeId");
     });
 
     it("should save a loop schedule with intervalSeconds", async () => {
@@ -352,12 +356,13 @@ describe("zero-job-detail signals", () => {
       await context.store.set(saveZeroJobSchedule$, params);
 
       expect(capturedBody).toMatchObject({
-        composeId: "compose-1",
+        zeroAgentId: "compose-1",
         prompt: "Poll every 5 min",
         intervalSeconds: 300,
       });
       expect(capturedBody).not.toHaveProperty("cronExpression");
       expect(capturedBody).not.toHaveProperty("atTime");
+      expect(capturedBody).not.toHaveProperty("composeId");
     });
 
     it("should throw for save when API returns error", async () => {
@@ -426,7 +431,7 @@ describe("zero-job-detail signals", () => {
       await context.store.set(deleteZeroJobSchedule$, "daily-run");
 
       expect(capturedUrl).toContain("/api/zero/schedules/daily-run");
-      expect(capturedUrl).toContain("composeId=compose-1");
+      expect(capturedUrl).toContain("zeroAgentId=compose-1");
 
       const entries = await context.store.get(zeroJobScheduleEntries$);
       expect(entries).toStrictEqual([]);
@@ -467,8 +472,9 @@ describe("zero-job-detail signals", () => {
   });
 
   describe("toggleZeroJobScheduleEnabled$", () => {
-    it("should send enable request for a schedule", async () => {
+    it("should send enable request with zeroAgentId in body", async () => {
       let capturedUrl = "";
+      let capturedBody: Record<string, unknown> | null = null;
 
       server.use(
         http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
@@ -491,8 +497,9 @@ describe("zero-job-detail signals", () => {
       server.use(
         http.post(
           "http://localhost:3000/api/zero/schedules/:name/:action",
-          ({ request }) => {
+          async ({ request }) => {
             capturedUrl = request.url;
+            capturedBody = (await request.json()) as Record<string, unknown>;
             return HttpResponse.json({ ok: true });
           },
         ),
@@ -507,6 +514,9 @@ describe("zero-job-detail signals", () => {
       });
 
       expect(capturedUrl).toContain("/api/zero/schedules/daily-run/enable");
+      expect(capturedBody).not.toBeNull();
+      expect(capturedBody!["zeroAgentId"]).toBe("compose-1");
+      expect(capturedBody).not.toHaveProperty("composeId");
     });
 
     it("should send disable request for a schedule", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
@@ -9,6 +9,11 @@ import {
   saveZeroSchedule$,
   deleteZeroSchedule$,
   toggleZeroScheduleEnabled$,
+  fetchAllOrgSchedules$,
+  allOrgScheduleEntries$,
+  saveOrgSchedule$,
+  toggleOrgScheduleEnabled$,
+  deleteOrgSchedule$,
 } from "../zero-schedule.ts";
 
 const context = testContext();
@@ -17,8 +22,8 @@ function createMockSchedules() {
   return [
     {
       id: "sched-1",
-      composeId: "mock-compose-id",
-      composeName: "zero",
+      zeroAgentId: "mock-compose-id",
+      agentName: "zero",
       orgSlug: "test",
       name: "morning-briefing",
       triggerType: "cron",
@@ -36,8 +41,8 @@ function createMockSchedules() {
     },
     {
       id: "sched-2",
-      composeId: "mock-compose-id",
-      composeName: "zero",
+      zeroAgentId: "mock-compose-id",
+      agentName: "zero",
       orgSlug: "test",
       name: "check-inbox",
       triggerType: "loop",
@@ -55,8 +60,8 @@ function createMockSchedules() {
     },
     {
       id: "sched-other",
-      composeId: "other-compose-id",
-      composeName: "other-agent",
+      zeroAgentId: "other-compose-id",
+      agentName: "other-agent",
       orgSlug: "test",
       name: "other-schedule",
       triggerType: "cron",
@@ -187,7 +192,7 @@ describe("zero-schedule signals", () => {
       });
 
       expect(captured.body).not.toBeNull();
-      expect(captured.body?.composeId).toBe("mock-compose-id");
+      expect(captured.body?.zeroAgentId).toBe("mock-compose-id");
       expect(captured.body?.prompt).toBe("Daily standup summary");
       expect(captured.body?.cronExpression).toBe("0 9 * * *");
       expect(captured.body?.timezone).toBe("UTC");
@@ -286,7 +291,7 @@ describe("zero-schedule signals", () => {
       });
 
       expect(captured.action).toBe("enable");
-      expect(captured.body?.composeId).toBe("mock-compose-id");
+      expect(captured.body?.zeroAgentId).toBe("mock-compose-id");
     });
 
     it("should POST to disable endpoint when enabled is false", async () => {
@@ -340,7 +345,7 @@ describe("zero-schedule signals", () => {
   describe("deleteZeroSchedule$", () => {
     it("should DELETE a schedule and refresh the list", async () => {
       let deletedName: string | null = null;
-      let deletedComposeId: string | null = null;
+      let deletedAgentId: string | null = null;
 
       server.use(
         http.delete(
@@ -348,7 +353,7 @@ describe("zero-schedule signals", () => {
           ({ params, request }) => {
             deletedName = params["name"] as string;
             const url = new URL(request.url);
-            deletedComposeId = url.searchParams.get("composeId");
+            deletedAgentId = url.searchParams.get("zeroAgentId");
             return new HttpResponse(null, { status: 204 });
           },
         ),
@@ -361,7 +366,145 @@ describe("zero-schedule signals", () => {
       await context.store.set(deleteZeroSchedule$, "morning-briefing");
 
       expect(deletedName).toBe("morning-briefing");
-      expect(deletedComposeId).toBe("mock-compose-id");
+      expect(deletedAgentId).toBe("mock-compose-id");
+    });
+  });
+});
+
+describe("org schedule signals", () => {
+  async function setup() {
+    await setupPage({
+      context,
+      path: "/schedule",
+      withoutRender: true,
+    });
+  }
+
+  describe("fetchAllOrgSchedules$ and allOrgScheduleEntries$", () => {
+    it("should map zeroAgentId and agentName fields from API response", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: createMockSchedules() });
+        }),
+      );
+
+      await setup();
+      await context.store.set(fetchAllOrgSchedules$);
+
+      const entries = context.store.get(allOrgScheduleEntries$);
+      expect(entries).toHaveLength(3);
+
+      const zeroEntry = entries.find((e) => e.name === "morning-briefing");
+      expect(zeroEntry?.zeroAgentId).toBe("mock-compose-id");
+      expect(zeroEntry?.agentName).toBe("zero");
+
+      const otherEntry = entries.find((e) => e.name === "other-schedule");
+      expect(otherEntry?.zeroAgentId).toBe("other-compose-id");
+      expect(otherEntry?.agentName).toBe("other-agent");
+    });
+  });
+
+  describe("saveOrgSchedule$", () => {
+    it("should send zeroAgentId in POST body", async () => {
+      const captured: { body: Record<string, unknown> | null } = {
+        body: null,
+      };
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/schedules",
+          async ({ request }) => {
+            captured.body = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ success: true });
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(saveOrgSchedule$, {
+        prompt: "Org-wide daily task",
+        freq: "every_day",
+        date: "2030-01-01",
+        hour: 8,
+        minute: 0,
+        timezone: "UTC",
+        intervalSeconds: 0,
+        zeroAgentId: "agent-uuid-123",
+      });
+
+      expect(captured.body).not.toBeNull();
+      expect(captured.body?.zeroAgentId).toBe("agent-uuid-123");
+      expect(captured.body).not.toHaveProperty("composeId");
+      expect(captured.body?.prompt).toBe("Org-wide daily task");
+      expect(captured.body?.cronExpression).toBe("0 8 * * *");
+    });
+  });
+
+  describe("toggleOrgScheduleEnabled$", () => {
+    it("should send zeroAgentId in toggle request body", async () => {
+      const captured: {
+        action: string | null;
+        body: Record<string, unknown> | null;
+      } = { action: null, body: null };
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/schedules/:name/:action",
+          async ({ params, request }) => {
+            captured.action = params["action"] as string;
+            captured.body = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ success: true });
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(toggleOrgScheduleEnabled$, {
+        name: "morning-briefing",
+        enabled: false,
+        zeroAgentId: "agent-uuid-123",
+      });
+
+      expect(captured.action).toBe("disable");
+      expect(captured.body?.zeroAgentId).toBe("agent-uuid-123");
+      expect(captured.body).not.toHaveProperty("composeId");
+    });
+  });
+
+  describe("deleteOrgSchedule$", () => {
+    it("should send zeroAgentId as query param in DELETE request", async () => {
+      let deletedName: string | null = null;
+      let deletedAgentId: string | null = null;
+
+      server.use(
+        http.delete(
+          "http://localhost:3000/api/zero/schedules/:name",
+          ({ params, request }) => {
+            deletedName = params["name"] as string;
+            const url = new URL(request.url);
+            deletedAgentId = url.searchParams.get("zeroAgentId");
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(deleteOrgSchedule$, {
+        name: "morning-briefing",
+        zeroAgentId: "agent-uuid-123",
+      });
+
+      expect(deletedName).toBe("morning-briefing");
+      expect(deletedAgentId).toBe("agent-uuid-123");
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/agents-list.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agents-list.ts
@@ -8,7 +8,7 @@ const L = logger("AgentsList");
 
 interface Schedule {
   name: string;
-  composeName: string;
+  agentName: string;
   enabled: boolean;
   cronExpression?: string;
   atTime?: string;

--- a/turbo/apps/platform/src/signals/zero-page/cron.ts
+++ b/turbo/apps/platform/src/signals/zero-page/cron.ts
@@ -13,7 +13,7 @@ export type CronTimeOption = Exclude<ScheduleTimeOption, "loop">;
 
 /** Discriminated union for schedule creation/update request body. */
 export type ScheduleBody = {
-  composeId: string;
+  zeroAgentId: string;
   name: string;
   timezone: string;
   prompt: string;

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -413,8 +413,8 @@ export const saveZeroJobConnectors$ = command(async ({ get, set }) => {
 
 interface ScheduleItem {
   id: string;
-  composeId: string;
-  composeName: string;
+  zeroAgentId: string;
+  agentName: string;
   name: string;
   enabled: boolean;
   triggerType: "cron" | "once" | "loop";
@@ -423,6 +423,7 @@ interface ScheduleItem {
   intervalSeconds: number | null;
   timezone: string;
   prompt: string;
+  description: string | null;
   createdAt: string;
 }
 
@@ -514,6 +515,7 @@ export const zeroJobScheduleEntries$ = computed((get) => {
         id: s.id,
         time: scheduleToTimeString(s),
         prompt: s.prompt,
+        description: s.description,
         enabled: s.enabled,
         name: s.name,
         intervalSeconds: s.intervalSeconds,
@@ -541,7 +543,7 @@ const fetchZeroJobSchedule$ = command(async ({ get, set }) => {
     }
 
     const data = (await response.json()) as { schedules: ScheduleItem[] };
-    const agentSchedules = data.schedules.filter((s) => s.composeName === name);
+    const agentSchedules = data.schedules.filter((s) => s.agentName === name);
     set(scheduleState$, { schedules: agentSchedules, error: null });
   } catch (error) {
     throwIfAbort(error);
@@ -582,7 +584,7 @@ export const saveZeroJobSchedule$ = command(
     const scheduleName = params.editName ?? `zero-${Date.now().toString(36)}`;
 
     const base = {
-      composeId: detail.agentComposeId,
+      zeroAgentId: detail.agentComposeId,
       name: scheduleName,
       timezone: params.timezone,
       prompt: params.prompt.trim(),
@@ -662,7 +664,7 @@ export const toggleZeroJobScheduleEnabled$ = command(
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ composeId: detail.agentComposeId }),
+        body: JSON.stringify({ zeroAgentId: detail.agentComposeId }),
       },
     );
 
@@ -690,7 +692,7 @@ export const deleteZeroJobSchedule$ = command(
 
     const fetchFn = get(fetch$);
     const response = await fetchFn(
-      `/api/zero/schedules/${encodeURIComponent(scheduleName)}?composeId=${encodeURIComponent(detail.agentComposeId)}`,
+      `/api/zero/schedules/${encodeURIComponent(scheduleName)}?zeroAgentId=${encodeURIComponent(detail.agentComposeId)}`,
       { method: "DELETE" },
     );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -20,8 +20,8 @@ const L = logger("ZeroSchedule");
 
 interface ScheduleResponse {
   id: string;
-  composeId: string;
-  composeName: string;
+  zeroAgentId: string;
+  agentName: string;
   orgSlug: string;
   name: string;
   triggerType: "cron" | "once" | "loop";
@@ -190,7 +190,7 @@ export const fetchZeroSchedules$ = command(async ({ get, set }) => {
 
     // Filter schedules for this agent's composeId
     const agentSchedules = data.schedules.filter(
-      (s) => s.composeId === composeId,
+      (s) => s.zeroAgentId === composeId,
     );
     set(internalSchedules$, agentSchedules);
   } catch (error) {
@@ -233,7 +233,7 @@ export const saveZeroSchedule$ = command(
     const scheduleName = params.editName ?? `zero-${Date.now().toString(36)}`;
 
     const base = {
-      composeId,
+      zeroAgentId: composeId,
       name: scheduleName,
       timezone: params.timezone,
       prompt: params.prompt.trim(),
@@ -327,7 +327,7 @@ export const toggleZeroScheduleEnabled$ = command(
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ composeId }),
+        body: JSON.stringify({ zeroAgentId: composeId }),
       },
     );
 
@@ -360,7 +360,7 @@ export const deleteZeroSchedule$ = command(
 
     const fetchFn = get(fetch$);
     const response = await fetchFn(
-      `/api/zero/schedules/${encodeURIComponent(scheduleName)}?composeId=${encodeURIComponent(composeId)}`,
+      `/api/zero/schedules/${encodeURIComponent(scheduleName)}?zeroAgentId=${encodeURIComponent(composeId)}`,
       { method: "DELETE" },
     );
 
@@ -379,7 +379,7 @@ export const deleteZeroSchedule$ = command(
 );
 
 // ---------------------------------------------------------------------------
-// All-org schedule entries (for schedule page — no composeId filter)
+// All-org schedule entries (for schedule page — no agent filter)
 // ---------------------------------------------------------------------------
 
 export interface OrgScheduleEntry {
@@ -392,8 +392,8 @@ export interface OrgScheduleEntry {
   notifySlack: boolean;
   name: string;
   intervalSeconds: number | null;
-  composeId: string;
-  composeName: string;
+  zeroAgentId: string;
+  agentName: string;
 }
 
 const internalAllSchedules$ = state<ScheduleResponse[]>([]);
@@ -419,8 +419,8 @@ export const allOrgScheduleEntries$ = computed((get) => {
         notifySlack: s.notifySlack,
         name: s.name,
         intervalSeconds: s.intervalSeconds,
-        composeId: s.composeId,
-        composeName: s.composeName,
+        zeroAgentId: s.zeroAgentId,
+        agentName: s.agentName,
       }),
     );
 });
@@ -449,13 +449,13 @@ export const fetchAllOrgSchedules$ = command(async ({ get, set }) => {
 export const saveOrgSchedule$ = command(
   async (
     { get, set },
-    params: ZeroScheduleSaveParams & { composeId: string },
+    params: ZeroScheduleSaveParams & { zeroAgentId: string },
   ) => {
     const fetchFn = get(fetch$);
     const scheduleName = params.editName ?? `zero-${Date.now().toString(36)}`;
 
     const base = {
-      composeId: params.composeId,
+      zeroAgentId: params.zeroAgentId,
       name: scheduleName,
       timezone: params.timezone,
       prompt: params.prompt.trim(),
@@ -531,7 +531,7 @@ export const saveOrgSchedule$ = command(
 export const toggleOrgScheduleEnabled$ = command(
   async (
     { get, set },
-    params: { name: string; enabled: boolean; composeId: string },
+    params: { name: string; enabled: boolean; zeroAgentId: string },
   ) => {
     const fetchFn = get(fetch$);
     const action = params.enabled ? "enable" : "disable";
@@ -540,7 +540,7 @@ export const toggleOrgScheduleEnabled$ = command(
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ composeId: params.composeId }),
+        body: JSON.stringify({ zeroAgentId: params.zeroAgentId }),
       },
     );
 
@@ -560,10 +560,10 @@ export const toggleOrgScheduleEnabled$ = command(
 );
 
 export const deleteOrgSchedule$ = command(
-  async ({ get, set }, params: { name: string; composeId: string }) => {
+  async ({ get, set }, params: { name: string; zeroAgentId: string }) => {
     const fetchFn = get(fetch$);
     const response = await fetchFn(
-      `/api/zero/schedules/${encodeURIComponent(params.name)}?composeId=${encodeURIComponent(params.composeId)}`,
+      `/api/zero/schedules/${encodeURIComponent(params.name)}?zeroAgentId=${encodeURIComponent(params.zeroAgentId)}`,
       { method: "DELETE" },
     );
 

--- a/turbo/apps/platform/src/views/schedule-page/__tests__/schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/schedule-page/__tests__/schedule-page.test.tsx
@@ -26,8 +26,8 @@ describe("schedule page", () => {
           schedules: [
             {
               id: "sched-1",
-              composeId: "compose-1",
-              composeName: "Test Agent",
+              zeroAgentId: "compose-1",
+              agentName: "Test Agent",
               orgSlug: "test",
               name: "test-schedule",
               triggerType: "cron",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
@@ -195,8 +195,8 @@ function mockAPIsWithSchedules() {
         schedules: [
           {
             id: "sched-1",
-            composeId: "agent-detail-id",
-            composeName: "my-agent",
+            zeroAgentId: "agent-detail-id",
+            agentName: "my-agent",
             orgSlug: "test",
             name: "morning-briefing",
             triggerType: "cron",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -11,8 +11,8 @@ function createMockSchedules() {
   return [
     {
       id: "sched-1",
-      composeId: "mock-compose-id",
-      composeName: "zero",
+      zeroAgentId: "mock-compose-id",
+      agentName: "zero",
       orgSlug: "test",
       name: "morning-briefing",
       triggerType: "cron",
@@ -32,8 +32,8 @@ function createMockSchedules() {
     },
     {
       id: "sched-2",
-      composeId: "mock-compose-id",
-      composeName: "zero",
+      zeroAgentId: "mock-compose-id",
+      agentName: "zero",
       orgSlug: "test",
       name: "check-inbox",
       triggerType: "loop",
@@ -53,8 +53,8 @@ function createMockSchedules() {
     },
     {
       id: "sched-disabled",
-      composeId: "mock-compose-id",
-      composeName: "zero",
+      zeroAgentId: "mock-compose-id",
+      agentName: "zero",
       orgSlug: "test",
       name: "disabled-schedule",
       triggerType: "cron",

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -68,7 +68,7 @@ import emptyScheduleImg from "./assets/empty-schedule.webp";
 
 type CombinedEntry = ScheduleEntry & {
   agentLabel: string;
-  composeId: string;
+  zeroAgentId: string;
 };
 
 function buildCombinedSchedule(
@@ -88,10 +88,10 @@ function buildCombinedSchedule(
     name: e.name,
     intervalSeconds: e.intervalSeconds,
     agentLabel:
-      e.composeId === defaultComposeId
+      e.zeroAgentId === defaultComposeId
         ? agentName
-        : (nameToDisplay.get(e.composeName) ?? e.composeName),
-    composeId: e.composeId,
+        : (nameToDisplay.get(e.agentName) ?? e.agentName),
+    zeroAgentId: e.zeroAgentId,
   }));
 }
 
@@ -580,7 +580,7 @@ function ScheduleEditFields({
 interface ScheduleEditDialogProps {
   entry: CombinedEntry | null;
   onClose: () => void;
-  onSave: (params: ZeroScheduleSaveParams & { composeId: string }) => void;
+  onSave: (params: ZeroScheduleSaveParams & { zeroAgentId: string }) => void;
   saving: boolean;
 }
 
@@ -616,7 +616,7 @@ function ScheduleEditDialogInner({
       timezone,
       intervalSeconds: loopMinutes * 60,
       editName: entry.name,
-      composeId: entry.composeId,
+      zeroAgentId: entry.zeroAgentId,
       notifyEmail,
       notifySlack,
     });
@@ -736,7 +736,7 @@ function ScheduleEditDialog(props: ScheduleEditDialogProps) {
 interface ScheduleCreateDialogProps {
   open: boolean;
   onClose: () => void;
-  onSave: (params: ZeroScheduleSaveParams & { composeId: string }) => void;
+  onSave: (params: ZeroScheduleSaveParams & { zeroAgentId: string }) => void;
   saving: boolean;
   agents: { id: string; name: string; displayName?: string | null }[];
   defaultComposeId: string | null;
@@ -751,7 +751,7 @@ function ScheduleCreateDialogInner({
 }: Omit<ScheduleCreateDialogProps, "open">) {
   const [prompt, setPrompt] = useState("");
   const [description, setDescription] = useState("");
-  const [composeId, setComposeId] = useState(
+  const [zeroAgentId, setZeroAgentId] = useState(
     defaultComposeId ?? agents[0]?.id ?? "",
   );
   const [freq, setFreq] = useState("every_day");
@@ -764,7 +764,7 @@ function ScheduleCreateDialogInner({
   const [loopMinutes, setLoopMinutes] = useState(15);
 
   const handleSave = () => {
-    if (!prompt.trim() || !composeId) {
+    if (!prompt.trim() || !zeroAgentId) {
       return;
     }
     onSave({
@@ -776,7 +776,7 @@ function ScheduleCreateDialogInner({
       minute,
       timezone,
       intervalSeconds: loopMinutes * 60,
-      composeId,
+      zeroAgentId,
     });
   };
 
@@ -793,7 +793,7 @@ function ScheduleCreateDialogInner({
           >
             Agent
           </label>
-          <Select value={composeId} onValueChange={setComposeId}>
+          <Select value={zeroAgentId} onValueChange={setZeroAgentId}>
             <SelectTrigger id="schedule-create-agent" className="h-9">
               <SelectValue />
             </SelectTrigger>
@@ -867,7 +867,7 @@ function ScheduleCreateDialogInner({
         <Button
           type="button"
           onClick={handleSave}
-          disabled={!prompt.trim() || !composeId || saving}
+          disabled={!prompt.trim() || !zeroAgentId || saving}
         >
           {saving ? "Creating\u2026" : "Create"}
         </Button>
@@ -1133,7 +1133,7 @@ export function ZeroSchedulePage() {
   };
 
   const handleCreateSave = (
-    params: ZeroScheduleSaveParams & { composeId: string },
+    params: ZeroScheduleSaveParams & { zeroAgentId: string },
   ) => {
     setSaving(true);
     detach(
@@ -1149,7 +1149,7 @@ export function ZeroSchedulePage() {
   };
 
   const handleDialogSave = (
-    params: ZeroScheduleSaveParams & { composeId: string },
+    params: ZeroScheduleSaveParams & { zeroAgentId: string },
   ) => {
     setSaving(true);
     detach(
@@ -1171,7 +1171,7 @@ export function ZeroSchedulePage() {
     await toggleEnabled({
       name: entry.name,
       enabled,
-      composeId: entry.composeId,
+      zeroAgentId: entry.zeroAgentId,
     });
   };
 
@@ -1189,7 +1189,7 @@ export function ZeroSchedulePage() {
     detach(
       deleteSchedule({
         name: pendingDelete.name,
-        composeId: pendingDelete.composeId,
+        zeroAgentId: pendingDelete.zeroAgentId,
       }),
       Reason.DomCallback,
     );


### PR DESCRIPTION
## Summary

- **Fix 400 errors** on schedule create/toggle/delete: backend PRs #6172/#6240 renamed schedule API fields from `composeId`/`composeName` to `zeroAgentId`/`agentName`, but the platform frontend was never updated
- **Migrate all schedule signals and views**: `ScheduleBody`, `ScheduleResponse`, `OrgScheduleEntry`, `ScheduleItem`, `CombinedEntry` types and all CRUD commands (`save`, `toggle`, `delete`) for both the default-agent and org-wide schedule flows
- **Pass through `description`** in the agent detail schedule flow (was missing from `ScheduleItem` interface and entry mapping)
- **Add tests** for org schedule CRUD (`saveOrgSchedule$`, `toggleOrgScheduleEnabled$`, `deleteOrgSchedule$`, `allOrgScheduleEntries$`) verifying the correct field names are sent in API requests

### Files changed (8)

| File | Change |
|------|--------|
| `cron.ts` | `ScheduleBody.composeId` → `zeroAgentId` |
| `zero-schedule.ts` | `ScheduleResponse`, `OrgScheduleEntry` interfaces + all CRUD commands |
| `zero-job-detail.ts` | `ScheduleItem` interface + description field + all CRUD commands |
| `zero-schedule-page.tsx` | `CombinedEntry` type, dialogs, and handler functions |
| `agents-list.ts` | `Schedule.composeName` → `agentName` |
| 3 test files | Mock data, assertions, and 4 new org schedule tests |

## Test plan

- [x] `pnpm check-types` — all 7 packages pass
- [x] `pnpm turbo run lint --filter=@vm0/app` — 0 warnings, 0 errors
- [x] `pnpm vitest run` — 56 tests pass (52 existing + 4 new)
- [ ] Verify schedule create/edit/delete works on the schedule page
- [ ] Verify schedule create/toggle/delete works on agent detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related Issues

Closes #6248