### PR TITLE
feat(cli): hide zero commands based on token capabilities

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Command } from "commander";
+import {
+  applyCapabilityVisibility,
+  decodeCapabilitiesFromZeroToken,
+} from "../zero";
+
+function buildZeroToken(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
+    "base64url",
+  );
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `vm0_sandbox_${header}.${body}.test-signature`;
+}
+
+function buildProgram(): Command {
+  const prog = new Command();
+  prog.addCommand(new Command("org"));
+  prog.addCommand(new Command("agent"));
+  prog.addCommand(new Command("connector"));
+  prog.addCommand(new Command("preference"));
+  prog.addCommand(new Command("schedule"));
+  prog.addCommand(new Command("secret"));
+  prog.addCommand(new Command("variable"));
+  prog.addCommand(new Command("whoami"));
+  return prog;
+}
+
+function visibleCommandNames(prog: Command): string[] {
+  return prog.commands
+    .filter((cmd) => !(cmd as unknown as { _hidden: boolean })._hidden)
+    .map((cmd) => cmd.name());
+}
+
+function hiddenCommandNames(prog: Command): string[] {
+  return prog.commands
+    .filter((cmd) => (cmd as unknown as { _hidden: boolean })._hidden)
+    .map((cmd) => cmd.name());
+}
+
+describe("decodeCapabilitiesFromZeroToken", () => {
+  it("should decode capabilities from a valid zero-scoped token", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["agent:read", "schedule:read"],
+    });
+    expect(decodeCapabilitiesFromZeroToken(token)).toEqual([
+      "agent:read",
+      "schedule:read",
+    ]);
+  });
+
+  it("should return null for token without vm0_sandbox_ prefix", () => {
+    expect(decodeCapabilitiesFromZeroToken("some-other-token")).toBeNull();
+  });
+
+  it("should return null for malformed JWT (not 3 parts)", () => {
+    expect(
+      decodeCapabilitiesFromZeroToken("vm0_sandbox_only-one-part"),
+    ).toBeNull();
+  });
+
+  it("should return null for non-zero scope", () => {
+    const token = buildZeroToken({
+      scope: "sandbox",
+      capabilities: ["agent:read"],
+    });
+    expect(decodeCapabilitiesFromZeroToken(token)).toBeNull();
+  });
+
+  it("should return null when capabilities is not an array", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: "not-an-array",
+    });
+    expect(decodeCapabilitiesFromZeroToken(token)).toBeNull();
+  });
+
+  it("should return null for invalid base64 payload", () => {
+    expect(
+      decodeCapabilitiesFromZeroToken("vm0_sandbox_a.!!!invalid.c"),
+    ).toBeNull();
+  });
+});
+
+describe("applyCapabilityVisibility", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("should not hide any commands when ZERO_TOKEN is absent", () => {
+    const prog = buildProgram();
+    applyCapabilityVisibility(prog);
+    expect(hiddenCommandNames(prog)).toEqual([]);
+  });
+
+  it("should hide unmapped commands and show capable ones with valid token", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: [
+        "agent:read",
+        "schedule:read",
+        "schedule:write",
+        "slack:write",
+      ],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+    applyCapabilityVisibility(prog);
+
+    expect(visibleCommandNames(prog)).toEqual(["agent", "schedule", "whoami"]);
+    expect(hiddenCommandNames(prog)).toEqual([
+      "org",
+      "connector",
+      "preference",
+      "secret",
+      "variable",
+    ]);
+  });
+
+  it("should not hide any commands with malformed token (graceful fallback)", () => {
+    vi.stubEnv("ZERO_TOKEN", "not-a-valid-token");
+
+    const prog = buildProgram();
+    applyCapabilityVisibility(prog);
+
+    expect(hiddenCommandNames(prog)).toEqual([]);
+  });
+
+  it("should not hide any commands when scope is not zero", () => {
+    const token = buildZeroToken({
+      scope: "sandbox",
+      capabilities: ["agent:read"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+    applyCapabilityVisibility(prog);
+
+    expect(hiddenCommandNames(prog)).toEqual([]);
+  });
+
+  it("should only show whoami when capabilities array is empty", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: [],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+    applyCapabilityVisibility(prog);
+
+    expect(visibleCommandNames(prog)).toEqual(["whoami"]);
+  });
+
+  it("should hide agent when agent:read capability is missing", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["schedule:read"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+    applyCapabilityVisibility(prog);
+
+    expect(visibleCommandNames(prog)).toEqual(["schedule", "whoami"]);
+    expect(hiddenCommandNames(prog)).toContain("agent");
+  });
+});

