### PR TITLE
refactor: rewrite inbound email parsing and routing to org-level

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/__tests__/route.test.ts
@@ -164,8 +164,7 @@ describe("POST /api/internal/callbacks/email/reply", () => {
         headers: Record<string, string>;
       };
       expect(sendArgs.to).toBe("test@example.com");
-      // From address uses org slug instead of agent name
-      expect(sendArgs.from).toMatch(/^org-[a-f0-9]+ from VM0/);
+      expect(sendArgs.from).toMatch(/^Zero <org-[a-f0-9]+@/);
       expect(sendArgs.replyTo).toContain("reply+");
       expect(sendArgs.headers["In-Reply-To"]).toBe(
         "<user-reply@mail.example.com>",

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/__tests__/route.test.ts
@@ -223,8 +223,7 @@ describe("POST /api/internal/callbacks/email/schedule", () => {
       };
       expect(sendArgs.to).toBe("test@example.com");
       expect(sendArgs.subject).toContain("completed");
-      // From address uses org slug instead of agent name
-      expect(sendArgs.from).toMatch(/^org-[a-f0-9]+ from VM0/);
+      expect(sendArgs.from).toMatch(/^Zero <org-[a-f0-9]+@/);
     });
 
     it("should send failure email for failed scheduled run", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
@@ -187,8 +187,7 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
         headers: Record<string, string>;
       };
       expect(sendArgs.to).toBe(senderEmail);
-      // From address uses org slug (org-{suffix}) instead of agent name
-      expect(sendArgs.from).toMatch(/^org-[a-f0-9]+ from VM0/);
+      expect(sendArgs.from).toMatch(/^Zero <org-[a-f0-9]+@/);
       expect(sendArgs.subject).toBe("Re: Help me with this");
       expect(sendArgs.replyTo).toContain("reply+");
       expect(sendArgs.headers).toMatchObject({
@@ -236,8 +235,7 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
         from: string;
       };
       expect(sendArgs.subject).toBe("Re: Original Topic");
-      // From address uses org slug instead of agent name
-      expect(sendArgs.from).toMatch(/^org-[a-f0-9]+ from VM0/);
+      expect(sendArgs.from).toMatch(/^Zero <org-[a-f0-9]+@/);
     });
 
     it("should send to multiple recipients when replyRecipientTo is provided", async () => {

--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -12,6 +12,7 @@ import {
   findTestRunsByUserAndPromptContaining,
   findTestCallbacksByRunId,
   insertOrgDefaultModelProvider,
+  updateOrgDefaultAgent,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -516,32 +517,29 @@ describe("POST /api/webhooks/email/inbound", () => {
     expect(JSON.stringify(args?.react)).toContain("DMARC verification failed");
   });
 
-  describe("Email Trigger (org+agent@domain)", () => {
+  describe("Email Trigger (org@domain)", () => {
     it("should dispatch agent run for valid trigger email", async () => {
       // Given a user with an org and compose
-      // setupUser creates a user with userId = "trigger-user-{suffix}" and
-      // org slug = "org-{suffix}" using the same suffix
       const user = await context.setupUser({ prefix: "trigger-user" });
 
-      // Extract suffix from userId to derive org slug
-      // userId format: "{prefix}-{suffix}" where suffix is an 8-char UUID
       const suffix = user.userId.slice("trigger-user-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("trigger-agent");
 
-      // Create compose (automatically associates with user's org)
+      // Create compose and set it as the org's default agent
       const { composeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, composeId);
 
       // Mock Clerk to return the user when looking up by email
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
 
-      // Build inbound email webhook payload with org+agent format
+      // Build inbound email webhook payload with org@domain format
       const payload = JSON.stringify({
         type: "email.received",
         data: {
           email_id: "trigger-email-123",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "Test Subject",
           created_at: new Date().toISOString(),
@@ -583,7 +581,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         replyToken: expect.any(String),
         inboundMessageId: "<default-msg-id@example.com>",
         subject: "Test Subject",
-        triggerLocalPart: `${orgSlug}+${agentName}`,
+        triggerLocalPart: orgSlug,
       });
     });
 
@@ -593,12 +591,12 @@ describe("POST /api/webhooks/email/inbound", () => {
       // Mock Clerk to return user only for registered email
       mockClerk({ userId: "some-user-id", email: "registered@example.com" });
 
-      // Send email from unregistered address
+      // Send email from unregistered address to org@domain
       const payload = JSON.stringify({
         type: "email.received",
         data: {
           email_id: "unreg-email",
-          to: ["someorg+someagent@vm7.bot"],
+          to: ["someorg@vm7.bot"],
           from: "unregistered@example.com",
           subject: "Test",
           created_at: new Date().toISOString(),
@@ -621,18 +619,18 @@ describe("POST /api/webhooks/email/inbound", () => {
       expect(args?.subject).toBe("Re: Test");
     });
 
-    it("should send error reply for trigger email to non-existent agent", async () => {
+    it("should send error reply for trigger email to non-existent org", async () => {
       mockResend.emails.receiving.get.mockClear();
 
       const senderEmail = "sender@example.com";
       mockClerk({ userId: "some-user-id", email: senderEmail });
 
-      // Send email to non-existent org/agent
+      // Send email to non-existent org
       const payload = JSON.stringify({
         type: "email.received",
         data: {
-          email_id: "no-agent-email",
-          to: ["nonexistent+fakeagent@vm7.bot"],
+          email_id: "no-org-email",
+          to: ["nonexistent@vm7.bot"],
           from: senderEmail,
           subject: "Test",
           created_at: new Date().toISOString(),
@@ -655,18 +653,15 @@ describe("POST /api/webhooks/email/inbound", () => {
       expect(args?.subject).toBe("Re: Test");
     });
 
-    it("should send error reply when user has no permission to access agent", async () => {
+    it("should send error reply when sender is not a member of the org", async () => {
       mockResend.emails.receiving.get.mockClear();
 
-      // Create a compose owned by user A
+      // Create a user with an org
       const ownerUser = await context.setupUser({ prefix: "perm-owner" });
       const suffix = ownerUser.userId.slice("perm-owner-".length);
       const orgSlug = `org-${suffix}`;
-      const agentName = uniqueId("perm-agent");
-      await createTestCompose(agentName);
 
-      // Mock Clerk to return a DIFFERENT user when looking up sender email.
-      // This user is not the compose owner, not in the org, and has no ACL entry.
+      // Mock Clerk to return a DIFFERENT user who is NOT a member of this org
       const senderEmail = "unauthorized@example.com";
       mockClerk({ userId: "unauthorized-user-id", email: senderEmail });
 
@@ -674,7 +669,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "no-perm-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "Forbidden",
           created_at: new Date().toISOString(),
@@ -687,7 +682,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       expect(response.status).toBe(200);
       await context.mocks.flushAfter();
 
-      // No email should have been fetched (early return after permission check)
+      // No email should have been fetched (early return after membership check)
       expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
 
       // Error reply should have been sent
@@ -697,12 +692,51 @@ describe("POST /api/webhooks/email/inbound", () => {
       expect(args?.subject).toBe("Re: Forbidden");
     });
 
+    it("should send error reply when org has no default agent configured", async () => {
+      mockResend.emails.receiving.get.mockClear();
+
+      // Create a user with an org but do NOT set a default agent
+      const user = await context.setupUser({ prefix: "no-default" });
+      const suffix = user.userId.slice("no-default-".length);
+      const orgSlug = `org-${suffix}`;
+
+      const senderEmail = "sender@example.com";
+      mockClerk({ userId: user.userId, email: senderEmail });
+
+      const payload = JSON.stringify({
+        type: "email.received",
+        data: {
+          email_id: "no-default-email",
+          to: [`${orgSlug}@vm7.bot`],
+          from: senderEmail,
+          subject: "No Agent",
+          created_at: new Date().toISOString(),
+        },
+      });
+
+      const request = createWebhookRequest(payload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // No email should have been fetched (early return — no default agent)
+      expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
+
+      // Error reply should have been sent
+      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
+      const args = getErrorReplyArgs();
+      expect(args?.to).toBe(senderEmail);
+      expect(args?.subject).toBe("Re: No Agent");
+    });
+
     it("should send error reply when DMARC fails", async () => {
       const user = await context.setupUser({ prefix: "dmarc-fail" });
       const suffix = user.userId.slice("dmarc-fail-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("dmarc-agent");
-      await createTestCompose(agentName);
+      const { composeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, composeId);
 
       const senderEmail = "spoofed@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
@@ -710,7 +744,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       // Override Resend mock to return dmarc=fail
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "Spoofed email",
         text: "I am pretending to be someone else",
         html: "<p>I am pretending to be someone else</p>",
@@ -724,7 +758,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "dmarc-fail-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "Spoofed email",
           created_at: new Date().toISOString(),
@@ -756,7 +790,8 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("dkim-pass-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("dkim-agent");
-      await createTestCompose(agentName);
+      const { composeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, composeId);
 
       const senderEmail = "user@nodmarc.com";
       mockClerk({ userId: user.userId, email: senderEmail });
@@ -764,7 +799,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       // Override Resend mock: dmarc=none but dkim=pass — still rejected
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "DKIM Only",
         text: "My domain has no DMARC but DKIM is valid",
         html: "<p>My domain has no DMARC but DKIM is valid</p>",
@@ -778,7 +813,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "dkim-pass-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "DKIM Only",
           created_at: new Date().toISOString(),
@@ -808,7 +843,8 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("no-auth-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("noauth-agent");
-      await createTestCompose(agentName);
+      const { composeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, composeId);
 
       const senderEmail = "user@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
@@ -816,7 +852,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       // Override Resend mock: no authentication-results header
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "No Auth Headers",
         text: "Email without authentication results",
         html: "<p>Email without authentication results</p>",
@@ -827,7 +863,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "no-auth-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "No Auth Headers",
           created_at: new Date().toISOString(),
@@ -857,7 +893,8 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("all-fail-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("allfail-agent");
-      await createTestCompose(agentName);
+      const { composeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, composeId);
 
       const senderEmail = "user@misconfigured.com";
       mockClerk({ userId: user.userId, email: senderEmail });
@@ -865,7 +902,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       // Override Resend mock: all authentication methods fail
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "All Fail",
         text: "Everything failed",
         html: "<p>Everything failed</p>",
@@ -879,7 +916,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "all-fail-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "All Fail",
           created_at: new Date().toISOString(),
@@ -909,7 +946,8 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("empty-trigger-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("empty-body-agent");
-      await createTestCompose(agentName);
+      const { composeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, composeId);
 
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
@@ -917,7 +955,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       // Return an email with empty text and empty HTML, DMARC passes
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "",
         text: "",
         html: "",
@@ -931,7 +969,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "empty-body-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "",
           created_at: new Date().toISOString(),
@@ -956,7 +994,8 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("html-trigger-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("html-agent");
-      await createTestCompose(agentName);
+      const { composeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, composeId);
 
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
@@ -964,7 +1003,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       // Override Resend mock to return HTML-only content (empty text)
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "Newsletter",
         text: "",
         html: "<p>Rich content from newsletter</p>",
@@ -978,7 +1017,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "html-only-trigger",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "Newsletter",
           created_at: new Date().toISOString(),
@@ -1066,7 +1105,8 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("att-trigger-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("att-agent");
-      await createTestCompose(agentName);
+      const { composeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, composeId);
 
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
@@ -1074,7 +1114,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       // Mock Resend to return email with attachment metadata
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "With Attachment",
         text: "Please review the attached file",
         html: "<p>Please review the attached file</p>",
@@ -1122,7 +1162,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "trigger-att-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "With Attachment",
           created_at: new Date().toISOString(),
@@ -1161,14 +1201,16 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("att-oversize-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("oversize-agent");
-      await createTestCompose(agentName);
+      const { composeId: oversizeComposeId } =
+        await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, oversizeComposeId);
 
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
 
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "Big File",
         text: "See attached",
         html: "<p>See attached</p>",
@@ -1194,7 +1236,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "oversize-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "Big File",
           created_at: new Date().toISOString(),
@@ -1222,14 +1264,15 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("att-dl-fail-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("dlfail-agent");
-      await createTestCompose(agentName);
+      const { composeId: dlfailComposeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, dlfailComposeId);
 
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
 
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "Broken Attachment",
         text: "File attached",
         html: "<p>File attached</p>",
@@ -1263,7 +1306,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "dl-fail-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "Broken Attachment",
           created_at: new Date().toISOString(),
@@ -1291,14 +1334,15 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("att-mixed-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("mixed-agent");
-      await createTestCompose(agentName);
+      const { composeId: mixedComposeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, mixedComposeId);
 
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
 
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "Multiple Files",
         text: "Several attachments",
         html: "<p>Several attachments</p>",
@@ -1356,7 +1400,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "mixed-att-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "Multiple Files",
           created_at: new Date().toISOString(),
@@ -1397,7 +1441,8 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("inline-img-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("inline-agent");
-      await createTestCompose(agentName);
+      const { composeId: inlineComposeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, inlineComposeId);
 
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
@@ -1406,7 +1451,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       const fakeBase64 = "A".repeat(1000);
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "Check this photo",
         text: "",
         html: `<p>Can you see what I'm doing?</p><img src="data:image/jpeg;base64,${fakeBase64}" alt="photo.jpg">`,
@@ -1444,7 +1489,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "inline-img-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "Check this photo",
           created_at: new Date().toISOString(),
@@ -1480,7 +1525,8 @@ describe("POST /api/webhooks/email/inbound", () => {
       const suffix = user.userId.slice("inline-noalt-".length);
       const orgSlug = `org-${suffix}`;
       const agentName = uniqueId("noalt-agent");
-      await createTestCompose(agentName);
+      const { composeId: noaltComposeId } = await createTestCompose(agentName);
+      await updateOrgDefaultAgent(user.orgId, noaltComposeId);
 
       const senderEmail = "sender@example.com";
       mockClerk({ userId: user.userId, email: senderEmail });
@@ -1489,7 +1535,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       const fakeBase64 = "B".repeat(500);
       mockReceivedEmailGet({
         from: senderEmail,
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         subject: "No Alt Image",
         text: "",
         html: `<p>Look at this</p><img src="data:image/png;base64,${fakeBase64}">`,
@@ -1524,7 +1570,7 @@ describe("POST /api/webhooks/email/inbound", () => {
         type: "email.received",
         data: {
           email_id: "noalt-img-email",
-          to: [`${orgSlug}+${agentName}@vm7.bot`],
+          to: [`${orgSlug}@vm7.bot`],
           from: senderEmail,
           subject: "No Alt Image",
           created_at: new Date().toISOString(),
@@ -1651,53 +1697,21 @@ describe("POST /api/webhooks/email/inbound", () => {
     });
   });
 
-  describe("Email Trigger (agent@domain, auto-detect org)", () => {
-    it("should send error reply for agent-only email without org context", async () => {
-      const user = await context.setupUser({ prefix: "auto-org" });
-      const agentName = uniqueId("auto-agent");
-      await createTestCompose(agentName);
+  describe("Email Trigger — old format rejection", () => {
+    it("should send error reply for old org+agent format", async () => {
+      mockResend.emails.receiving.get.mockClear();
 
       const senderEmail = "sender@example.com";
-      mockClerk({ userId: user.userId, email: senderEmail });
+      mockClerk({ userId: "some-user-id", email: senderEmail });
 
-      // Send to agentname@domain (no org, no plus sign) — no org context
+      // Old format: org+agent@domain — rejected by parseOrgEmailAddress
       const payload = JSON.stringify({
         type: "email.received",
         data: {
-          email_id: "auto-org-email",
-          to: [`${agentName}@vm7.bot`],
+          email_id: "old-format-email",
+          to: ["someorg+someagent@vm7.bot"],
           from: senderEmail,
-          subject: "Auto Org Test",
-          created_at: new Date().toISOString(),
-        },
-      });
-
-      const request = createWebhookRequest(payload);
-      const response = await POST(request);
-
-      expect(response.status).toBe(200);
-      await context.mocks.flushAfter();
-
-      // Without org context, the handler sends an error reply
-      const runs = await findTestRunsByUserAndPromptContaining(
-        user.userId,
-        "Auto Org Test",
-      );
-      expect(runs).toHaveLength(0);
-    });
-
-    it("should send error reply for agent-only email from unregistered sender", async () => {
-      mockResend.emails.receiving.get.mockClear();
-      mockClerk({ userId: "some-user-id", email: "registered@example.com" });
-
-      const senderEmail = "unregistered@example.com";
-      const payload = JSON.stringify({
-        type: "email.received",
-        data: {
-          email_id: "unreg-auto-email",
-          to: ["someagent@vm7.bot"],
-          from: senderEmail,
-          subject: "Test",
+          subject: "Old Format",
           created_at: new Date().toISOString(),
         },
       });
@@ -1709,59 +1723,23 @@ describe("POST /api/webhooks/email/inbound", () => {
       await context.mocks.flushAfter();
 
       expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
-
-      // Error reply should have been sent
       expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
       expect(getErrorReplyArgs()?.to).toBe(senderEmail);
     });
 
-    it("should send error reply for agent-only email when sender has no org", async () => {
+    it("should send error reply for old org/agent format", async () => {
       mockResend.emails.receiving.get.mockClear();
 
-      // Mock Clerk to return a userId that has no org in the database
-      const senderEmail = "noorguser@example.com";
-      mockClerk({ userId: "no-org-user-id", email: senderEmail });
-
-      const payload = JSON.stringify({
-        type: "email.received",
-        data: {
-          email_id: "no-org-email",
-          to: ["someagent@vm7.bot"],
-          from: senderEmail,
-          subject: "Test",
-          created_at: new Date().toISOString(),
-        },
-      });
-
-      const request = createWebhookRequest(payload);
-      const response = await POST(request);
-
-      expect(response.status).toBe(200);
-      await context.mocks.flushAfter();
-
-      // No email fetch should have happened (early return after org lookup failed)
-      expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
-
-      // Error reply should have been sent
-      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
-      expect(getErrorReplyArgs()?.to).toBe(senderEmail);
-    });
-
-    it("should send error reply for agent-only email to non-existent agent", async () => {
-      mockResend.emails.receiving.get.mockClear();
-
-      const user = await context.setupUser({ prefix: "no-agent" });
       const senderEmail = "sender@example.com";
-      mockClerk({ userId: user.userId, email: senderEmail });
+      mockClerk({ userId: "some-user-id", email: senderEmail });
 
-      // Send to an agent that doesn't exist in the sender's org
       const payload = JSON.stringify({
         type: "email.received",
         data: {
-          email_id: "no-agent-auto-email",
-          to: ["nonexistent@vm7.bot"],
+          email_id: "old-slash-email",
+          to: ["someorg/someagent@vm7.bot"],
           from: senderEmail,
-          subject: "Test",
+          subject: "Old Slash Format",
           created_at: new Date().toISOString(),
         },
       });
@@ -1773,58 +1751,6 @@ describe("POST /api/webhooks/email/inbound", () => {
       await context.mocks.flushAfter();
 
       expect(mockResend.emails.receiving.get).not.toHaveBeenCalled();
-
-      // Error reply should have been sent
-      expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
-      expect(getErrorReplyArgs()?.to).toBe(senderEmail);
-    });
-
-    it("should send error reply for agent-only email when DMARC fails", async () => {
-      const user = await context.setupUser({ prefix: "auto-dmarc" });
-      const agentName = uniqueId("auto-dmarc-agent");
-      await createTestCompose(agentName);
-
-      const senderEmail = "spoofed@example.com";
-      mockClerk({ userId: user.userId, email: senderEmail });
-
-      // Override Resend mock to return dmarc=fail
-      mockReceivedEmailGet({
-        from: senderEmail,
-        to: [`${agentName}@vm7.bot`],
-        subject: "Spoofed auto-org",
-        text: "I am pretending to be someone else",
-        html: "<p>I am pretending to be someone else</p>",
-        headers: {
-          "authentication-results":
-            "mx.resend.com; dkim=fail; spf=fail; dmarc=fail",
-        },
-      });
-
-      const payload = JSON.stringify({
-        type: "email.received",
-        data: {
-          email_id: "auto-dmarc-fail-email",
-          to: [`${agentName}@vm7.bot`],
-          from: senderEmail,
-          subject: "Spoofed auto-org",
-          created_at: new Date().toISOString(),
-        },
-      });
-
-      const request = createWebhookRequest(payload);
-      const response = await POST(request);
-
-      expect(response.status).toBe(200);
-      await context.mocks.flushAfter();
-
-      // No run should have been created
-      const runs = await findTestRunsByUserAndPrompt(
-        user.userId,
-        "Spoofed auto-org\n\nI am pretending to be someone else",
-      );
-      expect(runs).toHaveLength(0);
-
-      // Error reply should have been sent
       expect(mockResend.emails.send).toHaveBeenCalledTimes(1);
       expect(getErrorReplyArgs()?.to).toBe(senderEmail);
     });
@@ -1869,7 +1795,8 @@ describe("POST /api/webhooks/email/inbound", () => {
     const suffix = user.userId.slice("crash-user-".length);
     const orgSlug = `org-${suffix}`;
     const agentName = uniqueId("crash-agent");
-    await createTestCompose(agentName);
+    const { composeId: crashComposeId } = await createTestCompose(agentName);
+    await updateOrgDefaultAgent(user.orgId, crashComposeId);
 
     // Mock Clerk to return the user when looking up by email
     const senderEmail = "crash-sender@example.com";
@@ -1884,7 +1811,7 @@ describe("POST /api/webhooks/email/inbound", () => {
       type: "email.received",
       data: {
         email_id: "crash-email-123",
-        to: [`${orgSlug}+${agentName}@vm7.bot`],
+        to: [`${orgSlug}@vm7.bot`],
         from: senderEmail,
         subject: "Test crash",
         created_at: new Date().toISOString(),

--- a/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/email/handlers/__tests__/shared.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
-  parseInboundEmailAddress,
+  parseOrgEmailAddress,
   isReplyAddress,
   computeReplyRecipients,
   verifyUnsubscribeToken,
@@ -8,90 +8,41 @@ import {
   buildUnsubscribeHeaders,
 } from "../shared";
 
-describe("parseInboundEmailAddress", () => {
-  it("should parse runtimeorg+agentorg/agentname format", () => {
-    const result = parseInboundEmailAddress("alice+acme/support-bot@vm0.bot");
-    expect(result).toEqual({
-      runtimeOrg: "alice",
-      agentOrg: "acme",
-      agentName: "support-bot",
-    });
+describe("parseOrgEmailAddress", () => {
+  it("should parse org slug from email address", () => {
+    expect(parseOrgEmailAddress("acme@vm0.bot")).toBe("acme");
   });
 
-  it("should parse agentorg/agentname format", () => {
-    const result = parseInboundEmailAddress("acme/support-bot@vm0.bot");
-    expect(result).toEqual({
-      runtimeOrg: null,
-      agentOrg: "acme",
-      agentName: "support-bot",
-    });
+  it("should parse hyphenated org slug", () => {
+    expect(parseOrgEmailAddress("my-org@vm0.bot")).toBe("my-org");
   });
 
-  it("should parse legacy org+agent format", () => {
-    const result = parseInboundEmailAddress("lancy+my-agent@vm0.bot");
-    expect(result).toEqual({
-      runtimeOrg: null,
-      agentOrg: "lancy",
-      agentName: "my-agent",
-    });
-  });
-
-  it("should parse agent-only format", () => {
-    const result = parseInboundEmailAddress("support-bot@vm0.bot");
-    expect(result).toEqual({
-      runtimeOrg: null,
-      agentOrg: null,
-      agentName: "support-bot",
-    });
-  });
-
-  it("should return null for reply address", () => {
-    expect(parseInboundEmailAddress("reply+token123@vm0.bot")).toBeNull();
+  it("should parse org slug with numbers", () => {
+    expect(parseOrgEmailAddress("org123@vm0.bot")).toBe("org123");
   });
 
   it("should normalize to lowercase", () => {
-    const result = parseInboundEmailAddress("ALICE+ACME/SUPPORT-BOT@vm0.bot");
-    expect(result).toEqual({
-      runtimeOrg: "alice",
-      agentOrg: "acme",
-      agentName: "support-bot",
-    });
+    expect(parseOrgEmailAddress("ACME@vm0.bot")).toBe("acme");
   });
 
-  it("should handle numbers in all parts", () => {
-    const result = parseInboundEmailAddress("org1+org2/agent3@vm0.bot");
-    expect(result).toEqual({
-      runtimeOrg: "org1",
-      agentOrg: "org2",
-      agentName: "agent3",
-    });
+  it("should return null for reply address", () => {
+    expect(parseOrgEmailAddress("reply+token@vm0.bot")).toBeNull();
   });
 
-  it("should handle hyphens in all parts", () => {
-    const result = parseInboundEmailAddress(
-      "my-runtime+my-org/my-agent@vm0.bot",
-    );
-    expect(result).toEqual({
-      runtimeOrg: "my-runtime",
-      agentOrg: "my-org",
-      agentName: "my-agent",
-    });
+  it("should return null for plus sign address (old format)", () => {
+    expect(parseOrgEmailAddress("org+agent@vm0.bot")).toBeNull();
+  });
+
+  it("should return null for slash address (old format)", () => {
+    expect(parseOrgEmailAddress("org/agent@vm0.bot")).toBeNull();
+  });
+
+  it("should return null for empty local part", () => {
+    expect(parseOrgEmailAddress("@vm0.bot")).toBeNull();
   });
 
   it("should return null for empty string", () => {
-    expect(parseInboundEmailAddress("")).toBeNull();
-  });
-
-  it("should return null for address with only @domain", () => {
-    expect(parseInboundEmailAddress("@vm0.bot")).toBeNull();
-  });
-
-  it("should return null for slash without agent name", () => {
-    expect(parseInboundEmailAddress("org/@vm0.bot")).toBeNull();
-  });
-
-  it("should return null for slash without org name", () => {
-    expect(parseInboundEmailAddress("/agent@vm0.bot")).toBeNull();
+    expect(parseOrgEmailAddress("")).toBeNull();
   });
 });
 

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -3,8 +3,8 @@ import { processEmailAttachments } from "../attachment";
 import { extractEmailBody } from "../content-extract";
 import { verifySenderAuthenticity } from "../sender-auth";
 import {
-  parseInboundEmailAddress,
-  resolveAgentByAddress,
+  parseOrgEmailAddress,
+  resolveDefaultAgent,
   generateReplyToken,
   computeReplyRecipients,
   getFromDomain,
@@ -14,8 +14,8 @@ import { createZeroRun } from "../../zero/zero-run-service";
 import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
 import { getUserIdByEmail } from "../../auth/get-user-id-by-email";
-import { resolveOrgOrNull } from "../../org/resolve-org";
-import { canAccessCompose } from "../../agent/compose-access";
+import { getOrgBySlug } from "../../org/org-cache-service";
+import { verifyMembershipCached } from "../../org/org-membership-cache";
 import { logger } from "../../logger";
 
 const log = logger("email:inbound-trigger");
@@ -32,44 +32,33 @@ interface InboundEmailEvent {
 }
 
 interface ResolvedTrigger {
-  agentOrg: string;
-  agentName: string;
-  runtimeOrgId: string;
-  runtimeOrgSlug: string;
-  triggerLocalPart: string;
+  orgId: string;
+  orgSlug: string;
   userId: string;
+  composeId: string;
+  agentId: string;
 }
 
 /**
- * Parse trigger address from recipients and resolve the sender's user ID.
- *
- * Supports four address formats:
- * - runtimeorg+agentorg/agentname@domain (explicit runtime + agent org)
- * - agentorg/agentname@domain            (agent org explicit, runtime from user default)
- * - org+agent@domain                     (legacy: agentOrg=org, runtime from user default)
- * - agent@domain                         (both from user default)
+ * Parse org address from recipients, resolve sender, org, membership, and default agent.
  */
 async function resolveTrigger(
   to: string[],
   senderEmail: string,
 ): Promise<ResolvedTrigger | HandlerResult> {
-  // 1. Parse inbound address from recipients
-  let parsed = null;
-  let matchedAddress = "";
+  // 1. Parse org slug from recipients
+  let orgSlug: string | null = null;
   for (const addr of to) {
-    parsed = parseInboundEmailAddress(addr);
-    if (parsed) {
-      matchedAddress = addr;
-      break;
-    }
+    orgSlug = parseOrgEmailAddress(addr);
+    if (orgSlug) break;
   }
 
-  if (!parsed) {
-    log.debug("No trigger address found in recipients", { to });
+  if (!orgSlug) {
+    log.debug("No org address found in recipients", { to });
     return {
       ok: false,
       errorMessage:
-        "The email address could not be recognized as a valid agent address.",
+        "The email address could not be recognized as a valid org address.",
     };
   }
 
@@ -83,42 +72,42 @@ async function resolveTrigger(
     };
   }
 
-  // 3. Resolve runtime org (explicit slug from address, or agent's org as fallback)
-  const runtimeOrg = await resolveOrgOrNull(
-    { userId },
-    parsed.runtimeOrg ?? parsed.agentOrg,
-  );
-  if (!runtimeOrg) {
-    const msg = parsed.runtimeOrg
-      ? `Workspace "${parsed.runtimeOrg}" was not found.`
-      : "Your account does not have a workspace configured.";
-    log.debug("Runtime org resolution failed", {
-      from: senderEmail,
-      userId,
-      explicitOrg: parsed.runtimeOrg,
-    });
-    return { ok: false, errorMessage: msg };
+  // 3. Resolve org by slug
+  const orgData = await getOrgBySlug(orgSlug);
+  if (!orgData) {
+    log.debug("Org not found", { orgSlug });
+    return {
+      ok: false,
+      errorMessage: `Workspace "${orgSlug}" was not found.`,
+    };
   }
-  const runtimeOrgId = runtimeOrg.orgId;
-  const runtimeOrgSlug = runtimeOrg.slug;
 
-  // 4. Resolve agent org (defaults to runtime org if not specified)
-  const agentOrg = parsed.agentOrg ?? runtimeOrgSlug;
+  // 4. Verify org membership
+  const membership = await verifyMembershipCached(orgData.orgId, userId);
+  if (!membership) {
+    log.debug("User is not a member of org", { userId, orgId: orgData.orgId });
+    return {
+      ok: false,
+      errorMessage: "You are not a member of this workspace.",
+    };
+  }
 
-  // 5. Extract trigger local part from the matched address for reply-from
-  const atIndex = matchedAddress.indexOf("@");
-  const triggerLocalPart =
-    atIndex > 0
-      ? matchedAddress.slice(0, atIndex).toLowerCase()
-      : parsed.agentName;
+  // 5. Resolve default agent
+  const agent = await resolveDefaultAgent(orgData.orgId);
+  if (!agent) {
+    log.debug("No default agent configured", { orgId: orgData.orgId });
+    return {
+      ok: false,
+      errorMessage: "This workspace does not have a default agent configured.",
+    };
+  }
 
   return {
-    agentOrg,
-    agentName: parsed.agentName,
-    runtimeOrgId,
-    runtimeOrgSlug,
-    triggerLocalPart,
+    orgId: orgData.orgId,
+    orgSlug,
     userId,
+    composeId: agent.composeId,
+    agentId: agent.agentId,
   };
 }
 
@@ -126,10 +115,10 @@ async function resolveTrigger(
  * Handle an inbound email that triggers an agent run.
  *
  * Flow:
- * 1. Parse trigger address from recipients (org+agent or agent-only)
- * 2. Look up sender email in Clerk to get user ID
- * 3. Resolve agent by org slug + agent name
- * 4. Check if user has permission to access the agent
+ * 1. Parse org address from recipients
+ * 2. Look up sender email to get user ID
+ * 3. Verify org membership
+ * 4. Resolve org's default agent
  * 5. Fetch full email and verify sender via DMARC
  * 6. Create agent run with callback for response delivery
  *
@@ -140,53 +129,16 @@ export async function handleInboundEmailTrigger(
 ): Promise<HandlerResult> {
   const { email_id: emailId, to, from: senderEmail, subject } = event.data;
 
-  // 1-2. Resolve trigger address and sender
+  // 1-4. Resolve trigger: address, sender, org, membership, default agent
   const resolved = await resolveTrigger(to, senderEmail);
   if ("ok" in resolved) return resolved;
 
-  const {
-    agentOrg,
-    agentName,
-    runtimeOrgId,
-    runtimeOrgSlug,
-    triggerLocalPart,
-    userId,
-  } = resolved;
+  const { orgId, orgSlug, userId, composeId, agentId } = resolved;
 
   log.debug("Processing email trigger", {
-    agentOrg,
-    agentName,
-    runtimeOrg: runtimeOrgSlug,
+    orgSlug,
     from: senderEmail,
   });
-
-  // 3. Resolve agent
-  const compose = await resolveAgentByAddress(agentOrg, agentName);
-  if (!compose) {
-    log.debug("Agent not found", { org: agentOrg, agent: agentName });
-    return {
-      ok: false,
-      errorMessage: `Agent "${agentName}" was not found in org "${agentOrg}".`,
-    };
-  }
-
-  // 4. Check permission
-  const hasAccess = canAccessCompose(userId, runtimeOrgId, {
-    id: compose.composeId,
-    userId: compose.userId,
-    orgId: compose.orgId,
-  });
-
-  if (!hasAccess) {
-    log.debug("User does not have access to agent", {
-      userId,
-      composeId: compose.composeId,
-    });
-    return {
-      ok: false,
-      errorMessage: "You do not have permission to access this agent.",
-    };
-  }
 
   // 5. Fetch full email
   const email = await getReceivedEmail(emailId);
@@ -259,15 +211,15 @@ export async function handleInboundEmailTrigger(
       secret: generateCallbackSecret(),
       payload: {
         senderEmail,
-        composeId: compose.composeId,
+        composeId,
         userId,
         inboundEmailId: emailId,
         replyToken,
         inboundMessageId,
         inboundReferences,
         subject,
-        triggerLocalPart,
-        runtimeOrgId,
+        triggerLocalPart: orgSlug,
+        runtimeOrgId: orgId,
         replyRecipientTo: replyRecipients.to,
         replyRecipientCc: replyRecipients.cc,
       },
@@ -280,7 +232,7 @@ export async function handleInboundEmailTrigger(
     userId,
     prompt,
     appendSystemPrompt,
-    agentId: compose.agentId,
+    agentId,
     triggerSource: "email",
     callbacks,
   });
@@ -288,9 +240,7 @@ export async function handleInboundEmailTrigger(
   log.info("Dispatched agent run from email trigger", {
     runId: result.runId,
     emailId,
-    agentOrg,
-    agentName,
-    runtimeOrg: runtimeOrgSlug,
+    orgSlug,
   });
 
   return { ok: true };

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -3,7 +3,8 @@ import { eq, and } from "drizzle-orm";
 import { emailThreadSessions } from "../../../db/schema/email-thread-session";
 import { agentComposes } from "../../../db/schema/agent-compose";
 import { zeroAgents } from "../../../db/schema/zero-agent";
-import { getOrgBySlug } from "../../org/org-cache-service";
+import { orgMetadata } from "../../../db/schema/org-metadata";
+import { resolveDefaultAgentComposeId } from "../../agent-compose/resolve-default";
 import { env } from "../../../env";
 import { getAppUrl } from "../../url";
 import { getApiUrl } from "../../callback/dispatcher";
@@ -19,137 +20,17 @@ export type HandlerResult = { ok: true } | { ok: false; errorMessage: string };
 // Email Address Parsing
 // ============================================================================
 
-interface EmailTriggerAddress {
-  org: string;
-  agent: string;
-}
-
 /**
- * Parse a trigger email address in the format: org+agent@domain
- * Returns null if the address doesn't match the expected format.
- *
- * Examples:
- * - "lancy+my-agent@vm0.bot" → { org: "lancy", agent: "my-agent" }
- * - "reply+token@vm0.bot" → null (reply address, not trigger)
- * - "invalid@vm0.bot" → null (no plus sign)
+ * Parse an org-level email address: org@domain
+ * Returns the org slug, or null if not a valid org address.
+ * Excludes reply+token addresses and old formats with + or /.
  */
-function parseEmailTriggerAddress(
-  toAddress: string,
-): EmailTriggerAddress | null {
-  // Match: org+agent@domain (case-insensitive)
-  // Org and agent must start with alphanumeric, can contain hyphens
-  const match = toAddress.match(
-    /^([a-z0-9][a-z0-9-]*)\+([a-z0-9][a-z0-9-]*)@/i,
-  );
-  if (!match || !match[1] || !match[2]) return null;
-
-  const org = match[1].toLowerCase();
-  const agent = match[2].toLowerCase();
-
-  // Exclude reply addresses (reply+token@domain)
-  if (org === "reply") return null;
-
-  return { org, agent };
-}
-
-/**
- * Parse an agent-only email address in the format: agent@domain
- * Returns the agent name if the address is a simple local-part (no plus sign),
- * or null if the address contains a plus sign or doesn't match.
- *
- * Examples:
- * - "my-agent@vm0.bot" → "my-agent"
- * - "org+agent@vm0.bot" → null (has plus sign, use parseEmailTriggerAddress)
- * - "reply+token@vm0.bot" → null (has plus sign)
- * - "@vm0.bot" → null (empty local part)
- */
-function parseAgentOnlyAddress(toAddress: string): string | null {
-  if (toAddress.includes("+")) return null;
-
+export function parseOrgEmailAddress(toAddress: string): string | null {
+  if (isReplyAddress(toAddress)) return null;
+  if (toAddress.includes("+") || toAddress.includes("/")) return null;
   const match = toAddress.match(/^([a-z0-9][a-z0-9-]*)@/i);
   if (!match?.[1]) return null;
-
   return match[1].toLowerCase();
-}
-
-/**
- * Parsed inbound email address with separate runtime org and agent org.
- *
- * - runtimeOrg: explicit runtime org slug, or null (resolve from user default)
- * - agentOrg: explicit agent org slug, or null (same as runtime org)
- * - agentName: the agent name
- */
-interface ParsedEmailAddress {
-  runtimeOrg: string | null;
-  agentOrg: string | null;
-  agentName: string;
-}
-
-// Slug segment: starts with alphanumeric, may contain hyphens
-const SLUG = "[a-z0-9][a-z0-9-]*";
-
-// runtimeorg+agentorg/agentname@domain
-const RE_FULL = new RegExp(`^(${SLUG})\\+(${SLUG})/(${SLUG})@`, "i");
-// agentorg/agentname@domain
-const RE_ORG_SLASH_AGENT = new RegExp(`^(${SLUG})/(${SLUG})@`, "i");
-
-/**
- * Unified inbound email address parser.
- *
- * Supports four formats (tried in order of specificity):
- * 1. runtimeorg+agentorg/agentname@domain  → explicit runtime + agent org
- * 2. agentorg/agentname@domain             → agent org explicit, runtime from user default
- * 3. org+agent@domain (legacy)             → agentOrg=org, runtime from user default
- * 4. agentname@domain                      → both orgs from user default
- *
- * Returns null for reply+token addresses and unrecognized formats.
- */
-export function parseInboundEmailAddress(
-  toAddress: string,
-): ParsedEmailAddress | null {
-  if (isReplyAddress(toAddress)) return null;
-
-  // 1. runtimeorg+agentorg/agentname@domain
-  const fullMatch = toAddress.match(RE_FULL);
-  if (fullMatch?.[1] && fullMatch[2] && fullMatch[3]) {
-    return {
-      runtimeOrg: fullMatch[1].toLowerCase(),
-      agentOrg: fullMatch[2].toLowerCase(),
-      agentName: fullMatch[3].toLowerCase(),
-    };
-  }
-
-  // 2. agentorg/agentname@domain
-  const slashMatch = toAddress.match(RE_ORG_SLASH_AGENT);
-  if (slashMatch?.[1] && slashMatch[2]) {
-    return {
-      runtimeOrg: null,
-      agentOrg: slashMatch[1].toLowerCase(),
-      agentName: slashMatch[2].toLowerCase(),
-    };
-  }
-
-  // 3. org+agent@domain (legacy)
-  const triggerAddr = parseEmailTriggerAddress(toAddress);
-  if (triggerAddr) {
-    return {
-      runtimeOrg: null,
-      agentOrg: triggerAddr.org,
-      agentName: triggerAddr.agent,
-    };
-  }
-
-  // 4. agentname@domain
-  const agentOnly = parseAgentOnlyAddress(toAddress);
-  if (agentOnly) {
-    return {
-      runtimeOrg: null,
-      agentOrg: null,
-      agentName: agentOnly,
-    };
-  }
-
-  return null;
 }
 
 /**
@@ -250,55 +131,61 @@ export function computeReplyRecipients(opts: {
 // Agent Resolution
 // ============================================================================
 
-interface ResolvedAgent {
+interface ResolvedDefaultAgent {
   composeId: string;
   agentId: string;
   userId: string;
   orgId: string;
-  orgSlug: string;
   headVersionId: string;
 }
 
 /**
- * Resolve an agent compose by org slug and agent name.
- * Returns compose details if found, null otherwise.
+ * Resolve the org's default agent.
+ * Looks up default_agent_compose_id from org_metadata, falls back to VM0_DEFAULT_AGENT env var.
  */
-export async function resolveAgentByAddress(
-  orgSlug: string,
-  agentName: string,
-): Promise<ResolvedAgent | null> {
-  // 1. Resolve org by slug via org cache
-  const orgData = await getOrgBySlug(orgSlug);
-  if (!orgData) return null;
+export async function resolveDefaultAgent(
+  orgId: string,
+): Promise<ResolvedDefaultAgent | null> {
+  // 1. Look up default compose ID from org_metadata
+  const [orgRow] = await globalThis.services.db
+    .select({ defaultAgentComposeId: orgMetadata.defaultAgentComposeId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
 
-  // 2. Find compose by orgId + name
+  let composeId = orgRow?.defaultAgentComposeId ?? null;
+
+  // 2. Fallback to VM0_DEFAULT_AGENT env var
+  if (!composeId) {
+    composeId = await resolveDefaultAgentComposeId();
+  }
+
+  if (!composeId) return null;
+
+  // 3. Look up compose details
   const [compose] = await globalThis.services.db
     .select({
       id: agentComposes.id,
       userId: agentComposes.userId,
       orgId: agentComposes.orgId,
+      name: agentComposes.name,
       headVersionId: agentComposes.headVersionId,
     })
     .from(agentComposes)
-    .where(
-      and(
-        eq(agentComposes.orgId, orgData.orgId),
-        eq(agentComposes.name, agentName),
-      ),
-    )
+    .where(eq(agentComposes.id, composeId))
     .limit(1);
 
-  if (!compose) return null;
-
-  // Compose must have a published version to be triggerable
-  if (!compose.headVersionId) return null;
+  if (!compose || !compose.headVersionId) return null;
 
   // 3. Resolve agentId by (orgId, name)
   const [agent] = await globalThis.services.db
     .select({ id: zeroAgents.id })
     .from(zeroAgents)
     .where(
-      and(eq(zeroAgents.orgId, orgData.orgId), eq(zeroAgents.name, agentName)),
+      and(
+        eq(zeroAgents.orgId, compose.orgId),
+        eq(zeroAgents.name, compose.name),
+      ),
     )
     .limit(1);
 
@@ -309,7 +196,6 @@ export async function resolveAgentByAddress(
     agentId: agent.id,
     userId: compose.userId,
     orgId: compose.orgId,
-    orgSlug,
     headVersionId: compose.headVersionId,
   };
 }
@@ -376,11 +262,10 @@ export function buildReplyToAddress(token: string): string {
 
 /**
  * Build the from address for outbound emails.
- * The localPart is used as both the display name prefix and the email local part,
- * so the response mirrors the address the user sent to.
+ * Display name is always "Zero"; localPart is the org slug used as the email local part.
  */
 export function buildFromAddress(localPart: string): string {
-  return `${localPart} from VM0 <${localPart}@${getFromDomain()}>`;
+  return `Zero <${localPart}@${getFromDomain()}>`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace 4 inbound email address formats (`runtimeorg+agentorg/agentname@`, `agentorg/agentname@`, `org+agent@`, `agentname@`) with a single `org@domain` format that routes to the org's default zero agent
- Update permission model from agent-level (`canAccessCompose`) to org membership (`verifyMembershipCached`)
- Simplify `buildFromAddress` display name from `"${localPart} from VM0"` to `"Zero"`

Closes #6296

## Changes

**`shared.ts`** — Core rewrite:
- Remove `parseEmailTriggerAddress()`, `parseAgentOnlyAddress()`, `parseInboundEmailAddress()` and related types/regex
- Add `parseOrgEmailAddress()` — simple org slug extraction
- Replace `resolveAgentByAddress()` with `resolveDefaultAgent()` — looks up `defaultAgentComposeId` from `org_metadata`, falls back to `VM0_DEFAULT_AGENT` env var

**`inbound-trigger.ts`** — Simplified trigger flow:
- New `resolveTrigger()`: parse org slug → resolve sender → resolve org → verify membership → resolve default agent
- Remove separate agent resolution and `canAccessCompose` permission check

**Tests** — Updated for new format:
- 35 unit tests pass (shared.test.ts)
- 33 integration tests pass (route.test.ts)
- New test cases for non-member sender and no default agent configured

## Test plan

- [x] Unit tests: `parseOrgEmailAddress` correctly parses org slugs, rejects old formats
- [x] Integration tests: trigger flow with `org@domain`, membership verification, default agent resolution
- [x] Lint, type-check, format, knip all pass
- [x] Reply flow (inbound-reply.ts) unchanged and unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)