### PR TITLE
refactor: update email template signatures to use zero branding

### DIFF
--- a/turbo/apps/web/src/lib/email/templates/agent-reply.tsx
+++ b/turbo/apps/web/src/lib/email/templates/agent-reply.tsx
@@ -29,7 +29,7 @@ export function AgentReplyEmail({
         <Container style={containerStyle}>
           <Text style={outputStyle}>{output}</Text>
           <Hr style={hrStyle} />
-          <Text style={signatureStyle}>{agentName} from VM0</Text>
+          <Text style={signatureStyle}>Zero — {agentName}</Text>
           <Text style={footerStyle}>
             <Link href={logsUrl} style={linkStyle}>
               Audit

--- a/turbo/apps/web/src/lib/email/templates/schedule-completed.tsx
+++ b/turbo/apps/web/src/lib/email/templates/schedule-completed.tsx
@@ -29,7 +29,7 @@ export function ScheduleCompletedEmail({
         <Container style={containerStyle}>
           <Text style={outputStyle}>{output}</Text>
           <Hr style={hrStyle} />
-          <Text style={signatureStyle}>{agentName} from VM0</Text>
+          <Text style={signatureStyle}>Zero — {agentName}</Text>
           <Text style={footerStyle}>
             <Link href={logsUrl} style={linkStyle}>
               Audit

--- a/turbo/apps/web/src/lib/email/templates/schedule-failed.tsx
+++ b/turbo/apps/web/src/lib/email/templates/schedule-failed.tsx
@@ -29,7 +29,7 @@ export function ScheduleFailedEmail({
         <Container style={containerStyle}>
           <Text style={errorStyle}>{errorMessage}</Text>
           <Hr style={hrStyle} />
-          <Text style={signatureStyle}>{agentName} from VM0</Text>
+          <Text style={signatureStyle}>Zero — {agentName}</Text>
           <Text style={footerStyle}>
             <Link href={logsUrl} style={linkStyle}>
               Audit


### PR DESCRIPTION
## Summary

- Update in-body email signature from `{agentName} from VM0` to `Zero — {agentName}` in 3 templates
- Aligns template signatures with the `Zero <org@vm0.bot>` from-address format established in #6291

Closes #6439

## Test plan

- [x] Verified `grep "from VM0"` returns 0 results in templates directory
- [x] Lint, type-check, format all pass
- [x] All existing tests pass (4 flaky failures in unrelated `sandbox-capability.test.ts` — pass in isolation)
- [x] Knip reports no unused code

🤖 Generated with [Claude Code](https://claude.com/claude-code)