### PR TITLE
refactor: replace cert.pem with api token for cloudflared tunnel

### DIFF
--- a/.claude/skills/dev-server-bug-report/SKILL.md
+++ b/.claude/skills/dev-server-bug-report/SKILL.md
@@ -28,7 +28,7 @@ Scan the current conversation for traces of the following 7 dev server operation
 | Health check | `pnpm dev:status`, curl to `https://www.vm7.ai:8443` / `app.vm7.ai:8443` / `docs.vm7.ai:8443` |
 | Database migration | `pnpm db:migrate` (Drizzle ORM + PostgreSQL), connection failures, migration errors |
 | Log viewing | `TaskOutput` reads, `/dev-logs` invocations, runtime errors in output |
-| SSL certificates | Caddy auto-provisions via Let's Encrypt DNS-01 challenge, requires `CF_DNS_API_TOKEN` |
+| SSL certificates | Caddy auto-provisions via Let's Encrypt DNS-01 challenge, requires `CF_DNS_AND_TUNNEL_API_TOKEN` |
 | Chrome/VNC | `scripts/start-vnc.sh` (Xvfb + openbox + x11vnc + noVNC + Chrome CDP:9222), crashes, CDP unreachable |
 | Agent-Browser | `agent-browser open/snapshot/click`, `agent-browser.json` config, CDP connection failures, timeouts |
 

--- a/.claude/skills/local-testing/skill.md
+++ b/.claude/skills/local-testing/skill.md
@@ -286,7 +286,7 @@ scripts/sync-env.sh
 
 ### Problem: SSL Certificate Errors
 
