### PR TITLE
fix(platform): hide add/remove connector actions for members on default agent

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
@@ -328,3 +328,136 @@ describe("zero connector card scope review modal", () => {
     });
   });
 });
+
+/**
+ * Render the default agent's connector tab as a non-admin member.
+ * This triggers readOnly=true (hideProfileAndInstructions) in ZeroJobDetailPage.
+ */
+async function renderTeamPageAsMember(connectors: string[]) {
+  server.use(
+    // Agent detail — agentId matches defaultAgentId below
+    http.get("*/api/zero/agents/zero", () => {
+      return HttpResponse.json({
+        name: "zero",
+        agentId: "compose-1",
+        description: null,
+        displayName: null,
+        sound: null,
+        connectors,
+      });
+    }),
+    // Chat threads — required when viewing a job detail page
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    // Onboarding status — default agent matches the agent being viewed
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: false,
+        isAdmin: false,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: "compose-1",
+        defaultAgentMetadata: { displayName: "Zero" },
+        defaultAgentSkills: [],
+      });
+    }),
+    // Org — role=member so isOrgAdmin$ resolves to false
+    http.get("*/api/zero/org", () => {
+      return HttpResponse.json({
+        id: "org_1",
+        slug: "user-12345678",
+        name: "User 12345678",
+        role: "member",
+      });
+    }),
+  );
+
+  await setupPage({ context, path: "/team/zero" });
+}
+
+describe("zero connector card readOnly behavior (member on default agent)", () => {
+  it("hides the Add connector button when readOnly", async () => {
+    mockConnectors([
+      makeConnector({
+        type: "github",
+        externalUsername: "testuser",
+        oauthScopes: ["repo", "project"],
+      }),
+    ]);
+
+    await renderTeamPageAsMember(["github"]);
+
+    // Wait for the connector card to render
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "More options" }),
+      ).toBeInTheDocument();
+    });
+
+    // "Add connector" button should NOT be present
+    expect(screen.queryByText("Add connector")).not.toBeInTheDocument();
+  });
+
+  it("hides the dropdown menu entirely for unconnected connector when readOnly", async () => {
+    mockConnectors([]);
+
+    await renderTeamPageAsMember(["github"]);
+
+    // Wait for the Connect button to appear (proves the card rendered)
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Connect" }),
+      ).toBeInTheDocument();
+    });
+
+    // When readOnly and not connected, CardDropdownMenu returns null
+    expect(
+      screen.queryByRole("button", { name: "More options" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still shows Connect button for unconnected connector when readOnly", async () => {
+    mockConnectors([]);
+
+    await renderTeamPageAsMember(["github"]);
+
+    // Connect should still be available (user-scoped OAuth)
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Connect" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("still shows Disconnect in dropdown for connected connector when readOnly", async () => {
+    mockConnectors([
+      makeConnector({
+        type: "github",
+        externalUsername: "testuser",
+        oauthScopes: ["repo", "project"],
+      }),
+    ]);
+
+    await renderTeamPageAsMember(["github"]);
+
+    // Connected card should still have the dropdown menu
+    const menuButton = await waitFor(() =>
+      screen.getByRole("button", { name: "More options" }),
+    );
+
+    // Radix DropdownMenu requires pointerDown to open
+    fireEvent.pointerDown(menuButton, { button: 0, ctrlKey: false });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("menuitem", { name: "Disconnect" }),
+      ).toBeInTheDocument();
+    });
+
+    // "Remove connector" should NOT appear
+    expect(
+      screen.queryByRole("menuitem", { name: "Remove connector" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-card.tsx
@@ -18,11 +18,152 @@ interface ZeroConnectorCardProps {
   pollingType: ConnectorType | null;
   hasFirewall: boolean;
   isAdmin?: boolean;
+  /** When true, hide agent-level mutations (remove connector). Connect/Disconnect still works. */
+  readOnly?: boolean;
   onConnect: () => void;
   onDisconnect: () => void;
   onRemove: () => void;
   onReviewScopes?: () => void;
   onManagePermissions?: () => void;
+}
+
+function ConnectionStatus({
+  connector,
+  isPolling,
+  onConnect,
+  onReviewScopes,
+}: {
+  connector: ConnectorTypeWithStatus | null;
+  isPolling: boolean;
+  onConnect: () => void;
+  onReviewScopes?: () => void;
+}) {
+  if (!connector) {
+    return <span className="text-xs text-muted-foreground">Added</span>;
+  }
+
+  if (isPolling) {
+    return (
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <IconLoader2 size={12} stroke={1.5} className="animate-spin" />
+        Connecting…
+      </span>
+    );
+  }
+
+  if (connector.connected && connector.needsReconnect) {
+    return (
+      <span className="flex items-center gap-2 text-xs truncate">
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0" />
+        <span className="text-amber-600 dark:text-amber-400">
+          Connection expired
+        </span>
+        <button
+          type="button"
+          onClick={onConnect}
+          className="font-medium text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 transition-colors"
+        >
+          Reconnect
+        </button>
+      </span>
+    );
+  }
+
+  if (connector.connected && connector.scopeMismatch) {
+    return (
+      <span className="flex items-center gap-2 text-xs truncate">
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0" />
+        <span className="text-amber-600 dark:text-amber-400">
+          Permissions update available
+        </span>
+        <button
+          type="button"
+          onClick={onReviewScopes}
+          className="font-medium text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 transition-colors"
+        >
+          Review
+        </button>
+      </span>
+    );
+  }
+
+  if (connector.connected) {
+    return (
+      <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
+        {connector.connector?.externalUsername
+          ? `@${connector.connector.externalUsername}`
+          : "Connected"}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onConnect}
+      className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+    >
+      Connect
+    </button>
+  );
+}
+
+function CardDropdownMenu({
+  connector,
+  hasFirewall,
+  isAdmin,
+  readOnly,
+  onDisconnect,
+  onRemove,
+  onManagePermissions,
+}: {
+  connector: ConnectorTypeWithStatus | null;
+  hasFirewall: boolean;
+  isAdmin?: boolean;
+  readOnly?: boolean;
+  onDisconnect: () => void;
+  onRemove: () => void;
+  onManagePermissions?: () => void;
+}) {
+  // Hide entire menu when readOnly and no actionable items (not connected)
+  if (readOnly && !connector?.connected) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+          aria-label="More options"
+        >
+          <IconDotsVertical size={14} stroke={1.5} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        {hasFirewall && connector?.connected && isAdmin && (
+          <>
+            <DropdownMenuItem onClick={onManagePermissions}>
+              Permissions
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        {connector?.connected ? (
+          <DropdownMenuItem onClick={onDisconnect}>Disconnect</DropdownMenuItem>
+        ) : (
+          !readOnly && (
+            <DropdownMenuItem onClick={onRemove}>
+              Remove connector
+            </DropdownMenuItem>
+          )
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 }
 
 export function ZeroConnectorCard({
@@ -32,6 +173,7 @@ export function ZeroConnectorCard({
   pollingType,
   hasFirewall,
   isAdmin,
+  readOnly,
   onConnect,
   onDisconnect,
   onRemove,
@@ -64,91 +206,22 @@ export function ZeroConnectorCard({
 
       <div className="flex h-11 items-center justify-between border-t border-border/50 pl-5 pr-2">
         <div className="flex items-center gap-2 min-w-0">
-          {connector &&
-            (isPolling ? (
-              <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                <IconLoader2 size={12} stroke={1.5} className="animate-spin" />
-                Connecting…
-              </span>
-            ) : connector.connected && connector.needsReconnect ? (
-              <span className="flex items-center gap-2 text-xs truncate">
-                <span className="h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0" />
-                <span className="text-amber-600 dark:text-amber-400">
-                  Connection expired
-                </span>
-                <button
-                  type="button"
-                  onClick={onConnect}
-                  className="font-medium text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 transition-colors"
-                >
-                  Reconnect
-                </button>
-              </span>
-            ) : connector.connected && connector.scopeMismatch ? (
-              <span className="flex items-center gap-2 text-xs truncate">
-                <span className="h-1.5 w-1.5 rounded-full bg-amber-500 shrink-0" />
-                <span className="text-amber-600 dark:text-amber-400">
-                  Permissions update available
-                </span>
-                <button
-                  type="button"
-                  onClick={onReviewScopes}
-                  className="font-medium text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 transition-colors"
-                >
-                  Review
-                </button>
-              </span>
-            ) : connector.connected ? (
-              <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
-                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 shrink-0" />
-                {connector.connector?.externalUsername
-                  ? `@${connector.connector.externalUsername}`
-                  : "Connected"}
-              </span>
-            ) : (
-              <button
-                type="button"
-                onClick={onConnect}
-                className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
-              >
-                Connect
-              </button>
-            ))}
-          {!connector && (
-            <span className="text-xs text-muted-foreground">Added</span>
-          )}
+          <ConnectionStatus
+            connector={connector}
+            isPolling={isPolling}
+            onConnect={onConnect}
+            onReviewScopes={onReviewScopes}
+          />
         </div>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-              aria-label="More options"
-            >
-              <IconDotsVertical size={14} stroke={1.5} />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-44">
-            {hasFirewall && connector?.connected && isAdmin && (
-              <>
-                <DropdownMenuItem onClick={onManagePermissions}>
-                  Permissions
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-              </>
-            )}
-            {connector?.connected ? (
-              <DropdownMenuItem onClick={onDisconnect}>
-                Disconnect
-              </DropdownMenuItem>
-            ) : (
-              <DropdownMenuItem onClick={onRemove}>
-                Remove connector
-              </DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <CardDropdownMenu
+          connector={connector}
+          hasFirewall={hasFirewall}
+          isAdmin={isAdmin}
+          readOnly={readOnly}
+          onDisconnect={onDisconnect}
+          onRemove={onRemove}
+          onManagePermissions={onManagePermissions}
+        />
       </div>
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-tab.tsx
@@ -45,6 +45,8 @@ interface ZeroConnectorsTabProps {
   agentDisplayName?: string;
   firewallPolicies?: FirewallPolicies | null;
   onFirewallPoliciesChange?: (policies: FirewallPolicies | null) => void;
+  /** When true, hide agent-level mutations (add/remove/save). Connect/Disconnect still works. */
+  readOnly?: boolean;
 }
 
 export function ZeroConnectorsTab({
@@ -60,6 +62,7 @@ export function ZeroConnectorsTab({
   onRemoveConnector,
   onSaveConnectors,
   onDiscardConnectors,
+  readOnly,
 }: ZeroConnectorsTabProps) {
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const pollingType = useGet(pollingConnectorType$);
@@ -102,30 +105,32 @@ export function ZeroConnectorsTab({
   return (
     <div className="mx-auto max-w-[900px] flex flex-col gap-4">
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        {/* Add connector */}
-        <button
-          type="button"
-          onClick={() => setAddDialogOpen(true)}
-          className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-[hsl(var(--gray-400))] transition-colors hover:border-[hsl(var(--gray-400))] hover:bg-muted/30 group"
-        >
-          <div className="flex h-14 items-center gap-2.5 px-5">
-            <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-              <IconPlus
-                size={18}
-                stroke={2}
-                className="text-muted-foreground group-hover:text-foreground"
-              />
-            </span>
-            <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
-              Add connector
-            </span>
-          </div>
-          <div className="flex h-11 items-center border-t border-dashed border-[hsl(var(--gray-400))] px-5 group-hover:border-[hsl(var(--gray-400))]">
-            <span className="text-xs text-muted-foreground/70">
-              Browse 100+ popular connectors
-            </span>
-          </div>
-        </button>
+        {/* Add connector — hidden for read-only members on the default agent */}
+        {!readOnly && (
+          <button
+            type="button"
+            onClick={() => setAddDialogOpen(true)}
+            className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-[hsl(var(--gray-400))] transition-colors hover:border-[hsl(var(--gray-400))] hover:bg-muted/30 group"
+          >
+            <div className="flex h-14 items-center gap-2.5 px-5">
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+                <IconPlus
+                  size={18}
+                  stroke={2}
+                  className="text-muted-foreground group-hover:text-foreground"
+                />
+              </span>
+              <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground">
+                Add connector
+              </span>
+            </div>
+            <div className="flex h-11 items-center border-t border-dashed border-[hsl(var(--gray-400))] px-5 group-hover:border-[hsl(var(--gray-400))]">
+              <span className="text-xs text-muted-foreground/70">
+                Browse 100+ popular connectors
+              </span>
+            </div>
+          </button>
+        )}
 
         {/* Skeleton cards while loading */}
         {addedConnectorsLoading && (
@@ -165,6 +170,7 @@ export function ZeroConnectorsTab({
                 pollingType={pollingType}
                 hasFirewall={hasFirewallConfig(name as ConnectorType)}
                 isAdmin={isAdmin}
+                readOnly={readOnly}
                 onConnect={() => {
                   const ct = connectorMap.get(name as ConnectorType);
                   if (
@@ -244,7 +250,7 @@ export function ZeroConnectorsTab({
         />
       )}
 
-      {(connectorsDirty || connectorsSaving) && (
+      {!readOnly && (connectorsDirty || connectorsSaving) && (
         <ZeroUnsavedBar
           onDiscard={onDiscardConnectors}
           onSave={onSaveConnectors}

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -260,9 +260,11 @@ function extractAgentFields(
 function JobConnectorsTab({
   agentId,
   agentDisplayName,
+  readOnly,
 }: {
   agentId: string;
   agentDisplayName: string;
+  readOnly?: boolean;
 }) {
   const addedConnectors = useGet(zeroJobAddedConnectors$);
   const connectorsDirty = useGet(zeroJobConnectorsDirty$);
@@ -288,6 +290,7 @@ function JobConnectorsTab({
       onRemoveConnector={removeConnector}
       onSaveConnectors={() => detach(saveConnectors(), Reason.DomCallback)}
       onDiscardConnectors={() => discardConnectors()}
+      readOnly={readOnly}
     />
   );
 }
@@ -504,7 +507,11 @@ export function ZeroJobDetailPage({
 
       <main className="shrink-0 px-4 sm:px-6 pt-4 pb-16">
         {activeTab === "connectors" && (
-          <JobConnectorsTab agentId={agentId} agentDisplayName={displayName} />
+          <JobConnectorsTab
+            agentId={agentId}
+            agentDisplayName={displayName}
+            readOnly={hideProfileAndInstructions}
+          />
         )}
 
         {activeTab === "schedule" && <JobScheduleTab agentId={displayName} />}


### PR DESCRIPTION
## Summary
- Thread a `readOnly` prop from `ZeroJobDetailPage` through `ZeroConnectorsTab` → `ZeroConnectorCard`
- When `readOnly` (non-admin member on default agent): hide "Add connector" button, "Remove connector" dropdown item, and unsaved-changes bar
- Connect/Disconnect (OAuth) actions remain fully available — these are user-scoped operations
- Extract `ConnectionStatus` and `CardDropdownMenu` helper components from `ZeroConnectorCard` to stay under complexity limit

## Test plan
- [x] All 622 platform tests pass (82 test files)
- [x] Lint passes (0 errors, 0 warnings)
- [x] Type-check passes
- [x] Knip passes (no unused exports)
- [ ] Manual: member on default agent sees connector cards but no Add/Remove/Save
- [ ] Manual: admin on default agent has full functionality
- [ ] Manual: member on non-default agent has full functionality

Closes #6752

🤖 Generated with [Claude Code](https://claude.com/claude-code)