### PR TITLE
refactor: extract duplicated onboard guard into shared command

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
@@ -3,13 +3,10 @@ import { createElement } from "react";
 import { ZeroActivityDetailPageWrapper } from "../../views/activity-page/zero-activity-detail-page-wrapper.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { navigateTo$, pathParams$ } from "../route.ts";
+import { pathParams$ } from "../route.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
-import {
-  initZeroOnboarding$,
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "../zero-page/zero-onboarding.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
 import { setZeroActivitySelectedLogId$ } from "./activity-signals.ts";
 
@@ -35,12 +32,7 @@ export const setupActivityDetailPage$ = command(
     ]);
     signal.throwIfAborted();
 
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      set(navigateTo$, "/onboarding", { replace: true });
+    if (await set(onboardGuard$, signal)) {
       return;
     }
 

--- a/turbo/apps/platform/src/signals/activity-page/activity-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-page-setup.ts
@@ -3,18 +3,14 @@ import { createElement } from "react";
 import { ZeroActivityPageWrapper } from "../../views/activity-page/zero-activity-page-wrapper.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { navigateTo$ } from "../route.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
-import {
-  initZeroOnboarding$,
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "../zero-page/zero-onboarding.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
 import { initZeroActivity$, refreshZeroActivity$ } from "./activity-signals.ts";
 
 export const setupActivityPage$ = command(
-  async ({ set, get }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroActivityPageWrapper));
     set(updateDocumentTitle$, "Activity");
     set(refreshZeroActivity$);
@@ -25,12 +21,7 @@ export const setupActivityPage$ = command(
     ]);
     signal.throwIfAborted();
 
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      set(navigateTo$, "/onboarding", { replace: true });
+    if (await set(onboardGuard$, signal)) {
       return;
     }
 

--- a/turbo/apps/platform/src/signals/preferences-page/preferences-page-setup.ts
+++ b/turbo/apps/platform/src/signals/preferences-page/preferences-page-setup.ts
@@ -3,17 +3,13 @@ import { createElement } from "react";
 import { ZeroPreferencesPageWrapper } from "../../views/preferences-page/zero-preferences-page-wrapper.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { navigateTo$ } from "../route.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
-import {
-  initZeroOnboarding$,
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "../zero-page/zero-onboarding.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
 
 export const setupPreferencesPage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroPreferencesPageWrapper));
     set(updateDocumentTitle$, "Preferences");
     await Promise.all([
@@ -22,12 +18,7 @@ export const setupPreferencesPage$ = command(
     ]);
     signal.throwIfAborted();
 
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      set(navigateTo$, "/onboarding", { replace: true });
+    if (await set(onboardGuard$, signal)) {
       return;
     }
 

--- a/turbo/apps/platform/src/signals/queue-page/queue-page-setup.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-page-setup.ts
@@ -3,34 +3,20 @@ import { createElement } from "react";
 import { ZeroQueuePage } from "../../views/queue-page/zero-queue-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { navigateTo$ } from "../route.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
-import {
-  initZeroOnboarding$,
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "../zero-page/zero-onboarding.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
 
-export const setupQueuePage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    set(updatePage$, createElement(ZeroQueuePage));
-    set(updateDocumentTitle$, "Queue");
-    await Promise.all([
-      set(fetchAgentsList$),
-      set(initZeroOnboarding$, signal),
-    ]);
-    signal.throwIfAborted();
+export const setupQueuePage$ = command(async ({ set }, signal: AbortSignal) => {
+  set(updatePage$, createElement(ZeroQueuePage));
+  set(updateDocumentTitle$, "Queue");
+  await Promise.all([set(fetchAgentsList$), set(initZeroOnboarding$, signal)]);
+  signal.throwIfAborted();
 
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      set(navigateTo$, "/onboarding", { replace: true });
-      return;
-    }
+  if (await set(onboardGuard$, signal)) {
+    return;
+  }
 
-    set(switchActiveAgent$, null);
-  },
-);
+  set(switchActiveAgent$, null);
+});

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-page-setup.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-page-setup.ts
@@ -3,19 +3,15 @@ import { createElement } from "react";
 import { ZeroSchedulePageWrapper } from "../../views/schedule-page/zero-schedule-page-wrapper.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { navigateTo$ } from "../route.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
-import {
-  initZeroOnboarding$,
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "../zero-page/zero-onboarding.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
 import { fetchAllOrgSchedules$ } from "../zero-page/zero-schedule.ts";
 import { Reason, detach } from "../utils.ts";
 
 export const setupSchedulePage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
+  async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroSchedulePageWrapper));
     set(updateDocumentTitle$, "Schedule");
     detach(set(fetchAllOrgSchedules$), Reason.Entrance);
@@ -25,12 +21,7 @@ export const setupSchedulePage$ = command(
     ]);
     signal.throwIfAborted();
 
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      set(navigateTo$, "/onboarding", { replace: true });
+    if (await set(onboardGuard$, signal)) {
       return;
     }
 

