### PR TITLE
feat: add org-level targeting to feature switch system

### DIFF
--- a/turbo/apps/cli/src/commands/zero/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/connect.ts
@@ -14,6 +14,7 @@ import {
   setZeroSecret,
 } from "../../../lib/api";
 import { getBaseUrl } from "../../../lib/api/core/client-factory";
+import { getActiveOrg } from "../../../lib/api/config";
 import { withErrorHandler } from "../../../lib/command";
 import {
   checkComputerDependencies,
@@ -121,9 +122,10 @@ async function resolveAuthMethod(
 ): Promise<"oauth" | "api-token"> {
   const config = CONNECTOR_TYPES[connectorType];
   const oauthFlag = CONNECTOR_TYPES[connectorType].featureFlag;
+  const orgId = await getActiveOrg();
   const oauthAvailable =
     "oauth" in config.authMethods &&
-    (!oauthFlag || (await isFeatureEnabled(oauthFlag)));
+    (!oauthFlag || (await isFeatureEnabled(oauthFlag, { orgId })));
   const apiTokenAvailable = "api-token" in config.authMethods;
 
   if (tokenFlag) {

--- a/turbo/apps/cli/src/commands/zero/connector/list.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/list.ts
@@ -7,6 +7,7 @@ import {
   type ConnectorType,
 } from "@vm0/core";
 import { listZeroConnectors } from "../../../lib/api";
+import { getActiveOrg } from "../../../lib/api/config";
 import { withErrorHandler } from "../../../lib/command";
 
 export const listCommand = new Command()
@@ -17,13 +18,18 @@ export const listCommand = new Command()
     withErrorHandler(async () => {
       const result = await listZeroConnectors();
       const connectedMap = new Map(result.connectors.map((c) => [c.type, c]));
+      const orgId = await getActiveOrg();
 
       const allTypesRaw = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
       const allTypes: ConnectorType[] = [];
       for (const type of allTypesRaw) {
         const flag = CONNECTOR_TYPES[type].featureFlag;
         const hasApiToken = "api-token" in CONNECTOR_TYPES[type].authMethods;
-        if (flag && !(await isFeatureEnabled(flag)) && !hasApiToken) {
+        if (
+          flag &&
+          !(await isFeatureEnabled(flag, { orgId })) &&
+          !hasApiToken
+        ) {
           continue;
         }
         allTypes.push(type);

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -3,7 +3,7 @@ import { logger } from "../log";
 import { FeatureSwitchKey, getAllFeatureStates } from "@vm0/core";
 import { localStorageSignals } from "./local-storage";
 import { throwIfAbort } from "../utils";
-import { user$ } from "../auth";
+import { clerk$, user$ } from "../auth";
 
 const L = logger("FeatureSwitch");
 const { get$, set$ } = localStorageSignals("featureSwitch");
@@ -18,8 +18,10 @@ export const featureSwitch$ = computed(async (get) => {
   const user = await get(user$);
   const userId = user?.id;
   const email = user?.primaryEmailAddress?.emailAddress;
+  const clerk = await get(clerk$);
+  const orgId = clerk.organization?.id;
 
-  const result = await getAllFeatureStates(userId, email);
+  const result = await getAllFeatureStates({ userId, email, orgId });
 
   const override = get(get$);
   if (!override) {

--- a/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/__tests__/route.test.ts
@@ -120,6 +120,23 @@ describe("GET /api/zero/connectors/search", () => {
     expect(neon.authMethods).not.toContain("oauth");
   });
 
+  it("should show feature-flagged connector when orgId matches STAFF_ORG_ID_HASHES", async () => {
+    mockClerk({
+      userId: "random-non-staff-user",
+      orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+    });
+    const response = await searchConnectors();
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    // computer has a feature flag and is only visible to staff
+    // The orgId matches STAFF_ORG_ID_HASHES, so it should be visible
+    const computer = data.connectors.find(
+      (c: { id: string }) => c.id === "computer",
+    );
+    expect(computer).toBeDefined();
+  });
+
   it("should include connectors without feature flags", async () => {
     const response = await searchConnectors();
     expect(response.status).toBe(200);

--- a/turbo/apps/web/app/api/zero/connectors/search/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/route.ts
@@ -23,7 +23,10 @@ const router = tsr.router(zeroConnectorsSearchContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
-    const featureStates = await getAllFeatureStates(authCtx.userId);
+    const featureStates = await getAllFeatureStates({
+      userId: authCtx.userId,
+      orgId: authCtx.orgId,
+    });
     const keyword = query.keyword?.toLowerCase();
 
     const connectors = (

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -4,6 +4,7 @@ import {
   isFeatureEnabled,
   getAllFeatureStates,
   computeEmailHash,
+  computeOrgIdHash,
 } from "../feature-switch";
 
 describe("computeEmailHash", () => {
@@ -22,38 +23,84 @@ describe("computeEmailHash", () => {
   });
 });
 
+describe("computeOrgIdHash", () => {
+  it("should produce a consistent SHA-1 hex hash", async () => {
+    const hash = await computeOrgIdHash("org_test123");
+    expect(hash).toMatch(/^[0-9a-f]{40}$/);
+    // Same input should produce the same hash
+    const hash2 = await computeOrgIdHash("org_test123");
+    expect(hash).toBe(hash2);
+  });
+
+  it("should not lowercase the orgId before hashing", async () => {
+    const upper = await computeOrgIdHash("ABC");
+    const lower = await computeOrgIdHash("abc");
+    expect(upper).not.toBe(lower);
+  });
+});
+
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", async () => {
     await expect(isFeatureEnabled(FeatureSwitchKey.Dummy)).resolves.toBe(true);
   });
 
-  it("should return true for globally enabled switch even with userId", async () => {
+  it("should return true for globally enabled switch even with context", async () => {
     await expect(
-      isFeatureEnabled(FeatureSwitchKey.Dummy, "any-user"),
+      isFeatureEnabled(FeatureSwitchKey.Dummy, { userId: "any-user" }),
     ).resolves.toBe(true);
   });
 
-  it("should return false for disabled switch without userId", async () => {
+  it("should return false for disabled switch without context", async () => {
     await expect(isFeatureEnabled(FeatureSwitchKey.Pricing)).resolves.toBe(
       false,
     );
   });
 
-  it("should return false for disabled switch with userId when no enabledUserHashes configured", async () => {
+  it("should return false for disabled switch with non-matching userId", async () => {
     await expect(
-      isFeatureEnabled(FeatureSwitchKey.Pricing, "some-user"),
+      isFeatureEnabled(FeatureSwitchKey.Pricing, { userId: "some-user" }),
     ).resolves.toBe(false);
   });
 
   it("should return false for switch with enabledUserHashes but no enabledEmailHashes when only email provided", async () => {
     // AhrefsConnector has enabledUserHashes but no enabledEmailHashes
     await expect(
-      isFeatureEnabled(
-        FeatureSwitchKey.AhrefsConnector,
-        undefined,
-        "test@example.com",
-      ),
+      isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {
+        email: "test@example.com",
+      }),
     ).resolves.toBe(false);
+  });
+
+  it("should return true when orgId hash matches enabledOrgIdHashes", async () => {
+    // AhrefsConnector has enabledOrgIdHashes: STAFF_ORG_ID_HASHES
+    await expect(
+      isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {
+        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("should return false when orgId does not match enabledOrgIdHashes", async () => {
+    await expect(
+      isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {
+        orgId: "org_nonexistent",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("should return false when no orgId provided but switch has enabledOrgIdHashes", async () => {
+    await expect(
+      isFeatureEnabled(FeatureSwitchKey.AhrefsConnector),
+    ).resolves.toBe(false);
+  });
+
+  it("should return true when orgId matches even if userId does not", async () => {
+    await expect(
+      isFeatureEnabled(FeatureSwitchKey.AhrefsConnector, {
+        userId: "non-matching-user",
+        orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+      }),
+    ).resolves.toBe(true);
   });
 });
 
@@ -64,5 +111,26 @@ describe("getAllFeatureStates", () => {
     expect(states[FeatureSwitchKey.Dummy]).toBe(true);
     // Disabled switches without matching user/email should be false
     expect(states[FeatureSwitchKey.Pricing]).toBe(false);
+  });
+
+  it("should enable switches when orgId matches enabledOrgIdHashes", async () => {
+    const states = await getAllFeatureStates({
+      orgId: "org_3ANttyrbWYJk6JKRSTRLEsbsDLe",
+    });
+    // Switches with STAFF_ORG_ID_HASHES should be true
+    expect(states[FeatureSwitchKey.Pricing]).toBe(true);
+    expect(states[FeatureSwitchKey.AhrefsConnector]).toBe(true);
+    // Globally enabled should still be true
+    expect(states[FeatureSwitchKey.Dummy]).toBe(true);
+    // Switches without org hashes should remain false
+    expect(states[FeatureSwitchKey.Secrets]).toBe(false);
+  });
+
+  it("should return false for switches with orgId hashes when orgId does not match", async () => {
+    const states = await getAllFeatureStates({
+      orgId: "org_nonexistent",
+    });
+    expect(states[FeatureSwitchKey.Pricing]).toBe(false);
+    expect(states[FeatureSwitchKey.AhrefsConnector]).toBe(false);
   });
 });

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -12,6 +12,13 @@ export interface FeatureSwitch {
   readonly enabled: boolean;
   readonly enabledUserHashes?: readonly string[];
   readonly enabledEmailHashes?: readonly string[];
+  readonly enabledOrgIdHashes?: readonly string[];
+}
+
+export interface FeatureSwitchContext {
+  readonly userId?: string;
+  readonly email?: string;
+  readonly orgId?: string;
 }
 
 const sha1Cache = new Map<string, string>();
@@ -36,6 +43,15 @@ export async function computeEmailHash(email: string): Promise<string> {
   return sha1(email.toLowerCase());
 }
 
+/**
+ * Compute the SHA-1 hash of an organization ID.
+ * Used for org-based feature switch targeting.
+ * No lowercasing — orgId is case-sensitive.
+ */
+export async function computeOrgIdHash(orgId: string): Promise<string> {
+  return sha1(orgId);
+}
+
 const STAFF_USER_HASHES: readonly string[] = [
   "afc25aa601481d794372ed765038148d3a160e2a",
   "1e7de00267c699185653df499f68e8383013ca08",
@@ -43,6 +59,10 @@ const STAFF_USER_HASHES: readonly string[] = [
   "d938bb6e49cb8ccfaa962942d69c9ccd1ee239af",
   "67a65740246389d7fecf7702f8b7d6914ad38dc5",
   "55651a8b2c85b35ff0629fa3d4718b9476069d0f",
+];
+
+const STAFF_ORG_ID_HASHES: readonly string[] = [
+  "65de87977d6d1712cd88d7768209f33f7ed12e0b", // org_3ANttyrbWYJk6JKRSTRLEsbsDLe
 ];
 
 /**
@@ -53,6 +73,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.Dummy]: {
     maintainer: "ethan@vm0.ai",
@@ -78,200 +99,245 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.CanvaConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ComputerConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.DeelConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.DocuSignConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.DropboxConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.FigmaConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.MercuryConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.NeonConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.GarminConnectConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
 
   [FeatureSwitchKey.RedditConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.IntervalsIcuConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.SupabaseConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.CloseConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.WebflowConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.OutlookMailConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.OutlookCalendarConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.MetaAdsConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.StripeConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.PosthogConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.MailchimpConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ResendConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.GitHubIntegration]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.TelegramIntegration]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.DataExport]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.ShowSystemPrompt]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.Usage]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
     enabledUserHashes: STAFF_USER_HASHES,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
 };
 
+interface ResolvedHashes {
+  readonly userHash?: string;
+  readonly emailHash?: string;
+  readonly orgIdHash?: string;
+}
+
+function evaluateSwitch(fs: FeatureSwitch, hashes: ResolvedHashes): boolean {
+  if (fs.enabled) return true;
+  if (hashes.userHash && fs.enabledUserHashes?.includes(hashes.userHash))
+    return true;
+  if (hashes.emailHash && fs.enabledEmailHashes?.includes(hashes.emailHash))
+    return true;
+  if (hashes.orgIdHash && fs.enabledOrgIdHashes?.includes(hashes.orgIdHash))
+    return true;
+  return false;
+}
+
 /**
- * Evaluate all feature switches at once for the given user.
+ * Evaluate all feature switches at once for the given context.
  *
- * Computes the user hash once and checks all switches synchronously,
+ * Computes identity hashes once and checks all switches synchronously,
  * avoiding per-key async overhead.
  */
 export async function getAllFeatureStates(
-  userId?: string,
-  email?: string,
+  ctx?: FeatureSwitchContext,
 ): Promise<Record<FeatureSwitchKey, boolean>> {
   const switches = Object.values(FEATURE_SWITCHES);
-  const userHash =
-    userId && switches.some((s) => s.enabledUserHashes?.length)
-      ? await sha1(userId)
-      : undefined;
-  const emailHash =
-    email && switches.some((s) => s.enabledEmailHashes?.length)
-      ? await sha1(email.toLowerCase())
-      : undefined;
+  const hashes: ResolvedHashes = {
+    userHash:
+      ctx?.userId && switches.some((s) => s.enabledUserHashes?.length)
+        ? await sha1(ctx.userId)
+        : undefined,
+    emailHash:
+      ctx?.email && switches.some((s) => s.enabledEmailHashes?.length)
+        ? await sha1(ctx.email.toLowerCase())
+        : undefined,
+    orgIdHash:
+      ctx?.orgId && switches.some((s) => s.enabledOrgIdHashes?.length)
+        ? await sha1(ctx.orgId)
+        : undefined,
+  };
 
   const result = {} as Record<FeatureSwitchKey, boolean>;
   for (const key of Object.values(FeatureSwitchKey)) {
-    const fs = FEATURE_SWITCHES[key];
-    if (fs.enabled) {
-      result[key] = true;
-    } else if (userHash && fs.enabledUserHashes?.includes(userHash)) {
-      result[key] = true;
-    } else if (emailHash && fs.enabledEmailHashes?.includes(emailHash)) {
-      result[key] = true;
-    } else {
-      result[key] = false;
-    }
+    result[key] = evaluateSwitch(FEATURE_SWITCHES[key], hashes);
   }
   return result;
 }
 
 /**
- * Check if a feature is enabled for the given user.
+ * Check if a feature is enabled for the given context.
  *
  * When `userId` is provided and the switch has `enabledUserHashes`,
  * the userId is SHA-1 hashed and compared against the stored hashes.
  * When `email` is provided and the switch has `enabledEmailHashes`,
  * the email is SHA-1 hashed (lowercased) and compared.
+ * When `orgId` is provided and the switch has `enabledOrgIdHashes`,
+ * the orgId is SHA-1 hashed and compared.
  */
 export async function isFeatureEnabled(
   key: FeatureSwitchKey,
-  userId?: string,
-  email?: string,
+  ctx?: FeatureSwitchContext,
 ): Promise<boolean> {
   const featureSwitch = FEATURE_SWITCHES[key];
   if (featureSwitch.enabled) {
     return true;
   }
-  if (userId && featureSwitch.enabledUserHashes?.length) {
-    const hash = await sha1(userId);
+  if (ctx?.userId && featureSwitch.enabledUserHashes?.length) {
+    const hash = await sha1(ctx.userId);
     if (featureSwitch.enabledUserHashes.includes(hash)) return true;
   }
-  if (email && featureSwitch.enabledEmailHashes?.length) {
-    const hash = await sha1(email.toLowerCase());
+  if (ctx?.email && featureSwitch.enabledEmailHashes?.length) {
+    const hash = await sha1(ctx.email.toLowerCase());
     if (featureSwitch.enabledEmailHashes.includes(hash)) return true;
+  }
+  if (ctx?.orgId && featureSwitch.enabledOrgIdHashes?.length) {
+    const hash = await sha1(ctx.orgId);
+    if (featureSwitch.enabledOrgIdHashes.includes(hash)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

- Add `enabledOrgIdHashes` field to `FeatureSwitch` interface for org-level targeting
- Define `FeatureSwitchContext` type and refactor `getAllFeatureStates`/`isFeatureEnabled` from positional params to context object
- Add `STAFF_ORG_ID_HASHES` constant (SHA-1 of vm0 Clerk org ID) to all 28 staff-gated switches
- Wire orgId through platform (Clerk), web API (auth context), and CLI (getActiveOrg)

## Test plan

- [x] Core: `computeOrgIdHash` produces consistent SHA-1 hash without lowercasing
- [x] Core: `isFeatureEnabled` returns true/false based on orgId hash match
- [x] Core: `getAllFeatureStates` respects orgId hashes
- [x] Route: feature-flagged connector visible when orgId matches STAFF_ORG_ID_HASHES
- [x] All existing tests refactored to context object and passing
- [x] Lint, type-check, format, knip all passing

Closes #6643

🤖 Generated with [Claude Code](https://claude.com/claude-code)