### PR TITLE
fix(cli): remove vm0.yaml hint from zero secret/variable set output

### DIFF
--- a/e2e/tests/03-runner/t29-zero-secret.bats
+++ b/e2e/tests/03-runner/t29-zero-secret.bats
@@ -29,8 +29,6 @@ teardown() {
     run $ZERO_CLI secret set "$TEST_SECRET_NAME" --body "test-secret-value"
     assert_success
     assert_output --partial "Secret \"$TEST_SECRET_NAME\" saved"
-    assert_output --partial "Use in vm0.yaml"
-    assert_output --partial "\${{ secrets.$TEST_SECRET_NAME }}"
 }
 
 @test "zero secret list shows created secret" {

--- a/e2e/tests/03-runner/t31-zero-variable.bats
+++ b/e2e/tests/03-runner/t31-zero-variable.bats
@@ -29,8 +29,6 @@ teardown() {
     run $ZERO_CLI variable set "$TEST_VAR_NAME" "test-variable-value"
     assert_success
     assert_output --partial "Variable \"$TEST_VAR_NAME\" saved"
-    assert_output --partial "Use in vm0.yaml"
-    assert_output --partial "\${{ vars.$TEST_VAR_NAME }}"
 }
 
 @test "zero variable list shows created variable with value" {

--- a/turbo/apps/cli/src/commands/zero/org/secret/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/secret/__tests__/set.test.ts
@@ -52,7 +52,6 @@ describe("zero org secret set command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain('Org secret "MY_API_KEY" saved');
-      expect(logCalls).toContain("secrets.MY_API_KEY");
     });
 
     it("should set a secret with --body and --description", async () => {

--- a/turbo/apps/cli/src/commands/zero/org/secret/set.ts
+++ b/turbo/apps/cli/src/commands/zero/org/secret/set.ts
@@ -62,10 +62,6 @@ export const setCommand = new Command()
         }
 
         console.log(chalk.green(`✓ Org secret "${secret.name}" saved`));
-        console.log();
-        console.log("Use in vm0.yaml:");
-        console.log(chalk.cyan(`  environment:`));
-        console.log(chalk.cyan(`    ${name}: \${{ secrets.${name} }}`));
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/org/variable/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/variable/__tests__/set.test.ts
@@ -52,7 +52,6 @@ describe("zero org variable set command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain('Org variable "API_URL" saved');
-      expect(logCalls).toContain("vars.API_URL");
     });
 
     it("should set a variable with --description", async () => {

--- a/turbo/apps/cli/src/commands/zero/org/variable/set.ts
+++ b/turbo/apps/cli/src/commands/zero/org/variable/set.ts
@@ -38,10 +38,6 @@ export const setCommand = new Command()
         }
 
         console.log(chalk.green(`✓ Org variable "${variable.name}" saved`));
-        console.log();
-        console.log("Use in vm0.yaml:");
-        console.log(chalk.cyan(`  environment:`));
-        console.log(chalk.cyan(`    ${name}: \${{ vars.${name} }}`));
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/secret/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/__tests__/set.test.ts
@@ -52,7 +52,6 @@ describe("zero secret set command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain('Secret "MY_API_KEY" saved');
-      expect(logCalls).toContain("secrets.MY_API_KEY");
     });
 
     it("should set a secret with --body and --description", async () => {

--- a/turbo/apps/cli/src/commands/zero/secret/set.ts
+++ b/turbo/apps/cli/src/commands/zero/secret/set.ts
@@ -59,10 +59,6 @@ export const setCommand = new Command()
         }
 
         console.log(chalk.green(`✓ Secret "${secret.name}" saved`));
-        console.log();
-        console.log("Use in vm0.yaml:");
-        console.log(chalk.cyan(`  environment:`));
-        console.log(chalk.cyan(`    ${name}: \${{ secrets.${name} }}`));
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/variable/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/variable/__tests__/set.test.ts
@@ -47,7 +47,6 @@ describe("zero variable set command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain('Variable "MY_VAR" saved');
-      expect(logCalls).toContain("vars.MY_VAR");
     });
 
     it("should set a variable with --description", async () => {

--- a/turbo/apps/cli/src/commands/zero/variable/set.ts
+++ b/turbo/apps/cli/src/commands/zero/variable/set.ts
@@ -38,10 +38,6 @@ export const setCommand = new Command()
         }
 
         console.log(chalk.green(`✓ Variable "${variable.name}" saved`));
-        console.log();
-        console.log("Use in vm0.yaml:");
-        console.log(chalk.cyan(`  environment:`));
-        console.log(chalk.cyan(`    ${name}: \${{ vars.${name} }}`));
       },
     ),
   );


### PR DESCRIPTION
## Summary

- Remove misleading `vm0.yaml` usage hint from `zero secret set`, `zero variable set`, `zero org secret set`, and `zero org variable set` commands
- Update 4 test files to remove assertions on the removed hint output
- The `vm0.yaml` compose file is a `vm0` CLI concept — zero CLI users do not interact with it

Closes #6571

## Test plan

- [x] All 4 affected test files pass (22 tests)
- [x] Lint, type-check, format pass
- [x] Knip clean (no unused exports/dependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)