### PR TITLE
ci: switch release-please-action to vm0-ai fork

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,7 +35,7 @@ jobs:
       cli_version: ${{ steps.release.outputs['turbo/apps/cli--version'] }}
       docs_version: ${{ steps.release.outputs['turbo/apps/docs--version'] }}
     steps:
-      - uses: seven332/release-please-action@vm0
+      - uses: vm0-ai/release-please-action@vm0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch `release-please-action` from `seven332/release-please-action@vm0` to `vm0-ai/release-please-action@vm0`
- The vm0-ai fork contains the same patches (cargo workspace path + merge plugin fix)

## Test plan
- [ ] Verify release-please workflow triggers correctly on next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)