### PR TITLE
test: add regression tests for schedule timezone preservation

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -142,6 +142,8 @@ interface ZeroScheduleEntry {
   name: string;
   /** Raw interval in seconds for loop schedules */
   intervalSeconds: number | null;
+  /** IANA timezone identifier */
+  timezone: string;
 }
 
 export const zeroScheduleEntries$ = computed((get) => {
@@ -159,6 +161,7 @@ export const zeroScheduleEntries$ = computed((get) => {
         notifySlack: s.notifySlack,
         name: s.name,
         intervalSeconds: s.intervalSeconds,
+        timezone: s.timezone,
       }),
     );
 });
@@ -394,6 +397,8 @@ export interface OrgScheduleEntry {
   intervalSeconds: number | null;
   zeroAgentId: string;
   agentName: string;
+  /** IANA timezone identifier */
+  timezone: string;
 }
 
 const internalAllSchedules$ = state<ScheduleResponse[]>([]);
@@ -421,6 +426,7 @@ export const allOrgScheduleEntries$ = computed((get) => {
         intervalSeconds: s.intervalSeconds,
         zeroAgentId: s.zeroAgentId,
         agentName: s.agentName,
+        timezone: s.timezone,
       }),
     );
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -867,6 +867,100 @@ describe("zero schedule page - schedule dialog fields", () => {
   });
 });
 
+describe("zero schedule page - timezone preservation", () => {
+  it("should show stored timezone in edit dialog", async () => {
+    const schedules = [{ ...createMockSchedules()[0], timezone: "Asia/Tokyo" }];
+    mockScheduleAPI(schedules);
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    // The timezone selector trigger should show the stored timezone value
+    const tzTrigger = document.getElementById("schedule-dialog-tz");
+    expect(tzTrigger).toBeInTheDocument();
+    expect(tzTrigger?.textContent).toContain("Asia/Tokyo");
+  });
+
+  it("should show non-preset timezone in edit dialog", async () => {
+    const schedules = [
+      { ...createMockSchedules()[0], timezone: "Africa/Nairobi" },
+    ];
+    mockScheduleAPI(schedules);
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    // The timezone selector trigger should show the non-preset timezone value
+    const tzTrigger = document.getElementById("schedule-dialog-tz");
+    expect(tzTrigger).toBeInTheDocument();
+    expect(tzTrigger?.textContent).toContain("Africa/Nairobi");
+  });
+
+  it("should preserve timezone when saving edited schedule", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get("*/api/zero/schedules", () => {
+        return HttpResponse.json({
+          schedules: [{ ...createMockSchedules()[0], timezone: "Asia/Tokyo" }],
+        });
+      }),
+      http.post("*/api/zero/schedules", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ success: true });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await renderSchedulePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Edit Every weekday at 9:00 AM"),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByLabelText("Edit Every weekday at 9:00 AM"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Edit schedule")).toBeInTheDocument();
+    });
+
+    // Change only the prompt, do NOT change timezone
+    const promptInput = screen.getByLabelText("Prompt");
+    fireEvent.change(promptInput, {
+      target: { value: "Updated prompt text" },
+    });
+
+    // Click Save
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(capturedBody).toBeTruthy();
+    });
+    expect(capturedBody).toHaveProperty("timezone", "Asia/Tokyo");
+  });
+});
+
 describe("zero schedule page - view modes", () => {
   it("should render list and calendar view tabs", async () => {
     mockScheduleAPI();

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -360,7 +360,10 @@ function ScheduleTimingFields({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {COMMON_TIMEZONES.map((tz) => (
+              {((COMMON_TIMEZONES as readonly string[]).includes(timezone)
+                ? COMMON_TIMEZONES
+                : [timezone, ...COMMON_TIMEZONES]
+              ).map((tz) => (
                 <SelectItem key={tz} value={tz}>
                   {tz.replace(/_/g, " ")}
                 </SelectItem>

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -60,6 +60,7 @@ import emptyScheduleImg from "./assets/empty-schedule.webp";
 type CombinedEntry = ScheduleEntry & {
   agentLabel: string;
   zeroAgentId: string;
+  timezone: string;
 };
 
 function buildCombinedSchedule(
@@ -83,6 +84,7 @@ function buildCombinedSchedule(
         ? agentName
         : (nameToDisplay.get(e.agentName) ?? e.agentName),
     zeroAgentId: e.zeroAgentId,
+    timezone: e.timezone,
   }));
 }
 
@@ -850,7 +852,7 @@ export function ZeroSchedulePage() {
                 date: parsed.date,
                 hour: parsed.hour,
                 minute: parsed.minute,
-                timezone: parsed.timezone,
+                timezone: editingEntry.timezone ?? parsed.timezone,
                 loopMinutes: parsed.loopMinutes,
                 dayOfWeek: parsed.dayOfWeek ?? "1",
                 dayOfMonth: parsed.dayOfMonth ?? "1",


### PR DESCRIPTION
## Summary

- Add 3 regression tests to `zero-schedule-page.test.tsx` verifying timezone preservation when editing schedules
- Wire `timezone` field through `ZeroScheduleEntry` and `OrgScheduleEntry` interfaces and their signal computations
- Update edit dialog to use stored entry timezone instead of always defaulting to UTC from `parseScheduleTimeString()`
- Handle non-preset timezones in schedule dialog by prepending them to `COMMON_TIMEZONES` options

Closes #6306

## Test plan
- [x] Test A: Edit dialog shows stored common timezone (Asia/Tokyo) in selector
- [x] Test A2: Edit dialog shows non-preset timezone (Africa/Nairobi) in selector
- [x] Test B: Saving edited schedule without changing timezone preserves original timezone in API request
- [x] All 33 existing tests still pass
- [x] Lint passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)