### PR TITLE
ci: make e2e-auth informational in ci-gate-turbo

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2000,7 +2000,7 @@ jobs:
           check_result "deploy-app" "${{ needs.deploy-app.result }}" "true"
           check_result "build-cli" "${{ needs.build-cli.result }}" "true"
           check_result "build-e2b-template" "${{ needs.build-e2b-template.result }}" "true"
-          check_result "e2e-auth" "${{ needs.e2e-auth.result }}" "true"
+          check_result "e2e-auth" "${{ needs.e2e-auth.result }}" "informational"
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
           check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "true"
           check_result "deploy-runner-start" "${{ needs.deploy-runner-start.result }}" "true"


### PR DESCRIPTION
## Summary
- Change `e2e-auth` check from required to informational in `ci-gate-turbo` gate job
- e2e-auth failures will no longer block PR merges

## Test plan
- [ ] Verify ci-gate-turbo passes even if e2e-auth fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)