### PR TITLE
chore(cli): fix stale description in zero test and connector command

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -44,7 +44,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 8 commands", () => {
+  it("should have exactly 9 commands", () => {
     expect(commandNames).toHaveLength(9);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/connector/index.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/index.ts
@@ -6,7 +6,7 @@ import { disconnectCommand } from "./disconnect";
 
 export const zeroConnectorCommand = new Command()
   .name("connector")
-  .description("Manage third-party service connections (zero)")
+  .description("Manage third-party service connections")
   .addCommand(listCommand)
   .addCommand(statusCommand)
   .addCommand(connectCommand)


### PR DESCRIPTION
## Summary
- Fix test description in `zero.test.ts` to say "9 commands" matching the actual assertion of `toHaveLength(9)`
- Remove stale `(zero)` suffix from connector command description

## Test plan
- [x] `pnpm vitest run apps/cli/src/__tests__/zero.test.ts` — all 4 tests pass
- [x] Lint, type-check, format, and knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)