### PR TITLE
refactor(cli): rename agentCommand to zeroAgentCommand

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/index.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/index.ts
@@ -5,7 +5,7 @@ import { viewCommand } from "./view";
 import { listCommand } from "./list";
 import { deleteCommand } from "./delete";
 
-export const agentCommand = new Command("agent")
+export const zeroAgentCommand = new Command("agent")
   .description("Manage zero agents")
   .addCommand(createCommand)
   .addCommand(editCommand)

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -4,7 +4,7 @@ import "./instrument.js";
 import { Command } from "commander";
 import { configureGlobalProxyFromEnv } from "./lib/network/proxy.js";
 import { zeroOrgCommand } from "./commands/zero/org";
-import { agentCommand } from "./commands/zero/agent";
+import { zeroAgentCommand } from "./commands/zero/agent";
 import { zeroConnectorCommand } from "./commands/zero/connector";
 import { zeroPreferenceCommand } from "./commands/zero/preference";
 import { zeroScheduleCommand } from "./commands/zero/schedule";
@@ -90,7 +90,7 @@ program
 
 // Register all zero commands as top-level
 program.addCommand(zeroOrgCommand);
-program.addCommand(agentCommand);
+program.addCommand(zeroAgentCommand);
 program.addCommand(zeroConnectorCommand);
 program.addCommand(zeroPreferenceCommand);
 program.addCommand(zeroScheduleCommand);


### PR DESCRIPTION
## Summary
- Rename `agentCommand` to `zeroAgentCommand` in `turbo/apps/cli/src/commands/zero/agent/index.ts`
- Update import and usage in `turbo/apps/cli/src/zero.ts`
- Aligns with the existing `zeroXxxCommand` naming convention used by all other zero commands

## Test plan
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)
- [x] CLI zero tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)