### PR TITLE
feat(platform): polish zero ideation use case gallery

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -319,12 +319,8 @@ describe("zero chat page - ideation page", () => {
 
     // Category tabs should be visible
     expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Automated Reports" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "GitHub Operations" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reports" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "GitHub" })).toBeInTheDocument();
   });
 
   async function navigateToIdeation() {
@@ -349,18 +345,18 @@ describe("zero chat page - ideation page", () => {
     await navigateToIdeation();
 
     // Click a specific category tab
-    fireEvent.click(screen.getByRole("button", { name: "GitHub Operations" }));
+    fireEvent.click(screen.getByRole("button", { name: "GitHub" }));
 
     await waitFor(() => {
       // The selected category heading should be visible
       expect(
-        screen.getByRole("heading", { name: "GitHub Operations" }),
+        screen.getByRole("heading", { name: "GitHub" }),
       ).toBeInTheDocument();
     });
 
     // Other category headings should not be visible
     expect(
-      screen.queryByRole("heading", { name: "Automated Reports" }),
+      screen.queryByRole("heading", { name: "Reports" }),
     ).not.toBeInTheDocument();
   });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-data.ts
@@ -10,36 +10,31 @@ interface UseCase {
 interface Category {
   readonly id: string;
   readonly title: string;
-  readonly subtitle: string;
   readonly cases: readonly UseCase[];
 }
 
 const categories: readonly Category[] = [
   {
     id: "reports",
-    title: "Automated Reports",
-    subtitle:
-      "Pull multi-source data on a schedule, generate and distribute reports automatically",
+    title: "Reports",
     cases: [
       {
         title: "Daily standup report",
-        description:
-          "Pull GitHub, Sentry, Axiom, and Plausible data every morning, generate a pptx, and post to a Slack channel",
+        description: "Morning metrics become a slide deck posted to Slack",
         prompt:
           "Set up a daily standup report that pulls data from GitHub, Sentry, Axiom, and Plausible every morning, generates a pptx, and posts it to #all-vm0",
         connectors: ["github", "sentry", "axiom", "plausible", "slack"],
       },
       {
-        title: "Personal weekly / daily digest",
-        description:
-          "Merge GitHub PRs, Gmail, and Calendar into a summary and deliver to Slack",
+        title: "Personal weekly digest",
+        description: "Pull requests, email, and calendar in one Slack update",
         prompt:
           "Create a personal weekly report workflow that merges GitHub PRs, Gmail, and Calendar data into a summary and sends it to Slack",
         connectors: ["github", "gmail", "google-calendar", "slack"],
       },
       {
         title: "GitHub progress weekly",
-        description: "Summarize a week of GitHub activity by feature module",
+        description: "Weekly repo activity summarized by feature",
         prompt:
           "Generate a weekly GitHub progress report summarized by feature modules",
         connectors: ["github"],
@@ -47,7 +42,7 @@ const categories: readonly Category[] = [
       {
         title: "Morning brief",
         description:
-          "Pull updates from Gmail, Calendar, and Notion to give you a clear plan for the day",
+          "Email, calendar, and notes turned into a short daily plan",
         prompt:
           "Set up a morning brief that pulls updates from Gmail, Calendar, and Notion every morning and posts a daily plan to Slack",
         connectors: ["gmail", "google-calendar", "notion", "slack"],
@@ -55,23 +50,21 @@ const categories: readonly Category[] = [
       {
         title: "GitHub PR summarizer",
         description:
-          "Summarize merged PRs over a time window and save a daily report to Notion",
+          "Merged pull request summaries in Notion with optional Slack posts",
         prompt:
           "Summarize all merged GitHub PRs from the past week and save a daily report in Notion with an optional Slack post",
         connectors: ["github", "notion", "slack"],
       },
       {
         title: "Sentry issue digest",
-        description:
-          "Daily morning summaries of Sentry issues with severity and suggested fixes",
+        description: "Morning digest of issues grouped by severity",
         prompt:
           "Set up a daily Sentry issue digest that summarizes critical and high severity issues every morning and posts to Slack",
         connectors: ["sentry", "slack"],
       },
       {
         title: "PostHog funnel report",
-        description:
-          "Pull key product funnels from PostHog, aggregate in Google Sheets, and post a weekly digest to Slack",
+        description: "Funnel numbers in Sheets and a weekly Slack recap",
         prompt:
           "Set up a weekly PostHog funnel report that pulls conversion data, logs it to Google Sheets, and posts a summary to Slack",
         connectors: ["posthog", "google-sheets", "slack"],
@@ -79,31 +72,28 @@ const categories: readonly Category[] = [
       {
         title: "Vercel deploy digest",
         description:
-          "Track Vercel deployments, correlate with GitHub commits, and alert on failures",
+          "It links each deployment to its commit and alerts Slack when a deploy fails",
         prompt:
           "Set up a Vercel deploy digest that monitors deployments, links each to its GitHub commit, and sends Slack alerts on failures",
         connectors: ["vercel", "github", "slack"],
       },
       {
         title: "Ahrefs SEO weekly",
-        description:
-          "Pull weekly SEO rankings and backlink changes from Ahrefs, log to Google Sheets, and report to Slack",
+        description: "Rankings in Sheets with a weekly Slack summary",
         prompt:
           "Set up a weekly Ahrefs SEO report that tracks keyword rankings and backlink changes, logs data to Google Sheets, and posts a summary to Slack",
         connectors: ["ahrefs", "google-sheets", "slack"],
       },
       {
         title: "Cloudflare traffic & security report",
-        description:
-          "Summarize Cloudflare traffic analytics and security events into a weekly Slack digest",
+        description: "Weekly Slack recap of traffic and security events",
         prompt:
           "Set up a weekly Cloudflare report that summarizes traffic analytics, WAF events, and bot activity, then posts to Slack",
         connectors: ["cloudflare", "slack"],
       },
       {
         title: "Metabase dashboard digest",
-        description:
-          "Snapshot key Metabase dashboards and post charts to Slack on a weekly schedule",
+        description: "Dashboard snapshots posted to Slack on a schedule",
         prompt:
           "Set up a weekly Metabase digest that snapshots key dashboards, captures charts, and posts them to Slack every Monday morning",
         connectors: ["metabase", "slack"],
@@ -111,15 +101,14 @@ const categories: readonly Category[] = [
       {
         title: "RevenueCat subscription digest",
         description:
-          "Track subscription metrics from RevenueCat, log to Google Sheets, and alert on churn spikes",
+          "Subscription metrics in Sheets with churn alerts in Slack",
         prompt:
           "Set up a daily RevenueCat digest that tracks new subscriptions, renewals, and cancellations in Google Sheets and alerts on Slack for churn spikes",
         connectors: ["revenuecat", "google-sheets", "slack"],
       },
       {
         title: "Xero financial summary",
-        description:
-          "Pull weekly P&L and cash flow data from Xero and post a financial summary to Slack",
+        description: "Weekly profit and cash flow from Xero in Slack",
         prompt:
           "Set up a weekly Xero financial summary that pulls profit & loss and cash flow data and posts a formatted report to Slack",
         connectors: ["xero", "slack"],
@@ -128,62 +117,53 @@ const categories: readonly Category[] = [
   },
   {
     id: "github",
-    title: "GitHub Operations",
-    subtitle:
-      "Batch-manage issues, investigate codebases, and surface security alerts",
+    title: "GitHub",
     cases: [
       {
         title: "Batch-create issues",
-        description:
-          "Give Zero multiple issue instructions at once \u2014 it creates and assigns them automatically",
+        description: "Paste a list and Zero opens the issues for you",
         prompt:
           "Create the following GitHub issues and assign them to the right people: 1) ... 2) ... 3) ...",
         connectors: ["github"],
       },
       {
         title: "Codebase investigation",
-        description:
-          "Send a page URL and let Zero search the codebase to find the root cause",
+        description: "Give a URL and Zero traces the bug through the repo",
         prompt:
           "Look at this page and search the codebase to find the root cause of the bug: [paste URL]",
         connectors: ["github"],
       },
       {
         title: "Deep-research code analysis",
-        description:
-          "Deep-dive into technical implementations like locking mechanisms or queue architecture",
+        description: "Explains how a subsystem works in your codebase",
         prompt:
           "Do a deep research on how the agent run queue locking mechanism works in our codebase",
         connectors: ["github"],
       },
       {
         title: "Security & dependency alert digest",
-        description:
-          "Surface a weekly digest of security and dependency alerts from GitHub",
+        description: "Weekly security and dependency alerts from GitHub",
         prompt:
           "Generate a weekly GitHub security and dependency alert digest and post it to Slack",
         connectors: ["github", "slack"],
       },
       {
         title: "Jira \u2194 GitHub issue sync",
-        description:
-          "Keep Jira tickets and GitHub issues in sync, with bidirectional status updates",
+        description: "Keeps Jira tickets and GitHub issues in sync",
         prompt:
           "Set up a bidirectional sync between Jira and GitHub so that issue status, labels, and comments stay in sync across both platforms",
         connectors: ["jira", "github", "slack"],
       },
       {
         title: "GitLab to GitHub migration helper",
-        description:
-          "Mirror GitLab issues and MRs to GitHub issues and PRs for cross-platform teams",
+        description: "Mirrors GitLab issues and merge requests into GitHub",
         prompt:
           "Set up a workflow that mirrors GitLab issues to GitHub issues and notifies on Slack when new items are synced",
         connectors: ["gitlab", "github", "slack"],
       },
       {
         title: "Supabase health monitor",
-        description:
-          "Monitor Supabase database health, connection pool usage, and alert on anomalies",
+        description: "Alerts Slack when database health or pools look wrong",
         prompt:
           "Set up a Supabase health monitor that checks database metrics, connection pool usage, and sends Slack alerts for anomalies",
         connectors: ["supabase", "slack"],
@@ -192,106 +172,92 @@ const categories: readonly Category[] = [
   },
   {
     id: "collaboration",
-    title: "Daily Collaboration",
-    subtitle:
-      "Inbox summaries, calendar optimization, proxy messages, and more",
+    title: "Collaboration",
     cases: [
       {
         title: "Email assistant",
-        description:
-          "Summarize your inbox each morning and suggest whether to keep, archive, or reply",
+        description: "Morning inbox summary with suggested next steps",
         prompt:
           "Set up a daily email assistant that summarizes my inbox every morning and suggests actions for each thread",
         connectors: ["gmail"],
       },
       {
         title: "Calendar optimizer",
-        description:
-          "Analyze your daily calendar and recommend how to manage conflicts and schedule focus time",
+        description: "Helps with conflicts, overload, and focus time",
         prompt:
           "Analyze my calendar for today and recommend how to manage conflicts, prevent overload, and schedule focus time",
         connectors: ["google-calendar"],
       },
       {
         title: "Send messages on your behalf",
-        description:
-          "Have Zero post leave notices or announcements to the team as itself",
+        description: "Posts team announcements to Slack for you",
         prompt:
           "Send a message to the team on my behalf: I'll be taking a day off tomorrow. Please reach out to [name] for urgent matters.",
         connectors: ["slack"],
       },
       {
         title: "Browser screenshots",
-        description:
-          "Have Zero open a URL in agent-browser and return a screenshot",
+        description: "Opens a page in the browser and returns a screenshot",
         prompt:
           "Open this URL in the browser and take a screenshot: [paste URL]",
       },
       {
         title: "Self-update instructions",
-        description: "Tell Zero to update its own instructions on the fly",
+        description: "Update the agent instructions right in chat",
         prompt: "Update yourself: add the following instructions \u2014 ...",
       },
       {
         title: "Support ticket router",
-        description:
-          "Route incoming Gmail support emails to Notion by category and priority, alert on Slack for critical ones",
+        description: "Tickets go to Notion and urgent ones ping Slack",
         prompt:
           "Set up a support ticket router that monitors Gmail for support emails, classifies them by category and priority, creates Notion entries, and sends Slack alerts for critical tickets",
         connectors: ["gmail", "notion", "slack"],
       },
       {
         title: "Meeting notes pipeline",
-        description:
-          "Auto-transcribe meetings with Fireflies, summarize to Notion, and post action items to Slack",
+        description: "Fireflies notes to Notion with follow ups in Slack",
         prompt:
           "Set up a meeting notes pipeline that takes Fireflies transcripts, generates a summary in Notion, and posts action items to Slack after each meeting",
         connectors: ["fireflies", "notion", "slack"],
       },
       {
         title: "Calendly booking sync",
-        description:
-          "Sync new Calendly bookings to Google Calendar and notify the team on Slack",
+        description: "New bookings on your calendar with a Slack ping",
         prompt:
           "Set up a Calendly sync that adds new bookings to Google Calendar and sends a Slack notification with meeting details",
         connectors: ["calendly", "google-calendar", "slack"],
       },
       {
         title: "Outlook inbox digest",
-        description:
-          "Summarize your Outlook inbox each morning with priority flags and suggested actions",
+        description: "Morning Outlook summary sorted by priority",
         prompt:
           "Set up a daily Outlook inbox digest that summarizes emails by priority and suggests actions, then posts to Slack",
         connectors: ["outlook-mail", "slack"],
       },
       {
         title: "Todoist \u2192 Notion task sync",
-        description:
-          "Sync personal Todoist tasks into a Notion team workspace for visibility",
+        description: "Todoist tasks mirrored in Notion for the team",
         prompt:
           "Set up a sync that mirrors my Todoist tasks into a Notion database so the team can see what I'm working on",
         connectors: ["todoist", "notion"],
       },
       {
         title: "Lark \u2194 Slack message relay",
-        description:
-          "Bridge Lark and Slack channels so messages in one appear in the other",
+        description: "Forwards messages between Lark and Slack both ways",
         prompt:
           "Set up a message relay between a Lark group and a Slack channel so that messages are forwarded both ways",
         connectors: ["lark", "slack"],
       },
       {
         title: "Google Drive file organizer",
-        description:
-          "Auto-organize new Google Drive files into folders based on file type and content",
+        description: "New files sorted into folders automatically",
         prompt:
           "Set up a workflow that watches Google Drive for new files, classifies them by content, and moves them into the right folders",
         connectors: ["google-drive"],
       },
       {
         title: "Deel payroll notifier",
-        description:
-          "Notify the team on Slack when Deel payroll is processed or contracts are updated",
+        description: "Slack updates when payroll runs or contracts change",
         prompt:
           "Set up a Deel notifier that sends Slack messages when payroll is processed, new contracts are created, or invoices are due",
         connectors: ["deel", "slack"],
@@ -300,14 +266,11 @@ const categories: readonly Category[] = [
   },
   {
     id: "content",
-    title: "Content & Product",
-    subtitle:
-      "Content planning, GTM strategy, user research, and pricing analysis",
+    title: "Growth",
     cases: [
       {
         title: "Content planner",
-        description:
-          "Brainstorm content ideas, plan your editorial calendar, and structure posts and newsletters",
+        description: "Brainstorm topics and outline an editorial calendar",
         prompt:
           "Help me brainstorm content ideas and plan an editorial calendar for the next month in Notion",
         connectors: ["notion"],
@@ -315,30 +278,27 @@ const categories: readonly Category[] = [
       {
         title: "Marketing content planning",
         description:
-          "Plan GTM use-case content referencing Slack usage, user interviews, and competitors",
+          "Plans launch stories from Slack, interviews, and competitors",
         prompt:
           "Help me plan GTM use case content. Reference our team's Slack usage patterns, user interviews, and competitor analysis",
         connectors: ["slack"],
       },
       {
         title: "Onboarding email use cases",
-        description:
-          "Analyze Slack history and user interviews to extract onboarding use cases",
+        description: "Finds onboarding angles from Slack and interviews",
         prompt:
           "Analyze our Slack usage records and user interviews to extract key onboarding use cases for email campaigns",
         connectors: ["slack"],
       },
       {
         title: "Product copy & naming",
-        description:
-          "Brainstorm user-friendly alternatives for technical terms in your UI",
+        description: "Friendlier names for technical terms in the product",
         prompt:
           'Suggest user-friendly alternative names for "logs" in our product UI',
       },
       {
         title: "Competitor research to Notion",
-        description:
-          "Research a competitor on X/Twitter and save findings to a Notion database",
+        description: "Research on X saved as structured notes in Notion",
         prompt:
           "Research competitor [name] on X/Twitter and save the findings into our Notion research database",
         connectors: ["x", "notion"],
@@ -352,8 +312,7 @@ const categories: readonly Category[] = [
       },
       {
         title: "Social media content calendar",
-        description:
-          "Generate platform-optimized posts from a Google Sheets editorial calendar",
+        description: "Turns a Sheets calendar into posts for each network",
         prompt:
           "Generate social media content for Twitter and LinkedIn from my Google Sheets content calendar and schedule the posts",
         connectors: ["google-sheets", "x"],
@@ -369,7 +328,7 @@ const categories: readonly Category[] = [
       {
         title: "Competitive intel scraper",
         description:
-          "Scrape competitor websites with Firecrawl, extract key changes, and log findings to Notion",
+          "Firecrawl watches competitor sites and logs changes in Notion",
         prompt:
           "Set up a weekly competitor scraper using Firecrawl that monitors competitor websites for pricing and feature changes, saves findings to Notion, and alerts on Slack",
         connectors: ["firecrawl", "notion", "slack"],
@@ -377,71 +336,56 @@ const categories: readonly Category[] = [
       {
         title: "Figma design handoff",
         description:
-          "Monitor Figma file updates and auto-create Linear issues for each changed component",
+          "Figma updates become Linear issues for changed components",
         prompt:
           "Set up a design handoff workflow that watches a Figma file for updates and creates Linear issues for changed components, notifying the dev team on Slack",
         connectors: ["figma", "linear", "slack"],
       },
       {
         title: "Dev.to auto-publisher",
-        description:
-          "Publish blog posts from Notion to Dev.to and share on X when they go live",
+        description: "Publishes Notion posts to Dev.to and links them on X",
         prompt:
           "Set up a workflow that publishes Notion pages tagged as 'ready' to Dev.to and posts a link on X",
         connectors: ["devto", "notion", "x"],
       },
       {
         title: "Instagram engagement tracker",
-        description:
-          "Track Instagram post engagement and log metrics to Google Sheets with weekly Slack reports",
+        description: "Engagement in Sheets with weekly Slack summaries",
         prompt:
           "Set up an Instagram tracker that logs post engagement metrics to Google Sheets and posts a weekly summary to Slack",
         connectors: ["instagram", "google-sheets", "slack"],
       },
       {
         title: "Mailchimp campaign reporter",
-        description:
-          "Pull Mailchimp campaign open rates and clicks, save to Google Sheets, and post a digest to Slack",
+        description: "Campaign stats in Sheets with a Slack digest",
         prompt:
           "Set up a Mailchimp campaign report that pulls open rates, click rates, and unsubscribes after each send, logs to Google Sheets, and posts to Slack",
         connectors: ["mailchimp", "google-sheets", "slack"],
       },
       {
         title: "SimilarWeb traffic comparison",
-        description:
-          "Compare your website traffic against competitors using SimilarWeb and save to Notion",
+        description: "Traffic benchmarks versus competitors saved in Notion",
         prompt:
           "Run a monthly SimilarWeb traffic comparison between our site and top 5 competitors, save the report to Notion",
         connectors: ["similarweb", "notion"],
       },
       {
         title: "ElevenLabs audio content",
-        description:
-          "Generate voice narration from Notion articles and save audio files to Google Drive",
+        description: "Voice narration from Notion articles saved to Drive",
         prompt:
           "Set up a workflow that takes blog posts from Notion, generates voice narration with ElevenLabs, and saves the audio to Google Drive",
         connectors: ["elevenlabs", "notion", "google-drive"],
       },
       {
         title: "HeyGen video from script",
-        description:
-          "Turn a Notion script into an AI-generated video with HeyGen and notify the team",
+        description: "Notion script becomes a HeyGen video with a team ping",
         prompt:
           "Set up a workflow that takes a script from Notion, generates a video with HeyGen, and sends a Slack notification when it's ready",
         connectors: ["heygen", "notion", "slack"],
       },
-    ],
-  },
-  {
-    id: "sales",
-    title: "Sales & CRM",
-    subtitle:
-      "Lead qualification, deal tracking, pipeline reporting, and customer sync",
-    cases: [
       {
         title: "Lead follow-up pipeline",
-        description:
-          "Capture lead emails, analyze intent and urgency, create HubSpot tasks, and notify sales on Slack",
+        description: "New leads become HubSpot tasks with Slack alerts",
         prompt:
           "Set up a lead follow-up pipeline that monitors Gmail for new leads, analyzes them with AI, creates HubSpot tasks, and notifies the sales team on Slack",
         connectors: ["gmail", "hubspot", "slack"],
@@ -449,47 +393,42 @@ const categories: readonly Category[] = [
       {
         title: "Stripe customer sync",
         description:
-          "Automatically create Stripe customers and payment links when new entries are added to Notion",
+          "New Notion clients get Stripe customers and payment links",
         prompt:
           "Set up a Stripe sync that creates a Stripe customer and payment link whenever a new client is added to our Notion database",
         connectors: ["stripe", "notion"],
       },
       {
         title: "Win/loss reporter",
-        description:
-          "Analyze your sales pipeline to track wins and losses, then deliver trends to Slack",
+        description: "Win and loss trends from the pipeline in Slack",
         prompt:
           "Set up a weekly win/loss report that analyzes our HubSpot pipeline, tracks deal outcomes, and posts trends to Slack",
         connectors: ["hubspot", "slack"],
       },
       {
         title: "Intercom conversation triager",
-        description:
-          "Turn Intercom customer conversations into structured Notion tasks with priority labels",
+        description: "Intercom chats become prioritized Notion tasks",
         prompt:
           "Set up a workflow that takes Intercom conversations, classifies them, and creates structured tasks in Notion",
         connectors: ["intercom", "notion"],
       },
       {
         title: "DocuSign contract tracker",
-        description:
-          "When contracts are signed in DocuSign, update deal status in Notion and notify the team",
+        description: "Signed contracts update Notion deals and ping the team",
         prompt:
           "Set up a contract tracker that monitors DocuSign for completed signatures, updates the deal page in Notion, and sends a Slack notification",
         connectors: ["docusign", "notion", "slack"],
       },
       {
         title: "Meta Ads spend tracker",
-        description:
-          "Pull daily Meta Ads spend and performance data to Google Sheets with Slack alerts on budget thresholds",
+        description: "Daily spend in Sheets with Slack alerts on budget caps",
         prompt:
           "Set up a daily Meta Ads tracker that logs spend and performance to Google Sheets and alerts on Slack when budget thresholds are reached",
         connectors: ["meta-ads", "google-sheets", "slack"],
       },
       {
         title: "Salesforce pipeline digest",
-        description:
-          "Summarize Salesforce pipeline changes weekly and post opportunity updates to Slack",
+        description: "Weekly Salesforce opportunity updates in Slack",
         prompt:
           "Set up a weekly Salesforce pipeline digest that summarizes new opportunities, stage changes, and close dates, then posts to Slack",
         connectors: ["salesforce", "slack"],
@@ -504,16 +443,14 @@ const categories: readonly Category[] = [
       },
       {
         title: "Jotform intake to Notion",
-        description:
-          "Route Jotform submissions to Notion databases with Slack notifications for new entries",
+        description: "Form answers land in Notion with Slack notifications",
         prompt:
           "Set up a Jotform intake that routes new form submissions to the right Notion database and sends a Slack notification",
         connectors: ["jotform", "notion", "slack"],
       },
       {
         title: "Airtable deal tracker",
-        description:
-          "Sync Airtable deal records to Google Sheets and send Slack alerts when deals close",
+        description: "Deals sync to Sheets and Slack when they close",
         prompt:
           "Set up an Airtable deal tracker that syncs deal records to Google Sheets and sends a Slack notification when a deal is marked as closed-won",
         connectors: ["airtable", "google-sheets", "slack"],
@@ -522,30 +459,26 @@ const categories: readonly Category[] = [
   },
   {
     id: "workflows",
-    title: "Team-Built Workflows",
-    subtitle:
-      "Multi-agent systems, cross-tool pipelines, and automated operations",
+    title: "Workflows",
     cases: [
       {
         title: "Marketing automation system",
         description:
-          "Three agents working together: daily researcher, weekly monitor, and on-demand tasks",
+          "Three agents for research, weekly monitoring, and ad hoc work",
         prompt:
           "Set up a marketing automation system with three agents: a daily researcher for information collection, a weekly monitor for tracking, and an on-demand agent for ad-hoc tasks",
         connectors: ["slack"],
       },
       {
         title: "Linear PRD implementer",
-        description:
-          "Turn Notion product docs into well-structured Linear projects and issues",
+        description: "Notion specs become Linear projects and issues",
         prompt:
           "Take the product spec from Notion and create a structured Linear project with epics and issues",
         connectors: ["notion", "linear"],
       },
       {
         title: "Notion + Resend email pipeline",
-        description:
-          "Pull content from Notion, assemble into a template, and send via Resend",
+        description: "Notion content sent as email through Resend",
         prompt:
           "Create a workflow that takes content from Notion, assembles it into an email template, and sends it via Resend",
         connectors: ["notion", "resend"],
@@ -560,56 +493,49 @@ const categories: readonly Category[] = [
       },
       {
         title: "AgentMail inbox",
-        description:
-          "Create and manage email inboxes through the AgentMail API",
+        description: "Create and manage inboxes with the AgentMail API",
         prompt:
           "Create a new AgentMail inbox and set up email forwarding rules",
         connectors: ["agentmail"],
       },
       {
         title: "Customer support bot",
-        description:
-          "Auto-answer customer questions from your knowledge base and create tasks for gaps",
+        description: "Answers from the knowledge base and tasks for gaps",
         prompt:
           "Set up a customer support bot that answers questions from our Notion knowledge base and creates tasks for unanswered questions",
         connectors: ["slack", "notion"],
       },
       {
         title: "Feedback router",
-        description:
-          "Route Slack feedback by matching messages to your rules and taking specified actions",
+        description: "Slack feedback routed by your rules to the right place",
         prompt:
           "Set up a feedback router that watches a Slack channel and routes messages to the right team based on keywords and labels",
         connectors: ["slack", "notion"],
       },
       {
         title: "HubSpot sales reporter",
-        description:
-          "Generate weekly HubSpot sales summaries and save them as structured reports",
+        description: "Weekly HubSpot summaries saved as structured reports",
         prompt:
           "Generate a weekly HubSpot sales summary and save it as a structured report in Notion",
         connectors: ["hubspot", "notion"],
       },
       {
         title: "Discord community insights",
-        description:
-          "Monitor Discord for feature requests and bug reports, categorize in Notion, weekly digest to Slack",
+        description: "Discord feedback in Notion with a weekly Slack digest",
         prompt:
           "Set up a Discord community monitor that watches for feature requests and bug reports, categorizes them in Notion, and posts a weekly digest to Slack",
         connectors: ["discord", "notion", "slack"],
       },
       {
         title: "X brand monitor",
-        description:
-          "Watch X for brand mentions, save relevant posts to Notion, and alert the team",
+        description: "Brand mentions on X saved in Notion with team alerts",
         prompt:
           "Set up an X brand monitor that watches for mentions of our product, saves relevant posts to Notion, and sends Slack alerts for high-engagement posts",
         connectors: ["x", "notion", "slack"],
       },
       {
         title: "Mercury cash flow monitor",
-        description:
-          "Track Mercury transactions, log to Google Sheets, and alert on large or unusual movements",
+        description: "Transactions in Sheets with alerts on unusual activity",
         prompt:
           "Set up a cash flow monitor that tracks Mercury bank transactions, logs them to Google Sheets, and sends Slack alerts for transactions above a threshold",
         connectors: ["mercury", "google-sheets", "slack"],
@@ -624,80 +550,70 @@ const categories: readonly Category[] = [
       },
       {
         title: "Asana \u2192 Notion project sync",
-        description:
-          "Mirror Asana project milestones and tasks to Notion for cross-team visibility",
+        description: "Asana milestones and tasks mirrored in Notion",
         prompt:
           "Set up a sync between Asana and Notion that mirrors project milestones, task progress, and due dates into a Notion dashboard",
         connectors: ["asana", "notion", "slack"],
       },
       {
         title: "ClickUp \u2192 Slack standups",
-        description:
-          "Pull today's tasks from ClickUp and post a formatted daily standup to Slack",
+        description: "Daily ClickUp tasks posted as a standup in Slack",
         prompt:
           "Set up a daily standup that pulls each team member's tasks from ClickUp and posts a formatted summary to Slack every morning",
         connectors: ["clickup", "slack"],
       },
       {
         title: "Monday.com weekly digest",
-        description:
-          "Summarize Monday.com board activity and post a weekly progress digest to Slack",
+        description: "Weekly board progress from Monday.com in Slack",
         prompt:
           "Set up a weekly Monday.com digest that summarizes board activity, completed items, and blockers, then posts to Slack",
         connectors: ["monday", "slack"],
       },
       {
         title: "Google Docs \u2192 Notion migrator",
-        description:
-          "Batch-convert Google Docs into Notion pages while preserving formatting and images",
+        description: "Google Docs batches into Notion with layout preserved",
         prompt:
           "Set up a workflow that converts a folder of Google Docs into Notion pages, preserving headings, tables, and images",
         connectors: ["google-docs", "notion"],
       },
       {
         title: "Dropbox \u2192 Google Drive sync",
-        description:
-          "Mirror specific Dropbox folders to Google Drive for cross-platform access",
+        description: "Dropbox folders mirrored to Drive with Slack pings",
         prompt:
           "Set up a sync that mirrors files from a Dropbox folder to Google Drive and notifies on Slack when new files are synced",
         connectors: ["dropbox", "google-drive", "slack"],
       },
       {
         title: "Apify web scraper to Sheets",
-        description:
-          "Run Apify actors to scrape data from any website and save structured results to Google Sheets",
+        description: "Apify scrapes sites into structured Google Sheets rows",
         prompt:
           "Set up an Apify scraper that extracts product listings from a competitor website and saves them to Google Sheets daily",
         connectors: ["apify", "google-sheets", "slack"],
       },
       {
         title: "Canva design tracker",
-        description:
-          "Monitor Canva team designs and log new assets to Notion with Slack notifications",
+        description: "New Canva assets logged in Notion with Slack pings",
         prompt:
           "Set up a Canva tracker that logs new team designs to a Notion asset library and notifies the marketing channel on Slack",
         connectors: ["canva", "notion", "slack"],
       },
       {
         title: "Wrike project reporter",
-        description:
-          "Summarize Wrike project progress and post weekly reports to Slack",
+        description: "Weekly Wrike progress summaries in Slack",
         prompt:
           "Set up a weekly Wrike report that summarizes task completion, overdue items, and blockers across all projects, then posts to Slack",
         connectors: ["wrike", "slack"],
       },
       {
         title: "PDF contract processor",
-        description:
-          "Extract key fields from PDF contracts, save structured data to Notion, and alert on upcoming expirations",
+        description: "Contract fields in Notion with reminders before expiry",
         prompt:
           "Set up a workflow that processes PDF contracts, extracts key dates and terms into Notion, and sends Slack reminders before expiration dates",
         connectors: ["pdfco", "notion", "slack"],
       },
       {
         title: "Deel payroll report",
-        description:
-          "Track Deel payroll events, log to Google Sheets, and post monthly summaries to Slack",
+        description: "Payroll events in Sheets with monthly Slack summaries",
         prompt:
           "Set up a monthly Deel payroll report that logs all payroll events to Google Sheets and posts a summary to Slack",
         connectors: ["deel", "google-sheets", "slack"],

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
-import { IconArrowUpRight, IconMessageCircle } from "@tabler/icons-react";
-import { Card, CardContent, cn } from "@vm0/ui";
+import {
+  IconArrowUpRight,
+  IconMessageCircle,
+  IconSearch,
+} from "@tabler/icons-react";
+import { Card, CardContent, cn, Input } from "@vm0/ui";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { getCategories } from "./zero-ideation-data.ts";
 
@@ -15,17 +19,32 @@ export function ZeroIdeationPage({
   onBack,
   onSelectPrompt,
 }: ZeroIdeationPageProps) {
-  const categories = getCategories();
+  const categories = getCategories().slice(0, 5);
   const [activeTab, setActiveTab] = useState("all");
+  const [searchQuery, setSearchQuery] = useState("");
 
-  const visibleCategories =
+  const baseCategories =
     activeTab === "all"
       ? categories
       : categories.filter((c) => c.id === activeTab);
+  const searchNeedle = searchQuery.trim().toLowerCase();
+  const visibleCategories =
+    searchNeedle.length === 0
+      ? baseCategories
+      : baseCategories
+          .map((c) => ({
+            ...c,
+            cases: c.cases.filter(
+              (u) =>
+                u.title.toLowerCase().includes(searchNeedle) ||
+                u.description.toLowerCase().includes(searchNeedle),
+            ),
+          }))
+          .filter((c) => c.cases.length > 0);
 
   return (
-    <div className="flex flex-1 flex-col min-h-0">
-      <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
+    <div className="flex min-h-0 flex-1 flex-col">
+      <nav className="flex shrink-0 items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
         <button
           type="button"
           onClick={onBack}
@@ -40,100 +59,126 @@ export function ZeroIdeationPage({
         </span>
       </nav>
 
-      <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-6 pb-3">
-        <div className="mx-auto max-w-[900px]">
-          <h1 className="text-lg font-semibold tracking-tight text-foreground">
-            Ideas &amp; Use Cases
-          </h1>
-          <p className="mt-0.5 text-sm text-muted-foreground">
-            Click any card to start a conversation. It could become an on-demand
-            task, a recurring workflow, or a subagent.
-          </p>
-        </div>
-      </header>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <div className="px-4 pb-8 sm:px-6">
+          <div className="mx-auto w-full max-w-[900px]">
+            <header className="bg-transparent pt-6 pb-3">
+              <h1 className="text-lg font-semibold tracking-tight text-foreground">
+                Ideas &amp; Use Cases
+              </h1>
+              <p className="mt-1 text-sm text-muted-foreground leading-relaxed">
+                Click any card to start a conversation. It could become an
+                on-demand task, a recurring workflow, or a subagent.
+              </p>
+            </header>
 
-      <div className="shrink-0 px-4 sm:px-6 pt-2 pb-3">
-        <div className="mx-auto max-w-[900px] flex flex-wrap items-center gap-1.5">
-          <button
-            type="button"
-            className={cn(
-              "rounded-lg h-8 px-3 text-sm font-medium transition-colors cursor-pointer",
-              activeTab === "all"
-                ? "bg-muted text-foreground"
-                : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-            )}
-            onClick={() => setActiveTab("all")}
-          >
-            All
-          </button>
-          {categories.map((category) => (
-            <button
-              key={category.id}
-              type="button"
-              className={cn(
-                "rounded-lg h-8 px-3 text-sm font-medium transition-colors cursor-pointer",
-                activeTab === category.id
-                  ? "bg-muted text-foreground"
-                  : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-              )}
-              onClick={() => setActiveTab(category.id)}
-            >
-              {category.title}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <main className="flex-1 overflow-auto px-4 sm:px-6 pt-4 pb-8">
-        <div className="mx-auto max-w-[900px] flex flex-col gap-6">
-          {visibleCategories.map((category) => (
-            <section
-              key={category.id}
-              className="flex flex-col gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300"
-            >
-              <div>
-                <h2 className="text-base font-semibold tracking-tight text-foreground">
-                  {category.title}
-                </h2>
-                <p className="mt-0.5 text-xs text-muted-foreground">
-                  {category.subtitle}
-                </p>
-              </div>
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                {category.cases.map((useCase) => (
-                  <Card
-                    key={useCase.title}
-                    className="zero-card cursor-pointer hover:bg-muted/30 transition-colors"
-                    onClick={() => onSelectPrompt(useCase.prompt)}
+            <div className="pt-2 pb-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+                  <button
+                    type="button"
+                    className={cn(
+                      "h-7 shrink-0 rounded-md border border-border px-2.5 text-sm font-medium leading-none transition-colors cursor-pointer",
+                      activeTab === "all"
+                        ? "bg-muted text-foreground"
+                        : "bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                    )}
+                    onClick={() => setActiveTab("all")}
                   >
-                    <CardContent className="p-4 group relative">
-                      <IconArrowUpRight
-                        size={14}
-                        stroke={2}
-                        className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
-                      />
-                      <p className="text-sm font-medium text-foreground pr-5">
-                        {useCase.title}
-                      </p>
-                      <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
-                        {useCase.description}
-                      </p>
-                      {useCase.connectors && useCase.connectors.length > 0 && (
-                        <div className="flex items-center gap-2.5 mt-2.5">
-                          {useCase.connectors.map((type) => (
-                            <ConnectorIcon key={type} type={type} size={16} />
-                          ))}
-                        </div>
+                    All
+                  </button>
+                  {categories.map((category) => (
+                    <button
+                      key={category.id}
+                      type="button"
+                      className={cn(
+                        "h-7 shrink-0 rounded-md border border-border px-2.5 text-sm font-medium leading-none transition-colors cursor-pointer",
+                        activeTab === category.id
+                          ? "bg-muted text-foreground"
+                          : "bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground",
                       )}
-                    </CardContent>
-                  </Card>
+                      onClick={() => setActiveTab(category.id)}
+                    >
+                      {category.title}
+                    </button>
+                  ))}
+                </div>
+                <div className="relative w-full min-w-0 sm:max-w-[240px] sm:flex-1 sm:min-w-[12rem]">
+                  <IconSearch
+                    className="pointer-events-none absolute left-3 top-1/2 z-10 size-[14px] -translate-y-1/2 text-muted-foreground"
+                    stroke={1.5}
+                    aria-hidden
+                  />
+                  <Input
+                    type="search"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Search"
+                    className="pl-9"
+                    aria-label="Search use cases"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <main className="pt-4">
+              <div className="flex flex-col gap-6">
+                {visibleCategories.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No use cases match your search.
+                  </p>
+                ) : null}
+                {visibleCategories.map((category) => (
+                  <section
+                    key={category.id}
+                    className="flex flex-col gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300"
+                  >
+                    <h2 className="text-lg font-semibold tracking-tight text-foreground">
+                      {category.title}
+                    </h2>
+
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                      {category.cases.map((useCase) => (
+                        <Card
+                          key={useCase.title}
+                          className="zero-card cursor-pointer hover:bg-muted/30 transition-colors"
+                          onClick={() => onSelectPrompt(useCase.prompt)}
+                        >
+                          <CardContent className="p-4 group relative">
+                            <IconArrowUpRight
+                              size={14}
+                              stroke={2}
+                              className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
+                            />
+                            <p className="text-sm font-semibold text-foreground pr-5">
+                              {useCase.title}
+                            </p>
+                            <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
+                              {useCase.description}
+                            </p>
+                            {useCase.connectors &&
+                              useCase.connectors.length > 0 && (
+                                <div className="flex items-center gap-2.5 mt-2.5">
+                                  {useCase.connectors.map((type) => (
+                                    <ConnectorIcon
+                                      key={type}
+                                      type={type}
+                                      size={16}
+                                    />
+                                  ))}
+                                </div>
+                              )}
+                          </CardContent>
+                        </Card>
+                      ))}
+                    </div>
+                  </section>
                 ))}
               </div>
-            </section>
-          ))}
+            </main>
+          </div>
         </div>
-      </main>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Polishes the Zero **Ideas & Use Cases** gallery: fewer, shorter category tabs, search, tighter copy, and layout fixes.

## Changes
- **Categories**: At most five tabs (slice + data); merge former Sales into **Growth**; shorter labels (Reports, GitHub, Collaboration, Growth, Workflows).
- **Search**: Filter cards by title/description using the shared `Input` component.
- **Filter pills**: Slightly smaller, always bordered; inactive uses `bg-background`.
- **Copy**: Shorter card descriptions; removed subtitles under each section heading.
- **Layout**: Single `max-w-[900px]` column for title, filters, and cards; **scroll on the full-width panel** so the scrollbar sits on the outside; breadcrumb row restored to the previous full-width `nav` layout.
- **Tests**: Updated tab/heading assertions for new labels.

## Notes
- `useMemo` was removed to satisfy the platform ESLint rule on React imports.

Made with [Cursor](https://cursor.com)