### PR TITLE
refactor: unify schedule slack notifications with shared block builder

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/__tests__/route.test.ts
@@ -296,4 +296,69 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
       elements: [{ type: "mrkdwn", text: expect.stringContaining("Audit") }],
     });
   });
+
+  it("includes deep links when failure error contains connector keywords", async () => {
+    await setupSlackOrg(user);
+    mockClerk({ userId: user.userId });
+
+    const { composeId } = await createTestCompose(uniqueId("sched-agent"));
+    const schedule = await createTestSchedule(composeId, uniqueId("sched"));
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    await linkRunToSchedule(runId, schedule.id);
+
+    const payload: OrgScheduleCallbackPayload = {
+      scheduleId: schedule.id,
+      agentId: composeId,
+      agentName: "sched-agent",
+      userId: user.userId,
+      orgId: user.orgId,
+      slackChannelId: "C-DEEP-LINK",
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org/schedule",
+      payload: { ...payload },
+    });
+
+    const request = createCallbackRequest(
+      {
+        runId,
+        status: "failed",
+        error: "MCP server connection failed: connector timeout",
+        payload,
+      },
+      secret,
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+
+    const mockClient = new WebClient();
+    const postMessageMock = mockClient.chat.postMessage as ReturnType<
+      typeof import("vitest").vi.fn
+    >;
+    expect(postMessageMock).toHaveBeenCalledOnce();
+
+    const call = postMessageMock.mock.calls[0]![0] as {
+      blocks: (Block | KnownBlock)[];
+    };
+
+    // Should have 3 blocks: markdown, deep link context, audit context
+    const contextBlocks = call.blocks.filter((b) => b.type === "context");
+    expect(contextBlocks.length).toBe(2);
+
+    // First context block should be the connector deep link
+    const deepLinkBlock = contextBlocks[0] as {
+      type: "context";
+      elements: Array<{ type: string; text: string }>;
+    };
+    expect(deepLinkBlock.elements[0]!.text).toContain("Configure connectors");
+
+    // Second context block should be the audit link
+    expect(contextBlocks[1]).toMatchObject({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: expect.stringContaining("Audit") }],
+    });
+  });
 });

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { WebClient } from "@slack/web-api";
+import type { Block, KnownBlock } from "@slack/web-api";
 import { NextRequest } from "next/server";
 import { POST } from "../route";
 import {
@@ -161,8 +162,27 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
 
     const firstCall = postMessageMock.mock.calls[0]![0] as {
       channel: string;
+      blocks: (Block | KnownBlock)[];
     };
     expect(firstCall.channel).toBe("C-TARGET-CHANNEL");
+
+    // Verify blocks use markdown block type (from buildAgentResponseMessage)
+    const markdownBlock = firstCall.blocks.find((b) => b.type === "markdown");
+    expect(markdownBlock).toBeDefined();
+
+    // Verify header is included in the markdown content
+    const markdownText = (markdownBlock as { type: "markdown"; text: string })
+      .text;
+    expect(markdownText).toContain("Scheduled run for");
+    expect(markdownText).toContain("completed");
+
+    // Verify audit link is present as a context block
+    const contextBlock = firstCall.blocks.find((b) => b.type === "context");
+    expect(contextBlock).toBeDefined();
+    expect(contextBlock).toMatchObject({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: expect.stringContaining("Audit") }],
+    });
   });
 
   it("falls back to user DM when slackChannelId is not set", async () => {
@@ -255,8 +275,25 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
     const call = postMessageMock.mock.calls[0]![0] as {
       channel: string;
       text: string;
+      blocks: (Block | KnownBlock)[];
     };
     expect(call.channel).toBe("C-FAIL-CHANNEL");
     expect(call.text).toContain("failed");
+
+    // Verify failure message uses markdown block with error content
+    const markdownBlock = call.blocks.find((b) => b.type === "markdown");
+    expect(markdownBlock).toBeDefined();
+    const markdownText = (markdownBlock as { type: "markdown"; text: string })
+      .text;
+    expect(markdownText).toContain("failed");
+    expect(markdownText).toContain("Agent crashed");
+
+    // Verify audit link is present
+    const contextBlock = call.blocks.find((b) => b.type === "context");
+    expect(contextBlock).toBeDefined();
+    expect(contextBlock).toMatchObject({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: expect.stringContaining("Audit") }],
+    });
   });
 });

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
-import type { Block, KnownBlock } from "@slack/web-api";
 import { initServices } from "../../../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../../../src/lib/callback";
 import { decryptSecretValue } from "../../../../../../../src/lib/crypto/secrets-encryption";
