### PR TITLE
fix: validate uuid format in zero agent api path params

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -728,7 +728,7 @@ describe("Zero Agents API", () => {
     it("should return 401 without auth", async () => {
       mockClerk({ userId: null });
       const response = await patchAgent(
-        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-4000-8000-000000000001",
         { displayName: "X" },
         "no-token",
       );
@@ -838,10 +838,77 @@ describe("Zero Agents API", () => {
     it("should return 401 without auth", async () => {
       mockClerk({ userId: null });
       const response = await deleteAgent(
-        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-4000-8000-000000000001",
         "no-token",
       );
       expect(response.status).toBe(401);
+    });
+  });
+
+  describe("invalid UUID handling", () => {
+    it("GET should return 400 for invalid UUID", async () => {
+      const response = await getAgent("abc", testCliToken, testOrgSlug);
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("PUT should return 400 for invalid UUID", async () => {
+      const response = await putAgent(
+        "not-a-uuid",
+        { connectors: [] },
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("PATCH should return 400 for invalid UUID", async () => {
+      const response = await patchAgent(
+        "not-a-uuid",
+        { displayName: "X" },
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("DELETE should return 400 for invalid UUID", async () => {
+      const response = await deleteAgent(
+        "not-a-uuid",
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("GET instructions should return 400 for invalid UUID", async () => {
+      const response = await getAgentInstructions(
+        "not-a-uuid",
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
+    });
+
+    it("PUT instructions should return 400 for invalid UUID", async () => {
+      const response = await putAgentInstructions(
+        "not-a-uuid",
+        { content: "# test" },
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.code).toBe("BAD_REQUEST");
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/agents/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/sandbox-capability.test.ts
@@ -137,7 +137,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
       ]);
 
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/agents/some-agent?org=${orgSlug}`,
+        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000?org=${orgSlug}`,
         {
           headers: { Authorization: `Bearer ${token}` },
         },
@@ -210,7 +210,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
       ]);
 
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/agents/some-agent?org=${orgSlug}`,
+        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000?org=${orgSlug}`,
         {
           method: "PUT",
           headers: {
@@ -280,7 +280,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
       ]);
 
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/agents/some-agent/instructions?org=${orgSlug}`,
+        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000/instructions?org=${orgSlug}`,
         {
           headers: { Authorization: `Bearer ${token}` },
         },
@@ -350,7 +350,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
       ]);
 
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/agents/some-agent/instructions?org=${orgSlug}`,
+        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000/instructions?org=${orgSlug}`,
         {
           method: "PUT",
           headers: {

--- a/turbo/apps/web/app/api/zero/firewall-policies/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/firewall-policies/__tests__/route.test.ts
@@ -242,7 +242,7 @@ describe("PUT /api/zero/firewall-policies", () => {
     mockClerk({ userId: null });
 
     const response = await putPolicies(
-      "any-agent",
+      "00000000-0000-4000-8000-000000000001",
       { policies: {} },
       "no-token",
     );

--- a/turbo/packages/core/src/contracts/zero-agents.ts
+++ b/turbo/packages/core/src/contracts/zero-agents.ts
@@ -88,7 +88,7 @@ export const zeroAgentsByIdContract = c.router({
     method: "GET",
     path: "/api/zero/agents/:id",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: z.object({ id: z.string().uuid() }),
     responses: {
       200: zeroAgentResponseSchema,
       401: apiErrorSchema,
@@ -100,7 +100,7 @@ export const zeroAgentsByIdContract = c.router({
     method: "PUT",
     path: "/api/zero/agents/:id",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: z.object({ id: z.string().uuid() }),
     body: zeroAgentRequestSchema,
     responses: {
       200: zeroAgentResponseSchema,
@@ -115,7 +115,7 @@ export const zeroAgentsByIdContract = c.router({
     method: "PATCH",
     path: "/api/zero/agents/:id",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: z.object({ id: z.string().uuid() }),
     body: zeroAgentMetadataRequestSchema,
     responses: {
       200: zeroAgentResponseSchema,
@@ -128,7 +128,7 @@ export const zeroAgentsByIdContract = c.router({
     method: "DELETE",
     path: "/api/zero/agents/:id",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: z.object({ id: z.string().uuid() }),
     body: c.noBody(),
     responses: {
       204: c.noBody(),
@@ -143,7 +143,7 @@ export const zeroAgentsByIdContract = c.router({
  * Update firewall policies request schema
  */
 export const zeroAgentFirewallPoliciesRequestSchema = z.object({
-  agentId: z.string(),
+  agentId: z.string().uuid(),
   policies: firewallPoliciesSchema,
 });
 
@@ -175,7 +175,7 @@ export const zeroAgentInstructionsContract = c.router({
     method: "GET",
     path: "/api/zero/agents/:id/instructions",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: z.object({ id: z.string().uuid() }),
     responses: {
       200: zeroAgentInstructionsResponseSchema,
       401: apiErrorSchema,
@@ -187,7 +187,7 @@ export const zeroAgentInstructionsContract = c.router({
     method: "PUT",
     path: "/api/zero/agents/:id/instructions",
     headers: authHeadersSchema,
-    pathParams: z.object({ id: z.string() }),
+    pathParams: z.object({ id: z.string().uuid() }),
     body: zeroAgentInstructionsRequestSchema,
     responses: {
       200: zeroAgentResponseSchema,


### PR DESCRIPTION
## Summary

- Add `z.string().uuid()` validation to all `pathParams` in zero-agents contracts (`zeroAgentsByIdContract` and `zeroAgentInstructionsContract`)
- Add `z.string().uuid()` validation to `agentId` in `zeroAgentFirewallPoliciesRequestSchema`
- Invalid UUIDs are now rejected at the validation layer with 400 BAD_REQUEST instead of causing PostgreSQL `invalid input syntax for type uuid` errors that surface as 500
- Add 6 integration tests covering invalid UUID handling for GET, PUT, PATCH, DELETE, and instructions endpoints

## Test plan

- [x] All 37 agent route tests pass
- [x] All 12 firewall policies tests pass
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes
- [x] `zero agent view abc` returns 400 instead of 500
- [x] `zero agent view 00000000-0000-0000-0000-000000000000` returns 404 (unchanged)
- [x] Valid agent operations work as before

Closes #6621

🤖 Generated with [Claude Code](https://claude.com/claude-code)