### PR TITLE
feat: apply firewall policies when running zero agents

### DIFF
--- a/e2e/tests/03-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-runner/t42-firewall-placeholder.bats
@@ -173,3 +173,40 @@ EOF
     # DENY: search endpoint has no matching permission
     assert_output --partial "GET    DENY https://api.github.com/search/code?q=vm0 [github]"
 }
+
+@test "firewall: connector auto-adds firewall without experimental_firewalls" {
+    # GitHub connector is set up in setup_file().
+    # Compose does NOT declare experimental_firewalls — the system should
+    # auto-add a firewall for the connected GitHub connector with unrestricted access.
+    cat > "$TEST_DIR/vm0.yaml" <<EOF
+version: "1.0"
+
+agents:
+  ${AGENT_NAME}-auto:
+    description: "Auto-firewall connector test"
+    framework: claude-code
+    working_dir: /home/user/workspace
+    environment:
+      GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+EOF
+
+    create_artifact "$ARTIFACT_NAME-auto"
+
+    run $CLI_COMMAND compose "$TEST_DIR/vm0.yaml"
+    assert_success
+
+    # Verify GITHUB_TOKEN is replaced with placeholder (firewall auto-added)
+    # and a GitHub API call succeeds through the proxy (token replacement works).
+    run $CLI_COMMAND run "${AGENT_NAME}-auto" \
+        --artifact-name "$ARTIFACT_NAME-auto" \
+        "TOKEN_VAL=\$GITHUB_TOKEN && STARTS_WITH=\$(echo \$TOKEN_VAL | cut -c1-7) && STATUS=\$(curl -s -o /dev/null -w '%{http_code}' https://api.github.com/repos/vm0-ai/vm0) && echo \"PLACEHOLDER=\$STARTS_WITH\" && echo \"API_STATUS=\$STATUS\""
+
+    echo "$output"
+    assert_success
+    assert_output --partial "Run completed successfully"
+
+    # Token should be the placeholder (proxy will replace it with real token)
+    assert_output --partial "PLACEHOLDER=gho_Vm0"
+    # API call should succeed (proxy replaced placeholder with real token)
+    assert_output --partial "API_STATUS=200"
+}

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -58,6 +58,7 @@ import {
   VOLUME_ORG_USER_ID,
   SYSTEM_ORG_ID,
   type StoredExecutionContext,
+  type FirewallPolicies,
 } from "@vm0/core";
 
 // Route handlers - imported here so callers don't need to pass them
@@ -414,6 +415,7 @@ export async function createTestZeroAgent(
     displayName?: string;
     description?: string;
     sound?: string;
+    firewallPolicies?: FirewallPolicies;
   },
 ): Promise<void> {
   initServices();
@@ -425,6 +427,7 @@ export async function createTestZeroAgent(
       displayName: metadata.displayName ?? null,
       description: metadata.description ?? null,
       sound: metadata.sound ?? null,
+      firewallPolicies: metadata.firewallPolicies ?? null,
     })
     .onConflictDoUpdate({
       target: [zeroAgents.orgId, zeroAgents.name],
@@ -432,6 +435,7 @@ export async function createTestZeroAgent(
         displayName: metadata.displayName ?? null,
         description: metadata.description ?? null,
         sound: metadata.sound ?? null,
+        firewallPolicies: metadata.firewallPolicies ?? null,
       },
     });
 }

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -416,7 +416,7 @@ interface ConnectorSecretResult {
   injectedEnvVars: Record<string, string> | undefined;
   /** Maps secret names to connector types for refresh-capable OAuth connectors */
   secretConnectorMap: Record<string, string> | undefined;
-  /** Validated connector types for the user */
+  /** Validated connector types for the user (used for firewall resolution) */
   connectorTypes: ConnectorType[];
 }
 