-**Cause**: `CF_DNS_API_TOKEN` not set. Caddy needs this to provision Let's Encrypt certificates via DNS-01 challenge.
+**Cause**: `CF_DNS_AND_TUNNEL_API_TOKEN` not set. Caddy needs this to provision Let's Encrypt certificates via DNS-01 challenge.
 
 **Solution**:
 ```bash

--- a/scripts/.env.local.tpl
+++ b/scripts/.env.local.tpl
@@ -2,8 +2,9 @@
 CF_ACCESS_CLIENT_ID=op://Development/vm0/CF_ACCESS_CLIENT_ID_METAL
 CF_ACCESS_CLIENT_SECRET=op://Development/vm0/CF_ACCESS_CLIENT_SECRET_METAL
 
-# Cloudflare DNS API token for Let's Encrypt certificate provisioning (Zone:DNS:Edit on vm7.ai)
-CF_DNS_API_TOKEN=op://Development/cloudflare/CF_DNS_API_TOKEN
+# Cloudflare API token for DNS (Let's Encrypt) and Tunnel management (Zone:DNS:Edit + Account:Tunnel:Edit on vm7.ai)
+CF_DNS_AND_TUNNEL_API_TOKEN=op://Development/cloudflare/CF_DNS_AND_TUNNEL_API_TOKEN
+CF_ACCOUNT_ID=op://Development/cloudflare/CF_ACCOUNT_ID
 
 # Metal host for runner deployment (e.g. dev-1.aws.vm3.ai)
 RUNNER_LOCAL_HOST=op://Development/vm0/RUNNER_LOCAL_HOST

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -11,13 +11,32 @@
 # Port-to-service mapping: 3000=web, 3001=docs, 3002=app
 # Otherwise, creates an anonymous quick tunnel:
 #   <random>.trycloudflare.com
+#
+# Named tunnels use the Cloudflare API (CF_DNS_AND_TUNNEL_API_TOKEN + CF_ACCOUNT_ID)
+# to manage tunnels without requiring interactive `cloudflared tunnel login`.
 
 set -euo pipefail
 
 TUNNEL_BASE_DOMAIN="vm7.ai"
 MAX_WAIT=30
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 log() { echo -e "[tunnel] $1" >&2; }
+
+# --- Load env from scripts/.env.local if not already set ---
+load_env() {
+  local var="$1"
+  if [[ -z "${!var:-}" ]]; then
+    local env_file="$SCRIPT_DIR/.env.local"
+    if [[ -f "$env_file" ]]; then
+      local val
+      val=$(grep "^${var}=" "$env_file" 2>/dev/null | head -1 | cut -d= -f2-)
+      if [[ -n "$val" ]]; then
+        export "$var=$val"
+      fi
+    fi
+  fi
+}
 
 # --- Args ---
 if [[ $# -ne 1 ]]; then
@@ -45,7 +64,7 @@ else
   EMAIL=$(git config user.email 2>/dev/null || true)
   DOMAIN="${EMAIL##*@}"
 
-  if [[ "$DOMAIN" == "vm0.ai" ]] && [[ -f "$HOME/.cloudflared/cert.pem" ]]; then
+  if [[ "$DOMAIN" == "vm0.ai" ]]; then
     MODE="named"
     USERNAME="${EMAIL%%@*}"
     MACHINE_HOSTNAME=$(hostname)
@@ -62,57 +81,89 @@ else
     TUNNEL_NAME="tunnel-${USERNAME}-${MACHINE_HOSTNAME}-${SERVICE}"
     TUNNEL_URL="https://${FQDN}"
   else
-    if [[ "$DOMAIN" == "vm0.ai" ]]; then
-      log "Not authenticated (no cert.pem). Falling back to anonymous tunnel."
-      log "Run 'cloudflared tunnel login' to enable named tunnels."
-    fi
     MODE="anonymous"
   fi
 fi
 
-# --- Named tunnel setup ---
+# --- Named tunnel setup via Cloudflare API ---
 if [[ "$MODE" == "named" ]]; then
   log "Named tunnel: ${FQDN} -> localhost:${PORT}"
 
-  # Reuse existing tunnel or create a new one
-  TUNNEL_ID=$(cloudflared tunnel list --name "$TUNNEL_NAME" 2>/dev/null | { grep "$TUNNEL_NAME" || true; } | awk '{print $1}')
-  if [[ -n "$TUNNEL_ID" && -f "$HOME/.cloudflared/${TUNNEL_ID}.json" ]]; then
-    log "Reusing existing tunnel: ${TUNNEL_NAME}"
-  else
-    # Credentials missing — clean up and recreate
-    if [[ -n "$TUNNEL_ID" ]]; then
-      cloudflared tunnel cleanup "$TUNNEL_NAME" >/dev/null 2>&1 || true
-      cloudflared tunnel delete "$TUNNEL_NAME" >/dev/null 2>&1 || true
-    fi
-    log "Creating tunnel: ${TUNNEL_NAME}"
-    cloudflared tunnel create "$TUNNEL_NAME" >&2
-    TUNNEL_ID=$(cloudflared tunnel list --name "$TUNNEL_NAME" 2>/dev/null | { grep "$TUNNEL_NAME" || true; } | awk '{print $1}')
-  fi
-  if [[ -z "$TUNNEL_ID" ]]; then
-    log "Error: failed to get tunnel ID"
+  load_env CF_DNS_AND_TUNNEL_API_TOKEN
+  load_env CF_ACCOUNT_ID
+
+  if [[ -z "${CF_DNS_AND_TUNNEL_API_TOKEN:-}" || -z "${CF_ACCOUNT_ID:-}" ]]; then
+    log "Error: CF_DNS_AND_TUNNEL_API_TOKEN and CF_ACCOUNT_ID are required for named tunnels."
+    log "Run 'scripts/sync-env.sh' to sync them from 1Password."
     exit 1
   fi
 
-  CREDENTIALS_FILE="$HOME/.cloudflared/${TUNNEL_ID}.json"
+  CF_API="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel"
+  AUTH_HEADER="Authorization: Bearer ${CF_DNS_AND_TUNNEL_API_TOKEN}"
 
-  # Write config
-  CONFIG_FILE="$HOME/.cloudflared/config-${TUNNEL_NAME}.yml"
+  # Find existing tunnel by name
+  TUNNEL_RESPONSE=$(curl -sf "${CF_API}?name=${TUNNEL_NAME}&is_deleted=false" -H "$AUTH_HEADER")
+  TUNNEL_ID=$(echo "$TUNNEL_RESPONSE" | python3 -c "import sys,json; r=json.load(sys.stdin)['result']; print(r[0]['id'] if r else '')" 2>/dev/null || true)
+
+  if [[ -n "$TUNNEL_ID" ]]; then
+    log "Reusing existing tunnel: ${TUNNEL_NAME} (${TUNNEL_ID})"
+  else
+    # Create new tunnel
+    log "Creating tunnel: ${TUNNEL_NAME}"
+    CREATE_RESPONSE=$(curl -sf -X POST "$CF_API" \
+      -H "$AUTH_HEADER" \
+      -H "Content-Type: application/json" \
+      -d "{\"name\":\"${TUNNEL_NAME}\",\"tunnel_secret\":\"$(openssl rand -base64 32)\"}")
+    TUNNEL_ID=$(echo "$CREATE_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['id'])" 2>/dev/null || true)
+    if [[ -z "$TUNNEL_ID" ]]; then
+      log "Error: failed to create tunnel"
+      echo "$CREATE_RESPONSE" >&2
+      exit 1
+    fi
+    log "Created tunnel: ${TUNNEL_NAME} (${TUNNEL_ID})"
+  fi
+
+  # Get tunnel token
+  TUNNEL_TOKEN=$(curl -sf "${CF_API}/${TUNNEL_ID}/token" -H "$AUTH_HEADER" | python3 -c "import sys,json; print(json.load(sys.stdin)['result'])" 2>/dev/null || true)
+  if [[ -z "$TUNNEL_TOKEN" ]]; then
+    log "Error: failed to get tunnel token"
+    exit 1
+  fi
+
+  # Create DNS CNAME route via API
+  ZONE_RESPONSE=$(curl -sf "https://api.cloudflare.com/client/v4/zones?name=${TUNNEL_BASE_DOMAIN}" -H "$AUTH_HEADER")
+  ZONE_ID=$(echo "$ZONE_RESPONSE" | python3 -c "import sys,json; r=json.load(sys.stdin)['result']; print(r[0]['id'] if r else '')" 2>/dev/null || true)
+  if [[ -n "$ZONE_ID" ]]; then
+    CNAME_TARGET="${TUNNEL_ID}.cfargotunnel.com"
+    # Check if DNS record exists
+    EXISTING_RECORD=$(curl -sf "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${FQDN}&type=CNAME" -H "$AUTH_HEADER")
+    RECORD_ID=$(echo "$EXISTING_RECORD" | python3 -c "import sys,json; r=json.load(sys.stdin)['result']; print(r[0]['id'] if r else '')" 2>/dev/null || true)
+    if [[ -n "$RECORD_ID" ]]; then
+      # Update existing record
+      curl -sf -X PUT "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RECORD_ID}" \
+        -H "$AUTH_HEADER" -H "Content-Type: application/json" \
+        -d "{\"type\":\"CNAME\",\"name\":\"${FQDN}\",\"content\":\"${CNAME_TARGET}\",\"proxied\":true}" >/dev/null 2>&1
+    else
+      # Create new record
+      curl -sf -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" \
+        -H "$AUTH_HEADER" -H "Content-Type: application/json" \
+        -d "{\"type\":\"CNAME\",\"name\":\"${FQDN}\",\"content\":\"${CNAME_TARGET}\",\"proxied\":true}" >/dev/null 2>&1
+    fi
+    log "DNS route: ${FQDN} -> ${CNAME_TARGET}"
+  fi
+
+  # Write ingress config
+  CONFIG_FILE="/tmp/cloudflared-config-${TUNNEL_NAME}.yml"
   cat > "$CONFIG_FILE" <<EOF
-tunnel: ${TUNNEL_ID}
-credentials-file: ${CREDENTIALS_FILE}
-
 ingress:
   - hostname: ${FQDN}
     service: http://localhost:${PORT}
   - service: http_status:404
 EOF
 
-  # Create DNS route
-  cloudflared tunnel route dns --overwrite-dns "$TUNNEL_NAME" "$FQDN" >/dev/null 2>&1 || true
-
-  # Start tunnel in background
+  # Start tunnel with token (no cert.pem needed)
   # QUIC fails in devcontainer environment, must use HTTP/2
-  cloudflared tunnel --config "$CONFIG_FILE" --protocol http2 run "$TUNNEL_NAME" > "$TUNNEL_LOG" 2>&1 &
+  cloudflared tunnel --config "$CONFIG_FILE" --protocol http2 run --token "$TUNNEL_TOKEN" > "$TUNNEL_LOG" 2>&1 &
 
 else
   log "Anonymous tunnel: localhost:${PORT}"
@@ -143,7 +194,7 @@ while [[ $ATTEMPT -lt $MAX_WAIT ]]; do
     fi
   else
     # Anonymous tunnel: wait for trycloudflare.com URL
-    TUNNEL_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' "$TUNNEL_LOG" 2>/dev/null | head -n 1 || true)
+    TUNNEL_URL=$(grep -o 'https://[a-z0-9-]*\.trycloudflare\.com' "$TUNNEL_LOG" 2>/dev/null | head -n 1)
     if [[ -n "$TUNNEL_URL" ]]; then
       break
     fi

--- a/turbo/packages/proxy/Caddyfile
+++ b/turbo/packages/proxy/Caddyfile
@@ -9,7 +9,7 @@
 # Main domain redirect to www
 vm7.ai:8443 {
   tls {
-    dns cloudflare {env.CF_DNS_API_TOKEN}
+    dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
   }
   redir https://www.vm7.ai:8443{uri} permanent
 }
@@ -17,7 +17,7 @@ vm7.ai:8443 {
 # Web application
 www.vm7.ai:8443 {
   tls {
-    dns cloudflare {env.CF_DNS_API_TOKEN}
+    dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
   }
   reverse_proxy localhost:3000
 }
@@ -25,7 +25,7 @@ www.vm7.ai:8443 {
 # Docs application
 docs.vm7.ai:8443 {
   tls {
-    dns cloudflare {env.CF_DNS_API_TOKEN}
+    dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
   }
   reverse_proxy localhost:3001
 }
@@ -33,7 +33,7 @@ docs.vm7.ai:8443 {
 # App application
 app.vm7.ai:8443 {
   tls {
-    dns cloudflare {env.CF_DNS_API_TOKEN}
+    dns cloudflare {env.CF_DNS_AND_TUNNEL_API_TOKEN}
   }
   reverse_proxy localhost:3002
 }

--- a/turbo/packages/proxy/README.md
+++ b/turbo/packages/proxy/README.md
@@ -33,7 +33,7 @@ Web App        Docs App       App
 scripts/sync-env.sh
 ```
 
