### PR TITLE
refactor(core): make firewall config type-safe for model providers

### DIFF
--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -476,14 +476,23 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS: Record<
  * Get firewall gateway config for a model provider type.
  * Returns undefined for providers without static base URLs (aws-bedrock, azure-foundry).
  */
+type FirewallSupportedProvider = Exclude<
+  ModelProviderType,
+  FirewallExcludedProvider
+>;
+
+function isFirewallSupported(
+  type: ModelProviderType,
+): type is FirewallSupportedProvider {
+  return type in MODEL_PROVIDER_FIREWALL_CONFIGS;
+}
+
 export function getModelProviderFirewall(
   type: ModelProviderType,
 ): ExpandedFirewallConfig | undefined {
-  return (
-    MODEL_PROVIDER_FIREWALL_CONFIGS as Partial<
-      Record<ModelProviderType, ExpandedFirewallConfig>
-    >
-  )[type];
+  return isFirewallSupported(type)
+    ? MODEL_PROVIDER_FIREWALL_CONFIGS[type]
+    : undefined;
 }
 
 export const modelProviderTypeSchema = z.enum([

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -333,10 +333,12 @@ export type ModelProviderFramework = "claude-code";
  * replacement cannot be used.  New selection is blocked until a proper
  * solution is implemented; existing configurations continue to work.
  */
-type HiddenProviderType = "aws-bedrock" | "azure-foundry";
+const HIDDEN_PROVIDER_LIST = ["aws-bedrock", "azure-foundry"] as const;
+type HiddenProviderType = (typeof HIDDEN_PROVIDER_LIST)[number];
 
-const HIDDEN_PROVIDER_TYPES: ReadonlySet<ModelProviderType> =
-  new Set<HiddenProviderType>(["aws-bedrock", "azure-foundry"]);
+const HIDDEN_PROVIDER_TYPES: ReadonlySet<ModelProviderType> = new Set(
+  HIDDEN_PROVIDER_LIST,
+);
 
 /**
  * Providers excluded from static firewall configs.

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -328,11 +328,11 @@ export type ModelProviderType = keyof typeof MODEL_PROVIDER_TYPES;
 export type ModelProviderFramework = "claude-code";
 
 /**
- * Providers hidden from user-facing selection UI.
- * These providers cannot support token replacement (firewall-based secret protection),
- * so new selection is blocked until a proper solution is implemented.
+ * Provider types hidden from user-facing selection UI.
+ * These lack static firewall support (dynamic URLs or SigV4), so token
+ * replacement cannot be used.  New selection is blocked until a proper
+ * solution is implemented; existing configurations continue to work.
  */
-/** Provider types that lack static firewall support (dynamic URLs or SigV4). */
 type HiddenProviderType = "aws-bedrock" | "azure-foundry";
 
 const HIDDEN_PROVIDER_TYPES: ReadonlySet<ModelProviderType> =

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -328,15 +328,27 @@ export type ModelProviderType = keyof typeof MODEL_PROVIDER_TYPES;
 export type ModelProviderFramework = "claude-code";
 
 /**
- * Provider types hidden from user-facing selection UI.
+ * Providers hidden from user-facing selection UI.
  * These providers cannot support token replacement (firewall-based secret protection),
  * so new selection is blocked until a proper solution is implemented.
- * Existing configurations continue to work at runtime.
  */
-const HIDDEN_PROVIDER_TYPES: ReadonlySet<ModelProviderType> = new Set([
+const HIDDEN_PROVIDER_TYPES = new Set([
   "aws-bedrock",
   "azure-foundry",
-]);
+] as const);
+
+/** Union of hidden provider type literals. */
+type HiddenProviderType =
+  typeof HIDDEN_PROVIDER_TYPES extends ReadonlySet<infer T> ? T : never;
+
+/**
+ * Providers excluded from static firewall configs.
+ * = hidden providers (dynamic URLs / SigV4) + vm0 (meta-provider).
+ *
+ * Adding a new provider to MODEL_PROVIDER_TYPES without either adding it here
+ * or adding a firewall config entry will cause a compile error.
+ */
+type FirewallExcludedProvider = HiddenProviderType | "vm0";
 
 /**
  * Get provider types available for user selection.
@@ -381,8 +393,13 @@ function mpFirewall(
   };
 }
 
-export const MODEL_PROVIDER_FIREWALL_CONFIGS: Partial<
-  Record<ModelProviderType, ExpandedFirewallConfig>
+/**
+ * Every provider NOT in FirewallExcludedProvider must have an entry here.
+ * Adding a new provider without a firewall config will cause a type error.
+ */
+export const MODEL_PROVIDER_FIREWALL_CONFIGS: Record<
+  Exclude<ModelProviderType, FirewallExcludedProvider>,
+  ExpandedFirewallConfig
 > = {
   // Placeholder: sk-ant-api03-{93 word/hyphen chars}AA (108 chars total)
   // Source: Semgrep regex \Bsk-ant-api03-[\w\-]{93}AA\B
@@ -465,7 +482,11 @@ export const MODEL_PROVIDER_FIREWALL_CONFIGS: Partial<
 export function getModelProviderFirewall(
   type: ModelProviderType,
 ): ExpandedFirewallConfig | undefined {
-  return MODEL_PROVIDER_FIREWALL_CONFIGS[type];
+  return (
+    MODEL_PROVIDER_FIREWALL_CONFIGS as Partial<
+      Record<ModelProviderType, ExpandedFirewallConfig>
+    >
+  )[type];
 }
 
 export const modelProviderTypeSchema = z.enum([

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -332,14 +332,11 @@ export type ModelProviderFramework = "claude-code";
  * These providers cannot support token replacement (firewall-based secret protection),
  * so new selection is blocked until a proper solution is implemented.
  */
-const HIDDEN_PROVIDER_TYPES = new Set([
-  "aws-bedrock",
-  "azure-foundry",
-] as const);
+/** Provider types that lack static firewall support (dynamic URLs or SigV4). */
+type HiddenProviderType = "aws-bedrock" | "azure-foundry";
 
-/** Union of hidden provider type literals. */
-type HiddenProviderType =
-  typeof HIDDEN_PROVIDER_TYPES extends ReadonlySet<infer T> ? T : never;
+const HIDDEN_PROVIDER_TYPES: ReadonlySet<ModelProviderType> =
+  new Set<HiddenProviderType>(["aws-bedrock", "azure-foundry"]);
 
 /**
  * Providers excluded from static firewall configs.


### PR DESCRIPTION
## Summary

- Replace `Partial<Record<ModelProviderType, ...>>` with `Record<Exclude<ModelProviderType, FirewallExcludedProvider>, ...>` for `MODEL_PROVIDER_FIREWALL_CONFIGS`
- Now adding a new model provider to `MODEL_PROVIDER_TYPES` without a firewall config entry causes a **compile error** instead of silently returning `undefined`
- `FirewallExcludedProvider` is derived from `HIDDEN_PROVIDER_TYPES` (aws-bedrock, azure-foundry) + vm0 (meta-provider)
- `HIDDEN_PROVIDER_TYPES` uses `as const` so its literal types flow into `FirewallExcludedProvider` automatically

## Test plan

- [x] 343 core tests pass
- [x] Lint + knip clean
- [ ] Verify compile error when adding a new provider without firewall config

🤖 Generated with [Claude Code](https://claude.com/claude-code)