### PR TITLE
chore: remove clerk lazy migration fallbacks and clean up jwt session claims

### DIFF
--- a/turbo/apps/web/app/api/zero/user-preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/user-preferences/__tests__/route.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { clerkClient } from "@clerk/nextjs/server";
 import { GET, POST } from "../route";
 import { createTestRequest } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
@@ -523,83 +522,5 @@ describe("POST /api/zero/user-preferences", () => {
 
     expect(response.status).toBe(200);
     expect(data.sendMode).toBe("cmd-enter");
-  });
-
-  describe("Clerk fallback and backfill", () => {
-    it("should fall back to Clerk metadata when no DB row, then backfill", async () => {
-      const user = await context.setupUser();
-      mockClerk({ userId: user.userId, orgId: user.orgId });
-
-      // Override Clerk membership list to return metadata (one-shot)
-      const client = await clerkClient();
-      vi.mocked(
-        client.organizations.getOrganizationMembershipList,
-      ).mockResolvedValueOnce({
-        data: [
-          {
-            publicUserData: { userId: user.userId },
-            publicMetadata: {
-              timezone: "Europe/London",
-              notify_email: true,
-              notify_slack: false,
-              pinned_agent_ids: ["pinned-1", "pinned-2"],
-              send_mode: "cmd-enter",
-            },
-          },
-        ],
-      } as unknown as Awaited<
-        ReturnType<typeof client.organizations.getOrganizationMembershipList>
-      >);
-
-      // First GET: falls back to Clerk and backfills DB
-      const request1 = createTestRequest(
-        "http://localhost:3000/api/zero/user-preferences",
-      );
-      const response1 = await GET(request1);
-      const data1 = await response1.json();
-
-      expect(response1.status).toBe(200);
-      expect(data1).toEqual({
-        timezone: "Europe/London",
-        notifyEmail: true,
-        notifySlack: false,
-        pinnedAgentIds: ["pinned-1", "pinned-2"],
-        sendMode: "cmd-enter",
-      });
-
-      // Second GET: should return from DB (Clerk mock exhausted)
-      const request2 = createTestRequest(
-        "http://localhost:3000/api/zero/user-preferences",
-      );
-      const response2 = await GET(request2);
-      const data2 = await response2.json();
-
-      expect(response2.status).toBe(200);
-      expect(data2.timezone).toBe("Europe/London");
-      expect(data2.notifyEmail).toBe(true);
-      expect(data2.notifySlack).toBe(false);
-      expect(data2.sendMode).toBe("cmd-enter");
-    });
-
-    it("should return defaults when no DB row and Clerk has empty metadata", async () => {
-      const user = await context.setupUser();
-      mockClerk({ userId: user.userId, orgId: user.orgId });
-
-      // Default Clerk mock returns empty publicMetadata
-      const request = createTestRequest(
-        "http://localhost:3000/api/zero/user-preferences",
-      );
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data).toEqual({
-        timezone: null,
-        notifyEmail: false,
-        notifySlack: true,
-        pinnedAgentIds: [],
-        sendMode: "enter",
-      });
-    });
   });
 });

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -36,12 +36,11 @@ let createdOrgs: Array<{
   creatorUserId: string;
 }> = [];
 
-// Module-level tracking of org mutations (slug updates, metadata updates).
+// Module-level tracking of org slug mutations.
 // Persists across mockClerk() calls so that route handlers that mutate
-// org data (e.g. updateOrganization, updateOrganizationMetadata) are
-// reflected in subsequent getOrganization calls.
+// org data (e.g. updateOrganization) are reflected in subsequent
+// getOrganization calls.
 let orgSlugOverrides = new Map<string, string>();
-let orgMetadataOverrides = new Map<string, Record<string, unknown>>();
 
 // Module-level tracking of all userIds configured via mockClerk().
 // Used by testContext afterEach to scope user_cache cleanup to rows created
@@ -246,14 +245,13 @@ export function mockClerk(options: {
               (err as unknown as { code: string }).code = "NOT_FOUND";
               return Promise.reject(err);
             }
-            // Apply slug and metadata overrides
+            // Apply slug overrides
             const slug = orgSlugOverrides.get(org.id) ?? org.slug;
-            const metadata = orgMetadataOverrides.get(org.id) ?? {};
             return Promise.resolve({
               id: org.id,
               slug,
               name: org.name,
-              publicMetadata: metadata,
+              publicMetadata: {},
             });
           },
         ),
