### PR TITLE
refactor: remove unused triggerLocalPart from email trigger payload

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/__tests__/route.test.ts
@@ -31,7 +31,6 @@ interface TriggerCallbackPayload {
   inboundMessageId?: string;
   inboundReferences?: string;
   subject?: string;
-  triggerLocalPart?: string;
   replyRecipientTo?: string[];
   replyRecipientCc?: string[];
 }
@@ -150,7 +149,6 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
 
       const replyToken = generateReplyToken(crypto.randomUUID());
       const senderEmail = "sender@example.com";
-      const triggerLocalPart = `my-org+${agentName}`;
       const payload: TriggerCallbackPayload = {
         senderEmail,
         composeId,
@@ -159,7 +157,6 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
         replyToken,
         inboundMessageId: "<orig-msg-id@example.com>",
         subject: "Help me with this",
-        triggerLocalPart,
       };
 
       const { secret } = await createTestCallback({
@@ -212,7 +209,6 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
         inboundEmailId: "email-456",
         replyToken,
         subject: "Re: Original Topic",
-        triggerLocalPart: agentName,
       };
 
       const { secret } = await createTestCallback({
@@ -254,7 +250,6 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
         inboundEmailId: "email-replyall",
         replyToken,
         subject: "Group discussion",
-        triggerLocalPart: agentName,
         replyRecipientTo: ["user-a@example.com", "user-b@example.com"],
         replyRecipientCc: ["user-c@example.com"],
       };
@@ -298,7 +293,6 @@ describe("POST /api/internal/callbacks/email/trigger", () => {
         userId: user.userId,
         inboundEmailId: "email-fallback",
         replyToken,
-        triggerLocalPart: agentName,
       };
 
       const { secret } = await createTestCallback({

--- a/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/__tests__/route.test.ts
@@ -581,7 +581,6 @@ describe("POST /api/webhooks/email/inbound", () => {
         replyToken: expect.any(String),
         inboundMessageId: "<default-msg-id@example.com>",
         subject: "Test Subject",
-        triggerLocalPart: orgSlug,
       });
     });
 

--- a/turbo/apps/web/src/lib/callback/callback-payloads.ts
+++ b/turbo/apps/web/src/lib/callback/callback-payloads.ts
@@ -39,7 +39,6 @@ export interface EmailTriggerCallbackPayload {
   inboundMessageId?: string;
   inboundReferences?: string;
   subject?: string;
-  triggerLocalPart?: string;
   runtimeOrgId?: string;
   replyRecipientTo?: string[];
   replyRecipientCc?: string[];

--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -218,7 +218,6 @@ export async function handleInboundEmailTrigger(
         inboundMessageId,
         inboundReferences,
         subject,
-        triggerLocalPart: orgSlug,
         runtimeOrgId: orgId,
         replyRecipientTo: replyRecipients.to,
         replyRecipientCc: replyRecipients.cc,


### PR DESCRIPTION
## Summary

- Removed vestigial `triggerLocalPart` field from `EmailTriggerCallbackPayload` interface
- Removed the field assignment from inbound email trigger handler
- Cleaned up all test references (trigger callback tests + inbound webhook tests)

Closes #6440

## Context

After the org-level routing refactor (#6291), the trigger callback route resolves the org via `getOrgData(payload.runtimeOrgId)` and no longer reads `triggerLocalPart`. This field was set but never consumed.

## Test plan

- [x] TypeScript compilation passes (no missed references)
- [x] All 42 affected tests pass (9 trigger callback + 33 inbound webhook)
- [x] Lint passes with 0 warnings
- [x] `pnpm knip` confirms no orphaned code
- [x] Full codebase grep confirms zero remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)