### PR TITLE
feat: connect org management dialog billing tabs to real data

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -4,6 +4,7 @@ import {
   zeroBillingCheckoutContract,
   zeroBillingPortalContract,
   zeroBillingAutoRechargeContract,
+  zeroBillingInvoicesContract,
   type BillingStatusResponse,
 } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
@@ -173,3 +174,20 @@ export const saveAutoRecharge$ = command(
     return { ok: true };
   },
 );
+
+// ---------------------------------------------------------------------------
+// Invoices
+// ---------------------------------------------------------------------------
+
+/**
+ * Async computed signal that fetches invoices for the current org.
+ */
+export const invoicesAsync$ = computed(async (get) => {
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroBillingInvoicesContract);
+  const result = await client.get();
+  if (result.status !== 200) {
+    throw new Error(`Failed to fetch invoices: ${result.status}`);
+  }
+  return result.body;
+});

--- a/turbo/apps/platform/src/signals/zero-page/member-credit-caps.ts
+++ b/turbo/apps/platform/src/signals/zero-page/member-credit-caps.ts
@@ -1,0 +1,70 @@
+import { command, computed, state } from "ccstate";
+import { fetch$ } from "../fetch.ts";
+import { usageMembersAsync$ } from "../usage-page/usage-signals.ts";
+
+interface MemberCreditCap {
+  creditCap: number | null;
+  creditEnabled: boolean;
+}
+
+const memberCreditCapsReload$ = state(0);
+
+/**
+ * Fetches credit caps for all members returned by usageMembersAsync$.
+ * Returns a Map keyed by userId.
+ */
+export const memberCreditCaps$ = computed(async (get) => {
+  get(memberCreditCapsReload$);
+  const usage = await get(usageMembersAsync$);
+  const fetchFn = get(fetch$);
+
+  const caps = new Map<string, MemberCreditCap>();
+
+  // Fetch caps for all members in parallel
+  const results = await Promise.all(
+    usage.members.map(async (member) => {
+      const response = await fetchFn(
+        `/api/zero/org/members/credit-cap?userId=${encodeURIComponent(member.userId)}`,
+      );
+      if (!response.ok) {
+        return { userId: member.userId, cap: null };
+      }
+      const data = (await response.json()) as {
+        userId: string;
+        creditCap: number | null;
+        creditEnabled: boolean;
+      };
+      return {
+        userId: member.userId,
+        cap: { creditCap: data.creditCap, creditEnabled: data.creditEnabled },
+      };
+    }),
+  );
+
+  for (const result of results) {
+    if (result.cap) {
+      caps.set(result.userId, result.cap);
+    }
+  }
+
+  return caps;
+});
+
+/**
+ * Command to set/clear a member's credit cap.
+ * Invalidates the caps cache after mutation.
+ */
+export const setMemberCreditCap$ = command(
+  async (
+    { get, set },
+    params: { userId: string; creditCap: number | null },
+  ) => {
+    const fetchFn = get(fetch$);
+    await fetchFn("/api/zero/org/members/credit-cap", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+    });
+    set(memberCreditCapsReload$, (x) => x + 1);
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
@@ -22,26 +22,6 @@ export const setActiveTab$ = command(({ set }, tab: OrgManageTab) => {
 });
 
 // ---------------------------------------------------------------------------
-// org-billing-tab
-// ---------------------------------------------------------------------------
-
-const internalIsPro$ = state(false);
-
-export const billingIsPro$ = computed((get) => get(internalIsPro$));
-
-export const setBillingIsPro$ = command(({ set }, value: boolean) => {
-  set(internalIsPro$, value);
-});
-
-const internalPricingOpen$ = state(false);
-
-export const billingPricingOpen$ = computed((get) => get(internalPricingOpen$));
-
-export const setBillingPricingOpen$ = command(({ set }, value: boolean) => {
-  set(internalPricingOpen$, value);
-});
-
-// ---------------------------------------------------------------------------
 // org-general-tab: ProfileSection
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -1,12 +1,12 @@
-import { useGet, useSet } from "ccstate-react";
+import { useState } from "react";
+import { useLastLoadable, useSet } from "ccstate-react";
 import { IconExternalLink, IconCrown } from "@tabler/icons-react";
 import {
-  billingIsPro$,
-  setBillingIsPro$,
-  billingPricingOpen$,
-  setBillingPricingOpen$,
-} from "../../../../signals/zero-page/settings/org-manage-tabs-state.ts";
-import { Button, Dialog, DialogContent, Switch } from "@vm0/ui";
+  billingStatusAsync$,
+  startCheckout$,
+  startDowngrade$,
+} from "../../../../signals/zero-page/billing.ts";
+import { Button, Dialog, DialogContent } from "@vm0/ui";
 import planFreeImg from "./assets/plan-free.webp";
 import planProImg from "./assets/plan-pro.webp";
 import planTeamImg from "./assets/plan-team.webp";
