### PR TITLE
feat: add zero connector routes for sessions and computer

### DIFF
--- a/turbo/apps/web/app/api/zero/connectors/[type]/sessions/[sessionId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/sessions/[sessionId]/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+  createTestConnectorSession,
+} from "../../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zpoll");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function sessionUrl(type: string, sessionId: string): string {
+  return `http://localhost:3000/api/zero/connectors/${type}/sessions/${sessionId}`;
+}
+
+describe("GET /api/zero/connectors/:type/sessions/:sessionId", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return pending session status", async () => {
+    const userId = uniqueId("zpoll-pend");
+    await setupOrg(userId);
+    const session = await createTestConnectorSession(userId, "github");
+
+    const response = await GET(
+      createTestRequest(sessionUrl("github", session.id)),
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.status).toBe("pending");
+  });
+
+  it("should return completed session status", async () => {
+    const userId = uniqueId("zpoll-done");
+    await setupOrg(userId);
+    const session = await createTestConnectorSession(userId, "github", {
+      status: "complete",
+      completedAt: new Date(),
+    });
+
+    const response = await GET(
+      createTestRequest(sessionUrl("github", session.id)),
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.status).toBe("complete");
+  });
+
+  it("should mark expired session and return expired status", async () => {
+    const userId = uniqueId("zpoll-exp");
+    await setupOrg(userId);
+    const session = await createTestConnectorSession(userId, "github", {
+      expiresAt: new Date(Date.now() - 1000), // Already expired
+    });
+
+    const response = await GET(
+      createTestRequest(sessionUrl("github", session.id)),
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.status).toBe("expired");
+    expect(data.errorMessage).toBe("Session has expired");
+  });
+
+  it("should return 404 for non-existent session", async () => {
+    const userId = uniqueId("zpoll-nf");
+    await setupOrg(userId);
+
+    const response = await GET(
+      createTestRequest(
+        sessionUrl("github", "00000000-0000-0000-0000-000000000000"),
+      ),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest(
+        sessionUrl("github", "00000000-0000-0000-0000-000000000000"),
+      ),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("should not return another user's session", async () => {
+    const userA = uniqueId("zpoll-a");
+    await setupOrg(userA);
+    const session = await createTestConnectorSession(userA, "github");
+
+    // Switch to user B
+    const userB = uniqueId("zpoll-b");
+    await setupOrg(userB);
+
+    const response = await GET(
+      createTestRequest(sessionUrl("github", session.id)),
+    );
+    expect(response.status).toBe(404);
+  });
+});

--- a/turbo/apps/web/app/api/zero/connectors/[type]/sessions/[sessionId]/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/sessions/[sessionId]/route.ts
@@ -1,0 +1,72 @@
+import { eq, and } from "drizzle-orm";
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../../../src/lib/ts-rest-handler";
+import {
+  zeroConnectorSessionByIdContract,
+  createErrorResponse,
+} from "@vm0/core";
+import { initServices } from "../../../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../../src/lib/auth/require-auth";
+import { connectorSessions } from "../../../../../../../src/db/schema/connector-session";
+
+const router = tsr.router(zeroConnectorSessionByIdContract, {
+  get: async ({ params, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const [session] = await globalThis.services.db
+      .select()
+      .from(connectorSessions)
+      .where(
+        and(
+          eq(connectorSessions.id, params.sessionId),
+          eq(connectorSessions.type, params.type),
+          eq(connectorSessions.userId, userId),
+        ),
+      )
+      .limit(1);
+
+    if (!session) {
+      return createErrorResponse("NOT_FOUND", "Connector session not found");
+    }
+
+    // Check if expired
+    if (session.status === "pending" && new Date() > session.expiresAt) {
+      await globalThis.services.db
+        .update(connectorSessions)
+        .set({ status: "expired" })
+        .where(eq(connectorSessions.id, session.id));
+
+      return {
+        status: 200 as const,
+        body: {
+          status: "expired" as const,
+          errorMessage: "Session has expired",
+        },
+      };
+    }
+
+    return {
+      status: 200 as const,
+      body: {
+        status: session.status,
+        errorMessage: session.errorMessage,
+      },
+    };
+  },
+});
+
+const handler = createHandler(zeroConnectorSessionByIdContract, router, {
+  errorHandler: createSafeErrorHandler("zero-connectors:session-by-id"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/connectors/[type]/sessions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/sessions/__tests__/route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zsess");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function sessionsUrl(type: string): string {
+  return `http://localhost:3000/api/zero/connectors/${type}/sessions`;
+}
+
+describe("POST /api/zero/connectors/:type/sessions", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should create a connector session", async () => {
+    const userId = uniqueId("zsess-create");
+    await setupOrg(userId);
+
+    const response = await POST(
+      createTestRequest(sessionsUrl("github"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.id).toBeDefined();
+    expect(data.code).toMatch(/^[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    expect(data.type).toBe("github");
+    expect(data.status).toBe("pending");
+    expect(data.verificationUrl).toContain("/api/connectors/github/authorize");
+    expect(data.verificationUrl).toContain(`session=${data.id}`);
+    expect(data.expiresIn).toBe(900);
+    expect(data.interval).toBe(5);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(
+      createTestRequest(sessionsUrl("github"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
+    );
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/connectors/[type]/sessions/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/sessions/route.ts
@@ -1,0 +1,65 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../../src/lib/ts-rest-handler";
+import { zeroConnectorSessionsContract, createErrorResponse } from "@vm0/core";
+import { initServices } from "../../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../src/lib/auth/require-auth";
+import { connectorSessions } from "../../../../../../src/db/schema/connector-session";
+import { generateCode } from "../../../../../../src/lib/crypto";
+
+const router = tsr.router(zeroConnectorSessionsContract, {
+  create: async ({ params, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const code = generateCode();
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000); // 15 minutes
+
+    const [session] = await globalThis.services.db
+      .insert(connectorSessions)
+      .values({
+        code,
+        type: params.type,
+        userId,
+        status: "pending",
+        expiresAt,
+      })
+      .returning();
+
+    if (!session) {
+      return createErrorResponse(
+        "INTERNAL_SERVER_ERROR",
+        "Failed to create connector session",
+      );
+    }
+
+    const verificationUrl = `/api/connectors/${params.type}/authorize?session=${session.id}`;
+
+    return {
+      status: 200 as const,
+      body: {
+        id: session.id,
+        code,
+        type: params.type,
+        status: "pending" as const,
+        verificationUrl,
+        expiresIn: 900, // 15 minutes in seconds
+        interval: 5, // Poll every 5 seconds
+      },
+    };
+  },
+});
+
+const handler = createHandler(zeroConnectorSessionsContract, router, {
+  errorHandler: createSafeErrorHandler("zero-connectors:sessions"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../../src/mocks/server";
+import { GET, POST, DELETE } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zcomp");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function computerUrl(slug: string): string {
+  return `http://localhost:3000/api/zero/connectors/computer?org=${slug}`;
+}
+
+function setupNgrokMocks() {
+  const calls = {
+    createBotUser: [] as string[],
+    listBotUsers: 0,
+    createCredential: [] as string[],
+    deleteCredential: [] as string[],
+    createEndpoint: [] as string[],
+    deleteEndpoint: [] as string[],
+    createReservedDomain: [] as string[],
+    deleteReservedDomain: [] as string[],
+  };
+
+  server.use(
+    http.post("https://api.ngrok.com/bot_users", async ({ request }) => {
+      const body = (await request.json()) as { name: string };
+      calls.createBotUser.push(body.name);
+      return HttpResponse.json({
+        id: "bot_test_123",
+        name: body.name,
+      });
+    }),
+    http.get("https://api.ngrok.com/bot_users", () => {
+      calls.listBotUsers++;
+      return HttpResponse.json({
+        bot_users: [],
+        next_page_uri: null,
+      });
+    }),
+    http.post("https://api.ngrok.com/credentials", async ({ request }) => {
+      const body = (await request.json()) as {
+        owner_id: string;
+        acl: string[];
+      };
+      calls.createCredential.push(body.owner_id);
+      return HttpResponse.json({
+        id: "cr_test_456",
+        token: "2abc_test_ngrok_authtoken",
+      });
+    }),
+    http.delete("https://api.ngrok.com/credentials/:id", ({ params }) => {
+      calls.deleteCredential.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.post("https://api.ngrok.com/reserved_domains", async ({ request }) => {
+      const body = (await request.json()) as {
+        name: string;
+        region: string;
+      };
+      calls.createReservedDomain.push(body.name);
+      return HttpResponse.json({
+        id: "rd_test_abc",
+        domain: `${body.name}.ngrok-free.app`,
+        region: body.region,
+        cname_target: null,
+      });
+    }),
+    http.delete("https://api.ngrok.com/reserved_domains/:id", ({ params }) => {
+      calls.deleteReservedDomain.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.post("https://api.ngrok.com/endpoints", async ({ request }) => {
+      const body = (await request.json()) as { url: string };
+      calls.createEndpoint.push(body.url);
+      return HttpResponse.json({
+        id: "ep_test_789",
+        url: body.url,
+      });
+    }),
+    http.delete("https://api.ngrok.com/endpoints/:id", ({ params }) => {
+      calls.deleteEndpoint.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+  );
+
+  return calls;
+}
+
+function createPostRequest(slug: string) {
+  return createTestRequest(computerUrl(slug), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+}
+
+describe("POST /api/zero/connectors/computer", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(
+      createTestRequest(computerUrl("test"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("should create computer connector", async () => {
+    const userId = uniqueId("zcomp-create");
+    const { slug } = await setupOrg(userId);
+    const ngrokCalls = setupNgrokMocks();
+
+    const response = await POST(createPostRequest(slug));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBeDefined();
+    expect(data.ngrokToken).toBe("2abc_test_ngrok_authtoken");
+    expect(data.bridgeToken).toBeDefined();
+    expect(data.endpointPrefix).toContain("vm0-user-");
+    expect(data.domain).toContain(".ngrok-free.app");
+
+    expect(ngrokCalls.createBotUser.length).toBe(1);
+    expect(ngrokCalls.createCredential.length).toBe(1);
+    expect(ngrokCalls.createReservedDomain.length).toBe(1);
+    expect(ngrokCalls.createEndpoint.length).toBe(1);
+  });
+
+  it("should return 409 if connector already exists", async () => {
+    const userId = uniqueId("zcomp-dup");
+    const { slug } = await setupOrg(userId);
+    setupNgrokMocks();
+
+    const response1 = await POST(createPostRequest(slug));
+    expect(response1.status).toBe(200);
+
+    const response2 = await POST(createPostRequest(slug));
+    expect(response2.status).toBe(409);
+  });
+});
+
+describe("GET /api/zero/connectors/computer", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(createTestRequest(computerUrl("test")));
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 404 if connector not found", async () => {
+    const userId = uniqueId("zcomp-nf");
+    const { slug } = await setupOrg(userId);
+
+    const response = await GET(createTestRequest(computerUrl(slug)));
+    expect(response.status).toBe(404);
+  });
+
+  it("should return connector details", async () => {
+    const userId = uniqueId("zcomp-get");
+    const { slug } = await setupOrg(userId);
+    setupNgrokMocks();
+
+    await POST(createPostRequest(slug));
+
+    const response = await GET(createTestRequest(computerUrl(slug)));
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.type).toBe("computer");
+    expect(data.authMethod).toBe("api");
+  });
+});
+
+describe("DELETE /api/zero/connectors/computer", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await DELETE(
+      createTestRequest(computerUrl("test"), { method: "DELETE" }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 404 if connector not found", async () => {
+    const userId = uniqueId("zcomp-del-nf");
+    const { slug } = await setupOrg(userId);
+
+    const response = await DELETE(
+      createTestRequest(computerUrl(slug), { method: "DELETE" }),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("should delete connector and clean up", async () => {
+    const userId = uniqueId("zcomp-del");
+    const { slug } = await setupOrg(userId);
+    const ngrokCalls = setupNgrokMocks();
+
+    await POST(createPostRequest(slug));
+
+    const response = await DELETE(
+      createTestRequest(computerUrl(slug), { method: "DELETE" }),
+    );
+    expect(response.status).toBe(204);
+
+    expect(ngrokCalls.deleteCredential).toEqual(["cr_test_456"]);
+    expect(ngrokCalls.deleteEndpoint).toEqual(["ep_test_789"]);
+    expect(ngrokCalls.deleteReservedDomain).toEqual(["rd_test_abc"]);
+
+    // Verify GET returns 404
+    const getResponse = await GET(createTestRequest(computerUrl(slug)));
+    expect(getResponse.status).toBe(404);
+  });
+});

--- a/turbo/apps/web/app/api/zero/connectors/computer/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/route.ts
@@ -1,0 +1,91 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroComputerConnectorContract, createErrorResponse } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { getConnector } from "../../../../../src/lib/connector/connector-service";
+import {
+  createComputerConnector,
+  deleteComputerConnector,
+} from "../../../../../src/lib/computer-connector/computer-connector-service";
+import {
+  isBadRequest,
+  isConflict,
+  isNotFound,
+} from "../../../../../src/lib/errors";
+
+const router = tsr.router(zeroComputerConnectorContract, {
+  create: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const { org } = await resolveOrg(authCtx, orgSlug);
+      const result = await createComputerConnector(org.orgId, userId);
+      return { status: 200 as const, body: result };
+    } catch (error) {
+      if (isBadRequest(error)) {
+        return createErrorResponse("BAD_REQUEST", "Invalid request");
+      }
+      if (isConflict(error)) {
+        return createErrorResponse("CONFLICT", "Resource conflict");
+      }
+      throw error;
+    }
+  },
+
+  get: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+    const connector = await getConnector(org.orgId, userId, "computer");
+
+    if (!connector) {
+      return createErrorResponse("NOT_FOUND", "Computer connector not found");
+    }
+
+    return { status: 200 as const, body: connector };
+  },
+
+  delete: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const { org } = await resolveOrg(authCtx, orgSlug);
+      await deleteComputerConnector(org.orgId, userId);
+      return { status: 204 as const, body: undefined };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return createErrorResponse("NOT_FOUND", "Computer connector not found");
+      }
+      throw error;
+    }
+  },
+});
+
+const handler = createHandler(zeroComputerConnectorContract, router, {
+  errorHandler: createSafeErrorHandler("zero-connectors:computer"),
+});
+
+export { handler as GET, handler as POST, handler as DELETE };


### PR DESCRIPTION
## Summary

- Add missing zero connector route implementations for OAuth device flow sessions and computer connector CRUD
- Routes enable CLI to call `/api/zero/connectors/*` endpoints: session creation, session polling, and computer connector POST/GET/DELETE
- All routes use `requireAuth()` + `createSafeErrorHandler()` pattern consistent with existing zero connector routes

Closes #6293

## Test plan

- [x] 17 integration tests pass (2 session create + 6 session poll + 9 computer)
- [x] TypeScript type checking passes (`pnpm check-types`)
- [x] Linting passes (`pnpm turbo run lint`)
- [x] Knip reports no unused code
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)