### PR TITLE
fix(cli): remove redundant EPIPE handlers from entry points

### DIFF
--- a/turbo/apps/cli/src/index.ts
+++ b/turbo/apps/cli/src/index.ts
@@ -49,16 +49,6 @@ if (
   process.argv[1]?.endsWith("index.ts") ||
   process.argv[1]?.endsWith("vm0")
 ) {
-  // Handle EPIPE gracefully (e.g., `vm0 logs ... | head`)
-  process.stdout.on("error", (err) => {
-    if (err.code === "EPIPE") process.exit(0);
-    throw err;
-  });
-  process.stderr.on("error", (err) => {
-    if (err.code === "EPIPE") process.exit(0);
-    throw err;
-  });
-
   configureGlobalProxyFromEnv();
   program.parse();
 }

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -78,16 +78,6 @@ if (
   process.argv[1]?.endsWith("zero.ts") ||
   process.argv[1]?.endsWith("zero")
 ) {
-  // Handle EPIPE gracefully (e.g., `zero schedule list | head`)
-  process.stdout.on("error", (err) => {
-    if (err.code === "EPIPE") process.exit(0);
-    throw err;
-  });
-  process.stderr.on("error", (err) => {
-    if (err.code === "EPIPE") process.exit(0);
-    throw err;
-  });
-
   configureGlobalProxyFromEnv();
   applyCapabilityVisibility(program);
   program.parse();


### PR DESCRIPTION
## Summary

Closes #6694

- Remove duplicate EPIPE error handlers from `src/index.ts` and `src/zero.ts`
- The global handler in `src/instrument.ts` (imported first by both entry points) already covers both binaries
- Pure deletion of ~18 lines of redundant code, no behavioral change

## Test plan

- [x] Existing `instrument.test.ts` EPIPE tests pass (4/4)
- [x] Full CLI test suite passes (815 tests)
- [x] Lint, type check, format, and knip all pass
- [x] No new tests needed — removed code was a duplicate of already-tested behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)