### PR TITLE
refactor: delete stale msw mock handlers for /api/secrets and /api/variables

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-secrets.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-secrets.ts
@@ -1,11 +1,11 @@
 /**
  * Secrets API Handlers
  *
- * Mock handlers for /api/secrets and /api/zero/secrets endpoints.
+ * Mock handlers for /api/zero/secrets endpoints.
  */
 
 import { http, HttpResponse } from "msw";
-import type { SecretResponse, SecretListResponse } from "@vm0/core";
+import type { SecretResponse } from "@vm0/core";
 
 let mockSecrets: SecretResponse[] = [];
 
@@ -41,24 +41,6 @@ function handleSetSecret(body: {
 }
 
 export const apiSecretsHandlers = [
-  // GET /api/secrets - List all secrets
-  http.get("/api/secrets", () => {
-    const response: SecretListResponse = {
-      secrets: mockSecrets,
-    };
-    return HttpResponse.json(response);
-  }),
-
-  // PUT /api/secrets - Create or update a secret
-  http.put("/api/secrets", async ({ request }) => {
-    const body = (await request.json()) as {
-      name: string;
-      value: string;
-      description?: string;
-    };
-    return handleSetSecret(body);
-  }),
-
   // POST /api/zero/secrets - Create or update a secret (zero proxy)
   http.post("/api/zero/secrets", async ({ request }) => {
     const body = (await request.json()) as {
@@ -67,21 +49,5 @@ export const apiSecretsHandlers = [
       description?: string;
     };
     return handleSetSecret(body);
-  }),
-
-  // DELETE /api/secrets/:name - Delete a secret
-  http.delete("/api/secrets/:name", ({ params }) => {
-    const name = params.name as string;
-    const existing = mockSecrets.find((s) => s.name === name);
-
-    if (!existing) {
-      return HttpResponse.json(
-        { error: { message: "Secret not found", code: "NOT_FOUND" } },
-        { status: 404 },
-      );
-    }
-
-    mockSecrets = mockSecrets.filter((s) => s.name !== name);
-    return new HttpResponse(null, { status: 204 });
   }),
 ];

--- a/turbo/apps/platform/src/mocks/handlers/api-variables.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-variables.ts
@@ -1,11 +1,11 @@
 /**
  * Variables API Handlers
  *
- * Mock handlers for /api/variables and /api/zero/variables endpoints.
+ * Mock handlers for /api/zero/variables endpoints.
  */
 
 import { http, HttpResponse } from "msw";
-import type { VariableResponse, VariableListResponse } from "@vm0/core";
+import type { VariableResponse } from "@vm0/core";
 
 let mockVariables: VariableResponse[] = [];
 
@@ -43,24 +43,6 @@ function handleSetVariable(body: {
 }
 
 export const apiVariablesHandlers = [
-  // GET /api/variables - List all variables
-  http.get("/api/variables", () => {
-    const response: VariableListResponse = {
-      variables: mockVariables,
-    };
-    return HttpResponse.json(response);
-  }),
-
-  // PUT /api/variables - Create or update a variable
-  http.put("/api/variables", async ({ request }) => {
-    const body = (await request.json()) as {
-      name: string;
-      value: string;
-      description?: string;
-    };
-    return handleSetVariable(body);
-  }),
-
   // POST /api/zero/variables - Create or update a variable (zero proxy)
   http.post("/api/zero/variables", async ({ request }) => {
     const body = (await request.json()) as {
@@ -69,21 +51,5 @@ export const apiVariablesHandlers = [
       description?: string;
     };
     return handleSetVariable(body);
-  }),
-
-  // DELETE /api/variables/:name - Delete a variable
-  http.delete("/api/variables/:name", ({ params }) => {
-    const name = params.name as string;
-    const existing = mockVariables.find((v) => v.name === name);
-
-    if (!existing) {
-      return HttpResponse.json(
-        { error: { message: "Variable not found", code: "NOT_FOUND" } },
-        { status: 404 },
-      );
-    }
-
-    mockVariables = mockVariables.filter((v) => v.name !== name);
-    return new HttpResponse(null, { status: 204 });
   }),
 ];


### PR DESCRIPTION
## Summary

- Remove stale MSW mock handlers for deleted `/api/secrets` and `/api/variables` routes
- Keep `/api/zero/secrets` and `/api/zero/variables` POST handlers that serve the current zero architecture
- Clean up unused `SecretListResponse` and `VariableListResponse` imports

These old routes were deleted during the infra-to-zero migration (Epic #6074), but the corresponding MSW mocks were not cleaned up.

Closes #6515

## Test plan

- [x] All platform tests pass (76 files, 578 tests)
- [x] TypeScript type checking passes
- [x] Lint passes
- [x] Knip reports no unused exports
- [x] No tests reference the old `/api/secrets` or `/api/variables` routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)