@@ -16,6 +15,7 @@ import {
   saveThreadSession,
   buildLogsUrl,
 } from "../../../../../../../src/lib/slack-org/handlers/shared";
+import { buildAgentResponseMessage } from "../../../../../../../src/lib/slack/blocks";
 import { zeroAgents } from "../../../../../../../src/db/schema/zero-agent";
 import { env } from "../../../../../../../src/env";
 import type { SlackScheduleCallbackPayload } from "../../../../../../../src/lib/callback/callback-payloads";
@@ -73,42 +73,18 @@ async function postScheduleResults(
   let messageTs: string | undefined;
   let dmChannelId: string | undefined;
 
+  const header = `:white_check_mark: **Scheduled run for \`${displayName}\` completed**\n\n`;
+
   for (let i = 0; i < texts.length; i++) {
     const rawOutput = texts[i]!;
-    const truncatedOutput =
-      rawOutput.length > 2000 ? `${rawOutput.slice(0, 2000)}…` : rawOutput;
-
     const isFirst = i === 0;
     const isLast = i === texts.length - 1;
 
-    const blocks: (Block | KnownBlock)[] = [];
-
-    if (isFirst) {
-      blocks.push({
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `:white_check_mark: *Scheduled run for \`${displayName}\` completed*`,
-        },
-      });
-    }
-
-    blocks.push({
-      type: "section",
-      text: { type: "mrkdwn", text: truncatedOutput },
-    });
-
-    if (isLast) {
-      blocks.push({
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: `<${logsUrl}|Audit> · Reply in this thread to continue the conversation`,
-          },
-        ],
-      });
-    }
+    const content = isFirst ? header + rawOutput : rawOutput;
+    const blocks = buildAgentResponseMessage(
+      content,
+      isLast ? logsUrl : undefined,
+    );
 
     const threadTs = messageTs;
     const result = await postMessage(
@@ -116,7 +92,7 @@ async function postScheduleResults(
       dmChannelId ?? channel,
       isFirst
         ? `Scheduled run for "${displayName}" completed`
-        : truncatedOutput,
+        : rawOutput.slice(0, 2000),
       {
         ...(threadTs ? { threadTs } : {}),
         blocks,
@@ -256,29 +232,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   } else {
     // Failed run
     const errMsg = error ?? "Unknown error";
+    const failureContent = `:x: **Scheduled run for \`${displayName}\` failed**\n\n${errMsg}`;
     await postMessage(
       client,
       notifyChannel,
       `Scheduled run for "${displayName}" failed`,
       {
-        blocks: [
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: `:x: *Scheduled run for \`${displayName}\` failed*\n\n${errMsg}`,
-            },
-          },
-          {
-            type: "context",
-            elements: [
-              {
-                type: "mrkdwn",
-                text: `<${logsUrl}|Audit>`,
-              },
-            ],
-          },
-        ],
+        blocks: buildAgentResponseMessage(failureContent, logsUrl),
       },
     );
   }

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
@@ -10,12 +10,20 @@ import {
   createSlackClient,
   postMessage,
 } from "../../../../../../../src/lib/slack/client";
-import { getAllRunOutputTexts } from "../../../../../../../src/lib/run/extract-run-output";
+import {
+  extractAllRunOutputs,
+  buildDeepLinksFromFlags,
+  type RunOutput,
+} from "../../../../../../../src/lib/run/extract-run-output";
 import {
   saveThreadSession,
   buildLogsUrl,
 } from "../../../../../../../src/lib/slack-org/handlers/shared";
