### PR TITLE
refactor: switch coding loop from one-shot to recurring cron

### DIFF
--- a/.claude/skills/begin-coding-loop/SKILL.md
+++ b/.claude/skills/begin-coding-loop/SKILL.md
@@ -5,5 +5,9 @@ description: Start an adaptive coding loop that dynamically adjusts interval bas
 
 1. Run `scripts/coding-loop.sh ${ARGUMENTS:-$(hostname)}` and capture the stdout.
 2. Parse the first line `INTERVAL:N` and save N.
-3. If the remaining output (after the first line) is "idle", use CronCreate (one-shot) to schedule `/begin-coding-loop $ARGUMENTS` in N minutes immediately.
-4. If the remaining output is NOT "idle", launch a **general-purpose Agent** (subagent) with that output as the prompt. Do NOT execute the instructions yourself — always delegate to a subagent. **Wait for the subagent to complete**, then use CronCreate (one-shot) to schedule `/begin-coding-loop $ARGUMENTS` in N minutes.
+3. Use CronList to check if a recurring cron job for `/begin-coding-loop` already exists.
+   - If a matching job exists **and** its interval differs from N minutes, delete it with CronDelete and create a new recurring cron with `*/N * * * *` and prompt `/begin-coding-loop $ARGUMENTS`.
+   - If a matching job exists **and** its interval already matches N minutes, do nothing (keep it as-is).
+   - If no matching job exists, create a new recurring cron with `*/N * * * *` and prompt `/begin-coding-loop $ARGUMENTS`.
+4. If the remaining output (after the first line) is "idle", stop here — the recurring cron will trigger the next check.
+5. If the remaining output is NOT "idle", launch a **general-purpose Agent** (subagent) with that output as the prompt. Do NOT execute the instructions yourself — always delegate to a subagent. **Wait for the subagent to complete** before returning.


### PR DESCRIPTION
## Summary
- Change `begin-coding-loop` skill from one-shot cron scheduling to recurring `*/N * * * *` cron
- Check existing cron jobs via CronList before creating — update interval if changed, skip if same, create if missing

## Test plan
- [ ] Run `/begin-coding-loop` and verify recurring cron is created
- [ ] Run again with different interval and verify old cron is replaced
- [ ] Run again with same interval and verify no duplicate cron is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)