### PR TITLE
fix: prevent grep exit code from terminating tunnel script

### DIFF
--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -143,7 +143,7 @@ while [[ $ATTEMPT -lt $MAX_WAIT ]]; do
     fi
   else
     # Anonymous tunnel: wait for trycloudflare.com URL
-    TUNNEL_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' "$TUNNEL_LOG" 2>/dev/null | head -n 1)
+    TUNNEL_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' "$TUNNEL_LOG" 2>/dev/null | head -n 1 || true)
     if [[ -n "$TUNNEL_URL" ]]; then
       break
     fi


### PR DESCRIPTION
## Summary
- Add `|| true` to `grep` command in anonymous tunnel URL detection to prevent the script from exiting under `set -e` when grep finds no matches during the polling loop

## Test plan
- [ ] Verify tunnel script starts correctly with anonymous tunnel (no cert.pem)
- [ ] Confirm the grep polling loop continues retrying when URL is not yet available

🤖 Generated with [Claude Code](https://claude.com/claude-code)