### PR TITLE
feat: make agent list items clickable to chat and fix unpinned agent opacity

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
@@ -94,7 +94,7 @@ async function openChatListDialog() {
   });
 }
 
-describe("ChatListDialog", () => {
+describe("chatListDialog", () => {
   it("should navigate to chat when clicking a pinned agent", async () => {
     mockAPIsWithSubagents();
     await setupPage({ context, path: "/team" });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import {
+  screen,
+  waitFor,
+  fireEvent,
+  act,
+  within,
+} from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+function mockAPIsWithSubagents({
+  pinnedAgentIds = ["pinned-agent-id"],
+}: { pinnedAgentIds?: string[] } = {}) {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: "mock-compose-id",
+          displayName: null,
+          description: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "pinned-agent-id",
+          displayName: "Pinned Agent",
+          description: "A pinned sub-agent",
+          headVersionId: "version_2",
+          updatedAt: "2024-01-02T00:00:00Z",
+        },
+        {
+          id: "unpinned-agent-id",
+          displayName: "Unpinned Agent",
+          description: "An unpinned sub-agent",
+          headVersionId: "version_3",
+          updatedAt: "2024-01-03T00:00:00Z",
+        },
+      ]);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    http.get("*/api/zero/chat-threads/:id", () => {
+      return HttpResponse.json({
+        id: "new-thread-from-dialog",
+        title: null,
+        agentId: "mock-compose-id",
+        chatMessages: [],
+        latestSessionId: "session-new",
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      });
+    }),
+    http.post("*/api/zero/chat-threads", () => {
+      return HttpResponse.json(
+        { id: "new-thread-from-dialog", title: null },
+        { status: 201 },
+      );
+    }),
+    http.get("*/api/zero/user-preferences", () => {
+      return HttpResponse.json({
+        timezone: null,
+        pinnedAgentIds,
+        sendMode: "enter" as const,
+      });
+    }),
+    http.post("*/api/zero/user-preferences", async ({ request }) => {
+      const body = (await request.json()) as { pinnedAgentIds?: string[] };
+      return HttpResponse.json({
+        timezone: null,
+        pinnedAgentIds: body.pinnedAgentIds ?? pinnedAgentIds,
+        sendMode: "enter" as const,
+      });
+    }),
+  );
+}
+
+async function openChatListDialog() {
+  const openButton = await waitFor(
+    () => screen.getByLabelText("Open a conversation"),
+    { timeout: 5000 },
+  );
+  await act(() => {
+    fireEvent.click(openButton);
+  });
+  await waitFor(() => {
+    expect(screen.getByText("Talk to")).toBeInTheDocument();
+  });
+}
+
+describe("ChatListDialog", () => {
+  it("should navigate to chat when clicking a pinned agent", async () => {
+    mockAPIsWithSubagents();
+    await setupPage({ context, path: "/team" });
+
+    await openChatListDialog();
+
+    // Wait for the "Pinned" section label to appear, then find the chat button
+    await waitFor(
+      () => {
+        const dialog = screen.getByRole("dialog");
+        expect(within(dialog).getByText("Pinned")).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // The pinned agent's onChat button contains the agent name text
+    const dialog = screen.getByRole("dialog");
+    const pinnedAgentText = within(dialog).getByText("Pinned Agent");
+    const pinnedAgentButton = pinnedAgentText.closest("button")!;
+
+    await act(() => {
+      fireEvent.click(pinnedAgentButton);
+    });
+
+    // Should navigate to /chat/:threadId
+    await waitFor(
+      () => {
+        expect(pathname()).toBe("/chat/new-thread-from-dialog");
+      },
+      { timeout: 5000 },
+    );
+  }, 15_000);
+
+  it("should navigate to chat when clicking an unpinned agent", async () => {
+    mockAPIsWithSubagents();
+    await setupPage({ context, path: "/team" });
+
+    await openChatListDialog();
+
+    // Find the unpinned agent button and click it
+    const unpinnedAgentButton = await waitFor(() =>
+      screen.getByRole("button", { name: /Unpinned Agent/ }),
+    );
+
+    await act(() => {
+      fireEvent.click(unpinnedAgentButton);
+    });
+
+    await waitFor(
+      () => {
+        expect(pathname()).toBe("/chat/new-thread-from-dialog");
+      },
+      { timeout: 5000 },
+    );
+  }, 15_000);
+
+  it("should render unpinned agent avatars without reduced opacity", async () => {
+    mockAPIsWithSubagents();
+    await setupPage({ context, path: "/team" });
+
+    await openChatListDialog();
+
+    // Wait for the "Others" section to render with the unpinned agent
+    const dialog = screen.getByRole("dialog");
+    await waitFor(() => {
+      expect(within(dialog).getByText("Others")).toBeInTheDocument();
+    });
+
+    // Find the unpinned agent's avatar image within the dialog
+    const unpinnedAvatar = within(dialog).getByAltText("Unpinned Agent");
+    expect(unpinnedAvatar.className).not.toContain("opacity-60");
+  }, 15_000);
+
+  it("should navigate to chat when clicking the lead agent", async () => {
+    mockAPIsWithSubagents();
+    await setupPage({ context, path: "/team" });
+
+    await openChatListDialog();
+
+    // The lead agent section should have a clickable button
+    const leadButton = await waitFor(() => {
+      return screen
+        .getByText("Your lead assistant, always here for you")
+        .closest("button")!;
+    });
+
+    await act(() => {
+      fireEvent.click(leadButton);
+    });
+
+    await waitFor(
+      () => {
+        expect(pathname()).toBe("/chat/new-thread-from-dialog");
+      },
+      { timeout: 5000 },
+    );
+  }, 15_000);
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -44,9 +44,11 @@ import { type SubagentInfo, AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 function SortablePinnedAgent({
   agent,
   onUnpin,
+  onChat,
 }: {
   agent: SubagentInfo;
   onUnpin: () => void;
+  onChat?: () => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: agent.id });
@@ -61,14 +63,33 @@ function SortablePinnedAgent({
       style={style}
       className="flex items-center gap-2 px-1 py-2 rounded-lg hover:bg-accent transition-colors group"
     >
-      <AgentAvatarImg
-        name={agent.id}
-        alt={agent.displayName ?? agent.id}
-        className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
-      />
-      <span className="text-sm text-foreground min-w-0 flex-1 truncate">
-        {agent.displayName ?? agent.id}
-      </span>
+      {onChat ? (
+        <button
+          type="button"
+          onClick={onChat}
+          className="flex items-center gap-2 flex-1 min-w-0"
+        >
+          <AgentAvatarImg
+            name={agent.id}
+            alt={agent.displayName ?? agent.id}
+            className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+          />
+          <span className="text-sm text-foreground truncate">
+            {agent.displayName ?? agent.id}
+          </span>
+        </button>
+      ) : (
+        <>
+          <AgentAvatarImg
+            name={agent.id}
+            alt={agent.displayName ?? agent.id}
+            className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+          />
+          <span className="text-sm text-foreground min-w-0 flex-1 truncate">
+            {agent.displayName ?? agent.id}
+          </span>
+        </>
+      )}
       <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
         <button
           type="button"
@@ -237,9 +258,9 @@ export function ManagePinnedAgentsDialog({
                   <AgentAvatarImg
                     name={agent.id}
                     alt={agent.displayName ?? agent.id}
-                    className="h-8 w-8 shrink-0 rounded-lg object-cover object-top opacity-60"
+                    className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
                   />
-                  <span className="text-sm text-muted-foreground flex-1 truncate">
+                  <span className="text-sm text-foreground flex-1 truncate">
                     {agent.displayName ?? agent.id}
                   </span>
                   <TooltipProvider delayDuration={200}>
@@ -463,6 +484,7 @@ export function ChatListDialog({
                         key={agent.id}
                         agent={agent}
                         onUnpin={() => togglePin(agent.id)}
+                        onChat={() => handleChat(agent.id)}
                       />
                     ))}
                   </div>
@@ -491,9 +513,9 @@ export function ChatListDialog({
                       <AgentAvatarImg
                         name={agent.id}
                         alt={agent.displayName ?? agent.id}
-                        className="h-8 w-8 shrink-0 rounded-lg object-cover object-top opacity-60"
+                        className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
                       />
-                      <span className="text-sm text-muted-foreground truncate">
+                      <span className="text-sm text-foreground truncate">
                         {agent.displayName ?? agent.id}
                       </span>
                     </button>


### PR DESCRIPTION
## Summary

Closes #6762

- **Pinned agents clickable to chat**: Added `onChat` prop to `SortablePinnedAgent` component. In the `ChatListDialog`, clicking a pinned agent's name/avatar now navigates to chat, matching the existing behavior for unpinned agents and the "Chat XX" button on the profile page.
- **Unpinned agents at full opacity**: Removed `opacity-60` from unpinned agent avatars in both `ChatListDialog` and `ManagePinnedAgentsDialog`. Also updated text color from `text-muted-foreground` to `text-foreground` for consistent styling.

## Test plan

- [ ] Open the "Talk to" dialog (ChatListDialog) and verify clicking a pinned agent starts a chat
- [ ] Verify clicking an unpinned agent in "Others" section still starts a chat
- [ ] Verify unpinned agents in both dialogs render at full opacity (no dimming)
- [ ] Verify drag-and-drop reordering of pinned agents still works in both dialogs
- [ ] Verify pin/unpin actions still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)