### PR TITLE
fix(cli): add slack to capability map and replace curl guidance

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -21,6 +21,7 @@ function buildProgram(): Command {
   prog.addCommand(new Command("preference"));
   prog.addCommand(new Command("schedule"));
   prog.addCommand(new Command("secret"));
+  prog.addCommand(new Command("slack"));
   prog.addCommand(new Command("variable"));
   prog.addCommand(new Command("whoami"));
   return prog;
@@ -110,6 +111,7 @@ describe("applyCapabilityVisibility", () => {
       "connector",
       "preference",
       "secret",
+      "slack",
       "variable",
     ]);
   });
@@ -147,6 +149,20 @@ describe("applyCapabilityVisibility", () => {
     applyCapabilityVisibility(prog);
 
     expect(visibleCommandNames(prog)).toEqual(["whoami"]);
+  });
+
+  it("should show slack when slack:write capability is present", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["slack:write"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+    applyCapabilityVisibility(prog);
+
+    expect(visibleCommandNames(prog)).toContain("slack");
+    expect(visibleCommandNames(prog)).toContain("whoami");
   });
 
   it("should hide agent when agent:read capability is missing", () => {

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -44,7 +44,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 8 commands", () => {
+  it("should have exactly 9 commands", () => {
     expect(commandNames).toHaveLength(9);
   });
 });

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -21,6 +21,7 @@ import { zeroWhoamiCommand } from "./commands/zero/whoami";
 const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   agent: "agent:read",
   schedule: "schedule:read",
+  slack: "slack:write",
   whoami: null,
 };
 

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -42,6 +42,6 @@ export function buildZeroCliGuidance(): string {
     "For recurring or scheduled tasks, use the zero schedule CLI.",
     "",
     "## Sending Slack Messages",
-    "Use `zero slack message send` to send Slack messages. Do not use your own Slack tokens.",
+    "Use `zero slack message send` to send Slack messages as the bot user.",
   ].join("\n");
 }

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -40,21 +40,8 @@ export function buildZeroCliGuidance(): string {
     "Run `npx -p @vm0/cli zero --help` to see all available commands.",
     "Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "For recurring or scheduled tasks, use the zero schedule CLI.",
+    "",
+    "## Sending Slack Messages",
+    "Use `zero slack message send` to send Slack messages. Do not use your own Slack tokens.",
   ].join("\n");
-}
-
-/**
- * Build system prompt guidance for Slack messaging via the vm0 proxy API.
- * Injected into Slack-triggered runs so agents know how to send messages.
- */
-export function buildSlackMessagingGuidance(): string {
-  return `# Sending Slack Messages
-You can send Slack messages directly using the vm0 integration API:
-curl -X POST "$VM0_API_URL/api/zero/integrations/slack/message" \\
-  -H "Authorization: Bearer $ZERO_TOKEN" \\
-  -H "Content-Type: application/json" \\
-  -d '{"channel": "<channel-id>", "text": "your message"}'
-Note: $VM0_TOKEN also works during the transition period.
-Optional fields: threadTs (reply in thread), blocks (Block Kit JSON).
-Messages are sent as the bot user, not as an individual user.`;
 }

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -40,8 +40,6 @@ export function buildZeroCliGuidance(): string {
     "Run `npx -p @vm0/cli zero --help` to see all available commands.",
     "Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "For recurring or scheduled tasks, use the zero schedule CLI.",
-    "",
-    "## Sending Slack Messages",
     "Use `zero slack message send` to send Slack messages as the bot user.",
   ].join("\n");
 }

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -1,9 +1,6 @@
 import { isRunDispatchError } from "../../run";
 import { createZeroRun } from "../../zero/zero-run-service";
-import {
-  buildIntegrationContext,
-  buildSlackMessagingGuidance,
-} from "../../integration-context";
+import { buildIntegrationContext } from "../../integration-context";
 import { isApiError } from "../../errors";
 import { RUN_ERROR_GUIDANCE } from "@vm0/core";
 import { generateCallbackSecret, getApiUrl } from "../../callback";
@@ -64,7 +61,6 @@ export async function runAgentForSlackOrg(
       buildIntegrationContext("Slack", { botUserId }),
       threadContext,
       userContext,
-      buildSlackMessagingGuidance(),
     ].filter(Boolean);
     const appendSystemPrompt =
       contextParts.length > 0 ? contextParts.join("\n\n") : undefined;


### PR DESCRIPTION
## Summary

- Add `slack: "slack:write"` to `COMMAND_CAPABILITY_MAP` so sandbox agents can see the slack command in `zero --help`
- Delete `buildSlackMessagingGuidance()` which told agents to use raw `curl` for Slack messaging
- Add brief Slack section to `buildZeroCliGuidance()` pointing agents to `zero slack message send`
- Remove `buildSlackMessagingGuidance` import/call from Slack handler (guidance now comes from unified `buildZeroCliGuidance()` via `createZeroRun()`)
- Add `slack` to capability visibility test helper and add test case for `slack:write` capability
- Fix test description mismatch ("exactly 8 commands" → "exactly 9 commands")

Closes #6672

## Test plan

- [x] All 17 CLI tests pass (zero.test.ts + zero-capability-visibility.test.ts)
- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes
- [x] Knip finds no unused exports/dependencies
- [x] No remaining references to `buildSlackMessagingGuidance` in .ts files

🤖 Generated with [Claude Code](https://claude.com/claude-code)