### PR TITLE
feat(core): add zero capabilities constants for zero-layer capability system

### DIFF
--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -4,6 +4,8 @@ import {
   agentComposeApiContentSchema,
   VALID_CAPABILITIES,
   CAPABILITY_META,
+  ZERO_CAPABILITIES,
+  ZERO_CAPABILITY_META,
 } from "../composes";
 
 const baseAgent = {
@@ -127,5 +129,37 @@ describe("experimental_capabilities in agentComposeApiContentSchema", () => {
       }),
     );
     expect(result.success).toBe(false);
+  });
+});
+
+describe("ZERO_CAPABILITIES", () => {
+  it("should have exactly 7 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(7);
+  });
+
+  it("should follow {resource}:{action} naming pattern", () => {
+    for (const cap of ZERO_CAPABILITIES) {
+      expect(cap).toMatch(/^[a-z-]+:(read|write)$/);
+    }
+  });
+
+  it("should not include artifact capabilities", () => {
+    expect(ZERO_CAPABILITIES).not.toContain("artifact:read");
+    expect(ZERO_CAPABILITIES).not.toContain("artifact:write");
+  });
+
+  it("should use slack:write not integration-slack:write", () => {
+    expect(ZERO_CAPABILITIES).toContain("slack:write");
+    expect(ZERO_CAPABILITIES).not.toContain("integration-slack:write");
+  });
+});
+
+describe("ZERO_CAPABILITY_META", () => {
+  it("should have metadata for every ZERO_CAPABILITY", () => {
+    for (const cap of ZERO_CAPABILITIES) {
+      expect(ZERO_CAPABILITY_META[cap]).toBeDefined();
+      expect(ZERO_CAPABILITY_META[cap].group).toBeTruthy();
+      expect(ZERO_CAPABILITY_META[cap].label).toBeTruthy();
+    }
   });
 });

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -5,7 +5,6 @@ import {
   VALID_CAPABILITIES,
   CAPABILITY_META,
   ZERO_CAPABILITIES,
-  ZERO_CAPABILITY_META,
 } from "../composes";
 
 const baseAgent = {
@@ -133,10 +132,6 @@ describe("experimental_capabilities in agentComposeApiContentSchema", () => {
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 7 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(7);
-  });
-
   it("should follow {resource}:{action} naming pattern", () => {
     for (const cap of ZERO_CAPABILITIES) {
       expect(cap).toMatch(/^[a-z-]+:(read|write)$/);
@@ -151,15 +146,5 @@ describe("ZERO_CAPABILITIES", () => {
   it("should use slack:write not integration-slack:write", () => {
     expect(ZERO_CAPABILITIES).toContain("slack:write");
     expect(ZERO_CAPABILITIES).not.toContain("integration-slack:write");
-  });
-});
-
-describe("ZERO_CAPABILITY_META", () => {
-  it("should have metadata for every ZERO_CAPABILITY", () => {
-    for (const cap of ZERO_CAPABILITIES) {
-      expect(ZERO_CAPABILITY_META[cap]).toBeDefined();
-      expect(ZERO_CAPABILITY_META[cap].group).toBeTruthy();
-      expect(ZERO_CAPABILITY_META[cap].label).toBeTruthy();
-    }
   });
 });

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -5,6 +5,7 @@ import {
   VALID_CAPABILITIES,
   CAPABILITY_META,
   ZERO_CAPABILITIES,
+  ZERO_CAPABILITY_META,
 } from "../composes";
 
 const baseAgent = {
@@ -132,6 +133,10 @@ describe("experimental_capabilities in agentComposeApiContentSchema", () => {
 });
 
 describe("ZERO_CAPABILITIES", () => {
+  it("should have exactly 7 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(7);
+  });
+
   it("should follow {resource}:{action} naming pattern", () => {
     for (const cap of ZERO_CAPABILITIES) {
       expect(cap).toMatch(/^[a-z-]+:(read|write)$/);
@@ -146,5 +151,15 @@ describe("ZERO_CAPABILITIES", () => {
   it("should use slack:write not integration-slack:write", () => {
     expect(ZERO_CAPABILITIES).toContain("slack:write");
     expect(ZERO_CAPABILITIES).not.toContain("integration-slack:write");
+  });
+});
+
+describe("ZERO_CAPABILITY_META", () => {
+  it("should have metadata for every ZERO_CAPABILITY", () => {
+    for (const cap of ZERO_CAPABILITIES) {
+      expect(ZERO_CAPABILITY_META[cap]).toBeDefined();
+      expect(ZERO_CAPABILITY_META[cap].group).toBeTruthy();
+      expect(ZERO_CAPABILITY_META[cap].label).toBeTruthy();
+    }
   });
 });

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -80,6 +80,48 @@ export const CAPABILITY_META: Record<ValidCapability, CapabilityMeta> = {
 };
 
 /**
+ * Capabilities for the zero-layer capability system (ZERO_TOKEN).
+ * These protect /api/zero/* routes only.
+ */
+export const ZERO_CAPABILITIES = [
+  "agent:read",
+  "agent:write",
+  "agent-run:read",
+  "agent-run:write",
+  "schedule:read",
+  "schedule:write",
+  "slack:write",
+] as const;
+
+/** Inferred union type of all zero capability strings. */
+export type ZeroCapability = (typeof ZERO_CAPABILITIES)[number];
+
+/** Metadata for a single zero capability — group label and human-readable label. */
+export interface ZeroCapabilityMeta {
+  group: string;
+  label: string;
+}
+
+/**
+ * Exhaustive mapping from every zero capability to its UI group and label.
+ * Adding a new capability to ZERO_CAPABILITIES without updating this record
+ * will produce a TypeScript compile error.
+ */
+export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
+  {
+    "agent:read": { group: "Agent", label: "Read agents" },
+    "agent:write": { group: "Agent", label: "Create, update & delete agents" },
+    "agent-run:read": { group: "Agent Runs", label: "View runs & telemetry" },
+    "agent-run:write": { group: "Agent Runs", label: "Cancel runs" },
+    "schedule:read": { group: "Schedules", label: "View schedules" },
+    "schedule:write": {
+      group: "Schedules",
+      label: "Create & delete schedules",
+    },
+    "slack:write": { group: "Integrations", label: "Send Slack messages" },
+  };
+
+/**
  * Agent name validation schema
  * - Must be 3-64 characters
  * - Letters, numbers, and hyphens only

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -96,11 +96,8 @@ export const ZERO_CAPABILITIES = [
 /** Inferred union type of all zero capability strings. */
 export type ZeroCapability = (typeof ZERO_CAPABILITIES)[number];
 
-/** Metadata for a single zero capability — group label and human-readable label. */
-export interface ZeroCapabilityMeta {
-  group: string;
-  label: string;
-}
+/** Metadata for a single zero capability — reuses CapabilityMeta structure. */
+export type ZeroCapabilityMeta = CapabilityMeta;
 
 /**
  * Exhaustive mapping from every zero capability to its UI group and label.

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -47,6 +47,10 @@ export {
   CAPABILITY_META,
   type ValidCapability,
   type CapabilityMeta,
+  ZERO_CAPABILITIES,
+  ZERO_CAPABILITY_META,
+  type ZeroCapability,
+  type ZeroCapabilityMeta,
   // Inferred types
   type ComposeResponse,
   type ComposeListItem,


### PR DESCRIPTION
## Summary

- Add `ZERO_CAPABILITIES` constant with 7 capabilities for the zero-layer capability system (`ZERO_TOKEN`)
- Add `ZeroCapability` type, `ZeroCapabilityMeta` interface, and `ZERO_CAPABILITY_META` metadata record
- Re-export all new constants/types from `@vm0/core` package
- Add comprehensive tests: count, naming pattern, artifact exclusion, slack:write naming, meta coverage

## Context

Part of epic #6457 — migrate capabilities from vm0.yaml to zero agent configuration with ZERO_TOKEN. These constants will be consumed by ZERO_TOKEN generation and auth enforcement in subsequent sub-issues.

Purely additive — no existing code modified.

Closes #6489

## Test plan

- [x] All 18 tests pass in `composes.test.ts` (13 existing + 5 new)
- [x] Type-check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Format passes (`pnpm format`)
- [x] Knip clean — no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)