### PR TITLE
feat(web): add zero token generation, secrets injection, and auth

### DIFF
--- a/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { auth } from "@clerk/nextjs/server";
 import { getAuthContext, getUserId } from "../get-auth-context";
-import { generateSandboxToken } from "../sandbox-token";
+import { generateSandboxToken, generateZeroToken } from "../sandbox-token";
 
 describe("getUserId", () => {
   const mockAuth = vi.mocked(auth);
@@ -278,5 +278,103 @@ describe("getAuthContext auth() call optimization", () => {
   it("should call auth() for unknown Bearer token", async () => {
     await getAuthContext("Bearer unknown_token_format");
     expect(mockAuth).toHaveBeenCalled();
+  });
+
+  it("should not call auth() when zero token is provided", async () => {
+    const token = await generateZeroToken("user-1", "run-1", "org-1");
+    await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "agent:read",
+    });
+    expect(mockAuth).not.toHaveBeenCalled();
+  });
+});
+
+describe("getAuthContext with zero token and requiredCapability", () => {
+  const mockAuth = vi.mocked(auth);
+
+  beforeEach(() => {
+    mockAuth.mockResolvedValue({
+      userId: null,
+    } as Awaited<ReturnType<typeof auth>>);
+  });
+
+  it("should accept zero token with matching capability", async () => {
+    const token = await generateZeroToken("user-123", "run-456", "org-789");
+    const result = await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "agent:read",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe("user-123");
+    expect(result?.runId).toBe("run-456");
+    expect(result?.orgId).toBe("org-789");
+    expect(result?.capabilities).toContain("agent:read");
+  });
+
+  it("should reject zero token with missing capability", async () => {
+    const token = await generateZeroToken("user-123", "run-456", "org-789");
+    const result = await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "integration-slack:write",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("should reject zero token without requiredCapability opt-in", async () => {
+    const token = await generateZeroToken("user-123", "run-456", "org-789");
+    const result = await getAuthContext(`Bearer ${token}`);
+
+    expect(result).toBeNull();
+  });
+
+  it("should populate orgId from zero token", async () => {
+    const token = await generateZeroToken("user-123", "run-456", "org-789");
+    const result = await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "agent:read",
+    });
+
+    expect(result?.orgId).toBe("org-789");
+  });
+});
+
+describe("getAuthContext with zero token and acceptAnySandboxCapability", () => {
+  const mockAuth = vi.mocked(auth);
+
+  beforeEach(() => {
+    mockAuth.mockResolvedValue({
+      userId: null,
+    } as Awaited<ReturnType<typeof auth>>);
+  });
+
+  it("should accept zero token on infra routes", async () => {
+    const token = await generateZeroToken("user-123", "run-456", "org-789");
+    const result = await getAuthContext(`Bearer ${token}`, {
+      acceptAnySandboxCapability: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe("user-123");
+    expect(result?.runId).toBe("run-456");
+    expect(result?.orgId).toBe("org-789");
+    expect(result?.capabilities).toContain("agent:read");
+  });
+
+  it("should include all zero capabilities", async () => {
+    const token = await generateZeroToken("user-123", "run-456", "org-789");
+    const result = await getAuthContext(`Bearer ${token}`, {
+      acceptAnySandboxCapability: true,
+    });
+
+    expect(result?.capabilities).toEqual(
+      expect.arrayContaining([
+        "agent:read",
+        "agent:write",
+        "agent-run:read",
+        "agent-run:write",
+        "schedule:read",
+        "schedule:write",
+        "slack:write",
+      ]),
+    );
   });
 });

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -5,6 +5,8 @@ import {
   isSandboxToken,
   generateComposeJobToken,
   verifyComposeJobToken,
+  generateZeroToken,
+  verifyZeroToken,
   SANDBOX_TOKEN_PREFIX,
 } from "../sandbox-token";
 
@@ -268,6 +270,83 @@ describe("sandbox-token", () => {
     });
   });
 
