### PR TITLE
feat(auth): update server api endpoints to generate cli jwt tokens

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/org/__tests__/route.test.ts
@@ -15,7 +15,7 @@ import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 
 const context = testContext();
 
-function makeOrgSwitchRequest(slug: string, token?: string): Request {
+function makeOrgSwitchRequest(slug: string, token?: string) {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };

--- a/turbo/apps/web/app/api/cli/auth/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/org/__tests__/route.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestCliToken,
+  insertOrgCacheEntry,
+  insertOrgMembersCacheEntry,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+function makeOrgSwitchRequest(slug: string, token?: string): Request {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  return createTestRequest("http://localhost:3000/api/cli/auth/org", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ slug }),
+  });
+}
+
+describe("POST /api/cli/auth/org", () => {
+  let user: UserContext;
+  let cliToken: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    cliToken = await createTestCliToken(user.userId);
+  });
+
+  it("should return 200 with new JWT when switching to valid org", async () => {
+    // setupUser already creates org_cache for the default org.
+    // Insert membership cache so verifyMembershipCached succeeds without Clerk call.
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
+
+    // Get the org slug from org_cache (setupUser uses org-${suffix} pattern)
+    // We need to look it up — use the orgId to find the slug.
+    // Actually, setupUser creates slug as `org-${suffix}` and orgId as `org_mock_${userId}`.
+    // We can derive slug from userId: suffix is the last 8 chars of userId after "test-user-".
+    // But easier: create a known org with a known slug.
+    const slug = uniqueId("switch-org");
+    const orgId = uniqueId("org");
+    await insertOrgCacheEntry({ orgId, slug });
+    await insertOrgMembersCacheEntry({
+      orgId,
+      userId: user.userId,
+      role: "member",
+    });
+
+    const response = await POST(makeOrgSwitchRequest(slug, cliToken));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.access_token).toMatch(/^vm0_sandbox_/);
+    expect(body.token_type).toBe("Bearer");
+    expect(body.expires_in).toBe(90 * 24 * 60 * 60);
+    expect(body.org_slug).toBe(slug);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    // Override Clerk mock to return no session (simulates truly unauthenticated request)
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/cli/auth/org",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug: "some-org" }),
+      },
+    );
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("unauthorized");
+  });
+
+  it("should return 404 when org slug does not exist", async () => {
+    const response = await POST(
+      makeOrgSwitchRequest("nonexistent-org-slug", cliToken),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe("not_found");
+  });
+
+  it("should return 403 when user is not a member of the org", async () => {
+    // Create an org the user is NOT a member of
+    const slug = uniqueId("other-org");
+    const orgId = uniqueId("org");
+    await insertOrgCacheEntry({ orgId, slug });
+    // No membership cache entry — and Clerk mock won't return this org either
+
+    const response = await POST(makeOrgSwitchRequest(slug, cliToken));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe("forbidden");
+  });
+
+  it("should return 400 when slug is missing from body", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/cli/auth/org",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${cliToken}`,
+        },
+        body: JSON.stringify({}),
+      },
+    );
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_request");
+  });
+
+  it("should return 400 when slug is empty string", async () => {
+    const response = await POST(makeOrgSwitchRequest("", cliToken));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("invalid_request");
+  });
+});

