### PR TITLE
fix: update stale cascade comment in agent delete handler

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[name]/route.ts
@@ -321,10 +321,10 @@ const router = tsr.router(zeroAgentsByNameContract, {
 
     // Delete compose and metadata atomically
     await globalThis.services.db.transaction(async (tx) => {
-      // Delete compose (cascades to zero_agent_schedules via composeId FK)
+      // Delete compose
       await tx.delete(agentComposes).where(eq(agentComposes.id, compose.id));
 
-      // Delete zero_agents metadata record
+      // Delete zero_agents metadata (cascades to zero_agent_schedules via agentId FK)
       await tx
         .delete(zeroAgents)
         .where(


### PR DESCRIPTION
## Summary
- Updated stale comment in `turbo/apps/web/app/api/zero/agents/[name]/route.ts` (line 324)
- The comment incorrectly referenced a `composeId` FK that no longer exists in `zero_agent_schedules`
- `zero_agent_schedules` now uses `agentId` FK → `zeroAgents.id` with `onDelete: cascade`, so the cascade to schedules happens when `zeroAgents` is deleted, not when `agentComposes` is deleted

## Test plan
- [x] Comment-only change, no logic affected
- [x] Verified against current schema in `zero-agent-schedule.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)