### PR TITLE
feat(runner): add cache version seeds for rootfs and snapshot

### DIFF
--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -1,7 +1,6 @@
 # Firecracker VM rootfs image
 # Based on Node.js 24 with Python 3.11+, guest-init, and agent CLIs
 #
-#
 # Included CLIs:
 # - Claude Code CLI (@anthropic-ai/claude-code)
 # - GitHub CLI (gh)

--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -12,6 +12,9 @@ use crate::profile;
 const BUILD_SCRIPT: &str = include_str!("../../scripts/build-rootfs.sh");
 const VERIFY_SCRIPT: &str = include_str!("../../scripts/verify-rootfs.sh");
 
+/// Bump this to invalidate all cached rootfs images without changing any input files.
+const ROOTFS_CACHE_VERSION: u32 = 1;
+
 #[cfg(bundled_guests)]
 mod embedded {
     pub const GUEST_INIT: &[u8] = include_bytes!(env!("BUNDLED_GUEST_INIT"));
@@ -279,6 +282,10 @@ async fn compute_input_hash(
     guest_bins: &[(&Path, &str)],
 ) -> RunnerResult<String> {
     let mut hasher = Sha256::new();
+
+    // Cache version seed — bump ROOTFS_CACHE_VERSION to force invalidation.
+    hasher.update(b"version:");
+    hasher.update(ROOTFS_CACHE_VERSION.to_le_bytes());
 
     // Hash build script content (includes resolv.conf, constants, all logic)
     hasher.update(b"script:");

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -9,6 +9,9 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
 use crate::paths::{HomePaths, RootfsPaths, touch_mtime};
 
+/// Bump this to invalidate all cached snapshots without changing any input files.
+const SNAPSHOT_CACHE_VERSION: u32 = 1;
+
 #[derive(Args, Clone)]
 pub struct SnapshotArgs {
     /// SHA-256 hash of the rootfs inputs (output of `rootfs`).
@@ -135,6 +138,9 @@ async fn is_snapshot_complete(output: &SnapshotOutputPaths) -> RunnerResult<bool
 pub(crate) fn compute_snapshot_hash(args: &SnapshotArgs) -> String {
     let fc_config = sandbox_fc::config_hash();
     let mut hasher = Sha256::new();
+    // Cache version seed — bump SNAPSHOT_CACHE_VERSION to force invalidation.
+    hasher.update(b"version:");
+    hasher.update(SNAPSHOT_CACHE_VERSION.to_le_bytes());
     hasher.update(b"fc_config:");
     hasher.update(fc_config.as_bytes());
     hasher.update(b"rootfs:");
@@ -201,7 +207,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "293b14570b00874e4cf5adf3c8c099e18a59c2eadcce8c26f267a41ace35b5f8",
+            hash, "c3a6b6de68a3432cf445929376de33f7dfe854493ad91cd42d2b6bdc6d6adca6",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }


### PR DESCRIPTION
## Summary
- Add `ROOTFS_CACHE_VERSION` and `SNAPSHOT_CACHE_VERSION` constants included in hash computation
- Bumping these values invalidates all cached artifacts without modifying any input files
- Useful for forcing cache rebuild after operational issues (e.g., corrupted rootfs, stale snapshots)

## Context
Discovered during #6521 testing: when rootfs was manually deleted, we needed to force a hash change to avoid conflicts with stale caches. Previously this required modifying an actual input file (Dockerfile, build script, etc.) just to trigger invalidation.

## Test plan
- [x] `snapshot_hash_is_stable` test updated with new expected hash
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)