### PR TITLE
refactor: remove experimental_capabilities and make VM0_TOKEN injection unconditional

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -669,17 +669,10 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
     // The certificate is pre-baked into the rootfs at build time.
     env.insert("NODE_EXTRA_CA_CERTS".into(), VM_PROXY_CA_PATH.into());
 
-    // When capabilities are declared, inject CLI-compatible env vars
-    // so vm0 CLI can authenticate inside the sandbox.
-    if context
-        .experimental_capabilities
-        .as_ref()
-        .is_some_and(|caps| !caps.is_empty())
-    {
-        env.insert("VM0_TOKEN".into(), context.sandbox_token.clone());
-        if let Some(slug) = &context.agent_org_slug {
-            env.insert("VM0_ACTIVE_ORG".into(), slug.clone());
-        }
+    // Inject CLI-compatible env vars so vm0 CLI can authenticate inside the sandbox.
+    env.insert("VM0_TOKEN".into(), context.sandbox_token.clone());
+    if let Some(slug) = &context.agent_org_slug {
+        env.insert("VM0_ACTIVE_ORG".into(), slug.clone());
     }
 
     // Artifact config
@@ -790,7 +783,6 @@ mod tests {
             agent_org_slug: None,
             memory_name: None,
             experimental_firewalls: None,
-            experimental_capabilities: None,
             disallowed_tools: None,
             tools: None,
             settings: None,
@@ -1068,9 +1060,8 @@ mod tests {
     }
 
     #[test]
-    fn build_env_json_capabilities_inject_cli_vars() {
+    fn build_env_json_injects_cli_vars() {
         let mut ctx = minimal_context();
-        ctx.experimental_capabilities = Some(vec!["artifact:read".into()]);
         ctx.agent_org_slug = Some("my-org".into());
         let env = build_env_json(&ctx, "http://localhost");
         assert_eq!(env.get("VM0_TOKEN").unwrap(), "tok");
@@ -1078,26 +1069,16 @@ mod tests {
     }
 
     #[test]
-    fn build_env_json_no_capabilities_no_cli_vars() {
+    fn build_env_json_injects_vm0_token_without_org() {
         let ctx = minimal_context();
         let env = build_env_json(&ctx, "http://localhost");
-        assert!(!env.contains_key("VM0_TOKEN"));
+        assert_eq!(env.get("VM0_TOKEN").unwrap(), "tok");
         assert!(!env.contains_key("VM0_ACTIVE_ORG"));
     }
 
     #[test]
-    fn build_env_json_empty_capabilities_no_cli_vars() {
+    fn build_env_json_cli_vars_override_user_env() {
         let mut ctx = minimal_context();
-        ctx.experimental_capabilities = Some(vec![]);
-        let env = build_env_json(&ctx, "http://localhost");
-        assert!(!env.contains_key("VM0_TOKEN"));
-        assert!(!env.contains_key("VM0_ACTIVE_ORG"));
-    }
-
-    #[test]
-    fn build_env_json_capabilities_cli_vars_override_user_env() {
-        let mut ctx = minimal_context();
-        ctx.experimental_capabilities = Some(vec!["artifact:read".into()]);
         ctx.agent_org_slug = Some("my-org".into());
         ctx.environment = Some(HashMap::from([
             ("VM0_TOKEN".into(), "tampered".into()),
@@ -1106,21 +1087,6 @@ mod tests {
         let env = build_env_json(&ctx, "http://localhost");
         assert_eq!(env.get("VM0_TOKEN").unwrap(), "tok");
         assert_eq!(env.get("VM0_ACTIVE_ORG").unwrap(), "my-org");
-    }
-
-    #[test]
-    fn execution_context_deserializes_with_capabilities() {
-        let json = serde_json::json!({
-            "runId": "00000000-0000-0000-0000-000000000001",
-            "prompt": "test",
-            "sandboxToken": "tok",
-            "workingDir": "/workspace",
-            "cliAgentType": "claude-code",
-            "experimentalCapabilities": ["artifact:read", "artifact:write"]
-        });
-        let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
-        let caps = ctx.experimental_capabilities.unwrap();
-        assert_eq!(caps, vec!["artifact:read", "artifact:write"]);
     }
 
     #[test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -243,7 +243,6 @@ impl JobProvider for LocalProvider {
             agent_org_slug: None,
             memory_name: None,
             experimental_firewalls: None,
-            experimental_capabilities: None,
             disallowed_tools: None,
             tools: None,
             settings: None,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -69,7 +69,7 @@ pub struct ExecutionContext {
     pub api_start_time: Option<f64>,
     #[serde(default)]
     pub user_timezone: Option<String>,
-    // Org slug for agent — used for VM0_ACTIVE_ORG when capabilities are present
+    // Org slug for agent — used for VM0_ACTIVE_ORG
     #[serde(default)]
     pub agent_org_slug: Option<String>,
     // Memory storage name for first-run init — not yet consumed by runner
@@ -78,8 +78,6 @@ pub struct ExecutionContext {
     pub memory_name: Option<String>,
     #[serde(default)]
     pub experimental_firewalls: Option<Vec<Firewall>>,
-    #[serde(default)]
-    pub experimental_capabilities: Option<Vec<String>>,
     #[serde(default)]
     pub disallowed_tools: Option<Vec<String>>,
     #[serde(default)]

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -33,9 +33,6 @@ agents:
       - https://github.com/vm0-ai/vm0-skills/tree/main/hackernews
     volumes:
       - my-volume:/home/user/.config
-    experimental_capabilities:
-      - artifact:read
-      - artifact:write
     environment:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       MY_VAR: ${{ vars.MY_VAR }}
@@ -74,7 +71,6 @@ Each agent key must be a valid agent name: 3-64 characters, starting and ending 
 | `skills`                 | array  | No       | `[]`           | List of skill references. Supports bare names (e.g., `"slack"`) which resolve to `https://github.com/vm0-ai/vm0-skills/tree/main/slack`, or full GitHub URLs. See [Skills](/docs/core-concept/skills) |
 | `volumes`                | array  | No       | `[]`           | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
 | `environment`            | object | No       | `{}`           | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
-| `experimental_capabilities` | array  | No       | `[]`           | Sandbox API access permissions. See [Capabilities](/docs/core-concept/capabilities)                       |
 | `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `org/name` format (e.g., `acme/production`) |
 
 ## Volume Fields

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -337,44 +337,8 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
   });
 
-  describe("Claim flow - capabilities in sandbox token", () => {
-    it("should include capabilities in returned sandbox token", async () => {
-      const { composeId, versionId } = await createTestCompose("test-caps");
-      const composeInfo = await findTestComposeWithOrg(composeId);
-      const orgSlug = composeInfo!.orgSlug;
-
-      const { runId } = await createTestRunnerJob(
-        user.userId,
-        versionId,
-        `${orgSlug}/default`,
-        {
-          experimentalCapabilities: ["agent:read", "agent:write"],
-        },
-      );
-
-      const token = await createTestCliToken(user.userId);
-      const request = createTestRequest(
-        `http://localhost:3000/api/runners/jobs/${runId}/claim`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({}),
-        },
-      );
-
-      const response = await POST(request);
-      expect(response.status).toBe(200);
-
-      const data = await response.json();
-      const sandboxAuth = verifySandboxToken(data.sandboxToken);
-      expect(sandboxAuth).not.toBeNull();
-      expect(sandboxAuth!.capabilities).toEqual(["agent:read", "agent:write"]);
-    });
-
-    it("should generate token without capabilities when not in stored context", async () => {
+  describe("Claim flow - sandbox token generation", () => {
+    it("should generate sandbox token without capabilities", async () => {
       const { composeId, versionId } = await createTestCompose("test-no-caps");
       const composeInfo = await findTestComposeWithOrg(composeId);
       const orgSlug = composeInfo!.orgSlug;

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -139,12 +139,8 @@ const router = tsr.router(runnersJobClaimContract, {
       );
     }
 
-    // Generate sandbox token with capabilities from stored context
-    const sandboxToken = await generateSandboxToken(
-      run.userId,
-      run.id,
-      storedContext.experimentalCapabilities,
-    );
+    // Generate sandbox token for the run
+    const sandboxToken = await generateSandboxToken(run.userId, run.id);
 
     // Record api_to_claim metric
     if (storedContext.apiStartTime) {
@@ -203,7 +199,6 @@ const router = tsr.router(runnersJobClaimContract, {
         encryptedSecrets: storedContext.encryptedSecrets, // Encrypted blob for auth resolution
         cliAgentType: storedContext.cliAgentType,
         experimentalFirewalls: storedContext.experimentalFirewalls,
-        experimentalCapabilities: storedContext.experimentalCapabilities,
         disallowedTools: storedContext.disallowedTools,
         tools: storedContext.tools,
         settings: storedContext.settings,

--- a/turbo/apps/web/app/api/zero/__tests__/zero-agent.test.ts
+++ b/turbo/apps/web/app/api/zero/__tests__/zero-agent.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from "next/server";
 import { GET as getAgentRoute } from "../agents/[id]/route";
 import { POST as createRunRoute } from "../runs/route";
 import { POST as claimJobRoute } from "../../runners/jobs/[id]/claim/route";
+import { generateZeroToken } from "../../../../src/lib/auth/sandbox-token";
 import {
   seedSeedSkills,
   seedSeedSkillStorages,
@@ -15,13 +16,15 @@ const context = testContext();
 
 /**
  * End-to-end zero agent flow:
- *   onboarding (model provider) → create agent → run agent → claim job → use sandbox token
+ *   onboarding (model provider) → create agent → run agent → claim job → use zero token
  *
  * Every step goes through real API route handlers.
  * The only test helpers used are infrastructure (auth mock, skill seeding).
  */
-describe("Zero Agent E2E: create → run → sandbox token access", () => {
+describe("Zero Agent E2E: create → run → zero token access", () => {
   let orgSlug: string;
+  let orgId: string;
+  let userId: string;
   let agent: { agentId: string };
 
   beforeAll(async () => {
@@ -34,10 +37,12 @@ describe("Zero Agent E2E: create → run → sandbox token access", () => {
     context.setupMocks();
     const result = await onboardNewOrgAndUser(context);
     orgSlug = result.orgSlug;
+    orgId = result.user.orgId;
+    userId = result.user.userId;
     agent = result.agent;
   });
 
-  it("should allow sandbox token from claimed run to read agent details", async () => {
+  it("should allow zero token from claimed run to read agent details", async () => {
     // ── 4. Run agent via API ──
     const runRes = await createRunRoute(
       new NextRequest("http://localhost:3000/api/zero/runs", {
@@ -73,46 +78,25 @@ describe("Zero Agent E2E: create → run → sandbox token access", () => {
     expect(claimRes.status).toBe(200);
     const executionContext = (await claimRes.json()) as {
       sandboxToken: string;
-      experimentalCapabilities: string[];
     };
 
-    // Verify the execution context contains a sandbox token and capabilities
+    // Verify the execution context contains a sandbox token (now without capabilities)
     expect(executionContext.sandboxToken).toBeTruthy();
     expect(executionContext.sandboxToken).toMatch(/^vm0_sandbox_/);
-    expect(executionContext.experimentalCapabilities).toEqual(
-      expect.arrayContaining(["agent:read"]),
-    );
 
-    // ── 6. Use sandbox token to read agent details ──
-    // This is what happens inside the sandbox: the runner injects
-    // sandboxToken as VM0_TOKEN and VM0_ACTIVE_ORG, and the agent CLI
-    // uses them to call the API with ?org=<slug>.
-    // Sandbox tokens are processed before the Clerk session fallback in
-    // getAuthContext, so the Clerk session state does not affect sandbox auth.
+    // ── 6. Use ZERO_TOKEN to read agent details ──
+    // In production, zero agents use ZERO_TOKEN (injected via secrets) for
+    // zero-layer route auth, not the sandbox token (VM0_TOKEN).
+    const zeroToken = await generateZeroToken(userId, run.runId, orgId);
 
-    // 6a. Without ?org= → sandbox token has no orgId, request fails
-    // (in production, runner also injects VM0_ACTIVE_ORG for this reason)
-    const noOrgRes = await getAgentRoute(
-      new NextRequest(
-        `http://localhost:3000/api/zero/agents/${agent.agentId}`,
-        {
-          method: "GET",
-          headers: {
-            Authorization: `Bearer ${executionContext.sandboxToken}`,
-          },
-        },
-      ),
-    );
-    expect(noOrgRes.ok).toBe(false);
-
-    // 6b. With ?org= (simulating VM0_ACTIVE_ORG) → should succeed
+    // 6a. With ?org= → should succeed
     const getRes = await getAgentRoute(
       new NextRequest(
         `http://localhost:3000/api/zero/agents/${agent.agentId}?org=${orgSlug}`,
         {
           method: "GET",
           headers: {
-            Authorization: `Bearer ${executionContext.sandboxToken}`,
+            Authorization: `Bearer ${zeroToken}`,
           },
         },
       ),

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -10,7 +10,6 @@ import {
   getConnectorEnvironmentMapping,
   connectorTypeSchema,
   MODEL_PROVIDER_TYPES,
-  VALID_CAPABILITIES,
   getModelProviderFirewall,
   areProvidersCompatible,
   getVm0ConcreteProviderType,
@@ -1095,23 +1094,6 @@ function applyConnectorPolicies(
 }
 
 /**
- * Extract experimental_capabilities from the first agent in compose.
- * Returns undefined if not present or empty.
- */
-function buildExperimentalCapabilities(
-  agentCompose: unknown,
-): (typeof VALID_CAPABILITIES)[number][] | undefined {
-  const compose = agentCompose as AgentComposeYaml | undefined;
-  if (!compose?.agents) return undefined;
-
-  const firstAgent = Object.values(compose.agents)[0];
-  const capabilities = firstAgent?.experimental_capabilities;
-  if (!capabilities || capabilities.length === 0) return undefined;
-
-  return capabilities;
-}
-
-/**
  * Build unified execution context from various parameter sources.
  * Supports: new run, checkpoint resume, session continue.
  *
@@ -1253,9 +1235,6 @@ export async function buildExecutionContext(
     params.firewallPolicies,
   );
 
-  // Build experimental capabilities list from compose
-  const experimentalCapabilities = buildExperimentalCapabilities(agentCompose);
-
   // Disallowed tools from run-time params (not compose)
   const disallowedTools = params.disallowedTools;
 
@@ -1283,7 +1262,6 @@ export async function buildExecutionContext(
       environment,
       userTimezone,
       experimentalFirewalls,
-      experimentalCapabilities,
       disallowedTools,
       tools,
       settings: params.settings,

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -256,9 +256,6 @@ function buildPreparedContext(
     // Experimental firewall for proxy-side token replacement
     experimentalFirewalls: toNullable(context.experimentalFirewalls),
 
-    // Experimental capabilities
-    experimentalCapabilities: toNullable(context.experimentalCapabilities),
-
     // Disallowed tools
     disallowedTools: toNullable(context.disallowedTools),
 

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -61,7 +61,6 @@ export async function executeRunnerJob(
     secretConnectorMap: context.secretConnectorMap,
     cliAgentType: context.cliAgentType,
     experimentalFirewalls: context.experimentalFirewalls ?? undefined,
-    experimentalCapabilities: context.experimentalCapabilities ?? undefined,
     disallowedTools: context.disallowedTools ?? undefined,
     tools: context.tools ?? undefined,
     settings: context.settings ?? undefined,

--- a/turbo/apps/web/src/lib/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/run/executors/types.ts
@@ -1,7 +1,7 @@
 import type { StorageManifest } from "../../storage/types";
 import type { ResumeSession } from "../types";
 import type { ArtifactSnapshot } from "../../checkpoint/types";
-import type { ExperimentalFirewalls, VALID_CAPABILITIES } from "@vm0/core";
+import type { ExperimentalFirewalls } from "@vm0/core";
 
 /**
  * Prepared execution context for executors
@@ -45,9 +45,6 @@ export interface PreparedContext {
 
   // Experimental firewall for proxy-side token replacement
   experimentalFirewalls: ExperimentalFirewalls | null;
-
-  // Experimental capabilities for agent permission enforcement
-  experimentalCapabilities: (typeof VALID_CAPABILITIES)[number][] | null;
 
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
   disallowedTools: string[] | null;

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -761,17 +761,12 @@ async function buildAndDispatchRun(opts: {
   } = params;
 
   try {
-    // Extract capabilities from compose content for sandbox token
-    const capabilities = composeContent.agents
-      ? Object.values(composeContent.agents)[0]?.experimental_capabilities
-      : undefined;
-
     // Register callbacks and generate sandbox token in parallel (independent operations)
     const [, sandboxToken] = await Promise.all([
       params.callbacks && params.callbacks.length > 0
         ? registerCallbacks(runId, params.callbacks)
         : null,
-      generateSandboxToken(userId, runId, capabilities),
+      generateSandboxToken(userId, runId),
     ]);
 
     // Generate ZERO_TOKEN for zero agent runs

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -1,5 +1,5 @@
 import type { ArtifactSnapshot } from "../checkpoint/types";
-import type { ExperimentalFirewalls, VALID_CAPABILITIES } from "@vm0/core";
+import type { ExperimentalFirewalls } from "@vm0/core";
 
 /**
  * Run status values
@@ -80,9 +80,6 @@ export interface ExecutionContext {
 
   // Experimental firewall for proxy-side token replacement
   experimentalFirewalls?: ExperimentalFirewalls;
-
-  // Experimental capabilities for agent permission enforcement
-  experimentalCapabilities?: (typeof VALID_CAPABILITIES)[number][];
 
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
   disallowedTools?: string[];

--- a/turbo/apps/web/src/lib/zero/build-compose-content.ts
+++ b/turbo/apps/web/src/lib/zero/build-compose-content.ts
@@ -1,8 +1,4 @@
-import {
-  resolveSkillRef,
-  getInstructionsFilename,
-  VALID_CAPABILITIES,
-} from "@vm0/core";
+import { resolveSkillRef, getInstructionsFilename } from "@vm0/core";
 import { SEED_SKILLS } from "./seed-skills";
 
 /**
@@ -22,7 +18,6 @@ export function buildComposeContent(
   const agentDef: Record<string, unknown> = {
     framework: "claude-code",
     instructions: getInstructionsFilename("claude-code"),
-    experimental_capabilities: [...VALID_CAPABILITIES],
     environment: {
       ZERO_AGENT_ID: "${{ vars.ZERO_AGENT_ID }}",
       ZERO_TOKEN: "${{ secrets.ZERO_TOKEN }}",

--- a/turbo/apps/web/src/types/agent-compose.ts
+++ b/turbo/apps/web/src/types/agent-compose.ts
@@ -2,7 +2,7 @@
  * Agent compose types matching agent.yaml format
  */
 
-import type { ExpandedFirewallConfig, VALID_CAPABILITIES } from "@vm0/core";
+import type { ExpandedFirewallConfig } from "@vm0/core";
 
 /**
  * Volume configuration for static dependencies
@@ -54,11 +54,6 @@ interface AgentDefinition {
    * Input format (CLI): string[] — expanded server-side before storage.
    */
   experimental_firewalls?: ExpandedFirewallConfig[];
-  /**
-   * Capabilities that the agent is allowed to use.
-   * Validated at compose time against VALID_CAPABILITIES.
-   */
-  experimental_capabilities?: (typeof VALID_CAPABILITIES)[number][];
 }
 
 export interface AgentComposeYaml {

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
   agentDefinitionSchema,
-  agentComposeApiContentSchema,
   VALID_CAPABILITIES,
   CAPABILITY_META,
   ZERO_CAPABILITIES,
@@ -11,15 +10,6 @@ import {
 const baseAgent = {
   framework: "claude-code",
 };
-
-function wrapInCompose(agentOverrides: Record<string, unknown>) {
-  return {
-    version: "1.0",
-    agents: {
-      "test-agent": { ...baseAgent, ...agentOverrides },
-    },
-  };
-}
 
 describe("VALID_CAPABILITIES", () => {
   it("contains 9 capabilities", () => {
@@ -43,92 +33,16 @@ describe("CAPABILITY_META", () => {
   });
 });
 
-describe("experimental_capabilities in agentDefinitionSchema", () => {
-  it("accepts valid capabilities array", () => {
+describe("agentDefinitionSchema strips unknown experimental_capabilities", () => {
+  it("silently strips experimental_capabilities from input", () => {
     const result = agentDefinitionSchema.safeParse({
       ...baseAgent,
       experimental_capabilities: ["agent:read", "agent:write"],
     });
     expect(result.success).toBe(true);
-  });
-
-  it("accepts a single valid capability", () => {
-    const result = agentDefinitionSchema.safeParse({
-      ...baseAgent,
-      experimental_capabilities: ["agent:read"],
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it("accepts empty array", () => {
-    const result = agentDefinitionSchema.safeParse({
-      ...baseAgent,
-      experimental_capabilities: [],
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it("accepts missing field (backward compatibility)", () => {
-    const result = agentDefinitionSchema.safeParse(baseAgent);
-    expect(result.success).toBe(true);
-  });
-
-  it("rejects invalid capability name", () => {
-    const result = agentDefinitionSchema.safeParse({
-      ...baseAgent,
-      experimental_capabilities: ["invalid:capability"],
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects deprecated storage:read as direct value", () => {
-    const result = agentDefinitionSchema.safeParse({
-      ...baseAgent,
-      experimental_capabilities: ["storage:read"],
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects duplicate capabilities", () => {
-    const result = agentDefinitionSchema.safeParse({
-      ...baseAgent,
-      experimental_capabilities: ["agent:read", "agent:read"],
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0]?.message).toBe(
-        "Duplicate capabilities are not allowed",
-      );
+    if (result.success) {
+      expect(result.data).not.toHaveProperty("experimental_capabilities");
     }
-  });
-});
-
-describe("experimental_capabilities in agentComposeApiContentSchema", () => {
-  it("accepts compose with valid capabilities", () => {
-    const result = agentComposeApiContentSchema.safeParse(
-      wrapInCompose({
-        experimental_capabilities: [
-          "agent:read",
-          "agent:write",
-          "agent-run:read",
-        ],
-      }),
-    );
-    expect(result.success).toBe(true);
-  });
-
-  it("accepts compose without capabilities", () => {
-    const result = agentComposeApiContentSchema.safeParse(wrapInCompose({}));
-    expect(result.success).toBe(true);
-  });
-
-  it("rejects compose with invalid capability", () => {
-    const result = agentComposeApiContentSchema.safeParse(
-      wrapInCompose({
-        experimental_capabilities: ["not-a-capability"],
-      }),
-    );
-    expect(result.success).toBe(false);
   });
 });
 

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -24,8 +24,11 @@ const composeVersionQuerySchema = z
 export const AGENT_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9-]{1,62}[a-zA-Z0-9]$/;
 
 /**
- * Valid capability strings for experimental_capabilities.
+ * Valid capability strings for sandbox token verification.
  * Format: {resource}:{action}
+ *
+ * Kept for backward compatibility with in-flight sandbox tokens.
+ * New tokens are generated without capabilities.
  *
  * - agent:*       → Agent static resources (compose + volumes + storages)
  * - agent-run:*   → Run lifecycle operations
@@ -202,16 +205,6 @@ const agentDefinitionSchema = z.object({
         permissions: z.union([z.literal("all"), z.array(z.string()).min(1)]),
       }),
     )
-    .optional(),
-  /**
-   * Capabilities that the agent is allowed to use.
-   * Validated against VALID_CAPABILITIES at compose time.
-   */
-  experimental_capabilities: z
-    .array(z.enum(VALID_CAPABILITIES))
-    .refine((arr) => new Set(arr).size === arr.length, {
-      message: "Duplicate capabilities are not allowed",
-    })
     .optional(),
 });
 

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
-import { VALID_CAPABILITIES } from "./composes";
 import { experimentalFirewallsSchema } from "./firewalls";
 import { apiErrorSchema } from "./errors";
 
@@ -118,14 +117,12 @@ export const storedExecutionContextSchema = z.object({
   apiStartTime: z.number().optional(),
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   userTimezone: z.string().optional(),
-  // Org slug for agent — used for VM0_ACTIVE_ORG when capabilities are present
+  // Org slug for agent — used for VM0_ACTIVE_ORG
   agentOrgSlug: z.string().optional(),
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
   // Experimental firewall for proxy-side token replacement
   experimentalFirewalls: experimentalFirewallsSchema.optional(),
-  // Experimental capabilities for agent permission enforcement
-  experimentalCapabilities: z.array(z.enum(VALID_CAPABILITIES)).optional(),
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
   disallowedTools: z.array(z.string()).optional(),
   // Tools to make available in Claude CLI (passed as --tools)
@@ -166,14 +163,12 @@ export const executionContextSchema = z.object({
   apiStartTime: z.number().optional(),
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   userTimezone: z.string().optional(),
-  // Org slug for agent — used for VM0_ACTIVE_ORG when capabilities are present
+  // Org slug for agent — used for VM0_ACTIVE_ORG
   agentOrgSlug: z.string().optional(),
   // Memory storage name (for first-run when manifest.memory is null)
   memoryName: z.string().optional(),
   // Experimental firewall for proxy-side token replacement
   experimentalFirewalls: experimentalFirewallsSchema.optional(),
-  // Experimental capabilities for agent permission enforcement
-  experimentalCapabilities: z.array(z.enum(VALID_CAPABILITIES)).optional(),
   // Tools to disable in Claude CLI (passed as --disallowed-tools)
   disallowedTools: z.array(z.string()).optional(),
   // Tools to make available in Claude CLI (passed as --tools)


### PR DESCRIPTION
## Summary

- Remove `experimental_capabilities` from compose schema, ExecutionContext schemas, and runner types
- Make VM0_TOKEN injection unconditional in the runner — every agent run gets a sandbox token
- Update zero agent E2E test to use ZERO_TOKEN for zero-layer route auth

Part of Epic #6457 — migrate capability system from VM0 infra layer to zero app layer (ZERO_TOKEN).

Closes #6573

## Changes

### TypeScript (core + web)
- Remove `experimental_capabilities` from `agentDefinitionSchema` (composes.ts)
- Remove `experimentalCapabilities` from `storedExecutionContextSchema` and `executionContextSchema` (runners.ts)
- Remove from `AgentDefinition` interface (agent-compose.ts)
- Delete `buildExperimentalCapabilities()` function (build-context.ts)
- Stop passing capabilities to `generateSandboxToken()` (run-service.ts, claim/route.ts)
- Remove from build-compose-content.ts, execution-preparer.ts, executor types

### Rust (runner)
- Make VM0_TOKEN injection unconditional in `build_env_json()` (executor.rs)
- Remove `experimental_capabilities` from `ExecutionContext` struct (types.rs)
- Remove from local provider (local.rs)
- Update/delete related tests

### Documentation
- Remove `experimental_capabilities` from vm0.yaml reference docs

### What is NOT removed
- `VALID_CAPABILITIES`, `CAPABILITY_META` — still needed by `verifySandboxToken()` for in-flight tokens
- `ZERO_CAPABILITIES` — independent system
- `generateSandboxToken()` function signature — capabilities param is optional, stays for backward compat

## Test plan

- [x] Rust: `cargo build` + `cargo test` — 241 tests pass
- [x] TypeScript: `check-types` — all workspaces pass
- [x] TypeScript: `lint` — 0 warnings, 0 errors
- [x] TypeScript: `format` — all unchanged
- [x] TypeScript: `knip` — no issues
- [x] Directly related tests pass (composes, claim route, zero-agent E2E)
- [x] Grep verification: no stale references in TS or Rust source

🤖 Generated with [Claude Code](https://claude.com/claude-code)