### PR TITLE
fix(core): correct stale cli hint references in run error guidance

### DIFF
--- a/turbo/packages/core/src/contracts/errors.ts
+++ b/turbo/packages/core/src/contracts/errors.ts
@@ -73,12 +73,11 @@ export const RUN_ERROR_GUIDANCE: Record<
   NO_MODEL_PROVIDER: {
     title: "No model provider configured",
     guidance: "Configure a model provider to start running agents.",
-    cliHint: "vm0 org model-provider setup",
+    cliHint: "zero org model-provider setup",
   },
   INSUFFICIENT_CREDITS: {
     title: "Credits depleted",
     guidance: "Add credits or configure your own API key to continue.",
-    cliHint: "vm0 org billing",
   },
   PROVIDER_INCOMPATIBLE: {
     title: "Provider not compatible",


### PR DESCRIPTION
## Summary

- Update `NO_MODEL_PROVIDER.cliHint` from `"vm0 org model-provider setup"` to `"zero org model-provider setup"` — the `vm0 zero` bridge was removed in #6542
- Remove `INSUFFICIENT_CREDITS.cliHint` (`"vm0 org billing"`) — this command never existed in either CLI

Closes #6569

## Test plan

- [x] No tests assert on these cliHint values (confirmed via grep)
- [x] All existing tests pass (3 pre-existing failures in `sync-skills`, `zero/agents`, `zero/firewall-policies` unrelated to this change — they fail identically on main)
- [x] Lint, type-check, format, knip all pass
- [ ] Manual: trigger `NO_MODEL_PROVIDER` error on CLI → shows `zero org model-provider setup`
- [ ] Manual: trigger `INSUFFICIENT_CREDITS` error → no cliHint displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)