-import { buildAgentResponseMessage } from "../../../../../../../src/lib/slack/blocks";
+import {
+  buildAgentResponseMessage,
+  detectDeepLinks,
+} from "../../../../../../../src/lib/slack/blocks";
+import { getAppUrl } from "../../../../../../../src/lib/url";
 import { zeroAgents } from "../../../../../../../src/db/schema/zero-agent";
 import { env } from "../../../../../../../src/env";
 import type { SlackScheduleCallbackPayload } from "../../../../../../../src/lib/callback/callback-payloads";
@@ -61,29 +69,35 @@ function extractAgentSessionId(result: unknown): string | undefined {
  * Post all result texts as a threaded Slack conversation.
  *
  * The first message includes the header; subsequent results are threaded replies.
- * Only the last message includes the audit link.
+ * Only the last message includes the audit link and deep links.
  */
 async function postScheduleResults(
   client: ReturnType<typeof createSlackClient>,
   channel: string,
   displayName: string,
-  texts: string[],
+  outputs: RunOutput[],
   logsUrl: string,
+  agentName: string,
 ): Promise<{ messageTs: string | undefined; dmChannelId: string | undefined }> {
   let messageTs: string | undefined;
   let dmChannelId: string | undefined;
 
   const header = `:white_check_mark: **Scheduled run for \`${displayName}\` completed**\n\n`;
 
-  for (let i = 0; i < texts.length; i++) {
-    const rawOutput = texts[i]!;
+  for (let i = 0; i < outputs.length; i++) {
+    const output = outputs[i]!;
+    const rawOutput = output.result ?? "Task completed successfully.";
     const isFirst = i === 0;
-    const isLast = i === texts.length - 1;
+    const isLast = i === outputs.length - 1;
 
     const content = isFirst ? header + rawOutput : rawOutput;
+    const deepLinks = isLast
+      ? buildDeepLinksFromFlags(output, getAppUrl(), agentName)
+      : [];
     const blocks = buildAgentResponseMessage(
       content,
       isLast ? logsUrl : undefined,
+      deepLinks,
     );
 
     const threadTs = messageTs;
@@ -194,17 +208,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const notifyChannel = targetChannelId ?? connection.slackUserId;
 
   if (status === "completed") {
-    const allTexts = await getAllRunOutputTexts(runId);
-    if (allTexts.length === 0) {
-      allTexts.push("Task completed successfully.");
-    }
+    const allOutputs = await extractAllRunOutputs(runId);
 
     const { messageTs, dmChannelId } = await postScheduleResults(
       client,
       notifyChannel,
       displayName,
-      allTexts,
+      allOutputs,
       logsUrl,
+      agentName,
     );
 
     // Create thread session so user can reply to continue (only for DM)
@@ -233,12 +245,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Failed run
     const errMsg = error ?? "Unknown error";
     const failureContent = `:x: **Scheduled run for \`${displayName}\` failed**\n\n${errMsg}`;
+    const deepLinks = detectDeepLinks(errMsg, getAppUrl(), agentName);
     await postMessage(
       client,
       notifyChannel,
       `Scheduled run for "${displayName}" failed`,
       {
-        blocks: buildAgentResponseMessage(failureContent, logsUrl),
+        blocks: buildAgentResponseMessage(failureContent, logsUrl, deepLinks),
       },
     );
   }


### PR DESCRIPTION
## Summary
- Replace manual Block Kit section blocks in schedule Slack notifications with the shared `buildAgentResponseMessage` helper
- Schedule success and failure notifications now use the same markdown block format as regular conversation messages
- Removes manual 2,000 char truncation in favor of the 12,000 char limit in `buildAgentResponseMessage`
- Removes unused `Block`/`KnownBlock` type imports

## Test plan
- [ ] Verify schedule success notifications render with markdown blocks and audit link
- [ ] Verify schedule failure notifications render with markdown blocks and audit link
- [ ] Verify multi-message threaded output still works correctly
- [ ] Existing `blocks.test.ts` tests pass

Closes #6533

🤖 Generated with [Claude Code](https://claude.com/claude-code)