### PR TITLE
feat: add loading states and save indicators to org billing tabs

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/member-credit-caps.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/member-credit-caps.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { creditsMemberList$ } from "../member-credit-caps.ts";
+
+const context = testContext();
+
+interface CapturedCapCall {
+  userId: string;
+  creditCap: number | null;
+}
+
+interface MockMember {
+  userId: string;
+  email: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  creditsCharged: number;
+}
+
+function memberA(): MockMember {
+  return {
+    userId: "user-a",
+    email: "alice@example.com",
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+    creditsCharged: 500,
+  };
+}
+
+function memberB(): MockMember {
+  return {
+    userId: "user-b",
+    email: "bob@example.com",
+    inputTokens: 200,
+    outputTokens: 100,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+    creditsCharged: 1200,
+  };
+}
+
+function mockUsageMembers(members: MockMember[]) {
+  server.use(
+    http.get("*/api/zero/usage/members", () => {
+      return HttpResponse.json({
+        period: { start: "2026-03-01", end: "2026-03-31" },
+        members,
+      });
+    }),
+  );
+}
+
+function mockCreditCaps(
+  caps: Record<string, { creditCap: number | null; creditEnabled: boolean }>,
+) {
+  server.use(
+    http.get("*/api/zero/org/members/credit-cap", ({ request }) => {
+      const url = new URL(request.url);
+      const userId = url.searchParams.get("userId");
+      const cap = userId ? caps[userId] : undefined;
+      if (!cap) {
+        return HttpResponse.json({
+          userId,
+          creditCap: null,
+          creditEnabled: false,
+        });
+      }
+      return HttpResponse.json({ userId, ...cap });
+    }),
+  );
+}
+
+function mockCreditCapPut(captured: { calls: CapturedCapCall[] }) {
+  server.use(
+    http.put("*/api/zero/org/members/credit-cap", async ({ request }) => {
+      const body = (await request.json()) as CapturedCapCall;
+      captured.calls.push(body);
+      return HttpResponse.json({ ok: true });
+    }),
+  );
+}
+
+async function setup() {
+  await setupPage({ context, path: "/", withoutRender: true });
+}
+
+describe("creditsMemberList$", () => {
+  it("should return member settings with credit caps from API", async () => {
+    mockUsageMembers([memberA(), memberB()]);
+    mockCreditCaps({
+      "user-a": { creditCap: 1000, creditEnabled: true },
+      "user-b": { creditCap: null, creditEnabled: false },
+    });
+
+    await setup();
+
+    const members = await context.store.get(creditsMemberList$);
+    expect(members).toHaveLength(2);
+
+    expect(members[0].userId).toBe("user-a");
+    expect(members[0].email).toBe("alice@example.com");
+    expect(members[0].creditsCharged).toBe(500);
+    expect(members[0].creditCap).toBe(1000);
+
+    expect(members[1].userId).toBe("user-b");
+    expect(members[1].email).toBe("bob@example.com");
+    expect(members[1].creditCap).toBeNull();
+  });
+
+  it("should default creditCap to null when API returns non-OK", async () => {
+    mockUsageMembers([memberA()]);
+    server.use(
+      http.get("*/api/zero/org/members/credit-cap", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    await setup();
+
+    const members = await context.store.get(creditsMemberList$);
+    expect(members).toHaveLength(1);
+    expect(members[0].creditCap).toBeNull();
+  });
+});
+
+describe("save$ command", () => {
+  it("should call PUT with parsed credit cap and exit edit mode", async () => {
+    mockUsageMembers([memberA()]);
+    mockCreditCaps({
+      "user-a": { creditCap: null, creditEnabled: false },
+    });
+    const captured: { calls: CapturedCapCall[] } = { calls: [] };
+    mockCreditCapPut(captured);
+
+    await setup();
+
+    const members = await context.store.get(creditsMemberList$);
+    const member = members[0];
+
+    // Enter edit mode and set a value
+    context.store.set(member.enterEditMode$);
+    expect(context.store.get(member.editMode$)).toBeTruthy();
+
+    context.store.set(member.setValue$, "2000");
+    expect(context.store.get(member.value$)).toBe("2000");
+
+    // Save
+    context.store.set(member.save$);
+
+    // Wait for the saving promise to resolve
+    const promise = context.store.get(member.savingPromise$);
+    await promise;
+
+    expect(captured.calls).toHaveLength(1);
+    expect(captured.calls[0]).toStrictEqual({
+      userId: "user-a",
+      creditCap: 2000,
+    });
+    expect(context.store.get(member.editMode$)).toBeFalsy();
+  });
+
+  it("should not call PUT when value is invalid (non-positive)", async () => {
+    mockUsageMembers([memberA()]);
+    mockCreditCaps({
+      "user-a": { creditCap: null, creditEnabled: false },
+    });
+    const captured: { calls: CapturedCapCall[] } = { calls: [] };
+    mockCreditCapPut(captured);
+
+    await setup();
+
+    const members = await context.store.get(creditsMemberList$);
+    const member = members[0];
+
+    context.store.set(member.enterEditMode$);
+    context.store.set(member.setValue$, "-5");
+    context.store.set(member.save$);
+
+    expect(captured.calls).toHaveLength(0);
+  });
+
+  it("should not call PUT when value is NaN", async () => {
+    mockUsageMembers([memberA()]);
+    mockCreditCaps({
+      "user-a": { creditCap: null, creditEnabled: false },
+    });
+    const captured: { calls: CapturedCapCall[] } = { calls: [] };
+    mockCreditCapPut(captured);
+
+    await setup();
+
+    const members = await context.store.get(creditsMemberList$);
+    const member = members[0];
+
+    context.store.set(member.enterEditMode$);
+    context.store.set(member.setValue$, "abc");
+    context.store.set(member.save$);
+
+    expect(captured.calls).toHaveLength(0);
+  });
+
+  it("should call PUT with null creditCap when value is empty", async () => {
+    mockUsageMembers([memberA()]);
+    mockCreditCaps({
+      "user-a": { creditCap: 1000, creditEnabled: true },
+    });
+    const captured: { calls: CapturedCapCall[] } = { calls: [] };
+    mockCreditCapPut(captured);
+
+    await setup();
+
+    const members = await context.store.get(creditsMemberList$);
+    const member = members[0];
+
+    context.store.set(member.enterEditMode$);
+    context.store.set(member.setValue$, "");
+    context.store.set(member.save$);
+
+    const promise = context.store.get(member.savingPromise$);
+    await promise;
+
+    expect(captured.calls).toHaveLength(1);
+    expect(captured.calls[0]).toStrictEqual({
+      userId: "user-a",
+      creditCap: null,
+    });
+  });
+});
+
+describe("clearCap$ command", () => {
+  it("should call PUT with null creditCap and exit edit mode", async () => {
+    mockUsageMembers([memberA()]);
+    mockCreditCaps({
+      "user-a": { creditCap: 1000, creditEnabled: true },
+    });
+    const captured: { calls: CapturedCapCall[] } = { calls: [] };
+    mockCreditCapPut(captured);
+
+    await setup();
+
+    const members = await context.store.get(creditsMemberList$);
+    const member = members[0];
+
+    context.store.set(member.enterEditMode$);
+    context.store.set(member.clearCap$);
+
+    const promise = context.store.get(member.savingPromise$);
+    await promise;
+
+    expect(captured.calls).toHaveLength(1);
+    expect(captured.calls[0]).toStrictEqual({
+      userId: "user-a",
+      creditCap: null,
+    });
+    expect(context.store.get(member.editMode$)).toBeFalsy();
+  });
+});
+
+describe("edit mode signals", () => {
+  it("should toggle edit mode and reset value on enter", async () => {
+    mockUsageMembers([memberA()]);
+    mockCreditCaps({
+      "user-a": { creditCap: 500, creditEnabled: true },
+    });
+
+    await setup();
+
+    const members = await context.store.get(creditsMemberList$);
+    const member = members[0];
+
+    expect(context.store.get(member.editMode$)).toBeFalsy();
+
+    context.store.set(member.enterEditMode$);
+    expect(context.store.get(member.editMode$)).toBeTruthy();
+    expect(context.store.get(member.value$)).toBe("500");
+
+    context.store.set(member.exitEditMode$);
+    expect(context.store.get(member.editMode$)).toBeFalsy();
+  });
+
+  it("should initialize value to empty string when creditCap is null", async () => {
+    mockUsageMembers([memberA()]);
+    mockCreditCaps({
+      "user-a": { creditCap: null, creditEnabled: false },
+    });
+
+    await setup();
+
+    const members = await context.store.get(creditsMemberList$);
+    const member = members[0];
+
+    context.store.set(member.enterEditMode$);
+    expect(context.store.get(member.value$)).toBe("");
+  });
+});
+
+describe("creditsMemberList$ caching", () => {
+  it("should reuse cached setting when creditCap has not changed", async () => {
+    mockUsageMembers([memberA()]);
+    mockCreditCaps({
+      "user-a": { creditCap: 1000, creditEnabled: true },
+    });
+
+    await setup();
+
+    const members1 = await context.store.get(creditsMemberList$);
+    const setting1 = members1[0];
+
+    // Enter edit mode to create observable state
+    context.store.set(setting1.enterEditMode$);
+    context.store.set(setting1.setValue$, "9999");
+
+    // Re-evaluate the computed (same underlying data)
+    const members2 = await context.store.get(creditsMemberList$);
+    const setting2 = members2[0];
+
+    // Should be the same object reference (cached)
+    expect(setting2).toBe(setting1);
+    // Edit state should be preserved
+    expect(context.store.get(setting2.editMode$)).toBeTruthy();
+    expect(context.store.get(setting2.value$)).toBe("9999");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/member-credit-caps.ts
+++ b/turbo/apps/platform/src/signals/zero-page/member-credit-caps.ts
@@ -184,15 +184,35 @@ function createMemberCapSetting(
 }
 
 /**
+ * Signal holding a cache of MemberCapSetting objects keyed by userId.
+ * Preserved across recomputations so that in-progress edits
+ * (edit mode, typed input values, saving state) are not destroyed
+ * when another member's cap is saved.
+ */
+const memberCapSettingCache$ = state(new Map<string, MemberCapSetting>());
+
+/**
  * Async computed that fetches members + caps together,
  * returns MemberCapSetting[] with per-member signal bundles.
+ * Reuses existing MemberCapSetting objects when the creditCap hasn't changed,
+ * preserving in-progress edit state for other rows.
  */
 export const creditsMemberList$ = computed(async (get) => {
   const usage = await get(usageMembersAsync$);
   const caps = await get(memberCreditCaps$);
+  const cache = get(memberCapSettingCache$);
 
   return usage.members.map((member) => {
     const cap = caps.get(member.userId);
-    return createMemberCapSetting(member, cap?.creditCap ?? null);
+    const creditCap = cap?.creditCap ?? null;
+
+    const cached = cache.get(member.userId);
+    if (cached && cached.creditCap === creditCap) {
+      return cached;
+    }
+
+    const setting = createMemberCapSetting(member, creditCap);
+    cache.set(member.userId, setting);
+    return setting;
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/member-credit-caps.ts
+++ b/turbo/apps/platform/src/signals/zero-page/member-credit-caps.ts
@@ -1,6 +1,14 @@
-import { command, computed, state } from "ccstate";
+import {
+  command,
+  computed,
+  state,
+  type Command,
+  type Computed,
+  type State,
+} from "ccstate";
 import { fetch$ } from "../fetch.ts";
 import { usageMembersAsync$ } from "../usage-page/usage-signals.ts";
+import { toast } from "@vm0/ui/components/ui/sonner";
 
 interface MemberCreditCap {
   creditCap: number | null;
@@ -13,7 +21,7 @@ const memberCreditCapsReload$ = state(0);
  * Fetches credit caps for all members returned by usageMembersAsync$.
  * Returns a Map keyed by userId.
  */
-export const memberCreditCaps$ = computed(async (get) => {
+const memberCreditCaps$ = computed(async (get) => {
   get(memberCreditCapsReload$);
   const usage = await get(usageMembersAsync$);
   const fetchFn = get(fetch$);
@@ -54,7 +62,7 @@ export const memberCreditCaps$ = computed(async (get) => {
  * Command to set/clear a member's credit cap.
  * Invalidates the caps cache after mutation.
  */
-export const setMemberCreditCap$ = command(
+const setMemberCreditCap$ = command(
   async (
     { get, set },
     params: { userId: string; creditCap: number | null },
@@ -68,3 +76,123 @@ export const setMemberCreditCap$ = command(
     set(memberCreditCapsReload$, (x) => x + 1);
   },
 );
+
+// ---------------------------------------------------------------------------
+// Per-member signal factory
+// ---------------------------------------------------------------------------
+
+export interface MemberCapSetting {
+  userId: string;
+  email: string;
+  creditsCharged: number;
+  creditCap: number | null;
+  editMode$: State<boolean>;
+  value$: State<string>;
+  savingPromise$: Computed<Promise<unknown> | null>;
+  save$: Command<void, []>;
+  clearCap$: Command<void, []>;
+  enterEditMode$: Command<void, []>;
+  exitEditMode$: Command<void, []>;
+  setValue$: Command<void, [string]>;
+}
+
+function createMemberCapSetting(
+  member: { userId: string; email: string; creditsCharged: number },
+  creditCap: number | null,
+): MemberCapSetting {
+  const editMode$ = state(false);
+  const value$ = state(creditCap?.toString() ?? "");
+  const internalSavingPromise$ = state<Promise<unknown> | null>(null);
+  const savingPromise$ = computed((get) => get(internalSavingPromise$));
+
+  const save$ = command(({ get, set }) => {
+    const rawValue = get(value$);
+    const parsed =
+      rawValue.trim() === "" ? null : Number.parseInt(rawValue, 10);
+    if (parsed !== null && (Number.isNaN(parsed) || parsed <= 0)) {
+      return;
+    }
+
+    const promise = (async () => {
+      await set(setMemberCreditCap$, {
+        userId: member.userId,
+        creditCap: parsed,
+      });
+    })();
+
+    set(internalSavingPromise$, promise);
+
+    promise
+      .then(() => {
+        set(internalSavingPromise$, null);
+        set(editMode$, false);
+      })
+      .catch(() => {
+        set(internalSavingPromise$, null);
+        toast.error("Failed to update credit cap. Please try again.");
+      });
+  });
+
+  const clearCap$ = command(({ set }) => {
+    const promise = (async () => {
+      await set(setMemberCreditCap$, {
+        userId: member.userId,
+        creditCap: null,
+      });
+    })();
+
+    set(internalSavingPromise$, promise);
+
+    promise
+      .then(() => {
+        set(internalSavingPromise$, null);
+        set(editMode$, false);
+      })
+      .catch(() => {
+        set(internalSavingPromise$, null);
+        toast.error("Failed to clear credit cap. Please try again.");
+      });
+  });
+
+  const enterEditMode$ = command(({ set }) => {
+    set(value$, creditCap?.toString() ?? "");
+    set(editMode$, true);
+  });
+
+  const exitEditMode$ = command(({ set }) => {
+    set(editMode$, false);
+  });
+
+  const setValue$ = command(({ set }, newValue: string) => {
+    set(value$, newValue);
+  });
+
+  return {
+    userId: member.userId,
+    email: member.email,
+    creditsCharged: member.creditsCharged,
+    creditCap,
+    editMode$,
+    value$,
+    savingPromise$,
+    save$,
+    clearCap$,
+    enterEditMode$,
+    exitEditMode$,
+    setValue$,
+  };
+}
+
+/**
+ * Async computed that fetches members + caps together,
+ * returns MemberCapSetting[] with per-member signal bundles.
+ */
+export const creditsMemberList$ = computed(async (get) => {
+  const usage = await get(usageMembersAsync$);
+  const caps = await get(memberCreditCaps$);
+
+  return usage.members.map((member) => {
+    const cap = caps.get(member.userId);
+    return createMemberCapSetting(member, cap?.creditCap ?? null);
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -21,7 +21,7 @@ function LoadingButton({
   ...props
 }: ComponentProps<typeof Button> & { loading: boolean }) {
   return (
-    <Button {...props} disabled={props.disabled ?? loading}>
+    <Button {...props} disabled={props.disabled || loading}>
       {loading ? (
         <IconLoader2 size={13} stroke={1.5} className="animate-spin" />
       ) : null}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type ComponentProps, useState } from "react";
 import { useGet, useLastLoadable, useSet } from "ccstate-react";
 import { IconExternalLink, IconCrown, IconLoader2 } from "@tabler/icons-react";
 import {
@@ -14,6 +14,21 @@ import planProImg from "./assets/plan-pro.webp";
 import planTeamImg from "./assets/plan-team.webp";
 
 const cardBorder = { border: "0.7px solid hsl(var(--gray-400))" } as const;
+
+function LoadingButton({
+  loading,
+  children,
+  ...props
+}: ComponentProps<typeof Button> & { loading: boolean }) {
+  return (
+    <Button {...props} disabled={props.disabled ?? loading}>
+      {loading ? (
+        <IconLoader2 size={13} stroke={1.5} className="animate-spin" />
+      ) : null}
+      {children}
+    </Button>
+  );
+}
 
 interface PlanConfig {
   name: string;
@@ -179,31 +194,25 @@ function PlanCard({
             Current plan
           </Button>
         ) : plan.primary ? (
-          <Button
+          <LoadingButton
             size="sm"
             className="w-full rounded-lg h-9 text-xs"
-            disabled={loading}
+            loading={loading}
             onClick={() => plan.tier && onSelect(plan.tier)}
           >
-            {loading ? (
-              <IconLoader2 size={13} stroke={1.5} className="animate-spin" />
-            ) : null}
             {plan.cta}
-          </Button>
+          </LoadingButton>
         ) : (
-          <Button
+          <LoadingButton
             variant="outline"
             size="sm"
             className="w-full rounded-lg h-9 text-xs"
             style={cardBorder}
-            disabled={loading}
+            loading={loading}
             onClick={() => plan.tier && onSelect(plan.tier)}
           >
-            {loading ? (
-              <IconLoader2 size={13} stroke={1.5} className="animate-spin" />
-            ) : null}
             {plan.cta}
-          </Button>
+          </LoadingButton>
         )}
       </div>
     </div>
@@ -301,12 +310,12 @@ export function OrgBillingTab() {
               </span>
             </div>
             {isPro ? (
-              <Button
+              <LoadingButton
                 variant="outline"
                 size="sm"
                 className="shrink-0 rounded-lg h-8 text-xs gap-1.5"
                 style={cardBorder}
-                disabled={billingLoading}
+                loading={billingLoading}
                 onClick={() => {
                   downgrade().catch(() => {
                     toast.error(
@@ -315,32 +324,18 @@ export function OrgBillingTab() {
                   });
                 }}
               >
-                {billingLoading ? (
-                  <IconLoader2
-                    size={13}
-                    stroke={1.5}
-                    className="animate-spin"
-                  />
-                ) : null}
                 Manage billing
                 <IconExternalLink size={13} stroke={1.5} />
-              </Button>
+              </LoadingButton>
             ) : (
-              <Button
+              <LoadingButton
                 size="sm"
                 className="shrink-0 rounded-lg h-8 text-xs"
-                disabled={billingLoading}
+                loading={billingLoading}
                 onClick={() => setPricingOpen(true)}
               >
-                {billingLoading ? (
-                  <IconLoader2
-                    size={13}
-                    stroke={1.5}
-                    className="animate-spin"
-                  />
-                ) : null}
                 Upgrade
-              </Button>
+              </LoadingButton>
             )}
           </div>
           {isPro && (
@@ -356,12 +351,12 @@ export function OrgBillingTab() {
                     invoices on Stripe.
                   </span>
                 </div>
-                <Button
+                <LoadingButton
                   variant="outline"
                   size="sm"
                   className="shrink-0 rounded-lg h-8 text-xs gap-1.5"
                   style={cardBorder}
-                  disabled={billingLoading}
+                  loading={billingLoading}
                   onClick={() => {
                     downgrade().catch(() => {
                       toast.error(
@@ -370,16 +365,9 @@ export function OrgBillingTab() {
                     });
                   }}
                 >
-                  {billingLoading ? (
-                    <IconLoader2
-                      size={13}
-                      stroke={1.5}
-                      className="animate-spin"
-                    />
-                  ) : null}
                   Manage
                   <IconExternalLink size={13} stroke={1.5} />
-                </Button>
+                </LoadingButton>
               </div>
             </>
           )}
@@ -400,38 +388,24 @@ export function OrgBillingTab() {
               </span>
             </div>
             {isPro ? (
-              <Button
+              <LoadingButton
                 size="sm"
                 className="shrink-0 rounded-lg h-8 text-xs"
-                disabled={billingLoading}
+                loading={billingLoading}
               >
-                {billingLoading ? (
-                  <IconLoader2
-                    size={13}
-                    stroke={1.5}
-                    className="animate-spin"
-                  />
-                ) : null}
                 Add
-              </Button>
+              </LoadingButton>
             ) : (
-              <Button
+              <LoadingButton
                 variant="outline"
                 size="sm"
                 className="shrink-0 rounded-lg h-8 text-xs"
                 style={cardBorder}
-                disabled={billingLoading}
+                loading={billingLoading}
                 onClick={() => setPricingOpen(true)}
               >
-                {billingLoading ? (
-                  <IconLoader2
-                    size={13}
-                    stroke={1.5}
-                    className="animate-spin"
-                  />
-                ) : null}
                 Upgrade
-              </Button>
+              </LoadingButton>
             )}
           </div>
           <div className="h-px bg-border/40 mx-5" />
@@ -445,38 +419,24 @@ export function OrgBillingTab() {
               </span>
             </div>
             {isPro ? (
-              <Button
+              <LoadingButton
                 size="sm"
                 className="shrink-0 rounded-lg h-8 text-xs"
-                disabled={billingLoading}
+                loading={billingLoading}
               >
-                {billingLoading ? (
-                  <IconLoader2
-                    size={13}
-                    stroke={1.5}
-                    className="animate-spin"
-                  />
-                ) : null}
                 Add
-              </Button>
+              </LoadingButton>
             ) : (
-              <Button
+              <LoadingButton
                 variant="outline"
                 size="sm"
                 className="shrink-0 rounded-lg h-8 text-xs"
                 style={cardBorder}
-                disabled={billingLoading}
+                loading={billingLoading}
                 onClick={() => setPricingOpen(true)}
               >
-                {billingLoading ? (
-                  <IconLoader2
-                    size={13}
-                    stroke={1.5}
-                    className="animate-spin"
-                  />
-                ) : null}
                 Upgrade
-              </Button>
+              </LoadingButton>
             )}
           </div>
         </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { useLastLoadable, useSet } from "ccstate-react";
-import { IconExternalLink, IconCrown } from "@tabler/icons-react";
+import { useGet, useLastLoadable, useSet } from "ccstate-react";
+import { IconExternalLink, IconCrown, IconLoader2 } from "@tabler/icons-react";
 import {
   billingStatusAsync$,
+  billingDialogLoading$,
   startCheckout$,
   startDowngrade$,
 } from "../../../../signals/zero-page/billing.ts";
@@ -84,9 +85,11 @@ const PLANS = [
 function PlanCard({
   plan,
   onSelect,
+  loading,
 }: {
   plan: Readonly<PlanConfig>;
   onSelect: (tier: "pro" | "team") => void;
+  loading: boolean;
 }) {
   const isCurrentPlan = plan.cta === "Current plan";
 
@@ -179,8 +182,12 @@ function PlanCard({
           <Button
             size="sm"
             className="w-full rounded-lg h-9 text-xs"
+            disabled={loading}
             onClick={() => plan.tier && onSelect(plan.tier)}
           >
+            {loading ? (
+              <IconLoader2 size={13} stroke={1.5} className="animate-spin" />
+            ) : null}
             {plan.cta}
           </Button>
         ) : (
@@ -189,8 +196,12 @@ function PlanCard({
             size="sm"
             className="w-full rounded-lg h-9 text-xs"
             style={cardBorder}
+            disabled={loading}
             onClick={() => plan.tier && onSelect(plan.tier)}
           >
+            {loading ? (
+              <IconLoader2 size={13} stroke={1.5} className="animate-spin" />
+            ) : null}
             {plan.cta}
           </Button>
         )}
@@ -203,10 +214,12 @@ function PricingDialog({
   open,
   onOpenChange,
   onSelectTier,
+  loading,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSelectTier: (tier: "pro" | "team") => void;
+  loading: boolean;
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -230,7 +243,12 @@ function PricingDialog({
 
         <div className="grid grid-cols-3 gap-4 px-6 py-5">
           {PLANS.map((plan) => (
-            <PlanCard key={plan.name} plan={plan} onSelect={onSelectTier} />
+            <PlanCard
+              key={plan.name}
+              plan={plan}
+              onSelect={onSelectTier}
+              loading={loading}
+            />
           ))}
         </div>
       </DialogContent>
@@ -240,9 +258,18 @@ function PricingDialog({
 
 export function OrgBillingTab() {
   const billingLoadable = useLastLoadable(billingStatusAsync$);
+  const billingLoading = useGet(billingDialogLoading$);
   const checkout = useSet(startCheckout$);
   const downgrade = useSet(startDowngrade$);
   const [pricingOpen, setPricingOpen] = useState(false);
+
+  if (billingLoadable.state === "loading") {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-muted-foreground">Loading billing...</p>
+      </div>
+    );
+  }
 
   const isPro =
     billingLoadable.state === "hasData" && billingLoadable.data.tier !== "free";
@@ -279,6 +306,7 @@ export function OrgBillingTab() {
                 size="sm"
                 className="shrink-0 rounded-lg h-8 text-xs gap-1.5"
                 style={cardBorder}
+                disabled={billingLoading}
                 onClick={() => {
                   downgrade().catch(() => {
                     toast.error(
@@ -287,6 +315,13 @@ export function OrgBillingTab() {
                   });
                 }}
               >
+                {billingLoading ? (
+                  <IconLoader2
+                    size={13}
+                    stroke={1.5}
+                    className="animate-spin"
+                  />
+                ) : null}
                 Manage billing
                 <IconExternalLink size={13} stroke={1.5} />
               </Button>
@@ -294,8 +329,16 @@ export function OrgBillingTab() {
               <Button
                 size="sm"
                 className="shrink-0 rounded-lg h-8 text-xs"
+                disabled={billingLoading}
                 onClick={() => setPricingOpen(true)}
               >
+                {billingLoading ? (
+                  <IconLoader2
+                    size={13}
+                    stroke={1.5}
+                    className="animate-spin"
+                  />
+                ) : null}
                 Upgrade
               </Button>
             )}
@@ -318,6 +361,7 @@ export function OrgBillingTab() {
                   size="sm"
                   className="shrink-0 rounded-lg h-8 text-xs gap-1.5"
                   style={cardBorder}
+                  disabled={billingLoading}
                   onClick={() => {
                     downgrade().catch(() => {
                       toast.error(
@@ -326,6 +370,13 @@ export function OrgBillingTab() {
                     });
                   }}
                 >
+                  {billingLoading ? (
+                    <IconLoader2
+                      size={13}
+                      stroke={1.5}
+                      className="animate-spin"
+                    />
+                  ) : null}
                   Manage
                   <IconExternalLink size={13} stroke={1.5} />
                 </Button>
@@ -349,7 +400,18 @@ export function OrgBillingTab() {
               </span>
             </div>
             {isPro ? (
-              <Button size="sm" className="shrink-0 rounded-lg h-8 text-xs">
+              <Button
+                size="sm"
+                className="shrink-0 rounded-lg h-8 text-xs"
+                disabled={billingLoading}
+              >
+                {billingLoading ? (
+                  <IconLoader2
+                    size={13}
+                    stroke={1.5}
+                    className="animate-spin"
+                  />
+                ) : null}
                 Add
               </Button>
             ) : (
@@ -358,8 +420,16 @@ export function OrgBillingTab() {
                 size="sm"
                 className="shrink-0 rounded-lg h-8 text-xs"
                 style={cardBorder}
+                disabled={billingLoading}
                 onClick={() => setPricingOpen(true)}
               >
+                {billingLoading ? (
+                  <IconLoader2
+                    size={13}
+                    stroke={1.5}
+                    className="animate-spin"
+                  />
+                ) : null}
                 Upgrade
               </Button>
             )}
@@ -375,7 +445,18 @@ export function OrgBillingTab() {
               </span>
             </div>
             {isPro ? (
-              <Button size="sm" className="shrink-0 rounded-lg h-8 text-xs">
+              <Button
+                size="sm"
+                className="shrink-0 rounded-lg h-8 text-xs"
+                disabled={billingLoading}
+              >
+                {billingLoading ? (
+                  <IconLoader2
+                    size={13}
+                    stroke={1.5}
+                    className="animate-spin"
+                  />
+                ) : null}
                 Add
               </Button>
             ) : (
@@ -384,8 +465,16 @@ export function OrgBillingTab() {
                 size="sm"
                 className="shrink-0 rounded-lg h-8 text-xs"
                 style={cardBorder}
+                disabled={billingLoading}
                 onClick={() => setPricingOpen(true)}
               >
+                {billingLoading ? (
+                  <IconLoader2
+                    size={13}
+                    stroke={1.5}
+                    className="animate-spin"
+                  />
+                ) : null}
                 Upgrade
               </Button>
             )}
@@ -397,6 +486,7 @@ export function OrgBillingTab() {
         open={pricingOpen}
         onOpenChange={setPricingOpen}
         onSelectTier={handleSelectTier}
+        loading={billingLoading}
       />
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-credits-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-credits-tab.tsx
@@ -1,14 +1,12 @@
-import { useState } from "react";
-import { useLastLoadable, useSet } from "ccstate-react";
+import { useGet, useLastLoadable, useLoadable, useSet } from "ccstate-react";
+import { IconLoader2 } from "@tabler/icons-react";
 import { billingStatusAsync$ } from "../../../../signals/zero-page/billing.ts";
-import { usageMembersAsync$ } from "../../../../signals/usage-page/usage-signals.ts";
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
 import {
-  memberCreditCaps$,
-  setMemberCreditCap$,
+  creditsMemberList$,
+  type MemberCapSetting,
 } from "../../../../signals/zero-page/member-credit-caps.ts";
 import { Button, Input } from "@vm0/ui";
-import { toast } from "@vm0/ui/components/ui/sonner";
 
 const sectionCardStyle = {
   border: "0.7px solid hsl(var(--gray-400))",
@@ -18,86 +16,89 @@ function formatNumber(n: number): string {
   return n.toLocaleString();
 }
 
-function MemberCapEditor({
-  userId,
-  currentCap,
+function MemberRow({
+  member,
+  isAdmin,
 }: {
-  userId: string;
-  currentCap: number | null;
+  member: MemberCapSetting;
+  isAdmin: boolean;
 }) {
-  const setCap = useSet(setMemberCreditCap$);
-  const [editing, setEditing] = useState(false);
-  const [value, setValue] = useState(currentCap?.toString() ?? "");
-
-  const handleSave = () => {
-    const parsed = value.trim() === "" ? null : Number.parseInt(value, 10);
-    if (parsed !== null && (Number.isNaN(parsed) || parsed <= 0)) {
-      return;
-    }
-    setCap({ userId, creditCap: parsed }).catch(() => {
-      toast.error("Failed to update credit cap. Please try again.");
-    });
-    setEditing(false);
-  };
-
-  const handleClear = () => {
-    setCap({ userId, creditCap: null }).catch(() => {
-      toast.error("Failed to clear credit cap. Please try again.");
-    });
-    setEditing(false);
-  };
-
-  if (!editing) {
-    return (
-      <button
-        type="button"
-        onClick={() => {
-          setValue(currentCap?.toString() ?? "");
-          setEditing(true);
-        }}
-        className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-      >
-        {currentCap !== null ? formatNumber(currentCap) : "No limit"}
-      </button>
-    );
-  }
+  const editMode = useGet(member.editMode$);
+  const value = useGet(member.value$);
+  const savingStatus = useLoadable(member.savingPromise$);
+  const save = useSet(member.save$);
+  const clearCap = useSet(member.clearCap$);
+  const enterEdit = useSet(member.enterEditMode$);
+  const exitEdit = useSet(member.exitEditMode$);
+  const setValue = useSet(member.setValue$);
+  const isSaving = savingStatus.state === "loading";
 
   return (
-    <div className="flex items-center gap-1.5">
-      <Input
-        type="number"
-        min={1}
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        className="h-7 w-20 text-xs"
-        placeholder="No limit"
-        autoFocus
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            handleSave();
-          }
-          if (e.key === "Escape") {
-            setEditing(false);
-          }
-        }}
-      />
-      <Button
-        variant="outline"
-        size="sm"
-        className="h-7 text-xs px-2"
-        onClick={handleSave}
-      >
-        Save
-      </Button>
-      {currentCap !== null && (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 text-xs px-2"
-          onClick={handleClear}
-        >
-          Clear
-        </Button>
+    <div className="grid grid-cols-[1fr_6rem_6rem] gap-x-4 items-center px-5 py-3">
+      <span className="text-sm text-muted-foreground truncate">
+        {member.email}
+      </span>
+      <span className="text-sm text-muted-foreground tabular-nums text-right">
+        {formatNumber(member.creditsCharged)}
+      </span>
+      {isAdmin && (
+        <div className="flex justify-end">
+          {isSaving ? (
+            <IconLoader2
+              size={14}
+              stroke={1.5}
+              className="animate-spin text-muted-foreground"
+            />
+          ) : editMode ? (
+            <div className="flex items-center gap-1.5">
+              <Input
+                type="number"
+                min={1}
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                className="h-7 w-20 text-xs"
+                placeholder="No limit"
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    save();
+                  }
+                  if (e.key === "Escape") {
+                    exitEdit();
+                  }
+                }}
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-xs px-2"
+                onClick={() => save()}
+              >
+                Save
+              </Button>
+              {member.creditCap !== null && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-xs px-2"
+                  onClick={() => clearCap()}
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => enterEdit()}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {member.creditCap !== null
+                ? formatNumber(member.creditCap)
+                : "No limit"}
+            </button>
+          )}
+        </div>
       )}
     </div>
   );
@@ -105,8 +106,7 @@ function MemberCapEditor({
 
 export function OrgCreditsTab() {
   const billingLoadable = useLastLoadable(billingStatusAsync$);
-  const usageLoadable = useLastLoadable(usageMembersAsync$);
-  const capsLoadable = useLastLoadable(memberCreditCaps$);
+  const membersLoadable = useLastLoadable(creditsMemberList$);
   const isAdminLoadable = useLastLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
@@ -120,11 +120,20 @@ export function OrgCreditsTab() {
       ? billingLoadable.data.currentPeriodEnd
       : null;
 
-  const members =
-    usageLoadable.state === "hasData" ? usageLoadable.data.members : [];
-  const totalUsage = members.reduce((sum, m) => sum + m.creditsCharged, 0);
+  const isLoading =
+    billingLoadable.state === "loading" || membersLoadable.state === "loading";
 
-  const caps = capsLoadable.state === "hasData" ? capsLoadable.data : new Map();
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-muted-foreground">Loading credits...</p>
+      </div>
+    );
+  }
+
+  const members =
+    membersLoadable.state === "hasData" ? membersLoadable.data : [];
+  const totalUsage = members.reduce((sum, m) => sum + m.creditsCharged, 0);
 
   return (
     <div className="flex flex-col gap-8">
@@ -193,31 +202,13 @@ export function OrgCreditsTab() {
               <div className="text-right">Credits used</div>
               {isAdmin && <div className="text-right">Cap</div>}
             </div>
-            {members.map((member, i) => {
-              const cap = caps.get(member.userId);
-              return (
-                <div key={member.userId}>
-                  {i === 0 && <div className="h-px bg-border/40 mx-5" />}
-                  {i > 0 && <div className="h-px bg-border/40 mx-5" />}
-                  <div className="grid grid-cols-[1fr_6rem_6rem] gap-x-4 items-center px-5 py-3">
-                    <span className="text-sm text-muted-foreground truncate">
-                      {member.email}
-                    </span>
-                    <span className="text-sm text-muted-foreground tabular-nums text-right">
-                      {formatNumber(member.creditsCharged)}
-                    </span>
-                    {isAdmin && (
-                      <div className="flex justify-end">
-                        <MemberCapEditor
-                          userId={member.userId}
-                          currentCap={cap?.creditCap ?? null}
-                        />
-                      </div>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
+            {members.map((member, i) => (
+              <div key={member.userId}>
+                {i === 0 && <div className="h-px bg-border/40 mx-5" />}
+                {i > 0 && <div className="h-px bg-border/40 mx-5" />}
+                <MemberRow member={member} isAdmin={isAdmin} />
+              </div>
+            ))}
           </div>
         </section>
       )}


### PR DESCRIPTION
## Summary
- Rewrite `member-credit-caps.ts` with a per-member signal factory pattern (`createMemberCapSetting`) that provides isolated edit/save state per row, including `savingPromise$` for per-row spinner via `useLoadable`
- Add "Loading credits..." and "Loading billing..." placeholders to Credits and Billing tabs on initial data fetch, matching the existing Invoices tab pattern
- Consume `billingDialogLoading$` in `OrgBillingTab` to disable all action buttons (Upgrade, Manage billing, Add) with spinner during checkout/portal redirect
- Pass loading state to `PricingDialog` to disable plan card buttons during async operations
- Credit cap save failure now keeps editor open with error toast instead of silently reverting

## Test plan
- [ ] Billing tab shows "Loading billing..." on first load
- [ ] Credits tab shows "Loading credits..." on first load
- [ ] Credit cap save shows per-row spinner while saving
- [ ] Credit cap save failure keeps editor open with error toast
- [ ] Upgrade/Manage billing/Add buttons are disabled with spinner during checkout/portal redirect
- [ ] All pre-commit checks pass (lint, types, format, knip)

Closes #6722

🤖 Generated with [Claude Code](https://claude.com/claude-code)