### PR TITLE
fix: correct firewall placeholder formats

### DIFF
--- a/turbo/packages/core/src/firewalls/axiom.generated.ts
+++ b/turbo/packages/core/src/firewalls/axiom.generated.ts
@@ -10,7 +10,7 @@ export const axiomFirewall: FirewallConfig = {
   name: "axiom",
   description: "Axiom API",
   placeholders: {
-    AXIOM_TOKEN: "xaat-Vm0PlaceHolder0000000000000000000000000000",
+    AXIOM_TOKEN: "xaat-00000000-0000-0000-0000-000000000000",
   },
   apis: [
     {

--- a/turbo/packages/core/src/firewalls/monday.generated.ts
+++ b/turbo/packages/core/src/firewalls/monday.generated.ts
@@ -10,7 +10,8 @@ export const mondayFirewall: FirewallConfig = {
   name: "monday",
   description: "Monday.com API",
   placeholders: {
-    MONDAY_TOKEN: "Vm0PlaceHolder00000000000000000a",
+    MONDAY_TOKEN:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlZtMFBsYWNlSG9sZGVyIiwiaWF0IjoxNTE2MjM5MDIyfQ.Vm0PlaceHolder00000000000000000000000000000a",
   },
   apis: [
     {

--- a/turbo/packages/core/src/firewalls/posthog.generated.ts
+++ b/turbo/packages/core/src/firewalls/posthog.generated.ts
@@ -10,7 +10,7 @@ export const posthogFirewall: FirewallConfig = {
   name: "posthog",
   description: "PostHog API",
   placeholders: {
-    POSTHOG_TOKEN: "phx_Vm0PlaceHolder00000000000000000000000a",
+    POSTHOG_TOKEN: "phx_Vm0PlaceHolder00000000000000000000000000000000a",
   },
   apis: [
     {

--- a/turbo/packages/firewalls-generator/src/axiom.ts
+++ b/turbo/packages/firewalls-generator/src/axiom.ts
@@ -10,8 +10,8 @@
 import { writeOutput } from "./codegen";
 
 const DOCS_URL = "https://axiom.co/docs/reference/tokens";
-// Format: xaat- prefix + alphanumeric (exact length unknown)
-const PLACEHOLDER_VALUE = "xaat-Vm0PlaceHolder0000000000000000000000000000";
+// Format: xaat- prefix + UUID (8-4-4-4-12 hex) = 41 total
+const PLACEHOLDER_VALUE = "xaat-00000000-0000-0000-0000-000000000000";
 
 function generateTypeScript(): string {
   const lines: string[] = [

--- a/turbo/packages/firewalls-generator/src/monday.ts
+++ b/turbo/packages/firewalls-generator/src/monday.ts
@@ -5,15 +5,16 @@
  *
  * Monday.com uses token authentication via Authorization header.
  * OAuth access tokens use Bearer prefix in Authorization header.
- * No documented token format; using generic alphanumeric placeholder.
+ * OAuth tokens are JWTs (header.payload.signature).
  */
 
 import { writeOutput } from "./codegen";
 
 const DOCS_URL =
   "https://developer.monday.com/api-reference/docs/authentication";
-// No documented format; generic 32-char alphanumeric
-const PLACEHOLDER_VALUE = "Vm0PlaceHolder00000000000000000a";
+// Monday OAuth tokens are JWTs: base64url(header).base64url(payload).base64url(signature)
+const PLACEHOLDER_VALUE =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IlZtMFBsYWNlSG9sZGVyIiwiaWF0IjoxNTE2MjM5MDIyfQ.Vm0PlaceHolder00000000000000000000000000000a";
 
 function generateTypeScript(): string {
   const lines: string[] = [

--- a/turbo/packages/firewalls-generator/src/posthog.ts
+++ b/turbo/packages/firewalls-generator/src/posthog.ts
@@ -11,8 +11,8 @@
 import { writeOutput } from "./codegen";
 
 const DOCS_URL = "https://posthog.com/docs/api";
-// Format: phx_ + alphanumeric chars (length not documented)
-const PLACEHOLDER_VALUE = "phx_Vm0PlaceHolder00000000000000000000000a";
+// Format: phx_ + ~47 base62 chars = ~51 total (variable length, 35 bytes entropy)
+const PLACEHOLDER_VALUE = "phx_Vm0PlaceHolder00000000000000000000000000000000a";
 
 function generateTypeScript(): string {
   const lines: string[] = [


### PR DESCRIPTION
## Summary
- **monday**: placeholder changed from generic 32-char alphanumeric to JWT format (`eyJ...`), matching real Monday.com OAuth tokens
- **axiom**: placeholder changed from generic string to UUID format (`xaat-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`), matching real Axiom API tokens
- **posthog**: placeholder extended from 43 to 51 chars (`phx_` + 47 base62), matching real PostHog personal API key length

## Test plan
- [x] All generators produce valid TypeScript
- [x] Type check passes
- [x] Knip finds no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)