### PR TITLE
fix(web): return 502 when firewall auth token refresh fails

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -504,11 +504,11 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(data.expiresAt).toBeTypeOf("number");
     });
 
-    it("should use existing token when refresh fails", async () => {
+    it("should return 502 when token refresh fails", async () => {
       const expiredAt = new Date(Date.now() - 60 * 1000);
       await setupNotionConnector({ tokenExpiresAt: expiredAt });
 
-      // Provider returns error
+      // Provider returns error (e.g. refresh token revoked)
       server.use(
         mswHttp.post(NOTION_TOKEN_URL, () =>
           HttpResponse.json({ error: "invalid_grant" }, { status: 400 }),
@@ -533,13 +533,10 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
         ),
       );
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(502);
       const data = await response.json();
-      // Falls back to old token
-      expect(data.headers.Authorization).toBe("Bearer old-notion-token");
-      // expiresAt is the original expired value (not cached for long by addon)
-      const expiredEpoch = Math.floor(expiredAt.getTime() / 1000);
-      expect(data.expiresAt).toBe(expiredEpoch);
+      expect(data.error.code).toBe("TOKEN_REFRESH_FAILED");
+      expect(data.error.connectors).toEqual(["notion"]);
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -538,5 +538,81 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(data.error.code).toBe("TOKEN_REFRESH_FAILED");
       expect(data.error.connectors).toEqual(["notion"]);
     });
+
+    it("should return 502 when one of multiple connectors fails to refresh", async () => {
+      const CLOSE_TOKEN_URL = "https://api.close.com/oauth2/token/";
+      const expiredAt = new Date(Date.now() - 60 * 1000);
+
+      // Setup Notion (will succeed)
+      await setupNotionConnector({ tokenExpiresAt: expiredAt });
+
+      // Setup Close (will fail)
+      vi.stubEnv("CLOSE_OAUTH_CLIENT_ID", "test-close-client-id");
+      vi.stubEnv("CLOSE_OAUTH_CLIENT_SECRET", "test-close-client-secret");
+      const { reloadEnv } = await import("../../../../../../../src/env");
+      reloadEnv();
+
+      await context.createConnector(user.orgId, {
+        userId: user.userId,
+        type: "close",
+        authMethod: "oauth",
+        tokenExpiresAt: expiredAt,
+      });
+      await insertTestConnectorSecret(
+        user.orgId,
+        user.userId,
+        "CLOSE_ACCESS_TOKEN",
+        "old-close-token",
+      );
+      await insertTestConnectorSecret(
+        user.orgId,
+        user.userId,
+        "CLOSE_REFRESH_TOKEN",
+        "close-refresh-token",
+      );
+
+      // Notion refresh succeeds, Close refresh fails
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () =>
+          HttpResponse.json({
+            access_token: "fresh-notion-token",
+            expires_in: 3600,
+          }),
+        ),
+        mswHttp.post(CLOSE_TOKEN_URL, () =>
+          HttpResponse.json({ error: "invalid_grant" }, { status: 400 }),
+        ),
+      );
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "old-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+        CLOSE_ACCESS_TOKEN: "old-close-token",
+        CLOSE_REFRESH_TOKEN: "close-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
+              "X-Close-Token": "Bearer ${{ secrets.CLOSE_ACCESS_TOKEN }}",
+            },
+            secretConnectorMap: {
+              NOTION_ACCESS_TOKEN: "notion",
+              CLOSE_ACCESS_TOKEN: "close",
+            },
+          },
+          testToken,
+        ),
+      );
+
+      // Should still return 502 because one connector failed
+      expect(response.status).toBe(502);
+      const data = await response.json();
+      expect(data.error.code).toBe("TOKEN_REFRESH_FAILED");
+      expect(data.error.connectors).toEqual(["close"]);
+    });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -88,8 +88,7 @@ async function refreshExpiredTokens(
     envVarsByConnector.set(ct, arr);
   }
 
