### PR TITLE
feat(core): restrict default agent profile and instructions to admin only

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -66,6 +66,7 @@ import { detach, Reason } from "../../signals/utils.ts";
 import { AGENT_AVATARS, useAgentAvatar } from "./zero-sidebar.tsx";
 import { setAgentAvatar$ } from "../../signals/zero-page/zero-agent-avatars.ts";
 import { agentsList$ } from "../../signals/zero-page/agents-list.ts";
+import { isOrgAdmin$ } from "../../signals/org.ts";
 import { ZeroNoPermissionIllustration } from "./components/zero-no-permission-illustration.tsx";
 
 // ---------------------------------------------------------------------------
@@ -174,6 +175,62 @@ function DetailError({ error, agentId }: { error: string; agentId: string }) {
 
 const TAB_TRIGGER_CLASS =
   "gap-1.5 text-sm data-[state=active]:bg-background px-3";
+
+/** Coerce hidden tabs back to "connectors" for non-admin default-agent view. */
+function resolveVisibleTab(
+  rawTab: string,
+  hideProfileAndInstructions: boolean,
+): string {
+  if (
+    hideProfileAndInstructions &&
+    rawTab !== "connectors" &&
+    rawTab !== "schedule"
+  ) {
+    return "connectors";
+  }
+  return rawTab;
+}
+
+function AgentTabNav({
+  activeTab,
+  onTabChange,
+  showProfileAndInstructions,
+}: {
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+  showProfileAndInstructions: boolean;
+}) {
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={onTabChange}
+      className="flex-1 min-w-0"
+    >
+      <TabsList className="zero-tabs h-9 w-full sm:w-auto gap-1 px-1 py-1 overflow-x-auto">
+        <TabsTrigger value="connectors" className={TAB_TRIGGER_CLASS}>
+          <IconPlug size={14} stroke={1.5} />
+          Connectors
+        </TabsTrigger>
+        <TabsTrigger value="schedule" className={TAB_TRIGGER_CLASS}>
+          <IconCalendar size={14} stroke={1.5} />
+          Scheduled
+        </TabsTrigger>
+        {showProfileAndInstructions && (
+          <TabsTrigger value="profile" className={TAB_TRIGGER_CLASS}>
+            <IconUserCircle size={14} stroke={1.5} />
+            Profile
+          </TabsTrigger>
+        )}
+        {showProfileAndInstructions && (
+          <TabsTrigger value="instructions" className={TAB_TRIGGER_CLASS}>
+            <IconFileText size={14} stroke={1.5} />
+            Instructions
+          </TabsTrigger>
+        )}
+      </TabsList>
+    </Tabs>
+  );
+}
 
 function extractAgentFields(
   detail: AgentDetail | null,
@@ -350,13 +407,20 @@ export function ZeroJobDetailPage({
     (statusLoadable.data.defaultAgentId === agentId ||
       statusLoadable.data.defaultAgentId === detail?.agentId);
 
+  const adminLoadable = useLoadable(isOrgAdmin$);
+  const isAdmin = adminLoadable.state === "hasData" && adminLoadable.data;
+
+  // Non-admin users cannot access profile/instructions tabs for the default agent
+  const hideProfileAndInstructions = isDefaultAgent && !isAdmin;
+
   const handleDelete = async () => {
     await deleteAgent();
     nav("/team");
   };
 
-  const activeTab = useGet(zeroJobActiveTab$);
+  const rawTab = useGet(zeroJobActiveTab$);
   const setActiveTab = useSet(setZeroJobActiveTab$);
+  const activeTab = resolveVisibleTab(rawTab, hideProfileAndInstructions);
 
   const agentAvatar = useAgentAvatar(agentId);
   const setAgentAvatarCmd = useSet(setAgentAvatar$);
@@ -409,30 +473,11 @@ export function ZeroJobDetailPage({
           </div>
 
           <div className="mt-4 flex h-9 items-center justify-between gap-6">
-            <Tabs
-              value={activeTab}
-              onValueChange={setActiveTab}
-              className="flex-1 min-w-0"
-            >
-              <TabsList className="zero-tabs h-9 w-full sm:w-auto gap-1 px-1 py-1 overflow-x-auto">
-                <TabsTrigger value="connectors" className={TAB_TRIGGER_CLASS}>
-                  <IconPlug size={14} stroke={1.5} />
-                  Connectors
-                </TabsTrigger>
-                <TabsTrigger value="schedule" className={TAB_TRIGGER_CLASS}>
-                  <IconCalendar size={14} stroke={1.5} />
-                  Scheduled
-                </TabsTrigger>
-                <TabsTrigger value="profile" className={TAB_TRIGGER_CLASS}>
-                  <IconUserCircle size={14} stroke={1.5} />
-                  Profile
-                </TabsTrigger>
-                <TabsTrigger value="instructions" className={TAB_TRIGGER_CLASS}>
-                  <IconFileText size={14} stroke={1.5} />
-                  Instructions
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
+            <AgentTabNav
+              activeTab={activeTab}
+              onTabChange={setActiveTab}
+              showProfileAndInstructions={!hideProfileAndInstructions}
+            />
             <TooltipProvider delayDuration={300}>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/turbo/apps/web/app/api/zero/agents/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/instructions/route.ts
@@ -34,9 +34,34 @@ import {
 } from "../../../../../../src/lib/s3/s3-client";
 import { extractFileFromTar } from "../../../../../../src/lib/tar";
 import { env } from "../../../../../../src/env";
+import { isDefaultAgentCompose } from "../../../../../../src/lib/zero/resolve-default-agent";
 import { logger } from "../../../../../../src/lib/logger";
 
 const log = logger("api:zero-agents:instructions");
+
+type ForbiddenResponse = {
+  status: 403;
+  body: { error: { message: string; code: string } };
+};
+
+async function requireAdminForDefault(
+  orgId: string,
+  composeId: string,
+  memberRole: string,
+): Promise<ForbiddenResponse | null> {
+  if (memberRole === "admin") return null;
+  const isDefault = await isDefaultAgentCompose(orgId, composeId);
+  if (!isDefault) return null;
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: "Only org admins can update the default agent's instructions",
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
 
 const router = tsr.router(zeroAgentInstructionsContract, {
   get: async ({ params, headers }, { request }) => {
@@ -189,7 +214,7 @@ const router = tsr.router(zeroAgentInstructionsContract, {
     const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx, orgSlug);
 
     // Look up existing compose by ID
     const [compose] = await globalThis.services.db
@@ -222,6 +247,14 @@ const router = tsr.router(zeroAgentInstructionsContract, {
         },
       };
     }
+
+    // Only admins can update the default agent's instructions
+    const forbidden = await requireAdminForDefault(
+      org.orgId,
+      compose.id,
+      member.role,
+    );
+    if (forbidden) return forbidden;
 
     // Re-compose with existing content + new instructions
     const existingContent = (compose.content ?? {}) as Record<string, unknown>;

--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -15,9 +15,35 @@ import { zeroAgents } from "../../../../../src/db/schema/zero-agent";
 import { agentComposes } from "../../../../../src/db/schema/agent-compose";
 import { eq, and } from "drizzle-orm";
 import { buildComposeContent } from "../../../../../src/lib/zero/build-compose-content";
+import { isDefaultAgentCompose } from "../../../../../src/lib/zero/resolve-default-agent";
 import { logger } from "../../../../../src/lib/logger";
 
 const log = logger("api:zero-agents:id");
+
+type ForbiddenResponse = {
+  status: 403;
+  body: { error: { message: string; code: string } };
+};
+
+async function requireAdminForDefaultAgent(
+  orgId: string,
+  composeId: string,
+  memberRole: string,
+  label: string,
+): Promise<ForbiddenResponse | null> {
+  if (memberRole === "admin") return null;
+  const isDefault = await isDefaultAgentCompose(orgId, composeId);
+  if (!isDefault) return null;
+  return {
+    status: 403 as const,
+    body: {
+      error: {
+        message: `Only org admins can update the default agent's ${label}`,
+        code: "FORBIDDEN",
+      },
+    },
+  };
+}
 
 const router = tsr.router(zeroAgentsByIdContract, {
   get: async ({ params, headers }, { request }) => {
@@ -203,7 +229,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     if (isAuthError(authCtx)) return authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx, orgSlug);
 
     // Look up compose by ID
     const [compose] = await globalThis.services.db
@@ -231,6 +257,15 @@ const router = tsr.router(zeroAgentsByIdContract, {
         },
       };
     }
+
+    // Only admins can update the default agent's profile
+    const forbidden = await requireAdminForDefaultAgent(
+      org.orgId,
+      compose.id,
+      member.role,
+      "profile",
+    );
+    if (forbidden) return forbidden;
 
     // Upsert metadata — only overwrite fields explicitly provided
     const now = new Date();

--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -116,7 +116,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     const { userId } = authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx, orgSlug);
 
     // Verify agent exists by compose ID
     const [existing] = await globalThis.services.db
@@ -141,6 +141,15 @@ const router = tsr.router(zeroAgentsByIdContract, {
         },
       };
     }
+
+    // Only admins can update the default agent
+    const forbidden = await requireAdminForDefaultAgent(
+      org.orgId,
+      existing.id,
+      member.role,
+      "configuration",
+    );
+    if (forbidden) return forbidden;
 
     // Build compose content from connectors
     const content = buildComposeContent(existing.name, body.connectors);
@@ -325,7 +334,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     if (isAuthError(authCtx)) return authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx, orgSlug);
 
     // Find compose by ID
     const [compose] = await globalThis.services.db
@@ -350,6 +359,15 @@ const router = tsr.router(zeroAgentsByIdContract, {
         },
       };
     }
+
+    // Only admins can delete the default agent
+    const forbidden = await requireAdminForDefaultAgent(
+      org.orgId,
+      compose.id,
+      member.role,
+      "agent",
+    );
+    if (forbidden) return forbidden;
 
     // Delete compose and metadata atomically
     await globalThis.services.db.transaction(async (tx) => {

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -1060,5 +1060,84 @@ describe("Zero Agents API", () => {
       const data = await response.json();
       expect(data.displayName).toBe("Member Updated");
     });
+
+    it("should return 403 when member PUT-updates default agent", async () => {
+      const created = await (
+        await postAgent(
+          { connectors: [], displayName: "Default" },
+          testCliToken,
+          testOrgSlug,
+        )
+      ).json();
+
+      const orgId = `org_mock_${user.userId}`;
+      await setDefaultAgentByComposeId(orgId, created.agentId);
+
+      // Re-mock as member and clear cached admin role
+      mockClerk({
+        userId: user.userId,
+        orgId,
+        orgRole: "org:member",
+        clerkOrgs: [
+          {
+            id: orgId,
+            slug: testOrgSlug,
+            name: testOrgSlug,
+            role: "org:member",
+          },
+        ],
+      });
+      await clearOrgMembersCacheEntry(orgId, user.userId);
+      const memberToken = await createTestCliToken(user.userId);
+
+      const response = await putAgent(
+        created.agentId,
+        { connectors: [], displayName: "Hacked via PUT" },
+        memberToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("should return 403 when member deletes default agent", async () => {
+      const created = await (
+        await postAgent(
+          { connectors: [], displayName: "Default" },
+          testCliToken,
+          testOrgSlug,
+        )
+      ).json();
+
+      const orgId = `org_mock_${user.userId}`;
+      await setDefaultAgentByComposeId(orgId, created.agentId);
+
+      // Re-mock as member and clear cached admin role
+      mockClerk({
+        userId: user.userId,
+        orgId,
+        orgRole: "org:member",
+        clerkOrgs: [
+          {
+            id: orgId,
+            slug: testOrgSlug,
+            name: testOrgSlug,
+            role: "org:member",
+          },
+        ],
+      });
+      await clearOrgMembersCacheEntry(orgId, user.userId);
+      const memberToken = await createTestCliToken(user.userId);
+
+      const response = await deleteAgent(
+        created.agentId,
+        memberToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -20,6 +20,8 @@ import {
   insertTestSlackOrgConnection,
   insertTestSlackOrgThreadSession,
   insertTestSlackOrgPendingQuestion,
+  setDefaultAgentByComposeId,
+  clearOrgMembersCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -901,6 +903,162 @@ describe("Zero Agents API", () => {
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error.code).toBe("BAD_REQUEST");
+    });
+  });
+
+  describe("default agent admin restriction", () => {
+    it("should return 403 when member patches default agent metadata", async () => {
+      // Create agent as admin
+      const created = await (
+        await postAgent(
+          { connectors: [], displayName: "Default" },
+          testCliToken,
+          testOrgSlug,
+        )
+      ).json();
+
+      const orgId = `org_mock_${user.userId}`;
+      await setDefaultAgentByComposeId(orgId, created.agentId);
+
+      // Re-mock as member and clear cached admin role
+      mockClerk({
+        userId: user.userId,
+        orgId,
+        orgRole: "org:member",
+        clerkOrgs: [
+          {
+            id: orgId,
+            slug: testOrgSlug,
+            name: testOrgSlug,
+            role: "org:member",
+          },
+        ],
+      });
+      await clearOrgMembersCacheEntry(orgId, user.userId);
+      const memberToken = await createTestCliToken(user.userId);
+
+      const response = await patchAgent(
+        created.agentId,
+        { displayName: "Hacked" },
+        memberToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("should return 403 when member updates default agent instructions", async () => {
+      const created = await (
+        await postAgent(
+          { connectors: [], displayName: "Default" },
+          testCliToken,
+          testOrgSlug,
+        )
+      ).json();
+
+      const orgId = `org_mock_${user.userId}`;
+      await setDefaultAgentByComposeId(orgId, created.agentId);
+
+      // Re-mock as member and clear cached admin role
+      mockClerk({
+        userId: user.userId,
+        orgId,
+        orgRole: "org:member",
+        clerkOrgs: [
+          {
+            id: orgId,
+            slug: testOrgSlug,
+            name: testOrgSlug,
+            role: "org:member",
+          },
+        ],
+      });
+      await clearOrgMembersCacheEntry(orgId, user.userId);
+      const memberToken = await createTestCliToken(user.userId);
+
+      const response = await putAgentInstructions(
+        created.agentId,
+        { content: "# Hacked instructions" },
+        memberToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("should allow admin to patch default agent metadata", async () => {
+      const created = await (
+        await postAgent(
+          { connectors: [], displayName: "Default" },
+          testCliToken,
+          testOrgSlug,
+        )
+      ).json();
+
+      const orgId = `org_mock_${user.userId}`;
+      await setDefaultAgentByComposeId(orgId, created.agentId);
+
+      // Admin can still update
+      const response = await patchAgent(
+        created.agentId,
+        { displayName: "Updated by Admin" },
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.displayName).toBe("Updated by Admin");
+    });
+
+    it("should allow member to patch non-default agent metadata", async () => {
+      // Create two agents — mark only one as default
+      const defaultAgent = await (
+        await postAgent(
+          { connectors: [], displayName: "Default" },
+          testCliToken,
+          testOrgSlug,
+        )
+      ).json();
+      const otherAgent = await (
+        await postAgent(
+          { connectors: [], displayName: "Other" },
+          testCliToken,
+          testOrgSlug,
+        )
+      ).json();
+
+      const orgId = `org_mock_${user.userId}`;
+      await setDefaultAgentByComposeId(orgId, defaultAgent.agentId);
+
+      // Re-mock as member and clear cached admin role
+      mockClerk({
+        userId: user.userId,
+        orgId,
+        orgRole: "org:member",
+        clerkOrgs: [
+          {
+            id: orgId,
+            slug: testOrgSlug,
+            name: testOrgSlug,
+            role: "org:member",
+          },
+        ],
+      });
+      await clearOrgMembersCacheEntry(orgId, user.userId);
+      const memberToken = await createTestCliToken(user.userId);
+
+      // Member can update non-default agent
+      const response = await patchAgent(
+        otherAgent.agentId,
+        { displayName: "Member Updated" },
+        memberToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.displayName).toBe("Member Updated");
     });
   });
 });

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3041,6 +3041,51 @@ export async function findOrgMembersCacheEntry(orgId: string, userId: string) {
 }
 
 /**
+ * Delete a cached membership entry. Useful for tests that need to change
+ * a user's role mid-test (the cache would otherwise serve the stale role).
+ */
+export async function clearOrgMembersCacheEntry(
+  orgId: string,
+  userId: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .delete(orgMembersCache)
+    .where(
+      and(eq(orgMembersCache.orgId, orgId), eq(orgMembersCache.userId, userId)),
+    );
+}
+
+/**
+ * Set the org's default agent by compose ID.
+ * Resolves compose → zero_agent via (orgId, name) and sets default_agent_id.
+ */
+export async function setDefaultAgentByComposeId(
+  orgId: string,
+  composeId: string,
+): Promise<void> {
+  initServices();
+  const [compose] = await globalThis.services.db
+    .select({ name: agentComposes.name })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  if (!compose) throw new Error(`Compose not found: ${composeId}`);
+
+  const [agent] = await globalThis.services.db
+    .select({ id: zeroAgents.id })
+    .from(zeroAgents)
+    .where(and(eq(zeroAgents.orgId, orgId), eq(zeroAgents.name, compose.name)))
+    .limit(1);
+  if (!agent) throw new Error(`Zero agent not found for compose: ${composeId}`);
+
+  await globalThis.services.db
+    .update(orgMetadata)
+    .set({ defaultAgentId: agent.id, updatedAt: new Date() })
+    .where(eq(orgMetadata.orgId, orgId));
+}
+
+/**
  * Insert an org_members entry for testing member preferences.
  */
 export async function insertOrgMembersEntry(entry: {

--- a/turbo/apps/web/src/lib/zero/resolve-default-agent.ts
+++ b/turbo/apps/web/src/lib/zero/resolve-default-agent.ts
@@ -103,3 +103,19 @@ export async function resolveComposeIdFromAgentId(
 
   return row?.composeId ?? null;
 }
+
+/**
+ * Check whether a given compose ID belongs to the org's default agent.
+ * Reuses resolveDefaultAgentId (handles env-var fallback) and
+ * resolveComposeIdFromAgentId for the reverse lookup.
+ */
+export async function isDefaultAgentCompose(
+  orgId: string,
+  composeId: string,
+): Promise<boolean> {
+  const defaultAgentId = await resolveDefaultAgentId(orgId);
+  if (!defaultAgentId) return false;
+
+  const defaultComposeId = await resolveComposeIdFromAgentId(defaultAgentId);
+  return defaultComposeId === composeId;
+}


### PR DESCRIPTION
## Summary

- Hide **Profile** and **Instructions** tabs from non-admin users when viewing the default agent detail page
- Add backend **403 Forbidden** enforcement on `PATCH /api/zero/agents/:id` (metadata) and `PUT /api/zero/agents/:id/instructions` when the target agent is the org's default agent
- Non-default agents remain fully accessible to all org members
- Add `isDefaultAgentCompose()` helper to resolve whether a compose ID belongs to the default agent
- Add 403 response to ts-rest contracts for `updateMetadata` and `instructions.update`

## Test plan

- [x] Member PATCH on default agent metadata → 403 Forbidden
- [x] Member PUT on default agent instructions → 403 Forbidden
- [x] Admin PATCH on default agent metadata → 200 OK
- [x] Member PATCH on non-default agent metadata → 200 OK (unaffected)
- [ ] Manual: verify Profile/Instructions tabs hidden for non-admin on default agent
- [ ] Manual: verify tabs visible for admin on default agent
- [ ] Manual: verify tabs visible for all users on non-default agents
- [ ] Manual: verify `?tab=profile` URL falls back to connectors for non-admin on default agent

Closes #6646

🤖 Generated with [Claude Code](https://claude.com/claude-code)