### PR TITLE
perf: add inline skeleton shell to index.html for faster fcp

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -9,6 +9,20 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
+    <script>
+      // Inline theme detection — mirrors signals/theme.ts resolveTheme() + applyTheme()
+      (function () {
+        var p = localStorage.getItem("theme");
+        var t =
+          p === "dark" || p === "light"
+            ? p
+            : window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+        document.documentElement.dataset.theme = t;
+        if (t === "dark") document.documentElement.classList.add("dark");
+      })();
+    </script>
     <script type="module" src="/src/main.ts" defer></script>
     <script>
       function __initPlausible() {
@@ -47,7 +61,72 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <style>
+        .sk {
+          display: flex;
+          height: 100dvh;
+          background: #fdfdfe;
+        }
+        .sk-side {
+          width: 300px;
+          flex-shrink: 0;
+          background: #fafbfc;
+          border-right: 0.7px solid #dce1e8;
+          padding: 16px;
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+        }
+        .sk-bar {
+          height: 32px;
+          border-radius: 8px;
+          background: #e7ebf0;
+          animation: sk-pulse 2s ease-in-out infinite;
+        }
+        .sk-content {
+          flex: 1;
+          background: #fdfdfe;
+        }
+        @keyframes sk-pulse {
+          0%,
+          100% {
+            opacity: 1;
+          }
+          50% {
+            opacity: 0.4;
+          }
+        }
+        [data-theme="dark"] .sk {
+          background: #19191b;
+        }
+        [data-theme="dark"] .sk-side {
+          background: hsl(240 5% 8%);
+          border-color: #292a2e;
+        }
+        [data-theme="dark"] .sk-bar {
+          background: #222325;
+        }
+        [data-theme="dark"] .sk-content {
+          background: #19191b;
+        }
+        @media (max-width: 767px) {
+          .sk-side {
+            display: none;
+          }
+        }
+      </style>
+      <div class="sk">
+        <aside class="sk-side">
+          <div class="sk-bar"></div>
+          <div class="sk-bar" style="margin-top: 8px"></div>
+          <div class="sk-bar"></div>
+          <div class="sk-bar"></div>
+          <div class="sk-bar"></div>
+        </aside>
+        <div class="sk-content"></div>
+      </div>
+    </div>
     <script
       src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"
       integrity="sha384-PeueJ613SmtgegJQz/JL0K6uh1Q5Q4os+b/FZsvK9GoMFvyFlyBv8FiP62B3rilT"


### PR DESCRIPTION
## Summary

- Add a synchronous inline theme detection script in `<head>` that mirrors `signals/theme.ts` logic to set `data-theme` before any CSS is evaluated
- Add inline CSS skeleton shell (sidebar + content area) inside `<div id="root">` that renders immediately on HTML parse, eliminating the blank white screen during JS bundle download
- Skeleton respects dark/light theme, hides sidebar on mobile, and is automatically replaced when React mounts via `createRoot().render()`

Closes #6484

## Test plan

- [ ] Open `index.html` directly in browser — skeleton should render immediately without JS
- [ ] Set `localStorage.theme = "dark"` and reload — skeleton renders in dark colors with no flash
- [ ] Start dev server — skeleton is seamlessly replaced when React mounts, no flash or layout jump
- [ ] Run Lighthouse audit — CLS should remain at or below 0.01
- [ ] Verify build succeeds (`pnpm turbo run build --filter=@vm0/app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)