### PR TITLE
refactor(web): return flat array from team api endpoint

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-agents.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-agents.ts
@@ -10,17 +10,14 @@ import { http, HttpResponse } from "msw";
 export const apiAgentsHandlers = [
   // GET /api/zero/team
   http.get("/api/zero/team", () => {
-    return HttpResponse.json({
-      composes: [
-        {
-          id: "mock-compose-id",
-          displayName: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-          isOwner: true,
-        },
-      ],
-    });
+    return HttpResponse.json([
+      {
+        id: "mock-compose-id",
+        displayName: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    ]);
   }),
 
   // GET /api/zero/composes/list

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-added-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-added-connectors.test.ts
@@ -65,24 +65,20 @@ describe("zeroAddedConnectors$", () => {
       }),
       // Include cycling-coach in the team list so route setup resolves it
       http.get("*/api/zero/team", () => {
-        return HttpResponse.json({
-          composes: [
-            {
-              id: "mock-compose-id",
-              displayName: null,
-              headVersionId: "version_1",
-              updatedAt: "2024-01-01T00:00:00Z",
-              isOwner: true,
-            },
-            {
-              id: "sub-agent-compose-id",
-              displayName: "Cycling Coach",
-              headVersionId: "version_2",
-              updatedAt: "2024-01-01T00:00:00Z",
-              isOwner: false,
-            },
-          ],
-        });
+        return HttpResponse.json([
+          {
+            id: "mock-compose-id",
+            displayName: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "sub-agent-compose-id",
+            displayName: "Cycling Coach",
+            headVersionId: "version_2",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        ]);
       }),
     );
 

--- a/turbo/apps/platform/src/signals/zero-page/agents-list.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agents-list.ts
@@ -46,9 +46,7 @@ export const fetchAgentsList$ = command(async ({ get, set }) => {
       throw new Error(`Failed to fetch agents: ${agentsResponse.statusText}`);
     }
 
-    const agentsData = (await agentsResponse.json()) as {
-      composes: ComposeListItem[];
-    };
+    const agents = (await agentsResponse.json()) as ComposeListItem[];
 
     // Fetch schedules (optional - don't fail if schedules API is unavailable)
     let schedules: Schedule[] = [];
@@ -66,7 +64,7 @@ export const fetchAgentsList$ = command(async ({ get, set }) => {
     }
 
     set(agentsListState$, {
-      agents: agentsData.composes,
+      agents,
       schedules,
       loading: false,
       error: null,

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-detail-avatar.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-detail-avatar.test.tsx
@@ -15,19 +15,16 @@ const context = testContext();
 function mockDefaultAgentAPIs() {
   server.use(
     http.get("*/api/zero/team", () =>
-      HttpResponse.json({
-        composes: [
-          {
-            id: "mock-compose-id",
-            name: "zero",
-            displayName: "Zero",
-            description: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-            isOwner: true,
-          },
-        ],
-      }),
+      HttpResponse.json([
+        {
+          id: "mock-compose-id",
+          name: "zero",
+          displayName: "Zero",
+          description: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]),
     ),
     http.get("*/api/zero/chat-threads", () =>
       HttpResponse.json({ threads: [] }),
@@ -54,28 +51,24 @@ function mockDefaultAgentAPIs() {
 function mockSubAgentAPIs() {
   server.use(
     http.get("*/api/zero/team", () =>
-      HttpResponse.json({
-        composes: [
-          {
-            id: "mock-compose-id",
-            name: "zero",
-            displayName: null,
-            description: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-            isOwner: true,
-          },
-          {
-            id: "sub-agent-id",
-            name: "sub-agent",
-            displayName: "Sub Agent",
-            description: "A sub agent",
-            headVersionId: "version_2",
-            updatedAt: "2024-01-02T00:00:00Z",
-            isOwner: false,
-          },
-        ],
-      }),
+      HttpResponse.json([
+        {
+          id: "mock-compose-id",
+          name: "zero",
+          displayName: null,
+          description: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "sub-agent-id",
+          name: "sub-agent",
+          displayName: "Sub Agent",
+          description: "A sub agent",
+          headVersionId: "version_2",
+          updatedAt: "2024-01-02T00:00:00Z",
+        },
+      ]),
     ),
     http.get("*/api/zero/chat-threads", () =>
       HttpResponse.json({ threads: [] }),

--- a/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/team-page/__tests__/team-navigation.test.tsx
@@ -15,7 +15,6 @@ function createMockTeamWithSubagents() {
       description: null,
       headVersionId: "version_1",
       updatedAt: "2024-01-01T00:00:00Z",
-      isOwner: true,
     },
     {
       id: "agent-2",
@@ -23,7 +22,6 @@ function createMockTeamWithSubagents() {
       description: "Finds and summarizes information",
       headVersionId: "version_2",
       updatedAt: "2024-01-02T00:00:00Z",
-      isOwner: false,
     },
   ];
 }
@@ -31,7 +29,7 @@ function createMockTeamWithSubagents() {
 function mockAPIs() {
   server.use(
     http.get("*/api/zero/team", () => {
-      return HttpResponse.json({ composes: createMockTeamWithSubagents() });
+      return HttpResponse.json(createMockTeamWithSubagents());
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-general-tab.test.tsx
@@ -21,19 +21,16 @@ function mockAPIs(overrides?: { slug?: string; name?: string; role?: string }) {
     ),
     http.get("*/api/zero/org/logo", () => HttpResponse.json({ logoUrl: null })),
     http.get("*/api/zero/team", () =>
-      HttpResponse.json({
-        composes: [
-          {
-            id: "mock-compose-id",
-            name: "zero",
-            displayName: null,
-            description: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-            isOwner: true,
-          },
-        ],
-      }),
+      HttpResponse.json([
+        {
+          id: "mock-compose-id",
+          name: "zero",
+          displayName: null,
+          description: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]),
     ),
   );
   return org;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-navigation.test.tsx
@@ -10,18 +10,15 @@ const context = testContext();
 function mockAPIs() {
   server.use(
     http.get("*/api/zero/team", () => {
-      return HttpResponse.json({
-        composes: [
-          {
-            id: "mock-compose-id",
-            displayName: null,
-            description: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-            isOwner: true,
-          },
-        ],
-      });
+      return HttpResponse.json([
+        {
+          id: "mock-compose-id",
+          displayName: null,
+          description: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -11,24 +11,20 @@ const context = testContext();
 function mockSubagentAPIs() {
   server.use(
     http.get("*/api/zero/team", () => {
-      return HttpResponse.json({
-        composes: [
-          {
-            id: "mock-compose-id",
-            displayName: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-            isOwner: true,
-          },
-          {
-            id: "subagent-compose-id",
-            displayName: "Helper Bot",
-            headVersionId: "version_2",
-            updatedAt: "2024-01-01T00:00:00Z",
-            isOwner: true,
-          },
-        ],
-      });
+      return HttpResponse.json([
+        {
+          id: "mock-compose-id",
+          displayName: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "subagent-compose-id",
+          displayName: "Helper Bot",
+          headVersionId: "version_2",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page.test.tsx
@@ -10,28 +10,24 @@ const context = testContext();
 function mockAPIs() {
   server.use(
     http.get("*/api/zero/team", () => {
-      return HttpResponse.json({
-        composes: [
-          {
-            id: "mock-compose-id",
-            name: "zero",
-            displayName: null,
-            description: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-            isOwner: true,
-          },
-          {
-            id: "agent-detail-id",
-            name: "my-agent",
-            displayName: "My Agent",
-            description: "A helpful agent",
-            headVersionId: "version_2",
-            updatedAt: "2024-01-02T00:00:00Z",
-            isOwner: false,
-          },
-        ],
-      });
+      return HttpResponse.json([
+        {
+          id: "mock-compose-id",
+          name: "zero",
+          displayName: null,
+          description: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "agent-detail-id",
+          name: "my-agent",
+          displayName: "My Agent",
+          description: "A helpful agent",
+          headVersionId: "version_2",
+          updatedAt: "2024-01-02T00:00:00Z",
+        },
+      ]);
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });
@@ -102,19 +98,16 @@ describe("zero job detail page", () => {
   it("should show not-found error for unknown agent", async () => {
     server.use(
       http.get("*/api/zero/team", () => {
-        return HttpResponse.json({
-          composes: [
-            {
-              id: "mock-compose-id",
-              name: "zero",
-              displayName: null,
-              description: null,
-              headVersionId: "version_1",
-              updatedAt: "2024-01-01T00:00:00Z",
-              isOwner: true,
-            },
-          ],
-        });
+        return HttpResponse.json([
+          {
+            id: "mock-compose-id",
+            name: "zero",
+            displayName: null,
+            description: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        ]);
       }),
       http.get("*/api/zero/chat-threads", () => {
         return HttpResponse.json({ threads: [] });
@@ -151,28 +144,24 @@ describe("zero job detail page", () => {
 function mockAPIsWithSchedules() {
   server.use(
     http.get("*/api/zero/team", () => {
-      return HttpResponse.json({
-        composes: [
-          {
-            id: "mock-compose-id",
-            name: "zero",
-            displayName: null,
-            description: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-            isOwner: true,
-          },
-          {
-            id: "agent-detail-id",
-            name: "my-agent",
-            displayName: "My Agent",
-            description: "A helpful agent",
-            headVersionId: "version_2",
-            updatedAt: "2024-01-02T00:00:00Z",
-            isOwner: false,
-          },
-        ],
-      });
+      return HttpResponse.json([
+        {
+          id: "mock-compose-id",
+          name: "zero",
+          displayName: null,
+          description: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "agent-detail-id",
+          name: "my-agent",
+          displayName: "My Agent",
+          description: "A helpful agent",
+          headVersionId: "version_2",
+          updatedAt: "2024-01-02T00:00:00Z",
+        },
+      ]);
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
@@ -15,7 +15,6 @@ function createMockTeamWithSubagents() {
       description: null,
       headVersionId: "version_1",
       updatedAt: "2024-01-01T00:00:00Z",
-      isOwner: true,
     },
     {
       id: "agent-2",
@@ -23,7 +22,6 @@ function createMockTeamWithSubagents() {
       description: "Finds and summarizes information",
       headVersionId: "version_2",
       updatedAt: "2024-01-02T00:00:00Z",
-      isOwner: false,
     },
     {
       id: "agent-3",
@@ -31,15 +29,14 @@ function createMockTeamWithSubagents() {
       description: "Writes content based on research",
       headVersionId: "version_3",
       updatedAt: "2024-01-03T00:00:00Z",
-      isOwner: false,
     },
   ];
 }
 
-function mockTeamAPI(composes = createMockTeamWithSubagents()) {
+function mockTeamAPI(agents = createMockTeamWithSubagents()) {
   server.use(
     http.get("*/api/zero/team", () => {
-      return HttpResponse.json({ composes });
+      return HttpResponse.json(agents);
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });
@@ -92,7 +89,6 @@ describe("zero jobs page - team list", () => {
         description: null,
         headVersionId: "version_1",
         updatedAt: "2024-01-01T00:00:00Z",
-        isOwner: true,
       },
     ]);
     await renderTeamPage();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -40,18 +40,15 @@ function mockAPIs({
 } = {}) {
   server.use(
     http.get("*/api/zero/team", () => {
-      return HttpResponse.json({
-        composes: [
-          {
-            id: "mock-compose-id",
-            displayName: null,
-            description: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-            isOwner: true,
-          },
-        ],
-      });
+      return HttpResponse.json([
+        {
+          id: "mock-compose-id",
+          displayName: null,
+          description: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads });
@@ -62,26 +59,22 @@ function mockAPIs({
 function mockAPIsWithSubagents() {
   server.use(
     http.get("*/api/zero/team", () => {
-      return HttpResponse.json({
-        composes: [
-          {
-            id: "mock-compose-id",
-            displayName: null,
-            description: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-            isOwner: true,
-          },
-          {
-            id: "sub-agent-id",
-            displayName: "Research Agent",
-            description: "Finds information",
-            headVersionId: "version_2",
-            updatedAt: "2024-01-02T00:00:00Z",
-            isOwner: false,
-          },
-        ],
-      });
+      return HttpResponse.json([
+        {
+          id: "mock-compose-id",
+          displayName: null,
+          description: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "sub-agent-id",
+          displayName: "Research Agent",
+          description: "Finds information",
+          headVersionId: "version_2",
+          updatedAt: "2024-01-02T00:00:00Z",
+        },
+      ]);
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({

--- a/turbo/apps/web/app/api/zero/team/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/team/__tests__/route.test.ts
@@ -45,7 +45,7 @@ describe("GET /api/zero/team", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.composes).toEqual([]);
+    expect(data).toEqual([]);
   });
 
   it("should return composes for the active org", async () => {
@@ -56,9 +56,9 @@ describe("GET /api/zero/team", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data.composes).toHaveLength(1);
-    expect(data.composes[0].id).toBeDefined();
-    expect(data.composes[0].updatedAt).toBeDefined();
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBeDefined();
+    expect(data[0].updatedAt).toBeDefined();
   });
 
   it("should not return composes from other orgs", async () => {
@@ -79,7 +79,7 @@ describe("GET /api/zero/team", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    const ids = data.composes.map((c: { id: string }) => c.id);
+    const ids = data.map((c: { id: string }) => c.id);
     expect(ids).toHaveLength(1);
     expect(ids[0]).toBeDefined();
   });

--- a/turbo/apps/web/app/api/zero/team/route.ts
+++ b/turbo/apps/web/app/api/zero/team/route.ts
@@ -73,15 +73,14 @@ export async function GET() {
     .where(eq(agentComposes.orgId, resolvedOrgId))
     .orderBy(desc(agentComposes.updatedAt));
 
-  return NextResponse.json({
-    composes: composes.map((c) => ({
+  return NextResponse.json(
+    composes.map((c) => ({
       id: c.id,
       displayName: c.displayName ?? null,
       description: c.description ?? null,
       sound: c.sound ?? null,
       headVersionId: c.headVersionId,
       updatedAt: c.updatedAt.toISOString(),
-      isOwner: true,
     })),
-  });
+  );
 }


### PR DESCRIPTION
## Summary
- Simplify `GET /api/zero/team` response from `{ composes: [...] }` wrapper object to a flat array
- Remove unused `isOwner` field from the response payload
- Update platform signal consumer (`agents-list.ts`) and all mock handlers/tests to match the new response shape

## Test plan
- [ ] Verify `GET /api/zero/team` integration tests pass
- [ ] Verify all platform component tests referencing team API pass
- [ ] Verify zero-added-connectors signal test passes
- [ ] Confirm no regressions in sidebar, jobs page, and team navigation views

🤖 Generated with [Claude Code](https://claude.com/claude-code)