### PR TITLE
chore: remove stale test comments from cli entry point

### DIFF
--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -62,14 +62,3 @@ if (
   configureGlobalProxyFromEnv();
   program.parse();
 }
-// test comment Thu Feb 18 2026 v2
-// test comment Thu Feb 18 2026 v3
-// test comment Thu Feb 18 2026 v4
-// test comment Thu Feb 18 2026 v5
-// test comment Thu Feb 18 2026 v6
-// test comment Thu Feb 18 2026 v7
-// test comment Thu Feb 18 2026 v8
-// test comment Thu Feb 19 2026 v9
-// test comment Thu Feb 19 2026 v10
-// test comment Thu Feb 20 2026 v11
-// test comment Sat Feb 22 2026 v12


### PR DESCRIPTION
## Summary
- Remove 11 stale CI deployment test comments (v2–v12) from `turbo/apps/cli/src/index.ts`

## Test plan
- [ ] No functional changes — comments only
- [ ] CI passes (lint, type-check, format, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)