### PR TITLE
chore: update docker images to 20260324

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260323",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260324",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -67,7 +67,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     outputs:
       job-ref: ${{ steps.set-job-ref.outputs.job-ref }}
       web-preview-url: ${{ steps.preview-urls.outputs.web-url }}
@@ -276,7 +276,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -290,7 +290,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -304,7 +304,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -318,7 +318,7 @@ jobs:
     # Skip for release-please PRs, commits, and merge queue entries
     if: needs.detect-release.outputs.skip != 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -334,7 +334,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     services:
       postgres:
         image: postgres:17-alpine
@@ -380,7 +380,7 @@ jobs:
     # Only run when migration or schema files changed
     if: needs.prepare.outputs.migration-changed == 'true'
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     services:
       postgres:
         image: postgres:17-alpine
@@ -437,7 +437,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -466,7 +466,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -495,7 +495,7 @@ jobs:
     if: needs.detect-release.outputs.skip != 'true'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260324
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/toolchain-init
@@ -525,7 +525,7 @@ jobs:
       group: deploy-web-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and web, CLI, runner, or platform changed
     if: |
@@ -929,7 +929,7 @@ jobs:
       group: deploy-docs-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and docs changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.docs-changed == 'true' }}"
@@ -976,7 +976,7 @@ jobs:
       group: deploy-app-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     needs: [prepare]
     # Deploy if job-ref is set (PR or main), not a release-please commit, and platform changed
     if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.platform-changed == 'true' }}"
@@ -1072,7 +1072,7 @@ jobs:
   build-cli:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     needs: [prepare]
     if: |
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
@@ -1240,7 +1240,7 @@ jobs:
       group: deploy-runner-prepare-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260324
     needs: [prepare]
     timeout-minutes: 10
     env:
@@ -1751,7 +1751,7 @@ jobs:
   build-e2b-template:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vm0-ai/vm0-toolchain:20260320
+      image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     needs: [prepare]
     # Build on PR or main push when E2B templates changed, skip release-please commits
     if: |


### PR DESCRIPTION
## Summary
- Update `vm0-dev` image from `20260323` → `20260324` in devcontainer.json
- Update `vm0-toolchain` and `vm0-toolchain-rust` images from `20260320` → `20260324` in turbo.yml

Triggered by docker rebuild after merging #6519 and #6523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)