### PR TITLE
feat: add sign-in-token page for ticket-based authentication

### DIFF
--- a/turbo/apps/web/app/sign-in-token/page.tsx
+++ b/turbo/apps/web/app/sign-in-token/page.tsx
@@ -1,52 +1,51 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useSignIn } from "@clerk/nextjs";
 
 export default function SignInTokenPage() {
   const searchParams = useSearchParams();
   const { signIn, setActive, isLoaded } = useSignIn();
-  const [status, setStatus] = useState<"loading" | "success" | "error">(
-    "loading",
-  );
-  const [errorMessage, setErrorMessage] = useState("");
+  const [error, setError] = useState("");
+  const didRun = useRef(false);
+
+  const token = searchParams.get("token");
 
   useEffect(() => {
-    if (!isLoaded) return;
-
-    const token = searchParams.get("token");
-    if (!token) {
-      setStatus("error");
-      setErrorMessage("Missing token parameter");
-      return;
-    }
+    if (!isLoaded || !token || didRun.current) return;
+    didRun.current = true;
 
     signIn
       .create({ strategy: "ticket", ticket: token })
       .then((result) => {
         if (result.status === "complete" && result.createdSessionId) {
           return setActive({ session: result.createdSessionId }).then(() => {
-            setStatus("success");
             window.location.href = "/";
           });
         }
-        setStatus("error");
-        setErrorMessage(`Unexpected status: ${result.status}`);
+        throw new Error(`Unexpected status: ${result.status}`);
       })
       .catch((err: unknown) => {
-        setStatus("error");
-        setErrorMessage(
-          err instanceof Error ? err.message : "Sign-in failed",
-        );
+        setError(err instanceof Error ? err.message : "Sign-in failed");
       });
-  }, [isLoaded, searchParams, signIn, setActive]);
+  }, [isLoaded, token, signIn, setActive]);
+
+  if (!token) {
+    return (
+      <p style={{ padding: "2rem", fontFamily: "monospace" }}>
+        Error: Missing token parameter
+      </p>
+    );
+  }
+
+  if (error) {
+    return (
+      <p style={{ padding: "2rem", fontFamily: "monospace" }}>Error: {error}</p>
+    );
+  }
 
   return (
-    <div style={{ padding: "2rem", fontFamily: "monospace" }}>
-      {status === "loading" && <p>Signing in...</p>}
-      {status === "success" && <p>Success. Redirecting...</p>}
-      {status === "error" && <p>Error: {errorMessage}</p>}
-    </div>
+    <p style={{ padding: "2rem", fontFamily: "monospace" }}>Signing in...</p>
   );
 }

--- a/turbo/apps/web/app/sign-in-token/page.tsx
+++ b/turbo/apps/web/app/sign-in-token/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useSignIn } from "@clerk/nextjs";
+
+export default function SignInTokenPage() {
+  const searchParams = useSearchParams();
+  const { signIn, setActive, isLoaded } = useSignIn();
+  const [status, setStatus] = useState<"loading" | "success" | "error">(
+    "loading",
+  );
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    if (!isLoaded) return;
+
+    const token = searchParams.get("token");
+    if (!token) {
+      setStatus("error");
+      setErrorMessage("Missing token parameter");
+      return;
+    }
+
+    signIn
+      .create({ strategy: "ticket", ticket: token })
+      .then((result) => {
+        if (result.status === "complete" && result.createdSessionId) {
+          return setActive({ session: result.createdSessionId }).then(() => {
+            setStatus("success");
+            window.location.href = "/";
+          });
+        }
+        setStatus("error");
+        setErrorMessage(`Unexpected status: ${result.status}`);
+      })
+      .catch((err: unknown) => {
+        setStatus("error");
+        setErrorMessage(
+          err instanceof Error ? err.message : "Sign-in failed",
+        );
+      });
+  }, [isLoaded, searchParams, signIn, setActive]);
+
+  return (
+    <div style={{ padding: "2rem", fontFamily: "monospace" }}>
+      {status === "loading" && <p>Signing in...</p>}
+      {status === "success" && <p>Success. Redirecting...</p>}
+      {status === "error" && <p>Error: {errorMessage}</p>}
+    </div>
+  );
+}

--- a/turbo/apps/web/app/sign-in-token/page.tsx
+++ b/turbo/apps/web/app/sign-in-token/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useSignIn } from "@clerk/nextjs";
 
-export default function SignInTokenPage() {
+function SignInTokenContent() {
   const searchParams = useSearchParams();
   const { signIn, setActive, isLoaded } = useSignIn();
   const [error, setError] = useState("");
@@ -47,5 +47,17 @@ export default function SignInTokenPage() {
 
   return (
     <p style={{ padding: "2rem", fontFamily: "monospace" }}>Signing in...</p>
+  );
+}
+
+export default function SignInTokenPage() {
+  return (
+    <Suspense
+      fallback={
+        <p style={{ padding: "2rem", fontFamily: "monospace" }}>Loading...</p>
+      }
+    >
+      <SignInTokenContent />
+    </Suspense>
   );
 }

--- a/turbo/apps/web/proxy.layers.ts
+++ b/turbo/apps/web/proxy.layers.ts
@@ -18,6 +18,7 @@ const SKIP_I18N_PREFIXES = [
   "/connector/",
   "/slack/",
   "/sign-in",
+  "/sign-in-token",
   "/sign-up",
   "/privacy-policy",
   "/terms-of-use",

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -29,6 +29,8 @@ const isPublicRoute = createRouteMatcher([
   "/:locale/blog/posts/:slug",
   "/sign-in(.*)",
   "/sign-up(.*)",
+  "/sign-in-token",
+  "/:locale/sign-in-token",
   "/api/cli/auth/device",
   "/api/cli/auth/token",
   "/api/slack/oauth/(.*)",


### PR DESCRIPTION
## Summary
- Add `/sign-in-token` page that accepts a `token` query parameter and signs in the user via Clerk's ticket strategy
- Register the route as a public route in proxy middleware and skip i18n prefixing

## Test plan
- [ ] Navigate to `/sign-in-token?token=<valid-ticket>` and verify successful sign-in and redirect to `/`
- [ ] Navigate to `/sign-in-token` without a token and verify error message is displayed
- [ ] Verify the route works without locale prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)