### PR TITLE
fix: use dollar-single-quote syntax for dashboard color variables

### DIFF
--- a/scripts/coding-dashboard.sh
+++ b/scripts/coding-dashboard.sh
@@ -11,9 +11,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_common.sh
 source "$SCRIPT_DIR/_common.sh"
 
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+NC=$'\033[0m'
 
 MAX_WORKERS="${1:-4}"
 ME=$(gh api user --jq '.login')


### PR DESCRIPTION
## Summary
- Fix ANSI color codes in `coding-dashboard.sh` being displayed as literal `\033[...]` text instead of rendered colors
- Change color variable definitions from single quotes (`'...'`) to dollar-single-quotes (`$'...'`) so escape sequences produce actual bytes

## Test plan
- [ ] Run `scripts/coding-dashboard.sh` and verify `[Pending]`/`[Queued]` markers display in color

🤖 Generated with [Claude Code](https://claude.com/claude-code)