### PR TITLE
refactor: remove agent-composes dependency from email default agent resolver

### DIFF
--- a/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/email/handlers/inbound-trigger.ts
@@ -92,8 +92,8 @@ async function resolveTrigger(
   }
 
   // 5. Resolve default agent
-  const agent = await resolveDefaultAgent(orgData.orgId);
-  if (!agent) {
+  const agentId = await resolveDefaultAgent(orgData.orgId);
+  if (!agentId) {
     log.debug("No default agent configured", { orgId: orgData.orgId });
     return {
       ok: false,
@@ -105,7 +105,7 @@ async function resolveTrigger(
     orgId: orgData.orgId,
     orgSlug,
     userId,
-    agentId: agent.agentId,
+    agentId,
   };
 }
 

--- a/turbo/apps/web/src/lib/email/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/email/handlers/shared.ts
@@ -1,10 +1,7 @@
 import crypto from "crypto";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { emailThreadSessions } from "../../../db/schema/email-thread-session";
-import { agentComposes } from "../../../db/schema/agent-compose";
-import { zeroAgents } from "../../../db/schema/zero-agent";
-import { orgMetadata } from "../../../db/schema/org-metadata";
-import { resolveDefaultAgentComposeId } from "../../agent-compose/resolve-default";
+import { resolveDefaultAgentId } from "../../zero/resolve-default-agent";
 import { env } from "../../../env";
 import { getAppUrl } from "../../url";
 import { getApiUrl } from "../../callback/dispatcher";
@@ -131,71 +128,15 @@ export function computeReplyRecipients(opts: {
 // Agent Resolution
 // ============================================================================
 
-interface ResolvedDefaultAgent {
-  agentId: string;
-  userId: string;
-  orgId: string;
-  headVersionId: string;
-}
-
 /**
- * Resolve the org's default agent.
- * Looks up default_agent_compose_id from org_metadata, falls back to VM0_DEFAULT_AGENT env var.
+ * Resolve the org's default agent ID (zero layer).
+ * Delegates to resolveDefaultAgentId which handles both the org_metadata
+ * primary path and the VM0_DEFAULT_AGENT env var fallback.
  */
 export async function resolveDefaultAgent(
   orgId: string,
-): Promise<ResolvedDefaultAgent | null> {
-  // 1. Look up default compose ID from org_metadata
-  const [orgRow] = await globalThis.services.db
-    .select({ defaultAgentComposeId: orgMetadata.defaultAgentComposeId })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
-
-  let composeId = orgRow?.defaultAgentComposeId ?? null;
-
-  // 2. Fallback to VM0_DEFAULT_AGENT env var
-  if (!composeId) {
-    composeId = await resolveDefaultAgentComposeId();
-  }
-
-  if (!composeId) return null;
-
-  // 3. Look up compose details
-  const [compose] = await globalThis.services.db
-    .select({
-      id: agentComposes.id,
-      userId: agentComposes.userId,
-      orgId: agentComposes.orgId,
-      name: agentComposes.name,
-      headVersionId: agentComposes.headVersionId,
-    })
-    .from(agentComposes)
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
-
-  if (!compose || !compose.headVersionId) return null;
-
-  // 3. Resolve agentId by (orgId, name)
-  const [agent] = await globalThis.services.db
-    .select({ id: zeroAgents.id })
-    .from(zeroAgents)
-    .where(
-      and(
-        eq(zeroAgents.orgId, compose.orgId),
-        eq(zeroAgents.name, compose.name),
-      ),
-    )
-    .limit(1);
-
-  if (!agent) return null;
-
-  return {
-    agentId: agent.id,
-    userId: compose.userId,
-    orgId: compose.orgId,
-    headVersionId: compose.headVersionId,
-  };
+): Promise<string | null> {
+  return resolveDefaultAgentId(orgId);
 }
 
 // ============================================================================

--- a/turbo/apps/web/src/lib/zero/resolve-default-agent.ts
+++ b/turbo/apps/web/src/lib/zero/resolve-default-agent.ts
@@ -1,0 +1,101 @@
+import { eq, and } from "drizzle-orm";
+import { env } from "../../env";
+import { orgMetadata } from "../../db/schema/org-metadata";
+import { agentComposes } from "../../db/schema/agent-compose";
+import { zeroAgents } from "../../db/schema/zero-agent";
+import { getOrgBySlug } from "../org/org-cache-service";
+import { logger } from "../logger";
+
+const log = logger("zero:resolve-default-agent");
+
+/**
+ * Resolve the default zero-layer agent ID for an org.
+ *
+ * Primary path: reads defaultAgentComposeId from org_metadata, then JOINs
+ * agent_composes with zero_agents via (orgId, name) to get the agent ID.
+ *
+ * Fallback path: parses VM0_DEFAULT_AGENT env var ("org-slug/agent-name"),
+ * resolves the org, then queries zero_agents directly by (orgId, name).
+ *
+ * Returns the zero_agents.id or null if no default agent is configured.
+ */
+export async function resolveDefaultAgentId(
+  orgId: string,
+): Promise<string | null> {
+  // 1. Look up default compose ID from org_metadata
+  const [orgRow] = await globalThis.services.db
+    .select({ defaultAgentComposeId: orgMetadata.defaultAgentComposeId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  const composeId = orgRow?.defaultAgentComposeId ?? null;
+
+  if (composeId) {
+    // 2a. Primary path: resolve via compose → zero agent JOIN
+    const [row] = await globalThis.services.db
+      .select({ agentId: zeroAgents.id })
+      .from(agentComposes)
+      .innerJoin(
+        zeroAgents,
+        and(
+          eq(zeroAgents.orgId, agentComposes.orgId),
+          eq(zeroAgents.name, agentComposes.name),
+        ),
+      )
+      .where(eq(agentComposes.id, composeId))
+      .limit(1);
+
+    if (row) return row.agentId;
+  }
+
+  // 2b. Fallback: resolve via VM0_DEFAULT_AGENT env var → zero_agents directly
+  return resolveDefaultAgentIdFromEnv();
+}
+
+/**
+ * Resolve the default agent ID from the VM0_DEFAULT_AGENT env var.
+ * Format: "org-slug/agent-name" (e.g. "yuma/deep-dive")
+ *
+ * Queries zero_agents directly by (orgId, name) — no agentComposes needed.
+ */
+async function resolveDefaultAgentIdFromEnv(): Promise<string | null> {
+  const { VM0_DEFAULT_AGENT } = env();
+  if (!VM0_DEFAULT_AGENT) {
+    log.warn("VM0_DEFAULT_AGENT env var is not set");
+    return null;
+  }
+
+  const [orgSlug, agentName] = VM0_DEFAULT_AGENT.split("/");
+  if (!orgSlug || !agentName) {
+    log.warn("VM0_DEFAULT_AGENT has invalid format, expected 'org/name'", {
+      value: VM0_DEFAULT_AGENT,
+    });
+    return null;
+  }
+
+  const orgData = await getOrgBySlug(orgSlug);
+  if (!orgData) {
+    log.warn("Org not found for VM0_DEFAULT_AGENT", { orgSlug });
+    return null;
+  }
+
+  const [agent] = await globalThis.services.db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(
+      and(eq(zeroAgents.orgId, orgData.orgId), eq(zeroAgents.name, agentName)),
+    )
+    .limit(1);
+
+  if (!agent) {
+    log.warn("Zero agent not found for VM0_DEFAULT_AGENT", {
+      orgSlug,
+      agentName,
+      orgId: orgData.orgId,
+    });
+    return null;
+  }
+
+  return agent.id;
+}


### PR DESCRIPTION
## Summary

- Extract default agent resolution from email handlers into `lib/zero/resolve-default-agent.ts`
- Primary path uses a single JOIN (agent_composes → zero_agents) instead of 2 separate queries
- Fallback path (VM0_DEFAULT_AGENT env var) now queries zero_agents directly — no agent_composes needed
- Email handlers import only the zero-layer resolver, satisfying Epic #6226 success criterion

Closes #6497

## Test plan

- [x] `grep -r "agentComposes" turbo/apps/web/src/lib/email/` returns 0 results
- [x] TypeScript type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)
- [x] All tests pass (3927/3928, 1 pre-existing flaky test unrelated to changes)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)