### PR TITLE
fix(cli): include chunk files in npm package files glob

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1091,6 +1091,29 @@ jobs:
         run: cd turbo && pnpm install --frozen-lockfile --filter @vm0/cli
       - name: Build CLI
         run: cd turbo && pnpm --filter @vm0/cli build
+      - name: Verify CLI package contents
+        run: |
+          cd turbo/apps/cli/dist
+          # Ensure all imported chunks are present in the package
+          for f in index.js zero.js; do
+            grep -oP './chunk-[A-Z0-9]+\.js' "$f" 2>/dev/null || continue
+            grep -oP './chunk-[A-Z0-9]+\.js' "$f" | while read chunk; do
+              chunk_file="${chunk#./}"
+              if [ ! -f "$chunk_file" ]; then
+                echo "ERROR: $f imports $chunk but file is missing from dist/"
+                exit 1
+              fi
+            done
+          done
+          # Verify npm pack includes all JS files
+          npm pack --dry-run 2>&1 | tee /tmp/pack-list.txt
+          for js in *.js; do
+            if ! grep -q "$js" /tmp/pack-list.txt; then
+              echo "ERROR: $js exists in dist/ but would not be included in npm package"
+              exit 1
+            fi
+          done
+          echo "CLI package verification passed"
       - name: Deploy CLI with production dependencies
         run: cd turbo && pnpm deploy --filter @vm0/cli --prod --legacy --config.node-linker=hoisted /tmp/cli-deploy
       - name: Upload CLI artifact

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1093,11 +1093,12 @@ jobs:
         run: cd turbo && pnpm --filter @vm0/cli build
       - name: Verify CLI package contents
         run: |
+          set -euo pipefail
           cd turbo/apps/cli/dist
           # Ensure all imported chunks are present in the package
           for f in index.js zero.js; do
-            grep -oP './chunk-[A-Z0-9]+\.js' "$f" 2>/dev/null || continue
-            grep -oP './chunk-[A-Z0-9]+\.js' "$f" | while read chunk; do
+            chunks=$(grep -oP './chunk-[A-Z0-9]+\.js' "$f" 2>/dev/null || true)
+            for chunk in $chunks; do
               chunk_file="${chunk#./}"
               if [ ! -f "$chunk_file" ]; then
                 echo "ERROR: $f imports $chunk but file is missing from dist/"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1092,6 +1092,7 @@ jobs:
       - name: Build CLI
         run: cd turbo && pnpm --filter @vm0/cli build
       - name: Verify CLI package contents
+        shell: bash
         run: |
           set -euo pipefail
           cd turbo/apps/cli/dist

--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@vm0/cli\"; delete this.private; delete this.scripts; delete this.devDependencies; delete this.dependencies[\"@vm0/core\"]; this.bin[\"vm0\"]=\"index.js\"; this.bin[\"zero\"]=\"zero.js\"; this.files=[\".\"]'",
+    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@vm0/cli\"; delete this.private; delete this.scripts; delete this.devDependencies; delete this.dependencies[\"@vm0/core\"]; this.bin[\"vm0\"]=\"index.js\"; this.bin[\"zero\"]=\"zero.js\"; this.files=[\"*.js\",\"*.js.map\"]'",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

- Fix `files=["."]` → `files=["*.js","*.js.map"]` in the CLI postbuild script so tsup-generated chunk files are included in the npm package
- Add a CI verification step in the `build-cli` job that fails when any JS file in `dist/` would be missing from the published package

## Context

CLI v9.79.0 is completely broken — both `vm0` and `zero` binaries fail with `ERR_MODULE_NOT_FOUND` because the npm package is missing the `chunk-*.js` file that `index.js` and `zero.js` depend on. This is P0 since users cannot self-recover (`vm0 upgrade` is also broken).

## Root Cause

The postbuild script sets `this.files=["."]` in the dist `package.json`. npm's `files` field with `"."` only packs the bin entry files, not the chunk files produced by tsup's code splitting.

## Verification

After fix, `npm pack --dry-run` from `dist/` correctly lists all 7 files (chunk, entries, sourcemaps).

Closes #6500

## Test plan

- [x] `pnpm build` succeeds and `npm pack --dry-run` shows chunk files included
- [x] CI verification script passes locally
- [x] All 790 CLI tests pass
- [x] Lint and type-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)