### PR TITLE
fix(web): align secret connector map keys with firewall template references

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -459,6 +459,51 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(newExpiry).toBeGreaterThan(expectedMin);
     });
 
+    it("should refresh when template references mapped env var name", async () => {
+      const expiredAt = new Date(Date.now() - 60 * 1000);
+      await setupNotionConnector({ tokenExpiresAt: expiredAt });
+
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () =>
+          HttpResponse.json({
+            access_token: "fresh-mapped-token",
+            expires_in: 3600,
+          }),
+        ),
+      );
+
+      // Secrets contain both raw and mapped names (as build-context produces)
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "old-notion-token",
+        NOTION_TOKEN: "old-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            // Template references the MAPPED env var name
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.NOTION_TOKEN }}",
+            },
+            // secretConnectorMap includes both raw and mapped keys
+            secretConnectorMap: {
+              NOTION_ACCESS_TOKEN: "notion",
+              NOTION_TOKEN: "notion",
+            },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      // The mapped env var should have the refreshed token
+      expect(data.headers.Authorization).toBe("Bearer fresh-mapped-token");
+      expect(data.expiresAt).toBeTypeOf("number");
+    });
+
     it("should use existing token when refresh fails", async () => {
       const expiredAt = new Date(Date.now() - 60 * 1000);
       await setupNotionConnector({ tokenExpiresAt: expiredAt });

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -74,6 +74,15 @@ async function refreshExpiredTokens(
     );
   });
 
+  // Build reverse map: connectorType → [envVarNames that reference its token]
+  // so we can sync mapped env var values after refresh.
+  const envVarsByConnector = new Map<string, string[]>();
+  for (const [envVar, ct] of refreshable) {
+    const arr = envVarsByConnector.get(ct) ?? [];
+    arr.push(envVar);
+    envVarsByConnector.set(ct, arr);
+  }
+
   const results = await Promise.all(
     toRefresh.map(async (connectorType) => {
       log.debug(`[${auth.runId}] Refreshing expired ${connectorType} token`);
@@ -87,8 +96,15 @@ async function refreshExpiredTokens(
         log.warn(
           `[${auth.runId}] Failed to refresh ${connectorType} token, using existing`,
         );
+        return false;
       }
-      return !!freshToken;
+      // refreshConnectorAccessToken updates secrets[rawSecretName] but the
+      // template may reference a mapped env var name.  Sync all mapped keys
+      // so resolveTemplates picks up the fresh token.
+      for (const envVar of envVarsByConnector.get(connectorType) ?? []) {
+        secrets[envVar] = freshToken;
+      }
+      return true;
     }),
   );
   const refreshed = results.some(Boolean);

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -506,14 +506,25 @@ async function resolveConnectorSecrets(
   }
 
   // Build secretConnectorMap for refresh-capable OAuth connectors.
-  // Maps access token secret name → connector type so the auth endpoint
-  // can refresh expired tokens at runtime.
+  // Maps secret/env-var name → connector type so the auth endpoint can refresh
+  // expired tokens at runtime.  Both the raw secret name (e.g.
+  // GOOGLE_CALENDAR_ACCESS_TOKEN) and the mapped env var name (e.g.
+  // GOOGLE_CALENDAR_TOKEN) are included because firewall templates may
+  // reference either form.
   const secretConnectorMap: Record<string, string> = {};
   for (const { type } of validConnectors) {
     if (!(type in PROVIDER_HANDLERS)) continue;
     const handler = PROVIDER_HANDLERS[type as keyof typeof PROVIDER_HANDLERS];
-    if (handler.refreshToken) {
-      secretConnectorMap[handler.getSecretName()] = type;
+    if (!handler.refreshToken) continue;
+
+    const secretName = handler.getSecretName();
+    secretConnectorMap[secretName] = type;
+
+    const mapping = getConnectorEnvironmentMapping(type);
+    for (const [envVar, valueRef] of Object.entries(mapping)) {
+      if (valueRef === `$secrets.${secretName}`) {
+        secretConnectorMap[envVar] = type;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Include both raw secret names and mapped env var names in `secretConnectorMap` so firewall templates referencing either form can trigger runtime token refresh
- Sync refreshed token values to mapped env var keys in the auth endpoint so `resolveTemplates` picks up fresh tokens
- Add integration test covering the mapped env var name refresh scenario

Closes #6264

## Test plan

- [x] Existing 16 auth endpoint tests pass
- [x] New test: template references mapped env var name (`NOTION_TOKEN`), `secretConnectorMap` contains both raw + mapped keys, refreshed token is correctly resolved
- [x] Type check passes
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)