### PR TITLE
feat(cli): add zero slack message send command

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -16,6 +16,7 @@ describe("zero CLI program", () => {
       "preference",
       "schedule",
       "secret",
+      "slack",
       "variable",
       "whoami",
     ];
@@ -44,6 +45,6 @@ describe("zero CLI program", () => {
   });
 
   it("should have exactly 8 commands", () => {
-    expect(commandNames).toHaveLength(8);
+    expect(commandNames).toHaveLength(9);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/slack/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/__tests__/send.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for zero slack message send command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { sendCommand } from "../message/send";
+import chalk from "chalk";
+
+const SLACK_MESSAGE_URL =
+  "http://localhost:3000/api/zero/integrations/slack/message";
+
+describe("zero slack message send command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful send", () => {
+    it("should send a message with --text", async () => {
+      server.use(
+        http.post(SLACK_MESSAGE_URL, () => {
+          return HttpResponse.json(
+            { ok: true, ts: "1234567890.123456", channel: "C1234567" },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await sendCommand.parseAsync([
+        "node",
+        "cli",
+        "--channel",
+        "C1234567",
+        "--text",
+        "hello world",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Message sent");
+      expect(logCalls).toContain("ts: 1234567890.123456");
+    });
+
+    it("should send a message with --text and --thread", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(SLACK_MESSAGE_URL, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            { ok: true, ts: "1234567890.123456", channel: "C1234567" },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await sendCommand.parseAsync([
+        "node",
+        "cli",
+        "--channel",
+        "C1234567",
+        "--text",
+        "thread reply",
+        "--thread",
+        "1234567890.000000",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        channel: "C1234567",
+        text: "thread reply",
+        threadTs: "1234567890.000000",
+      });
+    });
+
+    it("should send a message with --blocks", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(SLACK_MESSAGE_URL, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            { ok: true, ts: "1234567890.123456", channel: "C1234567" },
+            { status: 200 },
+          );
+        }),
+      );
+
+      const blocks = JSON.stringify([
+        { type: "section", text: { type: "mrkdwn", text: "hello" } },
+      ]);
+
+      await sendCommand.parseAsync([
+        "node",
+        "cli",
+        "--channel",
+        "C1234567",
+        "--blocks",
+        blocks,
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        channel: "C1234567",
+        blocks: [{ type: "section", text: { type: "mrkdwn", text: "hello" } }],
+      });
+    });
+  });
+
+  describe("validation errors", () => {
+    it("should error when neither --text nor --blocks is provided", async () => {
+      await expect(async () => {
+        await sendCommand.parseAsync(["node", "cli", "--channel", "C1234567"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Either --text or --blocks must be provided"),
+      );
+    });
+
+    it("should error when --blocks contains invalid JSON", async () => {
+      await expect(async () => {
+        await sendCommand.parseAsync([
+          "node",
+          "cli",
+          "--channel",
+          "C1234567",
+          "--blocks",
+          "not-json",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid JSON for --blocks flag"),
+      );
+    });
+  });
+
+  describe("API errors", () => {
+    it("should handle 401 unauthorized", async () => {
+      server.use(
+        http.post(SLACK_MESSAGE_URL, () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await sendCommand.parseAsync([
+          "node",
+          "cli",
+          "--channel",
+          "C1234567",
+          "--text",
+          "hello",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+    });
+
+    it("should handle 404 no Slack installation", async () => {
+      server.use(
+        http.post(SLACK_MESSAGE_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "No Slack installation found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await sendCommand.parseAsync([
+          "node",
+          "cli",
+          "--channel",
+          "C1234567",
+          "--text",
+          "hello",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No Slack installation found"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/slack/index.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/index.ts
@@ -1,0 +1,7 @@
+import { Command } from "commander";
+import { zeroSlackMessageCommand } from "./message";
+
+export const zeroSlackCommand = new Command()
+  .name("slack")
+  .description("Manage Slack integrations")
+  .addCommand(zeroSlackMessageCommand);

--- a/turbo/apps/cli/src/commands/zero/slack/message/index.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/message/index.ts
@@ -1,0 +1,7 @@
+import { Command } from "commander";
+import { sendCommand } from "./send";
+
+export const zeroSlackMessageCommand = new Command()
+  .name("message")
+  .description("Manage Slack messages")
+  .addCommand(sendCommand);

--- a/turbo/apps/cli/src/commands/zero/slack/message/send.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/message/send.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "fs";
+import { Command } from "commander";
+import chalk from "chalk";
+import { sendSlackMessage } from "../../../../lib/api";
+import { withErrorHandler } from "../../../../lib/command";
+
+export const sendCommand = new Command()
+  .name("send")
+  .description("Send a message to a Slack channel")
+  .requiredOption("-c, --channel <id>", "Channel ID")
+  .option("-t, --text <message>", "Message text")
+  .option("--thread <ts>", "Thread timestamp for replies")
+  .option("--blocks <json>", "Block Kit JSON string")
+  .action(
+    withErrorHandler(
+      async (options: {
+        channel: string;
+        text?: string;
+        thread?: string;
+        blocks?: string;
+      }) => {
+        let text = options.text;
+        const { channel, thread, blocks: blocksStr } = options;
+
+        // Read from stdin if text not provided and stdin is explicitly piped
+        // (isTTY is false when piped, undefined when no TTY context e.g. tests)
+        if (!text && process.stdin.isTTY === false) {
+          text = readFileSync("/dev/stdin", "utf8").trim();
+        }
+
+        // Parse blocks JSON if provided
+        let blocks: Array<{ type: string; [key: string]: unknown }> | undefined;
+        if (blocksStr) {
+          try {
+            blocks = JSON.parse(blocksStr) as Array<{
+              type: string;
+              [key: string]: unknown;
+            }>;
+          } catch {
+            throw new Error("Invalid JSON for --blocks flag", {
+              cause: new Error(
+                "Provide a valid JSON array of Block Kit blocks",
+              ),
+            });
+          }
+        }
+
+        // Validate at least one of text or blocks
+        if (!text && !blocks) {
+          throw new Error("Either --text or --blocks must be provided", {
+            cause: new Error(
+              'Usage: zero slack message send -c CHANNEL_ID -t "your message"',
+            ),
+          });
+        }
+
+        const result = await sendSlackMessage({
+          channel,
+          text: text || undefined,
+          threadTs: thread,
+          blocks,
+        });
+
+        const tsInfo = result.ts ? ` (ts: ${result.ts})` : "";
+        console.log(chalk.green(`✓ Message sent${tsInfo}`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/integrations-slack.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-slack.ts
@@ -1,0 +1,31 @@
+import { initClient } from "@ts-rest/core";
+import { integrationsSlackMessageContract } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+interface SendSlackMessageParams {
+  channel: string;
+  text?: string;
+  threadTs?: string;
+  blocks?: Array<{ type: string; [key: string]: unknown }>;
+}
+
+interface SendSlackMessageResult {
+  ok: true;
+  ts?: string;
+  channel?: string;
+}
+
+export async function sendSlackMessage(
+  body: SendSlackMessageParams,
+): Promise<SendSlackMessageResult> {
+  const config = await getClientConfig();
+  const client = initClient(integrationsSlackMessageContract, config);
+
+  const result = await client.sendMessage({ body, headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to send Slack message");
+}

--- a/turbo/apps/cli/src/lib/api/domains/integrations-slack.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-slack.ts
@@ -1,23 +1,14 @@
 import { initClient } from "@ts-rest/core";
-import { integrationsSlackMessageContract } from "@vm0/core";
+import {
+  integrationsSlackMessageContract,
+  type SendSlackMessageBody,
+  type SendSlackMessageResponse,
+} from "@vm0/core";
 import { getClientConfig, handleError } from "../core/client-factory";
 
-interface SendSlackMessageParams {
-  channel: string;
-  text?: string;
-  threadTs?: string;
-  blocks?: Array<{ type: string; [key: string]: unknown }>;
-}
-
-interface SendSlackMessageResult {
-  ok: true;
-  ts?: string;
-  channel?: string;
-}
-
 export async function sendSlackMessage(
-  body: SendSlackMessageParams,
-): Promise<SendSlackMessageResult> {
+  body: SendSlackMessageBody,
+): Promise<SendSlackMessageResponse> {
   const config = await getClientConfig();
   const client = initClient(integrationsSlackMessageContract, config);
 

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -114,6 +114,9 @@ export {
   deleteZeroComputerConnector,
 } from "./domains/zero-connectors";
 
+// Domain modules - Integrations Slack
+export { sendSlackMessage } from "./domains/integrations-slack";
+
 // Domain modules - Zero Schedules
 export {
   deployZeroSchedule,

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -9,6 +9,7 @@ import { zeroConnectorCommand } from "./commands/zero/connector";
 import { zeroPreferenceCommand } from "./commands/zero/preference";
 import { zeroScheduleCommand } from "./commands/zero/schedule";
 import { zeroSecretCommand } from "./commands/zero/secret";
+import { zeroSlackCommand } from "./commands/zero/slack";
 import { zeroVariableCommand } from "./commands/zero/variable";
 import { zeroWhoamiCommand } from "./commands/zero/whoami";
 
@@ -28,6 +29,7 @@ program.addCommand(zeroConnectorCommand);
 program.addCommand(zeroPreferenceCommand);
 program.addCommand(zeroScheduleCommand);
 program.addCommand(zeroSecretCommand);
+program.addCommand(zeroSlackCommand);
 program.addCommand(zeroVariableCommand);
 program.addCommand(zeroWhoamiCommand);
 

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -577,6 +577,8 @@ export {
 export {
   integrationsSlackMessageContract,
   type IntegrationsSlackMessageContract,
+  type SendSlackMessageBody,
+  type SendSlackMessageResponse,
 } from "./integrations";
 export {
   zeroBillingStatusContract,

--- a/turbo/packages/core/src/contracts/integrations.ts
+++ b/turbo/packages/core/src/contracts/integrations.ts
@@ -11,23 +11,33 @@ const c = initContract();
  * Sends a Slack message via the org's installed bot token.
  * Requires `slack:write` capability (via ZERO_TOKEN).
  */
+const sendSlackMessageBodySchema = z.object({
+  channel: z.string().min(1, "Channel ID is required"),
+  text: z.string().optional(),
+  threadTs: z.string().optional(),
+  blocks: z.array(z.object({ type: z.string() }).passthrough()).optional(),
+});
+
+export type SendSlackMessageBody = z.infer<typeof sendSlackMessageBodySchema>;
+
+const sendSlackMessageResponseSchema = z.object({
+  ok: z.literal(true),
+  ts: z.string().optional(),
+  channel: z.string().optional(),
+});
+
+export type SendSlackMessageResponse = z.infer<
+  typeof sendSlackMessageResponseSchema
+>;
+
 export const integrationsSlackMessageContract = c.router({
   sendMessage: {
     method: "POST",
     path: "/api/zero/integrations/slack/message",
     headers: authHeadersSchema,
-    body: z.object({
-      channel: z.string().min(1, "Channel ID is required"),
-      text: z.string().optional(),
-      threadTs: z.string().optional(),
-      blocks: z.array(z.object({ type: z.string() }).passthrough()).optional(),
-    }),
+    body: sendSlackMessageBodySchema,
     responses: {
-      200: z.object({
-        ok: z.literal(true),
-        ts: z.string().optional(),
-        channel: z.string().optional(),
-      }),
+      200: sendSlackMessageResponseSchema,
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,


### PR DESCRIPTION
## Summary

- Add `zero slack message send` command for agents to send Slack messages without raw `curl`
- Supports `--channel`, `--text`, `--thread`, and `--blocks` flags with stdin piping
- Uses existing `integrationsSlackMessageContract` from `@vm0/core`

Closes #6650

## Test plan

- [x] Integration tests for successful send with `--text`, `--thread`, and `--blocks`
- [x] Validation error tests (missing text/blocks, invalid JSON)
- [x] API error handling tests (401, 404)
- [x] Updated `zero.test.ts` to expect 9 commands including `slack`
- [x] All 813 CLI tests pass
- [x] Type check, lint, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)