### PR TITLE
fix: remove noisy info log from slack status endpoint

### DIFF
--- a/turbo/apps/web/app/api/zero/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/route.ts
@@ -58,8 +58,6 @@ export async function GET(request: Request) {
 
   const db = globalThis.services.db;
 
-  log.info("Fetching Slack org status", { orgId: org.orgId, userId });
-
   // Find the workspace installation for this org
   const [orgInstallation] = await db
     .select()


### PR DESCRIPTION
## Summary
- Remove the `log.info("Fetching Slack org status")` call from `GET /api/zero/integrations/slack`
- This log fires on every request (~100/day) with no diagnostic value beyond what request logs already capture

## Test plan
- [x] Verified `log` is still used elsewhere in the file (uninstall + disconnect handlers)
- [ ] Deploy and confirm Axiom noise drops

Closes #6607

🤖 Generated with [Claude Code](https://claude.com/claude-code)