--- a/turbo/apps/web/app/api/cli/auth/org/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/org/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { getOrgBySlug } from "../../../../../src/lib/org/org-cache-service";
+import { verifyMembershipCached } from "../../../../../src/lib/org/org-membership-cache";
+import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
+import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
+
+/**
+ * Switch active organization and get a new CLI JWT.
+ *
+ * Requires Bearer token authentication (vm0_live_ or CLI JWT).
+ * Validates that the user is a member of the target organization.
+ */
+export async function POST(request: Request) {
+  initServices();
+
+  // 1. Authenticate — accept both vm0_live_ and CLI JWT
+  const authHeader = request.headers.get("authorization") ?? undefined;
+  const authCtx = await getAuthContext(authHeader);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Authentication required", code: "unauthorized" } },
+      { status: 401 },
+    );
+  }
+
+  // 2. Parse request body
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "invalid_request", error_description: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const slug =
+    typeof body === "object" && body !== null && "slug" in body
+      ? (body as Record<string, unknown>).slug
+      : undefined;
+  if (!slug || typeof slug !== "string" || slug.length === 0) {
+    return NextResponse.json(
+      { error: "invalid_request", error_description: "slug is required" },
+      { status: 400 },
+    );
+  }
+
+  // 3. Resolve org by slug
+  const orgData = await getOrgBySlug(slug);
+  if (!orgData) {
+    return NextResponse.json(
+      { error: { message: "Organization not found", code: "not_found" } },
+      { status: 404 },
+    );
+  }
+
+  // 4. Verify membership
+  const membership = await verifyMembershipCached(
+    orgData.orgId,
+    authCtx.userId,
+  );
+  if (!membership) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Not a member of this organization",
+          code: "forbidden",
+        },
+      },
+      { status: 403 },
+    );
+  }
+
+  // 5. Generate new CLI JWT with target org
+  const tokenId = crypto.randomUUID();
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000); // 90 days
+  const cliToken = await generateCliToken(
+    authCtx.userId,
+    orgData.orgId,
+    tokenId,
+  );
+
+  await globalThis.services.db.insert(cliTokens).values({
+    id: tokenId,
+    token: cliToken,
+    userId: authCtx.userId,
+    name: "CLI Org Switch",
+    expiresAt,
+    createdAt: now,
+  });
+
+  return NextResponse.json({
+    access_token: cliToken,
+    token_type: "Bearer",
+    expires_in: 90 * 24 * 60 * 60,
+    org_slug: orgData.slug,
+  });
+}

--- a/turbo/apps/web/app/api/cli/auth/org/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/org/route.ts
@@ -1,4 +1,9 @@
-import { NextResponse } from "next/server";
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../../src/lib/ts-rest-handler";
+import { cliAuthOrgContract } from "@vm0/core";
 import crypto from "crypto";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
@@ -10,93 +15,112 @@ import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 /**
  * Switch active organization and get a new CLI JWT.
  *
- * Requires Bearer token authentication (vm0_live_ or CLI JWT).
+ * Requires Bearer token authentication (CLI JWT).
  * Validates that the user is a member of the target organization.
  */
-export async function POST(request: Request) {
-  initServices();
+const router = tsr.router(cliAuthOrgContract, {
+  switchOrg: async ({ body, headers }) => {
+    initServices();
 
-  // 1. Authenticate — accept both vm0_live_ and CLI JWT
-  const authHeader = request.headers.get("authorization") ?? undefined;
-  const authCtx = await getAuthContext(authHeader);
-  if (!authCtx) {
-    return NextResponse.json(
-      { error: { message: "Authentication required", code: "unauthorized" } },
-      { status: 401 },
-    );
-  }
-
-  // 2. Parse request body
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json(
-      { error: "invalid_request", error_description: "Invalid JSON body" },
-      { status: 400 },
-    );
-  }
-
-  const slug =
-    typeof body === "object" && body !== null && "slug" in body
-      ? (body as Record<string, unknown>).slug
-      : undefined;
-  if (!slug || typeof slug !== "string" || slug.length === 0) {
-    return NextResponse.json(
-      { error: "invalid_request", error_description: "slug is required" },
-      { status: 400 },
-    );
-  }
-
-  // 3. Resolve org by slug
-  const orgData = await getOrgBySlug(slug);
-  if (!orgData) {
-    return NextResponse.json(
-      { error: { message: "Organization not found", code: "not_found" } },
-      { status: 404 },
-    );
-  }
-
-  // 4. Verify membership
-  const membership = await verifyMembershipCached(
-    orgData.orgId,
-    authCtx.userId,
-  );
-  if (!membership) {
-    return NextResponse.json(
-      {
-        error: {
-          message: "Not a member of this organization",
-          code: "forbidden",
+    // 1. Authenticate
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Authentication required", code: "unauthorized" },
         },
-      },
-      { status: 403 },
+      };
+    }
+
+    // 2. Resolve org by slug (body.slug is validated by contract — non-empty string)
+    const orgData = await getOrgBySlug(body.slug);
+    if (!orgData) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Organization not found", code: "not_found" },
+        },
+      };
+    }
+
+    // 3. Verify membership
+    const membership = await verifyMembershipCached(
+      orgData.orgId,
+      authCtx.userId,
     );