@@ -710,7 +710,7 @@ async function resolveSecretsAndEnvironment(
   resolvedModelProvider: ModelProviderType | undefined;
   modelProviderFirewall: ExpandedFirewallConfig | undefined;
   selectedModel: string | undefined;
-  connectorTypes: ConnectorType[];
+  connectorFirewalls: ExpandedFirewallConfig[];
 }> {
   // Model provider secret injection
   const hasExplicitModelProviderConfig = MODEL_PROVIDER_ENV_VARS.some(
@@ -787,13 +787,31 @@ async function resolveSecretsAndEnvironment(
   // Expand environment variables from compose config.
   // Model provider env vars are passed as additionalEnvironment so they go through
   // the same servicePlaceholders logic (secret-derived values use ${{ secrets.X }} templates).
+  // Build connector firewall configs for placeholder injection.
+  // builtinFirewalls configs carry `placeholders` (custom placeholder values),
+  // which expandEnvironmentFromCompose needs to replace secrets with placeholders.
+  const connectorFirewallConfigs = connectorResult.connectorTypes.flatMap(
+    (type) =>
+      getFirewallRefsForConnector(type)
+        .map((ref) => {
+          const config = builtinFirewalls[ref];
+          return config ? { ...config, ref } : undefined;
+        })
+        .filter(
+          (config): config is ExpandedFirewallConfig => config !== undefined,
+        ),
+  );
+
   const { environment } = expandEnvironmentFromCompose(
     agentCompose,
     mergedVars,
     secrets,
     checkEnv,
     modelProviderResult.injectedEnvironment,
-    modelProviderFirewall ? [modelProviderFirewall] : undefined,
+    [
+      ...(modelProviderFirewall ? [modelProviderFirewall] : []),
+      ...connectorFirewallConfigs,
+    ],
   );
 
   return {
@@ -803,7 +821,7 @@ async function resolveSecretsAndEnvironment(
     resolvedModelProvider: modelProviderResult.resolvedModelProvider,
     modelProviderFirewall,
     selectedModel: modelProviderResult.selectedModel,
-    connectorTypes: connectorResult.connectorTypes,
+    connectorFirewalls: connectorFirewallConfigs,
   };
 }
 
@@ -959,12 +977,15 @@ export function deduplicateAutoFirewalls<
 function mergeFirewalls(
   agentCompose: unknown,
   modelProviderFirewall: ExperimentalFirewalls[number] | null | undefined,
-  connectors: ConnectorType[],
+  connectorFirewalls: ExpandedFirewallConfig[],
   firewallPolicies?: FirewallPolicies,
 ): ExperimentalFirewalls | undefined {
   const composeFirewalls = buildExperimentalFirewalls(agentCompose);
   const autoFirewalls = modelProviderFirewall ? [modelProviderFirewall] : [];
-  const policyFirewalls = buildConnectorFirewalls(connectors, firewallPolicies);
+  const policyFirewalls = applyConnectorPolicies(
+    connectorFirewalls,
+    firewallPolicies,
+  );
   const allFirewalls = [
     ...(composeFirewalls ?? []),
     ...deduplicateAutoFirewalls(autoFirewalls, composeFirewalls ?? []),
@@ -1011,60 +1032,52 @@ const UNRESTRICTED_PERMISSION = {
 };
 
 /**
- * Build firewall entries for agent connectors based on builtinFirewalls.
+ * Apply firewall policies to connector firewall configs.
  *
- * For each connector, resolves its firewall ref(s) and builds a firewall entry:
+ * For each connector firewall:
  * - If the ref has explicit policies, only "allow" permissions are included.
  * - If the ref has no policies (or firewallPolicies is null), an "unrestricted"
  *   permission is added to allow all endpoints through the proxy.
+ * - If all permissions are denied, the entry is excluded entirely.
  */
-function buildConnectorFirewalls(
-  connectors: ConnectorType[],
+function applyConnectorPolicies(
+  connectorFirewalls: ExpandedFirewallConfig[],
   policies?: FirewallPolicies,
 ): ExperimentalFirewalls {
   const result: ExperimentalFirewalls = [];
-  const seen = new Set<string>();
 
-  for (const connector of connectors) {
-    for (const ref of getFirewallRefsForConnector(connector)) {
-      if (seen.has(ref)) continue;
-      seen.add(ref);
+  for (const fw of connectorFirewalls) {
+    const refPolicies = policies?.[fw.ref];
 
-      const config = builtinFirewalls[ref];
-      if (!config) continue;
-
-      const refPolicies = policies?.[ref];
-
-      const apis = config.apis.map((api) => {
-        if (!refPolicies) {
-          // No policies configured → unrestricted access
-          return {
-            base: api.base,
-            auth: api.auth,
-            permissions: [UNRESTRICTED_PERMISSION],
-          };
-        }
-
-        const allowed = api.permissions?.filter(
-          (perm) => refPolicies[perm.name] === "allow",
-        );
-
-        if (!allowed || allowed.length === 0) return null;
-
+    const apis = fw.apis.map((api) => {
+      if (!refPolicies) {
+        // No policies configured → unrestricted access
         return {
           base: api.base,
           auth: api.auth,
-          permissions: allowed,
+          permissions: [UNRESTRICTED_PERMISSION],
         };
-      });
+      }
 
-      const validApis = apis.filter(
-        (api): api is NonNullable<typeof api> => api !== null,
+      const allowed = api.permissions?.filter(
+        (perm) => refPolicies[perm.name] === "allow",
       );
-      if (validApis.length === 0) continue;
 
-      result.push({ name: config.name, ref, apis: validApis });
-    }
+      if (!allowed || allowed.length === 0) return null;
+
+      return {
+        base: api.base,
+        auth: api.auth,
+        permissions: allowed,
+      };
+    });
+
+    const validApis = apis.filter(
+      (api): api is NonNullable<typeof api> => api !== null,
+    );
+    if (validApis.length === 0) continue;
+
+    result.push({ name: fw.name, ref: fw.ref, apis: validApis });
   }
 
   return result;
@@ -1197,7 +1210,7 @@ export async function buildExecutionContext(
     resolvedModelProvider,
     modelProviderFirewall,
     selectedModel,
-    connectorTypes,
+    connectorFirewalls,
   } = secretsResult;
   const userTimezone = userPrefs?.timezone ?? undefined;
 
@@ -1225,7 +1238,7 @@ export async function buildExecutionContext(
   const experimentalFirewalls = mergeFirewalls(
     agentCompose,
     modelProviderFirewall,
-    connectorTypes,
+    connectorFirewalls,
     params.firewallPolicies,
   );
 

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -20,6 +20,9 @@ import {
   type ConnectorType,
   type ModelProviderType,
   type ModelProviderFramework,
+  type FirewallPolicies,
+  builtinFirewalls,
+  getFirewallRefsForConnector,
 } from "@vm0/core";
 import { agentComposeVersions } from "../../db/schema/agent-compose";
 import type { AgentComposeYaml } from "../../types/agent-compose";
@@ -413,6 +416,8 @@ interface ConnectorSecretResult {
   injectedEnvVars: Record<string, string> | undefined;
   /** Maps secret names to connector types for refresh-capable OAuth connectors */
   secretConnectorMap: Record<string, string> | undefined;
+  /** Validated connector types for the user */
+  connectorTypes: ConnectorType[];
 }
 
 /**
@@ -435,6 +440,7 @@ async function resolveConnectorSecrets(
       connectorSecrets: undefined,
       injectedEnvVars: undefined,
       secretConnectorMap: undefined,
+      connectorTypes: [],
     };
   }
 
@@ -444,6 +450,7 @@ async function resolveConnectorSecrets(
       connectorSecrets: undefined,
       injectedEnvVars: undefined,
       secretConnectorMap: undefined,
+      connectorTypes: [],
     };
   }
 
@@ -517,6 +524,7 @@ async function resolveConnectorSecrets(
       Object.keys(secretConnectorMap).length > 0
         ? secretConnectorMap
         : undefined,
+    connectorTypes: validConnectors.map((c) => c.type),
   };
 }
 
@@ -625,6 +633,8 @@ interface BuildContextParams {
   checkEnv?: boolean;
   // API start time for E2E timing metrics
   apiStartTime?: number;
+  // Per-permission firewall policies from zero agent configuration.
+  firewallPolicies?: FirewallPolicies;
   // Caller-resolved org context for secret/variable/storage resolution.
   orgSlug?: string;
   orgId: string;
@@ -700,6 +710,7 @@ async function resolveSecretsAndEnvironment(
   resolvedModelProvider: ModelProviderType | undefined;
   modelProviderFirewall: ExpandedFirewallConfig | undefined;
   selectedModel: string | undefined;
+  connectorTypes: ConnectorType[];
 }> {
   // Model provider secret injection
   const hasExplicitModelProviderConfig = MODEL_PROVIDER_ENV_VARS.some(
@@ -792,6 +803,7 @@ async function resolveSecretsAndEnvironment(
     resolvedModelProvider: modelProviderResult.resolvedModelProvider,
     modelProviderFirewall,
     selectedModel: modelProviderResult.selectedModel,
+    connectorTypes: connectorResult.connectorTypes,
   };
 }
 
@@ -940,6 +952,28 @@ export function deduplicateAutoFirewalls<
 }
 
 /**
+ * Merge compose-declared, auto-generated, and policy-based firewalls into a
+ * single manifest. Auto-generated and policy firewalls are deduplicated against
+ * compose-declared ones (prefix match on base URL).
+ */
+function mergeFirewalls(
+  agentCompose: unknown,
+  modelProviderFirewall: ExperimentalFirewalls[number] | null | undefined,
+  connectors: ConnectorType[],
+  firewallPolicies?: FirewallPolicies,
+): ExperimentalFirewalls | undefined {
+  const composeFirewalls = buildExperimentalFirewalls(agentCompose);
+  const autoFirewalls = modelProviderFirewall ? [modelProviderFirewall] : [];
+  const policyFirewalls = buildConnectorFirewalls(connectors, firewallPolicies);
+  const allFirewalls = [
+    ...(composeFirewalls ?? []),
+    ...deduplicateAutoFirewalls(autoFirewalls, composeFirewalls ?? []),
+    ...deduplicateAutoFirewalls(policyFirewalls, composeFirewalls ?? []),
+  ];
+  return allFirewalls.length > 0 ? allFirewalls : undefined;
+}
+
+/**
  * Build ExperimentalFirewalls manifest from agent compose's expanded experimental_firewalls.
  * Returns null if no firewall configs are declared.
  *
@@ -967,6 +1001,73 @@ function buildExperimentalFirewalls(
       ...(api.permissions ? { permissions: api.permissions } : {}),
     })),
   }));
+}
+
+/** Unrestricted permission — allows all endpoints through the proxy. */
+const UNRESTRICTED_PERMISSION = {
+  name: "unrestricted",
+  description: "Allow all endpoints",
+  rules: ["ANY /{path*}"],
+};
+
+/**
+ * Build firewall entries for agent connectors based on builtinFirewalls.
+ *
+ * For each connector, resolves its firewall ref(s) and builds a firewall entry:
+ * - If the ref has explicit policies, only "allow" permissions are included.
+ * - If the ref has no policies (or firewallPolicies is null), an "unrestricted"
+ *   permission is added to allow all endpoints through the proxy.
+ */
+function buildConnectorFirewalls(
+  connectors: ConnectorType[],
+  policies?: FirewallPolicies,
+): ExperimentalFirewalls {
+  const result: ExperimentalFirewalls = [];
+  const seen = new Set<string>();
+
+  for (const connector of connectors) {
+    for (const ref of getFirewallRefsForConnector(connector)) {
+      if (seen.has(ref)) continue;
+      seen.add(ref);
+
+      const config = builtinFirewalls[ref];
+      if (!config) continue;
+
+      const refPolicies = policies?.[ref];
+
+      const apis = config.apis.map((api) => {
+        if (!refPolicies) {
+          // No policies configured → unrestricted access
+          return {
+            base: api.base,
+            auth: api.auth,
+            permissions: [UNRESTRICTED_PERMISSION],
+          };
+        }
+
+        const allowed = api.permissions?.filter(
+          (perm) => refPolicies[perm.name] === "allow",
+        );
+
+        if (!allowed || allowed.length === 0) return null;
+
+        return {
+          base: api.base,
+          auth: api.auth,
+          permissions: allowed,
+        };
+      });
+
+      const validApis = apis.filter(
+        (api): api is NonNullable<typeof api> => api !== null,
+      );
+      if (validApis.length === 0) continue;
+
+      result.push({ name: config.name, ref, apis: validApis });
+    }
+  }
+
+  return result;
 }
 
 /**
@@ -1096,6 +1197,7 @@ export async function buildExecutionContext(
     resolvedModelProvider,
     modelProviderFirewall,
     selectedModel,
+    connectorTypes,
   } = secretsResult;
   const userTimezone = userPrefs?.timezone ?? undefined;
 
@@ -1120,18 +1222,12 @@ export async function buildExecutionContext(
   }
 
   // Build experimental firewall manifest (base + auth entries for the runner).
-  // Merge compose-declared firewalls with auto-generated model provider firewall.
-  // Auto-generated firewalls are skipped when compose already covers the same
-  // base URLs (prefix match — compose "https://api.x.com" covers auto
-  // "https://api.x.com/v1" but not vice versa).
-  const composeFirewalls = buildExperimentalFirewalls(agentCompose);
-  const autoFirewalls = modelProviderFirewall ? [modelProviderFirewall] : [];
-  const allFirewalls = [
-    ...(composeFirewalls ?? []),
-    ...deduplicateAutoFirewalls(autoFirewalls, composeFirewalls ?? []),
-  ];
-  const experimentalFirewalls =
-    allFirewalls.length > 0 ? allFirewalls : undefined;
+  const experimentalFirewalls = mergeFirewalls(
+    agentCompose,
+    modelProviderFirewall,
+    connectorTypes,
+    params.firewallPolicies,
+  );
 
   // Build experimental capabilities list from compose
   const experimentalCapabilities = buildExperimentalCapabilities(agentCompose);

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -47,6 +47,7 @@ import {
   type RunStatus,
   type TriggerSource,
   type GetRunResponse,
+  type FirewallPolicies,
   orgTierSchema,
 } from "@vm0/core";
 import { getOrgData } from "../org/org-cache-service";
@@ -471,6 +472,8 @@ export interface CreateRunParams {
   orgId: string;
   // Caller-resolved org tier for concurrency limit derivation.
   orgTier?: OrgTier;
+  // Per-permission firewall policies from zero agent configuration.
+  firewallPolicies?: FirewallPolicies;
 }
 
 /**
@@ -517,6 +520,7 @@ export interface StartRunParams {
   triggerSource?: TriggerSource;
   debugNoMockClaude?: boolean;
   checkEnv?: boolean;
+  firewallPolicies?: FirewallPolicies;
 }
 
 export interface CreateRunResult {
@@ -801,6 +805,7 @@ async function buildAndDispatchRun(opts: {
       debugNoMockClaude: params.debugNoMockClaude,
       modelProvider: params.modelProvider,
       checkEnv: params.checkEnv,
+      firewallPolicies: params.firewallPolicies,
       apiStartTime,
       orgSlug,
       orgId,
@@ -1083,6 +1088,7 @@ export async function startRun(
     triggerSource: params.triggerSource,
     debugNoMockClaude: params.debugNoMockClaude,
     checkEnv: params.checkEnv,
+    firewallPolicies: params.firewallPolicies,
     orgSlug: orgData.slug,
     orgId: authOrgId,
     orgTier,

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -286,5 +286,25 @@ describe("createZeroRun()", () => {
       );
       expect(slackFw).toBeUndefined();
     });
+
+    it("should add multiple firewall entries for multi-ref connector", async () => {
+      const agentName = uniqueId("fw-multi");
+      await createTestCompose(agentName);
+      // GitHub + Slack connectors → separate firewall entries
+      await createTestConnector({ type: "github" });
+      await createTestConnector({ type: "slack" });
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      const result = await createZeroRun(baseParams({ zeroAgentId: agentId }));
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      const firewalls = job!.executionContext.experimentalFirewalls;
+      expect(firewalls).toBeDefined();
+      const ghFw = firewalls!.find((fw) => fw.ref === "github");
+      const slackFw = firewalls!.find((fw) => fw.ref === "slack");
+      expect(ghFw).toBeDefined();
+      expect(slackFw).toBeDefined();
+    });
   });
 });

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../__tests__/test-helpers";
 import {
   createTestCompose,
+  createTestConnector,
   createTestSchedule,
   createTestZeroAgent,
   getTestZeroAgentId,
@@ -208,6 +209,82 @@ describe("createZeroRun()", () => {
       expect(run).toBeDefined();
       // appendSystemPrompt is prepended with agent identity, so check it contains our text
       expect(run!.appendSystemPrompt).toContain("You are a helpful bot.");
+    });
+  });
+
+  describe("firewall policies", () => {
+    it("should add firewall with only allowed permissions", async () => {
+      const agentName = uniqueId("fw-agent");
+      await createTestCompose(agentName);
+      await createTestConnector({ type: "github" });
+      await createTestZeroAgent(user.orgId, agentName, {
+        firewallPolicies: {
+          github: {
+            "actions:read": "allow",
+            "actions:write": "deny",
+            "issues:read": "allow",
+          },
+        },
+      });
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      const result = await createZeroRun(baseParams({ zeroAgentId: agentId }));
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      const firewalls = job!.executionContext.experimentalFirewalls;
+      expect(firewalls).toBeDefined();
+      const ghFirewall = firewalls!.find((fw) => fw.ref === "github");
+      expect(ghFirewall).toBeDefined();
+      const permNames = ghFirewall!.apis[0]!.permissions!.map((p) => p.name);
+      expect(permNames).toContain("actions:read");
+      expect(permNames).toContain("issues:read");
+      expect(permNames).not.toContain("actions:write");
+    });
+
+    it("should add unrestricted permission when no policies exist", async () => {
+      const agentName = uniqueId("fw-nopol");
+      await createTestCompose(agentName);
+      await createTestConnector({ type: "slack" });
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      const result = await createZeroRun(baseParams({ zeroAgentId: agentId }));
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      const firewalls = job!.executionContext.experimentalFirewalls;
+      expect(firewalls).toBeDefined();
+      const slackFw = firewalls!.find((fw) => fw.ref === "slack");
+      expect(slackFw).toBeDefined();
+      expect(slackFw!.apis[0]!.permissions).toEqual([
+        {
+          name: "unrestricted",
+          description: "Allow all endpoints",
+          rules: ["ANY /{path*}"],
+        },
+      ]);
+    });
+
+    it("should not add firewall entry when all permissions are denied", async () => {
+      const agentName = uniqueId("fw-allden");
+      await createTestCompose(agentName);
+      await createTestConnector({ type: "slack" });
+      await createTestZeroAgent(user.orgId, agentName, {
+        firewallPolicies: {
+          slack: { "bookmarks:read": "deny", "bookmarks:write": "deny" },
+        },
+      });
+      const agentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      const result = await createZeroRun(baseParams({ zeroAgentId: agentId }));
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      // All denied → no firewall entry
+      const slackFw = job!.executionContext.experimentalFirewalls?.find(
+        (fw) => fw.ref === "slack",
+      );
+      expect(slackFw).toBeUndefined();
     });
   });
 });

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -1,5 +1,5 @@
 import { eq, and } from "drizzle-orm";
-import type { TriggerSource } from "@vm0/core";
+import type { TriggerSource, FirewallPolicies } from "@vm0/core";
 import { startRun, type CreateRunResult } from "../run";
 import { DISALLOWED_CRON_TOOLS } from "../integration-context";
 import { formatAgentIdentityPrompt } from "../agent-identity";
@@ -17,6 +17,7 @@ async function resolveZeroAgent(zeroAgentId: string): Promise<{
   description: string | null;
   sound: string | null;
   composeId: string | null;
+  firewallPolicies: FirewallPolicies | null;
 }> {
   const [row] = await globalThis.services.db
     .select({
@@ -24,6 +25,7 @@ async function resolveZeroAgent(zeroAgentId: string): Promise<{
       description: zeroAgents.description,
       sound: zeroAgents.sound,
       composeId: agentComposes.id,
+      firewallPolicies: zeroAgents.firewallPolicies,
     })
     .from(zeroAgents)
     .leftJoin(
@@ -42,6 +44,7 @@ async function resolveZeroAgent(zeroAgentId: string): Promise<{
       description: null,
       sound: null,
       composeId: null,
+      firewallPolicies: null,
     }
   );
 }
@@ -98,5 +101,6 @@ export async function createZeroRun(
     memoryName: "memory",
     artifactName: "artifact",
     disallowedTools: [...DISALLOWED_CRON_TOOLS],
+    firewallPolicies: agent.firewallPolicies ?? undefined,
   });
 }

--- a/turbo/packages/core/src/contracts/firewalls.ts
+++ b/turbo/packages/core/src/contracts/firewalls.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { ConnectorType } from "./connectors";
 
 /**
  * Proxy-side firewall configuration for token replacement.
@@ -83,6 +84,34 @@ export type FirewallApi = z.infer<typeof firewallApiSchema>;
 export type FirewallConfig = z.infer<typeof firewallConfigSchema>;
 export type Firewall = z.infer<typeof firewallSchema>;
 export type ExperimentalFirewalls = z.infer<typeof experimentalFirewallsSchema>;
+
+/**
+ * Maps connector types (skill short names) to their builtin firewall ref(s).
+ * Only includes connectors that have builtin firewall configs.
+ */
+const CONNECTOR_FIREWALL_REFS: Readonly<
+  Partial<Record<ConnectorType, readonly string[]>>
+> = {
+  github: ["github"],
+  slack: ["slack"],
+  gmail: ["gmail"],
+  "google-sheets": ["google-sheets"],
+  "google-docs": ["google-docs"],
+  "google-drive": ["google-drive"],
+  "google-calendar": ["google-calendar"],
+  atlassian: ["jira", "confluence"],
+  jira: ["jira"],
+  figma: ["figma"],
+  notion: ["notion"],
+  vercel: ["vercel"],
+};
+
+/** Get the firewall ref names for a connector type. Returns empty array if none. */
+export function getFirewallRefsForConnector(
+  connector: ConnectorType,
+): string[] {
+  return [...(CONNECTOR_FIREWALL_REFS[connector] ?? [])];
+}
 
 /**
  * Regex pattern matching `${{ secrets.XXX }}` references in auth header templates.

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -413,6 +413,7 @@ export {
   type ExperimentalFirewalls,
   type FirewallPolicyValue,
   type FirewallPolicies,
+  getFirewallRefsForConnector,
 } from "./firewalls";
 
 export {


### PR DESCRIPTION
## Summary

- Integrate `zero_agents.firewallPolicies` into the run execution context so firewall policies take effect at runtime
- For each connector with a builtin firewall config, build firewall entries with only "allow" permissions
- Connectors without explicit policies get unrestricted access (default behavior)
- Connectors with all permissions denied are excluded entirely (proxy fail-closed)

Closes #5708

## Test plan

- [x] Integration tests: policy filtering (allow/deny), unrestricted default, all-denied exclusion
- [x] Type check passes
- [x] Lint passes (complexity kept under limit)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)