### PR TITLE
fix(core): align agent-run:write capability meta label with actual route usage

### DIFF
--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -107,7 +107,7 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     "agent:read": { group: "Agent", label: "Read agents" },
     "agent:write": { group: "Agent", label: "Create, update & delete agents" },
     "agent-run:read": { group: "Agent Runs", label: "View runs & telemetry" },
-    "agent-run:write": { group: "Agent Runs", label: "Cancel runs" },
+    "agent-run:write": { group: "Agent Runs", label: "Create & cancel runs" },
     "schedule:read": { group: "Schedules", label: "View schedules" },
     "schedule:write": {
       group: "Schedules",


### PR DESCRIPTION
## Summary
- The `ZERO_CAPABILITY_META` label for `agent-run:write` said "Cancel runs" but the capability also gates `POST /api/zero/runs` (create run)
- Updated label to "Create & cancel runs" to match the documentation and actual enforcement

Part of Epic #6457.

## Test plan
- [x] Lint passes
- [x] Type check passes
- [x] Format check passes
- [x] Knip passes (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)