### PR TITLE
fix(cli): address pr review findings for jwt org context

### DIFF
--- a/turbo/apps/cli/src/commands/zero/org/__tests__/leave.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/leave.test.ts
@@ -33,6 +33,7 @@ describe("zero org leave command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
+    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/set.test.ts
@@ -33,6 +33,7 @@ describe("zero org set command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
+    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/use.test.ts
@@ -33,6 +33,7 @@ describe("zero org use command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
+    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");

--- a/turbo/apps/cli/src/lib/api/core/client-factory.ts
+++ b/turbo/apps/cli/src/lib/api/core/client-factory.ts
@@ -19,14 +19,9 @@ export class ApiRequestError extends Error {
 }
 
 /**
- * Get authentication headers for API requests
+ * Build authentication headers from a token
  */
-async function getHeaders(): Promise<Record<string, string>> {
-  const token = await getActiveToken();
-  if (!token) {
-    throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);
-  }
-
+function buildHeaders(token: string): Record<string, string> {
   // Note: Don't set Content-Type here - ts-rest automatically adds it for requests with body.
   // Setting Content-Type for bodyless requests (GET, DELETE) can cause server-side parsing issues.
   const headers: Record<string, string> = {
@@ -58,14 +53,17 @@ export async function getBaseUrl(): Promise<string> {
  */
 export async function getClientConfig() {
   const baseUrl = await getBaseUrl();
-  const baseHeaders = await getHeaders();
+  const token = await getActiveToken();
+  if (!token) {
+    throw new ApiRequestError("Not authenticated", "UNAUTHORIZED", 401);
+  }
+  const baseHeaders = buildHeaders(token);
 
   // Check if current token is a self-signed JWT with embedded orgId
-  const token = await getActiveToken();
-  const isJwtToken =
+  const jwtPayload =
     decodeCliTokenPayload(token) ?? decodeZeroTokenPayload(token);
 
-  if (isJwtToken) {
+  if (jwtPayload) {
     // JWT tokens carry orgId in payload — server extracts it from authCtx.orgId
     return { baseUrl, baseHeaders, jsonQuery: false as const };
   }

--- a/turbo/apps/cli/src/lib/api/domains/zero-orgs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-orgs.ts
@@ -193,7 +193,7 @@ export async function switchZeroOrg(
   const client = initClient(cliAuthOrgContract, config);
 
   const result = await client.switchOrg({
-    headers: { authorization: `Bearer ${(await getToken())!}` },
+    headers: {},
     body: { slug },
   });
 


### PR DESCRIPTION
## Summary
- Refactor `getClientConfig()` to use `buildHeaders(token)` helper, eliminating double `getActiveToken()` call
- Remove redundant `authorization` header from `switchZeroOrg()` (already provided by `getUserTokenClientConfig`)
- Add `vi.clearAllMocks()` in `beforeEach` for `use.test.ts`, `set.test.ts`, `leave.test.ts` to prevent test pollution
- Rename `isJwtToken` → `jwtPayload` for clarity

## Context
Follow-up fixes from PR #6755 code review. The original PR merged before these fixes could be pushed.

Closes #6720

## Test plan
- [ ] Existing org command tests pass with `vi.clearAllMocks()` added
- [ ] `client-factory.ts` correctly builds headers with single token fetch
- [ ] `switchZeroOrg` works without redundant authorization header

🤖 Generated with [Claude Code](https://claude.com/claude-code)