### PR TITLE
feat(runner): detect host-side cgroup oom kill of firecracker process

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -431,9 +431,13 @@ fn dmesg_indicates_oom(stdout: &str) -> bool {
 }
 
 /// Check host dmesg for a cgroup OOM kill of a specific firecracker process.
+/// Only reads the last 200 lines to avoid loading the entire ring buffer.
 async fn check_host_oom(pid: u32) -> bool {
-    let output = tokio::process::Command::new("sudo")
-        .args(["dmesg", "--time-format", "iso"])
+    let output = tokio::process::Command::new("sh")
+        .args([
+            "-c",
+            &format!("sudo dmesg | tail -200 | grep 'task=firecracker,pid={pid}'"),
+        ])
         .output()
         .await;
     match output {

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -432,16 +432,20 @@ fn dmesg_indicates_oom(stdout: &str) -> bool {
 
 /// Check host dmesg for a cgroup OOM kill of a specific firecracker process.
 /// Only reads the last 200 lines to avoid loading the entire ring buffer.
+/// Times out after 5 seconds to avoid blocking if sudo or dmesg hangs.
 async fn check_host_oom(pid: u32) -> bool {
-    let output = tokio::process::Command::new("sh")
-        .args(["-c", "sudo dmesg | tail -200 | grep 'oom-kill'"])
-        .output()
-        .await;
-    match output {
-        Ok(out) if out.status.success() => {
+    let result = tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::process::Command::new("sh")
+            .args(["-c", "sudo dmesg | tail -200 | grep 'oom-kill'"])
+            .output()
+            .await
+    })
+    .await;
+    match result {
+        Ok(Ok(out)) if out.status.success() => {
             host_dmesg_indicates_oom(&String::from_utf8_lossy(&out.stdout), pid)
         }
-        Ok(out) => {
+        Ok(Ok(out)) => {
             // grep found no match (exit code 1) — not an OOM kill.
             debug!(
                 pid,
@@ -450,19 +454,39 @@ async fn check_host_oom(pid: u32) -> bool {
             );
             false
         }
-        Err(e) => {
+        Ok(Err(e)) => {
             warn!(pid, error = %e, "failed to run host dmesg for OOM check");
+            false
+        }
+        Err(_) => {
+            warn!(pid, "host dmesg OOM check timed out");
             false
         }
     }
 }
 
 /// Returns true if host dmesg output contains an OOM kill record for the
-/// given firecracker PID.  Uses a trailing comma to avoid prefix matches
-/// (e.g. pid=1234 must not match pid=12345).
+/// given firecracker PID.  Checks that the character after the PID is not
+/// a digit to avoid prefix matches (e.g. pid=1234 must not match pid=12345).
 fn host_dmesg_indicates_oom(dmesg: &str, pid: u32) -> bool {
-    let pattern = format!("task=firecracker,pid={pid},");
-    dmesg.contains("oom-kill") && dmesg.contains(&pattern)
+    if !dmesg.contains("oom-kill") {
+        return false;
+    }
+    let needle = format!("task=firecracker,pid={pid}");
+    let mut start = 0;
+    while let Some(pos) = dmesg[start..].find(&needle) {
+        let abs = start + pos + needle.len();
+        // Accept if needle is at end of string or next char is not a digit.
+        match dmesg.as_bytes().get(abs) {
+            None | Some(b',' | b' ' | b'\n' | b'\r') => return true,
+            Some(c) if !c.is_ascii_digit() => return true,
+            _ => {
+                // Prefix match (e.g. pid=1234 inside pid=12345) — keep searching.
+                start = abs;
+            }
+        }
+    }
+    false
 }
 
 /// Drain stdout chunks from the vsock receiver and write them to a host file.
@@ -1269,6 +1293,15 @@ mod tests {
         let dmesg = "oom-kill:constraint=CONSTRAINT_MEMCG,\
             task=firecracker,pid=12345,uid=1000";
         assert!(!host_dmesg_indicates_oom(dmesg, 1234));
+    }
+
+    #[test]
+    fn host_oom_pid_at_end_of_line() {
+        // PID at end of string (no trailing comma)
+        let dmesg = "oom-kill:constraint=CONSTRAINT_MEMCG,\
+            task=firecracker,pid=42";
+        assert!(host_dmesg_indicates_oom(dmesg, 42));
+        assert!(!host_dmesg_indicates_oom(dmesg, 4));
     }
 
     #[test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 /// Maximum wall-clock time for a single job (2 hours).
@@ -431,12 +431,13 @@ fn dmesg_indicates_oom(stdout: &str) -> bool {
 }
 
 /// Check host dmesg for a cgroup OOM kill of a specific firecracker process.
-/// Scans the entire ring buffer (~512KB) via `dmesg | grep` which takes <30ms
-/// on production hosts.  Times out after 5s to avoid blocking if sudo hangs.
+/// Reads the entire ring buffer (~512KB) directly — no shell wrapper needed
+/// since the pure function handles filtering.  Times out after 5s to avoid
+/// blocking if sudo hangs.
 async fn check_host_oom(pid: u32) -> bool {
     let result = tokio::time::timeout(Duration::from_secs(5), async {
-        tokio::process::Command::new("sh")
-            .args(["-c", "sudo -n dmesg | grep 'oom-kill'"])
+        tokio::process::Command::new("sudo")
+            .args(["-n", "dmesg"])
             .output()
             .await
     })
@@ -446,16 +447,11 @@ async fn check_host_oom(pid: u32) -> bool {
             host_dmesg_indicates_oom(&String::from_utf8_lossy(&out.stdout), pid)
         }
         Ok(Ok(out)) => {
-            // grep found no match (exit code 1) — not an OOM kill.
-            debug!(
-                pid,
-                exit_code = out.status.code(),
-                "host dmesg grep found no oom-kill"
-            );
+            warn!(pid, exit_code = out.status.code(), "sudo dmesg failed");
             false
         }
         Ok(Err(e)) => {
-            warn!(pid, error = %e, "failed to run host dmesg for OOM check");
+            warn!(pid, error = %e, "failed to run sudo dmesg for OOM check");
             false
         }
         Err(_) => {

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -436,7 +436,7 @@ fn dmesg_indicates_oom(stdout: &str) -> bool {
 async fn check_host_oom(pid: u32) -> bool {
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         tokio::process::Command::new("sh")
-            .args(["-c", "sudo dmesg | grep 'oom-kill'"])
+            .args(["-c", "sudo -n dmesg | grep 'oom-kill'"])
             .output()
             .await
     })

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -320,7 +320,27 @@ async fn run_in_sandbox(
     let success = result.as_ref().is_ok_and(|exit| exit.exit_code == 0);
     let err = result.as_ref().err().map(|e| e.to_string());
     telemetry.record("agent_execute", t.elapsed(), success, err.as_deref());
-    let exit = result?;
+    let exit = match result {
+        Ok(exit) => exit,
+        Err(e) => {
+            // Sandbox crashed — check host dmesg for cgroup OOM kill of the
+            // firecracker process before propagating a generic error.
+            if let Some(pid) = sandbox.process_pid()
+                && check_host_oom(pid).await
+            {
+                warn!(run_id = %context.run_id, pid, "host OOM kill detected for firecracker");
+                return Ok((
+                    1,
+                    Some(
+                        "Firecracker VM killed by host OOM killer \
+                         (cgroup memory limit exceeded)"
+                            .into(),
+                    ),
+                ));
+            }
+            return Err(e.into());
+        }
+    };
 
     info!(
         run_id = %context.run_id,
@@ -408,6 +428,27 @@ async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: Uuid) -> Option<St
 fn dmesg_indicates_oom(stdout: &str) -> bool {
     let lower = stdout.to_lowercase();
     lower.contains("out of memory") || lower.contains("oom-kill") || lower.contains("oom_reaper")
+}
+
+/// Check host dmesg for a cgroup OOM kill of a specific firecracker process.
+async fn check_host_oom(pid: u32) -> bool {
+    let output = tokio::process::Command::new("sudo")
+        .args(["dmesg", "--time-format", "iso"])
+        .output()
+        .await;
+    match output {
+        Ok(out) if out.status.success() => {
+            host_dmesg_indicates_oom(&String::from_utf8_lossy(&out.stdout), pid)
+        }
+        _ => false,
+    }
+}
+
+/// Returns true if host dmesg output contains an OOM kill record for the
+/// given firecracker PID.
+fn host_dmesg_indicates_oom(dmesg: &str, pid: u32) -> bool {
+    let pattern = format!("task=firecracker,pid={pid}");
+    dmesg.contains("oom-kill") && dmesg.contains(&pattern)
 }
 
 /// Drain stdout chunks from the vsock receiver and write them to a host file.
@@ -1172,6 +1213,40 @@ mod tests {
         assert!(dmesg_indicates_oom("Out Of Memory: killed process 99"));
         assert!(!dmesg_indicates_oom("Killed process 99 (agent)"));
         assert!(dmesg_indicates_oom("OOM-kill: constraint=MEMCG"));
+    }
+
+    #[test]
+    fn host_oom_matches_firecracker_pid() {
+        let dmesg = "2026-03-25T01:59:21 oom-kill:constraint=CONSTRAINT_MEMCG,\
+            task=firecracker,pid=586629,uid=1000\n\
+            Memory cgroup out of memory: Killed process 586629 (firecracker)";
+        assert!(host_dmesg_indicates_oom(dmesg, 586629));
+    }
+
+    #[test]
+    fn host_oom_no_match_different_pid() {
+        let dmesg = "oom-kill:constraint=CONSTRAINT_MEMCG,\
+            task=firecracker,pid=99999,uid=1000";
+        assert!(!host_dmesg_indicates_oom(dmesg, 12345));
+    }
+
+    #[test]
+    fn host_oom_no_match_different_process() {
+        let dmesg = "oom-kill:constraint=CONSTRAINT_MEMCG,\
+            task=node,pid=586629,uid=1000";
+        assert!(!host_dmesg_indicates_oom(dmesg, 586629));
+    }
+
+    #[test]
+    fn host_oom_no_match_empty() {
+        assert!(!host_dmesg_indicates_oom("", 12345));
+    }
+
+    #[test]
+    fn host_oom_no_match_without_oom_kill() {
+        // Has the PID pattern but not "oom-kill"
+        let dmesg = "task=firecracker,pid=12345 started successfully";
+        assert!(!host_dmesg_indicates_oom(dmesg, 12345));
     }
 
     #[test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -434,10 +434,7 @@ fn dmesg_indicates_oom(stdout: &str) -> bool {
 /// Only reads the last 200 lines to avoid loading the entire ring buffer.
 async fn check_host_oom(pid: u32) -> bool {
     let output = tokio::process::Command::new("sh")
-        .args([
-            "-c",
-            &format!("sudo dmesg | tail -200 | grep 'task=firecracker,pid={pid}'"),
-        ])
+        .args(["-c", "sudo dmesg | tail -200 | grep 'oom-kill'"])
         .output()
         .await;
     match output {
@@ -449,9 +446,10 @@ async fn check_host_oom(pid: u32) -> bool {
 }
 
 /// Returns true if host dmesg output contains an OOM kill record for the
-/// given firecracker PID.
+/// given firecracker PID.  Uses a trailing comma to avoid prefix matches
+/// (e.g. pid=1234 must not match pid=12345).
 fn host_dmesg_indicates_oom(dmesg: &str, pid: u32) -> bool {
-    let pattern = format!("task=firecracker,pid={pid}");
+    let pattern = format!("task=firecracker,pid={pid},");
     dmesg.contains("oom-kill") && dmesg.contains(&pattern)
 }
 
@@ -1248,9 +1246,17 @@ mod tests {
 
     #[test]
     fn host_oom_no_match_without_oom_kill() {
-        // Has the PID pattern but not "oom-kill"
-        let dmesg = "task=firecracker,pid=12345 started successfully";
+        // Has the PID pattern but missing oom-kill context
+        let dmesg = "task=firecracker,pid=12345,uid=1000 started successfully";
         assert!(!host_dmesg_indicates_oom(dmesg, 12345));
+    }
+
+    #[test]
+    fn host_oom_no_prefix_match() {
+        // pid=1234 must NOT match pid=12345
+        let dmesg = "oom-kill:constraint=CONSTRAINT_MEMCG,\
+            task=firecracker,pid=12345,uid=1000";
+        assert!(!host_dmesg_indicates_oom(dmesg, 1234));
     }
 
     #[test]

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1253,24 +1253,25 @@ mod tests {
         assert!(dmesg_indicates_oom("OOM-kill: constraint=MEMCG"));
     }
 
+    /// Real `sudo dmesg | grep 'oom-kill'` output captured from prod-3.
+    const PROD3_OOM_GREP: &str = "\
+        [1718300.650867] fc_vcpu 0 invoked oom-killer: gfp_mask=0xcc0(GFP_KERNEL), order=0, oom_score_adj=0\n\
+        [1718300.651117] oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=vm0-runner-v0.45.6.service,mems_allowed=0,oom_memcg=/system.slice/vm0-runner-v0.45.6.service,task_memcg=/system.slice/vm0-runner-v0.45.6.service,task=firecracker,pid=586629,uid=1000";
+
     #[test]
-    fn host_oom_matches_firecracker_pid() {
-        let dmesg = "2026-03-25T01:59:21 oom-kill:constraint=CONSTRAINT_MEMCG,\
-            task=firecracker,pid=586629,uid=1000\n\
-            Memory cgroup out of memory: Killed process 586629 (firecracker)";
-        assert!(host_dmesg_indicates_oom(dmesg, 586629));
+    fn host_oom_matches_real_prod3_output() {
+        assert!(host_dmesg_indicates_oom(PROD3_OOM_GREP, 586629));
     }
 
     #[test]
     fn host_oom_no_match_different_pid() {
-        let dmesg = "oom-kill:constraint=CONSTRAINT_MEMCG,\
-            task=firecracker,pid=99999,uid=1000";
-        assert!(!host_dmesg_indicates_oom(dmesg, 12345));
+        assert!(!host_dmesg_indicates_oom(PROD3_OOM_GREP, 12345));
     }
 
     #[test]
     fn host_oom_no_match_different_process() {
-        let dmesg = "oom-kill:constraint=CONSTRAINT_MEMCG,\
+        // Same structure as prod-3 but task=node instead of task=firecracker
+        let dmesg = "[1718300.651117] oom-kill:constraint=CONSTRAINT_MEMCG,\
             task=node,pid=586629,uid=1000";
         assert!(!host_dmesg_indicates_oom(dmesg, 586629));
     }
@@ -1282,24 +1283,21 @@ mod tests {
 
     #[test]
     fn host_oom_no_match_without_oom_kill() {
-        // Has the PID pattern but missing oom-kill context
-        let dmesg = "task=firecracker,pid=12345,uid=1000 started successfully";
+        // Has the PID pattern but no oom-kill keyword
+        let dmesg = "[1718300.651117] task=firecracker,pid=12345,uid=1000 started";
         assert!(!host_dmesg_indicates_oom(dmesg, 12345));
     }
 
     #[test]
     fn host_oom_no_prefix_match() {
-        // pid=1234 must NOT match pid=12345
-        let dmesg = "oom-kill:constraint=CONSTRAINT_MEMCG,\
-            task=firecracker,pid=12345,uid=1000";
-        assert!(!host_dmesg_indicates_oom(dmesg, 1234));
+        // pid=58662 must NOT match pid=586629
+        assert!(!host_dmesg_indicates_oom(PROD3_OOM_GREP, 58662));
     }
 
     #[test]
     fn host_oom_pid_at_end_of_line() {
-        // PID at end of string (no trailing comma)
-        let dmesg = "oom-kill:constraint=CONSTRAINT_MEMCG,\
-            task=firecracker,pid=42";
+        // PID at end of string (no trailing comma) — edge case
+        let dmesg = "[0.0] oom-kill:constraint=CONSTRAINT_MEMCG,task=firecracker,pid=42";
         assert!(host_dmesg_indicates_oom(dmesg, 42));
         assert!(!host_dmesg_indicates_oom(dmesg, 4));
     }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 use sandbox::{ExecRequest, Sandbox, SandboxConfig, SandboxFactory};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 /// Maximum wall-clock time for a single job (2 hours).
@@ -441,7 +441,19 @@ async fn check_host_oom(pid: u32) -> bool {
         Ok(out) if out.status.success() => {
             host_dmesg_indicates_oom(&String::from_utf8_lossy(&out.stdout), pid)
         }
-        _ => false,
+        Ok(out) => {
+            // grep found no match (exit code 1) — not an OOM kill.
+            debug!(
+                pid,
+                exit_code = out.status.code(),
+                "host dmesg grep found no oom-kill"
+            );
+            false
+        }
+        Err(e) => {
+            warn!(pid, error = %e, "failed to run host dmesg for OOM check");
+            false
+        }
     }
 }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -474,12 +474,11 @@ fn host_dmesg_indicates_oom(dmesg: &str, pid: u32) -> bool {
         let abs = start + pos + needle.len();
         // Accept if needle is at end of string or next char is not a digit.
         match dmesg.as_bytes().get(abs) {
-            None | Some(b',' | b' ' | b'\n' | b'\r') => return true,
-            Some(c) if !c.is_ascii_digit() => return true,
-            _ => {
+            Some(c) if c.is_ascii_digit() => {
                 // Prefix match (e.g. pid=1234 inside pid=12345) — keep searching.
                 start = abs;
             }
+            _ => return true,
         }
     }
     false

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -431,12 +431,12 @@ fn dmesg_indicates_oom(stdout: &str) -> bool {
 }
 
 /// Check host dmesg for a cgroup OOM kill of a specific firecracker process.
-/// Only reads the last 200 lines to avoid loading the entire ring buffer.
-/// Times out after 5 seconds to avoid blocking if sudo or dmesg hangs.
+/// Scans the entire ring buffer (~512KB) via `dmesg | grep` which takes <30ms
+/// on production hosts.  Times out after 5s to avoid blocking if sudo hangs.
 async fn check_host_oom(pid: u32) -> bool {
     let result = tokio::time::timeout(Duration::from_secs(5), async {
         tokio::process::Command::new("sh")
-            .args(["-c", "sudo dmesg | tail -200 | grep 'oom-kill'"])
+            .args(["-c", "sudo dmesg | grep 'oom-kill'"])
             .output()
             .await
     })

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -76,6 +76,9 @@ pub struct FirecrackerSandbox {
     /// Overlay file path (deleted on destroy).
     pub(crate) overlay: PathBuf,
     process: Option<tokio::process::Child>,
+    /// Firecracker process PID, captured at spawn time before the process
+    /// could exit and be reaped.  Used for host-side OOM detection.
+    firecracker_pid: Option<u32>,
     /// Lifecycle state, shared with background log tasks for crash detection.
     state: Arc<AtomicU8>,
     /// Vsock guest connection, shared with background log tasks so they can
@@ -111,6 +114,7 @@ impl FirecrackerSandbox {
             network,
             overlay,
             process: None,
+            firecracker_pid: None,
             state: Arc::new(AtomicU8::new(SandboxState::Created as u8)),
             guest: Arc::new(tokio::sync::Mutex::new(None::<Arc<VsockHost>>)),
             crash_notify: Arc::new(Notify::new()),
@@ -216,6 +220,7 @@ impl FirecrackerSandbox {
             .spawn()
             .map_err(|e| SandboxError::StartFailed(format!("spawn firecracker: {e}")))?;
 
+        self.firecracker_pid = child.id();
         monitor_process(
             &self.id,
             &mut child,
@@ -326,6 +331,7 @@ impl FirecrackerSandbox {
             .spawn()
             .map_err(|e| SandboxError::StartFailed(format!("spawn firecracker: {e}")))?;
 
+        self.firecracker_pid = child.id();
         monitor_process(
             &self.id,
             &mut child,
@@ -470,6 +476,10 @@ impl Sandbox for FirecrackerSandbox {
 
     fn source_ip(&self) -> &str {
         &self.network.peer_ip
+    }
+
+    fn process_pid(&self) -> Option<u32> {
+        self.firecracker_pid
     }
 
     // -- lifecycle --

--- a/crates/sandbox/src/sandbox.rs
+++ b/crates/sandbox/src/sandbox.rs
@@ -15,6 +15,11 @@ pub trait Sandbox: Send + Sync + Any {
     /// The network-visible source IP address for this sandbox.
     /// Used as the key for proxy VM registration.
     fn source_ip(&self) -> &str;
+    /// PID of the sandbox's main process (e.g. firecracker).
+    /// Used for host-side diagnostics like OOM detection.
+    fn process_pid(&self) -> Option<u32> {
+        None
+    }
 
     // -- lifecycle --
     async fn start(&mut self) -> Result<()>;


### PR DESCRIPTION
## Summary

- Add host-side OOM detection when firecracker is killed by the cgroup memory limit
- Store firecracker PID at spawn time in `FirecrackerSandbox` for post-mortem diagnostics
- Add `process_pid()` to `Sandbox` trait (default returns `None`)
- When sandbox crashes, check host `dmesg` for OOM kill matching the firecracker PID
- Return clear error message: "Firecracker VM killed by host OOM killer (cgroup memory limit exceeded)"

Closes #6614

## Context

The existing OOM detection runs `dmesg` inside the guest VM, which only catches guest-internal OOM. When the host cgroup kills firecracker itself, the VM is gone and guest dmesg is unreachable. The job fails with a generic "connection closed" error.

This adds a fallback: if the sandbox crashes and guest dmesg fails, check host dmesg for `oom-kill:...task=firecracker,pid={PID}`.

## Test plan

- [x] 5 new unit tests for `host_dmesg_indicates_oom()` pattern matching
- [x] All 45 executor tests pass
- [x] Clippy clean across runner, sandbox-fc, sandbox crates
- [x] cargo-fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)