### PR TITLE
fix: accept compose id as alternative to zero agent id in schedule api

### DIFF
--- a/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
@@ -75,6 +75,22 @@ describe("DELETE /api/zero/schedules/:name", () => {
     expect(data.error.code).toBe("NOT_FOUND");
   });
 
+  it("should delete schedule with composeId fallback", async () => {
+    await createTestSchedule(testComposeId, "del-compose", {
+      cronExpression: "0 9 * * *",
+      prompt: "Will be deleted via composeId",
+    });
+
+    const response = await DELETE(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/del-compose?composeId=${testComposeId}&org=${slug}`,
+        { method: "DELETE" },
+      ),
+    );
+
+    expect(response.status).toBe(204);
+  });
+
   it("should reject unauthenticated request", async () => {
     mockClerk({ userId: null });
 

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/__tests__/route.test.ts
@@ -93,6 +93,33 @@ describe("POST /api/zero/schedules/:name/disable", () => {
     expect(data.error.code).toBe("NOT_FOUND");
   });
 
+  it("should disable schedule with composeId fallback", async () => {
+    await createTestSchedule(testComposeId, "dis-compose", {
+      cronExpression: "0 9 * * *",
+      prompt: "Disable via composeId",
+    });
+    await enableTestSchedule(testComposeId, "dis-compose");
+
+    const before = await getTestSchedule(testComposeId, "dis-compose");
+    expect(before.enabled).toBe(true);
+
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/dis-compose/disable?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ composeId: testComposeId }),
+        },
+      ),
+      { params: Promise.resolve({ name: "dis-compose" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.enabled).toBe(false);
+  });
+
   it("should return 400 for invalid body", async () => {
     const response = await POST(
       createTestRequest(

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
@@ -8,7 +8,14 @@ import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 import { disableSchedule } from "../../../../../../src/lib/schedule";
 import { isNotFound } from "../../../../../../src/lib/errors";
 
-const bodySchema = z.object({ zeroAgentId: z.string() });
+const bodySchema = z
+  .object({
+    zeroAgentId: z.string().optional(),
+    composeId: z.string().optional(),
+  })
+  .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
+    message: "Either 'zeroAgentId' or 'composeId' must be provided",
+  });
 
 export async function POST(
   request: Request,
@@ -41,10 +48,11 @@ export async function POST(
   }
 
   try {
+    const resolvedAgentId = (parsed.data.zeroAgentId ?? parsed.data.composeId)!;
     const schedule = await disableSchedule(
       userId,
       orgId,
-      parsed.data.zeroAgentId,
+      resolvedAgentId,
       name,
     );
 

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
@@ -48,7 +48,8 @@ export async function POST(
   }
 
   try {
-    const resolvedAgentId = (parsed.data.zeroAgentId ?? parsed.data.composeId)!;
+    const resolvedAgentId = parsed.data.zeroAgentId ?? parsed.data.composeId;
+    if (!resolvedAgentId) throw new Error("Missing agent ID after validation");
     const schedule = await disableSchedule(
       userId,
       orgId,

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/__tests__/route.test.ts
@@ -91,6 +91,29 @@ describe("POST /api/zero/schedules/:name/enable", () => {
     expect(data.error.code).toBe("NOT_FOUND");
   });
 
+  it("should enable schedule with composeId fallback", async () => {
+    await createTestSchedule(testComposeId, "enable-compose", {
+      cronExpression: "0 9 * * *",
+      prompt: "Enable via composeId",
+    });
+
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/enable-compose/enable?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ composeId: testComposeId }),
+        },
+      ),
+      { params: Promise.resolve({ name: "enable-compose" }) },
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.enabled).toBe(true);
+  });
+
   it("should return 400 for invalid body", async () => {
     const response = await POST(
       createTestRequest(

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
@@ -48,7 +48,8 @@ export async function POST(
   }
 
   try {
-    const resolvedAgentId = (parsed.data.zeroAgentId ?? parsed.data.composeId)!;
+    const resolvedAgentId = parsed.data.zeroAgentId ?? parsed.data.composeId;
+    if (!resolvedAgentId) throw new Error("Missing agent ID after validation");
     const schedule = await enableSchedule(userId, orgId, resolvedAgentId, name);
 
     return Response.json(schedule, { status: 200 });

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
@@ -8,7 +8,14 @@ import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 import { enableSchedule } from "../../../../../../src/lib/schedule";
 import { isNotFound, isSchedulePast } from "../../../../../../src/lib/errors";
 
-const bodySchema = z.object({ zeroAgentId: z.string() });
+const bodySchema = z
+  .object({
+    zeroAgentId: z.string().optional(),
+    composeId: z.string().optional(),
+  })
+  .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
+    message: "Either 'zeroAgentId' or 'composeId' must be provided",
+  });
 
 export async function POST(
   request: Request,
@@ -41,12 +48,8 @@ export async function POST(
   }
 
   try {
-    const schedule = await enableSchedule(
-      userId,
-      orgId,
-      parsed.data.zeroAgentId,
-      name,
-    );
+    const resolvedAgentId = (parsed.data.zeroAgentId ?? parsed.data.composeId)!;
+    const schedule = await enableSchedule(userId, orgId, resolvedAgentId, name);
 
     return Response.json(schedule, { status: 200 });
   } catch (error) {

--- a/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
@@ -29,7 +29,9 @@ const router = tsr.router(zeroSchedulesByNameContract, {
         org: { orgId },
       } = await resolveOrg(authCtx, orgSlug);
 
-      const resolvedAgentId = (query.zeroAgentId ?? query.composeId)!;
+      const resolvedAgentId = query.zeroAgentId ?? query.composeId;
+      if (!resolvedAgentId)
+        throw new Error("Missing agent ID after validation");
       await deleteSchedule(userId, orgId, resolvedAgentId, params.name);
 
       return {

--- a/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
@@ -29,7 +29,8 @@ const router = tsr.router(zeroSchedulesByNameContract, {
         org: { orgId },
       } = await resolveOrg(authCtx, orgSlug);
 
-      await deleteSchedule(userId, orgId, query.zeroAgentId, params.name);
+      const resolvedAgentId = (query.zeroAgentId ?? query.composeId)!;
+      await deleteSchedule(userId, orgId, resolvedAgentId, params.name);
 
       return {
         status: 204 as const,

--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -123,6 +123,30 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
     expect(data.error.code).toBe("NOT_FOUND");
   });
 
+  it("should create schedule with composeId fallback", async () => {
+    const response = await POST(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            composeId: testComposeId,
+            name: "compose-fallback",
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+            prompt: "Run via composeId",
+          }),
+        },
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.created).toBe(true);
+    expect(data.schedule.name).toBe("compose-fallback");
+  });
+
   it("should reject unauthenticated request", async () => {
     mockClerk({ userId: null });
 

--- a/turbo/apps/web/app/api/zero/schedules/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/route.ts
@@ -34,9 +34,10 @@ const router = tsr.router(zeroSchedulesMainContract, {
         org: { orgId },
       } = await resolveOrg(authCtx, orgSlug);
 
+      const resolvedAgentId = body.zeroAgentId ?? body.composeId;
       const result = await deploySchedule(userId, orgId, {
         name: body.name,
-        zeroAgentId: body.zeroAgentId,
+        zeroAgentId: resolvedAgentId!,
         cronExpression: body.cronExpression,
         atTime: body.atTime,
         intervalSeconds: body.intervalSeconds,

--- a/turbo/apps/web/app/api/zero/schedules/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/route.ts
@@ -35,9 +35,11 @@ const router = tsr.router(zeroSchedulesMainContract, {
       } = await resolveOrg(authCtx, orgSlug);
 
       const resolvedAgentId = body.zeroAgentId ?? body.composeId;
+      if (!resolvedAgentId)
+        throw new Error("Missing agent ID after validation");
       const result = await deploySchedule(userId, orgId, {
         name: body.name,
-        zeroAgentId: resolvedAgentId!,
+        zeroAgentId: resolvedAgentId,
         cronExpression: body.cronExpression,
         atTime: body.atTime,
         intervalSeconds: body.intervalSeconds,

--- a/turbo/packages/core/src/contracts/zero-schedules.ts
+++ b/turbo/packages/core/src/contracts/zero-schedules.ts
@@ -48,7 +48,8 @@ export const deployScheduleResponseSchema = z.object({
 });
 
 /**
- * Zero deploy schedule request — uses zeroAgentId instead of composeId
+ * Zero deploy schedule request — accepts zeroAgentId or composeId (at least one required).
+ * The backend resolves composeId to zeroAgentId via loadZeroAgent() fallback.
  */
 const zeroDeployScheduleRequestSchema = z
   .object({
@@ -63,11 +64,14 @@ const zeroDeployScheduleRequestSchema = z
     artifactName: z.string().optional(),
     artifactVersion: z.string().optional(),
     volumeVersions: z.record(z.string(), z.string()).optional(),
-    // Resolved zero agent ID (platform resolves org/name → zeroAgentId)
-    zeroAgentId: z.string().uuid("Invalid agent ID"),
+    zeroAgentId: z.string().uuid("Invalid agent ID").optional(),
+    composeId: z.string().uuid("Invalid compose ID").optional(),
     enabled: z.boolean().optional(),
     notifyEmail: z.boolean().optional(),
     notifySlack: z.boolean().optional(),
+  })
+  .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
+    message: "Either 'zeroAgentId' or 'composeId' must be provided",
   })
   .refine(
     (data) => {
@@ -127,9 +131,14 @@ export const zeroSchedulesByNameContract = c.router({
     pathParams: z.object({
       name: z.string().min(1, "Schedule name required"),
     }),
-    query: z.object({
-      zeroAgentId: z.string().uuid("Agent ID required"),
-    }),
+    query: z
+      .object({
+        zeroAgentId: z.string().uuid("Invalid agent ID").optional(),
+        composeId: z.string().uuid("Invalid compose ID").optional(),
+      })
+      .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
+        message: "Either 'zeroAgentId' or 'composeId' must be provided",
+      }),
     responses: {
       204: c.noBody(),
       401: apiErrorSchema,
@@ -151,9 +160,14 @@ export const zeroSchedulesEnableContract = c.router({
     pathParams: z.object({
       name: z.string().min(1, "Schedule name required"),
     }),
-    body: z.object({
-      zeroAgentId: z.string().uuid("Agent ID required"),
-    }),
+    body: z
+      .object({
+        zeroAgentId: z.string().uuid("Invalid agent ID").optional(),
+        composeId: z.string().uuid("Invalid compose ID").optional(),
+      })
+      .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
+        message: "Either 'zeroAgentId' or 'composeId' must be provided",
+      }),
     responses: {
       200: scheduleResponseSchema,
       400: apiErrorSchema,
@@ -170,9 +184,14 @@ export const zeroSchedulesEnableContract = c.router({
     pathParams: z.object({
       name: z.string().min(1, "Schedule name required"),
     }),
-    body: z.object({
-      zeroAgentId: z.string().uuid("Agent ID required"),
-    }),
+    body: z
+      .object({
+        zeroAgentId: z.string().uuid("Invalid agent ID").optional(),
+        composeId: z.string().uuid("Invalid compose ID").optional(),
+      })
+      .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
+        message: "Either 'zeroAgentId' or 'composeId' must be provided",
+      }),
     responses: {
       200: scheduleResponseSchema,
       400: apiErrorSchema,


### PR DESCRIPTION
## Summary

- Accepts `composeId` as an alternative to `zeroAgentId` in all zero schedule API contracts (deploy, delete, enable, disable)
- Updates route handlers to resolve `zeroAgentId ?? composeId` before calling service functions
- The backend service layer already handles both IDs via `loadZeroAgent()` fallback — only the Zod validation layer was blocking `composeId`

## Test plan

- [x] Existing tests (18) continue to pass with `zeroAgentId`
- [x] New test: deploy schedule with `composeId` returns 201
- [x] New test: delete schedule with `composeId` returns 204
- [x] New test: enable schedule with `composeId` returns 200
- [x] New test: disable schedule with `composeId` returns 200

Closes #6248

🤖 Generated with [Claude Code](https://claude.com/claude-code)