### PR TITLE
fix(cli): standardize success message format across commands

### DIFF
--- a/e2e/tests/01-serial/ser-t05-zero-agent.bats
+++ b/e2e/tests/01-serial/ser-t05-zero-agent.bats
@@ -49,7 +49,7 @@ teardown_file() {
     assert_success
     assert_output --partial "created"
 
-    name=$(echo "$output" | grep -oP "agent '\K[^']+")
+    name=$(echo "$output" | grep -oP 'Agent "\K[^"]+')
     echo "$name" > "$(agent_name_file)"
 }
 

--- a/e2e/tests/03-runner/t20-zero-schedule.bats
+++ b/e2e/tests/03-runner/t20-zero-schedule.bats
@@ -74,8 +74,8 @@ setup() {
         --timezone "UTC" \
         --prompt "Run scheduled task"
     assert_success
-    assert_output --partial "Created schedule"
-    assert_output --partial "$AGENT_NAME"
+    assert_output --partial "created"
+    assert_output --partial "Schedule"
 
     # --- List ---
     run $ZERO_CLI schedule list
@@ -99,7 +99,7 @@ setup() {
         --timezone "America/New_York" \
         --prompt "Updated scheduled task"
     assert_success
-    assert_output --partial "Updated schedule"
+    assert_output --partial "updated"
 
     # Verify update via status
     run $ZERO_CLI schedule status "$AGENT_NAME"
@@ -109,7 +109,7 @@ setup() {
     # --- Enable ---
     run $ZERO_CLI schedule enable "$AGENT_NAME"
     assert_success
-    assert_output --partial "Enabled"
+    assert_output --partial "enabled"
 
     # Verify enabled in list
     run $ZERO_CLI schedule list
@@ -119,12 +119,12 @@ setup() {
     # --- Disable ---
     run $ZERO_CLI schedule disable "$AGENT_NAME"
     assert_success
-    assert_output --partial "Disabled"
+    assert_output --partial "disabled"
 
     # --- Delete ---
     run $ZERO_CLI schedule delete "$AGENT_NAME" --yes
     assert_success
-    assert_output --partial "Deleted"
+    assert_output --partial "deleted"
 }
 
 @test "t20-2: loop schedule lifecycle" {
@@ -153,7 +153,7 @@ EOF
         --timezone "UTC" \
         --prompt "Loop task every 5 minutes"
     assert_success
-    assert_output --partial "Created schedule"
+    assert_output --partial "created"
 
     # --- Status ---
     run $ZERO_CLI schedule status "$LOOP_AGENT_NAME"
@@ -169,17 +169,17 @@ EOF
     # --- Enable ---
     run $ZERO_CLI schedule enable "$LOOP_AGENT_NAME"
     assert_success
-    assert_output --partial "Enabled"
+    assert_output --partial "enabled"
 
     # --- Disable ---
     run $ZERO_CLI schedule disable "$LOOP_AGENT_NAME"
     assert_success
-    assert_output --partial "Disabled"
+    assert_output --partial "disabled"
 
     # --- Delete ---
     run $ZERO_CLI schedule delete "$LOOP_AGENT_NAME" --yes
     assert_success
-    assert_output --partial "Deleted"
+    assert_output --partial "deleted"
 
     # Clean up
     rm -rf "$LOOP_TEST_DIR"

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -41,7 +41,7 @@ export const createCommand = new Command()
           await updateZeroAgentInstructions(agent.agentId, content);
         }
 
-        console.log(chalk.green(`✓ Zero agent '${agent.agentId}' created`));
+        console.log(chalk.green(`✓ Agent "${agent.agentId}" created`));
         console.log(`  Agent ID:     ${agent.agentId}`);
         console.log(`  Connectors:   ${agent.connectors.join(", ")}`);
         if (agent.displayName) {

--- a/turbo/apps/cli/src/commands/zero/agent/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/delete.ts
@@ -29,6 +29,6 @@ export const deleteCommand = new Command()
       }
 
       await deleteZeroAgent(agentId);
-      console.log(chalk.green(`✓ Zero agent '${agentId}' deleted`));
+      console.log(chalk.green(`✓ Agent "${agentId}" deleted`));
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -75,7 +75,7 @@ export const editCommand = new Command()
           await updateZeroAgentInstructions(agentId, content);
         }
 
-        console.log(chalk.green(`✓ Zero agent '${agentId}' updated`));
+        console.log(chalk.green(`✓ Agent "${agentId}" updated`));
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/__tests__/connect.test.ts
@@ -72,7 +72,8 @@ describe("zero connector connect command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Session created");
       expect(logCalls).toContain("/authorize/github?code=ABC123");
-      expect(logCalls).toContain("connected successfully");
+      expect(logCalls).toContain("Connector");
+      expect(logCalls).toContain("connected");
     });
 
     it("should handle session creation failure", async () => {
@@ -124,7 +125,8 @@ describe("zero connector connect command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("connected successfully via API token");
+      expect(logCalls).toContain("Connector");
+      expect(logCalls).toContain("connected");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/connector/connect.ts
+++ b/turbo/apps/cli/src/commands/zero/connector/connect.ts
@@ -94,9 +94,7 @@ async function connectViaApiToken(
       description: `API token for ${config.label} connector`,
     });
   }
-  console.log(
-    chalk.green(`\n✓ ${config.label} connected successfully via API token!`),
-  );
+  console.log(chalk.green(`\n✓ Connector "${connectorType}" connected`));
 }
 
 /**
@@ -197,7 +195,7 @@ async function connectViaOAuth(connectorType: ConnectorType): Promise<void> {
     switch (status.status) {
       case "complete":
         console.log(
-          chalk.green(`\n\n${connectorType} connected successfully!`),
+          chalk.green(`\n\n✓ Connector "${connectorType}" connected`),
         );
         return;
       case "expired":

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/delete.test.ts
@@ -90,8 +90,8 @@ describe("zero schedule delete command", () => {
       await deleteCommand.parseAsync(["node", "cli", "my-agent", "--yes"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Deleted");
-      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("Schedule");
+      expect(logCalls).toContain("deleted");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/disable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/disable.test.ts
@@ -95,8 +95,8 @@ describe("zero schedule disable command", () => {
       await disableCommand.parseAsync(["node", "cli", "my-agent"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Disabled");
-      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("Schedule");
+      expect(logCalls).toContain("disabled");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/enable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/enable.test.ts
@@ -93,8 +93,8 @@ describe("zero schedule enable command", () => {
       await enableCommand.parseAsync(["node", "cli", "my-agent"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Enabled");
-      expect(logCalls).toContain("my-agent");
+      expect(logCalls).toContain("Schedule");
+      expect(logCalls).toContain("enabled");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
@@ -112,7 +112,8 @@ describe("zero schedule setup command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Created schedule");
+      expect(logCalls).toContain("Schedule");
+      expect(logCalls).toContain("created");
       expect(logCalls).toContain("my-agent");
     });
 
@@ -160,7 +161,8 @@ describe("zero schedule setup command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Created schedule");
+      expect(logCalls).toContain("Schedule");
+      expect(logCalls).toContain("created");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/schedule/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/delete.ts
@@ -44,9 +44,7 @@ export const deleteCommand = new Command()
           agentId: resolved.agentId,
         });
 
-        console.log(
-          chalk.green(`✓ Deleted schedule for agent ${chalk.cyan(agentName)}`),
-        );
+        console.log(chalk.green(`✓ Schedule "${resolved.name}" deleted`));
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/schedule/disable.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/disable.ts
@@ -26,8 +26,6 @@ export const disableCommand = new Command()
         agentId: resolved.agentId,
       });
 
-      console.log(
-        chalk.green(`✓ Disabled schedule for agent ${chalk.cyan(agentName)}`),
-      );
+      console.log(chalk.green(`✓ Schedule "${resolved.name}" disabled`));
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/enable.ts
@@ -26,8 +26,6 @@ export const enableCommand = new Command()
         agentId: resolved.agentId,
       });
 
-      console.log(
-        chalk.green(`✓ Enabled schedule for agent ${chalk.cyan(agentName)}`),
-      );
+      console.log(chalk.green(`✓ Schedule "${resolved.name}" enabled`));
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -561,17 +561,13 @@ async function buildAndDeploy(params: {
 }
 
 function displayDeployResult(
-  agentName: string,
+  scheduleName: string,
   deployResult: DeployResult,
 ): void {
   if (deployResult.created) {
-    console.log(
-      chalk.green(`✓ Created schedule for agent ${chalk.cyan(agentName)}`),
-    );
+    console.log(chalk.green(`✓ Schedule "${scheduleName}" created`));
   } else {
-    console.log(
-      chalk.green(`✓ Updated schedule for agent ${chalk.cyan(agentName)}`),
-    );
+    console.log(chalk.green(`✓ Schedule "${scheduleName}" updated`));
   }
 
   console.log(chalk.dim(`  Timezone: ${deployResult.schedule.timezone}`));
@@ -610,9 +606,7 @@ async function tryEnableSchedule(
 ): Promise<void> {
   try {
     await enableZeroSchedule({ name: scheduleName, agentId });
-    console.log(
-      chalk.green(`✓ Enabled schedule for agent ${chalk.cyan(agentName)}`),
-    );
+    console.log(chalk.green(`✓ Schedule "${scheduleName}" enabled`));
   } catch (error) {
     console.error(chalk.yellow("⚠ Failed to enable schedule"));
     if (error instanceof ApiRequestError) {
@@ -773,7 +767,7 @@ export const setupCommand = new Command()
       });
 
       // 9. Display deployment result
-      displayDeployResult(agentName, deployResult);
+      displayDeployResult(scheduleName, deployResult);
 
       // 10. Handle schedule enabling
       const shouldPromptEnable =


### PR DESCRIPTION
## Summary

- Standardize all CLI success messages to follow the pattern: `✓ {Resource} "{name}" {past-tense verb}`
- Agent commands: drop "Zero" prefix, single quotes → double quotes
- Schedule commands: verb-last pattern, use schedule name, remove `chalk.cyan` styling
- Connector commands: add `✓` to OAuth path, drop "successfully" and exclamation marks
- Update test assertions to match new message format

Closes #6716

## Test plan

- [x] All 54 existing tests pass (agent, schedule, connector)
- [x] Lint passes with 0 warnings
- [x] Type-check passes
- [x] Knip reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)