--- a/turbo/apps/platform/src/signals/team-page/team-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/team-page/team-detail-page-setup.ts
@@ -3,15 +3,12 @@ import { createElement } from "react";
 import { ZeroTeamDetailPage } from "../../views/team-page/zero-team-detail-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { navigateTo$, pathParams$ } from "../route.ts";
+import { pathParams$ } from "../route.ts";
 import { agentsList$ } from "../zero-page/agents-list.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
 import { fetchZeroJobData$ } from "../zero-page/zero-job-detail.ts";
-import {
-  initZeroOnboarding$,
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "../zero-page/zero-onboarding.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
 
 export const setupTeamDetailPage$ = command(
@@ -27,12 +24,7 @@ export const setupTeamDetailPage$ = command(
     ]);
     signal.throwIfAborted();
 
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      set(navigateTo$, "/onboarding", { replace: true });
+    if (await set(onboardGuard$, signal)) {
       return;
     }
 

--- a/turbo/apps/platform/src/signals/team-page/team-page-setup.ts
+++ b/turbo/apps/platform/src/signals/team-page/team-page-setup.ts
@@ -3,34 +3,20 @@ import { createElement } from "react";
 import { ZeroTeamPage } from "../../views/team-page/zero-team-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { navigateTo$ } from "../route.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
-import {
-  initZeroOnboarding$,
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "../zero-page/zero-onboarding.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
 
-export const setupTeamPage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    set(updatePage$, createElement(ZeroTeamPage));
-    set(updateDocumentTitle$, "Team");
-    await Promise.all([
-      set(fetchAgentsList$),
-      set(initZeroOnboarding$, signal),
-    ]);
-    signal.throwIfAborted();
+export const setupTeamPage$ = command(async ({ set }, signal: AbortSignal) => {
+  set(updatePage$, createElement(ZeroTeamPage));
+  set(updateDocumentTitle$, "Team");
+  await Promise.all([set(fetchAgentsList$), set(initZeroOnboarding$, signal)]);
+  signal.throwIfAborted();
 
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      set(navigateTo$, "/onboarding", { replace: true });
-      return;
-    }
+  if (await set(onboardGuard$, signal)) {
+    return;
+  }
 
-    set(switchActiveAgent$, null);
-  },
-);
+  set(switchActiveAgent$, null);
+});

--- a/turbo/apps/platform/src/signals/usage-page/usage-page-setup.ts
+++ b/turbo/apps/platform/src/signals/usage-page/usage-page-setup.ts
@@ -3,34 +3,20 @@ import { createElement } from "react";
 import { ZeroUsagePageWrapper } from "../../views/usage-page/zero-usage-page-wrapper.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { navigateTo$ } from "../route.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
-import {
-  initZeroOnboarding$,
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "../zero-page/zero-onboarding.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
 
-export const setupUsagePage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    set(updatePage$, createElement(ZeroUsagePageWrapper));
-    set(updateDocumentTitle$, "Usage");
-    await Promise.all([
-      set(fetchAgentsList$),
-      set(initZeroOnboarding$, signal),
-    ]);
-    signal.throwIfAborted();
+export const setupUsagePage$ = command(async ({ set }, signal: AbortSignal) => {
+  set(updatePage$, createElement(ZeroUsagePageWrapper));
+  set(updateDocumentTitle$, "Usage");
+  await Promise.all([set(fetchAgentsList$), set(initZeroOnboarding$, signal)]);
+  signal.throwIfAborted();
 
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      set(navigateTo$, "/onboarding", { replace: true });
-      return;
-    }
+  if (await set(onboardGuard$, signal)) {
+    return;
+  }
 
-    set(switchActiveAgent$, null);
-  },
-);
+  set(switchActiveAgent$, null);
+});

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -3,36 +3,25 @@ import { createElement } from "react";
 import { ZeroWorksPageWrapper } from "../../views/works-page/zero-works-page-wrapper.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { navigateTo$ } from "../route.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
-import {
-  initZeroOnboarding$,
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "../zero-page/zero-onboarding.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
 import { initSlackOrg$ } from "../zero-page/zero-slack.ts";
 
-export const setupWorksPage$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    set(updatePage$, createElement(ZeroWorksPageWrapper));
-    set(updateDocumentTitle$, "Works");
-    await Promise.all([
-      set(fetchAgentsList$),
-      set(initZeroOnboarding$, signal),
-      set(initSlackOrg$),
-    ]);
-    signal.throwIfAborted();
+export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
+  set(updatePage$, createElement(ZeroWorksPageWrapper));
+  set(updateDocumentTitle$, "Works");
+  await Promise.all([
+    set(fetchAgentsList$),
+    set(initZeroOnboarding$, signal),
+    set(initSlackOrg$),
+  ]);
+  signal.throwIfAborted();
 
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      set(navigateTo$, "/onboarding", { replace: true });
-      return;
-    }
+  if (await set(onboardGuard$, signal)) {
+    return;
+  }
 
