### PR TITLE
feat(cli): add whoami command to zero cli

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -17,6 +17,7 @@ describe("zero CLI program", () => {
       "schedule",
       "secret",
       "variable",
+      "whoami",
     ];
     for (const name of expectedCommands) {
       expect(commandNames).toContain(name);
@@ -35,7 +36,6 @@ describe("zero CLI program", () => {
       "cook",
       "init",
       "upgrade",
-      "whoami",
       "info",
     ];
     for (const name of excludedCommands) {
@@ -44,6 +44,6 @@ describe("zero CLI program", () => {
   });
 
   it("should have exactly 7 commands", () => {
-    expect(commandNames).toHaveLength(7);
+    expect(commandNames).toHaveLength(8);
   });
 });

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -43,7 +43,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 7 commands", () => {
+  it("should have exactly 8 commands", () => {
     expect(commandNames).toHaveLength(8);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync } from "fs";
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as os from "os";
+import chalk from "chalk";
+import { zeroWhoamiCommand } from "../whoami";
+
+// Mock os.homedir to use temp directory for config isolation
+const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-zero-whoami-home-"));
+vi.mock("os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("os")>();
+  return {
+    ...original,
+    homedir: () => TEST_HOME,
+  };
+});
+
+/**
+ * Build a valid ZERO_TOKEN for testing.
+ * Format: vm0_sandbox_<header>.<payload>.<signature>
+ */
+function buildZeroToken(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
+    "base64url",
+  );
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = "test-signature";
+  return `vm0_sandbox_${header}.${body}.${signature}`;
+}
+
+describe("zero whoami command", () => {
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  beforeEach(async () => {
+    chalk.level = 0;
+
+    // Ensure clean config state
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    mockConsoleLog.mockClear();
+    vi.unstubAllEnvs();
+
+    // Clean up config
+    const configDir = path.join(TEST_HOME, ".vm0");
+    await fs.rm(configDir, { recursive: true, force: true });
+  });
+
+  function getAllOutput(): string[] {
+    return mockConsoleLog.mock.calls
+      .map((call) => call[0] as string | undefined)
+      .filter((call): call is string => call !== undefined);
+  }
+
+  async function runWhoami(): Promise<void> {
+    await zeroWhoamiCommand.parseAsync(["node", "cli"]);
+  }
+
+  describe("sandbox mode (ZERO_AGENT_ID set)", () => {
+    it("should show agent ID, run context, and capabilities with full JWT", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "agent:write", "schedule:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(output.some((line) => line.includes("Agent:"))).toBe(true);
+      expect(output.some((line) => line.includes("agent-123"))).toBe(true);
+      expect(output.some((line) => line.includes("Run:"))).toBe(true);
+      expect(output.some((line) => line.includes("run-abc"))).toBe(true);
+      expect(output.some((line) => line.includes("org-xyz"))).toBe(true);
+      expect(output.some((line) => line.includes("Capabilities:"))).toBe(true);
+      expect(output.some((line) => line.includes("agent:read"))).toBe(true);
+      expect(output.some((line) => line.includes("schedule:read"))).toBe(true);
+    });
+
+    it("should show unavailable when ZERO_TOKEN is missing", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", "agent-no-token");
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(output.some((line) => line.includes("Agent:"))).toBe(true);
+      expect(output.some((line) => line.includes("agent-no-token"))).toBe(true);
+      expect(output.some((line) => line.includes("unavailable"))).toBe(true);
+      expect(output.some((line) => line.includes("Capabilities:"))).toBe(false);
+    });
+
+    it("should show unavailable when ZERO_TOKEN is malformed", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", "agent-bad-token");
+      vi.stubEnv("ZERO_TOKEN", "not-a-valid-token");
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(output.some((line) => line.includes("agent-bad-token"))).toBe(
+        true,
+      );
+      expect(output.some((line) => line.includes("unavailable"))).toBe(true);
+    });
+  });
+
+  describe("local mode (no ZERO_AGENT_ID)", () => {
+    it("should show authenticated via config file when token exists in config", async () => {
+      const configDir = path.join(TEST_HOME, ".vm0");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "config.json"),
+        JSON.stringify({ token: "test-token-config" }),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(output.some((line) => line.includes("Authenticated"))).toBe(true);
+      expect(output.some((line) => line.includes("config file"))).toBe(true);
+    });
+
+    it("should show authenticated via ZERO_TOKEN env var", async () => {
+      vi.stubEnv("ZERO_TOKEN", "env-token-test");
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(output.some((line) => line.includes("Authenticated"))).toBe(true);
+      expect(output.some((line) => line.includes("ZERO_TOKEN env var"))).toBe(
+        true,
+      );
+    });
+
+    it("should show not authenticated when no token exists", async () => {
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(output.some((line) => line.includes("Not authenticated"))).toBe(
+        true,
+      );
+    });
+
+    it("should display active org when set", async () => {
+      vi.stubEnv("VM0_ACTIVE_ORG", "test-org-slug");
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(output.some((line) => line.includes("Org:"))).toBe(true);
+      expect(output.some((line) => line.includes("test-org-slug"))).toBe(true);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -1,17 +1,12 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { getApiUrl, getActiveOrg, getToken } from "../../lib/api/config";
+import {
+  getApiUrl,
+  getActiveOrg,
+  getToken,
+  decodeZeroTokenPayload,
+} from "../../lib/api/config";
 import { withErrorHandler } from "../../lib/command";
-
-interface ZeroTokenPayload {
-  userId: string;
-  runId: string;
-  orgId: string;
-  scope: string;
-  capabilities: string[];
-  iat: number;
-  exp: number;
-}
 
 /**
  * Detect if running inside a zero sandbox (agent runtime).
@@ -22,31 +17,9 @@ function isInsideSandbox(): boolean {
   return !!process.env.ZERO_AGENT_ID;
 }
 
-function decodeZeroToken(): ZeroTokenPayload | undefined {
-  const token = process.env.ZERO_TOKEN;
-  if (!token) return undefined;
-
-  const prefix = "vm0_sandbox_";
-  if (!token.startsWith(prefix)) return undefined;
-  const jwt = token.slice(prefix.length);
-
-  const parts = jwt.split(".");
-  if (parts.length !== 3) return undefined;
-
-  try {
-    const payload = JSON.parse(
-      Buffer.from(parts[1]!, "base64url").toString(),
-    ) as ZeroTokenPayload;
-    if (payload.scope === "zero") return payload;
-  } catch {
-    // Malformed token
-  }
-  return undefined;
-}
-
 async function showSandboxInfo(): Promise<void> {
   const agentId = process.env.ZERO_AGENT_ID;
-  const payload = decodeZeroToken();
+  const payload = decodeZeroTokenPayload();
 
   // Agent section
   console.log(chalk.bold("Agent:"));

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -13,6 +13,11 @@ interface ZeroTokenPayload {
   exp: number;
 }
 
+/**
+ * Detect if running inside a zero sandbox (agent runtime).
+ * Uses ZERO_AGENT_ID (not VM0_RUN_ID) because the zero CLI operates in the
+ * zero agent context where ZERO_AGENT_ID is the canonical sandbox indicator.
+ */
 function isInsideSandbox(): boolean {
   return !!process.env.ZERO_AGENT_ID;
 }

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -1,0 +1,104 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getApiUrl, getActiveOrg, getToken } from "../../lib/api/config";
+import { withErrorHandler } from "../../lib/command";
+
+interface ZeroTokenPayload {
+  userId: string;
+  runId: string;
+  orgId: string;
+  scope: string;
+  capabilities: string[];
+  iat: number;
+  exp: number;
+}
+
+function isInsideSandbox(): boolean {
+  return !!process.env.ZERO_AGENT_ID;
+}
+
+function decodeZeroToken(): ZeroTokenPayload | undefined {
+  const token = process.env.ZERO_TOKEN;
+  if (!token) return undefined;
+
+  const prefix = "vm0_sandbox_";
+  if (!token.startsWith(prefix)) return undefined;
+  const jwt = token.slice(prefix.length);
+
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return undefined;
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1]!, "base64url").toString(),
+    ) as ZeroTokenPayload;
+    if (payload.scope === "zero") return payload;
+  } catch {
+    // Malformed token
+  }
+  return undefined;
+}
+
+async function showSandboxInfo(): Promise<void> {
+  const agentId = process.env.ZERO_AGENT_ID;
+  const payload = decodeZeroToken();
+
+  // Agent section
+  console.log(chalk.bold("Agent:"));
+  console.log(`  ID:           ${agentId}`);
+  console.log();
+
+  // Run section
+  console.log(chalk.bold("Run:"));
+  console.log(`  ID:           ${payload?.runId ?? chalk.dim("unavailable")}`);
+  console.log(`  Org:          ${payload?.orgId ?? chalk.dim("unavailable")}`);
+
+  // Capabilities section
+  if (payload?.capabilities?.length) {
+    console.log();
+    console.log(chalk.bold("Capabilities:"));
+    console.log(`  ${payload.capabilities.join(", ")}`);
+  }
+}
+
+async function showLocalInfo(): Promise<void> {
+  const token = await getToken();
+  const apiUrl = await getApiUrl();
+  const activeOrg = await getActiveOrg();
+
+  // Auth section
+  console.log(chalk.bold("Auth:"));
+  if (token) {
+    const tokenSource = process.env.ZERO_TOKEN
+      ? "ZERO_TOKEN env var"
+      : process.env.VM0_TOKEN
+        ? "VM0_TOKEN env var"
+        : "config file";
+    console.log(
+      `  Status:     ${chalk.green("Authenticated")} (via ${tokenSource})`,
+    );
+  } else {
+    console.log(`  Status:     ${chalk.dim("Not authenticated")}`);
+  }
+  console.log(`  API:        ${apiUrl}`);
+  console.log();
+
+  // Org section
+  if (activeOrg) {
+    console.log(chalk.bold("Org:"));
+    console.log(`  Active:     ${activeOrg}`);
+  }
+}
+
+export const zeroWhoamiCommand = new Command()
+  .name("whoami")
+  .description("Show current identity and environment information")
+  .action(
+    withErrorHandler(async () => {
+      if (isInsideSandbox()) {
+        await showSandboxInfo();
+      } else {
+        await showLocalInfo();
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/lib/api/config.ts
+++ b/turbo/apps/cli/src/lib/api/config.ts
@@ -74,12 +74,22 @@ export async function getApiUrl(): Promise<string> {
   return config.apiUrl ?? "https://www.vm0.ai";
 }
 
+interface ZeroTokenPayload {
+  userId: string;
+  runId: string;
+  orgId: string;
+  scope: string;
+  capabilities: string[];
+  iat: number;
+  exp: number;
+}
+
 /**
- * Decode orgId from ZERO_TOKEN JWT payload.
+ * Decode the ZERO_TOKEN JWT payload.
  * Only decodes — does NOT verify signature (server does that).
- * Returns undefined if token is missing, malformed, or not a zero token.
+ * Returns undefined if token is missing, malformed, or not a zero-scoped token.
  */
-function decodeOrgIdFromZeroToken(): string | undefined {
+export function decodeZeroTokenPayload(): ZeroTokenPayload | undefined {
   const token = process.env.ZERO_TOKEN;
   if (!token) return undefined;
 
@@ -93,10 +103,8 @@ function decodeOrgIdFromZeroToken(): string | undefined {
   try {
     const payload = JSON.parse(
       Buffer.from(parts[1]!, "base64url").toString(),
-    ) as Record<string, unknown>;
-    if (payload.scope === "zero" && typeof payload.orgId === "string") {
-      return payload.orgId;
-    }
+    ) as ZeroTokenPayload;
+    if (payload.scope === "zero") return payload;
   } catch {
     // Malformed token — fall through
   }
@@ -109,8 +117,8 @@ function decodeOrgIdFromZeroToken(): string | undefined {
  */
 export async function getActiveOrg(): Promise<string | undefined> {
   // Prefer orgId decoded from ZERO_TOKEN JWT (zero agent runs)
-  const zeroOrgId = decodeOrgIdFromZeroToken();
-  if (zeroOrgId) return zeroOrgId;
+  const zeroPayload = decodeZeroTokenPayload();
+  if (zeroPayload) return zeroPayload.orgId;
 
   // Fall back to VM0_ACTIVE_ORG env var (legacy)
   if (process.env.VM0_ACTIVE_ORG) {

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -10,6 +10,7 @@ import { zeroPreferenceCommand } from "./commands/zero/preference";
 import { zeroScheduleCommand } from "./commands/zero/schedule";
 import { zeroSecretCommand } from "./commands/zero/secret";
 import { zeroVariableCommand } from "./commands/zero/variable";
+import { zeroWhoamiCommand } from "./commands/zero/whoami";
 
 const program = new Command();
 
@@ -28,6 +29,7 @@ program.addCommand(zeroPreferenceCommand);
 program.addCommand(zeroScheduleCommand);
 program.addCommand(zeroSecretCommand);
 program.addCommand(zeroVariableCommand);
+program.addCommand(zeroWhoamiCommand);
 
 export { program };
 


### PR DESCRIPTION
## Summary

- Add `zero whoami` command with two modes: sandbox (agent ID + JWT-decoded run context + capabilities) and local (auth status + active org)
- Register the new command in the zero CLI entry point
- Add integration tests covering sandbox mode (full JWT, missing token, malformed token) and local mode (config auth, env auth, unauthenticated, active org)

Closes #6570

## Test plan

- [x] 7 integration tests pass for new whoami command
- [x] zero CLI structure test updated (8 commands, whoami included)
- [x] All existing tests pass
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)