### PR TITLE
fix: update outbox-service test fixture to use new from address format

### DIFF
--- a/turbo/apps/web/src/lib/email/__tests__/outbox-service.test.ts
+++ b/turbo/apps/web/src/lib/email/__tests__/outbox-service.test.ts
@@ -27,7 +27,7 @@ function baseEmail(
   overrides?: Partial<EnqueueEmailOptions>,
 ): EnqueueEmailOptions {
   return {
-    from: "test-agent from VM0 <test-agent@vm7.bot>",
+    from: "Zero <test-org@vm7.bot>",
     to: "user@example.com",
     subject: "Test email",
     template: {


### PR DESCRIPTION
## Summary

- Update the stale `from` field in the `baseEmail()` test helper from old `"test-agent from VM0 <test-agent@vm7.bot>"` format to new `"Zero <test-org@vm7.bot>"` format
- Aligns test fixture with production `buildFromAddress()` output (Epic #6291)

Closes #6441

## Test plan

- [x] All 11 existing `outbox-service.test.ts` tests pass
- [x] Lint passes
- [x] Type check passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)