### PR TITLE
refactor: move unused ref callbacks into signal layer

### DIFF
--- a/turbo/apps/platform/src/signals/queue-page/queue-page-setup.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-page-setup.ts
@@ -3,10 +3,12 @@ import { createElement } from "react";
 import { ZeroQueuePage } from "../../views/queue-page/zero-queue-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
+import { detach, Reason } from "../utils.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { startQueuePolling$ } from "./queue-signals.ts";
 
 export const setupQueuePage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(ZeroQueuePage));
@@ -19,4 +21,5 @@ export const setupQueuePage$ = command(async ({ set }, signal: AbortSignal) => {
   }
 
   set(switchActiveAgent$, null);
+  detach(set(startQueuePolling$, signal), Reason.Entrance);
 });

--- a/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
@@ -1,7 +1,7 @@
 import { command, state, computed } from "ccstate";
 import { delay } from "signal-timers";
 import { fetch$ } from "../fetch.ts";
-import { throwIfAbort, onRef, detach, Reason } from "../utils.ts";
+import { throwIfAbort } from "../utils.ts";
 import {
   queueResponseSchema,
   type QueueResponse,
@@ -28,32 +28,26 @@ const fetchQueueData$ = command(async ({ get, set }) => {
   set(internalQueueData$, data);
 });
 
-const startQueuePolling$ = command(async ({ set }, signal: AbortSignal) => {
-  // Initial fetch
-  await set(fetchQueueData$);
-  signal.throwIfAborted();
+export const startQueuePolling$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    // Initial fetch
+    await set(fetchQueueData$);
+    signal.throwIfAborted();
 
-  // Polling loop
-  while (!signal.aborted) {
-    try {
-      await delay(POLL_INTERVAL, { signal });
-      signal.throwIfAborted();
-      await set(fetchQueueData$);
-      signal.throwIfAborted();
-    } catch (error) {
-      throwIfAbort(error);
-      // Swallow non-abort errors and continue polling
+    // Polling loop
+    while (!signal.aborted) {
+      try {
+        await delay(POLL_INTERVAL, { signal });
+        signal.throwIfAborted();
+        await set(fetchQueueData$);
+        signal.throwIfAborted();
+      } catch (error) {
+        throwIfAbort(error);
+        // Swallow non-abort errors and continue polling
+      }
     }
-  }
-});
-
-const startPolling$ = command(
-  ({ set }, _el: HTMLElement, signal: AbortSignal) => {
-    detach(set(startQueuePolling$, signal), Reason.DomCallback);
   },
 );
-
-export const queuePollingRef$ = onRef(startPolling$);
 
 export const cancelQueueRun$ = command(async ({ get, set }, runId: string) => {
   const fetchFn = get(fetch$);

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -3,11 +3,15 @@ import { createElement } from "react";
 import { ZeroWorksPageWrapper } from "../../views/works-page/zero-works-page-wrapper.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
+import { detach, Reason } from "../utils.ts";
 import { fetchAgentsList$ } from "../zero-page/zero-agents.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
 import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
-import { initSlackOrg$ } from "../zero-page/zero-slack.ts";
+import {
+  initSlackOrg$,
+  pollSlackConnection$,
+} from "../zero-page/zero-slack.ts";
 
 export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(ZeroWorksPageWrapper));
@@ -18,6 +22,7 @@ export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
     set(initSlackOrg$),
   ]);
   signal.throwIfAborted();
+  detach(set(pollSlackConnection$, signal), Reason.Entrance);
 
   if (await set(onboardGuard$, signal)) {
     return;

--- a/turbo/apps/platform/src/signals/zero-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-page-setup.ts
@@ -5,6 +5,7 @@ import { logger } from "../log.ts";
 import { defaultAgentName$ } from "./zero-agent-name.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 import { loadInitialData$ } from "./zero-page.ts";
+import { detach, Reason } from "../utils.ts";
 
 const L = logger("ChatPage");
 
@@ -13,7 +14,7 @@ export const setupChatPage$ = command(
     await set(loadInitialData$, signal);
 
     // Consume ?settings=<tab> param before redirecting
-    set(checkSettingsParam$);
+    detach(set(checkSettingsParam$), Reason.Entrance);
 
     if (await set(onboardGuard$, signal)) {
       return;

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
@@ -12,12 +12,12 @@ import { searchParams$ } from "../../../route.ts";
 const context = testContext();
 
 describe("checkSettingsParam$", () => {
-  it("should open dialog on providers tab when ?settings=providers is present", () => {
+  it("should open dialog on providers tab when ?settings=providers is present", async () => {
     const { store, signal } = context;
     createPushStateMock(signal);
     mockLocation({ pathname: "/", search: "?settings=providers" }, signal);
 
-    store.set(checkSettingsParam$);
+    await store.set(checkSettingsParam$);
 
     expect(store.get(orgManageDialogOpen$)).toBeTruthy();
     expect(store.get(activeTab$)).toBe("providers");
@@ -25,40 +25,40 @@ describe("checkSettingsParam$", () => {
     expect(store.get(searchParams$).has("settings")).toBeFalsy();
   });
 
-  it("should open dialog on billing tab when ?settings=billing is present", () => {
+  it("should open dialog on billing tab when ?settings=billing is present", async () => {
     const { store, signal } = context;
     createPushStateMock(signal);
     mockLocation({ pathname: "/", search: "?settings=billing" }, signal);
 
-    store.set(checkSettingsParam$);
+    await store.set(checkSettingsParam$);
 
     expect(store.get(orgManageDialogOpen$)).toBeTruthy();
     expect(store.get(activeTab$)).toBe("billing");
   });
 
-  it("should not open dialog when no settings param is present", () => {
+  it("should not open dialog when no settings param is present", async () => {
     const { store, signal } = context;
     createPushStateMock(signal);
     mockLocation({ pathname: "/", search: "" }, signal);
 
-    store.set(checkSettingsParam$);
+    await store.set(checkSettingsParam$);
 
     expect(store.get(orgManageDialogOpen$)).toBeFalsy();
   });
 
-  it("should not open dialog for unknown settings value", () => {
+  it("should not open dialog for unknown settings value", async () => {
     const { store, signal } = context;
     createPushStateMock(signal);
     mockLocation({ pathname: "/", search: "?settings=unknown" }, signal);
 
-    store.set(checkSettingsParam$);
+    await store.set(checkSettingsParam$);
 
     expect(store.get(orgManageDialogOpen$)).toBeFalsy();
     // The param should still be stripped
     expect(store.get(searchParams$).has("settings")).toBeFalsy();
   });
 
-  it("should preserve other search params when stripping settings", () => {
+  it("should preserve other search params when stripping settings", async () => {
     const { store, signal } = context;
     createPushStateMock(signal);
     mockLocation(
@@ -66,7 +66,7 @@ describe("checkSettingsParam$", () => {
       signal,
     );
 
-    store.set(checkSettingsParam$);
+    await store.set(checkSettingsParam$);
 
     expect(store.get(orgManageDialogOpen$)).toBeTruthy();
     const params = store.get(searchParams$);

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
@@ -1,8 +1,12 @@
 import { command, computed, state } from "ccstate";
 import { clerk$ } from "../../auth.ts";
-import { onRef } from "../../utils.ts";
+import { detach, onRef, Reason } from "../../utils.ts";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
-import { setActiveTab$, type OrgManageTab } from "./org-manage-tabs-state.ts";
+import {
+  initProfileName$,
+  setActiveTab$,
+  type OrgManageTab,
+} from "./org-manage-tabs-state.ts";
 
 const internalOrgManageDialogOpen$ = state(false);
 
@@ -10,15 +14,20 @@ export const orgManageDialogOpen$ = computed((get) =>
   get(internalOrgManageDialogOpen$),
 );
 
-export const setOrgManageDialogOpen$ = command(({ set }, open: boolean) => {
-  set(internalOrgManageDialogOpen$, open);
-});
+export const setOrgManageDialogOpen$ = command(
+  async ({ set }, open: boolean) => {
+    if (open) {
+      await set(initProfileName$);
+    }
+    set(internalOrgManageDialogOpen$, open);
+  },
+);
 
 /**
  * Check URL for `?settings=<tab>` param and auto-open the org manage dialog
  * on the specified tab. Strips the param from the URL after consuming it.
  */
-export const checkSettingsParam$ = command(({ get, set }) => {
+export const checkSettingsParam$ = command(async ({ get, set }) => {
   const params = get(searchParams$);
   const settingsValue = params.get("settings");
   if (!settingsValue) {
@@ -36,7 +45,7 @@ export const checkSettingsParam$ = command(({ get, set }) => {
   const tab = settingsTabMap[settingsValue];
   if (tab) {
     set(setActiveTab$, tab);
-    set(internalOrgManageDialogOpen$, true);
+    await set(setOrgManageDialogOpen$, true);
   }
 
   // Strip the param so it doesn't re-trigger on navigation
@@ -55,7 +64,7 @@ const patchClerkOrgProfile$ = command(
 
     const original = clerk.openOrganizationProfile.bind(clerk);
     clerk.openOrganizationProfile = () => {
-      set(internalOrgManageDialogOpen$, true);
+      detach(set(setOrgManageDialogOpen$, true), Reason.DomCallback);
     };
     signal.addEventListener("abort", () => {
       clerk.openOrganizationProfile = original;

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
@@ -1,5 +1,4 @@
 import { command, computed, state } from "ccstate";
-import { onRef } from "../../utils.ts";
 import { org$ } from "../../org.ts";
 
 // ---------------------------------------------------------------------------
@@ -110,15 +109,10 @@ export const setLogoLoaded$ = command(({ set }, value: boolean) => {
   set(internalLogoLoaded$, value);
 });
 
-const initProfileSection$ = command(
-  async ({ get, set }, _el: HTMLElement, signal: AbortSignal) => {
-    const org = await get(org$);
-    signal.throwIfAborted();
-    set(internalProfileName$, org?.name ?? "");
-  },
-);
-
-export const profileSectionRef$ = onRef(initProfileSection$);
+export const initProfileName$ = command(async ({ get, set }) => {
+  const org = await get(org$);
+  set(internalProfileName$, org?.name ?? "");
+});
 
 // ---------------------------------------------------------------------------
 // org-general-tab: DangerZoneSection

--- a/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
@@ -2,7 +2,6 @@ import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { delay } from "signal-timers";
 import { fetch$ } from "../fetch.ts";
-import { detach, onRef, Reason } from "../utils.ts";
 
 interface SlackOrgData {
   isConnected: boolean;
@@ -120,7 +119,7 @@ const POLL_INTERVAL_MS = 3000;
  * Used on the works page so that after the user completes OAuth in another tab
  * the UI updates automatically without a manual refresh.
  */
-const pollSlackConnection$ = command(
+export const pollSlackConnection$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     // Already connected — nothing to poll.
     const current = get(slackOrgState$).data;
@@ -147,20 +146,6 @@ const pollSlackConnection$ = command(
     }
   },
 );
-
-// ---------------------------------------------------------------------------
-// Polling trigger — extracted from the view's useCommand + onRef pattern.
-// The command uses the AbortSignal from onRef so polling stops on unmount.
-// ---------------------------------------------------------------------------
-
-const startSlackPolling$ = command(
-  ({ set }, _el: HTMLElement, signal: AbortSignal) => {
-    detach(set(pollSlackConnection$, signal), Reason.DomCallback);
-  },
-);
-
-/** Ref callback that starts Slack connection polling when the element mounts. */
-export const slackPollingRef$ = onRef(startSlackPolling$);
 
 export const initSlackOrg$ = command(async ({ set }) => {
   await set(fetchSlackOrg$);

--- a/turbo/apps/platform/src/views/queue-page/queue-page.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-page.tsx
@@ -1,8 +1,5 @@
-import { useGet, useSet } from "ccstate-react";
-import {
-  queueData$,
-  queuePollingRef$,
-} from "../../signals/queue-page/queue-signals.ts";
+import { useGet } from "ccstate-react";
+import { queueData$ } from "../../signals/queue-page/queue-signals.ts";
 import { QueueOverview } from "./queue-overview.tsx";
 import { QueueRunningTable } from "./queue-running-table.tsx";
 import { QueueWaitingTable } from "./queue-waiting-table.tsx";
@@ -23,10 +20,9 @@ function QueueSkeleton() {
 
 export function QueuePage() {
   const data = useGet(queueData$);
-  const pollingRef = useSet(queuePollingRef$);
 
   return (
-    <div className="flex flex-1 flex-col min-h-0" ref={pollingRef}>
+    <div className="flex flex-1 flex-col min-h-0">
       <header className="shrink-0 px-4 sm:px-6 pt-10 pb-3">
         <div className="mx-auto max-w-[900px]">
           <h1 className="text-xl font-semibold tracking-tight text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/clerk-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/clerk-org-switcher.tsx
@@ -44,7 +44,10 @@ export function ClerkOrgSwitcher() {
           }}
         />
       </div>
-      <OrgManageDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+      <OrgManageDialog
+        open={dialogOpen}
+        onOpenChange={(open) => void setDialogOpen(open)}
+      />
     </>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -39,7 +39,6 @@ import {
   setFileInputEl$,
   logoLoaded$,
   setLogoLoaded$,
-  profileSectionRef$,
   leaving$,
   setLeaving$,
   deleting$,
@@ -87,8 +86,6 @@ function ProfileSection({
   org: OrgResponse;
   isAdmin: boolean;
 }) {
-  const sectionRef = useSet(profileSectionRef$);
-
   const name = useGet(profileName$);
   const setName = useSet(setProfileName$);
 
@@ -192,7 +189,7 @@ function ProfileSection({
   };
 
   return (
-    <section ref={sectionRef} className="flex flex-col gap-3">
+    <section className="flex flex-col gap-3">
       <h3 className="text-sm font-medium text-foreground">Profile</h3>
       <div
         className="overflow-hidden rounded-xl bg-card"

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -702,7 +702,7 @@ function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
                     className="inline-flex items-center gap-1 text-amber-500 underline underline-offset-2 hover:text-amber-400"
                     onClick={() => {
                       setTab("providers");
-                      setOrgManageOpen(true);
+                      setOrgManageOpen(true).catch(() => undefined);
                     }}
                   >
                     Set one up in Organization Settings

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -25,7 +25,6 @@ import {
   uninstallSlackOrg$,
   showUninstallDialog$,
   setShowUninstallDialog$,
-  slackPollingRef$,
 } from "../../signals/zero-page/zero-slack.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import slackIconImg from "./assets/slack-icon.svg";
@@ -135,14 +134,9 @@ function SlackCard({ agentName }: { agentName: string }) {
   const isInstalled = slackData?.isInstalled ?? isConnected;
   const isAdmin = slackData?.isAdmin ?? false;
 
-  const pollingRef = useSet(slackPollingRef$);
-
   return (
     <>
-      <div
-        ref={isConnected ? undefined : pollingRef}
-        className="zero-card flex items-center gap-4 p-4"
-      >
+      <div className="zero-card flex items-center gap-4 p-4">
         <div className="shrink-0">
           <img src={slackIconImg} alt="" className="h-7 w-7" />
         </div>


### PR DESCRIPTION
## Summary

- Move `queuePollingRef$` into `setupQueuePage$` using `detach`/`Reason.Entrance`, removing DOM coupling from queue page polling
- Move `slackPollingRef$` into `setupWorksPage$` after `Promise.all` completion, ensuring `initSlackOrg$` runs first
- Replace `profileSectionRef$` with `initProfileName$` triggered by `setOrgManageDialogOpen$`, consolidating all three dialog-open paths
- Update `checkSettingsParam$` and `patchClerkOrgProfile$` to route through `setOrgManageDialogOpen$`
- Update existing tests to handle async `checkSettingsParam$`

## Test plan

- [x] All existing `org-manage-dialog` tests pass (5/5)
- [x] Type check passes for platform app (no new errors)
- [x] Lint passes for modified files (no new errors)
- [x] Knip reports no unused exports/imports
- [ ] CI pipeline passes

Closes #6434

🤖 Generated with [Claude Code](https://claude.com/claude-code)