### PR TITLE
feat: show coding loop gist logs in lane dashboard

### DIFF
--- a/scripts/coding-dashboard.sh
+++ b/scripts/coding-dashboard.sh
@@ -172,15 +172,24 @@ MQ_NUMBERS=$(jq '[.merge_queue[].number]' "$WORK_DIR/pipeline.json")
 
 jq -r --argjson mq "$MQ_NUMBERS" '
   .[] |
-  "\n\(.lane)" as $header |
+  # Format gist updated_at as relative time suffix
+  (if .gist.updated_at then
+    "  (log updated: \(.gist.updated_at | split("T") | .[0] + " " + (.[1] | split(".")[0] | split("Z")[0])))"
+  else "" end) as $gist_time |
+  # Truncate gist content to last few lines for brevity
+  (if .gist.content then
+    (.gist.content | split("\n") | map(select(. != "")) | .[-5:] | map("  │ \(.)") | join("\n"))
+  else null end) as $gist_lines |
+  "\n\(.lane)\($gist_time)" as $header |
   if (.issue_count + .pr_count) == 0 then
-    "\($header)\n  -- idle"
+    ([$header, "  -- idle"] + (if $gist_lines then [$gist_lines] else [] end) | join("\n"))
   else
     # Collect all PR numbers linked to any issue
     ([.issues[].linked_prs[]?]) as $linked |
     # Index PRs by number for title lookup
     ([.prs[] | {(.number | tostring): .}] | add // {}) as $pr_map |
     [ $header ] +
+    (if $gist_lines then [$gist_lines] else [] end) +
     [
       .issues[] |
       # [Queued] if any linked PR is in merge queue

--- a/scripts/lane-status.sh
+++ b/scripts/lane-status.sh
@@ -73,6 +73,17 @@ query_lane() {
     --json number,title,labels,mergeable,headRefOid,headRefName --limit 50 \
     > "$dir/prs.json" &
 
+  # Gist log for this lane
+  local gist_name="coding-loop-log-${lane}"
+  (
+    gist_id=$(gh gist list --limit 100 2>/dev/null | awk -v name="$gist_name" '$0 ~ name {print $1; exit}' || true)
+    if [ -n "$gist_id" ]; then
+      gh api "gists/$gist_id" --jq '{content: .files[].content, updated_at: .updated_at}' > "$dir/gist.json" 2>/dev/null || echo '{}' > "$dir/gist.json"
+    else
+      echo '{}' > "$dir/gist.json"
+    fi
+  ) &
+
   wait
 }
 
@@ -123,19 +134,24 @@ build_output() {
     issue_count=$(echo "$issues" | jq 'length')
     pr_count=$(echo "$prs" | jq 'length')
 
+    local gist
+    gist=$(cat "$dir/gist.json")
+
     jq -n \
       --arg lane "$lane" \
       --argjson issues "$issues" \
       --argjson prs "$prs" \
       --argjson issue_count "$issue_count" \
       --argjson pr_count "$pr_count" \
+      --argjson gist "$gist" \
       '{
         lane: $lane,
         issues: $issues,
         prs: $prs,
         issue_count: $issue_count,
         pr_count: $pr_count,
-        total: ($issue_count + $pr_count)
+        total: ($issue_count + $pr_count),
+        gist: $gist
       }'
   done
   echo "]"


### PR DESCRIPTION
## Summary
- Fetch per-lane coding loop gist logs (`coding-loop-log-<lane>`) in `lane-status.sh` alongside existing issue/PR queries
- Display the last 5 non-empty lines of each gist and its update timestamp in `coding-dashboard.sh`
- Shows gist content for both idle and active lanes, giving visibility into what each coding agent is working on

## Test plan
- [ ] Run `scripts/lane-status.sh` and verify `gist.json` is populated for lanes with gists
- [ ] Run `scripts/coding-dashboard.sh` and confirm gist log lines appear under lane headers
- [ ] Verify lanes without gists display normally (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)