### PR TITLE
refactor(db): rename zeroAgentId to agentId across codebase

### DIFF
--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/delete.test.ts
@@ -15,7 +15,7 @@ import chalk from "chalk";
 
 const mockSchedule = {
   id: "sched-001",
-  zeroAgentId: "za-001",
+  agentId: "za-001",
   agentName: "my-agent",
   orgSlug: "my-org",
   userId: "user-001",

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/disable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/disable.test.ts
@@ -15,7 +15,7 @@ import chalk from "chalk";
 
 const mockSchedule = {
   id: "sched-001",
-  zeroAgentId: "za-001",
+  agentId: "za-001",
   agentName: "my-agent",
   orgSlug: "my-org",
   userId: "user-001",

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/enable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/enable.test.ts
@@ -15,7 +15,7 @@ import chalk from "chalk";
 
 const mockSchedule = {
   id: "sched-001",
-  zeroAgentId: "za-001",
+  agentId: "za-001",
   agentName: "my-agent",
   orgSlug: "my-org",
   userId: "user-001",

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/list.test.ts
@@ -15,7 +15,7 @@ import chalk from "chalk";
 
 const mockSchedule = {
   id: "sched-001",
-  zeroAgentId: "za-001",
+  agentId: "za-001",
   agentName: "my-agent",
   orgSlug: "my-org",
   userId: "user-001",

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
@@ -26,7 +26,7 @@ const mockDeployResponse = {
   created: true,
   schedule: {
     id: "sched-001",
-    zeroAgentId: "za-001",
+    agentId: "za-001",
     agentName: "my-agent",
     orgSlug: "my-org",
     userId: "user-001",

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
@@ -15,7 +15,7 @@ import chalk from "chalk";
 
 const mockSchedule = {
   id: "sched-001",
-  zeroAgentId: "za-001",
+  agentId: "za-001",
   agentName: "my-agent",
   orgSlug: "my-org",
   userId: "user-001",

--- a/turbo/apps/cli/src/commands/zero/schedule/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/delete.ts
@@ -41,7 +41,7 @@ export const deleteCommand = new Command()
 
         await deleteZeroSchedule({
           name: resolved.name,
-          zeroAgentId: resolved.zeroAgentId,
+          agentId: resolved.agentId,
         });
 
         console.log(

--- a/turbo/apps/cli/src/commands/zero/schedule/disable.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/disable.ts
@@ -23,7 +23,7 @@ export const disableCommand = new Command()
 
       await disableZeroSchedule({
         name: resolved.name,
-        zeroAgentId: resolved.zeroAgentId,
+        agentId: resolved.agentId,
       });
 
       console.log(

--- a/turbo/apps/cli/src/commands/zero/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/enable.ts
@@ -23,7 +23,7 @@ export const enableCommand = new Command()
 
       await enableZeroSchedule({
         name: resolved.name,
-        zeroAgentId: resolved.zeroAgentId,
+        agentId: resolved.agentId,
       });
 
       console.log(

--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -508,7 +508,7 @@ interface DeployResult {
 
 async function buildAndDeploy(params: {
   scheduleName: string;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   frequency: ScheduleFrequency;
   time: string | undefined;
@@ -542,7 +542,7 @@ async function buildAndDeploy(params: {
 
   const deployResult = await deployZeroSchedule({
     name: params.scheduleName,
-    zeroAgentId: params.zeroAgentId,
+    agentId: params.agentId,
     cronExpression,
     atTime: atTimeISO,
     intervalSeconds: params.intervalSeconds,
@@ -605,11 +605,11 @@ function displayDeployResult(
 
 async function tryEnableSchedule(
   scheduleName: string,
-  zeroAgentId: string,
+  agentId: string,
   agentName: string,
 ): Promise<void> {
   try {
-    await enableZeroSchedule({ name: scheduleName, zeroAgentId });
+    await enableZeroSchedule({ name: scheduleName, agentId });
     console.log(
       chalk.green(`✓ Enabled schedule for agent ${chalk.cyan(agentName)}`),
     );
@@ -639,28 +639,23 @@ function showEnableHint(agentName: string): void {
 
 async function handleScheduleEnabling(params: {
   scheduleName: string;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   enableFlag: boolean;
   shouldPromptEnable: boolean;
 }): Promise<void> {
-  const {
-    scheduleName,
-    zeroAgentId,
-    agentName,
-    enableFlag,
-    shouldPromptEnable,
-  } = params;
+  const { scheduleName, agentId, agentName, enableFlag, shouldPromptEnable } =
+    params;
 
   if (enableFlag) {
-    await tryEnableSchedule(scheduleName, zeroAgentId, agentName);
+    await tryEnableSchedule(scheduleName, agentId, agentName);
     return;
   }
 
   if (shouldPromptEnable && isInteractive()) {
     const enableNow = await promptConfirm("Enable this schedule?", true);
     if (enableNow) {
-      await tryEnableSchedule(scheduleName, zeroAgentId, agentName);
+      await tryEnableSchedule(scheduleName, agentId, agentName);
     } else {
       showEnableHint(agentName);
     }
@@ -691,9 +686,9 @@ export const setupCommand = new Command()
   .option("--no-notify-slack", "Disable Slack notifications")
   .action(
     withErrorHandler(async (agentName: string, options: SetupOptions) => {
-      // 1. Resolve agent to zeroAgentId (via agentComposeId — schedule service handles fallback)
+      // 1. Resolve agent to agentId (via agentComposeId — schedule service handles fallback)
       const agent = await getZeroAgent(agentName);
-      const zeroAgentId = agent.agentComposeId;
+      const agentId = agent.agentComposeId;
       const scheduleName = options.name || "default";
 
       // 2. Check for existing schedule
@@ -760,7 +755,7 @@ export const setupCommand = new Command()
       // 8. Build trigger and deploy
       const deployResult = await buildAndDeploy({
         scheduleName,
-        zeroAgentId,
+        agentId,
         agentName,
         frequency,
         time,
@@ -784,7 +779,7 @@ export const setupCommand = new Command()
 
       await handleScheduleEnabling({
         scheduleName,
-        zeroAgentId,
+        agentId,
         agentName,
         enableFlag: options.enable ?? false,
         shouldPromptEnable,

--- a/turbo/apps/cli/src/lib/api/domains/zero-schedules.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-schedules.ts
@@ -16,7 +16,7 @@ import type {
  */
 export async function deployZeroSchedule(body: {
   name: string;
-  zeroAgentId: string;
+  agentId: string;
   cronExpression?: string;
   atTime?: string;
   intervalSeconds?: number;
@@ -64,14 +64,14 @@ export async function listZeroSchedules(): Promise<ScheduleListResponse> {
  */
 export async function deleteZeroSchedule(params: {
   name: string;
-  zeroAgentId: string;
+  agentId: string;
 }): Promise<void> {
   const config = await getClientConfig();
   const client = initClient(zeroSchedulesByNameContract, config);
 
   const result = await client.delete({
     params: { name: params.name },
-    query: { zeroAgentId: params.zeroAgentId },
+    query: { agentId: params.agentId },
   });
 
   if (result.status === 204) {
@@ -86,14 +86,14 @@ export async function deleteZeroSchedule(params: {
  */
 export async function enableZeroSchedule(params: {
   name: string;
-  zeroAgentId: string;
+  agentId: string;
 }): Promise<ScheduleResponse> {
   const config = await getClientConfig();
   const client = initClient(zeroSchedulesEnableContract, config);
 
   const result = await client.enable({
     params: { name: params.name },
-    body: { zeroAgentId: params.zeroAgentId },
+    body: { agentId: params.agentId },
   });
 
   if (result.status === 200) {
@@ -108,14 +108,14 @@ export async function enableZeroSchedule(params: {
  */
 export async function disableZeroSchedule(params: {
   name: string;
-  zeroAgentId: string;
+  agentId: string;
 }): Promise<ScheduleResponse> {
   const config = await getClientConfig();
   const client = initClient(zeroSchedulesEnableContract, config);
 
   const result = await client.disable({
     params: { name: params.name },
-    body: { zeroAgentId: params.zeroAgentId },
+    body: { agentId: params.agentId },
   });
 
   if (result.status === 200) {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -59,7 +59,7 @@ function mockSchedules() {
     schedules: [
       {
         id: "sched-1",
-        zeroAgentId: "compose-1",
+        agentId: "compose-1",
         agentName: "my-agent",
         name: "daily-run",
         enabled: true,
@@ -74,7 +74,7 @@ function mockSchedules() {
       },
       {
         id: "sched-2",
-        zeroAgentId: "compose-2",
+        agentId: "compose-2",
         agentName: "other-agent",
         name: "other-run",
         enabled: true,
@@ -316,7 +316,7 @@ describe("zero-job-detail signals", () => {
       await context.store.set(saveZeroJobSchedule$, params);
 
       expect(capturedBody).toMatchObject({
-        zeroAgentId: "compose-1",
+        agentId: "compose-1",
         timezone: "UTC",
         prompt: "Run daily task",
         enabled: true,
@@ -426,7 +426,7 @@ describe("zero-job-detail signals", () => {
       await context.store.set(saveZeroJobSchedule$, params);
 
       expect(capturedBody).toMatchObject({
-        zeroAgentId: "compose-1",
+        agentId: "compose-1",
         prompt: "Poll every 5 min",
         intervalSeconds: 300,
       });
@@ -501,7 +501,7 @@ describe("zero-job-detail signals", () => {
       await context.store.set(deleteZeroJobSchedule$, "daily-run");
 
       expect(capturedUrl).toContain("/api/zero/schedules/daily-run");
-      expect(capturedUrl).toContain("zeroAgentId=compose-1");
+      expect(capturedUrl).toContain("agentId=compose-1");
 
       const entries = await context.store.get(zeroJobScheduleEntries$);
       expect(entries).toStrictEqual([]);
@@ -542,7 +542,7 @@ describe("zero-job-detail signals", () => {
   });
 
   describe("toggleZeroJobScheduleEnabled$", () => {
-    it("should send enable request with zeroAgentId in body", async () => {
+    it("should send enable request with agentId in body", async () => {
       let capturedUrl = "";
       let capturedBody: Record<string, unknown> | null = null;
 
@@ -585,7 +585,7 @@ describe("zero-job-detail signals", () => {
 
       expect(capturedUrl).toContain("/api/zero/schedules/daily-run/enable");
       expect(capturedBody).not.toBeNull();
-      expect(capturedBody!["zeroAgentId"]).toBe("compose-1");
+      expect(capturedBody!["agentId"]).toBe("compose-1");
       expect(capturedBody).not.toHaveProperty("composeId");
     });
 

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
@@ -22,7 +22,7 @@ function createMockSchedules() {
   return [
     {
       id: "sched-1",
-      zeroAgentId: "mock-compose-id",
+      agentId: "mock-compose-id",
       agentName: "zero",
       orgSlug: "test",
       name: "morning-briefing",
@@ -41,7 +41,7 @@ function createMockSchedules() {
     },
     {
       id: "sched-2",
-      zeroAgentId: "mock-compose-id",
+      agentId: "mock-compose-id",
       agentName: "zero",
       orgSlug: "test",
       name: "check-inbox",
@@ -60,7 +60,7 @@ function createMockSchedules() {
     },
     {
       id: "sched-other",
-      zeroAgentId: "other-compose-id",
+      agentId: "other-compose-id",
       agentName: "other-agent",
       orgSlug: "test",
       name: "other-schedule",
@@ -192,7 +192,7 @@ describe("zero-schedule signals", () => {
       });
 
       expect(captured.body).not.toBeNull();
-      expect(captured.body?.zeroAgentId).toBe("mock-compose-id");
+      expect(captured.body?.agentId).toBe("mock-compose-id");
       expect(captured.body?.prompt).toBe("Daily standup summary");
       expect(captured.body?.cronExpression).toBe("0 9 * * *");
       expect(captured.body?.timezone).toBe("UTC");
@@ -291,7 +291,7 @@ describe("zero-schedule signals", () => {
       });
 
       expect(captured.action).toBe("enable");
-      expect(captured.body?.zeroAgentId).toBe("mock-compose-id");
+      expect(captured.body?.agentId).toBe("mock-compose-id");
     });
 
     it("should POST to disable endpoint when enabled is false", async () => {
@@ -353,7 +353,7 @@ describe("zero-schedule signals", () => {
           ({ params, request }) => {
             deletedName = params["name"] as string;
             const url = new URL(request.url);
-            deletedAgentId = url.searchParams.get("zeroAgentId");
+            deletedAgentId = url.searchParams.get("agentId");
             return new HttpResponse(null, { status: 204 });
           },
         ),
@@ -381,7 +381,7 @@ describe("org schedule signals", () => {
   }
 
   describe("fetchAllOrgSchedules$ and allOrgScheduleEntries$", () => {
-    it("should map zeroAgentId and agentName fields from API response", async () => {
+    it("should map agentId and agentName fields from API response", async () => {
       server.use(
         http.get("http://localhost:3000/api/zero/schedules", () => {
           return HttpResponse.json({ schedules: createMockSchedules() });
@@ -395,17 +395,17 @@ describe("org schedule signals", () => {
       expect(entries).toHaveLength(3);
 
       const zeroEntry = entries.find((e) => e.name === "morning-briefing");
-      expect(zeroEntry?.zeroAgentId).toBe("mock-compose-id");
+      expect(zeroEntry?.agentId).toBe("mock-compose-id");
       expect(zeroEntry?.agentName).toBe("zero");
 
       const otherEntry = entries.find((e) => e.name === "other-schedule");
-      expect(otherEntry?.zeroAgentId).toBe("other-compose-id");
+      expect(otherEntry?.agentId).toBe("other-compose-id");
       expect(otherEntry?.agentName).toBe("other-agent");
     });
   });
 
   describe("saveOrgSchedule$", () => {
-    it("should send zeroAgentId in POST body", async () => {
+    it("should send agentId in POST body", async () => {
       const captured: { body: Record<string, unknown> | null } = {
         body: null,
       };
@@ -432,11 +432,11 @@ describe("org schedule signals", () => {
         minute: 0,
         timezone: "UTC",
         intervalSeconds: 0,
-        zeroAgentId: "agent-uuid-123",
+        agentId: "agent-uuid-123",
       });
 
       expect(captured.body).not.toBeNull();
-      expect(captured.body?.zeroAgentId).toBe("agent-uuid-123");
+      expect(captured.body?.agentId).toBe("agent-uuid-123");
       expect(captured.body).not.toHaveProperty("composeId");
       expect(captured.body?.prompt).toBe("Org-wide daily task");
       expect(captured.body?.cronExpression).toBe("0 8 * * *");
@@ -444,7 +444,7 @@ describe("org schedule signals", () => {
   });
 
   describe("toggleOrgScheduleEnabled$", () => {
-    it("should send zeroAgentId in toggle request body", async () => {
+    it("should send agentId in toggle request body", async () => {
       const captured: {
         action: string | null;
         body: Record<string, unknown> | null;
@@ -468,17 +468,17 @@ describe("org schedule signals", () => {
       await context.store.set(toggleOrgScheduleEnabled$, {
         name: "morning-briefing",
         enabled: false,
-        zeroAgentId: "agent-uuid-123",
+        agentId: "agent-uuid-123",
       });
 
       expect(captured.action).toBe("disable");
-      expect(captured.body?.zeroAgentId).toBe("agent-uuid-123");
+      expect(captured.body?.agentId).toBe("agent-uuid-123");
       expect(captured.body).not.toHaveProperty("composeId");
     });
   });
 
   describe("deleteOrgSchedule$", () => {
-    it("should send zeroAgentId as query param in DELETE request", async () => {
+    it("should send agentId as query param in DELETE request", async () => {
       let deletedName: string | null = null;
       let deletedAgentId: string | null = null;
 
@@ -488,7 +488,7 @@ describe("org schedule signals", () => {
           ({ params, request }) => {
             deletedName = params["name"] as string;
             const url = new URL(request.url);
-            deletedAgentId = url.searchParams.get("zeroAgentId");
+            deletedAgentId = url.searchParams.get("agentId");
             return new HttpResponse(null, { status: 204 });
           },
         ),
@@ -500,7 +500,7 @@ describe("org schedule signals", () => {
       await setup();
       await context.store.set(deleteOrgSchedule$, {
         name: "morning-briefing",
-        zeroAgentId: "agent-uuid-123",
+        agentId: "agent-uuid-123",
       });
 
       expect(deletedName).toBe("morning-briefing");

--- a/turbo/apps/platform/src/signals/zero-page/cron.ts
+++ b/turbo/apps/platform/src/signals/zero-page/cron.ts
@@ -13,7 +13,7 @@ export type CronTimeOption = Exclude<ScheduleTimeOption, "loop">;
 
 /** Discriminated union for schedule creation/update request body. */
 export type ScheduleBody = {
-  zeroAgentId: string;
+  agentId: string;
   name: string;
   timezone: string;
   prompt: string;

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -458,7 +458,7 @@ const fetchZeroJobFirewallPolicies$ = command(async ({ get, set }) => {
 
 interface ScheduleItem {
   id: string;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   name: string;
   enabled: boolean;
@@ -630,7 +630,7 @@ export const saveZeroJobSchedule$ = command(
     const scheduleName = params.editName ?? `zero-${Date.now().toString(36)}`;
 
     const base = {
-      zeroAgentId: detail.agentComposeId,
+      agentId: detail.agentComposeId,
       name: scheduleName,
       timezone: params.timezone,
       prompt: params.prompt.trim(),
@@ -711,7 +711,7 @@ export const toggleZeroJobScheduleEnabled$ = command(
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ zeroAgentId: detail.agentComposeId }),
+        body: JSON.stringify({ agentId: detail.agentComposeId }),
       },
     );
 
@@ -739,7 +739,7 @@ export const deleteZeroJobSchedule$ = command(
 
     const fetchFn = get(fetch$);
     const response = await fetchFn(
-      `/api/zero/schedules/${encodeURIComponent(scheduleName)}?zeroAgentId=${encodeURIComponent(detail.agentComposeId)}`,
+      `/api/zero/schedules/${encodeURIComponent(scheduleName)}?agentId=${encodeURIComponent(detail.agentComposeId)}`,
       { method: "DELETE" },
     );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -20,7 +20,7 @@ const L = logger("ZeroSchedule");
 
 interface ScheduleResponse {
   id: string;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   orgSlug: string;
   name: string;
@@ -193,7 +193,7 @@ export const fetchZeroSchedules$ = command(async ({ get, set }) => {
 
     // Filter schedules for this agent's composeId
     const agentSchedules = data.schedules.filter(
-      (s) => s.zeroAgentId === composeId,
+      (s) => s.agentId === composeId,
     );
     set(internalSchedules$, agentSchedules);
   } catch (error) {
@@ -236,7 +236,7 @@ export const saveZeroSchedule$ = command(
     const scheduleName = params.editName ?? `zero-${Date.now().toString(36)}`;
 
     const base = {
-      zeroAgentId: composeId,
+      agentId: composeId,
       name: scheduleName,
       timezone: params.timezone,
       prompt: params.prompt.trim(),
@@ -330,7 +330,7 @@ export const toggleZeroScheduleEnabled$ = command(
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ zeroAgentId: composeId }),
+        body: JSON.stringify({ agentId: composeId }),
       },
     );
 
@@ -363,7 +363,7 @@ export const deleteZeroSchedule$ = command(
 
     const fetchFn = get(fetch$);
     const response = await fetchFn(
-      `/api/zero/schedules/${encodeURIComponent(scheduleName)}?zeroAgentId=${encodeURIComponent(composeId)}`,
+      `/api/zero/schedules/${encodeURIComponent(scheduleName)}?agentId=${encodeURIComponent(composeId)}`,
       { method: "DELETE" },
     );
 
@@ -395,7 +395,7 @@ export interface OrgScheduleEntry {
   notifySlack: boolean;
   name: string;
   intervalSeconds: number | null;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   /** IANA timezone identifier */
   timezone: string;
@@ -424,7 +424,7 @@ export const allOrgScheduleEntries$ = computed((get) => {
         notifySlack: s.notifySlack,
         name: s.name,
         intervalSeconds: s.intervalSeconds,
-        zeroAgentId: s.zeroAgentId,
+        agentId: s.agentId,
         agentName: s.agentName,
         timezone: s.timezone,
       }),
@@ -455,13 +455,13 @@ export const fetchAllOrgSchedules$ = command(async ({ get, set }) => {
 export const saveOrgSchedule$ = command(
   async (
     { get, set },
-    params: ZeroScheduleSaveParams & { zeroAgentId: string },
+    params: ZeroScheduleSaveParams & { agentId: string },
   ) => {
     const fetchFn = get(fetch$);
     const scheduleName = params.editName ?? `zero-${Date.now().toString(36)}`;
 
     const base = {
-      zeroAgentId: params.zeroAgentId,
+      agentId: params.agentId,
       name: scheduleName,
       timezone: params.timezone,
       prompt: params.prompt.trim(),
@@ -537,7 +537,7 @@ export const saveOrgSchedule$ = command(
 export const toggleOrgScheduleEnabled$ = command(
   async (
     { get, set },
-    params: { name: string; enabled: boolean; zeroAgentId: string },
+    params: { name: string; enabled: boolean; agentId: string },
   ) => {
     const fetchFn = get(fetch$);
     const action = params.enabled ? "enable" : "disable";
@@ -546,7 +546,7 @@ export const toggleOrgScheduleEnabled$ = command(
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ zeroAgentId: params.zeroAgentId }),
+        body: JSON.stringify({ agentId: params.agentId }),
       },
     );
 
@@ -566,10 +566,10 @@ export const toggleOrgScheduleEnabled$ = command(
 );
 
 export const deleteOrgSchedule$ = command(
-  async ({ get, set }, params: { name: string; zeroAgentId: string }) => {
+  async ({ get, set }, params: { name: string; agentId: string }) => {
     const fetchFn = get(fetch$);
     const response = await fetchFn(
-      `/api/zero/schedules/${encodeURIComponent(params.name)}?zeroAgentId=${encodeURIComponent(params.zeroAgentId)}`,
+      `/api/zero/schedules/${encodeURIComponent(params.name)}?agentId=${encodeURIComponent(params.agentId)}`,
       { method: "DELETE" },
     );
 

--- a/turbo/apps/platform/src/views/schedule-page/__tests__/schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/schedule-page/__tests__/schedule-page.test.tsx
@@ -26,7 +26,7 @@ describe("schedule page", () => {
           schedules: [
             {
               id: "sched-1",
-              zeroAgentId: "compose-1",
+              agentId: "compose-1",
               agentName: "Test Agent",
               orgSlug: "test",
               name: "test-schedule",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
@@ -195,7 +195,7 @@ function mockAPIsWithSchedules() {
         schedules: [
           {
             id: "sched-1",
-            zeroAgentId: "agent-detail-id",
+            agentId: "agent-detail-id",
             agentName: "my-agent",
             orgSlug: "test",
             name: "morning-briefing",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -11,7 +11,7 @@ function createMockSchedules() {
   return [
     {
       id: "sched-1",
-      zeroAgentId: "mock-compose-id",
+      agentId: "mock-compose-id",
       agentName: "zero",
       orgSlug: "test",
       name: "morning-briefing",
@@ -32,7 +32,7 @@ function createMockSchedules() {
     },
     {
       id: "sched-2",
-      zeroAgentId: "mock-compose-id",
+      agentId: "mock-compose-id",
       agentName: "zero",
       orgSlug: "test",
       name: "check-inbox",
@@ -53,7 +53,7 @@ function createMockSchedules() {
     },
     {
       id: "sched-disabled",
-      zeroAgentId: "mock-compose-id",
+      agentId: "mock-compose-id",
       agentName: "zero",
       orgSlug: "test",
       name: "disabled-schedule",

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -59,7 +59,7 @@ import emptyScheduleImg from "./assets/empty-schedule.webp";
 
 type CombinedEntry = ScheduleEntry & {
   agentLabel: string;
-  zeroAgentId: string;
+  agentId: string;
   timezone: string;
 };
 
@@ -80,10 +80,10 @@ function buildCombinedSchedule(
     name: e.name,
     intervalSeconds: e.intervalSeconds,
     agentLabel:
-      e.zeroAgentId === defaultComposeId
+      e.agentId === defaultComposeId
         ? agentName
         : (nameToDisplay.get(e.agentName) ?? e.agentName),
-    zeroAgentId: e.zeroAgentId,
+    agentId: e.agentId,
     timezone: e.timezone,
   }));
 }
@@ -664,7 +664,7 @@ export function ZeroSchedulePage() {
         minute: values.minute,
         timezone: values.timezone,
         intervalSeconds: values.loopMinutes * 60,
-        zeroAgentId: values.composeId,
+        agentId: values.composeId,
         notifyEmail: values.notifyEmail,
         notifySlack: values.notifySlack,
       })
@@ -701,7 +701,7 @@ export function ZeroSchedulePage() {
         timezone: values.timezone,
         intervalSeconds: values.loopMinutes * 60,
         editName: editingEntry.name,
-        zeroAgentId: editingEntry.zeroAgentId,
+        agentId: editingEntry.agentId,
         notifyEmail: values.notifyEmail,
         notifySlack: values.notifySlack,
       })
@@ -728,7 +728,7 @@ export function ZeroSchedulePage() {
     await toggleEnabled({
       name: entry.name,
       enabled,
-      zeroAgentId: entry.zeroAgentId,
+      agentId: entry.agentId,
     });
   };
 
@@ -746,7 +746,7 @@ export function ZeroSchedulePage() {
     detach(
       deleteSchedule({
         name: pendingDelete.name,
-        zeroAgentId: pendingDelete.zeroAgentId,
+        agentId: pendingDelete.agentId,
       }),
       Reason.DomCallback,
     );

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/__tests__/route.test.ts
@@ -25,7 +25,7 @@ const mockResend = vi.mocked(new Resend(""), true);
 
 interface ScheduleCallbackPayload {
   scheduleId: string;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   userId: string;
 }
@@ -76,14 +76,14 @@ describe("POST /api/internal/callbacks/email/schedule", () => {
       const agentName = uniqueId("sched-agent");
       const { composeId } = await createTestCompose(agentName);
       await createTestZeroAgent(user.orgId, agentName, {});
-      const zeroAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
       const schedule = await createTestSchedule(composeId, uniqueId("sched"));
       const { runId } = await createTestRun(composeId, "Test prompt");
       await linkRunToSchedule(runId, schedule.id);
 
       const payload: ScheduleCallbackPayload = {
         scheduleId: schedule.id,
-        zeroAgentId,
+        agentId,
         agentName,
         userId: user.userId,
       };
@@ -110,14 +110,14 @@ describe("POST /api/internal/callbacks/email/schedule", () => {
       const agentName = uniqueId("sched-agent");
       const { composeId } = await createTestCompose(agentName);
       await createTestZeroAgent(user.orgId, agentName, {});
-      const zeroAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
       const schedule = await createTestSchedule(composeId, uniqueId("sched"));
       const { runId } = await createTestRun(composeId, "Test prompt");
       await linkRunToSchedule(runId, schedule.id);
 
       const payload: ScheduleCallbackPayload = {
         scheduleId: schedule.id,
-        zeroAgentId,
+        agentId,
         agentName,
         userId: user.userId,
       };
@@ -146,14 +146,14 @@ describe("POST /api/internal/callbacks/email/schedule", () => {
       const agentName = uniqueId("sched-agent");
       const { composeId } = await createTestCompose(agentName);
       await createTestZeroAgent(user.orgId, agentName, {});
-      const zeroAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
       const schedule = await createTestSchedule(composeId, uniqueId("sched"));
       const { runId } = await createTestRun(composeId, "Test prompt");
       await linkRunToSchedule(runId, schedule.id);
 
       const payload: ScheduleCallbackPayload = {
         scheduleId: schedule.id,
-        zeroAgentId,
+        agentId,
         agentName,
         userId: user.userId,
       };
@@ -186,7 +186,7 @@ describe("POST /api/internal/callbacks/email/schedule", () => {
       const agentName = uniqueId("sched-agent");
       const { composeId } = await createTestCompose(agentName);
       await createTestZeroAgent(user.orgId, agentName, {});
-      const zeroAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
       const schedule = await createTestSchedule(composeId, uniqueId("sched"));
       const { runId } = await createTestRun(composeId, "Test prompt");
       await linkRunToSchedule(runId, schedule.id);
@@ -194,7 +194,7 @@ describe("POST /api/internal/callbacks/email/schedule", () => {
 
       const payload: ScheduleCallbackPayload = {
         scheduleId: schedule.id,
-        zeroAgentId,
+        agentId,
         agentName,
         userId: user.userId,
       };
@@ -233,14 +233,14 @@ describe("POST /api/internal/callbacks/email/schedule", () => {
       const agentName = uniqueId("fail-agent");
       const { composeId } = await createTestCompose(agentName);
       await createTestZeroAgent(user.orgId, agentName, {});
-      const zeroAgentId = await getTestZeroAgentId(user.orgId, agentName);
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
       const schedule = await createTestSchedule(composeId, uniqueId("sched"));
       const { runId } = await createTestRun(composeId, "Test prompt");
       await linkRunToSchedule(runId, schedule.id);
 
       const payload: ScheduleCallbackPayload = {
         scheduleId: schedule.id,
-        zeroAgentId,
+        agentId,
         agentName,
         userId: user.userId,
       };

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
@@ -4,7 +4,7 @@ import { initServices } from "../../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../../src/lib/callback";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { getUserEmail } from "../../../../../../src/lib/auth/get-user-email";
-import { resolveComposeByZeroAgentId } from "../../../../../../src/lib/schedule/schedule-service";
+import { resolveComposeByAgentId } from "../../../../../../src/lib/schedule/schedule-service";
 import { getRunOutputText } from "../../../../../../src/lib/run/extract-run-output";
 import { enqueueEmail } from "../../../../../../src/lib/email/outbox-service";
 import {
@@ -28,7 +28,7 @@ function parsePayload(payload: unknown): EmailScheduleCallbackPayload | null {
   const p = payload as Record<string, unknown>;
   if (
     typeof p.scheduleId !== "string" ||
-    typeof p.zeroAgentId !== "string" ||
+    typeof p.agentId !== "string" ||
     typeof p.agentName !== "string" ||
     typeof p.userId !== "string"
   ) {
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const unsubscribeHeaders = buildUnsubscribeHeaders(unsubscribeUrl);
 
   // Resolve compose and org slug for from address
-  const compose = await resolveComposeByZeroAgentId(payload.zeroAgentId);
+  const compose = await resolveComposeByAgentId(payload.agentId);
   if (!compose) {
     return errorResponse("Compose not found for zero agent", 404);
   }

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
@@ -28,7 +28,7 @@ function parsePayload(payload: unknown): SlackScheduleCallbackPayload | null {
   const p = payload as Record<string, unknown>;
   if (
     typeof p.scheduleId !== "string" ||
-    typeof p.zeroAgentId !== "string" ||
+    typeof p.agentId !== "string" ||
     typeof p.agentName !== "string" ||
     typeof p.userId !== "string" ||
     typeof p.orgId !== "string"
@@ -202,7 +202,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const [agentInfo] = await globalThis.services.db
     .select({ displayName: zeroAgents.displayName })
     .from(zeroAgents)
-    .where(eq(zeroAgents.id, payload.zeroAgentId))
+    .where(eq(zeroAgents.id, payload.agentId))
     .limit(1);
   const displayName = agentInfo?.displayName ?? agentName;
 

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -1385,7 +1385,7 @@ describe("POST /api/webhooks/agent/complete", () => {
         url: "http://localhost/api/internal/callbacks/email/schedule",
         payload: {
           scheduleId: schedule.id,
-          zeroAgentId: schedule.zeroAgentId,
+          agentId: schedule.agentId,
           agentName,
           userId: schedUser.userId,
         },
@@ -1395,7 +1395,7 @@ describe("POST /api/webhooks/agent/complete", () => {
         url: "http://localhost/api/internal/callbacks/slack/schedule",
         payload: {
           scheduleId: schedule.id,
-          zeroAgentId: schedule.zeroAgentId,
+          agentId: schedule.agentId,
           agentName,
           userId: schedUser.userId,
         },

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -57,7 +57,7 @@ const router = tsr.router(zeroRunsMainContract, {
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      // Resolve zeroAgentId from agentComposeId
+      // Resolve agentId from agentComposeId
       const composeId = body.agentComposeId ?? "";
       const [agent] = await globalThis.services.db
         .select({ id: zeroAgents.id })
@@ -84,7 +84,7 @@ const router = tsr.router(zeroRunsMainContract, {
       const result = await createZeroRun({
         userId: authCtx.userId,
         prompt: body.prompt,
-        zeroAgentId: agent.id,
+        agentId: agent.id,
         sessionId: body.sessionId,
         appendSystemPrompt: body.appendSystemPrompt,
         modelProvider: body.modelProvider,

--- a/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
@@ -54,7 +54,7 @@ describe("DELETE /api/zero/schedules/:name", () => {
 
     const response = await DELETE(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/to-delete?zeroAgentId=${testZeroAgentId}&org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/to-delete?agentId=${testZeroAgentId}&org=${slug}`,
         { method: "DELETE" },
       ),
     );
@@ -65,7 +65,7 @@ describe("DELETE /api/zero/schedules/:name", () => {
   it("should return 404 for non-existent schedule", async () => {
     const response = await DELETE(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/non-existent?zeroAgentId=${testZeroAgentId}&org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/non-existent?agentId=${testZeroAgentId}&org=${slug}`,
         { method: "DELETE" },
       ),
     );
@@ -96,7 +96,7 @@ describe("DELETE /api/zero/schedules/:name", () => {
 
     const response = await DELETE(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/any?zeroAgentId=${testZeroAgentId}&org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/any?agentId=${testZeroAgentId}&org=${slug}`,
         { method: "DELETE" },
       ),
     );

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/__tests__/route.test.ts
@@ -64,7 +64,7 @@ describe("POST /api/zero/schedules/:name/disable", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ zeroAgentId: testZeroAgentId }),
+          body: JSON.stringify({ agentId: testZeroAgentId }),
         },
       ),
       { params: Promise.resolve({ name: "to-disable" }) },
@@ -82,7 +82,7 @@ describe("POST /api/zero/schedules/:name/disable", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ zeroAgentId: testZeroAgentId }),
+          body: JSON.stringify({ agentId: testZeroAgentId }),
         },
       ),
       { params: Promise.resolve({ name: "non-existent" }) },
@@ -147,7 +147,7 @@ describe("POST /api/zero/schedules/:name/disable", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ zeroAgentId: testZeroAgentId }),
+          body: JSON.stringify({ agentId: testZeroAgentId }),
         },
       ),
       { params: Promise.resolve({ name: "any" }) },

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
@@ -10,11 +10,11 @@ import { isNotFound } from "../../../../../../src/lib/errors";
 
 const bodySchema = z
   .object({
-    zeroAgentId: z.string().optional(),
+    agentId: z.string().optional(),
     composeId: z.string().optional(),
   })
-  .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
-    message: "Either 'zeroAgentId' or 'composeId' must be provided",
+  .refine((data) => Boolean(data.agentId ?? data.composeId), {
+    message: "Either 'agentId' or 'composeId' must be provided",
   });
 
 export async function POST(
@@ -48,7 +48,7 @@ export async function POST(
   }
 
   try {
-    const resolvedAgentId = parsed.data.zeroAgentId ?? parsed.data.composeId;
+    const resolvedAgentId = parsed.data.agentId ?? parsed.data.composeId;
     if (!resolvedAgentId) throw new Error("Missing agent ID after validation");
     const schedule = await disableSchedule(
       userId,

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/__tests__/route.test.ts
@@ -62,7 +62,7 @@ describe("POST /api/zero/schedules/:name/enable", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ zeroAgentId: testZeroAgentId }),
+          body: JSON.stringify({ agentId: testZeroAgentId }),
         },
       ),
       { params: Promise.resolve({ name: "to-enable" }) },
@@ -80,7 +80,7 @@ describe("POST /api/zero/schedules/:name/enable", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ zeroAgentId: testZeroAgentId }),
+          body: JSON.stringify({ agentId: testZeroAgentId }),
         },
       ),
       { params: Promise.resolve({ name: "non-existent" }) },
@@ -141,7 +141,7 @@ describe("POST /api/zero/schedules/:name/enable", () => {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ zeroAgentId: testZeroAgentId }),
+          body: JSON.stringify({ agentId: testZeroAgentId }),
         },
       ),
       { params: Promise.resolve({ name: "any" }) },

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
@@ -10,11 +10,11 @@ import { isNotFound, isSchedulePast } from "../../../../../../src/lib/errors";
 
 const bodySchema = z
   .object({
-    zeroAgentId: z.string().optional(),
+    agentId: z.string().optional(),
     composeId: z.string().optional(),
   })
-  .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
-    message: "Either 'zeroAgentId' or 'composeId' must be provided",
+  .refine((data) => Boolean(data.agentId ?? data.composeId), {
+    message: "Either 'agentId' or 'composeId' must be provided",
   });
 
 export async function POST(
@@ -48,7 +48,7 @@ export async function POST(
   }
 
   try {
-    const resolvedAgentId = parsed.data.zeroAgentId ?? parsed.data.composeId;
+    const resolvedAgentId = parsed.data.agentId ?? parsed.data.composeId;
     if (!resolvedAgentId) throw new Error("Missing agent ID after validation");
     const schedule = await enableSchedule(userId, orgId, resolvedAgentId, name);
 

--- a/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
@@ -29,7 +29,7 @@ const router = tsr.router(zeroSchedulesByNameContract, {
         org: { orgId },
       } = await resolveOrg(authCtx, orgSlug);
 
-      const resolvedAgentId = query.zeroAgentId ?? query.composeId;
+      const resolvedAgentId = query.agentId ?? query.composeId;
       if (!resolvedAgentId)
         throw new Error("Missing agent ID after validation");
       await deleteSchedule(userId, orgId, resolvedAgentId, params.name);

--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -54,7 +54,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            zeroAgentId: testZeroAgentId,
+            agentId: testZeroAgentId,
             name: "daily-zero",
             cronExpression: "0 9 * * *",
             timezone: "UTC",
@@ -84,7 +84,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            zeroAgentId: testZeroAgentId,
+            agentId: testZeroAgentId,
             name: "update-zero",
             cronExpression: "0 10 * * *",
             timezone: "UTC",
@@ -108,7 +108,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            zeroAgentId: "00000000-0000-0000-0000-000000000000",
+            agentId: "00000000-0000-0000-0000-000000000000",
             name: "will-fail",
             cronExpression: "0 9 * * *",
             timezone: "UTC",
@@ -157,7 +157,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            zeroAgentId: testZeroAgentId,
+            agentId: testZeroAgentId,
             name: "unauth",
             cronExpression: "0 9 * * *",
             timezone: "UTC",

--- a/turbo/apps/web/app/api/zero/schedules/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/route.ts
@@ -34,12 +34,12 @@ const router = tsr.router(zeroSchedulesMainContract, {
         org: { orgId },
       } = await resolveOrg(authCtx, orgSlug);
 
-      const resolvedAgentId = body.zeroAgentId ?? body.composeId;
+      const resolvedAgentId = body.agentId ?? body.composeId;
       if (!resolvedAgentId)
         throw new Error("Missing agent ID after validation");
       const result = await deploySchedule(userId, orgId, {
         name: body.name,
-        zeroAgentId: resolvedAgentId,
+        agentId: resolvedAgentId,
         cronExpression: body.cronExpression,
         atTime: body.atTime,
         intervalSeconds: body.intervalSeconds,

--- a/turbo/apps/web/app/api/zero/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/route.ts
@@ -572,7 +572,7 @@ async function finishSubmit(
 
   await runAgentForSlackOrg({
     composeId: claimed.composeId,
-    zeroAgentId: agentInfo.zeroAgentId,
+    agentId: agentInfo.agentId,
     agentName: claimed.agentName,
     sessionId: claimed.sessionId ?? undefined,
     prompt: answerPrompt,

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -384,7 +384,7 @@ export async function createTestCompose(
   const result: { composeId: string; versionId: string; name: string } =
     await response.json();
 
-  // Ensure a matching zero_agents row exists so callers can resolve zeroAgentId
+  // Ensure a matching zero_agents row exists so callers can resolve agentId
   initServices();
   const [compose] = await globalThis.services.db
     .select({ orgId: agentComposes.orgId })
@@ -985,12 +985,10 @@ export async function failTestRun(
 // ============================================================================
 
 /**
- * Resolve composeId to zeroAgentId for test helpers.
+ * Resolve composeId to agentId for test helpers.
  * Looks up the compose to get org/name, then finds the corresponding zero agent.
  */
-async function resolveZeroAgentIdFromCompose(
-  composeId: string,
-): Promise<string> {
+async function resolveAgentIdFromCompose(composeId: string): Promise<string> {
   const [compose] = await globalThis.services.db
     .select({ orgId: agentComposes.orgId, name: agentComposes.name })
     .from(agentComposes)
@@ -1031,7 +1029,7 @@ export async function createTestSchedule(
 ): Promise<ScheduleResponse> {
   initServices();
   const { userId, orgId } = await getTestAuthContext();
-  const zeroAgentId = await resolveZeroAgentIdFromCompose(composeId);
+  const agentId = await resolveAgentIdFromCompose(composeId);
 
   // Default to cron if no trigger specified
   const hasTrigger =
@@ -1041,7 +1039,7 @@ export async function createTestSchedule(
 
   const result = await deploySchedule(userId, orgId, {
     name,
-    zeroAgentId,
+    agentId,
     timezone: options?.timezone ?? "UTC",
     prompt: options?.prompt ?? "Test schedule prompt",
     cronExpression: hasTrigger ? options?.cronExpression : "0 0 * * *",
@@ -1065,8 +1063,8 @@ export async function getTestSchedule(
 ): Promise<ScheduleResponse> {
   initServices();
   const { userId, orgId } = await getTestAuthContext();
-  const zeroAgentId = await resolveZeroAgentIdFromCompose(composeId);
-  return getScheduleByName(userId, orgId, zeroAgentId, name);
+  const agentId = await resolveAgentIdFromCompose(composeId);
+  return getScheduleByName(userId, orgId, agentId, name);
 }
 
 /**
@@ -1082,8 +1080,8 @@ export async function enableTestSchedule(
 ): Promise<ScheduleResponse> {
   initServices();
   const { userId, orgId } = await getTestAuthContext();
-  const zeroAgentId = await resolveZeroAgentIdFromCompose(composeId);
-  return enableSchedule(userId, orgId, zeroAgentId, name);
+  const agentId = await resolveAgentIdFromCompose(composeId);
+  return enableSchedule(userId, orgId, agentId, name);
 }
 
 /**
@@ -1099,8 +1097,8 @@ export async function disableTestSchedule(
 ): Promise<ScheduleResponse> {
   initServices();
   const { userId, orgId } = await getTestAuthContext();
-  const zeroAgentId = await resolveZeroAgentIdFromCompose(composeId);
-  return disableSchedule(userId, orgId, zeroAgentId, name);
+  const agentId = await resolveAgentIdFromCompose(composeId);
+  return disableSchedule(userId, orgId, agentId, name);
 }
 
 /**
@@ -1115,8 +1113,8 @@ export async function deleteTestSchedule(
 ): Promise<void> {
   initServices();
   const { userId, orgId } = await getTestAuthContext();
-  const zeroAgentId = await resolveZeroAgentIdFromCompose(composeId);
-  await deleteSchedule(userId, orgId, zeroAgentId, name);
+  const agentId = await resolveAgentIdFromCompose(composeId);
+  await deleteSchedule(userId, orgId, agentId, name);
 }
 
 /**
@@ -1142,11 +1140,11 @@ export async function getTestScheduleRuns(
 }> {
   initServices();
   const { userId, orgId } = await getTestAuthContext();
-  const zeroAgentId = await resolveZeroAgentIdFromCompose(composeId);
+  const agentId = await resolveAgentIdFromCompose(composeId);
   const runs = await getScheduleRecentRuns(
     userId,
     orgId,
-    zeroAgentId,
+    agentId,
     name,
     limit ?? 5,
   );
@@ -3892,7 +3890,7 @@ export async function seedTestCompose(opts: {
     throw new Error("Failed to seed agent compose");
   }
 
-  // Ensure a matching zero_agents row exists so handlers can resolve zeroAgentId
+  // Ensure a matching zero_agents row exists so handlers can resolve agentId
   await globalThis.services.db
     .insert(zeroAgents)
     .values({ orgId: opts.orgId, name: opts.name })

--- a/turbo/apps/web/src/__tests__/github/api-helpers.ts
+++ b/turbo/apps/web/src/__tests__/github/api-helpers.ts
@@ -83,7 +83,7 @@ export async function givenGitHubInstallation(
     })
     .returning();
 
-  // Create zero agent so handler can resolve zeroAgentId
+  // Create zero agent so handler can resolve agentId
   await globalThis.services.db
     .insert(zeroAgents)
     .values({ orgId, name: compose!.name })

--- a/turbo/apps/web/src/db/migrations/0191_rename_zero_agent_id_to_agent_id.sql
+++ b/turbo/apps/web/src/db/migrations/0191_rename_zero_agent_id_to_agent_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "zero_agent_schedules" RENAME COLUMN "zero_agent_id" TO "agent_id";--> statement-breakpoint
+ALTER TABLE "zero_agent_schedules" RENAME CONSTRAINT "zero_agent_schedules_zero_agent_id_zero_agents_id_fk" TO "zero_agent_schedules_agent_id_zero_agents_id_fk";

--- a/turbo/apps/web/src/db/migrations/meta/0191_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0191_snapshot.json
@@ -1,0 +1,5991 @@
+{
+  "id": "ab4da0cf-dd9a-4eb5-b276-e782a42b12c0",
+  "prevId": "02fb1a5d-1ab1-4163-9982-324c36dda5e4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_org": {
+          "name": "idx_agent_composes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_org_name": {
+          "name": "idx_agent_composes_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_org_created_idx": {
+          "name": "agent_run_queue_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_schedule_created": {
+          "name": "idx_agent_runs_schedule_created",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_schedule_id_zero_agent_schedules_id_fk": {
+          "name": "agent_runs_schedule_id_zero_agent_schedules_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "zero_agent_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_name": {
+          "name": "memory_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_org": {
+          "name": "idx_agent_sessions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_runs": {
+      "name": "chat_thread_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_runs_unique": {
+          "name": "idx_chat_thread_runs_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_runs_thread": {
+          "name": "idx_chat_thread_runs_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_thread_runs_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_thread_runs_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_thread_runs",
+          "tableTo": "chat_threads",
+          "columnsFrom": ["chat_thread_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_thread_runs_run_id_agent_runs_id_fk": {
+          "name": "chat_thread_runs_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_thread_runs",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_compose_updated": {
+          "name": "idx_chat_threads_user_compose_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_agent_compose_id_agent_composes_id_fk": {
+          "name": "chat_threads_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_snapshot": {
+          "name": "memory_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_type": {
+          "name": "idx_connectors_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_pricing": {
+      "name": "credit_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_token_price": {
+          "name": "cache_creation_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_credit_pricing_model_provider": {
+          "name": "uq_credit_pricing_model_provider",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_usage": {
+      "name": "credit_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_uuid": {
+          "name": "result_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "web_search_requests": {
+          "name": "web_search_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_credit_usage_run_result": {
+          "name": "uq_credit_usage_run_result",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_run_id": {
+          "name": "idx_credit_usage_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_org_status": {
+          "name": "idx_credit_usage_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_org_created": {
+          "name": "idx_credit_usage_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_usage_run_id_agent_runs_id_fk": {
+          "name": "credit_usage_run_id_agent_runs_id_fk",
+          "tableFrom": "credit_usage",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_email_lower_idx": {
+          "name": "email_suppressions_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_compose_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_compose_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cached_at": {
+          "name": "billing_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_org_cache_slug": {
+          "name": "idx_org_cache_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_metadata": {
+      "name": "org_members_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "send_mode": {
+          "name": "send_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enter'"
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "credit_cap": {
+          "name": "credit_cap",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_enabled": {
+          "name": "credit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_metadata_org_id_user_id_pk": {
+          "name": "org_members_metadata_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_metadata": {
+      "name": "org_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "default_agent_compose_id": {
+          "name": "default_agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_enabled": {
+          "name": "auto_recharge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_threshold": {
+          "name": "auto_recharge_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_amount": {
+          "name": "auto_recharge_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_pending_at": {
+          "name": "auto_recharge_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_stripe_customer": {
+          "name": "uq_org_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0/default'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_profile_unclaimed_idx": {
+          "name": "runner_job_queue_group_profile_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_path": {
+          "name": "full_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_hash": {
+          "name": "version_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_name": {
+          "name": "idx_skills_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_storage_id": {
+          "name": "idx_skills_storage_id",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_storage_id_storages_id_fk": {
+          "name": "skills_storage_id_storages_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_url_unique": {
+          "name": "skills_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_vm0_user_workspace": {
+          "name": "idx_slack_org_connections_vm0_user_workspace",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": ["slack_workspace_id"],
+          "columnsTo": ["slack_workspace_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_pending_questions": {
+      "name": "slack_org_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_org_pending_questions_run_id": {
+          "name": "idx_slack_org_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_pending_questions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_pending_questions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slack_org_pending_questions_compose_id_agent_composes_id_fk": {
+          "name": "slack_org_pending_questions_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_pending_questions_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_pending_questions_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_thread_sessions": {
+      "name": "slack_org_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_thread_sessions_conn_channel_thread": {
+          "name": "idx_slack_org_thread_sessions_conn_channel_thread",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_thread_sessions_connection": {
+          "name": "idx_slack_org_thread_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_version_lineage": {
+      "name": "storage_version_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storage_version_lineage_storage_version": {
+          "name": "idx_storage_version_lineage_storage_version",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_storage_parent": {
+          "name": "idx_storage_version_lineage_storage_parent",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_run": {
+          "name": "idx_storage_version_lineage_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_version_lineage_storage_id_storages_id_fk": {
+          "name": "storage_version_lineage_storage_id_storages_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_version_lineage_run_id_agent_runs_id_fk": {
+          "name": "storage_version_lineage_run_id_agent_runs_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name_type": {
+          "name": "idx_storages_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_bot_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_org_date": {
+          "name": "uq_usage_daily_user_org_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_unsubscribed": {
+          "name": "email_unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_name": {
+          "name": "idx_variables_org_user_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vm0_api_keys": {
+      "name": "vm0_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vm0_api_keys_vendor": {
+          "name": "idx_vm0_api_keys_vendor",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agent_schedules": {
+      "name": "zero_agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_version": {
+          "name": "artifact_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agent_schedules_zero_agent": {
+          "name": "idx_zero_agent_schedules_zero_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_org": {
+          "name": "idx_zero_agent_schedules_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_agent_name_org_user": {
+          "name": "idx_zero_agent_schedules_agent_name_org_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_next_run": {
+          "name": "idx_zero_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agent_schedules_agent_id_zero_agents_id_fk": {
+          "name": "zero_agent_schedules_agent_id_zero_agents_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "zero_agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "zero_agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agents": {
+      "name": "zero_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sound": {
+          "name": "sound",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firewall_policies": {
+          "name": "firewall_policies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connectors": {
+          "name": "connectors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agents_org_name": {
+          "name": "idx_zero_agents_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agents_org": {
+          "name": "idx_zero_agents_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": ["pending", "complete", "expired", "error"]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/0191_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0191_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "ab4da0cf-dd9a-4eb5-b276-e782a42b12c0",
-  "prevId": "02fb1a5d-1ab1-4163-9982-324c36dda5e4",
+  "id": "53b43a3d-214d-4738-bb56-4b116a2673ab",
+  "prevId": "ab4da0cf-dd9a-4eb5-b276-e782a42b12c0",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -1338,6 +1338,13 @@
       "when": 1774483200000,
       "tag": "0190_add_connectors_to_zero_agents",
       "breakpoints": true
+    },
+    {
+      "idx": 191,
+      "version": "7",
+      "when": 1774569600000,
+      "tag": "0191_rename_zero_agent_id_to_agent_id",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/zero-agent-schedule.ts
+++ b/turbo/apps/web/src/db/schema/zero-agent-schedule.ts
@@ -33,7 +33,7 @@ export const zeroAgentSchedules = pgTable(
   "zero_agent_schedules",
   {
     id: uuid("id").defaultRandom().primaryKey(),
-    zeroAgentId: uuid("zero_agent_id")
+    agentId: uuid("agent_id")
       .notNull()
       .references(() => zeroAgents.id, { onDelete: "cascade" }),
     userId: text("user_id").notNull(),
@@ -86,10 +86,10 @@ export const zeroAgentSchedules = pgTable(
   },
   (table) => [
     // Index for finding schedules by agent
-    index("idx_zero_agent_schedules_zero_agent").on(table.zeroAgentId),
+    index("idx_zero_agent_schedules_zero_agent").on(table.agentId),
     index("idx_zero_agent_schedules_org").on(table.orgId),
     uniqueIndex("idx_zero_agent_schedules_agent_name_org_user").on(
-      table.zeroAgentId,
+      table.agentId,
       table.name,
       table.orgId,
       table.userId,

--- a/turbo/apps/web/src/lib/callback/callback-payloads.ts
+++ b/turbo/apps/web/src/lib/callback/callback-payloads.ts
@@ -56,14 +56,14 @@ export interface EmailReplyCallbackPayload {
 
 export interface EmailScheduleCallbackPayload {
   scheduleId: string;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   userId: string;
 }
 
 export interface SlackScheduleCallbackPayload {
   scheduleId: string;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   userId: string;
   orgId: string;

--- a/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-reply.ts
@@ -178,7 +178,7 @@ export async function handleInboundEmailReply(
     },
   ];
 
-  // 11. Resolve zeroAgentId from session's composeId
+  // 11. Resolve agentId from session's composeId
   const [agent] = await globalThis.services.db
     .select({ id: zeroAgents.id })
     .from(agentComposes)
@@ -208,7 +208,7 @@ export async function handleInboundEmailReply(
     userId: session.userId,
     prompt: replyContent,
     appendSystemPrompt,
-    zeroAgentId: agent.id,
+    agentId: agent.id,
     sessionId: session.agentSessionId,
     triggerSource: "email",
     callbacks,

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -280,7 +280,7 @@ export async function handleInboundEmailTrigger(
     userId,
     prompt,
     appendSystemPrompt,
-    zeroAgentId: compose.zeroAgentId,
+    agentId: compose.agentId,
     triggerSource: "email",
     callbacks,
   });

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -252,7 +252,7 @@ export function computeReplyRecipients(opts: {
 
 interface ResolvedAgent {
   composeId: string;
-  zeroAgentId: string;
+  agentId: string;
   userId: string;
   orgId: string;
   orgSlug: string;
@@ -293,7 +293,7 @@ export async function resolveAgentByAddress(
   // Compose must have a published version to be triggerable
   if (!compose.headVersionId) return null;
 
-  // 3. Resolve zeroAgentId by (orgId, name)
+  // 3. Resolve agentId by (orgId, name)
   const [agent] = await globalThis.services.db
     .select({ id: zeroAgents.id })
     .from(zeroAgents)
@@ -306,7 +306,7 @@ export async function resolveAgentByAddress(
 
   return {
     composeId: compose.id,
-    zeroAgentId: agent.id,
+    agentId: agent.id,
     userId: compose.userId,
     orgId: compose.orgId,
     orgSlug,

--- a/turbo/apps/web/src/lib/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/github/handlers/issue-event.ts
@@ -439,7 +439,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
     );
   }
 
-  // 3b. Resolve zeroAgentId from compose
+  // 3b. Resolve agentId from compose
   const [zeroAgent] = await globalThis.services.db
     .select({ id: zeroAgents.id })
     .from(zeroAgents)
@@ -512,7 +512,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
       userId: vm0UserId,
       prompt: resolvedPrompt,
       appendSystemPrompt,
-      zeroAgentId: zeroAgent.id,
+      agentId: zeroAgent.id,
       sessionId: existingSessionId,
       triggerSource: "github",
       callbacks: [

--- a/turbo/apps/web/src/lib/schedule/__tests__/notification-control.test.ts
+++ b/turbo/apps/web/src/lib/schedule/__tests__/notification-control.test.ts
@@ -28,7 +28,7 @@ const context = testContext();
  * enable it, and make it due for execution.
  */
 async function createDueSchedule(
-  zeroAgentId: string,
+  agentId: string,
   slug: string,
   name: string,
   options: { notifyEmail: boolean; notifySlack: boolean },
@@ -40,7 +40,7 @@ async function createDueSchedule(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        zeroAgentId,
+        agentId,
         name,
         cronExpression: "0 0 * * *",
         timezone: "UTC",
@@ -60,7 +60,7 @@ async function createDueSchedule(
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ zeroAgentId }),
+      body: JSON.stringify({ agentId }),
     },
   );
   await enableScheduleRoute(enableReq, {
@@ -76,7 +76,7 @@ async function createDueSchedule(
 
 describe("Schedule notification control - AND logic", () => {
   let user: UserContext;
-  let zeroAgentId: string;
+  let agentId: string;
   let slug: string;
 
   beforeEach(async () => {
@@ -91,7 +91,7 @@ describe("Schedule notification control - AND logic", () => {
     const agentName = uniqueId("notify-agent");
     await createTestCompose(agentName);
     await createTestZeroAgent(user.orgId, agentName, {});
-    zeroAgentId = await getTestZeroAgentId(user.orgId, agentName);
+    agentId = await getTestZeroAgentId(user.orgId, agentName);
 
     // Disable any schedules from other tests to avoid interference
     await disableAllSchedules();
@@ -107,7 +107,7 @@ describe("Schedule notification control - AND logic", () => {
     });
 
     // Schedule: both on
-    const scheduleId = await createDueSchedule(zeroAgentId, slug, "both-on", {
+    const scheduleId = await createDueSchedule(agentId, slug, "both-on", {
       notifyEmail: true,
       notifySlack: true,
     });
@@ -138,7 +138,7 @@ describe("Schedule notification control - AND logic", () => {
     });
 
     // Schedule: email off
-    const scheduleId = await createDueSchedule(zeroAgentId, slug, "email-off", {
+    const scheduleId = await createDueSchedule(agentId, slug, "email-off", {
       notifyEmail: false,
       notifySlack: true,
     });
@@ -169,7 +169,7 @@ describe("Schedule notification control - AND logic", () => {
     });
 
     // Schedule: slack off
-    const scheduleId = await createDueSchedule(zeroAgentId, slug, "slack-off", {
+    const scheduleId = await createDueSchedule(agentId, slug, "slack-off", {
       notifyEmail: true,
       notifySlack: false,
     });
@@ -201,7 +201,7 @@ describe("Schedule notification control - AND logic", () => {
 
     // Schedule: both on
     const scheduleId = await createDueSchedule(
-      zeroAgentId,
+      agentId,
       slug,
       "user-email-off",
       {
@@ -236,7 +236,7 @@ describe("Schedule notification control - AND logic", () => {
     });
 
     // Schedule: both off
-    const scheduleId = await createDueSchedule(zeroAgentId, slug, "silent", {
+    const scheduleId = await createDueSchedule(agentId, slug, "silent", {
       notifyEmail: false,
       notifySlack: false,
     });

--- a/turbo/apps/web/src/lib/schedule/__tests__/resolve-compose.test.ts
+++ b/turbo/apps/web/src/lib/schedule/__tests__/resolve-compose.test.ts
@@ -9,11 +9,11 @@ import {
   createTestZeroAgent,
   getTestZeroAgentId,
 } from "../../../__tests__/api-test-helpers";
-import { resolveComposeByZeroAgentId } from "../schedule-service";
+import { resolveComposeByAgentId } from "../schedule-service";
 
 const context = testContext();
 
-describe("resolveComposeByZeroAgentId", () => {
+describe("resolveComposeByAgentId", () => {
   let user: UserContext;
 
   beforeEach(async () => {
@@ -21,13 +21,13 @@ describe("resolveComposeByZeroAgentId", () => {
     user = await context.setupUser();
   });
 
-  it("should resolve compose from a valid zeroAgentId", async () => {
+  it("should resolve compose from a valid agentId", async () => {
     const agentName = uniqueId("resolve-ok");
     await createTestCompose(agentName);
     await createTestZeroAgent(user.orgId, agentName, {});
-    const zeroAgentId = await getTestZeroAgentId(user.orgId, agentName);
+    const agentId = await getTestZeroAgentId(user.orgId, agentName);
 
-    const compose = await resolveComposeByZeroAgentId(zeroAgentId);
+    const compose = await resolveComposeByAgentId(agentId);
 
     expect(compose).not.toBeNull();
     expect(compose!.name).toBe(agentName);
@@ -37,7 +37,7 @@ describe("resolveComposeByZeroAgentId", () => {
   it("should return null when agent does not exist", async () => {
     const nonExistentId = "00000000-0000-0000-0000-000000000000";
 
-    const compose = await resolveComposeByZeroAgentId(nonExistentId);
+    const compose = await resolveComposeByAgentId(nonExistentId);
 
     expect(compose).toBeNull();
   });
@@ -46,9 +46,9 @@ describe("resolveComposeByZeroAgentId", () => {
     const agentName = uniqueId("no-compose");
     // Create zero agent without a matching compose
     await createTestZeroAgent(user.orgId, agentName, {});
-    const zeroAgentId = await getTestZeroAgentId(user.orgId, agentName);
+    const agentId = await getTestZeroAgentId(user.orgId, agentName);
 
-    const compose = await resolveComposeByZeroAgentId(zeroAgentId);
+    const compose = await resolveComposeByAgentId(agentId);
 
     expect(compose).toBeNull();
   });

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -24,7 +24,7 @@ const log = logger("service:schedule");
  */
 export interface ScheduleResponse {
   id: string;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   orgSlug: string;
   userId: string;
@@ -70,7 +70,7 @@ interface RunSummary {
  */
 interface DeployScheduleRequest {
   name: string;
-  zeroAgentId: string;
+  agentId: string;
   cronExpression?: string;
   atTime?: string;
   intervalSeconds?: number;
@@ -115,8 +115,8 @@ function calculateNextRun(
  * Resolve the agent compose associated with a zero agent ID.
  * Uses a single JOIN query instead of two sequential lookups.
  */
-export async function resolveComposeByZeroAgentId(
-  zeroAgentId: string,
+export async function resolveComposeByAgentId(
+  agentId: string,
 ): Promise<typeof agentComposes.$inferSelect | null> {
   const [result] = await globalThis.services.db
     .select({
@@ -130,7 +130,7 @@ export async function resolveComposeByZeroAgentId(
         eq(agentComposes.name, zeroAgents.name),
       ),
     )
-    .where(eq(zeroAgents.id, zeroAgentId))
+    .where(eq(zeroAgents.id, agentId))
     .limit(1);
   return result?.compose ?? null;
 }
@@ -157,7 +157,7 @@ function toResponse(
 
   return {
     id: schedule.id,
-    zeroAgentId: schedule.zeroAgentId,
+    agentId: schedule.agentId,
     agentName,
     orgSlug,
     userId: schedule.userId,
@@ -195,16 +195,16 @@ function toResponse(
  * 2. Fallback: treat the id as a composeId, resolve the compose's
  *    (orgId, name), then find-or-create the zero_agents row.
  *    This is required because the CLI receives agentComposeId from
- *    GET /api/zero/agents/:name and sends it as zeroAgentId.
+ *    GET /api/zero/agents/:name and sends it as agentId.
  */
 async function loadZeroAgent(
-  zeroAgentId: string,
+  agentId: string,
 ): Promise<typeof zeroAgents.$inferSelect> {
   // 1. Direct zero_agents lookup
   const [agent] = await globalThis.services.db
     .select()
     .from(zeroAgents)
-    .where(eq(zeroAgents.id, zeroAgentId))
+    .where(eq(zeroAgents.id, agentId))
     .limit(1);
 
   if (agent) return agent;
@@ -213,7 +213,7 @@ async function loadZeroAgent(
   const [compose] = await globalThis.services.db
     .select()
     .from(agentComposes)
-    .where(eq(agentComposes.id, zeroAgentId))
+    .where(eq(agentComposes.id, agentId))
     .limit(1);
 
   if (!compose) throw notFound("Agent not found");
@@ -256,19 +256,19 @@ async function getOrgSlug(orgId: string): Promise<string> {
 }
 
 /**
- * Verify the user owns this schedule (by zeroAgentId + name + orgId + userId).
+ * Verify the user owns this schedule (by agentId + name + orgId + userId).
  */
 async function verifyScheduleOwnership(
   userId: string,
   orgId: string,
-  zeroAgentId: string,
+  agentId: string,
   name: string,
 ): Promise<{
   schedule: typeof zeroAgentSchedules.$inferSelect;
   agentName: string;
   orgSlug: string;
 }> {
-  const agent = await loadZeroAgent(zeroAgentId);
+  const agent = await loadZeroAgent(agentId);
   const resolvedId = agent.id;
 
   const [schedule] = await globalThis.services.db
@@ -276,7 +276,7 @@ async function verifyScheduleOwnership(
     .from(zeroAgentSchedules)
     .where(
       and(
-        eq(zeroAgentSchedules.zeroAgentId, resolvedId),
+        eq(zeroAgentSchedules.agentId, resolvedId),
         eq(zeroAgentSchedules.name, name),
         eq(zeroAgentSchedules.orgId, orgId),
         eq(zeroAgentSchedules.userId, userId),
@@ -382,7 +382,7 @@ async function insertNewSchedule(
   userId: string,
   orgId: string,
   request: DeployScheduleRequest,
-  zeroAgentId: string,
+  agentId: string,
   triggerType: "cron" | "once" | "loop",
   nextRunAt: Date | null,
 ): Promise<typeof zeroAgentSchedules.$inferSelect> {
@@ -390,7 +390,7 @@ async function insertNewSchedule(
   const [created] = await globalThis.services.db
     .insert(zeroAgentSchedules)
     .values({
-      zeroAgentId,
+      agentId,
       userId,
       orgId,
       name: request.name,
@@ -477,13 +477,11 @@ export async function deploySchedule(
   orgId: string,
   request: DeployScheduleRequest,
 ): Promise<{ schedule: ScheduleResponse; created: boolean }> {
-  log.debug(
-    `Deploying schedule ${request.name} for agent ${request.zeroAgentId}`,
-  );
+  log.debug(`Deploying schedule ${request.name} for agent ${request.agentId}`);
 
-  const agent = await loadZeroAgent(request.zeroAgentId);
-  // Normalize request to use the resolved zeroAgentId (handles composeId fallback from CLI)
-  request = { ...request, zeroAgentId: agent.id };
+  const agent = await loadZeroAgent(request.agentId);
+  // Normalize request to use the resolved agentId (handles composeId fallback from CLI)
+  request = { ...request, agentId: agent.id };
   const orgSlug = await getOrgSlug(orgId);
 
   // Validate timezone
@@ -509,7 +507,7 @@ export async function deploySchedule(
     .from(zeroAgentSchedules)
     .where(
       and(
-        eq(zeroAgentSchedules.zeroAgentId, request.zeroAgentId),
+        eq(zeroAgentSchedules.agentId, request.agentId),
         eq(zeroAgentSchedules.name, request.name),
         eq(zeroAgentSchedules.orgId, orgId),
         eq(zeroAgentSchedules.userId, userId),
@@ -575,7 +573,7 @@ export async function listSchedules(
   }
 
   // Load zero agent data for all schedules
-  const agentIds = [...new Set(userSchedules.map((s) => s.zeroAgentId))];
+  const agentIds = [...new Set(userSchedules.map((s) => s.agentId))];
   const agentRows = await globalThis.services.db
     .select()
     .from(zeroAgents)
@@ -593,10 +591,10 @@ export async function listSchedules(
     .filter((schedule) => {
       // FK constraints with CASCADE should guarantee these exist.
       // Skip orphaned rows rather than masking with fallback values.
-      return agentMap.has(schedule.zeroAgentId);
+      return agentMap.has(schedule.agentId);
     })
     .map((schedule) => {
-      const agent = agentMap.get(schedule.zeroAgentId)!;
+      const agent = agentMap.get(schedule.agentId)!;
       const orgSlug = orgDataMap.get(schedule.orgId)?.slug ?? "";
       return toResponse(schedule, agent.name, orgSlug);
     });
@@ -608,15 +606,15 @@ export async function listSchedules(
 export async function getScheduleByName(
   userId: string,
   orgId: string,
-  zeroAgentId: string,
+  agentId: string,
   name: string,
 ): Promise<ScheduleResponse> {
-  log.debug(`Getting schedule ${name} for agent ${zeroAgentId}`);
+  log.debug(`Getting schedule ${name} for agent ${agentId}`);
 
   const { schedule, agentName, orgSlug } = await verifyScheduleOwnership(
     userId,
     orgId,
-    zeroAgentId,
+    agentId,
     name,
   );
 
@@ -629,7 +627,7 @@ export async function getScheduleByName(
 export async function getScheduleRecentRuns(
   userId: string,
   orgId: string,
-  zeroAgentId: string,
+  agentId: string,
   scheduleName: string,
   limit: number,
 ): Promise<RunSummary[]> {
@@ -640,7 +638,7 @@ export async function getScheduleRecentRuns(
   const { schedule } = await verifyScheduleOwnership(
     userId,
     orgId,
-    zeroAgentId,
+    agentId,
     scheduleName,
   );
 
@@ -673,15 +671,15 @@ export async function getScheduleRecentRuns(
 export async function deleteSchedule(
   userId: string,
   orgId: string,
-  zeroAgentId: string,
+  agentId: string,
   name: string,
 ): Promise<void> {
-  log.debug(`Deleting schedule ${name} for agent ${zeroAgentId}`);
+  log.debug(`Deleting schedule ${name} for agent ${agentId}`);
 
   const { schedule } = await verifyScheduleOwnership(
     userId,
     orgId,
-    zeroAgentId,
+    agentId,
     name,
   );
 
@@ -698,15 +696,15 @@ export async function deleteSchedule(
 export async function enableSchedule(
   userId: string,
   orgId: string,
-  zeroAgentId: string,
+  agentId: string,
   name: string,
 ): Promise<ScheduleResponse> {
-  log.debug(`Enabling schedule ${name} for agent ${zeroAgentId}`);
+  log.debug(`Enabling schedule ${name} for agent ${agentId}`);
 
   const { schedule, agentName, orgSlug } = await verifyScheduleOwnership(
     userId,
     orgId,
-    zeroAgentId,
+    agentId,
     name,
   );
 
@@ -756,15 +754,15 @@ export async function enableSchedule(
 export async function disableSchedule(
   userId: string,
   orgId: string,
-  zeroAgentId: string,
+  agentId: string,
   name: string,
 ): Promise<ScheduleResponse> {
-  log.debug(`Disabling schedule ${name} for agent ${zeroAgentId}`);
+  log.debug(`Disabling schedule ${name} for agent ${agentId}`);
 
   const { schedule, agentName, orgSlug } = await verifyScheduleOwnership(
     userId,
     orgId,
-    zeroAgentId,
+    agentId,
     name,
   );
 
@@ -908,7 +906,7 @@ async function executeSchedule(
   log.debug(`Executing schedule ${schedule.name} (${schedule.id})`);
 
   // Resolve compose via zero agent (single JOIN query)
-  const compose = await resolveComposeByZeroAgentId(schedule.zeroAgentId);
+  const compose = await resolveComposeByAgentId(schedule.agentId);
 
   if (!compose) {
     log.error(`Agent or compose for schedule ${schedule.name} not found`);
@@ -947,7 +945,7 @@ async function executeSchedule(
   ) {
     const emailPayload: EmailScheduleCallbackPayload = {
       scheduleId: schedule.id,
-      zeroAgentId: schedule.zeroAgentId,
+      agentId: schedule.agentId,
       agentName: compose.name,
       userId: schedule.userId,
     };
@@ -962,7 +960,7 @@ async function executeSchedule(
   if (prefs.notifySlack && schedule.notifySlack) {
     const slackPayload: SlackScheduleCallbackPayload = {
       scheduleId: schedule.id,
-      zeroAgentId: schedule.zeroAgentId,
+      agentId: schedule.agentId,
       agentName: compose.name,
       userId: schedule.userId,
       orgId: schedule.orgId,
@@ -994,7 +992,7 @@ async function executeSchedule(
       userId: schedule.userId,
       prompt: schedule.prompt,
       appendSystemPrompt: schedule.appendSystemPrompt ?? undefined,
-      zeroAgentId: schedule.zeroAgentId,
+      agentId: schedule.agentId,
       scheduleId: schedule.id,
       triggerSource: "schedule",
       callbacks,

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -177,7 +177,7 @@ export async function handleOrgDirectMessage(
 
   const { status, response, runId, errorCode } = await runAgentForSlackOrg({
     composeId,
-    zeroAgentId: agent.zeroAgentId,
+    agentId: agent.agentId,
     agentName,
     sessionId: existingSessionId,
     prompt: messageContent,

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -175,7 +175,7 @@ export async function handleOrgMention(
 
   const { status, response, runId, errorCode } = await runAgentForSlackOrg({
     composeId,
-    zeroAgentId: agent.zeroAgentId,
+    agentId: agent.agentId,
     agentName,
     sessionId: existingSessionId,
     prompt: messageContent,

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -15,7 +15,7 @@ const log = logger("slack-org:run-agent");
 
 interface RunAgentParams {
   composeId: string;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   sessionId: string | undefined;
   prompt: string;
@@ -48,7 +48,7 @@ export async function runAgentForSlackOrg(
 ): Promise<RunAgentResult> {
   const {
     composeId,
-    zeroAgentId,
+    agentId,
     agentName,
     sessionId,
     prompt,
@@ -77,7 +77,7 @@ export async function runAgentForSlackOrg(
 
     const result = await createZeroRun({
       userId,
-      zeroAgentId,
+      agentId,
       prompt,
       appendSystemPrompt,
       sessionId,

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -332,7 +332,7 @@ export async function getWorkspaceAgent(composeId: string): Promise<
       id: string;
       name: string;
       displayName: string | null;
-      zeroAgentId: string;
+      agentId: string;
     }
   | undefined
 > {
@@ -351,7 +351,7 @@ export async function getWorkspaceAgent(composeId: string): Promise<
 
   const [agent] = await db
     .select({
-      zeroAgentId: zeroAgents.id,
+      agentId: zeroAgents.id,
       displayName: zeroAgents.displayName,
     })
     .from(zeroAgents)
@@ -369,7 +369,7 @@ export async function getWorkspaceAgent(composeId: string): Promise<
     id: compose.id,
     name: compose.name,
     displayName: agent.displayName,
-    zeroAgentId: agent.zeroAgentId,
+    agentId: agent.agentId,
   };
 }
 

--- a/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/direct-message.ts
@@ -160,7 +160,7 @@ export async function handleTelegramDirectMessage(
 
   const { status, response, runId } = await runAgentForTelegram({
     composeId,
-    zeroAgentId: defaultAgent.zeroAgentId,
+    agentId: defaultAgent.agentId,
     agentName,
     sessionId: existingSessionId,
     prompt: enrichedPrompt,

--- a/turbo/apps/web/src/lib/telegram/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/mention.ts
@@ -147,7 +147,7 @@ export async function handleTelegramMention(
   );
   const { status, response, runId } = await runAgentForTelegram({
     composeId,
-    zeroAgentId: defaultAgent.zeroAgentId,
+    agentId: defaultAgent.agentId,
     agentName,
     sessionId: existingSessionId,
     prompt: enrichedPrompt,

--- a/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/run-agent.ts
@@ -11,7 +11,7 @@ const log = logger("telegram:run-agent");
 
 interface RunAgentParams {
   composeId: string;
-  zeroAgentId: string;
+  agentId: string;
   agentName: string;
   sessionId: string | undefined;
   prompt: string;
@@ -37,7 +37,7 @@ export async function runAgentForTelegram(
 ): Promise<RunAgentResult> {
   const {
     composeId,
-    zeroAgentId,
+    agentId,
     agentName,
     sessionId,
     prompt,
@@ -59,7 +59,7 @@ export async function runAgentForTelegram(
   try {
     const result = await createZeroRun({
       userId,
-      zeroAgentId,
+      agentId,
       prompt,
       appendSystemPrompt,
       sessionId,

--- a/turbo/apps/web/src/lib/telegram/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/telegram/handlers/shared.ts
@@ -260,7 +260,7 @@ export async function ensureOrgAndArtifact(vm0UserId: string): Promise<void> {
  */
 export async function getWorkspaceAgent(
   composeId: string,
-): Promise<{ id: string; name: string; zeroAgentId: string } | undefined> {
+): Promise<{ id: string; name: string; agentId: string } | undefined> {
   const db = globalThis.services.db;
   const [compose] = await db
     .select({
@@ -275,7 +275,7 @@ export async function getWorkspaceAgent(
   if (!compose) return undefined;
 
   const [agent] = await db
-    .select({ zeroAgentId: zeroAgents.id })
+    .select({ agentId: zeroAgents.id })
     .from(zeroAgents)
     .where(
       and(
@@ -290,7 +290,7 @@ export async function getWorkspaceAgent(
   return {
     id: compose.id,
     name: compose.name,
-    zeroAgentId: agent.zeroAgentId,
+    agentId: agent.agentId,
   };
 }
 

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -22,14 +22,14 @@ const context = testContext();
 
 describe("createZeroRun()", () => {
   let user: UserContext;
-  let zeroAgentId: string;
+  let agentId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
     const agentName = uniqueId("agent");
     await createTestCompose(agentName);
-    zeroAgentId = await getTestZeroAgentId(user.orgId, agentName);
+    agentId = await getTestZeroAgentId(user.orgId, agentName);
     vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
     reloadEnv();
   });
@@ -40,7 +40,7 @@ describe("createZeroRun()", () => {
     return {
       userId: user.userId,
       prompt: "Hello, world!",
-      zeroAgentId,
+      agentId,
       triggerSource: "web" as TriggerSource,
       ...overrides,
     };
@@ -83,7 +83,7 @@ describe("createZeroRun()", () => {
       });
       const agentId = await getTestZeroAgentId(user.orgId, agentName);
 
-      const result = await createZeroRun(baseParams({ zeroAgentId: agentId }));
+      const result = await createZeroRun(baseParams({ agentId: agentId }));
 
       const run = await findTestRunRecord(result.runId);
       expect(run).toBeDefined();
@@ -101,7 +101,7 @@ describe("createZeroRun()", () => {
 
       const result = await createZeroRun(
         baseParams({
-          zeroAgentId: agentId,
+          agentId: agentId,
           appendSystemPrompt: "Custom instructions",
         }),
       );
@@ -163,7 +163,7 @@ describe("createZeroRun()", () => {
       );
       const result = await createZeroRun(
         baseParams({
-          zeroAgentId: agentId,
+          agentId: agentId,
           scheduleId: schedule.id,
           triggerSource: "schedule",
         }),
@@ -228,7 +228,7 @@ describe("createZeroRun()", () => {
       });
       const agentId = await getTestZeroAgentId(user.orgId, agentName);
 
-      const result = await createZeroRun(baseParams({ zeroAgentId: agentId }));
+      const result = await createZeroRun(baseParams({ agentId: agentId }));
 
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
@@ -248,7 +248,7 @@ describe("createZeroRun()", () => {
       await createTestConnector({ type: "slack" });
       const agentId = await getTestZeroAgentId(user.orgId, agentName);
 
-      const result = await createZeroRun(baseParams({ zeroAgentId: agentId }));
+      const result = await createZeroRun(baseParams({ agentId: agentId }));
 
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
@@ -276,7 +276,7 @@ describe("createZeroRun()", () => {
       });
       const agentId = await getTestZeroAgentId(user.orgId, agentName);
 
-      const result = await createZeroRun(baseParams({ zeroAgentId: agentId }));
+      const result = await createZeroRun(baseParams({ agentId: agentId }));
 
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
@@ -295,7 +295,7 @@ describe("createZeroRun()", () => {
       await createTestConnector({ type: "slack" });
       const agentId = await getTestZeroAgentId(user.orgId, agentName);
 
-      const result = await createZeroRun(baseParams({ zeroAgentId: agentId }));
+      const result = await createZeroRun(baseParams({ agentId: agentId }));
 
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -9,10 +9,10 @@ import { agentComposes } from "../../db/schema/agent-compose";
 
 /**
  * Resolve agent identity metadata and the corresponding composeId
- * from a zeroAgentId. Uses leftJoin so it works even if no matching
+ * from a agentId. Uses leftJoin so it works even if no matching
  * agentComposes row exists (forward-compatible).
  */
-async function resolveZeroAgent(zeroAgentId: string): Promise<{
+async function resolveZeroAgent(agentId: string): Promise<{
   displayName: string | null;
   description: string | null;
   sound: string | null;
@@ -35,7 +35,7 @@ async function resolveZeroAgent(zeroAgentId: string): Promise<{
         eq(agentComposes.name, zeroAgents.name),
       ),
     )
-    .where(eq(zeroAgents.id, zeroAgentId))
+    .where(eq(zeroAgents.id, agentId))
     .limit(1);
 
   return (
@@ -57,7 +57,7 @@ async function resolveZeroAgent(zeroAgentId: string): Promise<{
 interface ZeroRunParams {
   userId: string;
   prompt: string;
-  zeroAgentId: string;
+  agentId: string;
   triggerSource: TriggerSource;
   sessionId?: string;
   appendSystemPrompt?: string;
@@ -69,7 +69,7 @@ interface ZeroRunParams {
 /**
  * Create an agent run with zero-layer defaults.
  *
- * Resolves the agent's composeId internally from zeroAgentId, then injects
+ * Resolves the agent's composeId internally from agentId, then injects
  * agent identity, memoryName, artifactName, and disallowedTools so that
  * every zero trigger path gets consistent identity, memory persistence,
  * artifact storage, and cron-tool restrictions.
@@ -77,7 +77,7 @@ interface ZeroRunParams {
 export async function createZeroRun(
   params: ZeroRunParams,
 ): Promise<CreateRunResult> {
-  const agent = await resolveZeroAgent(params.zeroAgentId);
+  const agent = await resolveZeroAgent(params.agentId);
 
   // Inject agent identity into appendSystemPrompt
   let { appendSystemPrompt } = params;

--- a/turbo/packages/core/src/contracts/zero-schedules.ts
+++ b/turbo/packages/core/src/contracts/zero-schedules.ts
@@ -9,7 +9,7 @@ const c = initContract();
  */
 export const scheduleResponseSchema = z.object({
   id: z.string().uuid(),
-  zeroAgentId: z.string().uuid(),
+  agentId: z.string().uuid(),
   agentName: z.string(),
   orgSlug: z.string(),
   userId: z.string(),
@@ -48,8 +48,8 @@ export const deployScheduleResponseSchema = z.object({
 });
 
 /**
- * Zero deploy schedule request — accepts zeroAgentId or composeId (at least one required).
- * The backend resolves composeId to zeroAgentId via loadZeroAgent() fallback.
+ * Zero deploy schedule request — accepts agentId or composeId (at least one required).
+ * The backend resolves composeId to agentId via loadZeroAgent() fallback.
  */
 const zeroDeployScheduleRequestSchema = z
   .object({
@@ -64,14 +64,14 @@ const zeroDeployScheduleRequestSchema = z
     artifactName: z.string().optional(),
     artifactVersion: z.string().optional(),
     volumeVersions: z.record(z.string(), z.string()).optional(),
-    zeroAgentId: z.string().uuid("Invalid agent ID").optional(),
+    agentId: z.string().uuid("Invalid agent ID").optional(),
     composeId: z.string().uuid("Invalid compose ID").optional(),
     enabled: z.boolean().optional(),
     notifyEmail: z.boolean().optional(),
     notifySlack: z.boolean().optional(),
   })
-  .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
-    message: "Either 'zeroAgentId' or 'composeId' must be provided",
+  .refine((data) => Boolean(data.agentId ?? data.composeId), {
+    message: "Either 'agentId' or 'composeId' must be provided",
   })
   .refine(
     (data) => {
@@ -133,11 +133,11 @@ export const zeroSchedulesByNameContract = c.router({
     }),
     query: z
       .object({
-        zeroAgentId: z.string().uuid("Invalid agent ID").optional(),
+        agentId: z.string().uuid("Invalid agent ID").optional(),
         composeId: z.string().uuid("Invalid compose ID").optional(),
       })
-      .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
-        message: "Either 'zeroAgentId' or 'composeId' must be provided",
+      .refine((data) => Boolean(data.agentId ?? data.composeId), {
+        message: "Either 'agentId' or 'composeId' must be provided",
       }),
     responses: {
       204: c.noBody(),
@@ -162,11 +162,11 @@ export const zeroSchedulesEnableContract = c.router({
     }),
     body: z
       .object({
-        zeroAgentId: z.string().uuid("Invalid agent ID").optional(),
+        agentId: z.string().uuid("Invalid agent ID").optional(),
         composeId: z.string().uuid("Invalid compose ID").optional(),
       })
-      .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
-        message: "Either 'zeroAgentId' or 'composeId' must be provided",
+      .refine((data) => Boolean(data.agentId ?? data.composeId), {
+        message: "Either 'agentId' or 'composeId' must be provided",
       }),
     responses: {
       200: scheduleResponseSchema,
@@ -186,11 +186,11 @@ export const zeroSchedulesEnableContract = c.router({
     }),
     body: z
       .object({
-        zeroAgentId: z.string().uuid("Invalid agent ID").optional(),
+        agentId: z.string().uuid("Invalid agent ID").optional(),
         composeId: z.string().uuid("Invalid compose ID").optional(),
       })
-      .refine((data) => Boolean(data.zeroAgentId ?? data.composeId), {
-        message: "Either 'zeroAgentId' or 'composeId' must be provided",
+      .refine((data) => Boolean(data.agentId ?? data.composeId), {
+        message: "Either 'agentId' or 'composeId' must be provided",
       }),
     responses: {
       200: scheduleResponseSchema,


### PR DESCRIPTION
## Summary

- Rename DB column `zero_agent_schedules.zero_agent_id` → `agent_id` with migration
- Rename all TypeScript `zeroAgentId` references to `agentId` (187 occurrences across 47 files)
- Rename API contract fields from `zeroAgentId` to `agentId` in request/response schemas
- Rename function `resolveComposeByZeroAgentId` → `resolveComposeByAgentId`

The `zero_` prefix was redundant — these IDs always reference `zero_agents.id`, and no other `agent_id` column exists in the schema.

Closes #6267

## Test plan

- [x] All 3903 existing tests pass
- [x] Type check passes across all workspaces
- [x] Lint passes with zero warnings
- [x] Knip passes (no unused code)
- [x] Grep verification: zero remaining `zeroAgentId` references (excluding migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)