### PR TITLE
fix: confirm dialogs close only after async operation completes

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-members-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-members-dialog.test.tsx
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function mockMembersAPI() {
+  server.use(
+    http.get("*/api/zero/org/members", () => {
+      return HttpResponse.json({
+        members: [
+          {
+            userId: "test-user-123",
+            email: "admin@example.com",
+            firstName: "Admin",
+            lastName: "User",
+            imageUrl: "",
+            role: "admin",
+            joinedAt: "2026-01-01T00:00:00Z",
+          },
+          {
+            userId: "user-member",
+            email: "member@example.com",
+            firstName: "Regular",
+            lastName: "Member",
+            imageUrl: "",
+            role: "member",
+            joinedAt: "2026-02-01T00:00:00Z",
+          },
+        ],
+        pendingInvitations: [],
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+async function renderMembersTab() {
+  await setupPage({ context, path: "/?settings=members" });
+}
+
+describe("org members - invite dialog loading state", () => {
+  it("should show loading state and close after invite completes", async () => {
+    let resolveInvite: (() => void) | null = null;
+
+    mockMembersAPI();
+    server.use(
+      http.post("*/api/zero/org/invite", () => {
+        return new Promise<Response>((resolve) => {
+          resolveInvite = () =>
+            resolve(HttpResponse.json({ message: "ok" }, { status: 200 }));
+        });
+      }),
+    );
+
+    await renderMembersTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("admin@example.com")).toBeInTheDocument();
+    });
+
+    // Open invite dialog
+    fireEvent.click(screen.getByRole("button", { name: /Invite/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Invite member" }),
+      ).toBeInTheDocument();
+    });
+
+    // Fill email and submit
+    const emailInput = screen.getByPlaceholderText("email@example.com");
+    fireEvent.change(emailInput, { target: { value: "new@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /Send invitation/i }));
+
+    // Should show loading state while dialog stays open
+    await waitFor(() => {
+      expect(screen.getByText("Sending...")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("heading", { name: "Invite member" }),
+    ).toBeInTheDocument();
+
+    // Buttons should be disabled during loading
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Sending..." })).toBeDisabled();
+
+    // Resolve the API call
+    resolveInvite!();
+
+    // Dialog should close after completion
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Invite member" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("should keep dialog open on invite error", async () => {
+    mockMembersAPI();
+    server.use(
+      http.post("*/api/zero/org/invite", () => {
+        return HttpResponse.json(
+          { error: { message: "Already a member" } },
+          { status: 400 },
+        );
+      }),
+    );
+
+    await renderMembersTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("admin@example.com")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Invite/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Invite member" }),
+      ).toBeInTheDocument();
+    });
+
+    const emailInput = screen.getByPlaceholderText("email@example.com");
+    fireEvent.change(emailInput, { target: { value: "admin@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /Send invitation/i }));
+
+    // Loading appears briefly, then clears
+    await waitFor(() => {
+      expect(screen.getByText("Sending...")).toBeInTheDocument();
+    });
+
+    // After error resolves, dialog stays open (loading clears)
+    await waitFor(() => {
+      expect(screen.getByText("Send invitation")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("heading", { name: "Invite member" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should disable input and cancel button during invite", async () => {
+    let resolveInvite: (() => void) | null = null;
+
+    mockMembersAPI();
+    server.use(
+      http.post("*/api/zero/org/invite", () => {
+        return new Promise<Response>((resolve) => {
+          resolveInvite = () =>
+            resolve(HttpResponse.json({ message: "ok" }, { status: 200 }));
+        });
+      }),
+    );
+
+    await renderMembersTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("admin@example.com")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Invite/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Invite member" }),
+      ).toBeInTheDocument();
+    });
+
+    const emailInput = screen.getByPlaceholderText("email@example.com");
+    fireEvent.change(emailInput, { target: { value: "new@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /Send invitation/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Sending...")).toBeInTheDocument();
+    });
+
+    // Email input should be disabled during loading
+    expect(screen.getByPlaceholderText("email@example.com")).toBeDisabled();
+
+    // Cleanup
+    resolveInvite!();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Invite member" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -375,6 +375,56 @@ describe("zero schedule page - delete confirmation", () => {
       expect(deletedName).toBe("morning-briefing");
     });
   });
+
+  it("should show loading state and close only after delete completes", async () => {
+    let resolveDelete: (() => void) | null = null;
+
+    server.use(
+      http.get("*/api/zero/schedules", () => {
+        return HttpResponse.json({ schedules: createMockSchedules() });
+      }),
+      http.delete("*/api/zero/schedules/:name", () => {
+        return new Promise<Response>((resolve) => {
+          resolveDelete = () =>
+            resolve(new HttpResponse(null, { status: 204 }));
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Delete Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Delete Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    // Dialog should stay open with loading state
+    await waitFor(() => {
+      expect(screen.getByText("Deleting...")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+
+    // Resolve the delete
+    resolveDelete!();
+
+    // Dialog should close after completion
+    await waitFor(() => {
+      expect(screen.queryByText("Delete schedule?")).not.toBeInTheDocument();
+    });
+  });
 });
 
 describe("zero schedule page - edit dialog confirm close", () => {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useGet, useLoadable, useSet } from "ccstate-react";
 import {
   IconSearch,
@@ -10,7 +11,6 @@ import {
   cn,
   Button,
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -182,13 +182,7 @@ export function OrgMembersTab() {
             className="h-9 w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input pl-9 pr-3 text-sm text-foreground outline-none placeholder:text-muted-foreground/50 transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10"
           />
         </div>
-        {isAdmin && (
-          <InviteDialog
-            onInvite={(email) =>
-              detach(handleInvite(email), Reason.DomCallback)
-            }
-          />
-        )}
+        {isAdmin && <InviteDialog onInvite={handleInvite} />}
       </div>
 
       <div
@@ -234,12 +228,8 @@ export function OrgMembersTab() {
                 member={m}
                 isCurrentUser={m.userId === currentUserId}
                 isAdmin={isAdmin}
-                onRoleChange={(email, role) =>
-                  detach(handleRoleChange(email, role), Reason.DomCallback)
-                }
-                onRemove={(email) =>
-                  detach(handleRemove(email), Reason.DomCallback)
-                }
+                onRoleChange={handleRoleChange}
+                onRemove={handleRemove}
               />
             </div>
           ))}
@@ -258,9 +248,15 @@ export function OrgMembersTab() {
   );
 }
 
-function InviteDialog({ onInvite }: { onInvite: (email: string) => void }) {
+function InviteDialog({
+  onInvite,
+}: {
+  onInvite: (email: string) => Promise<void>;
+}) {
   const email = useGet(inviteEmail$);
   const setEmail = useSet(setInviteEmail$);
+  const [open, setOpen] = useState(false);
+  const [sending, setSending] = useState(false);
 
   const trimmed = email.trim();
   const isValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed);
@@ -268,8 +264,25 @@ function InviteDialog({ onInvite }: { onInvite: (email: string) => void }) {
   const touched = useGet(inviteTouched$);
   const setTouched = useSet(setInviteTouched$);
 
+  const handleSend = () => {
+    setSending(true);
+    detach(
+      onInvite(trimmed).then(
+        () => {
+          setOpen(false);
+          setEmail("");
+          setSending(false);
+        },
+        () => {
+          setSending(false);
+        },
+      ),
+      Reason.DomCallback,
+    );
+  };
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={sending ? undefined : setOpen}>
       <DialogTrigger asChild>
         <Button size="sm" className="gap-1.5 rounded-lg">
           <IconPlus size={14} stroke={2} />
@@ -288,6 +301,7 @@ function InviteDialog({ onInvite }: { onInvite: (email: string) => void }) {
             placeholder="email@example.com"
             type="email"
             value={email}
+            disabled={sending}
             onChange={(e) => {
               setEmail(e.target.value);
               setTouched(false);
@@ -301,23 +315,17 @@ function InviteDialog({ onInvite }: { onInvite: (email: string) => void }) {
           )}
         </div>
         <DialogFooter>
-          <DialogClose asChild>
-            <Button variant="outline" size="sm">
-              Cancel
-            </Button>
-          </DialogClose>
-          <DialogClose asChild>
-            <Button
-              size="sm"
-              disabled={!isValid}
-              onClick={() => {
-                onInvite(trimmed);
-                setEmail("");
-              }}
-            >
-              Send invitation
-            </Button>
-          </DialogClose>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setOpen(false)}
+            disabled={sending}
+          >
+            Cancel
+          </Button>
+          <Button size="sm" disabled={!isValid || sending} onClick={handleSend}>
+            {sending ? "Sending..." : "Send invitation"}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -334,8 +342,8 @@ function MemberRow({
   member: OrgMember;
   isCurrentUser: boolean;
   isAdmin: boolean;
-  onRoleChange: (email: string, role: OrgRole) => void;
-  onRemove: (email: string) => void;
+  onRoleChange: (email: string, role: OrgRole) => Promise<void>;
+  onRemove: (email: string) => Promise<void>;
 }) {
   const name = displayName(member);
   const initial = (name || member.email).charAt(0).toUpperCase();
@@ -404,10 +412,29 @@ function SelfDemoteAction({
   onRoleChange,
 }: {
   email: string;
-  onRoleChange: (email: string, role: OrgRole) => void;
+  onRoleChange: (email: string, role: OrgRole) => Promise<void>;
 }) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleConfirm = () => {
+    setLoading(true);
+    detach(
+      onRoleChange(email, "member").then(
+        () => {
+          setOpen(false);
+          setLoading(false);
+        },
+        () => {
+          setLoading(false);
+        },
+      ),
+      Reason.DomCallback,
+    );
+  };
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={loading ? undefined : setOpen}>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/50 transition-colors">
@@ -430,20 +457,22 @@ function SelfDemoteAction({
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <DialogClose asChild>
-            <Button variant="outline" size="sm">
-              Cancel
-            </Button>
-          </DialogClose>
-          <DialogClose asChild>
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={() => onRoleChange(email, "member")}
-            >
-              Confirm
-            </Button>
-          </DialogClose>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setOpen(false)}
+            disabled={loading}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            disabled={loading}
+            onClick={handleConfirm}
+          >
+            {loading ? "Switching..." : "Confirm"}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -456,13 +485,31 @@ function MemberActions({
   onRemove,
 }: {
   member: OrgMember;
-  onRoleChange: (email: string, role: OrgRole) => void;
-  onRemove: (email: string) => void;
+  onRoleChange: (email: string, role: OrgRole) => Promise<void>;
+  onRemove: (email: string) => Promise<void>;
 }) {
   const newRole: OrgRole = member.role === "admin" ? "member" : "admin";
+  const [open, setOpen] = useState(false);
+  const [removing, setRemoving] = useState(false);
+
+  const handleRemove = () => {
+    setRemoving(true);
+    detach(
+      onRemove(member.email).then(
+        () => {
+          setOpen(false);
+          setRemoving(false);
+        },
+        () => {
+          setRemoving(false);
+        },
+      ),
+      Reason.DomCallback,
+    );
+  };
 
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={removing ? undefined : setOpen}>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/50 transition-colors">
@@ -470,7 +517,11 @@ function MemberActions({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
-          <DropdownMenuItem onClick={() => onRoleChange(member.email, newRole)}>
+          <DropdownMenuItem
+            onClick={() =>
+              detach(onRoleChange(member.email, newRole), Reason.DomCallback)
+            }
+          >
             {newRole === "admin" ? "Make admin" : "Make member"}
           </DropdownMenuItem>
           <DialogTrigger asChild>
@@ -490,17 +541,21 @@ function MemberActions({
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
-          <DialogClose asChild>
-            <Button variant="outline" size="sm">
-              Cancel
-            </Button>
-          </DialogClose>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setOpen(false)}
+            disabled={removing}
+          >
+            Cancel
+          </Button>
           <Button
             variant="destructive"
             size="sm"
-            onClick={() => onRemove(member.email)}
+            disabled={removing}
+            onClick={handleRemove}
           >
-            Remove
+            {removing ? "Removing..." : "Remove"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -273,8 +273,13 @@ function InviteDialog({
           setEmail("");
           setSending(false);
         },
-        () => {
+        (error: unknown) => {
           setSending(false);
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Failed to send invitation";
+          toast.error(message);
         },
       ),
       Reason.DomCallback,
@@ -432,8 +437,11 @@ function SelfDemoteAction({
           setOpen(false);
           setLoading(false);
         },
-        () => {
+        (error: unknown) => {
           setLoading(false);
+          const message =
+            error instanceof Error ? error.message : "Failed to change role";
+          toast.error(message);
         },
       ),
       Reason.DomCallback,
@@ -514,8 +522,11 @@ function MemberActions({
           setOpen(false);
           setRemoving(false);
         },
-        () => {
+        (error: unknown) => {
           setRemoving(false);
+          const message =
+            error instanceof Error ? error.message : "Failed to remove member";
+          toast.error(message);
         },
       ),
       Reason.DomCallback,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -282,7 +282,14 @@ function InviteDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={sending ? undefined : setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!sending) {
+          setOpen(v);
+        }
+      }}
+    >
       <DialogTrigger asChild>
         <Button size="sm" className="gap-1.5 rounded-lg">
           <IconPlus size={14} stroke={2} />
@@ -434,7 +441,14 @@ function SelfDemoteAction({
   };
 
   return (
-    <Dialog open={open} onOpenChange={loading ? undefined : setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!loading) {
+          setOpen(v);
+        }
+      }}
+    >
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/50 transition-colors">
@@ -509,7 +523,14 @@ function MemberActions({
   };
 
   return (
-    <Dialog open={open} onOpenChange={removing ? undefined : setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!removing) {
+          setOpen(v);
+        }
+      }}
+    >
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/50 transition-colors">

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -112,16 +112,17 @@ export function OrgMembersTab() {
     if (result.status === 200) {
       toast.success(`Invitation sent to ${email}`);
       refreshMembers();
-    } else {
-      const msg =
-        result.status === 400 ||
-        result.status === 401 ||
-        result.status === 403 ||
-        result.status === 500
-          ? result.body.error.message
-          : undefined;
-      toast.error(msg ?? `Failed to invite (${result.status})`);
+      return;
     }
+    const msg =
+      result.status === 400 ||
+      result.status === 401 ||
+      result.status === 403 ||
+      result.status === 500
+        ? result.body.error.message
+        : undefined;
+    toast.error(msg ?? `Failed to invite (${result.status})`);
+    throw new Error(msg ?? `Failed to invite (${result.status})`);
   };
 
   const handleRoleChange = async (email: string, role: OrgRole) => {
@@ -135,16 +136,17 @@ export function OrgMembersTab() {
       }
       refreshMembers();
       refreshOrg();
-    } else {
-      const msg =
-        result.status === 400 ||
-        result.status === 401 ||
-        result.status === 403 ||
-        result.status === 500
-          ? result.body.error.message
-          : undefined;
-      toast.error(msg ?? `Failed to update role (${result.status})`);
+      return;
     }
+    const msg =
+      result.status === 400 ||
+      result.status === 401 ||
+      result.status === 403 ||
+      result.status === 500
+        ? result.body.error.message
+        : undefined;
+    toast.error(msg ?? `Failed to update role (${result.status})`);
+    throw new Error(msg ?? `Failed to update role (${result.status})`);
   };
 
   const handleRemove = async (email: string) => {
@@ -153,16 +155,17 @@ export function OrgMembersTab() {
     if (result.status === 200) {
       toast.success(`Removed ${email}`);
       refreshMembers();
-    } else {
-      const msg =
-        result.status === 400 ||
-        result.status === 401 ||
-        result.status === 403 ||
-        result.status === 500
-          ? result.body.error.message
-          : undefined;
-      toast.error(msg ?? `Failed to remove member (${result.status})`);
+      return;
     }
+    const msg =
+      result.status === 400 ||
+      result.status === 401 ||
+      result.status === 403 ||
+      result.status === 500
+        ? result.body.error.message
+        : undefined;
+    toast.error(msg ?? `Failed to remove member (${result.status})`);
+    throw new Error(msg ?? `Failed to remove member (${result.status})`);
   };
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -20,6 +20,7 @@ import {
   cn,
 } from "@vm0/ui";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   Popover,
   PopoverContent,
@@ -754,8 +755,13 @@ export function ZeroSchedulePage() {
           setPendingDelete(null);
           setDeleting(false);
         },
-        () => {
+        (error: unknown) => {
           setDeleting(false);
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Failed to delete schedule";
+          toast.error(message);
         },
       ),
       Reason.DomCallback,
@@ -885,15 +891,11 @@ export function ZeroSchedulePage() {
       />
       <Dialog
         open={pendingDelete !== null}
-        onOpenChange={
-          deleting
-            ? undefined
-            : (open) => {
-                if (!open) {
-                  setPendingDelete(null);
-                }
-              }
-        }
+        onOpenChange={(open) => {
+          if (!deleting && !open) {
+            setPendingDelete(null);
+          }
+        }}
       >
         <DialogContent>
           <DialogHeader>

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -635,6 +635,7 @@ export function ZeroSchedulePage() {
   const [pendingDelete, setPendingDelete] = useState<CombinedEntry | null>(
     null,
   );
+  const [deleting, setDeleting] = useState(false);
 
   const combinedSchedule = buildCombinedSchedule(
     entries,
@@ -743,14 +744,22 @@ export function ZeroSchedulePage() {
     if (pendingDelete?.name === undefined) {
       return;
     }
+    setDeleting(true);
     detach(
       deleteSchedule({
         name: pendingDelete.name,
         agentId: pendingDelete.agentId,
-      }),
+      }).then(
+        () => {
+          setPendingDelete(null);
+          setDeleting(false);
+        },
+        () => {
+          setDeleting(false);
+        },
+      ),
       Reason.DomCallback,
     );
-    setPendingDelete(null);
   };
 
   return (
@@ -876,11 +885,15 @@ export function ZeroSchedulePage() {
       />
       <Dialog
         open={pendingDelete !== null}
-        onOpenChange={(open) => {
-          if (!open) {
-            setPendingDelete(null);
-          }
-        }}
+        onOpenChange={
+          deleting
+            ? undefined
+            : (open) => {
+                if (!open) {
+                  setPendingDelete(null);
+                }
+              }
+        }
       >
         <DialogContent>
           <DialogHeader>
@@ -894,11 +907,19 @@ export function ZeroSchedulePage() {
             </p>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setPendingDelete(null)}>
+            <Button
+              variant="outline"
+              onClick={() => setPendingDelete(null)}
+              disabled={deleting}
+            >
               Cancel
             </Button>
-            <Button variant="destructive" onClick={confirmDelete}>
-              Delete
+            <Button
+              variant="destructive"
+              onClick={confirmDelete}
+              disabled={deleting}
+            >
+              {deleting ? "Deleting..." : "Delete"}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary

- Convert 3 uncontrolled dialogs in `org-members-tab.tsx` (Invite, Self-demote, Remove member) to controlled dialogs with loading state, so they stay open until the API call finishes
- Fix delete schedule dialog in `zero-schedule-page.tsx` to close only after the delete operation resolves instead of immediately
- All 4 dialogs now show loading text on the confirm button, disable both buttons during the operation, and prevent dismissal via overlay/escape while saving

## Test plan

- [ ] Invite member: dialog stays open with "Sending..." until API responds, then closes
- [ ] Self-demote (Switch to member): dialog stays open with "Switching..." until role change completes
- [ ] Remove member: dialog stays open with "Removing..." until member is removed
- [ ] Delete schedule: dialog stays open with "Deleting..." until schedule is deleted
- [ ] Cancel buttons still work when not in loading state
- [ ] Dialog cannot be dismissed via overlay click or Escape while operation is in progress
- [ ] On API error, toast shows and dialog stays open (user can retry or cancel)

Closes #6300

🤖 Generated with [Claude Code](https://claude.com/claude-code)