@@ -265,23 +263,7 @@ export function mockClerk(options: {
           }
           return Promise.resolve({});
         }),
-      updateOrganizationMetadata: vi
-        .fn()
-        .mockImplementation(
-          (
-            orgId: string,
-            data: { publicMetadata?: Record<string, unknown> },
-          ) => {
-            if (data.publicMetadata) {
-              const existing = orgMetadataOverrides.get(orgId) ?? {};
-              orgMetadataOverrides.set(orgId, {
-                ...existing,
-                ...data.publicMetadata,
-              });
-            }
-            return Promise.resolve({});
-          },
-        ),
+      updateOrganizationMetadata: vi.fn().mockResolvedValue({}),
       updateOrganizationMembershipMetadata: vi.fn().mockResolvedValue({}),
     },
   } as unknown as Awaited<ReturnType<typeof clerkClient>>);
@@ -298,7 +280,6 @@ export function clearClerkMock(): string[] {
   mockClerkClient.mockClear();
   createdOrgs = [];
   orgSlugOverrides = new Map();
-  orgMetadataOverrides = new Map();
   mockUserIds = [];
   return userIds;
 }

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -16,7 +16,7 @@ export type AuthContext = {
   userId: string;
   orgId?: string;
   orgRole?: OrgRole;
-  sessionClaims?: CustomJwtSessionClaims;
+  sessionClaims?: Record<string, unknown>;
   capabilities?: readonly Capability[];
   runId?: string;
 };
@@ -138,7 +138,7 @@ async function getClerkSessionAuth(): Promise<AuthContext | null> {
         : "member"
       : undefined,
     sessionClaims: authResult.sessionClaims as
-      | CustomJwtSessionClaims
+      | Record<string, unknown>
       | undefined,
   };
 }

--- a/turbo/apps/web/src/lib/email/unsubscribe-service.ts
+++ b/turbo/apps/web/src/lib/email/unsubscribe-service.ts
@@ -1,17 +1,9 @@
 import { eq } from "drizzle-orm";
-import { clerkClient } from "@clerk/nextjs/server";
 import { users } from "../../db/schema/user";
