### PR TITLE
fix(cli): flatten zero whoami sandbox output labels

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -76,10 +76,11 @@ describe("zero whoami command", () => {
       await runWhoami();
 
       const output = getAllOutput();
-      expect(output.some((line) => line.includes("Agent:"))).toBe(true);
+      expect(output.some((line) => line.includes("Agent ID:"))).toBe(true);
       expect(output.some((line) => line.includes("agent-123"))).toBe(true);
-      expect(output.some((line) => line.includes("Run:"))).toBe(true);
+      expect(output.some((line) => line.includes("Run ID:"))).toBe(true);
       expect(output.some((line) => line.includes("run-abc"))).toBe(true);
+      expect(output.some((line) => line.includes("Org ID:"))).toBe(true);
       expect(output.some((line) => line.includes("org-xyz"))).toBe(true);
       expect(output.some((line) => line.includes("Capabilities:"))).toBe(true);
       expect(output.some((line) => line.includes("agent:read"))).toBe(true);
@@ -92,8 +93,9 @@ describe("zero whoami command", () => {
       await runWhoami();
 
       const output = getAllOutput();
-      expect(output.some((line) => line.includes("Agent:"))).toBe(true);
+      expect(output.some((line) => line.includes("Agent ID:"))).toBe(true);
       expect(output.some((line) => line.includes("agent-no-token"))).toBe(true);
+      expect(output.some((line) => line.includes("Run ID:"))).toBe(true);
       expect(output.some((line) => line.includes("unavailable"))).toBe(true);
       expect(output.some((line) => line.includes("Capabilities:"))).toBe(false);
     });

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -21,15 +21,9 @@ async function showSandboxInfo(): Promise<void> {
   const agentId = process.env.ZERO_AGENT_ID;
   const payload = decodeZeroTokenPayload();
 
-  // Agent section
-  console.log(chalk.bold("Agent:"));
-  console.log(`  ID:           ${agentId}`);
-  console.log();
-
-  // Run section
-  console.log(chalk.bold("Run:"));
-  console.log(`  ID:           ${payload?.runId ?? chalk.dim("unavailable")}`);
-  console.log(`  Org:          ${payload?.orgId ?? chalk.dim("unavailable")}`);
+  console.log(`Agent ID:   ${agentId}`);
+  console.log(`Run ID:     ${payload?.runId ?? chalk.dim("unavailable")}`);
+  console.log(`Org ID:     ${payload?.orgId ?? chalk.dim("unavailable")}`);
 
   // Capabilities section
   if (payload?.capabilities?.length) {


### PR DESCRIPTION
## Summary
- Flatten `zero whoami` sandbox output from nested group headers (`Agent:` / `Run:`) to flat key-value pairs (`Agent ID:`, `Run ID:`, `Org ID:`)

## Test plan
- [ ] Run `zero whoami` inside a sandbox and verify flat label format

🤖 Generated with [Claude Code](https://claude.com/claude-code)