### PR TITLE
fix: rename agent command argument from <name> to <agent-id>

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/delete.ts
@@ -8,18 +8,18 @@ export const deleteCommand = new Command()
   .name("delete")
   .alias("rm")
   .description("Delete a zero agent")
-  .argument("<name>", "Agent name")
+  .argument("<agent-id>", "Agent ID")
   .option("-y, --yes", "Skip confirmation prompt")
   .action(
-    withErrorHandler(async (name: string, options: { yes?: boolean }) => {
-      await getZeroAgent(name);
+    withErrorHandler(async (agentId: string, options: { yes?: boolean }) => {
+      await getZeroAgent(agentId);
 
       if (!options.yes) {
         if (!isInteractive()) {
           throw new Error("--yes flag is required in non-interactive mode");
         }
         const confirmed = await promptConfirm(
-          `Delete zero agent '${name}'?`,
+          `Delete zero agent '${agentId}'?`,
           false,
         );
         if (!confirmed) {
@@ -28,7 +28,7 @@ export const deleteCommand = new Command()
         }
       }
 
-      await deleteZeroAgent(name);
-      console.log(chalk.green(`✓ Zero agent '${name}' deleted`));
+      await deleteZeroAgent(agentId);
+      console.log(chalk.green(`✓ Zero agent '${agentId}' deleted`));
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -11,7 +11,7 @@ import { withErrorHandler } from "../../../lib/command";
 export const editCommand = new Command()
   .name("edit")
   .description("Edit a zero agent")
-  .argument("<name>", "Agent name")
+  .argument("<agent-id>", "Agent ID")
   .option(
     "--connectors <items>",
     "Comma-separated connector short names (e.g. github,linear)",
@@ -26,7 +26,7 @@ export const editCommand = new Command()
   .action(
     withErrorHandler(
       async (
-        name: string,
+        agentId: string,
         options: {
           connectors?: string;
           displayName?: string;
@@ -48,12 +48,12 @@ export const editCommand = new Command()
         }
 
         if (hasAgentUpdate) {
-          const current = await getZeroAgent(name);
+          const current = await getZeroAgent(agentId);
           const connectors = options.connectors
             ? options.connectors.split(",").map((s) => s.trim())
             : current.connectors;
 
-          await updateZeroAgent(name, {
+          await updateZeroAgent(agentId, {
             connectors,
             displayName:
               options.displayName !== undefined
@@ -72,10 +72,10 @@ export const editCommand = new Command()
 
         if (options.instructionsFile) {
           const content = readFileSync(options.instructionsFile, "utf-8");
-          await updateZeroAgentInstructions(name, content);
+          await updateZeroAgentInstructions(agentId, content);
         }
 
-        console.log(chalk.green(`✓ Zero agent '${name}' updated`));
+        console.log(chalk.green(`✓ Zero agent '${agentId}' updated`));
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -6,12 +6,12 @@ import { withErrorHandler } from "../../../lib/command";
 export const viewCommand = new Command()
   .name("view")
   .description("View a zero agent")
-  .argument("<name>", "Agent name")
+  .argument("<agent-id>", "Agent ID")
   .option("--instructions", "Also show instructions content")
   .action(
     withErrorHandler(
-      async (name: string, options: { instructions?: boolean }) => {
-        const agent = await getZeroAgent(name);
+      async (agentId: string, options: { instructions?: boolean }) => {
+        const agent = await getZeroAgent(agentId);
 
         console.log(chalk.bold(agent.agentId));
         if (agent.displayName) console.log(chalk.dim(agent.displayName));
@@ -24,7 +24,7 @@ export const viewCommand = new Command()
 
         if (options.instructions) {
           console.log();
-          const result = await getZeroAgentInstructions(name);
+          const result = await getZeroAgentInstructions(agentId);
           if (result.content) {
             console.log(chalk.dim("── Instructions ──"));
             console.log(result.content);


### PR DESCRIPTION
## Summary
- Rename CLI argument from `<name>`/"Agent name" to `<agent-id>`/"Agent ID" in `zero agent edit/view/delete` commands
- Rename internal handler parameter from `name` to `agentId` and update all usages
- No behavioral changes — purely cosmetic/naming fix to align CLI help text with API expectations

Closes #6620

## Test plan
- [x] All 17 existing agent command tests pass unchanged
- [x] Lint, type-check, format, knip all pass
- [x] No new tests needed (pure rename, no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)