### PR TITLE
refactor(web): convert skill sync to async i/o and concurrent processing

### DIFF
--- a/turbo/apps/web/src/lib/skills/sync-skills.ts
+++ b/turbo/apps/web/src/lib/skills/sync-skills.ts
@@ -6,13 +6,8 @@
  * and database upserts for storages, storageVersions, and skills tables.
  */
 
-import {
-  mkdtempSync,
-  mkdirSync,
-  writeFileSync,
-  readFileSync,
-  rmSync,
-} from "node:fs";
+import { mkdirSync, rmSync } from "node:fs";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import * as tar from "tar";
@@ -80,24 +75,31 @@ export async function syncSkills(): Promise<SyncResult> {
   // 3. Download and extract tarball
   const extractedSkills = await downloadAndExtractSkills();
 
-  // 4. Sync each skill
+  // 4. Sync each skill concurrently
+  const results = await Promise.allSettled(
+    extractedSkills.map((extracted) => syncSingleSkill(db, extracted, headSha)),
+  );
+
   let synced = 0;
   let skipped = 0;
   let failed = 0;
 
-  for (const extracted of extractedSkills) {
-    try {
-      const wasUpdated = await syncSingleSkill(db, extracted, headSha);
-      if (wasUpdated) {
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]!;
+    if (result.status === "fulfilled") {
+      if (result.value) {
         synced++;
       } else {
         skipped++;
       }
-    } catch (error) {
+    } else {
       failed++;
       log.warn("Skipping skill due to sync error", {
-        skillName: extracted.skillName,
-        error: error instanceof Error ? error.message : String(error),
+        skillName: extractedSkills[i]!.skillName,
+        error:
+          result.reason instanceof Error
+            ? result.reason.message
+            : String(result.reason),
       });
     }
   }
@@ -166,7 +168,7 @@ async function syncSingleSkill(
   }
 
   // Create archive.tar.gz and manifest.json
-  const { archiveBuffer, manifestBuffer } = createSkillArchive(files);
+  const { archiveBuffer, manifestBuffer } = await createSkillArchive(files);
 
   // Upload to S3
   const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
@@ -286,35 +288,36 @@ async function syncSingleSkill(
  * Writes files to a temp directory, creates the tar with `tar.create()`,
  * then reads the result back as Buffers.
  */
-function createSkillArchive(
+async function createSkillArchive(
   files: Array<{ path: string; content: Buffer; hash: string; size: number }>,
-): { archiveBuffer: Buffer; manifestBuffer: Buffer } {
-  const tmpDir = mkdtempSync(join(tmpdir(), "vm0-skill-"));
+): Promise<{ archiveBuffer: Buffer; manifestBuffer: Buffer }> {
+  const tmpDir = await mkdtemp(join(tmpdir(), "vm0-skill-"));
 
   try {
     // Write files to temp directory
-    for (const file of files) {
-      const filePath = join(tmpDir, file.path);
-      const dir = join(filePath, "..");
-      mkdirSync(dir, { recursive: true });
-      writeFileSync(filePath, file.content);
-    }
+    await Promise.all(
+      files.map((file) => {
+        const filePath = join(tmpDir, file.path);
+        const dir = join(filePath, "..");
+        mkdirSync(dir, { recursive: true });
+        return writeFile(filePath, file.content);
+      }),
+    );
 
-    // Create tar.gz synchronously
+    // Create tar.gz asynchronously
     const tarPath = join(tmpDir, "__archive.tar.gz");
     const filePaths = files.map((f) => f.path);
 
-    tar.create(
+    await tar.create(
       {
         gzip: true,
         file: tarPath,
         cwd: tmpDir,
-        sync: true,
       },
       filePaths,
     );
 
-    const archiveBuffer = readFileSync(tarPath);
+    const archiveBuffer = await readFile(tarPath);
 
     // Create manifest
     const manifest = {

--- a/turbo/apps/web/src/lib/skills/sync-skills.ts
+++ b/turbo/apps/web/src/lib/skills/sync-skills.ts
@@ -75,32 +75,36 @@ export async function syncSkills(): Promise<SyncResult> {
   // 3. Download and extract tarball
   const extractedSkills = await downloadAndExtractSkills();
 
-  // 4. Sync each skill concurrently
-  const results = await Promise.allSettled(
-    extractedSkills.map((extracted) => syncSingleSkill(db, extracted, headSha)),
-  );
-
+  // 4. Sync each skill concurrently (batched to avoid exhausting DB pool / S3)
+  const BATCH_SIZE = 5;
   let synced = 0;
   let skipped = 0;
   let failed = 0;
 
-  for (let i = 0; i < results.length; i++) {
-    const result = results[i]!;
-    if (result.status === "fulfilled") {
-      if (result.value) {
-        synced++;
+  for (let i = 0; i < extractedSkills.length; i += BATCH_SIZE) {
+    const batch = extractedSkills.slice(i, i + BATCH_SIZE);
+    const results = await Promise.allSettled(
+      batch.map((extracted) => syncSingleSkill(db, extracted, headSha)),
+    );
+
+    for (let j = 0; j < results.length; j++) {
+      const result = results[j]!;
+      if (result.status === "fulfilled") {
+        if (result.value) {
+          synced++;
+        } else {
+          skipped++;
+        }
       } else {
-        skipped++;
+        failed++;
+        log.warn("Skipping skill due to sync error", {
+          skillName: batch[j]!.skillName,
+          error:
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason),
+        });
       }
-    } else {
-      failed++;
-      log.warn("Skipping skill due to sync error", {
-        skillName: extractedSkills[i]!.skillName,
-        error:
-          result.reason instanceof Error
-            ? result.reason.message
-            : String(result.reason),
-      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace synchronous fs operations (`mkdtempSync`, `writeFileSync`, `readFileSync`) with async equivalents (`mkdtemp`, `writeFile`, `readFile`) from `node:fs/promises`
- Convert `tar.create` from sync mode to its native async/promise form
- Process skills concurrently via `Promise.allSettled` instead of sequentially in a `for` loop

## Test plan
- [ ] Verify skill sync completes successfully in dev environment
- [ ] Confirm error handling works correctly for individual skill failures (Promise.allSettled rejection path)
- [ ] Validate archive creation produces identical output to previous sync implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)