### PR TITLE
fix: update sandbox schedule and Slack guidance for zero CLI

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -29,17 +29,18 @@ export const DISALLOWED_CRON_TOOLS = [
 
 /**
  * Build schedule guidance prompt that redirects agents from ephemeral cron
- * tools to vm0's persistent schedule system.
+ * tools to the zero schedule CLI.
  */
 export function buildScheduleGuidance(): string {
   return [
     "# Scheduling Tasks",
     "Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
-    "For recurring or scheduled tasks, use the vm0 schedule CLI:",
-    "- Create: vm0 schedule setup $VM0_AGENT_NAME",
-    "- List: vm0 schedule list",
-    "- Delete: vm0 schedule delete $VM0_AGENT_NAME --name <schedule-name>",
-    "- Enable/Disable: vm0 schedule enable/disable $VM0_AGENT_NAME --name <schedule-name>",
+    "For recurring or scheduled tasks, use the zero schedule CLI:",
+    "- Create: npx -p @vm0/cli zero schedule setup $VM0_AGENT_NAME",
+    "- List: npx -p @vm0/cli zero schedule list",
+    "- Delete: npx -p @vm0/cli zero schedule delete $VM0_AGENT_NAME --name <schedule-name>",
+    "- Enable/Disable: npx -p @vm0/cli zero schedule enable/disable $VM0_AGENT_NAME --name <schedule-name>",
+    'Alternative: use "npx @vm0/cli zero schedule" instead of "npx -p @vm0/cli zero schedule".',
     'Choose a short, descriptive schedule name based on the task (e.g., "deploy-check", "daily-report").',
   ].join("\n");
 }
@@ -52,9 +53,10 @@ export function buildSlackMessagingGuidance(): string {
   return `# Sending Slack Messages
 You can send Slack messages directly using the vm0 integration API:
 curl -X POST "$VM0_API_URL/api/zero/integrations/slack/message" \\
-  -H "Authorization: Bearer $VM0_TOKEN" \\
+  -H "Authorization: Bearer $ZERO_TOKEN" \\
   -H "Content-Type: application/json" \\
   -d '{"channel": "<channel-id>", "text": "your message"}'
+Note: $VM0_TOKEN also works during the transition period.
 Optional fields: threadTs (reply in thread), blocks (Block Kit JSON).
 Messages are sent as the bot user, not as an individual user.`;
 }


### PR DESCRIPTION
## Summary

Closes #6472

- Updated `buildScheduleGuidance()` to reference `npx -p @vm0/cli zero schedule` instead of stale `vm0 schedule` commands
- Updated `buildSlackMessagingGuidance()` to use `$ZERO_TOKEN` as primary auth token with `$VM0_TOKEN` fallback note for transition period
- Added alternative invocation style (`npx @vm0/cli zero schedule`) for sandbox agents

## Changes

Single file: `turbo/apps/web/src/lib/integration-context.ts`

- `buildScheduleGuidance()`: replaced all `vm0 schedule` references with `npx -p @vm0/cli zero schedule`, added alternative npx style
- `buildSlackMessagingGuidance()`: changed `$VM0_TOKEN` → `$ZERO_TOKEN` in curl example, added transition period note
- `buildIntegrationContext()` and `DISALLOWED_CRON_TOOLS`: unchanged

## Test plan

- [x] Grep confirms no remaining `vm0 schedule setup/list/delete` in integration-context.ts
- [x] Grep confirms `npx -p @vm0/cli zero schedule` present in guidance
- [x] Grep confirms `$ZERO_TOKEN` present in Slack guidance
- [x] Grep confirms `$VM0_TOKEN` still mentioned (transition note)
- [x] `DISALLOWED_CRON_TOOLS` export unchanged
- [x] `buildIntegrationContext()` unchanged
- [x] Lint, type-check, format all pass
- [x] All tests pass (pre-existing failures in sync-skills/agents/firewall-policies are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)