### PR TITLE
feat: add personal env file support to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,13 +11,16 @@
   },
   "remoteUser": "vscode",
   "forwardPorts": [6080, 8443],
+  "initializeCommand": "touch .devcontainer/.env.run",
   "runArgs": [
     "-p",
     "6080",
     "-p",
     "8443",
     "--hostname",
-    "${localWorkspaceFolderBasename}"
+    "${localWorkspaceFolderBasename}",
+    "--env-file",
+    ".devcontainer/.env.run"
   ],
   "remoteEnv": {
     "CLAUDE_CONFIG_DIR": "/home/vscode/.config/claude",

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Dev container personal env
+.devcontainer/.env.run
+
 # Created by https://www.toptal.com/developers/gitignore/api/node
 # Edit at https://www.toptal.com/developers/gitignore?templates=node
 


### PR DESCRIPTION
## Summary
- Add `.devcontainer/.env.run` support so developers can inject personal environment variables into the devcontainer at runtime via `--env-file`
- Add `initializeCommand` to ensure the env file exists (prevents Docker errors if the file is missing)
- Add `.devcontainer/.env.run` to `.gitignore` to keep personal env values out of version control

## Test plan
- [ ] Verify devcontainer starts successfully with an empty `.env.run` file
- [ ] Verify custom env vars in `.env.run` are available inside the container
- [ ] Verify `.devcontainer/.env.run` is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)