-import { logger } from "../logger";
-
-const log = logger("service:unsubscribe");
 
 /**
  * Check if a user has unsubscribed from system-initiated emails.
  * Reads `email_unsubscribed` from the users table.
- *
- * // TODO(#5514): remove this fallback after full backfill
- * Falls back to Clerk publicMetadata if DB says false/missing,
- * and lazy-migrates the value to DB on first access.
  */
 export async function isUserUnsubscribed(userId: string): Promise<boolean> {
   const [row] = await globalThis.services.db
@@ -20,36 +12,7 @@ export async function isUserUnsubscribed(userId: string): Promise<boolean> {
     .where(eq(users.id, userId))
     .limit(1);
 
-  if (row?.emailUnsubscribed) {
-    return true;
-  }
-
-  // TODO(#5514): remove this fallback after full backfill
-  const client = await clerkClient();
-  const clerkUser = await client.users.getUser(userId);
-  const clerkValue =
-    (clerkUser.publicMetadata as Record<string, unknown> | undefined)
-      ?.email_unsubscribed === true;
-
-  if (clerkValue) {
-    log.info("lazy migration: email_unsubscribed from Clerk", { userId });
-    await globalThis.services.db
-      .insert(users)
-      .values({ id: userId, emailUnsubscribed: true })
-      .onConflictDoUpdate({
-        target: users.id,
-        set: { emailUnsubscribed: true, updatedAt: new Date() },
-      })
-      .catch((err: unknown) =>
-        log.warn("lazy migration: email_unsubscribed write failed", {
-          userId,
-          err,
-        }),
-      );
-    return true;
-  }
-
-  return false;
+  return row?.emailUnsubscribed ?? false;
 }
 
 /**

--- a/turbo/apps/web/src/lib/org/__tests__/org-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-cache-service.test.ts
@@ -164,45 +164,6 @@ describe("getOrgData", () => {
     expect(result.tier).toBe("pro");
   });
 
-  it("falls back to Clerk tier on cache miss when DB has free", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    mockClerk({
-      userId,
-      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
-    });
-    await createTestOrg(slug);
-    const orgId = `org_mock_${slug}`;
-
-    // Ensure org row exists for this orgId (createTestOrg uses org_mock_${userId})
-    await ensureOrgRow(orgId);
-
-    // Delete cache to force Clerk fetch
-    await deleteOrgCacheEntry(orgId);
-
-    // Override getOrganization to return tier in publicMetadata
-    const client = await clerkClient();
-    vi.mocked(client.organizations.getOrganization).mockResolvedValueOnce({
-      id: orgId,
-      slug,
-      name: slug,
-      publicMetadata: { tier: "pro" },
-    } as unknown as Awaited<
-      ReturnType<typeof client.organizations.getOrganization>
-    >);
-
-    const result = await getOrgData(orgId);
-    expect(result.tier).toBe("pro");
-
-    // Verify backfill (fire-and-forget, wait a tick)
-    await new Promise((r) => setTimeout(r, 50));
-
-    // Re-read via getOrgData with fresh cache (just written above)
-    // to confirm the DB was updated
-    const recheck = await getOrgData(orgId);
-    expect(recheck.tier).toBe("pro");
-  });
-
   it("returns DB tier directly when DB has non-free on cache miss", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");

--- a/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
@@ -31,7 +31,7 @@ function authCtx(opts: {
   userId: string;
   orgId?: string | null;
   orgRole?: "admin" | "member";
-  sessionClaims?: CustomJwtSessionClaims;
+  sessionClaims?: Record<string, unknown>;
 }): AuthContext {
   return {
     userId: opts.userId,

--- a/turbo/apps/web/src/lib/org/org-cache-service.ts
+++ b/turbo/apps/web/src/lib/org/org-cache-service.ts
@@ -23,47 +23,15 @@ interface OrgData {
 /**
  * Read tier from the org table (source of truth).
  * Returns "free" if the org row does not exist.
- *
- * // TODO(#5514): remove clerkMetadata fallback after full backfill
- * When clerkMetadata is provided and DB tier is "free", falls back to
- * Clerk publicMetadata and lazy-migrates the value to DB.
  */
-async function readTier(
-  orgId: string,
-  clerkMetadata?: Record<string, unknown>,
-): Promise<string> {
+async function readTier(orgId: string): Promise<string> {
   const db = globalThis.services.db;
   const [orgRow] = await db
     .select({ tier: orgMetadata.tier })
     .from(orgMetadata)
     .where(eq(orgMetadata.orgId, orgId))
     .limit(1);
-  const dbTier = orgRow?.tier ?? "free";
-
-  if (dbTier !== "free") {
-    return dbTier;
-  }
-
-  // TODO(#5514): remove this fallback after full backfill
-  if (clerkMetadata) {
-    const clerkTier = clerkMetadata.tier;
-    if (typeof clerkTier === "string" && clerkTier !== "free") {
-      log.info("lazy migration: tier from Clerk", { orgId, clerkTier });
-      void db
-        .insert(orgMetadata)
-        .values({ orgId, tier: clerkTier })
-        .onConflictDoUpdate({
-          target: orgMetadata.orgId,
-          set: { tier: clerkTier, updatedAt: new Date() },
-        })
-        .catch((err: unknown) =>
-          log.warn("lazy migration: tier write failed", { orgId, err }),
-        );
-      return clerkTier;
-    }
-  }
-
-  return "free";
+  return orgRow?.tier ?? "free";
 }
 
 /**
@@ -83,7 +51,6 @@ export async function getOrgData(orgId: string): Promise<OrgData> {
     .limit(1);
 
   if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
-    // Cache hit — no Clerk metadata available for tier fallback
     const tier = await readTier(orgId);
     return { orgId, slug: cached.slug, name: cached.name, tier };
   }
@@ -100,11 +67,7 @@ export async function getOrgData(orgId: string): Promise<OrgData> {
   const slug = clerkOrg.slug;
   const name = clerkOrg.name;
 
-  // Read tier with Clerk metadata fallback (lazy migration)
-  const tier = await readTier(
-    orgId,
-    clerkOrg.publicMetadata as Record<string, unknown> | undefined,
-  );
+  const tier = await readTier(orgId);
 
   // Upsert slug cache
   const now = new Date();
@@ -150,7 +113,6 @@ export async function getOrgBySlug(slug: string): Promise<OrgData | null> {
     .limit(1);
 
   if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
-    // Cache hit — no Clerk metadata available for tier fallback
     const tier = await readTier(cached.orgId);
     return { orgId: cached.orgId, slug: cached.slug, name: cached.name, tier };
   }
@@ -169,11 +131,7 @@ export async function getOrgBySlug(slug: string): Promise<OrgData | null> {
     return null;
   }
 
-  // Read tier with Clerk metadata fallback (lazy migration)
-  const tier = await readTier(
-    clerkOrg.id,
-    clerkOrg.publicMetadata as Record<string, unknown> | undefined,
-  );
+  const tier = await readTier(clerkOrg.id);
 
   // Upsert slug cache
   const now = new Date();

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -1,5 +1,4 @@
 import { eq, and } from "drizzle-orm";
-import { clerkClient } from "@clerk/nextjs/server";
 import { slackOrgInstallations } from "../../../db/schema/slack-org-installation";
 import { slackOrgConnections } from "../../../db/schema/slack-org-connection";
 import { slackOrgThreadSessions } from "../../../db/schema/slack-org-thread-session";
@@ -70,9 +69,7 @@ export async function resolveConnectionFromSlackUser(
 
 /**
  * Resolve default agent compose ID from org table.
- * Falls back to Clerk publicMetadata, then VM0_DEFAULT_AGENT env var.
- *
- * // TODO(#5514): remove Clerk fallback after full backfill
+ * Falls back to VM0_DEFAULT_AGENT env var.
  */
 export async function resolveDefaultComposeId(
   orgId: string,
@@ -87,34 +84,6 @@ export async function resolveDefaultComposeId(
     return orgRow.defaultAgentComposeId;
   }
 
-  // TODO(#5514): remove this fallback after full backfill
-  const client = await clerkClient();
-  const clerkOrg = await client.organizations.getOrganization({
-    organizationId: orgId,
-  });
-  const clerkComposeId = (
-    clerkOrg.publicMetadata as Record<string, unknown> | undefined
-  )?.default_agent_compose_id;
-
-  if (typeof clerkComposeId === "string" && clerkComposeId) {
-    log.info("lazy migration: default_agent_compose_id from Clerk", { orgId });
-    await globalThis.services.db
-      .insert(orgTable)
-      .values({ orgId, defaultAgentComposeId: clerkComposeId })
-      .onConflictDoUpdate({
-        target: orgTable.orgId,
-        set: { defaultAgentComposeId: clerkComposeId, updatedAt: new Date() },
-      })
-      .catch((err: unknown) =>
-        log.warn("lazy migration: default_agent_compose_id write failed", {
-          orgId,
-          err,
-        }),
-      );
-    return clerkComposeId;
-  }
-
-  // Fallback: resolve from VM0_DEFAULT_AGENT env var
   return resolveDefaultAgentComposeId();
 }
 

--- a/turbo/apps/web/src/lib/user/user-preferences-service.ts
+++ b/turbo/apps/web/src/lib/user/user-preferences-service.ts
@@ -1,5 +1,4 @@
 import { eq, and } from "drizzle-orm";
-import { clerkClient } from "@clerk/nextjs/server";
 import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
 import { badRequest } from "../errors";
 import { logger } from "../logger";
@@ -51,10 +50,6 @@ const DEFAULTS: UserPreferences = {
 /**
  * Get user preferences from org_members table.
  * Returns defaults if no row exists (new member).
- *
- * // TODO(#5514): remove this fallback after full backfill
- * Falls back to Clerk membership publicMetadata if no DB row,
- * and lazy-migrates the value to DB on first access.
  */
 export async function getUserPreferences(
   orgId: string,
@@ -81,62 +76,6 @@ export async function getUserPreferences(
       pinnedAgentIds: toStringArray(row.pinnedAgentIds),
       sendMode: parseSendMode(row.sendMode),
     };
-  }
-
-  // TODO(#5514): remove this fallback after full backfill
-  const client = await clerkClient();
-  const { data: memberships } =
-    await client.organizations.getOrganizationMembershipList({
-      organizationId: orgId,
-    });
-
-  const membership = memberships.find(
-    (m) => m.publicUserData?.userId === userId,
-  );
-  const meta = membership?.publicMetadata as
-    | Record<string, unknown>
-    | undefined;
-
-  if (meta && Object.keys(meta).length > 0) {
-    const prefs: UserPreferences = {
-      timezone: typeof meta.timezone === "string" ? meta.timezone : null,
-      notifyEmail: meta.notify_email === true,
-      notifySlack: meta.notify_slack !== false,
-      pinnedAgentIds: toStringArray(meta.pinned_agent_ids),
-      sendMode: parseSendMode(meta.send_mode),
-    };
-
-    const onboardingDone = meta.onboarding_done === true;
-
-    log.info("lazy migration: org_members preferences from Clerk", {
-      orgId,
-      userId,
-    });
-    const now = new Date();
-    await db
-      .insert(orgMembersMetadata)
-      .values({
-        orgId,
-        userId,
-        timezone: prefs.timezone,
-        notifyEmail: prefs.notifyEmail,
-        notifySlack: prefs.notifySlack,
-        pinnedAgentIds: prefs.pinnedAgentIds,
-        sendMode: prefs.sendMode,
-        onboardingDone,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoNothing()
-      .catch((err: unknown) =>
-        log.warn("lazy migration: org_members write failed", {
-          orgId,
-          userId,
-          err,
-        }),
-      );
-
-    return prefs;
   }
 
   return { ...DEFAULTS };

--- a/turbo/apps/web/src/types/global.d.ts
+++ b/turbo/apps/web/src/types/global.d.ts
@@ -24,9 +24,4 @@ declare global {
   var services: Services;
   // Captured Next.js after() callbacks for test assertions (see setup.ts)
   var nextAfterCallbacks: Array<() => Promise<unknown>>;
-
-  // Clerk custom JWT session claims (configured in Clerk Dashboard).
-  // org_tier and membership_* claims have been migrated to the org and
-  // org_members tables respectively. Add new claims here as needed.
-  type CustomJwtSessionClaims = Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

Add a builtin firewall config for the `intercom` connector so that API requests go through the firewall proxy for token replacement.

## Steps

### 1. Research token format
- Check [gitleaks rules](https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml) for a matching regex
- If not in gitleaks, search official API docs / SDK source for example tokens
- Determine: prefix, length, character set

### 2. Research API base URL and auth header
- Find the official API docs URL
- Confirm the API base URL (e.g. `https://api.example.com`)
- Confirm the auth header format (e.g. `Authorization: Bearer <token>` or custom header like `X-Api-Key`)

### 3. Write generator
Create `turbo/packages/firewalls-generator/src/intercom.ts`:
```typescript
import { writeOutput } from "./codegen";

const DOCS_URL = "<official API docs URL>";
// Format: <describe token format, e.g. "am_" + 32 hex chars>
const PLACEHOLDER_VALUE = "<realistic placeholder matching token format>";

function generateTypeScript(): string {
  const lines: string[] = [
    "// Auto-generated from <Service> API docs.",
    \`// Source: \${DOCS_URL}\`,
    "// Regenerate: cd turbo && pnpm -F @vm0/firewalls-generator generate:intercom",
    "//",
    "// DO NOT EDIT THIS FILE MANUALLY.",
    "",
    'import type { FirewallConfig } from "../contracts/firewalls";',
    "",
    // ... firewall config with unrestricted permissions
  ];
  return lines.join("\n");
}

export async function generate(): Promise<void> {
  console.error("Generating intercom firewall config...");
  const ts = generateTypeScript();
  writeOutput("intercom", ts, import.meta.dirname);
}
```

### 4. Register generator
- `turbo/packages/firewalls-generator/src/index.ts` — add import + entry
- `turbo/packages/firewalls-generator/package.json` — add `generate:intercom` script

### 5. Generate and register output
- Run: `cd turbo && pnpm -F @vm0/firewalls-generator generate:intercom`
- `turbo/packages/core/src/firewalls/index.ts` — add to `builtinFirewalls`
- `turbo/packages/core/src/contracts/firewalls.ts` — add to `CONNECTOR_FIREWALL_REFS`

### 6. Verify
- `pnpm check-types --filter @vm0/core --filter @vm0/firewalls-generator`

## Reference
- Existing example: `turbo/packages/firewalls-generator/src/agentmail.ts`
- PR #6430 (agentmail) as template