### PR TITLE
fix: replace broken agent-browser role button clicks with text clicks in e2e-auth

### DIFF
--- a/e2e/cli-auth-automation.sh
+++ b/e2e/cli-auth-automation.sh
@@ -107,7 +107,7 @@ full_snapshot() {
 # Helper: dismiss cookie consent banner if present
 # ---------------------------------------------------------------------------
 dismiss_cookie_banner() {
-  if agent-browser find role button click --name "Accept" 2>/dev/null; then
+  if agent-browser find text "Accept" click 2>/dev/null; then
     agent-browser wait 500
     echo "🍪 Dismissed cookie consent banner"
   fi
@@ -168,9 +168,9 @@ enter_otp() {
   agent-browser wait 2000
 
   # Click Continue/Verify button if present (needed when OTP is a single text input)
-  if agent-browser find role button click --name "Continue" --exact 2>/dev/null; then
+  if agent-browser find text "Continue" click 2>/dev/null; then
     echo "➡️ Clicking Continue"
-  elif agent-browser find role button click --name "Verify" --exact 2>/dev/null; then
+  elif agent-browser find text "Verify" click 2>/dev/null; then
     echo "➡️ Clicking Verify"
   fi
   agent-browser wait 5000
@@ -274,7 +274,7 @@ else
   echo "📧 Entering email: $EMAIL"
   agent-browser find label "Email address" fill "$EMAIL"
   agent-browser wait 500
-  agent-browser find role button click --name "Continue" --exact
+  agent-browser find text "Continue" click
   agent-browser wait 5000
   step_screenshot "after-email-continue"
 
@@ -313,7 +313,7 @@ else
     agent-browser wait 500
     agent-browser find label "Password" fill "$SIGNUP_PASSWORD"
     agent-browser wait 500
-    agent-browser find role button click --name "Continue" --exact
+    agent-browser find text "Continue" click
     agent-browser wait 5000
     step_screenshot "after-sign-up-continue"
 
@@ -462,9 +462,9 @@ echo "✅ Device code entered"
 agent-browser wait 1000
 
 # Click Verify button
-if agent-browser find role button click --name "Verify" 2>/dev/null; then
+if agent-browser find text "Verify" click 2>/dev/null; then
   echo "➡️ Clicked Verify"
-elif agent-browser find role button click --name "Authorize Device" 2>/dev/null; then
+elif agent-browser find text "Authorize Device" click 2>/dev/null; then
   echo "➡️ Clicked Authorize Device"
 else
   step_screenshot "verify-button-not-found"


### PR DESCRIPTION
## Summary

- Replace all 7 `agent-browser find role button click --name "X"` commands with `agent-browser find text "X" click` in `e2e/cli-auth-automation.sh`
- The `find role button click` command does not trigger actual click events on Clerk forms, causing the e2e-auth CI job to silently fail 100% of the time
- The `find text click` alternative has been verified working locally

## Test plan

- [ ] Verify no `find role button click` patterns remain in the script (`grep` returns zero matches)
- [ ] Verify shell syntax is valid (`bash -n` passes)
- [ ] CI e2e-auth job runs successfully on the PR

Closes #6637

🤖 Generated with [Claude Code](https://claude.com/claude-code)