-  const failedConnectors: string[] = [];
-  const results = await Promise.all(
+  const refreshResults = await Promise.all(
     toRefresh.map(async (connectorType) => {
       log.debug(`[${auth.runId}] Refreshing expired ${connectorType} token`);
       const freshToken = await refreshConnectorAccessToken(
@@ -100,8 +99,7 @@ async function refreshExpiredTokens(
       );
       if (!freshToken) {
         log.warn(`[${auth.runId}] Failed to refresh ${connectorType} token`);
-        failedConnectors.push(connectorType);
-        return false;
+        return { connectorType, ok: false as const };
       }
       // refreshConnectorAccessToken updates secrets[rawSecretName] but the
       // template may reference a mapped env var name.  Sync all mapped keys
@@ -109,10 +107,13 @@ async function refreshExpiredTokens(
       for (const envVar of envVarsByConnector.get(connectorType) ?? []) {
         secrets[envVar] = freshToken;
       }
-      return true;
+      return { connectorType, ok: true as const };
     }),
   );
-  const refreshed = results.some(Boolean);
+  const refreshed = refreshResults.some((r) => r.ok);
+  const failedConnectors = refreshResults
+    .filter((r) => !r.ok)
+    .map((r) => r.connectorType);
 
   // Use accurate DB values after refresh; skip extra query if nothing changed
   const finalExpiryMap = refreshed

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -28,19 +28,24 @@ const SECRET_TEMPLATE_RE = /\$\{\{\s*secrets\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
  * Mutates `secrets` in place with fresh token values.
  * Returns the earliest expiry timestamp (epoch seconds) or null if all are non-expiring.
  */
+interface RefreshResult {
+  expiresAt: number | null;
+  failedConnectors: string[];
+}
+
 async function refreshExpiredTokens(
   auth: SandboxAuth,
   secrets: Record<string, string>,
   secretConnectorMap: Record<string, string>,
   referencedKeys: Set<string>,
-): Promise<number | null> {
+): Promise<RefreshResult> {
   // Find which referenced secrets are refreshable OAuth tokens
   const refreshable = new Map<string, string>();
   for (const key of referencedKeys) {
     const connectorType = secretConnectorMap[key];
     if (connectorType) refreshable.set(key, connectorType);
   }
-  if (refreshable.size === 0) return null;
+  if (refreshable.size === 0) return { expiresAt: null, failedConnectors: [] };
 
   // Look up orgId from runId
   const [run] = await globalThis.services.db
@@ -51,7 +56,7 @@ async function refreshExpiredTokens(
 
   if (!run) {
     log.warn(`[${auth.runId}] Run not found for token refresh`);
-    return null;
+    return { expiresAt: null, failedConnectors: [] };
   }
 
   const connectorTypes = [...new Set(refreshable.values())];
@@ -83,6 +88,7 @@ async function refreshExpiredTokens(
     envVarsByConnector.set(ct, arr);
   }
 
+  const failedConnectors: string[] = [];
   const results = await Promise.all(
     toRefresh.map(async (connectorType) => {
       log.debug(`[${auth.runId}] Refreshing expired ${connectorType} token`);
@@ -93,9 +99,8 @@ async function refreshExpiredTokens(
         secrets,
       );
       if (!freshToken) {
-        log.warn(
-          `[${auth.runId}] Failed to refresh ${connectorType} token, using existing`,
-        );
+        log.warn(`[${auth.runId}] Failed to refresh ${connectorType} token`);
+        failedConnectors.push(connectorType);
         return false;
       }
       // refreshConnectorAccessToken updates secrets[rawSecretName] but the
@@ -123,7 +128,7 @@ async function refreshExpiredTokens(
     }
   }
 
-  return earliestExpiry;
+  return { expiresAt: earliestExpiry, failedConnectors };
 }
 
 /**
@@ -235,12 +240,30 @@ export async function POST(request: Request) {
 
   // Refresh expired OAuth tokens (mutates secrets map with fresh values)
   let expiresAt: number | null = null;
+  let failedConnectors: string[] = [];
   if (secretConnectorMap) {
-    expiresAt = await refreshExpiredTokens(
+    const result = await refreshExpiredTokens(
       auth,
       secrets,
       secretConnectorMap,
       referencedKeys,
+    );
+    expiresAt = result.expiresAt;
+    failedConnectors = result.failedConnectors;
+  }
+
+  // If any connector token refresh failed, return an error so the addon
+  // surfaces a clear message instead of silently using a stale token.
+  if (failedConnectors.length > 0) {
+    return NextResponse.json(
+      {
+        error: {
+          message: `OAuth token expired and refresh failed for: ${failedConnectors.join(", ")}. The connector may need to be reconnected.`,
+          code: "TOKEN_REFRESH_FAILED",
+          connectors: failedConnectors,
+        },
+      },
+      { status: 502 },
     );
   }
 


### PR DESCRIPTION
## Summary

- Return 502 with `TOKEN_REFRESH_FAILED` error code when OAuth token refresh fails in the firewall auth endpoint, instead of silently returning the stale expired token
- Track which connectors failed to refresh and include them in the error response
- Addon already handles non-2xx as `firewall_auth_failed`, so agent gets a clear error message

Closes #6461

## Test plan

- [x] Existing 16 auth endpoint tests pass
- [x] Updated test: refresh failure now expects 502 with error code and connector list
- [x] Type check passes
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)