--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -97,12 +97,7 @@ describe("applyCapabilityVisibility", () => {
   it("should hide unmapped commands and show capable ones with valid token", () => {
     const token = buildZeroToken({
       scope: "zero",
-      capabilities: [
-        "agent:read",
-        "schedule:read",
-        "schedule:write",
-        "slack:write",
-      ],
+      capabilities: ["agent:read", "schedule:read", "schedule:write"],
     });
     vi.stubEnv("ZERO_TOKEN", token);
 

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -12,6 +12,73 @@ import { zeroSecretCommand } from "./commands/zero/secret";
 import { zeroVariableCommand } from "./commands/zero/variable";
 import { zeroWhoamiCommand } from "./commands/zero/whoami";
 
+/**
+ * Map of command names to the capability required to see them.
+ * Commands not in this map are hidden when ZERO_TOKEN is active.
+ * Use `null` for commands that should always be visible in sandbox.
+ */
+const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
+  agent: "agent:read",
+  schedule: "schedule:read",
+  slack: "slack:write",
+  whoami: null,
+};
+
+/**
+ * Decode capabilities from a ZERO_TOKEN JWT without signature verification.
+ * Returns null if token is missing, malformed, or not a zero-scoped token.
+ *
+ * Mirrors the decode logic in src/lib/api/config.ts but kept local
+ * to avoid pulling config dependencies into the entry point.
+ */
+export function decodeCapabilitiesFromZeroToken(
+  token: string,
+): string[] | null {
+  const prefix = "vm0_sandbox_";
+  if (!token.startsWith(prefix)) return null;
+  const jwt = token.slice(prefix.length);
+
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return null;
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1]!, "base64url").toString(),
+    ) as Record<string, unknown>;
+    if (payload.scope === "zero" && Array.isArray(payload.capabilities)) {
+      return payload.capabilities as string[];
+    }
+  } catch {
+    // Malformed token — fall through
+  }
+  return null;
+}
+
+/**
+ * Hide commands that the current ZERO_TOKEN does not grant access to.
+ * When no ZERO_TOKEN is present (human user with VM0_TOKEN or config),
+ * all commands remain visible.
+ */
+export function applyCapabilityVisibility(prog: Command): void {
+  const token = process.env.ZERO_TOKEN;
+  if (!token) return;
+
+  const capabilities = decodeCapabilitiesFromZeroToken(token);
+  if (!capabilities) return;
+
+  for (const cmd of prog.commands) {
+    const requiredCap = COMMAND_CAPABILITY_MAP[cmd.name()];
+    if (requiredCap === undefined) {
+      // Command not in map → hide in sandbox
+      (cmd as unknown as { _hidden: boolean })._hidden = true;
+    } else if (requiredCap !== null && !capabilities.includes(requiredCap)) {
+      // Command in map but capability missing → hide
+      (cmd as unknown as { _hidden: boolean })._hidden = true;
+    }
+    // requiredCap === null → always visible (e.g., whoami)
+  }
+}
+
 const program = new Command();
 
 declare const __CLI_VERSION__: string;
@@ -49,5 +116,6 @@ if (
   });
 
   configureGlobalProxyFromEnv();
+  applyCapabilityVisibility(program);
   program.parse();
 }

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -20,7 +20,6 @@ import { zeroWhoamiCommand } from "./commands/zero/whoami";
 const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   agent: "agent:read",
   schedule: "schedule:read",
-  slack: "slack:write",
   whoami: null,
 };
 


### PR DESCRIPTION
## Summary

- Add capability-based command visibility filtering to the Zero CLI entry point (`zero.ts`)
- When `ZERO_TOKEN` is present (agent sandbox mode), hide commands from `--help` that the token does not grant access to
- Human users (no `ZERO_TOKEN`) see all commands unchanged — this is a UX improvement, not security enforcement

## Changes

**`turbo/apps/cli/src/zero.ts`**:
- `COMMAND_CAPABILITY_MAP` — declarative map of command names to required capabilities (`null` = always visible)
- `decodeCapabilitiesFromZeroToken()` — decode JWT capabilities without signature verification (mirrors `config.ts` pattern, kept local to avoid entry point deps)
- `applyCapabilityVisibility()` — iterate registered commands and hide those lacking required capabilities

**`turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts`** (new):
- 12 integration tests covering: no token, valid token with capabilities, malformed token fallback, wrong scope, empty capabilities, partial capabilities

## Behavior

| Scenario | Result |
|----------|--------|
| No `ZERO_TOKEN` (human user) | All commands visible |
| Valid `ZERO_TOKEN` with capabilities | Only matching commands + `whoami` visible |
| Malformed `ZERO_TOKEN` | All commands visible (graceful fallback) |
| Empty capabilities | Only `whoami` visible |

## Test plan

- [x] All 12 new tests pass
- [x] Existing `zero.test.ts` tests still pass
- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes (0 warnings, 0 errors)
- [x] `pnpm knip` passes (no unused exports)

Closes #6655

🤖 Generated with [Claude Code](https://claude.com/claude-code)