### PR TITLE
refactor: update email callback from addresses to use org slug

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/__tests__/route.test.ts
@@ -164,6 +164,8 @@ describe("POST /api/internal/callbacks/email/reply", () => {
         headers: Record<string, string>;
       };
       expect(sendArgs.to).toBe("test@example.com");
+      // From address uses org slug instead of agent name
+      expect(sendArgs.from).toMatch(/^org-[a-f0-9]+ from VM0/);
       expect(sendArgs.replyTo).toContain("reply+");
       expect(sendArgs.headers["In-Reply-To"]).toBe(
         "<user-reply@mail.example.com>",

--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
@@ -15,6 +15,7 @@ import {
   buildUnsubscribeUrl,
   buildUnsubscribeHeaders,
 } from "../../../../../../src/lib/email/handlers/shared";
+import { getOrgData } from "../../../../../../src/lib/org/org-cache-service";
 import type { EmailReplyCallbackPayload } from "../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/logger";
 
@@ -125,7 +126,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Get compose name
   const [compose] = await globalThis.services.db
-    .select({ name: agentComposes.name })
+    .select({ name: agentComposes.name, orgId: agentComposes.orgId })
     .from(agentComposes)
     .where(eq(agentComposes.id, session.composeId))
     .limit(1);
@@ -133,6 +134,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!compose) {
     return errorResponse("Compose not found", 404);
   }
+
+  // Resolve org slug for from address
+  const orgId = session.orgId ?? compose.orgId;
+  const org = await getOrgData(orgId);
 
   // Get user email
   const userEmail = await getUserEmail(session.userId);
@@ -173,7 +178,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Send response email via outbox queue
   await enqueueEmail({
-    from: buildFromAddress(compose.name),
+    from: buildFromAddress(org.slug),
     to: emailTo,
     subject: `Re: VM0 - Scheduled run for "${compose.name}" completed`,
     template: {

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/__tests__/route.test.ts
@@ -223,7 +223,8 @@ describe("POST /api/internal/callbacks/email/schedule", () => {
       };
       expect(sendArgs.to).toBe("test@example.com");
       expect(sendArgs.subject).toContain("completed");
-      expect(sendArgs.from).toContain("sched-agent");
+      // From address uses org slug instead of agent name
+      expect(sendArgs.from).toMatch(/^org-[a-f0-9]+ from VM0/);
     });
 
     it("should send failure email for failed scheduled run", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
@@ -102,8 +102,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Resolve compose and org slug for from address
   const compose = await resolveComposeByZeroAgentId(payload.zeroAgentId);
-  const org = compose ? await getOrgData(compose.orgId) : null;
-  const fromLocalPart = org?.slug ?? "vm0";
+  if (!compose) {
+    return errorResponse("Compose not found for zero agent", 404);
+  }
+  const org = await getOrgData(compose.orgId);
 
   if (status === "completed") {
     // Get agent output
@@ -129,7 +131,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const replyToAddress = buildReplyToAddress(replyToken);
 
     await enqueueEmail({
-      from: buildFromAddress(fromLocalPart),
+      from: buildFromAddress(org.slug),
       to: userEmail,
       subject: `VM0 - Scheduled run for "${agentName}" completed`,
       template: {
@@ -143,21 +145,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       },
       replyTo: replyToAddress,
       headers: unsubscribeHeaders,
-      threadAction:
-        agentSessionId && compose
-          ? {
-              action: "save_thread_session" as const,
-              userId,
-              composeId: compose.id,
-              agentSessionId,
-              replyToToken: replyToken,
-            }
-          : undefined,
+      threadAction: agentSessionId
+        ? {
+            action: "save_thread_session" as const,
+            userId,
+            composeId: compose.id,
+            agentSessionId,
+            replyToToken: replyToken,
+          }
+        : undefined,
     });
   } else {
     // Failed run
     await enqueueEmail({
-      from: buildFromAddress(fromLocalPart),
+      from: buildFromAddress(org.slug),
       to: userEmail,
       subject: `VM0 - Scheduled run for "${agentName}" failed`,
       template: {

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../../../../src/lib/email/handlers/shared";
 import { isUserUnsubscribed } from "../../../../../../src/lib/email/unsubscribe-service";
 import { env } from "../../../../../../src/env";
+import { getOrgData } from "../../../../../../src/lib/org/org-cache-service";
 import type { EmailScheduleCallbackPayload } from "../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/logger";
 
@@ -38,6 +39,18 @@ function parsePayload(payload: unknown): EmailScheduleCallbackPayload | null {
 
 function errorResponse(message: string, status: number): NextResponse {
   return NextResponse.json({ error: message }, { status });
+}
+
+function extractAgentSessionId(result: unknown): string | undefined {
+  if (
+    result &&
+    typeof result === "object" &&
+    "agentSessionId" in result &&
+    typeof result.agentSessionId === "string"
+  ) {
+    return result.agentSessionId;
+  }
+  return undefined;
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -87,6 +100,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const unsubscribeUrl = buildUnsubscribeUrl(userId);
   const unsubscribeHeaders = buildUnsubscribeHeaders(unsubscribeUrl);
 
+  // Resolve compose and org slug for from address
+  const compose = await resolveComposeByZeroAgentId(payload.zeroAgentId);
+  const org = compose ? await getOrgData(compose.orgId) : null;
+  const fromLocalPart = org?.slug ?? "vm0";
+
   if (status === "completed") {
     // Get agent output
     const output = await getRunOutputText(runId);
@@ -103,14 +121,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       .where(eq(agentRuns.id, runId))
       .limit(1);
 
-    const runResult = run?.result;
-    const agentSessionId =
-      runResult &&
-      typeof runResult === "object" &&
-      "agentSessionId" in runResult &&
-      typeof runResult.agentSessionId === "string"
-        ? runResult.agentSessionId
-        : undefined;
+    const agentSessionId = extractAgentSessionId(run?.result);
 
     // Generate reply token and send email
     const sessionPlaceholderId = crypto.randomUUID();
@@ -118,7 +129,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const replyToAddress = buildReplyToAddress(replyToken);
 
     await enqueueEmail({
-      from: buildFromAddress(agentName),
+      from: buildFromAddress(fromLocalPart),
       to: userEmail,
       subject: `VM0 - Scheduled run for "${agentName}" completed`,
       template: {
@@ -132,26 +143,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       },
       replyTo: replyToAddress,
       headers: unsubscribeHeaders,
-      threadAction: agentSessionId
-        ? await (async () => {
-            const compose = await resolveComposeByZeroAgentId(
-              payload.zeroAgentId,
-            );
-            if (!compose) return undefined;
-            return {
+      threadAction:
+        agentSessionId && compose
+          ? {
               action: "save_thread_session" as const,
               userId,
               composeId: compose.id,
               agentSessionId,
               replyToToken: replyToken,
-            };
-          })()
-        : undefined,
+            }
+          : undefined,
     });
   } else {
     // Failed run
     await enqueueEmail({
-      from: buildFromAddress(agentName),
+      from: buildFromAddress(fromLocalPart),
       to: userEmail,
       subject: `VM0 - Scheduled run for "${agentName}" failed`,
       template: {

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
@@ -187,7 +187,8 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
         headers: Record<string, string>;
       };
       expect(sendArgs.to).toBe(senderEmail);
-      expect(sendArgs.from).toContain(triggerLocalPart);
+      // From address uses org slug (org-{suffix}) instead of agent name
+      expect(sendArgs.from).toMatch(/^org-[a-f0-9]+ from VM0/);
       expect(sendArgs.subject).toBe("Re: Help me with this");
       expect(sendArgs.replyTo).toContain("reply+");
       expect(sendArgs.headers).toMatchObject({
@@ -235,7 +236,8 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
         from: string;
       };
       expect(sendArgs.subject).toBe("Re: Original Topic");
-      expect(sendArgs.from).toContain(agentName);
+      // From address uses org slug instead of agent name
+      expect(sendArgs.from).toMatch(/^org-[a-f0-9]+ from VM0/);
     });
 
     it("should send to multiple recipients when replyRecipientTo is provided", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -14,6 +14,7 @@ import {
   buildUnsubscribeHeaders,
 } from "../../../../../../src/lib/email/handlers/shared";
 import { env } from "../../../../../../src/env";
+import { getOrgData } from "../../../../../../src/lib/org/org-cache-service";
 import type { EmailTriggerCallbackPayload } from "../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/logger";
 
@@ -130,7 +131,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Get compose name
   const [compose] = await globalThis.services.db
-    .select({ name: agentComposes.name })
+    .select({ name: agentComposes.name, orgId: agentComposes.orgId })
     .from(agentComposes)
     .where(eq(agentComposes.id, composeId))
     .limit(1);
@@ -138,6 +139,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!compose) {
     return errorResponse("Compose not found", 404);
   }
+
+  // Resolve org slug for from address
+  const orgId = payload.runtimeOrgId ?? compose.orgId;
+  const org = await getOrgData(orgId);
 
   // Get run output and session ID
   const logsUrl = buildLogsUrl(runId);
@@ -178,7 +183,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       : undefined;
 
   await enqueueEmail({
-    from: buildFromAddress(payload.triggerLocalPart ?? compose.name),
+    from: buildFromAddress(org.slug),
     to: emailTo,
     subject: buildSubject(payload.subject, compose.name),
     template: {


### PR DESCRIPTION
## Summary

- Update all three email callback routes (trigger, reply, schedule) to use org slug instead of agent/compose name in `buildFromAddress()`
- Emails now come from `orgslug@vm0.bot` instead of `agentname@vm0.bot`, aligning with org-level email routing
- Schedule callback: hoisted `resolveComposeByZeroAgentId` to eliminate duplicate call and extracted `extractAgentSessionId` helper to reduce function complexity

Closes #6297

## Test plan

- [x] All 21 email callback tests pass (trigger: 9, reply: 7, schedule: 5)
- [x] TypeScript type check passes
- [x] Lint passes (including complexity check)
- [x] Knip passes (no unused exports/dependencies)
- [x] `grep buildFromAddress(compose.name)` returns zero results in callback files
- [x] `grep buildFromAddress(agentName)` returns zero results in callback files

🤖 Generated with [Claude Code](https://claude.com/claude-code)