+    if (!membership) {
+      return {
+        status: 403 as const,
+        body: {
+          error: {
+            message: "Not a member of this organization",
+            code: "forbidden",
+          },
+        },
+      };
+    }
+
+    // 4. Generate new CLI JWT with target org
+    const tokenId = crypto.randomUUID();
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000); // 90 days
+    const cliToken = await generateCliToken(
+      authCtx.userId,
+      orgData.orgId,
+      tokenId,
+    );
+
+    await globalThis.services.db.insert(cliTokens).values({
+      id: tokenId,
+      token: cliToken,
+      userId: authCtx.userId,
+      name: "CLI Org Switch",
+      expiresAt,
+      createdAt: now,
+    });
+
+    return {
+      status: 200 as const,
+      body: {
+        access_token: cliToken,
+        token_type: "Bearer" as const,
+        expires_in: 90 * 24 * 60 * 60,
+        org_slug: orgData.slug,
+      },
+    };
+  },
+});
+
+/**
+ * Custom error handler to convert Zod validation errors to OAuth error format.
+ * Matches the contract's 400 response schema (oauthErrorSchema).
+ */
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (err && typeof err === "object" && "bodyError" in err) {
+    const validationError = err as {
+      bodyError: { issues: Array<{ path: string[]; message: string }> } | null;
+    };
+
+    if (validationError.bodyError) {
+      const issue = validationError.bodyError.issues[0];
+      if (issue) {
+        return TsRestResponse.fromJson(
+          {
+            error: "invalid_request",
+            error_description: `${issue.path.join(".")}: ${issue.message}`,
+          },
+          { status: 400 },
+        );
+      }
+    }
   }
 
-  // 5. Generate new CLI JWT with target org
-  const tokenId = crypto.randomUUID();
-  const now = new Date();
-  const expiresAt = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000); // 90 days
-  const cliToken = await generateCliToken(
-    authCtx.userId,
-    orgData.orgId,
-    tokenId,
-  );
-
-  await globalThis.services.db.insert(cliTokens).values({
-    id: tokenId,
-    token: cliToken,
-    userId: authCtx.userId,
-    name: "CLI Org Switch",
-    expiresAt,
-    createdAt: now,
-  });
-
-  return NextResponse.json({
-    access_token: cliToken,
-    token_type: "Bearer",
-    expires_in: 90 * 24 * 60 * 60,
-    org_slug: orgData.slug,
-  });
+  return undefined;
 }