-This provisions `CF_DNS_API_TOKEN` needed for Let's Encrypt DNS-01 challenge.
+This provisions `CF_DNS_AND_TUNNEL_API_TOKEN` needed for Let's Encrypt DNS-01 challenge.
 
 ### 2. Start Development Servers
 
@@ -91,7 +91,7 @@ The `Caddyfile` defines:
 
 ## Troubleshooting
 
-### Caddy won't start — missing CF_DNS_API_TOKEN
+### Caddy won't start — missing CF_DNS_AND_TUNNEL_API_TOKEN
 
 Run `scripts/sync-env.sh` to provision the Cloudflare DNS token from 1Password.
 

--- a/turbo/packages/proxy/scripts/start-caddy.js
+++ b/turbo/packages/proxy/scripts/start-caddy.js
@@ -8,22 +8,24 @@ const CADDYFILE = path.join(__dirname, "../Caddyfile");
 
 console.log("🚀 Starting Caddy reverse proxy...\n");
 
-// Ensure CF_DNS_API_TOKEN is available (needed for Let's Encrypt DNS-01 challenge)
-if (!process.env.CF_DNS_API_TOKEN) {
+// Ensure CF_DNS_AND_TUNNEL_API_TOKEN is available (needed for Let's Encrypt DNS-01 challenge)
+if (!process.env.CF_DNS_AND_TUNNEL_API_TOKEN) {
   // Try loading from scripts/.env.local
   const envLocalPath = path.join(__dirname, "../../../../scripts/.env.local");
   if (fs.existsSync(envLocalPath)) {
     const content = fs.readFileSync(envLocalPath, "utf-8");
-    const match = content.match(/^CF_DNS_API_TOKEN=(.+)$/m);
+    const match = content.match(/^CF_DNS_AND_TUNNEL_API_TOKEN=(.+)$/m);
     if (match) {
-      process.env.CF_DNS_API_TOKEN = match[1].trim();
-      console.log("✓ Loaded CF_DNS_API_TOKEN from scripts/.env.local\n");
+      process.env.CF_DNS_AND_TUNNEL_API_TOKEN = match[1].trim();
+      console.log(
+        "✓ Loaded CF_DNS_AND_TUNNEL_API_TOKEN from scripts/.env.local\n",
+      );
     }
   }
 }
 
-if (!process.env.CF_DNS_API_TOKEN) {
-  console.error("❌ CF_DNS_API_TOKEN is not set.");
+if (!process.env.CF_DNS_AND_TUNNEL_API_TOKEN) {
+  console.error("❌ CF_DNS_AND_TUNNEL_API_TOKEN is not set.");
   console.error(
     "\nThis token is required for automatic Let's Encrypt certificate provisioning.",
   );


### PR DESCRIPTION
## Summary
- Replace `cloudflared tunnel login` (cert.pem) with Cloudflare API token for named tunnel management, fixing non-interactive environments (Claude Code devcontainers)
- Rename `CF_DNS_API_TOKEN` → `CF_DNS_AND_TUNNEL_API_TOKEN` across all config files (Caddyfile, start-caddy.js, env template, skill docs)
- Add `CF_ACCOUNT_ID` env var for API-based tunnel lookup/creation and DNS CNAME management

## Test plan
- [x] Verified `tunnel.sh` starts named tunnel via API token (`tunnel-ethan-vm01-www.vm7.ai`)
- [x] Verified DNS CNAME route created via API
- [x] Verified `sync-env.sh` syncs new env vars from 1Password
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)