### PR TITLE
ci: gate migrate-production on releases_created

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,6 +71,7 @@ jobs:
   # Run database migrations in production (always runs as a gate for all deploy jobs)
   migrate-production:
     needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260320


### PR DESCRIPTION
## Summary
- Gate `migrate-production` job on `releases_created == 'true'` so it only runs during actual releases, not when release-please merely creates/updates a PR
- Eliminates spurious "Database Migration ⏭ Skipped" Slack notifications on PR events

## Test plan
- [ ] Verify release-please PR creation no longer triggers migrate-production job
- [ ] Verify actual release still triggers migration check and deploy pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)