### PR TITLE
feat: add gist logging to coding loop script

### DIFF
--- a/scripts/coding-loop.sh
+++ b/scripts/coding-loop.sh
@@ -23,30 +23,29 @@ CONTENT_DIR="/tmp/coding-loop"
 mkdir -p "$CONTENT_DIR/issues" "$CONTENT_DIR/prs"
 
 # --- Gist logging setup ---
-# Capture all stdout to a temp file, flush to real stdout + gist on exit.
-_LOG_OUTPUT="/tmp/coding-loop-output-${LABEL}"
-exec 3>&1           # save real stdout to fd 3
-exec 1>"$_LOG_OUTPUT" # redirect stdout to file
+# Mirror stdout to a log file via tee so the caller still receives output in real-time.
+_LOG_OUTPUT="/tmp/coding-loop-output-${LABEL}.$$"
+exec > >(tee "$_LOG_OUTPUT")
 
-_flush_and_update_gist() {
-  exec 1>&3  # restore real stdout
-  cat "$_LOG_OUTPUT"
+_update_gist() {
+  # Wait for tee to finish flushing
+  wait 2>/dev/null || true
 
   local gist_name="coding-loop-log-${LABEL}"
   local gist_id
   gist_id=$(gh gist list --limit 100 2>/dev/null | awk -v name="$gist_name" '$0 ~ name {print $1; exit}' || true)
 
   if [ -n "$gist_id" ]; then
-    jq -n --arg c "$(cat "$_LOG_OUTPUT")" --arg f "$gist_name" \
-      '{"files": {($f): {"content": $c}}}' | \
-      gh api --method PATCH "gists/$gist_id" --input - >/dev/null 2>&1 || true
+    gh api --method PATCH "gists/$gist_id" \
+      --input <(jq -Rs --arg f "$gist_name" '{"files": {($f): {"content": .}}}' "$_LOG_OUTPUT") \
+      >/dev/null 2>&1 || true
   else
     gh gist create --filename "$gist_name" --desc "$gist_name" - < "$_LOG_OUTPUT" >/dev/null 2>&1 || true
   fi
   rm -f "$_LOG_OUTPUT"
 }
 
-trap _flush_and_update_gist EXIT
+trap _update_gist EXIT
 
 # --- Helper functions ---
 

--- a/scripts/coding-loop.sh
+++ b/scripts/coding-loop.sh
@@ -26,9 +26,12 @@ mkdir -p "$CONTENT_DIR/issues" "$CONTENT_DIR/prs"
 # Mirror stdout and stderr to a log file via tee so the caller still sees
 # output in real-time while we capture everything for gist upload.
 _LOG_OUTPUT="/tmp/coding-loop-output-${LABEL}.$$"
-
-# Use a FIFO so we can reliably wait for tee to drain before uploading.
 _LOG_FIFO="/tmp/coding-loop-fifo-${LABEL}.$$"
+_TEE_PID=""
+
+# Timeout (seconds) for gist upload to prevent hanging the autonomous loop.
+_GIST_TIMEOUT=30
+
 mkfifo "$_LOG_FIFO"
 tee "$_LOG_OUTPUT" < "$_LOG_FIFO" &
 _TEE_PID=$!
@@ -38,23 +41,36 @@ exec 3>&2
 exec > "$_LOG_FIFO" 2>&1
 
 _update_gist() {
+  # Disable errexit inside trap to ensure full cleanup on any failure.
+  set +e
+
   # Close the FIFO so tee receives EOF, then wait for it to flush.
   exec >/dev/null 2>&1
-  wait "$_TEE_PID" 2>/dev/null || true
+  if [ -n "$_TEE_PID" ]; then
+    wait "$_TEE_PID" 2>/dev/null
+  fi
   rm -f "$_LOG_FIFO"
+
+  # Only attempt upload if the log file exists and is non-empty.
+  if [ ! -s "$_LOG_OUTPUT" ]; then
+    exec 3>&-
+    rm -f "$_LOG_OUTPUT"
+    return
+  fi
 
   local gist_name="coding-loop-log-${LABEL}"
   local gist_id
-  gist_id=$(gh gist list --limit 100 | awk -v name="$gist_name" '$2 == name {print $1; exit}' || true)
+  gist_id=$(timeout "$_GIST_TIMEOUT" gh gist list --limit 100 2>/dev/null \
+    | awk -v name="$gist_name" '$2 == name {print $1; exit}') || true
 
   if [ -n "$gist_id" ]; then
-    if ! gh api --method PATCH "gists/$gist_id" \
+    if ! timeout "$_GIST_TIMEOUT" gh api --method PATCH "gists/$gist_id" \
       --input <(jq -Rs --arg f "$gist_name" '{"files": {($f): {"content": .}}}' "$_LOG_OUTPUT") \
-      >/dev/null; then
+      >/dev/null 2>&1; then
       echo "warning: failed to update gist $gist_id" >&3
     fi
   else
-    if ! gh gist create --filename "$gist_name" --desc "$gist_name" - < "$_LOG_OUTPUT" >/dev/null; then
+    if ! timeout "$_GIST_TIMEOUT" gh gist create --filename "$gist_name" --desc "$gist_name" - < "$_LOG_OUTPUT" >/dev/null 2>&1; then
       echo "warning: failed to create gist for $gist_name" >&3
     fi
   fi

--- a/scripts/coding-loop.sh
+++ b/scripts/coding-loop.sh
@@ -32,6 +32,8 @@ _LOG_FIFO="/tmp/coding-loop-fifo-${LABEL}.$$"
 mkfifo "$_LOG_FIFO"
 tee "$_LOG_OUTPUT" < "$_LOG_FIFO" &
 _TEE_PID=$!
+# Save original stderr so trap warnings are visible after exec >/dev/null.
+exec 3>&2
 # Redirect both stdout and stderr through the FIFO → tee.
 exec > "$_LOG_FIFO" 2>&1
 
@@ -49,13 +51,14 @@ _update_gist() {
     if ! gh api --method PATCH "gists/$gist_id" \
       --input <(jq -Rs --arg f "$gist_name" '{"files": {($f): {"content": .}}}' "$_LOG_OUTPUT") \
       >/dev/null; then
-      echo "warning: failed to update gist $gist_id" >&2
+      echo "warning: failed to update gist $gist_id" >&3
     fi
   else
     if ! gh gist create --filename "$gist_name" --desc "$gist_name" - < "$_LOG_OUTPUT" >/dev/null; then
-      echo "warning: failed to create gist for $gist_name" >&2
+      echo "warning: failed to create gist for $gist_name" >&3
     fi
   fi
+  exec 3>&-
   rm -f "$_LOG_OUTPUT"
 }
 

--- a/scripts/coding-loop.sh
+++ b/scripts/coding-loop.sh
@@ -22,6 +22,32 @@ CONTENT_DIR="/tmp/coding-loop"
 
 mkdir -p "$CONTENT_DIR/issues" "$CONTENT_DIR/prs"
 
+# --- Gist logging setup ---
+# Capture all stdout to a temp file, flush to real stdout + gist on exit.
+_LOG_OUTPUT="/tmp/coding-loop-output-${LABEL}"
+exec 3>&1           # save real stdout to fd 3
+exec 1>"$_LOG_OUTPUT" # redirect stdout to file
+
+_flush_and_update_gist() {
+  exec 1>&3  # restore real stdout
+  cat "$_LOG_OUTPUT"
+
+  local gist_name="coding-loop-log-${LABEL}"
+  local gist_id
+  gist_id=$(gh gist list --limit 100 2>/dev/null | awk -v name="$gist_name" '$0 ~ name {print $1; exit}' || true)
+
+  if [ -n "$gist_id" ]; then
+    jq -n --arg c "$(cat "$_LOG_OUTPUT")" --arg f "$gist_name" \
+      '{"files": {($f): {"content": $c}}}' | \
+      gh api --method PATCH "gists/$gist_id" --input - >/dev/null 2>&1 || true
+  else
+    gh gist create --filename "$gist_name" --desc "$gist_name" - < "$_LOG_OUTPUT" >/dev/null 2>&1 || true
+  fi
+  rm -f "$_LOG_OUTPUT"
+}
+
+trap _flush_and_update_gist EXIT
+
 # --- Helper functions ---
 
 output_action() {

--- a/scripts/coding-loop.sh
+++ b/scripts/coding-loop.sh
@@ -23,24 +23,38 @@ CONTENT_DIR="/tmp/coding-loop"
 mkdir -p "$CONTENT_DIR/issues" "$CONTENT_DIR/prs"
 
 # --- Gist logging setup ---
-# Mirror stdout to a log file via tee so the caller still receives output in real-time.
+# Mirror stdout and stderr to a log file via tee so the caller still sees
+# output in real-time while we capture everything for gist upload.
 _LOG_OUTPUT="/tmp/coding-loop-output-${LABEL}.$$"
-exec > >(tee "$_LOG_OUTPUT")
+
+# Use a FIFO so we can reliably wait for tee to drain before uploading.
+_LOG_FIFO="/tmp/coding-loop-fifo-${LABEL}.$$"
+mkfifo "$_LOG_FIFO"
+tee "$_LOG_OUTPUT" < "$_LOG_FIFO" &
+_TEE_PID=$!
+# Redirect both stdout and stderr through the FIFO → tee.
+exec > "$_LOG_FIFO" 2>&1
 
 _update_gist() {
-  # Wait for tee to finish flushing
-  wait 2>/dev/null || true
+  # Close the FIFO so tee receives EOF, then wait for it to flush.
+  exec >/dev/null 2>&1
+  wait "$_TEE_PID" 2>/dev/null || true
+  rm -f "$_LOG_FIFO"
 
   local gist_name="coding-loop-log-${LABEL}"
   local gist_id
-  gist_id=$(gh gist list --limit 100 2>/dev/null | awk -v name="$gist_name" '$0 ~ name {print $1; exit}' || true)
+  gist_id=$(gh gist list --limit 100 | awk -v name="$gist_name" '$2 == name {print $1; exit}' || true)
 
   if [ -n "$gist_id" ]; then
-    gh api --method PATCH "gists/$gist_id" \
+    if ! gh api --method PATCH "gists/$gist_id" \
       --input <(jq -Rs --arg f "$gist_name" '{"files": {($f): {"content": .}}}' "$_LOG_OUTPUT") \
-      >/dev/null 2>&1 || true
+      >/dev/null; then
+      echo "warning: failed to update gist $gist_id" >&2
+    fi
   else
-    gh gist create --filename "$gist_name" --desc "$gist_name" - < "$_LOG_OUTPUT" >/dev/null 2>&1 || true
+    if ! gh gist create --filename "$gist_name" --desc "$gist_name" - < "$_LOG_OUTPUT" >/dev/null; then
+      echo "warning: failed to create gist for $gist_name" >&2
+    fi
   fi
   rm -f "$_LOG_OUTPUT"
 }


### PR DESCRIPTION
## Summary
- Adds gist-based logging to `scripts/coding-loop.sh` so each run's stdout is captured and uploaded to a GitHub Gist on exit
- Creates or updates a gist named `coding-loop-log-<LABEL>` for persistent log inspection
- Uses fd redirection and an EXIT trap to flush output and restore stdout cleanly

## Test plan
- [ ] Run `scripts/coding-loop.sh` and verify stdout appears both in terminal and in a gist after exit
- [ ] Run again with the same label and confirm the existing gist is updated rather than duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)