### PR TITLE
fix: require user-level slack connection for schedule notifications

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/slack-schedule-notification.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/slack-schedule-notification.test.ts
@@ -193,6 +193,37 @@ describe("slack schedule notification signals", () => {
     });
   });
 
+  describe("/schedule page — installed but user not connected", () => {
+    it("should have isInstalled true but isConnected false", async () => {
+      server.use(
+        http.get("*/api/zero/integrations/slack", () => {
+          return HttpResponse.json({
+            isConnected: false,
+            isInstalled: true,
+            workspaceName: "Test Workspace",
+            isAdmin: false,
+            installUrl: null,
+            connectUrl: "https://example.com/connect",
+            defaultAgentName: null,
+            agentOrgSlug: null,
+            environment: {
+              requiredSecrets: [],
+              requiredVars: [],
+              missingSecrets: [],
+              missingVars: [],
+            },
+          });
+        }),
+      );
+
+      await setup("/schedule");
+
+      const data = context.store.get(slackOrgData$);
+      expect(data?.isInstalled).toBeTruthy();
+      expect(data?.isConnected).toBeFalsy();
+    });
+  });
+
   describe("/schedule page — no slack installation", () => {
     it("should show not installed and return empty channels", async () => {
       server.use(

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -441,6 +441,7 @@ function ScheduleNotificationFields({
   notifySlack,
   setNotifySlack,
   slackHasBot,
+  slackIsInstalled,
   slackChannels,
   slackChannelId,
   setSlackChannelId,
@@ -450,6 +451,7 @@ function ScheduleNotificationFields({
   notifySlack: boolean;
   setNotifySlack: (v: boolean) => void;
   slackHasBot: boolean;
+  slackIsInstalled: boolean;
   slackChannels: SlackChannelOption[];
   slackChannelId: string | null;
   setSlackChannelId: (v: string | null) => void;
@@ -473,7 +475,9 @@ function ScheduleNotificationFields({
       </div>
       {!slackHasBot && (
         <p className="text-xs text-muted-foreground">
-          Connect a Slack workspace in Settings to enable Slack notifications.
+          {slackIsInstalled
+            ? "Connect your Slack account in Settings to enable Slack notifications."
+            : "Install Slack in Settings to enable Slack notifications."}
         </p>
       )}
       {notifySlack && slackHasBot && slackChannels.length > 0 && (
@@ -582,6 +586,8 @@ function ScheduleFormDialogInner({
 }: Omit<ScheduleFormDialogProps, "open">) {
   const slackData = useLoadable(slackOrgData$);
   const slackHasBot =
+    slackData.state === "hasData" && slackData.data?.isConnected === true;
+  const slackIsInstalled =
     slackData.state === "hasData" && slackData.data?.isInstalled === true;
   const slackChannelsLoadable = useLoadable(slackChannels$);
   const slackChannels: SlackChannelOption[] =
@@ -765,6 +771,7 @@ function ScheduleFormDialogInner({
               notifySlack={notifySlack}
               setNotifySlack={setNotifySlack}
               slackHasBot={slackHasBot}
+              slackIsInstalled={slackIsInstalled}
               slackChannels={slackChannels}
               slackChannelId={slackChannelId}
               setSlackChannelId={setSlackChannelId}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -246,7 +246,7 @@ function ScheduleNotificationSettings({
 }) {
   const slackData = useLoadable(slackOrgData$);
   const slackHasBot =
-    slackData.state === "hasData" && slackData.data?.isInstalled === true;
+    slackData.state === "hasData" && slackData.data?.isConnected === true;
   const slackChannelsLoadable = useLoadable(slackChannels$);
   const slackChannelsList =
     slackChannelsLoadable.state === "hasData" ? slackChannelsLoadable.data : [];
@@ -271,7 +271,9 @@ function ScheduleNotificationSettings({
         description={
           slackHasBot
             ? "Send a Slack message when a run completes."
-            : "Connect a Slack workspace in Settings to enable Slack notifications."
+            : slackData.state === "hasData" && slackData.data?.isInstalled
+              ? "Connect your Slack account in Settings to enable Slack notifications."
+              : "Install Slack in Settings to enable Slack notifications."
         }
         alignControls="center"
       >

--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -7,6 +7,8 @@ import {
   getTestZeroAgentId,
   createTestOrg,
   createTestSchedule,
+  createTestSlackOrgInstallation,
+  createTestSlackOrgConnection,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -44,6 +46,15 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
     testComposeId = composeId;
     await createTestZeroAgent(orgId, agentName, {});
     testZeroAgentId = await getTestZeroAgentId(orgId, agentName);
+
+    // Set up Slack installation + user connection (required for notifySlack: true tests)
+    const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+      orgId,
+    });
+    await createTestSlackOrgConnection({
+      slackWorkspaceId,
+      vm0UserId: user.userId,
+    });
   });
 
   it("should create schedule and return 201", async () => {

--- a/turbo/apps/web/src/lib/schedule/__tests__/notification-control.test.ts
+++ b/turbo/apps/web/src/lib/schedule/__tests__/notification-control.test.ts
@@ -14,6 +14,8 @@ import {
   findTestScheduleById,
   updateTestScheduleState,
   disableAllSchedules,
+  createTestSlackOrgInstallation,
+  createTestSlackOrgConnection,
 } from "../../../__tests__/api-test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
 import { POST as deployScheduleRoute } from "../../../../app/api/zero/schedules/route";
@@ -93,6 +95,15 @@ describe("Schedule notification control - per-schedule settings", () => {
     await createTestCompose(agentName);
     await createTestZeroAgent(user.orgId, agentName, {});
     agentId = await getTestZeroAgentId(user.orgId, agentName);
+
+    // Set up Slack installation + user connection (required for notifySlack: true)
+    const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+      orgId: user.orgId,
+    });
+    await createTestSlackOrgConnection({
+      slackWorkspaceId,
+      vm0UserId: user.userId,
+    });
 
     // Disable any schedules from other tests to avoid interference
     await disableAllSchedules(user.orgId);
@@ -184,5 +195,78 @@ describe("Schedule notification control - per-schedule settings", () => {
     expect(callbackUrls).not.toContainEqual(
       expect.stringContaining("/callbacks/slack/org/schedule"),
     );
+  });
+
+  it("should reject notifySlack: true when user has no Slack connection", async () => {
+    // Create a second user without Slack connection (custom prefix to avoid cache)
+    const user2 = await context.setupUser({ prefix: "no-slack-user" });
+    const slug2 = uniqueId("no-slack");
+    mockClerk({
+      userId: user2.userId,
+      orgId: user2.orgId,
+      orgRole: "org:admin",
+    });
+    await createTestOrg(slug2);
+
+    const agentName2 = uniqueId("no-slack-agent");
+    await createTestCompose(agentName2);
+    await createTestZeroAgent(user2.orgId, agentName2, {});
+    const agentId2 = await getTestZeroAgentId(user2.orgId, agentName2);
+
+    const createReq = createTestRequest(
+      `http://localhost:3000/api/zero/schedules?org=${slug2}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: agentId2,
+          name: "no-slack-schedule",
+          cronExpression: "0 0 * * *",
+          timezone: "UTC",
+          prompt: "Test no slack connection",
+          notifySlack: true,
+        }),
+      },
+    );
+    const res = await deployScheduleRoute(createReq);
+    expect(res.status).toBe(400);
+
+    const data = await res.json();
+    expect(data.error.message).toContain("Slack");
+  });
+
+  it("should accept notifySlack: false without Slack connection", async () => {
+    // Create a second user without Slack connection (custom prefix to avoid cache)
+    const user2 = await context.setupUser({ prefix: "no-slack-ok-user" });
+    const slug2 = uniqueId("no-slack-ok");
+    mockClerk({
+      userId: user2.userId,
+      orgId: user2.orgId,
+      orgRole: "org:admin",
+    });
+    await createTestOrg(slug2);
+
+    const agentName2 = uniqueId("no-slack-ok-agent");
+    await createTestCompose(agentName2);
+    await createTestZeroAgent(user2.orgId, agentName2, {});
+    const agentId2 = await getTestZeroAgentId(user2.orgId, agentName2);
+
+    const createReq = createTestRequest(
+      `http://localhost:3000/api/zero/schedules?org=${slug2}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: agentId2,
+          name: "no-slack-ok-schedule",
+          cronExpression: "0 0 * * *",
+          timezone: "UTC",
+          prompt: "Test no slack but not requesting it",
+          notifySlack: false,
+        }),
+      },
+    );
+    const res = await deployScheduleRoute(createReq);
+    expect(res.status).toBe(201);
   });
 });

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -2,6 +2,8 @@ import { eq, and, lte, inArray, desc } from "drizzle-orm";
 import { Cron } from "croner";
 import { zeroAgentSchedules } from "../../db/schema/zero-agent-schedule";
 import { agentComposes } from "../../db/schema/agent-compose";
+import { slackOrgConnections } from "../../db/schema/slack-org-connection";
+import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
 import { agentRuns } from "../../db/schema/agent-run";
 import { decryptSecretsMap } from "../crypto";
 import { getOrgData } from "../org/org-cache-service";
@@ -422,6 +424,31 @@ export async function deploySchedule(
 
   // Reject one-time schedules with past atTime when enabled
   validateAtTimeNotPast(request);
+
+  // Validate Slack connection exists when Slack notifications are requested
+  if (request.notifySlack) {
+    const [slackConnection] = await globalThis.services.db
+      .select({ id: slackOrgConnections.id })
+      .from(slackOrgConnections)
+      .innerJoin(
+        slackOrgInstallations,
+        eq(
+          slackOrgConnections.slackWorkspaceId,
+          slackOrgInstallations.slackWorkspaceId,
+        ),
+      )
+      .where(
+        and(
+          eq(slackOrgConnections.vm0UserId, userId),
+          eq(slackOrgInstallations.orgId, orgId),
+        ),
+      )
+      .limit(1);
+
+    if (!slackConnection) {
+      throw badRequest("Slack notifications require a connected Slack account");
+    }
+  }
 
   // Auto-generate description if not provided (undefined/null means not provided;
   // empty string means the user explicitly cleared it — skip auto-generation)


### PR DESCRIPTION
## Summary

- **Frontend**: Gate Slack notification toggle on `isConnected` (user-level) instead of `isInstalled` (org-level), so users without a personal Slack connection cannot enable Slack notifications that would silently never arrive
- **Frontend**: Distinguish disabled messages — "Install Slack..." vs "Connect your Slack account..."
- **Backend**: Validate Slack connection in `deploySchedule()` — reject `notifySlack: true` with 400 when user has no connection (defense in depth for API/CLI consumers)

## Test plan

- [x] Existing notification control tests updated with Slack connection setup (4 tests pass)
- [x] New test: `notifySlack: true` rejected when user has no Slack connection (400)
- [x] New test: `notifySlack: false` accepted without Slack connection (201)
- [x] New signal test: `isInstalled && !isConnected` state correctly represented
- [x] Lint, type check, knip all pass

Closes #6757

🤖 Generated with [Claude Code](https://claude.com/claude-code)