### PR TITLE
fix(web): harden zero token validation and update stale capability jsdoc

### DIFF
--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -341,6 +341,18 @@ describe("sandbox-token", () => {
       expect(verifyZeroToken("header.payload.signature")).toBeNull();
     });
 
+    it("should return null for token with empty orgId", async () => {
+      const token = await generateZeroToken("user-123", "run-456", "");
+      const auth = verifyZeroToken(token);
+      expect(auth).toBeNull();
+    });
+
+    it("should return null for token with empty runId", async () => {
+      const token = await generateZeroToken("user-123", "", "org-789");
+      const auth = verifyZeroToken(token);
+      expect(auth).toBeNull();
+    });
+
     it("should identify zero tokens with isSandboxToken", async () => {
       const token = await generateZeroToken("user-123", "run-456", "org-789");
       expect(isSandboxToken(token)).toBe(true);

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -331,7 +331,7 @@ export function verifyZeroToken(token: string): ZeroAuth | null {
   if (payload.scope !== "zero") {
     return null;
   }
-  if (!("runId" in payload) || !("orgId" in payload)) {
+  if (!payload.userId || !payload.runId || !payload.orgId) {
     return null;
   }
 

--- a/turbo/packages/core/src/contracts/integrations.ts
+++ b/turbo/packages/core/src/contracts/integrations.ts
@@ -9,7 +9,7 @@ const c = initContract();
  * POST /api/zero/integrations/slack/message
  *
  * Sends a Slack message via the org's installed bot token.
- * Requires `integration-slack:write` capability.
+ * Requires `slack:write` capability (via ZERO_TOKEN).
  */
 export const integrationsSlackMessageContract = c.router({
   sendMessage: {


### PR DESCRIPTION
## Summary

- Harden `verifyZeroToken()` field validation to use truthiness checks (`!payload.userId || !payload.runId || !payload.orgId`) instead of `in` operator, aligning with `verifySandboxToken()` and `verifyComposeJobToken()` patterns — rejects empty strings
- Update `integrations.ts` JSDoc from `integration-slack:write` to `slack:write (via ZERO_TOKEN)` to match the rename in PR #6552
- Add edge case tests for empty `orgId` and empty `runId` rejection

Closes #6565

## Test plan

- [x] New test: `verifyZeroToken` rejects token with empty `orgId`
- [x] New test: `verifyZeroToken` rejects token with empty `runId`
- [x] All 40 existing sandbox-token tests pass
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)