### PR TITLE
feat(cli): decode org from zero token jwt in active org resolution

### DIFF
--- a/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
@@ -14,7 +14,7 @@ vi.mock("os", async (importOriginal) => {
   };
 });
 
-import { getToken, getActiveToken } from "../config";
+import { getToken, getActiveToken, getActiveOrg } from "../config";
 
 describe("token resolution", () => {
   beforeEach(async () => {
@@ -70,6 +70,107 @@ describe("token resolution", () => {
     it("should return undefined when no token source is available", async () => {
       const token = await getActiveToken();
       expect(token).toBeUndefined();
+    });
+  });
+
+  describe("getActiveOrg", () => {
+    function buildFakeJwt(payload: Record<string, unknown>): string {
+      const header = Buffer.from(
+        JSON.stringify({ alg: "HS256", typ: "JWT" }),
+      ).toString("base64url");
+      const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+      const sig = Buffer.from("fake-signature").toString("base64url");
+      return `vm0_sandbox_${header}.${body}.${sig}`;
+    }
+
+    async function writeConfigOrg(activeOrg: string): Promise<void> {
+      const configDir = path.join(TEST_HOME, ".vm0");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "config.json"),
+        JSON.stringify({ activeOrg }),
+      );
+    }
+
+    it("should return orgId from ZERO_TOKEN when set", async () => {
+      vi.stubEnv(
+        "ZERO_TOKEN",
+        buildFakeJwt({ scope: "zero", orgId: "org-from-jwt" }),
+      );
+
+      const org = await getActiveOrg();
+      expect(org).toBe("org-from-jwt");
+    });
+
+    it("should prefer ZERO_TOKEN over VM0_ACTIVE_ORG", async () => {
+      vi.stubEnv(
+        "ZERO_TOKEN",
+        buildFakeJwt({ scope: "zero", orgId: "jwt-org" }),
+      );
+      vi.stubEnv("VM0_ACTIVE_ORG", "env-org");
+
+      const org = await getActiveOrg();
+      expect(org).toBe("jwt-org");
+    });
+
+    it("should fall back to VM0_ACTIVE_ORG when ZERO_TOKEN is absent", async () => {
+      vi.stubEnv("VM0_ACTIVE_ORG", "env-org");
+
+      const org = await getActiveOrg();
+      expect(org).toBe("env-org");
+    });
+
+    it("should fall back to config file when both env vars are absent", async () => {
+      vi.stubEnv("VM0_ACTIVE_ORG", "");
+      await writeConfigOrg("config-org");
+
+      const org = await getActiveOrg();
+      expect(org).toBe("config-org");
+    });
+
+    it("should return undefined when nothing is set", async () => {
+      vi.stubEnv("VM0_ACTIVE_ORG", "");
+
+      const org = await getActiveOrg();
+      expect(org).toBeUndefined();
+    });
+
+    it("should ignore sandbox-scoped token", async () => {
+      vi.stubEnv(
+        "ZERO_TOKEN",
+        buildFakeJwt({ scope: "sandbox", runId: "run-1" }),
+      );
+      vi.stubEnv("VM0_ACTIVE_ORG", "fallback-org");
+
+      const org = await getActiveOrg();
+      expect(org).toBe("fallback-org");
+    });
+
+    it("should ignore compose-job-scoped token", async () => {
+      vi.stubEnv(
+        "ZERO_TOKEN",
+        buildFakeJwt({ scope: "compose-job", jobId: "job-1" }),
+      );
+      vi.stubEnv("VM0_ACTIVE_ORG", "fallback-org");
+
+      const org = await getActiveOrg();
+      expect(org).toBe("fallback-org");
+    });
+
+    it("should ignore malformed ZERO_TOKEN", async () => {
+      vi.stubEnv("ZERO_TOKEN", "not-a-valid-token");
+      vi.stubEnv("VM0_ACTIVE_ORG", "fallback-org");
+
+      const org = await getActiveOrg();
+      expect(org).toBe("fallback-org");
+    });
+
+    it("should ignore ZERO_TOKEN with invalid base64 payload", async () => {
+      vi.stubEnv("ZERO_TOKEN", "vm0_sandbox_header.!!!invalid!!!.signature");
+      vi.stubEnv("VM0_ACTIVE_ORG", "fallback-org");
+
+      const org = await getActiveOrg();
+      expect(org).toBe("fallback-org");
     });
   });
 

--- a/turbo/apps/cli/src/lib/api/config.ts
+++ b/turbo/apps/cli/src/lib/api/config.ts
@@ -75,13 +75,49 @@ export async function getApiUrl(): Promise<string> {
 }
 
 /**
+ * Decode orgId from ZERO_TOKEN JWT payload.
+ * Only decodes — does NOT verify signature (server does that).
+ * Returns undefined if token is missing, malformed, or not a zero token.
+ */
+function decodeOrgIdFromZeroToken(): string | undefined {
+  const token = process.env.ZERO_TOKEN;
+  if (!token) return undefined;
+
+  const prefix = "vm0_sandbox_";
+  if (!token.startsWith(prefix)) return undefined;
+  const jwt = token.slice(prefix.length);
+
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return undefined;
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1]!, "base64url").toString(),
+    ) as Record<string, unknown>;
+    if (payload.scope === "zero" && typeof payload.orgId === "string") {
+      return payload.orgId;
+    }
+  } catch {
+    // Malformed token — fall through
+  }
+  return undefined;
+}
+
+/**
  * Get the active organization for API requests.
- * Priority: VM0_ACTIVE_ORG env var > activeOrg from config file
+ * Priority: ZERO_TOKEN JWT orgId > VM0_ACTIVE_ORG env var > activeOrg from config file
  */
 export async function getActiveOrg(): Promise<string | undefined> {
+  // Prefer orgId decoded from ZERO_TOKEN JWT (zero agent runs)
+  const zeroOrgId = decodeOrgIdFromZeroToken();
+  if (zeroOrgId) return zeroOrgId;
+
+  // Fall back to VM0_ACTIVE_ORG env var (legacy)
   if (process.env.VM0_ACTIVE_ORG) {
     return process.env.VM0_ACTIVE_ORG;
   }
+
+  // Fall back to config file
   const config = await loadConfig();
   return config.activeOrg;
 }


### PR DESCRIPTION
## Summary

- Add `decodeOrgIdFromZeroToken()` helper to decode `orgId` from `ZERO_TOKEN` JWT payload without signature verification
- Update `getActiveOrg()` priority chain: ZERO_TOKEN JWT orgId > VM0_ACTIVE_ORG env var > config file
- Add comprehensive tests covering all priority paths and edge cases (malformed tokens, wrong scopes, fallbacks)

Closes #6546

## Test plan

- [x] All 9 new `getActiveOrg` tests pass
- [x] All 799 existing CLI tests pass
- [x] Lint, type-check, format, knip all pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)