### PR TITLE
refactor(web): rename integration-slack:write to slack:write and add run route capability checks

### DIFF
--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -13,7 +13,10 @@ import {
   type UserContext,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
-import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
+import {
+  generateSandboxToken,
+  generateZeroToken,
+} from "../../../../../../../src/lib/auth/sandbox-token";
 
 const URL = "http://localhost:3000/api/zero/integrations/slack/message";
 
@@ -52,7 +55,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
     expect(response.status).toBe(401);
   });
 
-  it("returns 403 when sandbox token lacks integration-slack:write", async () => {
+  it("returns 403 when sandbox token lacks slack:write", async () => {
     const { token } = await sandboxTokenWithRun(["agent:read"]);
 
     const request = createTestRequest(URL, {
@@ -68,11 +71,12 @@ describe("POST /api/zero/integrations/slack/message", () => {
     expect(response.status).toBe(403);
 
     const data = await response.json();
-    expect(data.error.message).toContain("integration-slack:write");
+    expect(data.error.message).toContain("slack:write");
   });
 
   it("returns 404 when no Slack installation exists for org", async () => {
-    const { token } = await sandboxTokenWithRun(["integration-slack:write"]);
+    mockClerk({ userId: null });
+    const token = await generateZeroToken(user.userId, "run-1", user.orgId);
 
     const request = createTestRequest(URL, {
       method: "POST",
@@ -91,7 +95,8 @@ describe("POST /api/zero/integrations/slack/message", () => {
   });
 
   it("sends message successfully and returns Slack response", async () => {
-    const { token } = await sandboxTokenWithRun(["integration-slack:write"]);
+    mockClerk({ userId: null });
+    const token = await generateZeroToken(user.userId, "run-1", user.orgId);
 
     // Create Slack installation for the user's org
     await createTestSlackOrgInstallation({ orgId: user.orgId });
@@ -128,7 +133,8 @@ describe("POST /api/zero/integrations/slack/message", () => {
   });
 
   it("forwards Slack API error with 400 status", async () => {
-    const { token } = await sandboxTokenWithRun(["integration-slack:write"]);
+    mockClerk({ userId: null });
+    const token = await generateZeroToken(user.userId, "run-1", user.orgId);
 
     await createTestSlackOrgInstallation({ orgId: user.orgId });
 

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
@@ -36,14 +36,16 @@ const router = tsr.router(integrationsSlackMessageContract, {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
-      requiredCapability: "integration-slack:write",
+      requiredCapability: "slack:write",
     });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    // Resolve orgId — sandbox tokens derive from runId, CLI/session use resolveOrg
+    // Resolve orgId — zero tokens carry orgId directly, sandbox tokens derive from runId
     let orgId: string;
-    if (isSandboxAuth(authCtx)) {
+    if (authCtx.orgId) {
+      orgId = authCtx.orgId;
+    } else if (isSandboxAuth(authCtx)) {
       const [sandboxRun] = await globalThis.services.db
         .select({ orgId: agentRuns.orgId })
         .from(agentRuns)

--- a/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
@@ -12,6 +12,7 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -65,5 +66,23 @@ describe("GET /api/zero/runs/:id", () => {
       createTestRequest("http://localhost:3000/api/zero/runs/some-id?org=test"),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should return 403 for sandbox token without agent-run:read capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken("user-1", "run-1", ["agent:read"]);
+
+    const response = await GET(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/some-id?org=test",
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      ),
+    );
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("agent-run:read");
   });
 });

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
@@ -12,6 +12,7 @@ import {
   uniqueId,
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -87,5 +88,24 @@ describe("POST /api/zero/runs/:id/cancel", () => {
       ),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should return 403 for sandbox token without agent-run:write capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken("user-1", "run-1", ["agent:read"]);
+
+    const response = await POST(
+      createTestRequest(
+        "http://localhost:3000/api/zero/runs/some-id/cancel?org=test",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      ),
+    );
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("agent-run:write");
   });
 });

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
@@ -21,7 +21,9 @@ const router = tsr.router(zeroRunsCancelContract, {
   cancel: async ({ params, headers }, { request }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:write",
+    });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/route.ts
@@ -16,7 +16,9 @@ const router = tsr.router(zeroRunsByIdContract, {
   getById: async ({ params, headers }, { request }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -12,6 +12,7 @@ import {
   uniqueId,
 } from "../../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -70,5 +71,23 @@ describe("GET /api/zero/runs/:id/telemetry/agent", () => {
       ),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should return 403 for sandbox token without agent-run:read capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken("user-1", "run-1", ["agent:read"]);
+
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/runs/${randomUUID()}/telemetry/agent?org=test&limit=10&order=desc`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      ),
+    );
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("agent-run:read");
   });
 });

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
@@ -17,7 +17,9 @@ const router = tsr.router(zeroRunAgentEventsContract, {
   getAgentEvents: async ({ params, query, headers }, { request }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 

--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../route";
+import { createTestRequest } from "../../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
+
+const context = testContext();
+
+const URL = "http://localhost:3000/api/zero/runs";
+
+describe("POST /api/zero/runs", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return 403 for sandbox token without agent-run:write capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken("user-1", "run-1", ["agent:read"]);
+
+    const response = await POST(
+      createTestRequest(URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          agentComposeId: "some-compose-id",
+          prompt: "test prompt",
+        }),
+      }),
+    );
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("agent-run:write");
+  });
+});

--- a/turbo/apps/web/app/api/zero/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -72,5 +73,20 @@ describe("GET /api/zero/runs/queue", () => {
       createTestRequest("http://localhost:3000/api/zero/runs/queue?org=test"),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should return 403 for sandbox token without agent-run:read capability", async () => {
+    mockClerk({ userId: null });
+    const token = await generateSandboxToken("user-1", "run-1", ["agent:read"]);
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/runs/queue?org=test", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    );
+    expect(response.status).toBe(403);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("agent-run:read");
   });
 });

--- a/turbo/apps/web/app/api/zero/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/route.ts
@@ -16,7 +16,9 @@ const router = tsr.router(zeroRunsQueueContract, {
   getQueue: async ({ headers }, { request }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -53,7 +53,9 @@ const router = tsr.router(zeroRunsMainContract, {
   create: async ({ body, headers }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:write",
+    });
     if (isAuthError(authCtx)) return authCtx;
 
     try {

--- a/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { auth } from "@clerk/nextjs/server";
 import { requireAuth, isAuthError } from "../require-auth";
-import { generateSandboxToken } from "../sandbox-token";
+import { generateSandboxToken, generateZeroToken } from "../sandbox-token";
 
 describe("requireAuth", () => {
   const mockAuth = vi.mocked(auth);
@@ -134,6 +134,53 @@ describe("requireAuth", () => {
     if (isAuthError(result)) {
       expect(result.status).toBe(401);
       expect(result.body.error.code).toBe("UNAUTHORIZED");
+    }
+  });
+
+  it("should return AuthContext for zero token with matching capability", async () => {
+    const token = await generateZeroToken("user-1", "run-1", "org-1");
+
+    const result = await requireAuth(`Bearer ${token}`, {
+      requiredCapability: "agent-run:read",
+    });
+
+    expect(isAuthError(result)).toBe(false);
+    if (!isAuthError(result)) {
+      expect(result.userId).toBe("user-1");
+      expect(result.orgId).toBe("org-1");
+      expect(result.runId).toBe("run-1");
+      expect(result.capabilities).toContain("agent-run:read");
+    }
+  });
+
+  it("should return 403 for zero token missing required capability", async () => {
+    const token = await generateZeroToken("user-1", "run-1", "org-1");
+
+    // "integration-slack:write" is NOT in ZERO_CAPABILITIES
+    const result = await requireAuth(`Bearer ${token}`, {
+      requiredCapability: "integration-slack:write",
+    });
+
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.status).toBe(403);
+      expect(result.body.error.code).toBe("FORBIDDEN");
+      expect(result.body.error.message).toBe(
+        "Missing required capability: integration-slack:write",
+      );
+    }
+  });
+
+  it("should return 403 for zero token on uncovered endpoint", async () => {
+    const token = await generateZeroToken("user-1", "run-1", "org-1");
+
+    // No requiredCapability = uncovered endpoint
+    const result = await requireAuth(`Bearer ${token}`);
+
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.status).toBe(403);
+      expect(result.body.error.code).toBe("FORBIDDEN");
     }
   });
 });

--- a/turbo/apps/web/src/lib/auth/capability-check.ts
+++ b/turbo/apps/web/src/lib/auth/capability-check.ts
@@ -1,7 +1,7 @@
-import type { VALID_CAPABILITIES } from "@vm0/core";
+import type { ValidCapability, ZeroCapability } from "@vm0/core";
 import type { AuthContext } from "./get-auth-context";
 
-type Capability = (typeof VALID_CAPABILITIES)[number];
+type AnyCapability = ValidCapability | ZeroCapability;
 
 /**
  * Check if auth context is from a sandbox token.
@@ -18,7 +18,7 @@ export function isSandboxAuth(
  * Build 403 response body for missing capability.
  * Response body tells which capability is missing (aids debugging).
  */
-export function missingCapabilityError(capability: Capability): {
+export function missingCapabilityError(capability: AnyCapability): {
   error: { message: string; code: string };
 } {
   return {

--- a/turbo/apps/web/src/lib/auth/require-auth.ts
+++ b/turbo/apps/web/src/lib/auth/require-auth.ts
@@ -1,9 +1,13 @@
-import type { VALID_CAPABILITIES } from "@vm0/core";
+import type { ValidCapability, ZeroCapability } from "@vm0/core";
 import { getAuthContext, type AuthContext } from "./get-auth-context";
-import { isSandboxToken, verifySandboxToken } from "./sandbox-token";
+import {
+  isSandboxToken,
+  verifySandboxToken,
+  verifyZeroToken,
+} from "./sandbox-token";
 import { missingCapabilityError } from "./capability-check";
 
-type Capability = (typeof VALID_CAPABILITIES)[number];
+type AnyCapability = ValidCapability | ZeroCapability;
 
 type AuthErrorResponse = {
   status: 401 | 403;
@@ -19,7 +23,7 @@ type AuthErrorResponse = {
 export async function requireAuth(
   authHeader: string | undefined,
   options?: {
-    requiredCapability?: Capability;
+    requiredCapability?: AnyCapability;
     acceptAnySandboxCapability?: boolean;
   },
 ): Promise<AuthContext | AuthErrorResponse> {
@@ -36,7 +40,8 @@ export async function requireAuth(
     const token = authHeader.substring(7);
     if (isSandboxToken(token)) {
       const sandboxAuth = verifySandboxToken(token);
-      if (sandboxAuth) {
+      const zeroAuth = !sandboxAuth ? verifyZeroToken(token) : null;
+      if (sandboxAuth || zeroAuth) {
         // Token is valid → this is a capability/access issue, not auth
         if (options?.requiredCapability) {
           return {


### PR DESCRIPTION
## Summary

- Widen `requireAuth()` and `missingCapabilityError()` types to accept `AnyCapability` (both `ValidCapability` and `ZeroCapability`)
- Fix 403 detection for zero tokens — valid zero tokens with missing capabilities now correctly return 403 instead of 401
- Rename Slack message route capability from `integration-slack:write` to `slack:write` (aligning with `ZERO_CAPABILITIES` naming)
- Add `agent-run:read/write` capability checks to all 5 `/api/zero/runs/*` routes (previously unprotected)
- Optimize Slack route `orgId` resolution for zero tokens (use `authCtx.orgId` directly instead of DB lookup)

## Test plan

- [x] `require-auth.test.ts` — 3 new tests for zero token: matching capability returns AuthContext, missing capability returns 403, uncovered endpoint returns 403
- [x] Slack message route test — updated capability name to `slack:write`, switched success tests to use `generateZeroToken`
- [x] Run route tests (4 files) — added 403 capability check tests for each route
- [x] All 36 affected tests pass (14 require-auth + 22 route tests)
- [x] Lint, type-check, format, knip all pass
- [x] `grep -r "integration-slack:write" turbo/apps/web/app/api/zero/` returns zero results

Closes #6547

🤖 Generated with [Claude Code](https://claude.com/claude-code)