### PR TITLE
chore(email): delete legacy email route re-exports

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/reply/route.ts
@@ -1,5 +1,0 @@
-/**
- * Legacy path — forwards to /api/zero/email/callbacks/reply.
- * Keep for in-flight runs created before this deploy.
- */
-export { POST } from "../../../../../api/zero/email/callbacks/reply/route";

--- a/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/schedule/route.ts
@@ -1,5 +1,0 @@
-/**
- * Legacy path — forwards to /api/zero/email/callbacks/schedule.
- * Keep for in-flight runs created before this deploy.
- */
-export { POST } from "../../../../../api/zero/email/callbacks/schedule/route";

--- a/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/email/trigger/route.ts
@@ -1,5 +1,0 @@
-/**
- * Legacy path — forwards to /api/zero/email/callbacks/trigger.
- * Keep for in-flight runs created before this deploy.
- */
-export { POST } from "../../../../../api/zero/email/callbacks/trigger/route";

--- a/turbo/apps/web/app/api/webhooks/email/inbound/route.ts
+++ b/turbo/apps/web/app/api/webhooks/email/inbound/route.ts
@@ -1,5 +1,0 @@
-/**
- * Legacy path — forwards to /api/zero/email/inbound.
- * Keep until Resend dashboard webhook URL is updated.
- */
-export { POST } from "../../../../api/zero/email/inbound/route";


### PR DESCRIPTION
## Summary

- Delete the 4 legacy re-export shims at old email route paths, left behind by PR #6470
- All in-flight runs have completed and no code references the old paths

Part of #6226. Closes #6480.

## Files Deleted

- `app/api/internal/callbacks/email/trigger/route.ts`
- `app/api/internal/callbacks/email/reply/route.ts`
- `app/api/internal/callbacks/email/schedule/route.ts`
- `app/api/webhooks/email/inbound/route.ts`

## Important

Resend dashboard webhook URL must point to `/api/zero/email/inbound` (documented in Epic #6226).

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] Knip passes
- [x] Canonical routes under `/api/zero/email/` verified intact
- [x] No remaining references to old paths in codebase
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)