### PR TITLE
refactor(cli): export logs domain through api barrel file

### DIFF
--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -8,7 +8,7 @@ import {
   type TelemetryMetric,
   type RunEvent,
   type NetworkLogEntry,
-} from "../../lib/api/domains/logs";
+} from "../../lib/api";
 import { getApiUrl } from "../../lib/api/config";
 import { parseTime } from "../../lib/utils/time-parser";
 import { formatBytes } from "../../lib/utils/file-utils";

--- a/turbo/apps/cli/src/commands/logs/search.ts
+++ b/turbo/apps/cli/src/commands/logs/search.ts
@@ -4,7 +4,7 @@ import {
   searchLogs,
   type RunEvent,
   type LogsSearchResponse,
-} from "../../lib/api/domains/logs";
+} from "../../lib/api";
 import { parseTime } from "../../lib/utils/time-parser";
 import { ClaudeEventParser } from "../../lib/events/claude-event-parser";
 import { EventRenderer } from "../../lib/events/event-renderer";

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -126,3 +126,16 @@ export {
   disableZeroSchedule,
   resolveZeroScheduleByAgent,
 } from "./domains/zero-schedules";
+
+// Domain modules - Logs
+export {
+  getSystemLog,
+  getMetrics,
+  getAgentEvents,
+  getNetworkLogs,
+  searchLogs,
+  type RunEvent,
+  type TelemetryMetric,
+  type NetworkLogEntry,
+  type LogsSearchResponse,
+} from "./domains/logs";

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -28,7 +28,9 @@
     "apps/cli": {
       "entry": [
         "src/**/__tests__/**/*.{test,spec}.ts",
-        "src/**/*.{test,spec}.ts"
+        "src/**/*.{test,spec}.ts",
+        "src/commands/logs/index.ts",
+        "src/commands/logs/search.ts"
       ],
       "project": ["src/**/*.ts"],
       "ignoreDependencies": ["@types/tar"],
@@ -103,7 +105,6 @@
     "apps/platform/src/test/mocks/clerk-react-experimental.ts",
     "apps/web/src/lib/schedule/schedule-service.ts",
     "apps/web/src/lib/model-provider/model-provider-service.ts",
-    "apps/cli/src/lib/api/domains/logs.ts",
     "apps/cli/src/lib/utils/paginate.ts",
     "apps/cli/src/commands/cook/cook.ts",
     "apps/web/src/lib/auth/sandbox-token.ts",


### PR DESCRIPTION
## Summary
- Export logs domain types and functions (`getSystemLog`, `getMetrics`, `getAgentEvents`, `getNetworkLogs`, `searchLogs`, `RunEvent`, `TelemetryMetric`, `NetworkLogEntry`, `LogsSearchResponse`) through the API barrel file (`src/lib/api/index.ts`)
- Update `logs/index.ts` and `logs/search.ts` to import from the barrel file instead of directly from `domains/logs`
- Update knip config to add logs command files as entry points and remove the now-unnecessary ignore for `domains/logs.ts`

Closes #6750

## Test plan
- [ ] Verify `pnpm turbo run lint` passes
- [ ] Verify `pnpm check-types` passes
- [ ] Verify existing logs-related tests still pass
- [ ] Confirm knip reports no new unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)