### PR TITLE
fix: new chat button should create session and navigate to thread page

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -10,6 +10,7 @@ import { timeout } from "signal-timers";
 import type { AgentEvent, LogStatus } from "./log-types.ts";
 import { fetch$ } from "../fetch.ts";
 import { throwIfAbort, detach, Reason } from "../utils.ts";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { logger } from "../log.ts";
 import { setupPollingLoop$, type PageResult } from "./polling.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
@@ -186,14 +187,14 @@ async function createChatThread(
   fetchFn: typeof fetch,
   agentComposeId: string,
   title?: string,
-): Promise<{ id: string; title: string | null } | null> {
+): Promise<{ id: string; title: string | null }> {
   const response = await fetchFn("/api/zero/chat-threads", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ agentComposeId, title }),
   });
   if (!response.ok) {
-    return null;
+    throw new Error("Failed to create chat thread");
   }
   const data = (await response.json()) as {
     id: string;
@@ -948,16 +949,12 @@ export const createNewChatSession$ = command(
         agentComposeId ??
         (await get(zeroOnboardingStatus$)).defaultAgentComposeId;
       if (!resolvedComposeId) {
-        L.warn("No compose ID available for new chat session");
+        toast.error("No agent available for new chat session");
         return;
       }
 
       const fetchFn = get(fetch$);
       const thread = await createChatThread(fetchFn, resolvedComposeId);
-      if (!thread) {
-        L.warn("Failed to create chat thread for new session");
-        return;
-      }
 
       set(internalChatThreadId$, thread.id);
 
@@ -975,6 +972,10 @@ export const createNewChatSession$ = command(
       ]);
 
       set(navigateToZeroSession$, thread.id);
+    } catch (error) {
+      throwIfAbort(error);
+      L.error("Failed to create new chat session:", error);
+      toast.error("Failed to create new chat session");
     } finally {
       set(creatingNewSession$, false);
     }
@@ -1053,8 +1054,11 @@ async function ensureChatThread(
   }
 
   const title = prompt.trim().slice(0, 100);
