### PR TITLE
fix(cli): replace internal _hidden access with public hidden option

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { Command } from "commander";
-import { applyCapabilityVisibility } from "../zero";
+import { Command, Help } from "commander";
+import { registerZeroCommands } from "../zero";
 import { decodeZeroTokenPayload } from "../lib/api/zero-token";
 
 function buildZeroToken(payload: Record<string, unknown>): string {
@@ -11,30 +11,38 @@ function buildZeroToken(payload: Record<string, unknown>): string {
   return `vm0_sandbox_${header}.${body}.test-signature`;
 }
 
+function buildCommands(): Command[] {
+  return [
+    new Command("org"),
+    new Command("agent"),
+    new Command("connector"),
+    new Command("preference"),
+    new Command("schedule"),
+    new Command("secret"),
+    new Command("slack"),
+    new Command("variable"),
+    new Command("whoami"),
+  ];
+}
+
 function buildProgram(): Command {
   const prog = new Command();
-  prog.addCommand(new Command("org"));
-  prog.addCommand(new Command("agent"));
-  prog.addCommand(new Command("connector"));
-  prog.addCommand(new Command("preference"));
-  prog.addCommand(new Command("schedule"));
-  prog.addCommand(new Command("secret"));
-  prog.addCommand(new Command("slack"));
-  prog.addCommand(new Command("variable"));
-  prog.addCommand(new Command("whoami"));
+  registerZeroCommands(prog, buildCommands());
   return prog;
 }
 
 function visibleCommandNames(prog: Command): string[] {
-  return prog.commands
-    .filter((cmd) => !(cmd as unknown as { _hidden: boolean })._hidden)
-    .map((cmd) => cmd.name());
+  return new Help()
+    .visibleCommands(prog)
+    .map((cmd) => cmd.name())
+    .filter((name) => name !== "help");
 }
 
 function hiddenCommandNames(prog: Command): string[] {
+  const visible = new Set(visibleCommandNames(prog));
   return prog.commands
-    .filter((cmd) => (cmd as unknown as { _hidden: boolean })._hidden)
-    .map((cmd) => cmd.name());
+    .map((cmd) => cmd.name())
+    .filter((name) => !visible.has(name));
 }
 
 describe("decodeZeroTokenPayload", () => {
@@ -91,14 +99,13 @@ describe("decodeZeroTokenPayload", () => {
   });
 });
 
-describe("applyCapabilityVisibility", () => {
+describe("registerZeroCommands", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
   it("should not hide any commands when ZERO_TOKEN is absent", () => {
     const prog = buildProgram();
-    applyCapabilityVisibility(prog);
     expect(hiddenCommandNames(prog)).toEqual([]);
   });
 
@@ -110,7 +117,6 @@ describe("applyCapabilityVisibility", () => {
     vi.stubEnv("ZERO_TOKEN", token);
 
     const prog = buildProgram();
-    applyCapabilityVisibility(prog);
 
     expect(visibleCommandNames(prog)).toEqual(["agent", "schedule", "whoami"]);
     expect(hiddenCommandNames(prog)).toEqual([
@@ -127,7 +133,6 @@ describe("applyCapabilityVisibility", () => {
     vi.stubEnv("ZERO_TOKEN", "not-a-valid-token");
 
     const prog = buildProgram();
-    applyCapabilityVisibility(prog);
 
     expect(hiddenCommandNames(prog)).toEqual([]);
   });
@@ -140,7 +145,6 @@ describe("applyCapabilityVisibility", () => {
     vi.stubEnv("ZERO_TOKEN", token);
 
     const prog = buildProgram();
-    applyCapabilityVisibility(prog);
 
     expect(hiddenCommandNames(prog)).toEqual([]);
   });
@@ -153,7 +157,6 @@ describe("applyCapabilityVisibility", () => {
     vi.stubEnv("ZERO_TOKEN", token);
 
     const prog = buildProgram();
-    applyCapabilityVisibility(prog);
 
     expect(visibleCommandNames(prog)).toEqual(["whoami"]);
   });
@@ -166,7 +169,6 @@ describe("applyCapabilityVisibility", () => {
     vi.stubEnv("ZERO_TOKEN", token);
 
     const prog = buildProgram();
-    applyCapabilityVisibility(prog);
 
     expect(visibleCommandNames(prog)).toContain("slack");
     expect(visibleCommandNames(prog)).toContain("whoami");
@@ -180,7 +182,6 @@ describe("applyCapabilityVisibility", () => {
     vi.stubEnv("ZERO_TOKEN", token);
 
     const prog = buildProgram();
-    applyCapabilityVisibility(prog);
 
     expect(visibleCommandNames(prog)).toEqual(["schedule", "whoami"]);
     expect(hiddenCommandNames(prog)).toContain("agent");

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { program } from "../zero";
+import { program, registerZeroCommands } from "../zero";
 
 describe("zero CLI program", () => {
+  registerZeroCommands(program);
   const commandNames = program.commands.map((cmd) => cmd.name());
 
   it("should be named 'zero'", () => {

--- a/turbo/apps/cli/src/lib/api/zero-token.ts
+++ b/turbo/apps/cli/src/lib/api/zero-token.ts
@@ -1,4 +1,4 @@
-interface ZeroTokenPayload {
+export interface ZeroTokenPayload {
   userId: string;
   runId: string;
   orgId: string;

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -12,7 +12,10 @@ import { zeroSecretCommand } from "./commands/zero/secret";
 import { zeroSlackCommand } from "./commands/zero/slack";
 import { zeroVariableCommand } from "./commands/zero/variable";
 import { zeroWhoamiCommand } from "./commands/zero/whoami";
-import { decodeZeroTokenPayload } from "./lib/api/zero-token.js";
+import {
+  decodeZeroTokenPayload,
+  type ZeroTokenPayload,
+} from "./lib/api/zero-token.js";
 
 /**
  * Map of command names to the capability required to see them.
@@ -26,28 +29,46 @@ const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   whoami: null,
 };
 
+const DEFAULT_COMMANDS: Command[] = [
+  zeroOrgCommand,
+  zeroAgentCommand,
+  zeroConnectorCommand,
+  zeroPreferenceCommand,
+  zeroScheduleCommand,
+  zeroSecretCommand,
+  zeroSlackCommand,
+  zeroVariableCommand,
+  zeroWhoamiCommand,
+];
+
+function shouldHideCommand(
+  name: string,
+  payload: ZeroTokenPayload | undefined,
+): boolean {
+  if (!payload) return false;
+  const requiredCap = COMMAND_CAPABILITY_MAP[name];
+  if (requiredCap === undefined) return true;
+  return requiredCap !== null && !payload.capabilities.includes(requiredCap);
+}
+
 /**
- * Hide commands that the current ZERO_TOKEN does not grant access to.
- * When no ZERO_TOKEN is present (human user with VM0_TOKEN or config),
- * all commands remain visible.
+ * Register commands with visibility based on ZERO_TOKEN capabilities.
+ * Commands not granted by the token are registered as hidden via
+ * Commander's public `addCommand(cmd, { hidden: true })` API.
+ * When no ZERO_TOKEN is present, all commands remain visible.
+ *
+ * @param commands - override default commands (used in tests)
  */
-export function applyCapabilityVisibility(prog: Command): void {
+export function registerZeroCommands(
+  prog: Command,
+  commands?: Command[],
+): void {
   const token = process.env.ZERO_TOKEN;
-  if (!token) return;
+  const payload = token ? decodeZeroTokenPayload(token) : undefined;
 
-  const payload = decodeZeroTokenPayload(token);
-  if (!payload) return;
-
-  for (const cmd of prog.commands) {
-    const requiredCap = COMMAND_CAPABILITY_MAP[cmd.name()];
-    if (requiredCap === undefined) {
-      (cmd as unknown as { _hidden: boolean })._hidden = true;
-    } else if (
-      requiredCap !== null &&
-      !payload.capabilities.includes(requiredCap)
-    ) {
-      (cmd as unknown as { _hidden: boolean })._hidden = true;
-    }
+  for (const cmd of commands ?? DEFAULT_COMMANDS) {
+    const hidden = shouldHideCommand(cmd.name(), payload);
+    prog.addCommand(cmd, hidden ? { hidden: true } : {});
   }
 }
 
@@ -60,17 +81,6 @@ program
   .description("Zero CLI - Manage your zero platform")
   .version(__CLI_VERSION__);
 
-// Register all zero commands as top-level
-program.addCommand(zeroOrgCommand);
-program.addCommand(zeroAgentCommand);
-program.addCommand(zeroConnectorCommand);
-program.addCommand(zeroPreferenceCommand);
-program.addCommand(zeroScheduleCommand);
-program.addCommand(zeroSecretCommand);
-program.addCommand(zeroSlackCommand);
-program.addCommand(zeroVariableCommand);
-program.addCommand(zeroWhoamiCommand);
-
 export { program };
 
 if (
@@ -79,6 +89,6 @@ if (
   process.argv[1]?.endsWith("zero")
 ) {
   configureGlobalProxyFromEnv();
-  applyCapabilityVisibility(program);
+  registerZeroCommands(program);
   program.parse();
 }


### PR DESCRIPTION
## Summary

- Replace unsafe `_hidden` internal property access with Commander.js public `addCommand(cmd, { hidden: true })` API
- Restructure command registration in `zero.ts` to compute visibility at registration time
- Update test helpers to use `Help.visibleCommands()` instead of reading `_hidden` directly
- Export `ZeroTokenPayload` type from `zero-token.ts` for use in `zero.ts`

## Test plan

- [x] All 13 existing tests pass (zero-capability-visibility.test.ts)
- [x] Lint passes (oxlint + eslint)
- [x] Type check passes
- [x] Knip passes (no unused exports)
- [ ] CI pipeline passes

Closes #6707

🤖 Generated with [Claude Code](https://claude.com/claude-code)