### PR TITLE
fix: disable color codes when stdout is not a terminal

### DIFF
--- a/scripts/coding-dashboard.sh
+++ b/scripts/coding-dashboard.sh
@@ -11,9 +11,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=_common.sh
 source "$SCRIPT_DIR/_common.sh"
 
-GREEN=$'\033[0;32m'
-YELLOW=$'\033[1;33m'
-NC=$'\033[0m'
+if [[ -t 1 ]]; then
+  GREEN=$'\033[0;32m'
+  YELLOW=$'\033[1;33m'
+  NC=$'\033[0m'
+else
+  GREEN=""
+  YELLOW=""
+  NC=""
+fi
 
 MAX_WORKERS="${1:-4}"
 ME=$(gh api user --jq '.login')


### PR DESCRIPTION
## Summary
- Wraps ANSI color code assignments in `coding-dashboard.sh` with a `[[ -t 1 ]]` terminal check
- When stdout is not a terminal (e.g., piped or redirected), color variables are set to empty strings to avoid garbled output

## Test plan
- [ ] Run `scripts/coding-dashboard.sh` in a terminal and verify colors still appear
- [ ] Run `scripts/coding-dashboard.sh | cat` and verify no ANSI escape codes in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)