@@ -23,6 +23,7 @@ interface PlanConfig {
   badge?: string;
   image?: string;
   features: readonly string[];
+  tier?: "pro" | "team";
 }
 
 const PLANS = [
@@ -50,6 +51,7 @@ const PLANS = [
     primary: true,
     badge: "Popular",
     image: planProImg,
+    tier: "pro",
     features: [
       "20,000 credits / month",
       "2 active agents",
@@ -66,6 +68,7 @@ const PLANS = [
     description: "Scale fast with zero friction and full flexibility.",
     cta: "Upgrade to Team",
     image: planTeamImg,
+    tier: "team",
     features: [
       "120,000 credits / month",
       "5 active agents",
@@ -79,10 +82,10 @@ const PLANS = [
 
 function PlanCard({
   plan,
-  onClose,
+  onSelect,
 }: {
   plan: Readonly<PlanConfig>;
-  onClose: () => void;
+  onSelect: (tier: "pro" | "team") => void;
 }) {
   const isCurrentPlan = plan.cta === "Current plan";
 
@@ -175,7 +178,7 @@ function PlanCard({
           <Button
             size="sm"
             className="w-full rounded-lg h-9 text-xs"
-            onClick={() => onClose()}
+            onClick={() => plan.tier && onSelect(plan.tier)}
           >
             {plan.cta}
           </Button>
@@ -185,7 +188,7 @@ function PlanCard({
             size="sm"
             className="w-full rounded-lg h-9 text-xs"
             style={cardBorder}
-            onClick={() => onClose()}
+            onClick={() => plan.tier && onSelect(plan.tier)}
           >
             {plan.cta}
           </Button>
@@ -198,9 +201,11 @@ function PlanCard({
 function PricingDialog({
   open,
   onOpenChange,
+  onSelectTier,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onSelectTier: (tier: "pro" | "team") => void;
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -224,11 +229,7 @@ function PricingDialog({
 
         <div className="grid grid-cols-3 gap-4 px-6 py-5">
           {PLANS.map((plan) => (
-            <PlanCard
-              key={plan.name}
-              plan={plan}
-              onClose={() => onOpenChange(false)}
-            />
+            <PlanCard key={plan.name} plan={plan} onSelect={onSelectTier} />
           ))}
         </div>
       </DialogContent>
@@ -237,36 +238,33 @@ function PricingDialog({
 }
 
 export function OrgBillingTab() {
-  const isPro = useGet(billingIsPro$);
-  const setIsPro = useSet(setBillingIsPro$);
-  const pricingOpen = useGet(billingPricingOpen$);
-  const setPricingOpen = useSet(setBillingPricingOpen$);
+  const billingLoadable = useLastLoadable(billingStatusAsync$);
+  const checkout = useSet(startCheckout$);
+  const downgrade = useSet(startDowngrade$);
+  const [pricingOpen, setPricingOpen] = useState(false);
+
+  const isPro =
+    billingLoadable.state === "hasData" && billingLoadable.data.tier !== "free";
+
+  const tierLabel =
+    billingLoadable.state === "hasData"
+      ? `${billingLoadable.data.tier.charAt(0).toUpperCase()}${billingLoadable.data.tier.slice(1)} plan`
+      : "Loading...";
+
+  const handleSelectTier = (tier: "pro" | "team") => {
+    setPricingOpen(false);
+    checkout(tier).catch(() => {});
+  };
 
   return (
     <div className="flex flex-col gap-8">
       <section className="flex flex-col gap-3">
-        <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium text-foreground">Plan</h3>
-          <div className="flex items-center gap-2">
-            <label
-              htmlFor="plan-toggle"
-              className="text-xs text-muted-foreground cursor-pointer"
-            >
-              Preview Pro
-            </label>
-            <Switch
-              id="plan-toggle"
-              checked={isPro}
-              onCheckedChange={setIsPro}
-              className="scale-75"
-            />
-          </div>
-        </div>
+        <h3 className="text-sm font-medium text-foreground">Plan</h3>
         <div className="overflow-hidden rounded-xl bg-card" style={cardBorder}>
           <div className="flex items-center justify-between gap-4 px-5 py-4">
             <div className="flex flex-col gap-0.5 min-w-0">
               <span className="text-sm font-medium text-foreground flex items-center gap-2">
-                {isPro ? "Pro plan" : "Free plan"}
+                {tierLabel}
               </span>
               <span className="text-[13px] text-muted-foreground">
                 Your current plan
@@ -276,10 +274,14 @@ export function OrgBillingTab() {
               <Button
                 variant="outline"
                 size="sm"
-                className="shrink-0 rounded-lg h-8 text-xs"
+                className="shrink-0 rounded-lg h-8 text-xs gap-1.5"
                 style={cardBorder}
+                onClick={() => {
+                  downgrade().catch(() => {});
+                }}
               >
-                Downgrade
+                Manage billing
+                <IconExternalLink size={13} stroke={1.5} />
               </Button>
             ) : (
               <Button
@@ -309,12 +311,12 @@ export function OrgBillingTab() {
                   size="sm"
                   className="shrink-0 rounded-lg h-8 text-xs gap-1.5"
                   style={cardBorder}
-                  asChild
+                  onClick={() => {
+                    downgrade().catch(() => {});
+                  }}
                 >
-                  <a href="#" target="_blank" rel="noopener noreferrer">
-                    Manage
-                    <IconExternalLink size={13} stroke={1.5} />
-                  </a>
+                  Manage
+                  <IconExternalLink size={13} stroke={1.5} />
                 </Button>
               </div>
             </>
@@ -380,7 +382,11 @@ export function OrgBillingTab() {
         </div>
       </section>
 
-      <PricingDialog open={pricingOpen} onOpenChange={setPricingOpen} />
+      <PricingDialog
+        open={pricingOpen}
+        onOpenChange={setPricingOpen}
+        onSelectTier={handleSelectTier}
+      />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -7,6 +7,7 @@ import {
   startDowngrade$,
 } from "../../../../signals/zero-page/billing.ts";
 import { Button, Dialog, DialogContent } from "@vm0/ui";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import planFreeImg from "./assets/plan-free.webp";
 import planProImg from "./assets/plan-pro.webp";
 import planTeamImg from "./assets/plan-team.webp";
@@ -253,7 +254,9 @@ export function OrgBillingTab() {
 
   const handleSelectTier = (tier: "pro" | "team") => {
     setPricingOpen(false);
-    checkout(tier).catch(() => {});
+    checkout(tier).catch(() => {
+      toast.error("Failed to start checkout. Please try again.");
+    });
   };
 
   return (
@@ -277,7 +280,11 @@ export function OrgBillingTab() {
                 className="shrink-0 rounded-lg h-8 text-xs gap-1.5"
                 style={cardBorder}
                 onClick={() => {
-                  downgrade().catch(() => {});
+                  downgrade().catch(() => {
+                    toast.error(
+                      "Failed to open billing portal. Please try again.",
+                    );
+                  });
                 }}
               >
                 Manage billing
@@ -312,7 +319,11 @@ export function OrgBillingTab() {
                   className="shrink-0 rounded-lg h-8 text-xs gap-1.5"
                   style={cardBorder}
                   onClick={() => {
-                    downgrade().catch(() => {});
+                    downgrade().catch(() => {
+                      toast.error(
+                        "Failed to open billing portal. Please try again.",
+                      );
+                    });
                   }}
                 >
                   Manage

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-credits-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-credits-tab.tsx
@@ -8,6 +8,7 @@ import {
   setMemberCreditCap$,
 } from "../../../../signals/zero-page/member-credit-caps.ts";
 import { Button, Input } from "@vm0/ui";
+import { toast } from "@vm0/ui/components/ui/sonner";
 
 const sectionCardStyle = {
   border: "0.7px solid hsl(var(--gray-400))",
@@ -33,12 +34,16 @@ function MemberCapEditor({
     if (parsed !== null && (Number.isNaN(parsed) || parsed <= 0)) {
       return;
     }
-    setCap({ userId, creditCap: parsed }).catch(() => {});
+    setCap({ userId, creditCap: parsed }).catch(() => {
+      toast.error("Failed to update credit cap. Please try again.");
+    });
     setEditing(false);
   };
 
   const handleClear = () => {
-    setCap({ userId, creditCap: null }).catch(() => {});
+    setCap({ userId, creditCap: null }).catch(() => {
+      toast.error("Failed to clear credit cap. Please try again.");
+    });
     setEditing(false);
   };
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-credits-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-credits-tab.tsx
@@ -1,8 +1,126 @@
+import { useState } from "react";
+import { useLastLoadable, useSet } from "ccstate-react";
+import { billingStatusAsync$ } from "../../../../signals/zero-page/billing.ts";
+import { usageMembersAsync$ } from "../../../../signals/usage-page/usage-signals.ts";
+import { isOrgAdmin$ } from "../../../../signals/org.ts";
+import {
+  memberCreditCaps$,
+  setMemberCreditCap$,
+} from "../../../../signals/zero-page/member-credit-caps.ts";
+import { Button, Input } from "@vm0/ui";
+
 const sectionCardStyle = {
   border: "0.7px solid hsl(var(--gray-400))",
 } as const;
 
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+function MemberCapEditor({
+  userId,
+  currentCap,
+}: {
+  userId: string;
+  currentCap: number | null;
+}) {
+  const setCap = useSet(setMemberCreditCap$);
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(currentCap?.toString() ?? "");
+
+  const handleSave = () => {
+    const parsed = value.trim() === "" ? null : Number.parseInt(value, 10);
+    if (parsed !== null && (Number.isNaN(parsed) || parsed <= 0)) {
+      return;
+    }
+    setCap({ userId, creditCap: parsed }).catch(() => {});
+    setEditing(false);
+  };
+
+  const handleClear = () => {
+    setCap({ userId, creditCap: null }).catch(() => {});
+    setEditing(false);
+  };
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setValue(currentCap?.toString() ?? "");
+          setEditing(true);
+        }}
+        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {currentCap !== null ? formatNumber(currentCap) : "No limit"}
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Input
+        type="number"
+        min={1}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="h-7 w-20 text-xs"
+        placeholder="No limit"
+        autoFocus
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            handleSave();
+          }
+          if (e.key === "Escape") {
+            setEditing(false);
+          }
+        }}
+      />
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 text-xs px-2"
+        onClick={handleSave}
+      >
+        Save
+      </Button>
+      {currentCap !== null && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 text-xs px-2"
+          onClick={handleClear}
+        >
+          Clear
+        </Button>
+      )}
+    </div>
+  );
+}
+
 export function OrgCreditsTab() {
+  const billingLoadable = useLastLoadable(billingStatusAsync$);
+  const usageLoadable = useLastLoadable(usageMembersAsync$);
+  const capsLoadable = useLastLoadable(memberCreditCaps$);
+  const isAdminLoadable = useLastLoadable(isOrgAdmin$);
+  const isAdmin =
+    isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
+
+  const credits =
+    billingLoadable.state === "hasData" ? billingLoadable.data.credits : null;
+  const tier =
+    billingLoadable.state === "hasData" ? billingLoadable.data.tier : null;
+  const periodEnd =
+    billingLoadable.state === "hasData"
+      ? billingLoadable.data.currentPeriodEnd
+      : null;
+
+  const members =
+    usageLoadable.state === "hasData" ? usageLoadable.data.members : [];
+  const totalUsage = members.reduce((sum, m) => sum + m.creditsCharged, 0);
+
+  const caps = capsLoadable.state === "hasData" ? capsLoadable.data : new Map();
+
   return (
     <div className="flex flex-col gap-8">
       <section className="flex flex-col gap-3">
@@ -21,29 +139,83 @@ export function OrgCreditsTab() {
               </span>
             </div>
             <span className="text-lg font-semibold text-foreground tabular-nums shrink-0">
-              0
+              {credits !== null ? formatNumber(credits) : "--"}
             </span>
           </div>
           <div className="h-px bg-border/40 mx-5" />
           <div className="flex items-center justify-between gap-4 px-5 py-4">
             <div className="flex flex-col gap-0.5 min-w-0">
               <span className="text-sm font-medium text-foreground">
-                Usage this month
+                Usage this period
               </span>
               <span className="text-[13px] text-muted-foreground">
-                Total credits consumed in the current billing period
+                {periodEnd
+                  ? `Current billing period ends ${new Date(periodEnd).toLocaleDateString()}`
+                  : "Total credits consumed in the current billing period"}
               </span>
             </div>
             <span className="text-sm text-muted-foreground tabular-nums shrink-0">
-              0 / 1,000
+              {formatNumber(totalUsage)}
             </span>
           </div>
+          {tier !== null && tier !== "free" && (
+            <>
+              <div className="h-px bg-border/40 mx-5" />
+              <div className="flex items-center justify-between gap-4 px-5 py-4">
+                <div className="flex flex-col gap-0.5 min-w-0">
+                  <span className="text-sm font-medium text-foreground">
+                    Plan
+                  </span>
+                  <span className="text-[13px] text-muted-foreground">
+                    {tier.charAt(0).toUpperCase() + tier.slice(1)} tier
+                  </span>
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </section>
 
-      <p className="text-[13px] text-muted-foreground/60">
-        Credit management coming soon.
-      </p>
+      {members.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <h3 className="text-sm font-medium text-foreground">Member usage</h3>
+          <div
+            className="overflow-hidden rounded-xl bg-card"
+            style={sectionCardStyle}
+          >
+            <div className="grid grid-cols-[1fr_6rem_6rem] gap-x-4 px-5 py-3 text-sm font-medium text-foreground">
+              <div>Member</div>
+              <div className="text-right">Credits used</div>
+              {isAdmin && <div className="text-right">Cap</div>}
+            </div>
+            {members.map((member, i) => {
+              const cap = caps.get(member.userId);
+              return (
+                <div key={member.userId}>
+                  {i === 0 && <div className="h-px bg-border/40 mx-5" />}
+                  {i > 0 && <div className="h-px bg-border/40 mx-5" />}
+                  <div className="grid grid-cols-[1fr_6rem_6rem] gap-x-4 items-center px-5 py-3">
+                    <span className="text-sm text-muted-foreground truncate">
+                      {member.email}
+                    </span>
+                    <span className="text-sm text-muted-foreground tabular-nums text-right">
+                      {formatNumber(member.creditsCharged)}
+                    </span>
+                    {isAdmin && (
+                      <div className="flex justify-end">
+                        <MemberCapEditor
+                          userId={member.userId}
+                          currentCap={cap?.creditCap ?? null}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -1,19 +1,42 @@
+import { useLastLoadable } from "ccstate-react";
 import { IconCircleCheck, IconDownload } from "@tabler/icons-react";
 import { cn } from "@vm0/ui";
+import { invoicesAsync$ } from "../../../../signals/zero-page/billing.ts";
 
 const cardBorder = { border: "0.7px solid hsl(var(--gray-400))" } as const;
 
 const ROW_GRID = "grid grid-cols-[1fr_8rem_6rem_3rem] gap-x-6 items-center";
 
-const MOCK_INVOICES = [
-  { id: "INV-2026-003", date: "3/1/2026", amount: "$40.00", status: "Paid" },
-  { id: "INV-2026-002", date: "2/1/2026", amount: "$40.00", status: "Paid" },
-  { id: "INV-2026-001", date: "1/1/2026", amount: "$40.00", status: "Paid" },
-  { id: "INV-2025-012", date: "12/1/2025", amount: "$49.00", status: "Paid" },
-  { id: "INV-2025-011", date: "11/1/2025", amount: "$40.00", status: "Paid" },
-] as const;
+function formatDate(unixTimestamp: number): string {
+  return new Date(unixTimestamp * 1000).toLocaleDateString();
+}
+
+function formatAmount(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
 
 export function OrgInvoicesTab() {
+  const invoicesLoadable = useLastLoadable(invoicesAsync$);
+
+  const invoices =
+    invoicesLoadable.state === "hasData" ? invoicesLoadable.data.invoices : [];
+
+  if (invoicesLoadable.state === "loading") {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-muted-foreground">Loading invoices...</p>
+      </div>
+    );
+  }
+
+  if (invoices.length === 0) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-muted-foreground">No invoices yet.</p>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <div
@@ -33,39 +56,49 @@ export function OrgInvoicesTab() {
         </div>
         <div className="h-px bg-border/40 mx-4" />
 
-        {MOCK_INVOICES.map((inv, i) => (
+        {invoices.map((inv, i) => (
           <div key={inv.id}>
             {i > 0 && <div className="h-px bg-border/40 mx-4" />}
             <div className={cn(ROW_GRID, "px-4 py-3")}>
               <div className="flex items-center gap-3 min-w-0">
                 <span className="text-sm font-medium text-foreground truncate">
-                  {inv.id}
+                  {inv.number ?? inv.id}
                 </span>
-                <span
-                  className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground"
-                  style={{
-                    border: "0.7px solid hsl(var(--gray-400))",
-                    backgroundColor: "hsl(var(--gray-0))",
-                  }}
-                >
-                  <IconCircleCheck size={12} className="text-green-600" />
-                  {inv.status}
-                </span>
+                {inv.status && (
+                  <span
+                    className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                    style={{
+                      border: "0.7px solid hsl(var(--gray-400))",
+                      backgroundColor: "hsl(var(--gray-0))",
+                    }}
+                  >
+                    <IconCircleCheck size={12} className="text-green-600" />
+                    {inv.status.charAt(0).toUpperCase() + inv.status.slice(1)}
+                  </span>
+                )}
               </div>
               <div className="text-left text-sm text-muted-foreground tabular-nums">
-                {inv.date}
+                {formatDate(inv.date)}
               </div>
               <div className="text-left text-sm text-foreground tabular-nums">
-                {inv.amount}
+                {formatAmount(inv.amount)}
               </div>
               <div className="flex justify-end">
-                <button
-                  type="button"
-                  className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-                  aria-label="Download invoice"
-                >
-                  <IconDownload size={14} stroke={1.5} />
-                </button>
+                {inv.hostedInvoiceUrl ? (
+                  <a
+                    href={inv.hostedInvoiceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                    aria-label="Download invoice"
+                  >
+                    <IconDownload size={14} stroke={1.5} />
+                  </a>
+                ) : (
+                  <span className="flex h-7 w-7 items-center justify-center text-muted-foreground/30">
+                    <IconDownload size={14} stroke={1.5} />
+                  </span>
+                )}
               </div>
             </div>
           </div>

--- a/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -21,6 +21,7 @@ import { reloadEnv } from "../../../../../src/env";
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
   invoicesRetrieve: vi.fn(),
+  invoicesList: vi.fn(),
   customersCreate: vi.fn(),
   checkoutSessionsCreate: vi.fn(),
   billingPortalSessionsCreate: vi.fn(),
@@ -31,7 +32,10 @@ vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
       subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
-      invoices: { retrieve: stripeMocks.invoicesRetrieve },
+      invoices: {
+        retrieve: stripeMocks.invoicesRetrieve,
+        list: stripeMocks.invoicesList,
+      },
       customers: { create: stripeMocks.customersCreate },
       checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
       billingPortal: {

--- a/turbo/apps/web/app/api/zero/billing/checkout/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/checkout/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import { reloadEnv } from "../../../../../../src/env";
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
   invoicesRetrieve: vi.fn(),
+  invoicesList: vi.fn(),
   customersCreate: vi.fn(),
   checkoutSessionsCreate: vi.fn(),
   billingPortalSessionsCreate: vi.fn(),
@@ -21,7 +22,10 @@ vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
       subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
-      invoices: { retrieve: stripeMocks.invoicesRetrieve },
+      invoices: {
+        retrieve: stripeMocks.invoicesRetrieve,
+        list: stripeMocks.invoicesList,
+      },
       customers: { create: stripeMocks.customersCreate },
       checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
       billingPortal: {

--- a/turbo/apps/web/app/api/zero/billing/invoices/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/invoices/__tests__/route.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  updateOrgStripeFields,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock";
+import { reloadEnv } from "../../../../../../src/env";
+
+const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
+  subscriptionsRetrieve: vi.fn(),
+  invoicesRetrieve: vi.fn(),
+  invoicesList: vi.fn(),
+  customersCreate: vi.fn(),
+  checkoutSessionsCreate: vi.fn(),
+  billingPortalSessionsCreate: vi.fn(),
+  constructEvent: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: function MockStripe() {
+    return {
+      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      invoices: {
+        retrieve: stripeMocks.invoicesRetrieve,
+        list: stripeMocks.invoicesList,
+      },
+      customers: { create: stripeMocks.customersCreate },
+      checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+      billingPortal: {
+        sessions: { create: stripeMocks.billingPortalSessionsCreate },
+      },
+      webhooks: { constructEvent: stripeMocks.constructEvent },
+    };
+  },
+}));
+
+import { GET } from "../route";
+
+const context = testContext();
+
+describe("GET /api/zero/billing/invoices", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+    reloadEnv();
+
+    stripeMocks.invoicesList.mockReset();
+  });
+
+  it("returns invoices for org with active subscription", async () => {
+    const { orgId } = await context.setupUser({ prefix: "inv-user" });
+    const customerId = uniqueId("cus-inv");
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: uniqueId("sub-inv"),
+      subscriptionStatus: "active",
+      tier: "pro",
+    });
+
+    stripeMocks.invoicesList.mockResolvedValue({
+      data: [
+        {
+          id: "inv_001",
+          number: "INV-2026-001",
+          created: 1740000000,
+          amount_paid: 4000,
+          status: "paid",
+          hosted_invoice_url: "https://stripe.com/invoice/inv_001",
+        },
+        {
+          id: "inv_002",
+          number: "INV-2026-002",
+          created: 1737400000,
+          amount_paid: 4000,
+          status: "paid",
+          hosted_invoice_url: "https://stripe.com/invoice/inv_002",
+        },
+      ],
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/invoices",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.invoices).toHaveLength(2);
+    expect(data.invoices[0]).toEqual({
+      id: "inv_001",
+      number: "INV-2026-001",
+      date: 1740000000,
+      amount: 4000,
+      status: "paid",
+      hostedInvoiceUrl: "https://stripe.com/invoice/inv_001",
+    });
+    expect(data.invoices[1]).toEqual({
+      id: "inv_002",
+      number: "INV-2026-002",
+      date: 1737400000,
+      amount: 4000,
+      status: "paid",
+      hostedInvoiceUrl: "https://stripe.com/invoice/inv_002",
+    });
+  });
+
+  it("returns empty array for org without Stripe customer", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/invoices",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.invoices).toEqual([]);
+  });
+
+  it("returns empty array when Stripe returns no invoices", async () => {
+    const { orgId } = await context.setupUser({ prefix: "empty-inv" });
+    const customerId = uniqueId("cus-empty");
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: customerId,
+      stripeSubscriptionId: uniqueId("sub-empty"),
+      subscriptionStatus: "active",
+      tier: "pro",
+    });
+
+    stripeMocks.invoicesList.mockResolvedValue({ data: [] });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/invoices",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.invoices).toEqual([]);
+  });
+});

--- a/turbo/apps/web/app/api/zero/billing/invoices/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/invoices/route.ts
@@ -1,0 +1,38 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroBillingInvoicesContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { getOrgInvoices } from "../../../../../src/lib/billing/billing-service";
+
+const router = tsr.router(zeroBillingInvoicesContract, {
+  get: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org } = await resolveOrg(authCtx, orgSlug);
+
+    const result = await getOrgInvoices(org.orgId);
+
+    return {
+      status: 200 as const,
+      body: result,
+    };
+  },
+});
+
+const handler = createHandler(zeroBillingInvoicesContract, router, {
+  errorHandler: createSafeErrorHandler("zero-billing-invoices"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/billing/portal/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/portal/__tests__/route.test.ts
@@ -15,6 +15,7 @@ import { reloadEnv } from "../../../../../../src/env";
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
   invoicesRetrieve: vi.fn(),
+  invoicesList: vi.fn(),
   customersCreate: vi.fn(),
   checkoutSessionsCreate: vi.fn(),
   billingPortalSessionsCreate: vi.fn(),
@@ -25,7 +26,10 @@ vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
       subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
-      invoices: { retrieve: stripeMocks.invoicesRetrieve },
+      invoices: {
+        retrieve: stripeMocks.invoicesRetrieve,
+        list: stripeMocks.invoicesList,
+      },
       customers: { create: stripeMocks.customersCreate },
       checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
       billingPortal: {

--- a/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
@@ -13,6 +13,7 @@ import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock"
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
   invoicesRetrieve: vi.fn(),
+  invoicesList: vi.fn(),
   customersCreate: vi.fn(),
   checkoutSessionsCreate: vi.fn(),
   billingPortalSessionsCreate: vi.fn(),
@@ -23,7 +24,10 @@ vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
       subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
-      invoices: { retrieve: stripeMocks.invoicesRetrieve },
+      invoices: {
+        retrieve: stripeMocks.invoicesRetrieve,
+        list: stripeMocks.invoicesList,
+      },
       customers: { create: stripeMocks.customersCreate },
       checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
       billingPortal: {

--- a/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
@@ -14,6 +14,7 @@ import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock"
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
   invoicesRetrieve: vi.fn(),
+  invoicesList: vi.fn(),
   customersCreate: vi.fn(),
   checkoutSessionsCreate: vi.fn(),
   billingPortalSessionsCreate: vi.fn(),
@@ -24,7 +25,10 @@ vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
       subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
-      invoices: { retrieve: stripeMocks.invoicesRetrieve },
+      invoices: {
+        retrieve: stripeMocks.invoicesRetrieve,
+        list: stripeMocks.invoicesList,
+      },
       customers: { create: stripeMocks.customersCreate },
       checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
       billingPortal: {

--- a/turbo/apps/web/src/__tests__/stripe-mock.ts
+++ b/turbo/apps/web/src/__tests__/stripe-mock.ts
@@ -14,6 +14,7 @@ import type { Mock } from "vitest";
  * const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
  *   subscriptionsRetrieve: vi.fn(),
  *   invoicesRetrieve: vi.fn(),
+ *   invoicesList: vi.fn(),
  *   customersCreate: vi.fn(),
  *   checkoutSessionsCreate: vi.fn(),
  *   billingPortalSessionsCreate: vi.fn(),
@@ -24,7 +25,7 @@ import type { Mock } from "vitest";
  *   default: function MockStripe() {
  *     return {
  *       subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
- *       invoices: { retrieve: stripeMocks.invoicesRetrieve },
+ *       invoices: { retrieve: stripeMocks.invoicesRetrieve, list: stripeMocks.invoicesList },
  *       customers: { create: stripeMocks.customersCreate },
  *       checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
  *       billingPortal: { sessions: { create: stripeMocks.billingPortalSessionsCreate } },
@@ -37,6 +38,7 @@ import type { Mock } from "vitest";
 export interface StripeMockFns {
   subscriptionsRetrieve: Mock;
   invoicesRetrieve: Mock;
+  invoicesList: Mock;
   customersCreate: Mock;
   checkoutSessionsCreate: Mock;
   billingPortalSessionsCreate: Mock;

--- a/turbo/apps/web/src/lib/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/billing/billing-service.ts
@@ -490,6 +490,49 @@ export async function updateAutoRechargeConfig(
 }
 
 /**
+ * Get invoices for an org from Stripe.
+ * Returns an empty array if the org has no Stripe customer.
+ */
+export async function getOrgInvoices(orgId: string): Promise<{
+  invoices: Array<{
+    id: string;
+    number: string | null;
+    date: number;
+    amount: number;
+    status: string | null;
+    hostedInvoiceUrl: string | null;
+  }>;
+}> {
+  const db = globalThis.services.db;
+  const [row] = await db
+    .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  if (!row?.stripeCustomerId) {
+    return { invoices: [] };
+  }
+
+  const stripe = getStripe();
+  const result = await stripe.invoices.list({
+    customer: row.stripeCustomerId,
+    limit: 24,
+  });
+
+  const invoices = result.data.map((inv) => ({
+    id: inv.id,
+    number: inv.number ?? null,
+    date: inv.created,
+    amount: inv.amount_paid ?? 0,
+    status: inv.status ?? null,
+    hostedInvoiceUrl: inv.hosted_invoice_url ?? null,
+  }));
+
+  return { invoices };
+}
+
+/**
  * Get billing status for an org.
  */
 export async function getBillingStatus(orgId: string): Promise<{

--- a/turbo/apps/web/src/lib/org/__tests__/org-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-cache-service.test.ts
@@ -23,6 +23,7 @@ import {
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
   invoicesRetrieve: vi.fn(),
+  invoicesList: vi.fn(),
   customersCreate: vi.fn(),
   checkoutSessionsCreate: vi.fn(),
   billingPortalSessionsCreate: vi.fn(),
@@ -33,7 +34,10 @@ vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
       subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
-      invoices: { retrieve: stripeMocks.invoicesRetrieve },
+      invoices: {
+        retrieve: stripeMocks.invoicesRetrieve,
+        list: stripeMocks.invoicesList,
+      },
       customers: { create: stripeMocks.customersCreate },
       checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
       billingPortal: {

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -581,15 +581,19 @@ export {
   zeroBillingCheckoutContract,
   zeroBillingPortalContract,
   zeroBillingAutoRechargeContract,
+  zeroBillingInvoicesContract,
   type ZeroBillingStatusContract,
   type ZeroBillingCheckoutContract,
   type ZeroBillingPortalContract,
   type ZeroBillingAutoRechargeContract,
+  type ZeroBillingInvoicesContract,
   // Inferred types
   type BillingStatusResponse,
   type AutoRechargeConfig,
   type CheckoutResponse,
   type PortalResponse,
+  type BillingInvoice,
+  type BillingInvoicesResponse,
 } from "./zero-billing";
 export {
   zeroUsageMembersContract,

--- a/turbo/packages/core/src/contracts/zero-billing.ts
+++ b/turbo/packages/core/src/contracts/zero-billing.ts
@@ -152,8 +152,44 @@ export const zeroBillingAutoRechargeContract = c.router({
 export type ZeroBillingAutoRechargeContract =
   typeof zeroBillingAutoRechargeContract;
 
+/**
+ * Zero contract for GET /api/zero/billing/invoices
+ */
+const invoiceSchema = z.object({
+  id: z.string(),
+  number: z.string().nullable(),
+  date: z.number(),
+  amount: z.number(),
+  status: z.string().nullable(),
+  hostedInvoiceUrl: z.string().nullable(),
+});
+
+const billingInvoicesResponseSchema = z.object({
+  invoices: z.array(invoiceSchema),
+});
+
+export const zeroBillingInvoicesContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/billing/invoices",
+    headers: authHeadersSchema,
+    responses: {
+      200: billingInvoicesResponseSchema,
+      401: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get invoices for current org",
+  },
+});
+
+export type ZeroBillingInvoicesContract = typeof zeroBillingInvoicesContract;
+
 // Inferred types from Zod schemas
 export type BillingStatusResponse = z.infer<typeof billingStatusResponseSchema>;
 export type AutoRechargeConfig = z.infer<typeof autoRechargeSchema>;
 export type CheckoutResponse = z.infer<typeof checkoutResponseSchema>;
 export type PortalResponse = z.infer<typeof portalResponseSchema>;
+export type BillingInvoice = z.infer<typeof invoiceSchema>;
+export type BillingInvoicesResponse = z.infer<
+  typeof billingInvoicesResponseSchema
+>;


### PR DESCRIPTION
## Summary

- Wire all 3 billing-related tabs (Billing, Credits, Invoices) in the org management dialog to consume real API data instead of hardcoded mockups
- Add new `GET /api/zero/billing/invoices` backend endpoint backed by `stripe.invoices.list`
- Create `member-credit-caps.ts` signal module for admin credit cap management
- Clean up unused mock billing signals (`billingIsPro$`, `setBillingIsPro$`, etc.)

All changes are behind `FeatureSwitchKey.Pricing` (staff-only).

## Changes

### Billing Tab
- Replace "Preview Pro" toggle with real billing status from `billingStatusAsync$`
- Wire Upgrade button to `startCheckout$` (Stripe checkout)
- Wire "Manage billing" to `startDowngrade$` (Stripe portal)

### Credits Tab
- Display real credit balance from `billingStatusAsync$`
- Display per-member usage from `usageMembersAsync$`
- Add admin-only member credit cap editing via new `memberCreditCaps$`/`setMemberCreditCap$` signals

### Invoices Tab
- New `zeroBillingInvoicesContract` in `@vm0/core`
- New `getOrgInvoices()` in `billing-service.ts`
- New route handler at `/api/zero/billing/invoices`
- New `invoicesAsync$` signal
- Download button links to Stripe hosted invoice URL

### Cleanup
- Remove `billingIsPro$`, `setBillingIsPro$`, `billingPricingOpen$`, `setBillingPricingOpen$` from `org-manage-tabs-state.ts`
- Add `invoicesList` to `StripeMockFns` interface

## Test plan

- [x] 3 backend integration tests for invoices endpoint (field mapping, empty customer, empty invoices)
- [x] All 4083 existing tests pass
- [x] Type check passes (`check-types`)
- [x] Lint passes (oxlint + eslint)
- [x] Knip passes (no dead exports)
- [x] Format passes (prettier)

Closes #6645

🤖 Generated with [Claude Code](https://claude.com/claude-code)