-    set(switchActiveAgent$, null);
-  },
-);
+  set(switchActiveAgent$, null);
+});

--- a/turbo/apps/platform/src/signals/zero-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-page-setup.ts
@@ -3,11 +3,8 @@ import { navigateTo$ } from "../route.ts";
 import { checkSettingsParam$ } from "./settings/org-manage-dialog.ts";
 import { logger } from "../log.ts";
 import { defaultAgentName$ } from "./zero-agent-name.ts";
+import { onboardGuard$ } from "./onboard-guard.ts";
 import { loadInitialData$ } from "./zero-page.ts";
-import {
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "./zero-onboarding.ts";
 
 const L = logger("ChatPage");
 
@@ -18,14 +15,7 @@ export const setupChatPage$ = command(
     // Consume ?settings=<tab> param before redirecting
     set(checkSettingsParam$);
 
-    // Redirect to /onboarding when needed
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      L.info("redirecting to /onboarding");
-      set(navigateTo$, "/onboarding", { replace: true });
+    if (await set(onboardGuard$, signal)) {
       return;
     }
 

--- a/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
@@ -10,6 +10,7 @@ import {
   zeroSessionList$,
 } from "./zero-chat.ts";
 import { zeroSessionId$ } from "./zero-nav.ts";
+import { onboardGuard$ } from "./onboard-guard.ts";
 import { loadInitialData$ } from "./zero-page.ts";
 import { syncModelPreference$ } from "./zero-model-preference.ts";
 
@@ -29,6 +30,10 @@ export const setupChatSessionPage$ = command(
 
     await set(loadInitialData$, signal);
     signal.throwIfAborted();
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
 
     await set(syncUrlSession$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/onboard-guard.ts
@@ -1,0 +1,25 @@
+import { command } from "ccstate";
+import { navigateTo$ } from "../route.ts";
+import {
+  zeroNeedsOnboarding$,
+  zeroNeedsMemberOnboarding$,
+} from "./zero-onboarding.ts";
+
+/**
+ * Check whether the current user needs onboarding and redirect if so.
+ * Returns `true` when a redirect was triggered (caller should bail out),
+ * `false` otherwise.
+ */
+export const onboardGuard$ = command(
+  async ({ get, set }, signal: AbortSignal): Promise<boolean> => {
+    const needsOnboarding = await get(zeroNeedsOnboarding$);
+    signal.throwIfAborted();
+    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
+    signal.throwIfAborted();
+    if (needsOnboarding || needsMemberOnboarding) {
+      set(navigateTo$, "/onboarding", { replace: true });
+      return true;
+    }
+    return false;
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
@@ -3,16 +3,13 @@ import { createElement } from "react";
 import { ZeroTalkPage } from "../../views/zero-page/zero-talk-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
-import { navigateTo$, pathParams$ } from "../route.ts";
+import { pathParams$ } from "../route.ts";
 import { syncModelPreference$ } from "./zero-model-preference.ts";
 import { logger } from "../log.ts";
 import { agentDisplayName$, defaultAgentName$ } from "./zero-agent-name.ts";
 import { zeroSubagents$ } from "./zero-agents.ts";
+import { onboardGuard$ } from "./onboard-guard.ts";
 import { loadInitialData$, resolveAgentByName } from "./zero-page.ts";
-import {
-  zeroNeedsOnboarding$,
-  zeroNeedsMemberOnboarding$,
-} from "./zero-onboarding.ts";
 
 const L = logger("TalkPage");
 
@@ -23,13 +20,7 @@ export const setupTalkPage$ = command(
 
     await set(loadInitialData$, signal);
 
-    // Redirect to /onboarding when needed
-    const needsOnboarding = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    const needsMemberOnboarding = await get(zeroNeedsMemberOnboarding$);
-    signal.throwIfAborted();
-    if (needsOnboarding || needsMemberOnboarding) {
-      set(navigateTo$, "/onboarding", { replace: true });
+    if (await set(onboardGuard$, signal)) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- Extract the 6-line onboarding guard block duplicated across 11 page setup files into a shared `onboardGuard$` ccstate command in `onboard-guard.ts`
- Add missing onboard guard to `chat-session-page-setup.ts` which was allowing users to bypass onboarding via `/chat/:sessionId`
- Clean up unused imports (`navigateTo$`, `zeroNeedsOnboarding$`, `zeroNeedsMemberOnboarding$`, `get`) from all updated files

## Test plan

- [ ] Verify lint passes (`pnpm turbo run lint`)
- [ ] Verify knip passes (`pnpm knip`)
- [ ] Verify all page routes still redirect to `/onboarding` when onboarding is needed
- [ ] Verify `/chat/:sessionId` now correctly redirects to `/onboarding` when needed

Closes #6269

🤖 Generated with [Claude Code](https://claude.com/claude-code)