### PR TITLE
fix: skip startup skills sync in production

### DIFF
--- a/turbo/apps/web/instrumentation.ts
+++ b/turbo/apps/web/instrumentation.ts
@@ -2,17 +2,19 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("./sentry.server.config");
 
-    // Sync skills cache on startup (needed for dev environments without Vercel cron)
-    const { initServices } = await import("./src/lib/init-services");
-    initServices();
-    const { logger } = await import("./src/lib/logger");
-    const log = logger("instrumentation");
-    const { syncSkills } = await import("./src/lib/skills/sync-skills");
-    syncSkills().catch((error: unknown) => {
-      log.error("Failed to sync skills on startup", {
-        error: error instanceof Error ? error.message : String(error),
+    // Sync skills cache on startup (only in dev — production uses cron at /api/cron/sync-skills)
+    if (process.env.NODE_ENV === "development") {
+      const { initServices } = await import("./src/lib/init-services");
+      initServices();
+      const { logger } = await import("./src/lib/logger");
+      const log = logger("instrumentation");
+      const { syncSkills } = await import("./src/lib/skills/sync-skills");
+      syncSkills().catch((error: unknown) => {
+        log.error("Failed to sync skills on startup", {
+          error: error instanceof Error ? error.message : String(error),
+        });
       });
-    });
+    }
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {


### PR DESCRIPTION
## Summary

- Wrap the `syncSkills()` call in `instrumentation.ts` with a `NODE_ENV === "development"` guard
- Production uses the cron job at `/api/cron/sync-skills` — startup sync is unnecessary and was causing 68+ error logs per deployment

Closes #6608

## Test plan

- [x] Lint passes
- [x] Type check passes
- [x] Knip passes (no unused code)
- [ ] Verify no "Failed to sync skills on startup" errors in production Axiom logs after deploy
- [ ] Verify local dev server still syncs skills on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)