### PR TITLE
refactor(web): rename firewall type variable for clarity

### DIFF
--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -772,11 +772,11 @@ async function resolveSecretsAndEnvironment(
 
   // Auto-generate firewall entry for model provider (if applicable).
   // For meta-providers like "vm0", use the concrete provider type for firewall lookup.
-  const firewallType =
+  const modelProviderFirewallType =
     modelProviderResult.concreteProviderType ??
     modelProviderResult.resolvedModelProvider;
-  const modelProviderFirewall = firewallType
-    ? getModelProviderFirewall(firewallType)
+  const modelProviderFirewall = modelProviderFirewallType
+    ? getModelProviderFirewall(modelProviderFirewallType)
     : undefined;
 
   // Expand environment variables from compose config.


### PR DESCRIPTION
## Summary

- Rename `firewallType` to `modelProviderFirewallType` in `build-context.ts`
- The old name was ambiguous — it sounded like "type of firewall" rather than "model provider type used for firewall lookup"

## Test plan

- [ ] No behavioral change, rename only

🤖 Generated with [Claude Code](https://claude.com/claude-code)