### PR TITLE
feat(dev-server): notify #flaky-test slack channel when prepare.sh fails

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -60,8 +60,43 @@ While the runner is initializing in the background, run `prepare.sh` to set up t
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT" && bash scripts/prepare.sh
+cd "$PROJECT_ROOT" && bash scripts/prepare.sh 2>&1 | tee /tmp/prepare-output.log
 ```
+
+#### If prepare.sh fails
+
+If the command above exits with a non-zero code, do the following **before** reporting the failure to the user:
+
+1. **Gather diagnostic info** by running:
+
+```bash
+echo "HOSTNAME: $(hostname)"
+echo "BRANCH: $(git branch --show-current)"
+echo "--- LAST 20 LINES ---"
+tail -20 /tmp/prepare-output.log
+```
+
+2. **Determine the failed step**: inspect the output for `db:migrate` or `Database migrations failed`. If found, the failed step is `db:migrate`; otherwise, report it as `prepare.sh`.
+
+3. **Send a Slack notification** to `#flaky-test` using the Slack MCP tool (`slack_send_message`) with the following message format:
+
+```
+🔴 Dev server prepare failed on `<hostname>` (branch: `<branch>`)
+
+**Failed step:** <prepare.sh or db:migrate>
+**Error snippet:**
+\`\`\`
+<last ~20 lines of /tmp/prepare-output.log>
+\`\`\`
+
+> ℹ️ This may be caused by FK constraints preventing migration on databases with real data.
+```
+
+4. **Report the failure to the user** as normal — do NOT silently swallow the error, and do NOT proceed to Step 4.
+
+#### If prepare.sh succeeds
+
+Proceed to Step 4 as normal. No Slack notification is sent.
 
 ### Step 4: Start Dev Server in Background
 

--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -60,7 +60,7 @@ While the runner is initializing in the background, run `prepare.sh` to set up t
 
 ```bash
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
-cd "$PROJECT_ROOT" && bash scripts/prepare.sh 2>&1 | tee /tmp/prepare-output.log
+cd "$PROJECT_ROOT" && bash -c 'set -o pipefail; bash scripts/prepare.sh 2>&1 | tee /tmp/prepare-output.log'
 ```
 
 #### If prepare.sh fails


### PR DESCRIPTION
## Summary

- Add failure handling to the dev-server skill's Step 3 (Run prepare.sh) so that when `prepare.sh` or `db:migrate` fails, a notification is sent to `#flaky-test` via Slack MCP tool
- Message includes hostname, branch, error snippet (last ~20 lines), and FK constraint hint
- Failure is still surfaced to the user (not silently swallowed)

Closes #6738

## Test plan

- [ ] Verify that when `prepare.sh` succeeds, no Slack message is sent and behavior is unchanged
- [ ] Verify that when `prepare.sh` fails, a message is posted to `#flaky-test` via `slack_send_message`
- [ ] Verify the failure is still reported to the user in the conversation
- [ ] Verify the message includes: hostname, branch, error snippet, FK constraint hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)