### PR TITLE
feat(cli): add cli-side jwt decoding and org resolution from token

### DIFF
--- a/turbo/apps/cli/src/lib/api/__tests__/cli-token.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/cli-token.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { decodeCliTokenPayload } from "../cli-token";
+
+function buildCliJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const sig = Buffer.from("fake-signature").toString("base64url");
+  return `vm0_sandbox_${header}.${body}.${sig}`;
+}
+
+describe("decodeCliTokenPayload", () => {
+  it("should decode valid CLI JWT with scope 'cli'", () => {
+    const token = buildCliJwt({
+      userId: "user-1",
+      orgId: "org-1",
+      tokenId: "tok-1",
+      scope: "cli",
+      iat: 1000,
+      exp: 2000,
+    });
+    const result = decodeCliTokenPayload(token);
+    expect(result).toEqual({
+      userId: "user-1",
+      orgId: "org-1",
+      tokenId: "tok-1",
+      scope: "cli",
+      iat: 1000,
+      exp: 2000,
+    });
+  });
+
+  it("should return undefined for vm0_live_ tokens (old format)", () => {
+    expect(decodeCliTokenPayload("vm0_live_abc123")).toBeUndefined();
+  });
+
+  it("should return undefined for zero-scoped tokens", () => {
+    const token = buildCliJwt({
+      scope: "zero",
+      orgId: "org-1",
+      userId: "user-1",
+      capabilities: [],
+    });
+    expect(decodeCliTokenPayload(token)).toBeUndefined();
+  });
+
+  it("should return undefined for malformed JWT", () => {
+    expect(decodeCliTokenPayload("vm0_sandbox_not.valid")).toBeUndefined();
+  });
+
+  it("should return undefined for undefined input", () => {
+    expect(decodeCliTokenPayload(undefined)).toBeUndefined();
+  });
+
+  it("should return undefined for empty string", () => {
+    expect(decodeCliTokenPayload("")).toBeUndefined();
+  });
+
+  it("should return undefined when orgId is missing", () => {
+    const token = buildCliJwt({ scope: "cli", userId: "user-1" });
+    expect(decodeCliTokenPayload(token)).toBeUndefined();
+  });
+
+  it("should return undefined when userId is missing", () => {
+    const token = buildCliJwt({ scope: "cli", orgId: "org-1" });
+    expect(decodeCliTokenPayload(token)).toBeUndefined();
+  });
+
+  it("should return undefined for invalid base64 payload", () => {
+    expect(
+      decodeCliTokenPayload("vm0_sandbox_header.!!!invalid!!!.signature"),
+    ).toBeUndefined();
+  });
+});

--- a/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
@@ -176,6 +176,63 @@ describe("token resolution", () => {
       const org = await getActiveOrg();
       expect(org).toBe("fallback-org");
     });
