### PR TITLE
fix(web): exclude connector env vars from secret connector map override filter

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/secret-connector-map-filter.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/secret-connector-map-filter.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { filterSecretConnectorMap } from "../build-context";
+
+describe("filterSecretConnectorMap", () => {
+  it("returns undefined when input is undefined", () => {
+    expect(filterSecretConnectorMap(undefined, [])).toBeUndefined();
+  });
+
+  it("returns all keys when no override sources exist", () => {
+    const map = {
+      GOOGLE_CALENDAR_ACCESS_TOKEN: "google-calendar",
+      GOOGLE_CALENDAR_TOKEN: "google-calendar",
+    };
+    expect(filterSecretConnectorMap(map, [])).toEqual(map);
+  });
+
+  it("removes keys overridden by CLI secrets", () => {
+    const map = {
+      GOOGLE_CALENDAR_ACCESS_TOKEN: "google-calendar",
+      NOTION_ACCESS_TOKEN: "notion",
+    };
+    const cliSecrets = { NOTION_ACCESS_TOKEN: "manual-value" };
+    expect(filterSecretConnectorMap(map, [cliSecrets])).toEqual({
+      GOOGLE_CALENDAR_ACCESS_TOKEN: "google-calendar",
+    });
+  });
+
+  it("removes keys overridden by DB secrets", () => {
+    const map = {
+      GOOGLE_CALENDAR_ACCESS_TOKEN: "google-calendar",
+      SLACK_ACCESS_TOKEN: "slack",
+    };
+    const dbSecrets = { SLACK_ACCESS_TOKEN: "db-value" };
+    expect(filterSecretConnectorMap(map, [undefined, dbSecrets])).toEqual({
+      GOOGLE_CALENDAR_ACCESS_TOKEN: "google-calendar",
+    });
+  });
+
+  it("preserves connector mapped env var names (not treated as overrides)", () => {
+    // This is the regression case from #6681: connector's own injected env
+    // vars should NOT be passed as an override source.
+    const map = {
+      GOOGLE_CALENDAR_ACCESS_TOKEN: "google-calendar", // raw secret name
+      GOOGLE_CALENDAR_TOKEN: "google-calendar", // mapped env var name
+    };
+    // injectedEnvVars would contain GOOGLE_CALENDAR_TOKEN — but it must NOT
+    // be in the override sources array.  Only CLI/DB/model-provider go there.
+    expect(filterSecretConnectorMap(map, [])).toEqual(map);
+  });
+
+  it("returns undefined when all keys are overridden", () => {
+    const map = { NOTION_ACCESS_TOKEN: "notion" };
+    const cliSecrets = { NOTION_ACCESS_TOKEN: "manual" };
+    expect(filterSecretConnectorMap(map, [cliSecrets])).toBeUndefined();
+  });
+
+  it("handles multiple override sources", () => {
+    const map = {
+      GOOGLE_CALENDAR_ACCESS_TOKEN: "google-calendar",
+      NOTION_ACCESS_TOKEN: "notion",
+      SLACK_ACCESS_TOKEN: "slack",
+    };
+    const modelProviderSecrets = { NOTION_ACCESS_TOKEN: "mp-value" };
+    const cliSecrets = { SLACK_ACCESS_TOKEN: "cli-value" };
+    expect(
+      filterSecretConnectorMap(map, [
+        modelProviderSecrets,
+        undefined,
+        cliSecrets,
+      ]),
+    ).toEqual({
+      GOOGLE_CALENDAR_ACCESS_TOKEN: "google-calendar",
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -765,22 +765,10 @@ async function resolveSecretsAndEnvironment(
     : undefined;
 
   // Filter secretConnectorMap: remove keys overridden by higher-priority sources.
-  // If a secret is provided by CLI, user DB, or model-provider, OAuth refresh should
-  // not overwrite it at runtime.
-  let secretConnectorMap: Record<string, string> | undefined;
-  if (connectorResult.secretConnectorMap) {
-    const overrideKeys = new Set(
-      [modelProviderResult.secrets, dbSecrets, cliSecrets].flatMap((s) =>
-        s ? Object.keys(s) : [],
-      ),
-    );
-    const filtered = Object.fromEntries(
-      Object.entries(connectorResult.secretConnectorMap).filter(
-        ([key]) => !overrideKeys.has(key),
-      ),
-    );
-    if (Object.keys(filtered).length) secretConnectorMap = filtered;
-  }
+  const secretConnectorMap = filterSecretConnectorMap(
+    connectorResult.secretConnectorMap,
+    [modelProviderResult.secrets, dbSecrets, cliSecrets],
+  );
 
   // Auto-generate firewall entry for model provider (if applicable).
   // For meta-providers like "vm0", use the concrete provider type for firewall lookup.
@@ -926,6 +914,29 @@ interface BuildContextResult {
   resolvedModelProvider: ModelProviderType | undefined;
   /** The logical model name selected by the user, for credit usage billing. */
   selectedModel: string | undefined;
+}
+
+/**
+ * Filter secretConnectorMap by removing keys that are overridden by
+ * higher-priority secret sources (CLI, DB, model-provider).  Connector's own
+ * injected env vars are NOT overrides — they come from the connector itself.
+ *
+ * @internal Exported for testing.
+ */
+export function filterSecretConnectorMap(
+  secretConnectorMap: Record<string, string> | undefined,
+  overrideSources: (Record<string, string> | undefined)[],
+): Record<string, string> | undefined {
+  if (!secretConnectorMap) return undefined;
+  const overrideKeys = new Set(
+    overrideSources.flatMap((s) => (s ? Object.keys(s) : [])),
+  );
+  const filtered = Object.fromEntries(
+    Object.entries(secretConnectorMap).filter(
+      ([key]) => !overrideKeys.has(key),
+    ),
+  );
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -770,12 +770,9 @@ async function resolveSecretsAndEnvironment(
   let secretConnectorMap: Record<string, string> | undefined;
   if (connectorResult.secretConnectorMap) {
     const overrideKeys = new Set(
-      [
-        connectorResult.injectedEnvVars,
-        modelProviderResult.secrets,
-        dbSecrets,
-        cliSecrets,
-      ].flatMap((s) => (s ? Object.keys(s) : [])),
+      [modelProviderResult.secrets, dbSecrets, cliSecrets].flatMap((s) =>
+        s ? Object.keys(s) : [],
+      ),
     );
     const filtered = Object.fromEntries(
       Object.entries(connectorResult.secretConnectorMap).filter(


### PR DESCRIPTION
## Summary

- Remove `connectorResult.injectedEnvVars` from the `overrideKeys` set in `build-context.ts` secretConnectorMap filter
- The filter was incorrectly treating the connector's own mapped env vars as "higher-priority overrides", causing all mapped env var names to be stripped from `secretConnectorMap`
- This prevented firewall auth from triggering OAuth token refresh when templates reference mapped names (e.g. `${{ secrets.GOOGLE_CALENDAR_TOKEN }}`)

## Test plan

- [ ] Verify firewall auth refresh works with mapped env var names
- [ ] Verify CLI/DB secret overrides still suppress OAuth refresh correctly

Closes #6681

🤖 Generated with [Claude Code](https://claude.com/claude-code)