+
+const handler = createHandler(cliAuthOrgContract, router, {
+  errorHandler,
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -201,7 +201,7 @@ describe("/api/cli/auth/test-token", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(data.access_token).toMatch(/^vm0_live_/);
+      expect(data.access_token).toMatch(/^vm0_sandbox_/);
       expect(data.token_type).toBe("Bearer");
       expect(data.expires_in).toBe(90 * 24 * 60 * 60);
       expect(data.user_id).toBe("user_test123");

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -7,7 +7,11 @@ import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 import { orgCache } from "../../../../../src/db/schema/org-cache";
 import { orgMetadata } from "../../../../../src/db/schema/org-metadata";
 import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
-import { getOrgData } from "../../../../../src/lib/org/org-cache-service";
+import {
+  getOrgData,
+  getOrgBySlug,
+} from "../../../../../src/lib/org/org-cache-service";
+import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
 import {
   resolveTestUserId,
   isTestVariant,
@@ -144,13 +148,18 @@ export async function POST(request: Request) {
   // Auto-create org if user doesn't have one (creates real Clerk org or sentinel)
   const { slug: orgSlug } = await ensureTestOrg(userId);
 
-  // Generate CLI token
-  const randomBytes = crypto.randomBytes(32);
-  const token = `vm0_live_${randomBytes.toString("base64url")}`;
+  // Resolve orgId from slug (ensureTestOrg creates org_cache entry, so this is a cache hit)
+  const orgData = await getOrgBySlug(orgSlug);
+  const orgId = orgData?.orgId ?? "";
+
+  // Generate CLI JWT with tokenId for revocation tracking
+  const tokenId = crypto.randomUUID();
   const now = new Date();
   const expiresAt = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000); // 90 days
+  const token = await generateCliToken(userId, orgId, tokenId);
 
   await globalThis.services.db.insert(cliTokens).values({
+    id: tokenId,
     token,
     userId,
     name: "CI Test Token",

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -150,7 +150,13 @@ export async function POST(request: Request) {
 
   // Resolve orgId from slug (ensureTestOrg creates org_cache entry, so this is a cache hit)
   const orgData = await getOrgBySlug(orgSlug);
-  const orgId = orgData?.orgId ?? "";
+  if (!orgData) {
+    return NextResponse.json(
+      { error: `Organization not found for slug: ${orgSlug}` },
+      { status: 500 },
+    );
+  }
+  const orgId = orgData.orgId;
 
   // Generate CLI JWT with tokenId for revocation tracking
   const tokenId = crypto.randomUUID();

--- a/turbo/apps/web/app/api/cli/auth/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   createTestDeviceCode,
   findTestDeviceCode,
   findTestCliToken,
+  insertOrgCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -107,6 +108,9 @@ describe("POST /api/cli/auth/token", () => {
   });
 
   it("should return org_slug when device code has org context", async () => {
+    // Insert org_cache entry so getOrgBySlug resolves the slug to an orgId
+    await insertOrgCacheEntry({ orgId: "org_my_test", slug: "my-test-org" });
+
     const code = await createTestDeviceCode({
       status: "authenticated",
       userId: user.userId,

--- a/turbo/apps/web/app/api/cli/auth/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/__tests__/route.test.ts
@@ -92,7 +92,7 @@ describe("POST /api/cli/auth/token", () => {
 
     expect(response.status).toBe(200);
     expect(body).not.toHaveProperty("error");
-    expect(body.access_token).toMatch(/^vm0_live_/);
+    expect(body.access_token).toMatch(/^vm0_sandbox_/);
     expect(body.token_type).toBe("Bearer");
     expect(body.expires_in).toBe(90 * 24 * 60 * 60);
 

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -79,7 +79,16 @@ const router = tsr.router(cliAuthTokenContract, {
         let orgId = "";
         if (session.orgSlug) {
           const orgData = await getOrgBySlug(session.orgSlug);
-          orgId = orgData?.orgId ?? "";
+          if (!orgData) {
+            return {
+              status: 500 as const,
+              body: {
+                error: "server_error",
+                error_description: `Organization not found for slug: ${session.orgSlug}`,
+              },
+            };
+          }
+          orgId = orgData.orgId;
         }
 
         // Generate CLI JWT with tokenId for revocation tracking

--- a/turbo/apps/web/app/api/cli/auth/token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/token/route.ts
@@ -9,6 +9,8 @@ import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { deviceCodes } from "../../../../../src/db/schema/device-codes";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
+import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
+import { getOrgBySlug } from "../../../../../src/lib/org/org-cache-service";
 
 const router = tsr.router(cliAuthTokenContract, {
   exchange: async ({ body }) => {
@@ -73,13 +75,21 @@ const router = tsr.router(cliAuthTokenContract, {
       case "authenticated": {
         const userId = session.userId as string;
 
-        // Generate CLI token (no org binding — org context comes from client-side activeOrg)
-        const randomBytes = crypto.randomBytes(32);
-        const cliToken = `vm0_live_${randomBytes.toString("base64url")}`;
+        // Resolve orgId from orgSlug (set during device flow approval)
+        let orgId = "";
+        if (session.orgSlug) {
+          const orgData = await getOrgBySlug(session.orgSlug);
+          orgId = orgData?.orgId ?? "";
+        }
+
+        // Generate CLI JWT with tokenId for revocation tracking
+        const tokenId = crypto.randomUUID();
         const now = new Date();
         const expiresAt = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000); // 90 days
+        const cliToken = await generateCliToken(userId, orgId, tokenId);
 
         await globalThis.services.db.insert(cliTokens).values({
+          id: tokenId,
           token: cliToken,
           userId,
           name: "CLI Device Flow Authentication",

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -8,6 +8,7 @@ import {
   verifyZeroToken,
   verifyCliToken,
 } from "./sandbox-token";
+import { verifyMembershipCached } from "../org/org-membership-cache";
 import { logger } from "../logger";
 
 const log = logger("auth:user");
@@ -47,7 +48,18 @@ export async function getAuthContext(
       // Try CLI JWT first (accepted on all endpoints, no capability gating)
       const cliAuth = verifyCliToken(token);
       if (cliAuth) {
-        return resolveCliTokenFromDb(cliAuth);
+        const resolved = await resolveCliTokenFromDb(cliAuth);
+        if (!resolved) return null;
+        // Resolve org role so downstream admin checks work correctly
+        let orgRole: AuthContext["orgRole"];
+        if (resolved.orgId) {
+          const membership = await verifyMembershipCached(
+            resolved.orgId,
+            resolved.userId,
+          );
+          orgRole = membership?.role;
+        }
+        return { userId: resolved.userId, orgId: resolved.orgId, orgRole };
       }
       return authenticateSandboxToken(token, options);
     }

--- a/turbo/packages/core/src/contracts/cli-auth.ts
+++ b/turbo/packages/core/src/contracts/cli-auth.ts
@@ -70,5 +70,41 @@ export const cliAuthTokenContract = c.router({
   },
 });
 
+/**
+ * Error response schema for structured API errors
+ */
+const apiErrorResponseSchema = z.object({
+  error: z.object({ message: z.string(), code: z.string() }),
+});
+
+/**
+ * CLI auth org switch contract for /api/cli/auth/org
+ */
+export const cliAuthOrgContract = c.router({
+  /**
+   * POST /api/cli/auth/org
+   * Switch active organization and get new CLI JWT
+   */
+  switchOrg: {
+    method: "POST",
+    path: "/api/cli/auth/org",
+    body: z.object({ slug: z.string().min(1) }),
+    responses: {
+      200: z.object({
+        access_token: z.string(),
+        token_type: z.literal("Bearer"),
+        expires_in: z.number(),
+        org_slug: z.string(),
+      }),
+      400: oauthErrorSchema,
+      401: apiErrorResponseSchema,
+      403: apiErrorResponseSchema,
+      404: apiErrorResponseSchema,
+    },
+    summary: "Switch active organization and get new CLI JWT",
+  },
+});
+
 export type CliAuthDeviceContract = typeof cliAuthDeviceContract;
 export type CliAuthTokenContract = typeof cliAuthTokenContract;
+export type CliAuthOrgContract = typeof cliAuthOrgContract;

--- a/turbo/packages/core/src/contracts/cli-auth.ts
+++ b/turbo/packages/core/src/contracts/cli-auth.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { initContract } from "./base";
+import { initContract, authHeadersSchema } from "./base";
 
 const c = initContract();
 
@@ -88,6 +88,7 @@ export const cliAuthOrgContract = c.router({
   switchOrg: {
     method: "POST",
     path: "/api/cli/auth/org",
+    headers: authHeadersSchema,
     body: z.object({ slug: z.string().min(1) }),
     responses: {
       200: z.object({

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -168,8 +168,10 @@ export {
 export {
   cliAuthDeviceContract,
   cliAuthTokenContract,
+  cliAuthOrgContract,
   type CliAuthDeviceContract,
   type CliAuthTokenContract,
+  type CliAuthOrgContract,
 } from "./cli-auth";
 export { authContract, type AuthContract } from "./auth";
 export {


### PR DESCRIPTION
## Summary

- Replace opaque `vm0_live_*` token generation with CLI JWT (`vm0_sandbox_*`) in token exchange and test-token endpoints
- Add new org switch endpoint (`POST /api/cli/auth/org`) that validates membership and issues a new JWT with the target org's orgId
- Add `cliAuthOrgContract` to `@vm0/core` contracts and export from index

## Changes

### Token Exchange (`/api/cli/auth/token`)
- Resolve `orgSlug` → `orgId` via `getOrgBySlug()` for JWT payload
- Generate CLI JWT via `generateCliToken(userId, orgId, tokenId)` instead of random opaque token
- Store explicit `tokenId` (UUID) in `cli_tokens.id` for revocation tracking

### Test Token (`/api/cli/auth/test-token`)
- Same JWT generation pattern as token exchange
- Resolve `orgId` from `getOrgBySlug()` after `ensureTestOrg()` creates the cache entry

### Org Switch Endpoint (`/api/cli/auth/org`) — NEW
- `POST` with `{ slug }` body and Bearer token auth
- Validates: auth → org exists → user is member → generate new JWT
- Returns `{ access_token, token_type, expires_in, org_slug }`
- Error responses: 400 (bad request), 401 (unauthorized), 403 (not member), 404 (org not found)

### Tests
- Updated token format assertions from `vm0_live_` to `vm0_sandbox_` in existing tests
- Added 6 integration tests for org switch endpoint (200, 401, 403, 404, 400 cases)

## Test plan

- [x] Token exchange tests pass (8 tests)
- [x] Test-token tests pass (10 tests)
- [x] Org switch tests pass (6 tests)
- [x] All CLI auth tests pass (38 tests across 5 files)
- [x] Full test suite: no new failures (pre-existing zero/agents failures confirmed on main)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)

Closes #6719

🤖 Generated with [Claude Code](https://claude.com/claude-code)