### PR TITLE
test: add zero cli binary e2e smoke test

### DIFF
--- a/e2e/tests/01-serial/ser-t06-zero-cli-smoke.bats
+++ b/e2e/tests/01-serial/ser-t06-zero-cli-smoke.bats
@@ -12,7 +12,7 @@ load '../../helpers/setup'
     assert_output --partial "org"
 }
 
-@test "zero --help does not show compose, run, volume commands" {
+@test "zero --help does not show compose, volume, artifact commands" {
     run zero --help
     assert_success
     refute_output --partial "compose"

--- a/e2e/tests/01-serial/ser-t06-zero-cli-smoke.bats
+++ b/e2e/tests/01-serial/ser-t06-zero-cli-smoke.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# Smoke tests for the zero CLI binary entry point
+# Verifies the zero binary works independently from vm0
+
+load '../../helpers/setup'
+
+@test "zero --help shows schedule, agent, org commands" {
+    run zero --help
+    assert_success
+    assert_output --partial "schedule"
+    assert_output --partial "agent"
+    assert_output --partial "org"
+}
+
+@test "zero --help does not show compose, run, volume commands" {
+    run zero --help
+    assert_success
+    refute_output --partial "compose"
+    refute_output --partial "volume"
+    refute_output --partial "artifact"
+}
+
+@test "zero --version outputs version" {
+    run zero --version
+    assert_success
+    assert_output --regexp '^[0-9]+\.[0-9]+\.[0-9]+'
+}
+
+@test "zero agent list returns successfully" {
+    run zero agent list
+    assert_success
+}
+
+@test "zero schedule list returns successfully" {
+    run zero schedule list
+    assert_success
+}


### PR DESCRIPTION
## Summary

- Add minimal E2E smoke test for the `zero` CLI binary entry point
- Tests invoke `zero` binary directly (not through `trace-cli.sh`) to verify the standalone binary works
- 5 tests: help output (positive + negative), version, agent list, schedule list

## Test plan

- [ ] `zero --help` shows expected commands (schedule, agent, org)
- [ ] `zero --help` does NOT show infra commands (compose, volume, artifact)
- [ ] `zero --version` outputs semver format
- [ ] `zero agent list` authenticates and returns successfully
- [ ] `zero schedule list` authenticates and returns successfully
- [ ] CI `cli-e2e-01-serial` job passes

Closes #6491

🤖 Generated with [Claude Code](https://claude.com/claude-code)