-  const thread = await createChatThread(fetchFn, composeId, title);
-  if (!thread) {
+  let thread: { id: string; title: string | null };
+  try {
+    thread = await createChatThread(fetchFn, composeId, title);
+  } catch (error) {
+    throwIfAbort(error);
     set(internalMessages$, (prev) => {
       const updated = [...prev];
       updated[updated.length - 1] = {

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -930,6 +930,58 @@ export const startNewZeroSession$ = command(({ get, set }) => {
 });
 
 // ---------------------------------------------------------------------------
+// Commands: create new chat session (from sidebar "New chat" button)
+// ---------------------------------------------------------------------------
+
+const creatingNewSession$ = state(false);
+export const zeroCreatingNewSession$ = computed((get) =>
+  get(creatingNewSession$),
+);
+
+export const createNewChatSession$ = command(
+  async ({ get, set }, agentComposeId: string | null) => {
+    set(creatingNewSession$, true);
+    try {
+      set(startNewZeroSession$);
+
+      const resolvedComposeId =
+        agentComposeId ??
+        (await get(zeroOnboardingStatus$)).defaultAgentComposeId;
+      if (!resolvedComposeId) {
+        L.warn("No compose ID available for new chat session");
+        return;
+      }
+
+      const fetchFn = get(fetch$);
+      const thread = await createChatThread(fetchFn, resolvedComposeId);
+      if (!thread) {
+        L.warn("Failed to create chat thread for new session");
+        return;
+      }
+
+      set(internalChatThreadId$, thread.id);
+
+      const now = new Date().toISOString();
+      set(internalSessionList$, (prev) => [
+        {
+          id: thread.id,
+          title: thread.title,
+          preview: null,
+          agentComposeId: resolvedComposeId,
+          createdAt: now,
+          updatedAt: now,
+        },
+        ...prev,
+      ]);
+
+      set(navigateToZeroSession$, thread.id);
+    } finally {
+      set(creatingNewSession$, false);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Commands: send message
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor, fireEvent } from "@testing-library/react";
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse, delay } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
@@ -68,11 +68,17 @@ function mockSubagentAPIs() {
         updatedAt: "2026-03-10T00:00:01Z",
       });
     }),
+    http.post("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({
+        id: "new-thread-id",
+        title: null,
+      });
+    }),
   );
 }
 
 describe("sidebar new chat navigation", () => {
-  it("should navigate to / when clicking new chat for default agent", async () => {
+  it("should create thread and navigate to /chat/:threadId when clicking new chat for default agent", async () => {
     mockSubagentAPIs();
 
     // Start on /team so the "new chat" button navigates away
@@ -88,13 +94,13 @@ describe("sidebar new chat navigation", () => {
 
     fireEvent.click(newChatButton);
 
-    // Verify navigation to /
+    // Verify navigation to /chat/:threadId
     await waitFor(() => {
-      expect(pathname()).toBe("/");
+      expect(pathname()).toBe("/chat/new-thread-id");
     });
   }, 15_000);
 
-  it("should navigate to /talk/:name when clicking new chat for a subagent", async () => {
+  it("should create thread and navigate to /chat/:threadId when clicking new chat for a subagent", async () => {
     mockSubagentAPIs();
 
     await setupPage({ context, path: "/talk/helper" });
@@ -109,9 +115,78 @@ describe("sidebar new chat navigation", () => {
 
     fireEvent.click(newChatButton);
 
-    // Verify navigation to /talk/helper
+    // Verify navigation to /chat/:threadId
     await waitFor(() => {
-      expect(pathname()).toBe("/talk/helper");
+      expect(pathname()).toBe("/chat/new-thread-id");
     });
+  }, 15_000);
+
+  it("should disable button during thread creation", async () => {
+    mockSubagentAPIs();
+    // Override POST to add a delay
+    server.use(
+      http.post("*/api/zero/chat-threads", async () => {
+        await delay(500);
+        return HttpResponse.json({
+          id: "delayed-thread-id",
+          title: null,
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/team" });
+
+    const newChatButton = await waitFor(
+      () => {
+        return screen.getByLabelText("New chat with Zero");
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(newChatButton);
+
+    // Button should be disabled while creating
+    await waitFor(() => {
+      expect(newChatButton).toBeDisabled();
+    });
+
+    // After creation completes, button should be re-enabled
+    await waitFor(
+      () => {
+        expect(pathname()).toBe("/chat/delayed-thread-id");
+      },
+      { timeout: 5000 },
+    );
+  }, 15_000);
+
+  it("should handle API failure gracefully", async () => {
+    mockSubagentAPIs();
+    // Override POST to return error
+    server.use(
+      http.post("*/api/zero/chat-threads", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    await setupPage({ context, path: "/team" });
+
+    const initialPath = pathname();
+
+    const newChatButton = await waitFor(
+      () => {
+        return screen.getByLabelText("New chat with Zero");
+      },
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(newChatButton);
+
+    // Wait for the request to complete (button should become enabled again)
+    await waitFor(() => {
+      expect(newChatButton).not.toBeDisabled();
+    });
+
+    // Should not have navigated
+    expect(pathname()).toBe(initialPath);
   }, 15_000);
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -65,9 +65,9 @@ import {
   zeroSessionList$,
   zeroSessionListLoading$,
   zeroSessionListError$,
-  startNewZeroSession$,
+  createNewChatSession$,
+  zeroCreatingNewSession$,
 } from "../../signals/zero-page/zero-chat.ts";
-import { navigateTo$ } from "../../signals/route.ts";
 import {
   pinnedAgentIds$,
   savingPinnedAgents$,
@@ -455,6 +455,7 @@ function RecentChatSection({
   selectedRecentId,
   onRecentSelect,
   onNewChat,
+  newChatDisabled,
 }: {
   currentChatAgentId: string | null;
   displayName: string;
@@ -465,6 +466,7 @@ function RecentChatSection({
   selectedRecentId: string | null;
   onRecentSelect?: (id: string) => void;
   onNewChat?: (agent: { id: string; name: string } | null) => void;
+  newChatDisabled?: boolean;
 }) {
   const searchOpen = useGet(sidebarSearchOpen$);
   const setSearchOpen = useSet(setSidebarSearchOpen$);
@@ -555,7 +557,8 @@ function RecentChatSection({
               <button
                 type="button"
                 onClick={handleNewChat}
-                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+                disabled={newChatDisabled}
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors disabled:opacity-50 disabled:pointer-events-none"
                 aria-label={`New chat with ${agentLabel}`}
               >
                 <IconPlus size={15} stroke={2.5} />
@@ -838,15 +841,10 @@ export function ZeroSidebar() {
   const recentSessions = useGet(zeroSessionList$);
   const recentSessionsLoading = useGet(zeroSessionListLoading$);
   const recentSessionsError = useGet(zeroSessionListError$);
-  const startNewSession = useSet(startNewZeroSession$);
-  const navigateTo = useSet(navigateTo$);
+  const createNewChat = useSet(createNewChatSession$);
+  const creatingNewSession = useGet(zeroCreatingNewSession$);
   const onNewChat = (agent: { id: string; name: string } | null) => {
-    startNewSession();
-    if (agent) {
-      navigateTo("/talk/:name", { pathParams: { name: agent.name } });
-    } else {
-      navigateTo("/");
-    }
+    detach(createNewChat(agent?.id ?? null), Reason.DomCallback);
   };
   const displayName = agentName || "Zero";
   const pinnedIdsLoadable = useLastLoadable(pinnedAgentIds$);
@@ -1056,6 +1054,7 @@ export function ZeroSidebar() {
             selectedRecentId={selectedRecentId}
             onRecentSelect={onRecentSelect}
             onNewChat={onNewChat}
+            newChatDisabled={creatingNewSession}
           />
         </nav>
 


### PR DESCRIPTION
## Summary

- Add `createNewChatSession$` command in `zero-chat.ts` that creates a chat thread via `POST /api/zero/chat-threads` and navigates to `/chat/:threadId`
- Update sidebar `onNewChat` callback to use the new command instead of navigating to `/` or `/talk/:name`
- Disable the "New chat" button while thread creation is in flight to prevent rapid clicks

## Test plan

- [x] Existing test updated: clicking "New chat with Zero" creates thread and navigates to `/chat/:threadId`
- [x] Existing test updated: clicking "New chat with Helper Bot" creates thread and navigates to `/chat/:threadId`
- [x] New test: button is disabled during thread creation
- [x] New test: API failure handled gracefully (no navigation, button re-enabled)

Closes #6247

🤖 Generated with [Claude Code](https://claude.com/claude-code)