+  describe("zero tokens", () => {
+    it("should generate a prefixed zero token", async () => {
+      const token = await generateZeroToken("user-123", "run-456", "org-789");
+
+      expect(token.startsWith(SANDBOX_TOKEN_PREFIX)).toBe(true);
+      const jwt = token.slice(SANDBOX_TOKEN_PREFIX.length);
+      expect(jwt.split(".")).toHaveLength(3);
+    });
+
+    it("should generate different tokens for different runs", async () => {
+      const token1 = await generateZeroToken("user-123", "run-1", "org-789");
+      const token2 = await generateZeroToken("user-123", "run-2", "org-789");
+
+      expect(token1).not.toBe(token2);
+    });
+
+    it("should verify a valid zero token", async () => {
+      const token = await generateZeroToken("user-123", "run-456", "org-789");
+      const auth = verifyZeroToken(token);
+
+      expect(auth).not.toBeNull();
+      expect(auth?.userId).toBe("user-123");
+      expect(auth?.runId).toBe("run-456");
+      expect(auth?.orgId).toBe("org-789");
+    });
+
+    it("should include all ZERO_CAPABILITIES", async () => {
+      const token = await generateZeroToken("user-123", "run-456", "org-789");
+      const auth = verifyZeroToken(token);
+
+      expect(auth?.capabilities).toEqual([
+        "agent:read",
+        "agent:write",
+        "agent-run:read",
+        "agent-run:write",
+        "schedule:read",
+        "schedule:write",
+        "slack:write",
+      ]);
+    });
+
+    it("should return null for expired zero token", async () => {
+      const token = await generateZeroToken("user-123", "run-456", "org-789");
+
+      const realDateNow = Date.now;
+      Date.now = () => realDateNow() + 3 * 60 * 60 * 1000;
+
+      try {
+        const auth = verifyZeroToken(token);
+        expect(auth).toBeNull();
+      } finally {
+        Date.now = realDateNow;
+      }
+    });
+
+    it("should return null for tampered zero token", async () => {
+      const token = await generateZeroToken("user-123", "run-456", "org-789");
+      const jwt = token.slice(SANDBOX_TOKEN_PREFIX.length);
+      const parts = jwt.split(".");
+      parts[1] = parts[1] + "tampered";
+      const tamperedToken = SANDBOX_TOKEN_PREFIX + parts.join(".");
+
+      const auth = verifyZeroToken(tamperedToken);
+
+      expect(auth).toBeNull();
+    });
+
+    it("should return null for token without prefix", () => {
+      expect(verifyZeroToken("header.payload.signature")).toBeNull();
+    });
+
+    it("should identify zero tokens with isSandboxToken", async () => {
+      const token = await generateZeroToken("user-123", "run-456", "org-789");
+      expect(isSandboxToken(token)).toBe(true);
+    });
+  });
+
   describe("cross-scope rejection", () => {
     it("should reject sandbox token with verifyComposeJobToken", async () => {
       const token = await generateSandboxToken("user-123", "run-456");
@@ -283,12 +362,39 @@ describe("sandbox-token", () => {
       expect(auth).toBeNull();
     });
 
-    it("should identify both token types with isSandboxToken", async () => {
+    it("should reject zero token with verifySandboxToken", async () => {
+      const token = await generateZeroToken("user-123", "run-456", "org-789");
+      const auth = verifySandboxToken(token);
+
+      expect(auth).toBeNull();
+    });
+
+    it("should reject sandbox token with verifyZeroToken", async () => {
+      const token = await generateSandboxToken("user-123", "run-456");
+      const auth = verifyZeroToken(token);
+
+      expect(auth).toBeNull();
+    });
+
+    it("should reject compose job token with verifyZeroToken", async () => {
+      const token = await generateComposeJobToken("user-123", "job-456");
+      const auth = verifyZeroToken(token);
+
+      expect(auth).toBeNull();
+    });
+
+    it("should identify all token types with isSandboxToken", async () => {
       const sandboxToken = await generateSandboxToken("user-123", "run-456");
       const composeToken = await generateComposeJobToken("user-123", "job-456");
+      const zeroToken = await generateZeroToken(
+        "user-123",
+        "run-456",
+        "org-789",
+      );
 
       expect(isSandboxToken(sandboxToken)).toBe(true);
       expect(isSandboxToken(composeToken)).toBe(true);
+      expect(isSandboxToken(zeroToken)).toBe(true);
     });
   });
 });

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -1,6 +1,6 @@
 import { eq, and, gt } from "drizzle-orm";
 import { auth } from "@clerk/nextjs/server";
-import type { OrgRole } from "@vm0/core";
+import type { OrgRole, ValidCapability, ZeroCapability } from "@vm0/core";
 import { cliTokens } from "../../db/schema/cli-tokens";
 import {
   isSandboxToken,
@@ -8,6 +8,8 @@ import {
   verifyZeroToken,
 } from "./sandbox-token";
 import { logger } from "../logger";
+
+type AnyCapability = ValidCapability | ZeroCapability;
 
 const log = logger("auth:user");
 
@@ -19,7 +21,7 @@ export type AuthContext = {
   orgId?: string;
   orgRole?: OrgRole;
   sessionClaims?: Record<string, unknown>;
-  capabilities?: readonly string[];
+  capabilities?: readonly AnyCapability[];
   runId?: string;
 };
 
@@ -34,7 +36,7 @@ export type AuthContext = {
 export async function getAuthContext(
   authHeader?: string,
   options?: {
-    requiredCapability?: string;
+    requiredCapability?: AnyCapability;
     acceptAnySandboxCapability?: boolean;
   },
 ): Promise<AuthContext | null> {
@@ -81,7 +83,7 @@ export async function getAuthContext(
 function authenticateSandboxToken(
   token: string,
   options?: {
-    requiredCapability?: string;
+    requiredCapability?: AnyCapability;
     acceptAnySandboxCapability?: boolean;
   },
 ): AuthContext | null {
@@ -111,10 +113,10 @@ function resolveSandboxAuth(
   sandboxAuth: {
     userId: string;
     runId: string;
-    capabilities?: readonly string[];
+    capabilities?: readonly AnyCapability[];
   },
   options: {
-    requiredCapability?: string;
+    requiredCapability?: AnyCapability;
     acceptAnySandboxCapability?: boolean;
   },
 ): AuthContext | null {
@@ -154,10 +156,10 @@ function resolveZeroAuth(
     userId: string;
     runId: string;
     orgId: string;
-    capabilities: readonly string[];
+    capabilities: readonly AnyCapability[];
   },
   options: {
-    requiredCapability?: string;
+    requiredCapability?: AnyCapability;
     acceptAnySandboxCapability?: boolean;
   },
 ): AuthContext | null {
@@ -214,7 +216,7 @@ async function getClerkSessionAuth(): Promise<AuthContext | null> {
 export async function getUserId(
   authHeader?: string,
   options?: {
-    requiredCapability?: string;
+    requiredCapability?: AnyCapability;
     acceptAnySandboxCapability?: boolean;
   },
 ): Promise<string | null> {

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -1,11 +1,13 @@
 import { eq, and, gt } from "drizzle-orm";
 import { auth } from "@clerk/nextjs/server";
-import type { VALID_CAPABILITIES, OrgRole } from "@vm0/core";
+import type { OrgRole } from "@vm0/core";
 import { cliTokens } from "../../db/schema/cli-tokens";
-import { isSandboxToken, verifySandboxToken } from "./sandbox-token";
+import {
+  isSandboxToken,
+  verifySandboxToken,
+  verifyZeroToken,
+} from "./sandbox-token";
 import { logger } from "../logger";
-
-type Capability = (typeof VALID_CAPABILITIES)[number];
 
 const log = logger("auth:user");
 
@@ -17,7 +19,7 @@ export type AuthContext = {
   orgId?: string;
   orgRole?: OrgRole;
   sessionClaims?: Record<string, unknown>;
-  capabilities?: readonly Capability[];
+  capabilities?: readonly string[];
   runId?: string;
 };
 
@@ -32,7 +34,7 @@ export type AuthContext = {
 export async function getAuthContext(
   authHeader?: string,
   options?: {
-    requiredCapability?: Capability;
+    requiredCapability?: string;
     acceptAnySandboxCapability?: boolean;
   },
 ): Promise<AuthContext | null> {
@@ -41,56 +43,7 @@ export async function getAuthContext(
     const token = authHeader.substring(7); // Remove "Bearer "
 
     if (isSandboxToken(token)) {
-      // Without any sandbox opt-in, reject sandbox tokens (existing behavior)
-      if (
-        !options?.requiredCapability &&
-        !options?.acceptAnySandboxCapability
-      ) {
-        log.debug("Rejected sandbox JWT token on normal API endpoint");
-        return null;
-      }
-
-      // Verify sandbox token signature and expiry
-      const sandboxAuth = verifySandboxToken(token);
-      if (!sandboxAuth) {
-        log.debug("Invalid or expired sandbox token");
-        return null;
-      }
-
-      // acceptAnySandboxCapability: accept if token has any capability
-      if (options?.acceptAnySandboxCapability) {
-        if (
-          !sandboxAuth.capabilities ||
-          sandboxAuth.capabilities.length === 0
-        ) {
-          log.debug("Sandbox token has no capabilities");
-          return null;
-        }
-        return {
-          userId: sandboxAuth.userId,
-          runId: sandboxAuth.runId,
-          capabilities: [...sandboxAuth.capabilities],
-        };
-      }
-
-      // requiredCapability: check specific capability
-      const hasCap = sandboxAuth.capabilities?.some(
-        (cap) => cap === options.requiredCapability,
-      );
-      if (!hasCap) {
-        log.debug(
-          `Sandbox token missing required capability: ${options.requiredCapability}`,
-        );
-        return null;
-      }
-
-      return {
-        userId: sandboxAuth.userId,
-        runId: sandboxAuth.runId,
-        capabilities: sandboxAuth.capabilities
-          ? [...sandboxAuth.capabilities]
-          : undefined,
-      };
+      return authenticateSandboxToken(token, options);
     }
 
     // Check for CLI token format (vm0_live_)
@@ -124,6 +77,117 @@ export async function getAuthContext(
   return getClerkSessionAuth();
 }
 
+/** Authenticate a sandbox-prefixed token (sandbox or zero scope). */
+function authenticateSandboxToken(
+  token: string,
+  options?: {
+    requiredCapability?: string;
+    acceptAnySandboxCapability?: boolean;
+  },
+): AuthContext | null {
+  // Without any sandbox opt-in, reject sandbox tokens (existing behavior)
+  if (!options?.requiredCapability && !options?.acceptAnySandboxCapability) {
+    log.debug("Rejected sandbox JWT token on normal API endpoint");
+    return null;
+  }
+
+  // Try sandbox token first
+  const sandboxAuth = verifySandboxToken(token);
+  if (sandboxAuth) {
+    return resolveSandboxAuth(sandboxAuth, options);
+  }
+
+  // Try zero token (scope: "zero")
+  const zeroAuth = verifyZeroToken(token);
+  if (zeroAuth) {
+    return resolveZeroAuth(zeroAuth, options);
+  }
+
+  log.debug("Invalid or expired sandbox/zero token");
+  return null;
+}
+
+function resolveSandboxAuth(
+  sandboxAuth: {
+    userId: string;
+    runId: string;
+    capabilities?: readonly string[];
+  },
+  options: {
+    requiredCapability?: string;
+    acceptAnySandboxCapability?: boolean;
+  },
+): AuthContext | null {
+  if (options.acceptAnySandboxCapability) {
+    if (!sandboxAuth.capabilities || sandboxAuth.capabilities.length === 0) {
+      log.debug("Sandbox token has no capabilities");
+      return null;
+    }
+    return {
+      userId: sandboxAuth.userId,
+      runId: sandboxAuth.runId,
+      capabilities: [...sandboxAuth.capabilities],
+    };
+  }
+
+  const hasCap = sandboxAuth.capabilities?.some(
+    (cap) => cap === options.requiredCapability,
+  );
+  if (!hasCap) {
+    log.debug(
+      `Sandbox token missing required capability: ${options.requiredCapability}`,
+    );
+    return null;
+  }
+
+  return {
+    userId: sandboxAuth.userId,
+    runId: sandboxAuth.runId,
+    capabilities: sandboxAuth.capabilities
+      ? [...sandboxAuth.capabilities]
+      : undefined,
+  };
+}
+
+function resolveZeroAuth(
+  zeroAuth: {
+    userId: string;
+    runId: string;
+    orgId: string;
+    capabilities: readonly string[];
+  },
+  options: {
+    requiredCapability?: string;
+    acceptAnySandboxCapability?: boolean;
+  },
+): AuthContext | null {
+  if (options.acceptAnySandboxCapability) {
+    return {
+      userId: zeroAuth.userId,
+      runId: zeroAuth.runId,
+      orgId: zeroAuth.orgId,
+      capabilities: [...zeroAuth.capabilities],
+    };
+  }
+
+  const hasCap = zeroAuth.capabilities.some(
+    (cap) => cap === options.requiredCapability,
+  );
+  if (!hasCap) {
+    log.debug(
+      `Zero token missing required capability: ${options.requiredCapability}`,
+    );
+    return null;
+  }
+
+  return {
+    userId: zeroAuth.userId,
+    runId: zeroAuth.runId,
+    orgId: zeroAuth.orgId,
+    capabilities: [...zeroAuth.capabilities],
+  };
+}
+
 /** Extract AuthContext from Clerk session, or null if not authenticated. */
 async function getClerkSessionAuth(): Promise<AuthContext | null> {
   const authResult = await auth();
@@ -150,7 +214,7 @@ async function getClerkSessionAuth(): Promise<AuthContext | null> {
 export async function getUserId(
   authHeader?: string,
   options?: {
-    requiredCapability?: Capability;
+    requiredCapability?: string;
     acceptAnySandboxCapability?: boolean;
   },
 ): Promise<string | null> {

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -1,9 +1,10 @@
 import { createHmac, hkdfSync } from "crypto";
-import { VALID_CAPABILITIES } from "@vm0/core";
+import { VALID_CAPABILITIES, ZERO_CAPABILITIES } from "@vm0/core";
 import { env } from "../../env";
 import { logger } from "../logger";
 
 type Capability = (typeof VALID_CAPABILITIES)[number];
+type ZeroCapability = (typeof ZERO_CAPABILITIES)[number];
 
 const log = logger("auth:sandbox");
 
@@ -38,12 +39,35 @@ interface ComposeJobTokenPayload {
 }
 
 /**
+ * JWT payload for zero tokens (zero agent runs)
+ */
+interface ZeroTokenPayload {
+  userId: string;
+  runId: string;
+  orgId: string;
+  scope: "zero";
+  capabilities: readonly ZeroCapability[];
+  iat: number;
+  exp: number;
+}
+
+/**
  * Result of verifying a sandbox token
  */
 export interface SandboxAuth {
   userId: string;
   runId: string;
   capabilities?: readonly Capability[];
+}
+
+/**
+ * Result of verifying a zero token
+ */
+export interface ZeroAuth {
+  userId: string;
+  runId: string;
+  orgId: string;
+  capabilities: readonly ZeroCapability[];
 }
 
 /**
@@ -93,7 +117,10 @@ function getJwtKey(): Buffer {
 /**
  * Union of all self-signed JWT payload types
  */
-type JwtPayload = SandboxTokenPayload | ComposeJobTokenPayload;
+type JwtPayload =
+  | SandboxTokenPayload
+  | ComposeJobTokenPayload
+  | ZeroTokenPayload;
 
 /**
  * Create a JWT token with HMAC-SHA256 signature
@@ -246,11 +273,85 @@ export function verifySandboxToken(token: string): SandboxAuth | null {
 }
 
 /**
- * Check if a token is a self-signed JWT (sandbox or compose-job)
+ * Check if a token is a self-signed JWT (sandbox, compose-job, or zero)
  * by checking for the vm0_sandbox_ prefix.
  */
 export function isSandboxToken(token: string): boolean {
   return token.startsWith(SANDBOX_TOKEN_PREFIX);
+}
+
+// ============================================================================
+// Zero Token Functions
+// ============================================================================
+
+/**
+ * Generate a JWT token for zero agent authentication.
+ * Token is valid for 2 hours and carries all ZERO_CAPABILITIES plus orgId.
+ */
+export async function generateZeroToken(
+  userId: string,
+  runId: string,
+  orgId: string,
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const expiresIn = 2 * 60 * 60; // 2 hours
+
+  const payload: ZeroTokenPayload = {
+    userId,
+    runId,
+    orgId,
+    scope: "zero",
+    capabilities: [...ZERO_CAPABILITIES],
+    iat: now,
+    exp: now + expiresIn,
+  };
+
+  const jwt = createJwt(payload);
+  log.debug(`Generated zero JWT for run ${runId}`);
+  return SANDBOX_TOKEN_PREFIX + jwt;
+}
+
+/**
+ * Verify a zero JWT token and extract auth info.
+ * Returns null if token is invalid, expired, or not a zero token.
+ *
+ * @param token - The full prefixed token (without "Bearer " prefix)
+ */
+export function verifyZeroToken(token: string): ZeroAuth | null {
+  if (!token.startsWith(SANDBOX_TOKEN_PREFIX)) {
+    return null;
+  }
+
+  const rawJwt = token.slice(SANDBOX_TOKEN_PREFIX.length);
+  const payload = verifyJwtPayload(rawJwt);
+  if (!payload) {
+    return null;
+  }
+
+  if (payload.scope !== "zero") {
+    return null;
+  }
+  if (!("runId" in payload) || !("orgId" in payload)) {
+    return null;
+  }
+
+  const p = payload as ZeroTokenPayload;
+  if (!Array.isArray(p.capabilities)) {
+    return null;
+  }
+  const validSet = new Set<string>(ZERO_CAPABILITIES);
+  for (const cap of p.capabilities) {
+    if (typeof cap !== "string" || !validSet.has(cap)) {
+      return null;
+    }
+  }
+
+  return {
+    userId: p.userId,
+    runId: p.runId,
+    orgId: p.orgId,
+    capabilities: p.capabilities,
+  };
 }
 
 // ============================================================================

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -35,7 +35,7 @@ import {
   buildExecutionContext as buildContext,
   MODEL_PROVIDER_ENV_VARS,
 } from "./build-context";
-import { generateSandboxToken } from "../auth/sandbox-token";
+import { generateSandboxToken, generateZeroToken } from "../auth/sandbox-token";
 import { recordSandboxOperation } from "../metrics";
 import { extractTemplateVars } from "../config-validator";
 import { canAccessCompose } from "../agent/compose-access";
@@ -474,6 +474,8 @@ export interface CreateRunParams {
   orgTier?: OrgTier;
   // Per-permission firewall policies from zero agent configuration.
   firewallPolicies?: FirewallPolicies;
+  // When true, generate a ZERO_TOKEN JWT and inject into secrets.
+  injectZeroToken?: boolean;
 }
 
 /**
@@ -521,6 +523,7 @@ export interface StartRunParams {
   debugNoMockClaude?: boolean;
   checkEnv?: boolean;
   firewallPolicies?: FirewallPolicies;
+  injectZeroToken?: boolean;
 }
 
 export interface CreateRunResult {
@@ -770,6 +773,14 @@ async function buildAndDispatchRun(opts: {
         : null,
       generateSandboxToken(userId, runId, capabilities),
     ]);
+
+    // Generate ZERO_TOKEN for zero agent runs
+    let augmentedSecrets = params.secrets;
+    if (params.injectZeroToken) {
+      const zeroToken = await generateZeroToken(userId, runId, orgId);
+      augmentedSecrets = { ...params.secrets, ZERO_TOKEN: zeroToken };
+    }
+
     const tokenTime = Date.now();
 
     // Build execution context
@@ -788,7 +799,7 @@ async function buildAndDispatchRun(opts: {
       artifactVersion: params.artifactVersion,
       memoryName: params.memoryName,
       vars: params.vars,
-      secrets: params.secrets,
+      secrets: augmentedSecrets,
       volumeVersions: params.volumeVersions,
       agentCompose: composeContent,
       prompt,
@@ -1089,6 +1100,7 @@ export async function startRun(
     debugNoMockClaude: params.debugNoMockClaude,
     checkEnv: params.checkEnv,
     firewallPolicies: params.firewallPolicies,
+    injectZeroToken: params.injectZeroToken,
     orgSlug: orgData.slug,
     orgId: authOrgId,
     orgTier,

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -15,6 +15,8 @@ import {
   findTestRunnerJobEntry,
 } from "../../../__tests__/api-test-helpers";
 import { createZeroRun } from "../zero-run-service";
+import { verifyZeroToken } from "../../auth/sandbox-token";
+import { decryptSecretsMap } from "../../crypto/secrets-encryption";
 import { reloadEnv } from "../../../env";
 import type { TriggerSource } from "@vm0/core";
 
@@ -117,6 +119,33 @@ describe("createZeroRun()", () => {
       const run = await findTestRunRecord(result.runId);
       expect(run).toBeDefined();
       expect(run!.appendSystemPrompt).toBeNull();
+    });
+
+    it("should inject ZERO_TOKEN into execution context secrets", async () => {
+      const result = await createZeroRun(baseParams());
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      const encrypted = job!.executionContext.encryptedSecrets;
+      expect(encrypted).not.toBeNull();
+
+      // Decrypt and verify the ZERO_TOKEN
+      const secrets = decryptSecretsMap(
+        encrypted,
+        globalThis.services.env.SECRETS_ENCRYPTION_KEY,
+      );
+      expect(secrets).not.toBeNull();
+      expect(secrets!.ZERO_TOKEN).toBeDefined();
+
+      // Verify the token is a valid zero token
+      const auth = verifyZeroToken(secrets!.ZERO_TOKEN!);
+      expect(auth).not.toBeNull();
+      expect(auth!.userId).toBe(user.userId);
+      expect(auth!.runId).toBe(result.runId);
+      expect(auth!.orgId).toBe(user.orgId);
+      expect(auth!.capabilities).toEqual(
+        expect.arrayContaining(["agent:read", "agent:write"]),
+      );
     });
 
     it("should inject disallowedTools with cron tools", async () => {

--- a/turbo/apps/web/src/lib/zero/build-compose-content.ts
+++ b/turbo/apps/web/src/lib/zero/build-compose-content.ts
@@ -25,6 +25,7 @@ export function buildComposeContent(
     experimental_capabilities: [...VALID_CAPABILITIES],
     environment: {
       ZERO_AGENT_ID: "${{ vars.ZERO_AGENT_ID }}",
+      ZERO_TOKEN: "${{ secrets.ZERO_TOKEN }}",
     },
     volumes: [],
   };

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -103,5 +103,6 @@ export async function createZeroRun(
     disallowedTools: [...DISALLOWED_CRON_TOOLS],
     vars: agent.composeId ? { ZERO_AGENT_ID: agent.composeId } : undefined,
     firewallPolicies: agent.firewallPolicies ?? undefined,
+    injectZeroToken: true,
   });
 }


### PR DESCRIPTION
## Summary
- Add `generateZeroToken()` / `verifyZeroToken()` with a new `"zero"` scope JWT carrying `ZERO_CAPABILITIES` and `orgId`
- Update `getAuthContext()` to accept zero tokens via `requiredCapability` and `acceptAnySandboxCapability`, populating `orgId` from the token
- Inject `ZERO_TOKEN` into execution context secrets during `createZeroRun()` via `injectZeroToken` flag in the run pipeline
- Add `ZERO_TOKEN: "${{ secrets.ZERO_TOKEN }}"` to the compose environment template so sandboxes can access the token
- Refactor `getAuthContext()` into smaller helper functions to stay under cyclomatic complexity limit

## Test plan
- [x] 38 sandbox-token tests pass (7 new zero token tests + 3 cross-scope rejection tests)
- [x] 29 get-auth-context tests pass (7 new zero token auth tests)
- [x] 22 zero-run-service integration tests pass (1 new ZERO_TOKEN secrets injection test with decrypt verification)
- [x] Lint, type-check, format, and knip all pass

Closes #6525

🤖 Generated with [Claude Code](https://claude.com/claude-code)