### PR TITLE
refactor: unify zero cli guidance for sandbox agents

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -38,15 +38,7 @@ export function buildZeroCliGuidance(): string {
     "Run commands with: npx -p @vm0/cli zero <command>",
     "Tip: run `alias zero='npx -p @vm0/cli zero'` first, then use `zero <command>` for brevity.",
     "Run `npx -p @vm0/cli zero --help` to see all available commands.",
-    "",
-    "## Scheduling Tasks",
     "Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
-    "For recurring or scheduled tasks, use the zero schedule CLI:",
-    "- Create: zero schedule setup $ZERO_AGENT_ID",
-    "- List: zero schedule list",
-    "- Delete: zero schedule delete $ZERO_AGENT_ID --name <schedule-name>",
-    "- Enable/Disable: zero schedule enable/disable $ZERO_AGENT_ID --name <schedule-name>",
-    'Choose a short, descriptive schedule name based on the task (e.g., "deploy-check", "daily-report").',
   ].join("\n");
 }
 

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -28,19 +28,24 @@ export const DISALLOWED_CRON_TOOLS = [
 ] as const;
 
 /**
- * Build schedule guidance prompt that redirects agents from ephemeral cron
- * tools to the zero schedule CLI.
+ * Build Zero CLI guidance prompt so sandbox agents know how to use the CLI.
+ * Injected by createZeroRun() for all trigger paths.
  */
-export function buildScheduleGuidance(): string {
+export function buildZeroCliGuidance(): string {
   return [
-    "# Scheduling Tasks",
+    "# Zero CLI",
+    "You have access to the Zero CLI for managing platform resources.",
+    "Run commands with: npx -p @vm0/cli zero <command>",
+    "Tip: run `alias zero='npx -p @vm0/cli zero'` first, then use `zero <command>` for brevity.",
+    "Run `npx -p @vm0/cli zero --help` to see all available commands.",
+    "",
+    "## Scheduling Tasks",
     "Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
-    "For recurring or scheduled tasks, use the vm0 schedule CLI:",
-    "- Create: vm0 schedule setup $ZERO_AGENT_ID",
-    "- List: vm0 schedule list",
-    "- Delete: vm0 schedule delete $ZERO_AGENT_ID --name <schedule-name>",
-    "- Enable/Disable: vm0 schedule enable/disable $ZERO_AGENT_ID --name <schedule-name>",
-    'Alternative: use "npx @vm0/cli zero schedule" instead of "vm0 schedule".',
+    "For recurring or scheduled tasks, use the zero schedule CLI:",
+    "- Create: zero schedule setup $ZERO_AGENT_ID",
+    "- List: zero schedule list",
+    "- Delete: zero schedule delete $ZERO_AGENT_ID --name <schedule-name>",
+    "- Enable/Disable: zero schedule enable/disable $ZERO_AGENT_ID --name <schedule-name>",
     'Choose a short, descriptive schedule name based on the task (e.g., "deploy-check", "daily-report").',
   ].join("\n");
 }

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -39,6 +39,7 @@ export function buildZeroCliGuidance(): string {
     "Tip: run `alias zero='npx -p @vm0/cli zero'` first, then use `zero <command>` for brevity.",
     "Run `npx -p @vm0/cli zero --help` to see all available commands.",
     "Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
+    "For recurring or scheduled tasks, use the zero schedule CLI.",
   ].join("\n");
 }
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -2,7 +2,6 @@ import { isRunDispatchError } from "../../run";
 import { createZeroRun } from "../../zero/zero-run-service";
 import {
   buildIntegrationContext,
-  buildScheduleGuidance,
   buildSlackMessagingGuidance,
 } from "../../integration-context";
 import { isApiError } from "../../errors";
@@ -65,7 +64,6 @@ export async function runAgentForSlackOrg(
       buildIntegrationContext("Slack", { botUserId }),
       threadContext,
       userContext,
-      buildScheduleGuidance(),
       buildSlackMessagingGuidance(),
     ].filter(Boolean);
     const appendSystemPrompt =

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -113,12 +113,13 @@ describe("createZeroRun()", () => {
       expect(run!.appendSystemPrompt).toMatch(/Bot[\s\S]*Custom instructions/);
     });
 
-    it("should not inject identity when no metadata exists", async () => {
+    it("should inject zero CLI guidance even when no identity metadata exists", async () => {
       const result = await createZeroRun(baseParams());
 
       const run = await findTestRunRecord(result.runId);
       expect(run).toBeDefined();
-      expect(run!.appendSystemPrompt).toBeNull();
+      expect(run!.appendSystemPrompt).toContain("Zero CLI");
+      expect(run!.appendSystemPrompt).not.toContain("# Agent Identity");
     });
 
     it("should inject ZERO_TOKEN into execution context secrets", async () => {

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -1,7 +1,10 @@
 import { eq, and } from "drizzle-orm";
 import type { TriggerSource, FirewallPolicies } from "@vm0/core";
 import { startRun, type CreateRunResult } from "../run";
-import { DISALLOWED_CRON_TOOLS } from "../integration-context";
+import {
+  DISALLOWED_CRON_TOOLS,
+  buildZeroCliGuidance,
+} from "../integration-context";
 import { formatAgentIdentityPrompt } from "../agent-identity";
 import type { CallbackPayload } from "../callback/callback-payloads";
 import { zeroAgents } from "../../db/schema/zero-agent";
@@ -87,6 +90,12 @@ export async function createZeroRun(
       ? `${identity}\n\n${appendSystemPrompt}`
       : identity;
   }
+
+  // Append zero CLI guidance so all trigger paths know how to use the CLI
+  const zeroGuidance = buildZeroCliGuidance();
+  appendSystemPrompt = appendSystemPrompt
+    ? `${appendSystemPrompt}\n\n${zeroGuidance}`
+    : zeroGuidance;
 
   return startRun({
     userId: params.userId,


### PR DESCRIPTION
## Summary

- Rename `buildScheduleGuidance()` → `buildZeroCliGuidance()` with expanded content covering the full Zero CLI (not just scheduling)
- Inject guidance in `createZeroRun()` so **all** trigger paths (Slack, Email, Telegram, GitHub, Schedule, Web) receive CLI guidance
- Remove old Slack-only injection of schedule guidance
- Fix incorrect `vm0 schedule` references → correct `zero schedule` (via `npx -p @vm0/cli zero`)

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes  
- [x] `pnpm vitest run apps/web/src/lib/zero/__tests__/zero-run-service.test.ts` — all 22 tests pass
- [x] No remaining references to `buildScheduleGuidance` in codebase
- [x] Knip reports no unused exports

Closes #6642

🤖 Generated with [Claude Code](https://claude.com/claude-code)