### PR TITLE
feat: add create teammate card in team empty state

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
@@ -98,6 +98,25 @@ describe("zero jobs page - team list", () => {
     });
   });
 
+  it("should show create teammate button in empty state", async () => {
+    mockTeamAPI([
+      {
+        id: "mock-compose-id",
+        displayName: null,
+        description: null,
+        headVersionId: "version_1",
+        updatedAt: "2024-01-01T00:00:00Z",
+        isOwner: true,
+      },
+    ]);
+    await renderTeamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Just Zero for now")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Create teammate")).toBeInTheDocument();
+  });
+
   it("should show create teammate button when sub-agents exist", async () => {
     mockTeamAPI();
     await renderTeamPage();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page.test.tsx
@@ -106,7 +106,6 @@ describe("zero jobs page - team list", () => {
         description: null,
         headVersionId: "version_1",
         updatedAt: "2024-01-01T00:00:00Z",
-        isOwner: true,
       },
     ]);
     await renderTeamPage();

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -195,25 +195,51 @@ export function ZeroJobsPage() {
           )}
 
           {!loading && !error && agents && agents.length === 0 && (
-            <Card className="zero-card">
-              <CardContent className="flex flex-col items-center justify-center px-6 py-12 gap-3">
-                <img
-                  src={emptyChatImg}
-                  alt="No teammates"
-                  loading="lazy"
-                  className="h-20 w-20 object-contain opacity-80"
-                />
-                <div className="text-center">
-                  <p className="text-sm font-medium text-foreground">
-                    Just {agentName} for now
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Ask {agentName} to create a teammate and they&apos;ll show
-                    up here.
-                  </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <button
+                type="button"
+                onClick={() => setDialogOpen(true)}
+                className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-[hsl(var(--gray-400))] transition-colors hover:border-[hsl(var(--gray-400))] hover:bg-muted/30 group cursor-pointer text-left"
+              >
+                <div className="flex items-center gap-3 px-4 py-3.5">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors">
+                    <IconPlus
+                      size={18}
+                      stroke={2}
+                      className="text-foreground/50 group-hover:text-foreground transition-colors"
+                    />
+                  </span>
+                  <span className="text-sm font-medium text-foreground/80 group-hover:text-foreground transition-colors">
+                    Create teammate
+                  </span>
                 </div>
-              </CardContent>
-            </Card>
+                <div className="border-t border-dashed border-[hsl(var(--gray-400))] px-4 py-2.5">
+                  <span className="text-xs text-muted-foreground">
+                    Create a new subagent
+                  </span>
+                </div>
+              </button>
+
+              <Card className="zero-card">
+                <CardContent className="flex flex-col items-center justify-center px-6 py-12 gap-3">
+                  <img
+                    src={emptyChatImg}
+                    alt="No teammates"
+                    loading="lazy"
+                    className="h-20 w-20 object-contain opacity-80"
+                  />
+                  <div className="text-center">
+                    <p className="text-sm font-medium text-foreground">
+                      Just {agentName} for now
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Ask {agentName} to create a teammate and they&apos;ll show
+                      up here.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
           )}
 
           {agents && agents.length > 0 && (

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -196,29 +196,7 @@ export function ZeroJobsPage() {
 
           {!loading && !error && agents && agents.length === 0 && (
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <button
-                type="button"
-                onClick={() => setDialogOpen(true)}
-                className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-[hsl(var(--gray-400))] transition-colors hover:border-[hsl(var(--gray-400))] hover:bg-muted/30 group cursor-pointer text-left"
-              >
-                <div className="flex items-center gap-3 px-4 py-3.5">
-                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors">
-                    <IconPlus
-                      size={18}
-                      stroke={2}
-                      className="text-foreground/50 group-hover:text-foreground transition-colors"
-                    />
-                  </span>
-                  <span className="text-sm font-medium text-foreground/80 group-hover:text-foreground transition-colors">
-                    Create teammate
-                  </span>
-                </div>
-                <div className="border-t border-dashed border-[hsl(var(--gray-400))] px-4 py-2.5">
-                  <span className="text-xs text-muted-foreground">
-                    Create a new subagent
-                  </span>
-                </div>
-              </button>
+              <CreateTeammateButton onClick={() => setDialogOpen(true)} />
 
               <Card className="zero-card">
                 <CardContent className="flex flex-col items-center justify-center px-6 py-12 gap-3">
@@ -244,30 +222,7 @@ export function ZeroJobsPage() {
 
           {agents && agents.length > 0 && (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-              {/* Create teammate */}
-              <button
-                type="button"
-                onClick={() => setDialogOpen(true)}
-                className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-[hsl(var(--gray-400))] transition-colors hover:border-[hsl(var(--gray-400))] hover:bg-muted/30 group cursor-pointer text-left"
-              >
-                <div className="flex items-center gap-3 px-4 py-3.5">
-                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors">
-                    <IconPlus
-                      size={18}
-                      stroke={2}
-                      className="text-foreground/50 group-hover:text-foreground transition-colors"
-                    />
-                  </span>
-                  <span className="text-sm font-medium text-foreground/80 group-hover:text-foreground transition-colors">
-                    Create teammate
-                  </span>
-                </div>
-                <div className="border-t border-dashed border-[hsl(var(--gray-400))] px-4 py-2.5">
-                  <span className="text-xs text-muted-foreground">
-                    Create a new subagent
-                  </span>
-                </div>
-              </button>
+              <CreateTeammateButton onClick={() => setDialogOpen(true)} />
 
               {agents.map((agent) => (
                 <Link
@@ -293,6 +248,34 @@ export function ZeroJobsPage() {
         creating={creating}
       />
     </div>
+  );
+}
+
+function CreateTeammateButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-[hsl(var(--gray-400))] transition-colors hover:border-[hsl(var(--gray-400))] hover:bg-muted/30 group cursor-pointer text-left"
+    >
+      <div className="flex items-center gap-3 px-4 py-3.5">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors">
+          <IconPlus
+            size={18}
+            stroke={2}
+            className="text-foreground/50 group-hover:text-foreground transition-colors"
+          />
+        </span>
+        <span className="text-sm font-medium text-foreground/80 group-hover:text-foreground transition-colors">
+          Create teammate
+        </span>
+      </div>
+      <div className="border-t border-dashed border-[hsl(var(--gray-400))] px-4 py-2.5">
+        <span className="text-xs text-muted-foreground">
+          Create a new subagent
+        </span>
+      </div>
+    </button>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -195,7 +195,7 @@ export function ZeroJobsPage() {
           )}
 
           {!loading && !error && agents && agents.length === 0 && (
-            <div className="flex flex-col gap-3">
+            <>
               <CreateTeammateButton onClick={() => setDialogOpen(true)} />
               <Card className="zero-card">
                 <CardContent className="flex flex-col items-center justify-center px-6 py-12 gap-3">
@@ -216,7 +216,7 @@ export function ZeroJobsPage() {
                   </div>
                 </CardContent>
               </Card>
-            </div>
+            </>
           )}
 
           {agents && agents.length > 0 && (

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -195,9 +195,8 @@ export function ZeroJobsPage() {
           )}
 
           {!loading && !error && agents && agents.length === 0 && (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="flex flex-col gap-3">
               <CreateTeammateButton onClick={() => setDialogOpen(true)} />
-
               <Card className="zero-card">
                 <CardContent className="flex flex-col items-center justify-center px-6 py-12 gap-3">
                   <img


### PR DESCRIPTION
## Summary
- Add a dashed-border "Create teammate" card in the team page empty state (when no sub-agents exist)
- The card sits alongside the existing "Just Zero for now" card in a 2-column grid
- Clicking it opens the create teammate dialog, same as the existing button when agents are present
- Add test to verify the create teammate button appears in empty state

## Test plan
- [x] Existing tests pass (5/5)
- [ ] Verify empty state shows both "Create teammate" card and "Just Zero for now" card side by side
- [ ] Verify clicking the dashed card opens the create dialog
- [ ] Verify responsive layout (1 col on mobile, 2 cols on sm+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)