### PR TITLE
refactor: rename "Zero's team" to "Agents" in sidebar and team pages

### DIFF
--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-refresh.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-refresh.test.tsx
@@ -83,7 +83,7 @@ describe("activity list refresh on navigation", () => {
     const initialFetchCount = fetchCount;
 
     // Navigate to team page via sidebar
-    const teamLink = screen.getByText("Zero's team").closest("a");
+    const teamLink = screen.getByText("Agents").closest("a");
     expect(teamLink).not.toBeNull();
     fireEvent.click(teamLink!);
 

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -95,7 +95,7 @@ describe("team page navigation", () => {
     });
 
     // Click the breadcrumb link to navigate back to /team
-    const teamLinks = screen.getAllByText("Zero's team");
+    const teamLinks = screen.getAllByText("Agents");
     // Find the breadcrumb link (inside a nav with breadcrumb-like structure)
     const breadcrumbLink = teamLinks
       .map((el) => el.closest("a"))
@@ -107,7 +107,9 @@ describe("team page navigation", () => {
 
     // Wait for team list to render
     await waitFor(() => {
-      expect(screen.getByText(/team/i, { selector: "h1" })).toBeInTheDocument();
+      expect(
+        screen.getByText(/agents/i, { selector: "h1" }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-navigation.test.tsx
@@ -67,9 +67,11 @@ describe("sidebar chat navigation from /team", () => {
     mockAPIs();
     await setupPage({ context, path: "/team" });
 
-    // Verify team page is rendered
+    // Verify agents page is rendered
     await waitFor(() => {
-      expect(screen.getByText(/team/i, { selector: "h1" })).toBeInTheDocument();
+      expect(
+        screen.getByText(/agents/i, { selector: "h1" }),
+      ).toBeInTheDocument();
     });
 
     // Find and click the chat thread in sidebar

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -87,7 +87,7 @@ function Breadcrumb({ currentName }: { currentName?: string }) {
         className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-muted hover:text-foreground transition-colors no-underline text-inherit"
       >
         <IconUsers size={14} stroke={1.5} className="shrink-0" />
-        Zero&apos;s team
+        Agents
       </Link>
       <span className="text-muted-foreground/40 select-none">/</span>
       <span className="rounded-md px-1.5 py-0.5 text-foreground font-medium truncate">

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -95,7 +95,7 @@ export function ZeroJobsPage() {
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-10 pb-3">
         <div className="mx-auto max-w-[900px]">
           <h1 className="text-lg font-semibold tracking-tight text-foreground">
-            {agentName}&apos;s team
+            Agents
           </h1>
           <p className="mt-0.5 text-sm text-muted-foreground">
             {agentName} and sub-agents working together to run tailored

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -117,7 +117,7 @@ export type ZeroNavId =
 
 type NavIcon = (props: { size?: number; className?: string }) => ReactNode;
 const MANAGE_NAV = [
-  { id: "team", label: "Zero's team", icon: IconUsers as NavIcon },
+  { id: "team", label: "Agents", icon: IconUsers as NavIcon },
   { id: "schedule", label: "Scheduled", icon: IconCalendar as NavIcon },
   { id: "activity", label: "Activity logs", icon: IconChartLine as NavIcon },
 ] as const;


### PR DESCRIPTION
## Summary
- Rename sidebar navigation label from "Zero's team" to "Agents"
- Update team page header, breadcrumbs, and related test assertions to match the new naming

## Test plan
- [ ] Verify sidebar shows "Agents" instead of "Zero's team"
- [ ] Verify team page header displays "Agents"
- [ ] Verify breadcrumb in job detail page shows "Agents"
- [ ] Confirm existing tests pass with updated text assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)