### PR TITLE
fix: remove hardcoded memorymax=2g from runner systemd service

### DIFF
--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -153,7 +153,6 @@ Type=simple
 ExecStart=\"{exe}\" start --config \"{config}\"{local_flag}
 Restart=on-failure
 RestartSec=5
-MemoryMax=2G
 KillSignal=SIGTERM
 TimeoutStopSec=300
 User={user}
@@ -289,7 +288,6 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
         "--property=Type=exec",
         "--property=Restart=on-failure",
         "--property=RestartSec=5",
-        "--property=MemoryMax=2G",
         "--property=StandardOutput=journal",
         "--property=StandardError=journal",
         "--property=KillSignal=SIGTERM",
@@ -510,7 +508,6 @@ mod tests {
         assert!(content.contains("SyslogIdentifier=vm0-runner-v0.1.0"));
         assert!(content.contains("Restart=on-failure"));
         assert!(content.contains("TimeoutStopSec=300"));
-        assert!(content.contains("MemoryMax=2G"));
         assert!(content.contains("[Install]"));
         assert!(content.contains("WantedBy=multi-user.target"));
         assert!(!content.contains("Environment="));


### PR DESCRIPTION
## Summary

- Removes hardcoded `MemoryMax=2G` from both the systemd unit file template and `systemd-run` invocation
- The 2G cgroup limit conflicted with `ResourceBudget` admission control, which reads host total memory (128GB on prod) and was unaware of the cgroup constraint

## Incident

On prod-3, 4 concurrent VMs (each 2GB) were admitted by `ResourceBudget` into a 2G cgroup, triggering OOM that killed all VMs and mitmproxy.

`ResourceBudget` already handles memory-based admission control — the cgroup limit was redundant and harmful.

Closes #6631

## Test plan

- [x] `cargo check -p runner` passes
- [x] `cargo test -p runner -- service` passes (10 tests)
- [ ] Deploy to staging and verify runner starts without `MemoryMax` constraint
- [ ] Verify concurrent VMs run without cgroup OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)