### PR TITLE
fix: display dashboard lane status from interval marker downward

### DIFF
--- a/scripts/coding-dashboard.sh
+++ b/scripts/coding-dashboard.sh
@@ -178,7 +178,14 @@ jq -r --argjson mq "$MQ_NUMBERS" '
   else "" end) as $gist_time |
   # Truncate gist content to last few lines for brevity
   (if .gist.content then
-    (.gist.content | split("\n") | map(select(. != "")) | .[-5:] | map("  │ \(.)") | join("\n"))
+    (.gist.content | split("\n") |
+      . as $lines |
+      [to_entries[] | select(.value | test("^INTERVAL:"))] |
+      if length > 0 then
+        (last.key) as $idx | $lines[$idx:] | map(select(. != "")) | map("  │ \(.)") | join("\n")
+      else
+        $lines | map(select(. != "")) | .[-5:] | map("  │ \(.)") | join("\n")
+      end)
   else null end) as $gist_lines |
   "\n\(.lane)\($gist_time)" as $header |
   if (.issue_count + .pr_count) == 0 then


### PR DESCRIPTION
## Summary

- Replace the "last 5 non-empty lines" gist display logic in `coding-dashboard.sh` with logic that shows all non-empty lines from the last `INTERVAL:` line downward
- Falls back to original last-5-lines behavior when no `INTERVAL:` line exists
- Filters out git fetch/checkout noise that appeared before the meaningful status output

Closes #6287

## Test plan

- [x] Verified jq expression with sample data containing INTERVAL line (shows from INTERVAL onward)
- [x] Verified fallback behavior when no INTERVAL line present (shows last 5 lines)
- [x] Verified correct handling of multiple INTERVAL lines (uses the last one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)