+
+    it("should return orgId from CLI JWT when config token is JWT format", async () => {
+      const cliJwt = buildFakeJwt({
+        scope: "cli",
+        orgId: "cli-org",
+        userId: "user-1",
+        tokenId: "tok-1",
+      });
+      await writeConfigToken(cliJwt);
+
+      const org = await getActiveOrg();
+      expect(org).toBe("cli-org");
+    });
+
+    it("should fall back to config activeOrg when token is vm0_live_ format", async () => {
+      vi.stubEnv("VM0_ACTIVE_ORG", "");
+      const configDir = path.join(TEST_HOME, ".vm0");
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        path.join(configDir, "config.json"),
+        JSON.stringify({ token: "vm0_live_abc123", activeOrg: "config-org" }),
+      );
+
+      const org = await getActiveOrg();
+      expect(org).toBe("config-org");
+    });
+
+    it("should prefer ZERO_TOKEN JWT over CLI JWT", async () => {
+      vi.stubEnv(
+        "ZERO_TOKEN",
+        buildFakeJwt({ scope: "zero", orgId: "zero-org", capabilities: [] }),
+      );
+      const cliJwt = buildFakeJwt({
+        scope: "cli",
+        orgId: "cli-org",
+        userId: "user-1",
+        tokenId: "tok-1",
+      });
+      await writeConfigToken(cliJwt);
+
+      const org = await getActiveOrg();
+      expect(org).toBe("zero-org");
+    });
+
+    it("should prefer CLI JWT over VM0_ACTIVE_ORG env var", async () => {
+      vi.stubEnv("VM0_ACTIVE_ORG", "env-org");
+      const cliJwt = buildFakeJwt({
+        scope: "cli",
+        orgId: "cli-org",
+        userId: "user-1",
+        tokenId: "tok-1",
+      });
+      await writeConfigToken(cliJwt);
+
+      const org = await getActiveOrg();
+      expect(org).toBe("cli-org");
+    });
   });
 
   describe("getToken", () => {

--- a/turbo/apps/cli/src/lib/api/cli-token.ts
+++ b/turbo/apps/cli/src/lib/api/cli-token.ts
@@ -1,0 +1,39 @@
+interface CliTokenPayload {
+  userId: string;
+  orgId: string;
+  tokenId: string;
+  scope: string;
+  iat: number;
+  exp: number;
+}
+
+/**
+ * Decode a CLI JWT token payload.
+ * Only decodes — does NOT verify signature (server does that).
+ * Returns undefined if token is missing, malformed, or not a cli-scoped token.
+ */
+export function decodeCliTokenPayload(
+  token?: string,
+): CliTokenPayload | undefined {
+  const raw = token ?? undefined;
+  if (!raw) return undefined;
+
+  const prefix = "vm0_sandbox_";
+  if (!raw.startsWith(prefix)) return undefined;
+  const jwt = raw.slice(prefix.length);
+
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return undefined;
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1]!, "base64url").toString(),
+    ) as CliTokenPayload;
+    if (payload.scope === "cli" && payload.orgId && payload.userId) {
+      return payload;
+    }
+  } catch {
+    // Malformed token
+  }
+  return undefined;
+}

--- a/turbo/apps/cli/src/lib/api/config.ts
+++ b/turbo/apps/cli/src/lib/api/config.ts
@@ -2,6 +2,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { readFile, writeFile, mkdir, unlink } from "fs/promises";
 import { existsSync } from "fs";
+import { decodeCliTokenPayload } from "./cli-token.js";
 import { decodeZeroTokenPayload } from "./zero-token.js";
 
 interface CliConfig {
@@ -79,12 +80,17 @@ export { decodeZeroTokenPayload };
 
 /**
  * Get the active organization for API requests.
- * Priority: ZERO_TOKEN JWT orgId > VM0_ACTIVE_ORG env var > activeOrg from config file
+ * Priority: ZERO_TOKEN JWT orgId > CLI JWT orgId > VM0_ACTIVE_ORG env var > activeOrg from config file
  */
 export async function getActiveOrg(): Promise<string | undefined> {
   // Prefer orgId decoded from ZERO_TOKEN JWT (zero agent runs)
   const zeroPayload = decodeZeroTokenPayload();
   if (zeroPayload) return zeroPayload.orgId;
+
+  // Try CLI JWT token (new format: vm0_sandbox_ with scope "cli")
+  const token = await getToken();
+  const cliPayload = decodeCliTokenPayload(token);
+  if (cliPayload) return cliPayload.orgId;
 
   // Fall back to VM0_ACTIVE_ORG env var (legacy)
   if (process.env.VM0_ACTIVE_ORG) {


### PR DESCRIPTION
## Summary

- Add `decodeCliTokenPayload()` in new `cli-token.ts` module that decodes CLI JWT tokens (`vm0_sandbox_` prefix with scope `"cli"`) to extract `orgId`
- Update `getActiveOrg()` priority chain: ZERO_TOKEN JWT > **CLI JWT** > VM0_ACTIVE_ORG env > config file
- Backward compatible — `vm0_live_*` tokens fall through to existing `activeOrg` config path

## Test plan

- [x] 9 unit tests for `decodeCliTokenPayload()` (valid JWT, wrong prefix, wrong scope, malformed, missing fields, etc.)
- [x] 4 new integration tests for `getActiveOrg()` with CLI JWT (JWT in config, `vm0_live_` fallback, ZERO_TOKEN priority, CLI JWT > env var)
- [x] All 22 existing config tests still pass
- [x] Lint, type-check, format, knip all pass

Closes #6718

🤖 Generated with [Claude Code](https://claude.com/claude-code)