### PR TITLE
feat: include creator-owned unassigned issues in next-issue.sh selection

### DIFF
--- a/scripts/next-issue.sh
+++ b/scripts/next-issue.sh
@@ -17,18 +17,28 @@ source "$SCRIPT_DIR/_common.sh"
 LABEL="$1"
 ME=$(gh api user --jq '.login')
 
-# Find first actionable issue: not pending, not linked to PR, sorted by number
-ISSUE=$(gh issue list --repo "$REPO" --label "$LABEL" --assignee "$ME" --state open \
-  --json number,title,labels,closedByPullRequestsReferences --limit 50 \
-  --jq '
-    [.[]
+# Issues assigned to me
+ASSIGNED=$(gh issue list --repo "$REPO" --label "$LABEL" --assignee "$ME" --state open \
+  --json number,title,labels,closedByPullRequestsReferences --limit 50)
+
+# Issues authored by me with no assignee
+AUTHORED=$(gh issue list --repo "$REPO" --label "$LABEL" --author "$ME" --state open \
+  --json number,title,labels,closedByPullRequestsReferences,assignees --limit 50 \
+  --jq '[.[] | select(.assignees | length == 0) | del(.assignees)]')
+
+# Merge, dedup, filter, pick first actionable issue
+ISSUE=$(jq -n --argjson a "$ASSIGNED" --argjson b "$AUTHORED" '
+  [$a[], $b[]]
+  | group_by(.number)
+  | map(.[0])
+  | [.[]
       | select(([.labels[].name] | any(. == "pending")) | not)
       | select(.closedByPullRequestsReferences | length == 0)
     ]
-    | sort_by(.number)
-    | .[0]
-    // empty
-  ')
+  | sort_by(.number)
+  | .[0]
+  // empty
+')
 
 [[ -z "$ISSUE" ]] && exit 0
 


### PR DESCRIPTION
## Summary

- Add a second `gh issue list --author` query to `next-issue.sh` that finds issues created by the current user with no assignee
- Merge both result sets (assigned + authored-unassigned), deduplicate by issue number, and apply existing filters
- Follows the dual-query + merge pattern already established in `lane-status.sh`

Closes #6281

## Test plan

- [ ] Run `bash -n scripts/next-issue.sh` to verify no syntax errors
- [ ] Verify assigned issues still appear (regression check)
- [ ] Verify author-created unassigned issues now appear in results
- [ ] Verify pending and PR-linked issues are still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)