### PR TITLE
feat(telegram): add org-level telegram integration

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
@@ -1,16 +1,21 @@
 /**
- * Telegram Integration API Handlers
+ * Org-scoped Telegram Integration API Handlers
  *
- * Mock handlers for /api/integrations/telegram and /api/telegram/register endpoints.
- * Default behavior: user has a linked Telegram bot with an agent configured.
+ * Mock handlers for /api/zero/integrations/telegram endpoints.
+ * Default behavior: org has a Telegram bot installed and current user is connected.
  */
 
 import { http, HttpResponse } from "msw";
 
-interface MockTelegramIntegrationData {
-  bot: { id: string; username: string };
-  agent: { id: string; name: string; orgSlug: string } | null;
+interface MockTelegramOrgData {
+  isConnected: boolean;
+  isInstalled: boolean;
   isAdmin: boolean;
+  enabled: boolean;
+  bot: { id: string; username: string } | null;
+  defaultAgentName: string | null;
+  agentOrgSlug: string | null;
+  domainConfigured: boolean;
   environment: {
     requiredSecrets: string[];
     requiredVars: string[];
@@ -19,10 +24,15 @@ interface MockTelegramIntegrationData {
   };
 }
 
-let mockTelegramData: MockTelegramIntegrationData = {
-  bot: { id: "bot_123", username: "test_bot" },
-  agent: { id: "compose_1", name: "default-agent", orgSlug: "test-org" },
+let mockTelegramData: MockTelegramOrgData = {
+  isConnected: true,
+  isInstalled: true,
   isAdmin: true,
+  enabled: true,
+  bot: { id: "bot_123", username: "test_bot" },
+  defaultAgentName: "default-agent",
+  agentOrgSlug: "test-org",
+  domainConfigured: true,
   environment: {
     requiredSecrets: ["ANTHROPIC_API_KEY"],
     requiredVars: [],
@@ -31,54 +41,92 @@ let mockTelegramData: MockTelegramIntegrationData = {
   },
 };
 
+const defaultData = (): MockTelegramOrgData => ({
+  isConnected: true,
+  isInstalled: true,
+  isAdmin: true,
+  enabled: true,
+  bot: { id: "bot_123", username: "test_bot" },
+  defaultAgentName: "default-agent",
+  agentOrgSlug: "test-org",
+  domainConfigured: true,
+  environment: {
+    requiredSecrets: ["ANTHROPIC_API_KEY"],
+    requiredVars: [],
+    missingSecrets: [],
+    missingVars: [],
+  },
+});
+
 export function resetMockTelegramIntegration(): void {
-  mockTelegramData = {
-    bot: { id: "bot_123", username: "test_bot" },
-    agent: {
-      id: "compose_1",
-      name: "default-agent",
-      orgSlug: "test-org",
-    },
-    isAdmin: true,
-    environment: {
-      requiredSecrets: ["ANTHROPIC_API_KEY"],
-      requiredVars: [],
-      missingSecrets: [],
-      missingVars: [],
-    },
-  };
+  mockTelegramData = defaultData();
 }
 
 export const apiIntegrationsTelegramHandlers = [
-  // GET /api/integrations/telegram
-  http.get("/api/integrations/telegram", () => {
+  // GET /api/zero/integrations/telegram
+  http.get("/api/zero/integrations/telegram", () => {
     return HttpResponse.json(mockTelegramData);
   }),
 
-  // PATCH /api/integrations/telegram
-  http.patch("/api/integrations/telegram", async ({ request }) => {
-    const body = (await request.json()) as { agentName?: string };
-    if (body.agentName && mockTelegramData.agent) {
-      mockTelegramData.agent.name = body.agentName;
+  // POST /api/zero/integrations/telegram/install
+  http.post("/api/zero/integrations/telegram/install", () => {
+    mockTelegramData = {
+      ...mockTelegramData,
+      isInstalled: true,
+      isConnected: true,
+      enabled: true,
+      bot: { id: "bot_456", username: "installed_bot" },
+    };
+    return HttpResponse.json(
+      {
+        installationId: "installation_1",
+        bot: mockTelegramData.bot,
+      },
+      { status: 201 },
+    );
+  }),
+
+  // POST /api/zero/integrations/telegram/connect
+  http.post("/api/zero/integrations/telegram/connect", () => {
+    mockTelegramData = { ...mockTelegramData, isConnected: true };
+    return HttpResponse.json({
+      botUsername: mockTelegramData.bot?.username ?? null,
+      telegramUserId: "tg_user_1",
+    });
+  }),
+
+  // PATCH /api/zero/integrations/telegram
+  http.patch("/api/zero/integrations/telegram", async ({ request }) => {
+    const body = (await request.json()) as {
+      enabled?: boolean;
+      agentName?: string;
+    };
+    if (body.enabled !== undefined) {
+      mockTelegramData = { ...mockTelegramData, enabled: body.enabled };
+    }
+    if (body.agentName !== undefined) {
+      mockTelegramData = {
+        ...mockTelegramData,
+        defaultAgentName: body.agentName,
+      };
     }
     return HttpResponse.json({ ok: true });
   }),
 
-  // DELETE /api/integrations/telegram
-  http.delete("/api/integrations/telegram", () => {
+  // DELETE /api/zero/integrations/telegram
+  http.delete("/api/zero/integrations/telegram", ({ request }) => {
+    const url = new URL(request.url);
+    if (url.searchParams.get("action") === "uninstall") {
+      mockTelegramData = {
+        ...mockTelegramData,
+        isInstalled: false,
+        isConnected: false,
+        enabled: false,
+        bot: null,
+      };
+    } else {
+      mockTelegramData = { ...mockTelegramData, isConnected: false };
+    }
     return HttpResponse.json({ ok: true });
-  }),
-
-  // GET /api/integrations/telegram/link
-  http.get("/api/integrations/telegram/link", () => {
-    return HttpResponse.json({ linked: false });
-  }),
-
-  // POST /api/telegram/register
-  http.post("/api/telegram/register", () => {
-    return HttpResponse.json({
-      id: "installation_1",
-      botUsername: "test_bot",
-    });
   }),
 ];

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -12,6 +12,10 @@ import {
   initSlackOrg$,
   pollSlackConnection$,
 } from "../zero-page/zero-slack.ts";
+import {
+  initTelegramOrg$,
+  pollTelegramConnection$,
+} from "../zero-page/zero-telegram.ts";
 
 export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(ZeroWorksPageWrapper));
@@ -20,9 +24,11 @@ export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
     set(fetchAgentsList$),
     set(initZeroOnboarding$, signal),
     set(initSlackOrg$),
+    set(initTelegramOrg$),
   ]);
   signal.throwIfAborted();
   detach(set(pollSlackConnection$, signal), Reason.Entrance);
+  detach(set(pollTelegramConnection$, signal), Reason.Entrance);
 
   if (await set(onboardGuard$, signal)) {
     return;

--- a/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
@@ -1,0 +1,237 @@
+import { command, computed, state } from "ccstate";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { delay } from "signal-timers";
+import {
+  zeroIntegrationsTelegramContract,
+  type TelegramOrgStatus,
+} from "@vm0/core";
+import { zeroClient$ } from "../api-client.ts";
+
+interface TelegramOrgState {
+  data: TelegramOrgStatus | null;
+  loading: boolean;
+  error: string | null;
+}
+
+const telegramOrgState$ = state<TelegramOrgState>({
+  data: null,
+  loading: false,
+  error: null,
+});
+
+export const telegramOrgData$ = computed((get) => get(telegramOrgState$).data);
+
+// ---------------------------------------------------------------------------
+// Dialog visibility
+// ---------------------------------------------------------------------------
+
+const showInstallDialogState$ = state(false);
+
+export const showTelegramInstallDialog$ = computed((get) =>
+  get(showInstallDialogState$),
+);
+
+export const setShowTelegramInstallDialog$ = command(
+  ({ set }, show: boolean) => {
+    set(showInstallDialogState$, show);
+  },
+);
+
+const showUninstallDialogState$ = state(false);
+
+export const showTelegramUninstallDialog$ = computed((get) =>
+  get(showUninstallDialogState$),
+);
+
+export const setShowTelegramUninstallDialog$ = command(
+  ({ set }, show: boolean) => {
+    set(showUninstallDialogState$, show);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+
+const fetchTelegramOrg$ = command(async ({ get, set }) => {
+  set(telegramOrgState$, (prev) => ({
+    ...prev,
+    loading: true,
+    error: null,
+  }));
+
+  const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+  const result = await client.getStatus();
+
+  if (result.status !== 200) {
+    set(telegramOrgState$, (prev) => ({
+      ...prev,
+      loading: false,
+      error: "Failed to fetch Telegram status",
+    }));
+    return;
+  }
+
+  set(telegramOrgState$, {
+    data: result.body,
+    loading: false,
+    error: null,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export const installTelegramOrg$ = command(
+  async (
+    { get, set },
+    params: {
+      botToken: string;
+      telegramAuth: Record<string, unknown>;
+    },
+  ) => {
+    const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+    const result = await client.install({
+      body: {
+        botToken: params.botToken,
+        telegramAuth: params.telegramAuth as Parameters<
+          typeof client.install
+        >[0]["body"]["telegramAuth"],
+      },
+    });
+
+    if (result.status !== 201) {
+      const errorBody = result.body as { error?: { message?: string } };
+      toast.error(
+        errorBody?.error?.message ?? "Failed to install Telegram bot",
+      );
+      return null;
+    }
+
+    toast.success("Telegram bot installed successfully");
+    await set(fetchTelegramOrg$);
+    return result.body;
+  },
+);
+
+export const connectTelegramOrg$ = command(
+  async (
+    { get, set },
+    params: {
+      telegramAuth?: Record<string, unknown>;
+      connectSignature?: {
+        telegramUserId: string;
+        timestamp: number;
+        signature: string;
+      };
+    },
+  ) => {
+    const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+    const result = await client.connect({
+      body: params as Parameters<typeof client.connect>[0]["body"],
+    });
+
+    if (result.status !== 200) {
+      const errorBody = result.body as { error?: { message?: string } };
+      toast.error(
+        errorBody?.error?.message ?? "Failed to connect Telegram account",
+      );
+      return null;
+    }
+
+    toast.success("Telegram connected successfully");
+    await set(fetchTelegramOrg$);
+    return result.body;
+  },
+);
+
+export const toggleTelegramOrg$ = command(
+  async ({ get, set }, enabled: boolean) => {
+    const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+    const result = await client.update({
+      body: { enabled },
+    });
+
+    if (result.status !== 200) {
+      toast.error("Failed to update Telegram bot");
+      return;
+    }
+
+    toast.success(enabled ? "Telegram bot enabled" : "Telegram bot disabled");
+    await set(fetchTelegramOrg$);
+  },
+);
+
+export const disconnectTelegramOrg$ = command(async ({ get, set }) => {
+  const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+  const result = await client.disconnect();
+
+  if (result.status !== 200) {
+    toast.error("Failed to disconnect Telegram");
+    return;
+  }
+
+  toast.success("Disconnected from Telegram");
+  await set(fetchTelegramOrg$);
+});
+
+export const uninstallTelegramOrg$ = command(async ({ get, set }) => {
+  const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+  const result = await client.disconnect({
+    query: { action: "uninstall" },
+  });
+
+  if (result.status !== 200) {
+    toast.error("Failed to uninstall Telegram bot");
+    return;
+  }
+
+  toast.success("Telegram bot uninstalled");
+  await set(fetchTelegramOrg$);
+});
+
+// ---------------------------------------------------------------------------
+// Polling — for member connect via /connect command in Telegram
+// ---------------------------------------------------------------------------
+
+const POLL_INTERVAL_MS = 3000;
+
+export const pollTelegramConnection$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const current = get(telegramOrgState$).data;
+    if (current?.isConnected) {
+      return;
+    }
+
+    while (!signal.aborted) {
+      await delay(POLL_INTERVAL_MS, { signal });
+
+      const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
+      const result = await client.getStatus();
+      signal.throwIfAborted();
+      if (result.status !== 200) {
+        continue;
+      }
+
+      set(telegramOrgState$, {
+        data: result.body,
+        loading: false,
+        error: null,
+      });
+
+      if (result.body.isConnected) {
+        toast.success("Telegram connected successfully");
+        return;
+      }
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+export const initTelegramOrg$ = command(async ({ set }) => {
+  await set(fetchTelegramOrg$);
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-telegram.ts
@@ -61,7 +61,7 @@ const fetchTelegramOrg$ = command(async ({ get, set }) => {
   }));
 
   const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
-  const result = await client.getStatus();
+  const result = await client.getStatus({ headers: {} });
 
   if (result.status !== 200) {
     set(telegramOrgState$, (prev) => ({
@@ -129,7 +129,7 @@ export const connectTelegramOrg$ = command(
   ) => {
     const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
     const result = await client.connect({
-      body: params as Parameters<typeof client.connect>[0]["body"],
+      body: params as NonNullable<Parameters<typeof client.connect>[0]>["body"],
     });
 
     if (result.status !== 200) {
@@ -208,7 +208,7 @@ export const pollTelegramConnection$ = command(
       await delay(POLL_INTERVAL_MS, { signal });
 
       const client = get(zeroClient$)(zeroIntegrationsTelegramContract);
-      const result = await client.getStatus();
+      const result = await client.getStatus({ headers: {} });
       signal.throwIfAborted();
       if (result.status !== 200) {
         continue;

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -1,5 +1,7 @@
-import { useGet, useSet, useLoadable } from "ccstate-react";
+import { useGet, useSet, useLoadable, useLastResolved } from "ccstate-react";
+import { useState } from "react";
 import {
+  IconBrandTelegram,
   IconCircleCheck,
   IconDotsVertical,
   IconDownload,
@@ -18,6 +20,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@vm0/ui/components/ui/dialog";
+import { Input } from "@vm0/ui/components/ui/input";
+import { FeatureSwitchKey } from "@vm0/core";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import {
   slackOrgData$,
@@ -26,6 +30,20 @@ import {
   showUninstallDialog$,
   setShowUninstallDialog$,
 } from "../../signals/zero-page/zero-slack.ts";
+import {
+  telegramOrgData$,
+  installTelegramOrg$,
+  connectTelegramOrg$,
+  toggleTelegramOrg$,
+  disconnectTelegramOrg$,
+  uninstallTelegramOrg$,
+  showTelegramInstallDialog$,
+  setShowTelegramInstallDialog$,
+  showTelegramUninstallDialog$,
+  setShowTelegramUninstallDialog$,
+} from "../../signals/zero-page/zero-telegram.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 import slackIconImg from "./assets/slack-icon.svg";
 
@@ -193,10 +211,354 @@ function SlackCard({ displayName }: { displayName: string }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Telegram
+// ---------------------------------------------------------------------------
+
+/**
+ * Open the Telegram Login Widget popup. The callback page at
+ * /api/zero/integrations/telegram/auth-callback sends auth data back via
+ * `postMessage({ type: "telegram-auth", data })`.
+ */
+function openTelegramLogin(botId: string) {
+  const callbackUrl = `${window.location.origin}/api/zero/integrations/telegram/auth-callback`;
+  const url = `https://oauth.telegram.org/auth?bot_id=${botId}&origin=${encodeURIComponent(window.location.origin)}&return_to=${encodeURIComponent(callbackUrl)}`;
+  window.open(url, "_blank", "width=550,height=450");
+}
+
+function TelegramInstallDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const telegramData = useGet(telegramOrgData$);
+  const install = useSet(installTelegramOrg$);
+
+  const [botToken, setBotToken] = useState("");
+  const [installing, setInstalling] = useState(false);
+
+  const domainConfigured = telegramData?.domainConfigured ?? false;
+
+  // Can only proceed to login step when we have a token and domain is ready
+  const canLogin = botToken.trim().length > 10 && domainConfigured;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Install Telegram Bot</DialogTitle>
+          <DialogDescription>
+            Enter your bot token from @BotFather, then verify your Telegram
+            identity.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          {!domainConfigured && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+              Your domain must be configured before installing a Telegram bot.
+              Please set up your domain in Settings first.
+            </div>
+          )}
+
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="telegram-bot-token"
+              className="text-sm font-medium text-foreground"
+            >
+              Bot Token
+            </label>
+            <Input
+              id="telegram-bot-token"
+              type="password"
+              placeholder="123456:ABC-DEF1234..."
+              value={botToken}
+              onChange={(e) => setBotToken(e.target.value)}
+              disabled={installing}
+            />
+            <p className="text-xs text-muted-foreground">
+              Get this from{" "}
+              <a
+                href="https://t.me/BotFather"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                @BotFather
+              </a>{" "}
+              on Telegram.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={!canLogin || installing}
+            onClick={() => {
+              // Extract bot ID from token (format: "botId:secretPart")
+              const extractedBotId = botToken.split(":")[0];
+              if (!extractedBotId) {
+                return;
+              }
+
+              // Listen for postMessage from Login Widget popup
+              const onMessage = (e: MessageEvent) => {
+                if (
+                  e.origin !== window.location.origin ||
+                  e.data?.type !== "telegram-auth"
+                ) {
+                  return;
+                }
+                window.removeEventListener("message", onMessage);
+                const auth = e.data.data as Record<string, unknown>;
+                setInstalling(true);
+                detach(
+                  (async () => {
+                    const result = await install({
+                      botToken,
+                      telegramAuth: auth,
+                    });
+                    setInstalling(false);
+                    if (result) {
+                      onOpenChange(false);
+                      setBotToken("");
+                    }
+                  })(),
+                  Reason.DomCallback,
+                );
+              };
+              window.addEventListener("message", onMessage);
+              openTelegramLogin(extractedBotId);
+            }}
+          >
+            {installing ? "Installing…" : "Continue with Telegram"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function TelegramCardActions({
+  isConnected,
+  isInstalled,
+  isAdmin,
+  enabled,
+  botId,
+  onToggle,
+  onDisconnect,
+  onUninstall,
+  onInstall,
+}: {
+  isConnected: boolean;
+  isInstalled: boolean;
+  isAdmin: boolean;
+  enabled: boolean;
+  botId: string | null;
+  onToggle: (enabled: boolean) => void;
+  onDisconnect: () => void;
+  onUninstall: () => void;
+  onInstall: () => void;
+}) {
+  const [toggling, setToggling] = useState(false);
+  const connect = useSet(connectTelegramOrg$);
+
+  return (
+    <>
+      {isConnected ? (
+        <span className="shrink-0 inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+          <IconCircleCheck className="h-3 w-3 text-green-600" />
+          Connected
+        </span>
+      ) : null}
+      {isInstalled && isAdmin && (
+        <LoadingSwitch
+          checked={enabled}
+          loading={toggling}
+          onCheckedChange={(val) => {
+            setToggling(true);
+            onToggle(val);
+            setToggling(false);
+          }}
+          ariaLabel="Toggle Telegram bot"
+        />
+      )}
+      {!isInstalled && isAdmin && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 shrink-0 gap-1.5 rounded-lg"
+          onClick={onInstall}
+        >
+          <IconDownload size={14} stroke={1.5} />
+          Install Telegram
+        </Button>
+      )}
+      {isInstalled && !isConnected && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 shrink-0 gap-1.5 rounded-lg"
+          onClick={() => {
+            if (!botId) {
+              return;
+            }
+            const onMessage = (e: MessageEvent) => {
+              if (
+                e.origin !== window.location.origin ||
+                e.data?.type !== "telegram-auth"
+              ) {
+                return;
+              }
+              window.removeEventListener("message", onMessage);
+              const auth = e.data.data as Record<string, unknown>;
+              detach(connect({ telegramAuth: auth }), Reason.DomCallback);
+            };
+            window.addEventListener("message", onMessage);
+            openTelegramLogin(botId);
+          }}
+        >
+          Connect
+        </Button>
+      )}
+      {isInstalled && (isConnected || isAdmin) && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="shrink-0 rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              aria-label="More options"
+            >
+              <IconDotsVertical size={16} stroke={1.5} />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            className="flex flex-col gap-0.5 w-40 p-2"
+          >
+            {isConnected && (
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-left hover:bg-accent hover:text-accent-foreground transition-colors"
+                onClick={onDisconnect}
+              >
+                Disconnect
+              </button>
+            )}
+            {isAdmin && (
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-left text-destructive hover:bg-accent hover:text-accent-foreground transition-colors"
+                onClick={onUninstall}
+              >
+                Uninstall
+              </button>
+            )}
+          </PopoverContent>
+        </Popover>
+      )}
+    </>
+  );
+}
+
+function TelegramCard({ displayName }: { displayName: string }) {
+  const telegramData = useGet(telegramOrgData$);
+  const toggle = useSet(toggleTelegramOrg$);
+  const disconnect = useSet(disconnectTelegramOrg$);
+  const uninstall = useSet(uninstallTelegramOrg$);
+
+  const showInstallDialog = useGet(showTelegramInstallDialog$);
+  const setShowInstallDialog = useSet(setShowTelegramInstallDialog$);
+  const showUninstallTgDialog = useGet(showTelegramUninstallDialog$);
+  const setShowUninstallTgDialog = useSet(setShowTelegramUninstallDialog$);
+
+  const isConnected = telegramData?.isConnected ?? false;
+  const isInstalled = telegramData?.isInstalled ?? isConnected;
+  const isAdmin = telegramData?.isAdmin ?? false;
+  const enabled = telegramData?.enabled ?? true;
+
+  return (
+    <>
+      <div className="zero-card flex items-center gap-4 p-4">
+        <div className="shrink-0">
+          <IconBrandTelegram className="h-7 w-7 text-[#26A5E4]" />
+        </div>
+        <div className="flex flex-1 flex-col gap-1 min-w-0">
+          <div className="text-sm font-medium text-foreground">Telegram</div>
+          <div className="text-sm text-muted-foreground">
+            {!isInstalled && !isAdmin
+              ? "Ask your admin to install the Telegram integration"
+              : "Messaging and bot interactions"}
+          </div>
+        </div>
+        <TelegramCardActions
+          isConnected={isConnected}
+          isInstalled={isInstalled}
+          isAdmin={isAdmin}
+          enabled={enabled}
+          botId={telegramData?.bot?.id ?? null}
+          onToggle={(val) => detach(toggle(val), Reason.DomCallback)}
+          onDisconnect={() => detach(disconnect(), Reason.DomCallback)}
+          onUninstall={() => setShowUninstallTgDialog(true)}
+          onInstall={() => setShowInstallDialog(true)}
+        />
+      </div>
+
+      <TelegramInstallDialog
+        open={showInstallDialog}
+        onOpenChange={setShowInstallDialog}
+      />
+
+      <Dialog
+        open={showUninstallTgDialog}
+        onOpenChange={setShowUninstallTgDialog}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Uninstall Telegram integration?</DialogTitle>
+            <DialogDescription>
+              This will remove the Telegram bot for your entire workspace. All
+              connected users will be disconnected and {displayName} will no
+              longer respond to messages in Telegram. This action cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowUninstallTgDialog(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setShowUninstallTgDialog(false);
+                detach(uninstall(), Reason.DomCallback);
+              }}
+            >
+              Uninstall
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
 export function ZeroWorksPage() {
   const displayNameLoadable = useLoadable(agentDisplayName$);
   const displayName =
     displayNameLoadable.state === "hasData" ? displayNameLoadable.data : "Zero";
+
+  const features = useLastResolved(featureSwitch$);
+  const showTelegram =
+    features?.[FeatureSwitchKey.TelegramIntegration] ?? false;
 
   return (
     <div className="flex flex-1 flex-col min-h-0">
@@ -214,6 +576,7 @@ export function ZeroWorksPage() {
       <main className="flex-1 overflow-auto px-4 sm:px-6 pt-4 pb-8">
         <div className="mx-auto max-w-[900px] flex flex-col gap-4">
           <SlackCard displayName={displayName} />
+          {showTelegram && <TelegramCard displayName={displayName} />}
         </div>
       </main>
     </div>

--- a/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/[installationId]/route.ts
@@ -49,12 +49,13 @@ export async function POST(
 
   initServices();
 
-  // Look up installation for webhook secret
+  // Look up installation for webhook secret and enabled status
   const [installation] = await globalThis.services.db
     .select({
       id: telegramInstallations.id,
       webhookSecret: telegramInstallations.webhookSecret,
       botUsername: telegramInstallations.botUsername,
+      enabled: telegramInstallations.enabled,
     })
     .from(telegramInstallations)
     .where(eq(telegramInstallations.id, installationId))
@@ -62,6 +63,11 @@ export async function POST(
 
   if (!installation) {
     return new Response("Not Found", { status: 404 });
+  }
+
+  // Silently drop messages when bot is disabled (return 200 to avoid Telegram retries)
+  if (!installation.enabled) {
+    return new Response("OK", { status: 200 });
   }
 
   // Verify webhook secret

--- a/turbo/apps/web/app/api/zero/integrations/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/__tests__/route.test.ts
@@ -1,6 +1,9 @@
+import { createHash, createHmac } from "node:crypto";
 import { describe, it, expect, beforeEach } from "vitest";
 import { http as mswHttp, HttpResponse } from "msw";
 import { GET, PATCH, DELETE } from "../route";
+import { POST as installPOST } from "../install/route";
+import { POST as connectPOST } from "../connect/route";
 import {
   testContext,
   uniqueId,
@@ -8,11 +11,15 @@ import {
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import {
   createTestOrg,
+  createTestCompose,
   createTestOrgTelegramInstallation,
   findTestOrgTelegramInstallation,
   findTestTelegramUserLink,
+  updateOrgDefaultAgent,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { server } from "../../../../../../src/mocks/server";
+import { http } from "../../../../../../src/__tests__/msw";
+import { signConnectParams } from "../../../../../../src/lib/telegram/connect-token";
 
 const context = testContext();
 
@@ -28,6 +35,86 @@ function telegramDeleteWebhook() {
   return mswHttp.post(/api\.telegram\.org\/bot.*\/deleteWebhook/, () =>
     HttpResponse.json({ ok: true, result: true }),
   );
+}
+
+const TEST_BOT_TOKEN = "123456:ABC-test-token";
+
+function telegramGetMe(botId: string, username: string) {
+  return http.post(/api\.telegram\.org\/bot.*\/getMe/, () =>
+    HttpResponse.json({
+      ok: true,
+      result: { id: Number(botId), is_bot: true, first_name: "Bot", username },
+    }),
+  );
+}
+
+function telegramGetMeFail() {
+  return http.post(/api\.telegram\.org\/bot.*\/getMe/, () =>
+    HttpResponse.json(
+      { ok: false, description: "Unauthorized" },
+      { status: 401 },
+    ),
+  );
+}
+
+function telegramSetWebhook(succeed = true) {
+  return http.post(/api\.telegram\.org\/bot.*\/setWebhook/, () =>
+    succeed
+      ? HttpResponse.json({ ok: true, result: true })
+      : HttpResponse.json(
+          { ok: false, description: "Webhook failed" },
+          { status: 400 },
+        ),
+  );
+}
+
+function telegramSetMyCommands() {
+  return http.post(/api\.telegram\.org\/bot.*\/setMyCommands/, () =>
+    HttpResponse.json({ ok: true, result: true }),
+  );
+}
+
+function telegramSendMessage() {
+  return http.post(/api\.telegram\.org\/bot.*\/sendMessage/, () =>
+    HttpResponse.json({
+      ok: true,
+      result: { message_id: 1, chat: { id: 1 }, text: "ok" },
+    }),
+  );
+}
+
+/**
+ * Generate valid Telegram Login Widget auth data for testing.
+ * Uses the same HMAC-SHA256 verification algorithm as verifyTelegramLogin.
+ */
+function generateTelegramAuth(
+  botToken: string,
+  telegramUserId: number,
+): Record<string, unknown> {
+  const authDate = Math.floor(Date.now() / 1000);
+  const authData: Record<string, unknown> = {
+    id: telegramUserId,
+    first_name: "Test",
+    auth_date: authDate,
+  };
+
+  const checkString = Object.entries(authData)
+    .filter(([, value]) => value !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+
+  const secretKey = createHash("sha256").update(botToken).digest();
+  const hash = createHmac("sha256", secretKey)
+    .update(checkString)
+    .digest("hex");
+
+  return { ...authData, hash };
+}
+
+/** Generate a unique numeric bot ID */
+function testBotId(): string {
+  return String(Date.now() + Math.floor(Math.random() * 100000));
 }
 
 async function givenOrgTelegramSetup(
@@ -312,6 +399,446 @@ describe("/api/zero/integrations/telegram", () => {
       // Verify link was deleted
       const link = await findTestTelegramUserLink(user.userId, installationId);
       expect(link).toBeUndefined();
+    });
+  });
+
+  describe("POST /install", () => {
+    async function givenOrgWithDefaultAgent() {
+      const user = await context.setupUser();
+      const org = await createTestOrg(uniqueId("org"));
+      const { composeId } = await createTestCompose(uniqueId("agent"));
+
+      // Set it as org default agent (composeId = zero_agents.id)
+      await updateOrgDefaultAgent(org.id, composeId);
+
+      mockClerk({
+        userId: user.userId,
+        orgId: org.id,
+        orgRole: "org:admin",
+      });
+
+      return { user, org, composeId };
+    }
+
+    function installRequest(body: Record<string, unknown>) {
+      return new Request(
+        "http://localhost:3000/api/zero/integrations/telegram/install",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+    }
+
+    it("returns 401 when not authenticated", async () => {
+      mockClerk({ userId: null });
+
+      const response = await installPOST(
+        installRequest({
+          botToken: TEST_BOT_TOKEN,
+          telegramAuth: generateTelegramAuth(TEST_BOT_TOKEN, 12345),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 403 when non-admin tries to install", async () => {
+      const user = await context.setupUser();
+      const org = await createTestOrg(uniqueId("org"));
+      mockClerk({
+        userId: user.userId,
+        orgId: org.id,
+        orgRole: "org:member",
+      });
+
+      const response = await installPOST(
+        installRequest({
+          botToken: TEST_BOT_TOKEN,
+          telegramAuth: generateTelegramAuth(TEST_BOT_TOKEN, 12345),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("returns 400 when bot token is invalid", async () => {
+      await givenOrgWithDefaultAgent();
+
+      const getMeHandler = telegramGetMeFail();
+      server.use(getMeHandler.handler);
+
+      const response = await installPOST(
+        installRequest({
+          botToken: TEST_BOT_TOKEN,
+          telegramAuth: generateTelegramAuth(TEST_BOT_TOKEN, 12345),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("Invalid bot token");
+    });
+
+    it("installs bot and auto-connects admin", async () => {
+      const { user, org } = await givenOrgWithDefaultAgent();
+
+      const botId = testBotId();
+      const telegramUserId = 99001;
+      const getMeHandler = telegramGetMe(botId, `bot_${botId}`);
+      const setWebhookHandler = telegramSetWebhook(true);
+      const setCommandsHandler = telegramSetMyCommands();
+      server.use(
+        getMeHandler.handler,
+        setWebhookHandler.handler,
+        setCommandsHandler.handler,
+      );
+
+      const response = await installPOST(
+        installRequest({
+          botToken: TEST_BOT_TOKEN,
+          telegramAuth: generateTelegramAuth(TEST_BOT_TOKEN, telegramUserId),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(data.bot.id).toBe(botId);
+      expect(data.bot.username).toBe(`bot_${botId}`);
+      expect(data.installationId).toBeDefined();
+
+      // Verify installation was created in DB
+      const installation = await findTestOrgTelegramInstallation(org.id);
+      expect(installation).toBeDefined();
+      expect(installation!.telegramBotId).toBe(botId);
+      expect(installation!.orgId).toBe(org.id);
+
+      // Verify auto-connect user link
+      const link = await findTestTelegramUserLink(
+        user.userId,
+        data.installationId,
+      );
+      expect(link).toBeDefined();
+    });
+
+    it("returns 409 when org already has a bot", async () => {
+      const { user, org } = await givenOrgWithDefaultAgent();
+
+      // Pre-install a bot for the org
+      await createTestOrgTelegramInstallation({
+        orgId: org.id,
+        adminUserId: user.userId,
+      });
+
+      const botId = testBotId();
+      const getMeHandler = telegramGetMe(botId, `bot_${botId}`);
+      server.use(getMeHandler.handler);
+
+      const response = await installPOST(
+        installRequest({
+          botToken: TEST_BOT_TOKEN,
+          telegramAuth: generateTelegramAuth(TEST_BOT_TOKEN, 12345),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.error.code).toBe("CONFLICT");
+      expect(data.error.message).toContain("already has a Telegram bot");
+    });
+
+    it("returns 409 when bot is already registered to another org", async () => {
+      // Set up first org with a bot using a different user prefix
+      const otherUser = await context.setupUser({ prefix: "other-admin" });
+      const otherOrg = await createTestOrg(uniqueId("org"));
+      const existingBotId = testBotId();
+      await createTestOrgTelegramInstallation({
+        orgId: otherOrg.id,
+        adminUserId: otherUser.userId,
+        telegramBotId: existingBotId,
+      });
+
+      // Set up a second org with its own admin
+      const user = await context.setupUser({ prefix: "new-admin" });
+      const org = await createTestOrg(uniqueId("org"));
+      const { composeId } = await createTestCompose(uniqueId("agent"));
+      await updateOrgDefaultAgent(org.id, composeId);
+      mockClerk({
+        userId: user.userId,
+        orgId: org.id,
+        orgRole: "org:admin",
+      });
+
+      const getMeHandler = telegramGetMe(
+        existingBotId,
+        `dup_bot_${existingBotId}`,
+      );
+      server.use(getMeHandler.handler);
+
+      const response = await installPOST(
+        installRequest({
+          botToken: TEST_BOT_TOKEN,
+          telegramAuth: generateTelegramAuth(TEST_BOT_TOKEN, 12345),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.error.code).toBe("CONFLICT");
+      expect(data.error.message).toContain("already registered");
+    });
+
+    it("rolls back installation when webhook setup fails", async () => {
+      const { org } = await givenOrgWithDefaultAgent();
+
+      const botId = testBotId();
+      const getMeHandler = telegramGetMe(botId, `bot_${botId}`);
+      const setWebhookHandler = telegramSetWebhook(false);
+      server.use(getMeHandler.handler, setWebhookHandler.handler);
+
+      const response = await installPOST(
+        installRequest({
+          botToken: TEST_BOT_TOKEN,
+          telegramAuth: generateTelegramAuth(TEST_BOT_TOKEN, 12345),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(502);
+      expect(data.error.code).toBe("BAD_GATEWAY");
+
+      // Verify installation was rolled back
+      const installation = await findTestOrgTelegramInstallation(org.id);
+      expect(installation).toBeUndefined();
+    });
+  });
+
+  describe("POST /connect", () => {
+    function connectRequest(body: Record<string, unknown>) {
+      return new Request(
+        "http://localhost:3000/api/zero/integrations/telegram/connect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+    }
+
+    it("returns 401 when not authenticated", async () => {
+      mockClerk({ userId: null });
+
+      const response = await connectPOST(
+        connectRequest({
+          telegramAuth: generateTelegramAuth(TEST_BOT_TOKEN, 12345),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 404 when no installation exists for the org", async () => {
+      await context.setupUser();
+      await createTestOrg(uniqueId("org"));
+
+      const response = await connectPOST(
+        connectRequest({
+          telegramAuth: generateTelegramAuth(TEST_BOT_TOKEN, 12345),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("connects user via Telegram Login Widget auth", async () => {
+      const user = await context.setupUser();
+      const org = await createTestOrg(uniqueId("org"));
+      const { installationId } = await createTestOrgTelegramInstallation({
+        orgId: org.id,
+        adminUserId: user.userId,
+      });
+
+      // mockClerk is already set up by createTestOrg+setupUser flow
+      // but we need to ensure correct identity
+      mockClerk({
+        userId: user.userId,
+        orgId: org.id,
+        orgRole: "org:member",
+      });
+
+      const telegramUserId = 55001;
+      // The bot token used in createTestOrgTelegramInstallation is "test-bot-token"
+      const response = await connectPOST(
+        connectRequest({
+          telegramAuth: generateTelegramAuth("test-bot-token", telegramUserId),
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.botUsername).toBeDefined();
+      expect(data.telegramUserId).toBe(String(telegramUserId));
+
+      // Verify user link was created
+      const link = await findTestTelegramUserLink(user.userId, installationId);
+      expect(link).toBeDefined();
+    });
+
+    it("connects user via connect signature", async () => {
+      const user = await context.setupUser();
+      const org = await createTestOrg(uniqueId("org"));
+      const { installationId } = await createTestOrgTelegramInstallation({
+        orgId: org.id,
+        adminUserId: user.userId,
+      });
+
+      mockClerk({
+        userId: user.userId,
+        orgId: org.id,
+        orgRole: "org:member",
+      });
+
+      const sendMsgHandler = telegramSendMessage();
+      server.use(sendMsgHandler.handler);
+
+      const telegramUserId = "77001";
+      const timestamp = Math.floor(Date.now() / 1000);
+      // The bot token stored in test installations is "test-bot-token"
+      const signature = signConnectParams(
+        installationId,
+        telegramUserId,
+        timestamp,
+        "test-bot-token",
+      );
+
+      const response = await connectPOST(
+        connectRequest({
+          connectSignature: {
+            telegramUserId,
+            timestamp,
+            signature,
+          },
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.botUsername).toBeDefined();
+      expect(data.telegramUserId).toBe(telegramUserId);
+
+      // Verify user link was created
+      const link = await findTestTelegramUserLink(user.userId, installationId);
+      expect(link).toBeDefined();
+    });
+
+    it("returns 400 when Telegram Login Widget auth is invalid", async () => {
+      const user = await context.setupUser();
+      const org = await createTestOrg(uniqueId("org"));
+      await createTestOrgTelegramInstallation({
+        orgId: org.id,
+        adminUserId: user.userId,
+      });
+
+      mockClerk({
+        userId: user.userId,
+        orgId: org.id,
+        orgRole: "org:member",
+      });
+
+      const response = await connectPOST(
+        connectRequest({
+          telegramAuth: {
+            id: 12345,
+            first_name: "Test",
+            auth_date: Math.floor(Date.now() / 1000),
+            hash: "invalid_hash_value",
+          },
+        }),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain("Invalid Telegram authorization");
+    });
+
+    it("returns 400 when neither telegramAuth nor connectSignature is provided", async () => {
+      const user = await context.setupUser();
+      const org = await createTestOrg(uniqueId("org"));
+      await createTestOrgTelegramInstallation({
+        orgId: org.id,
+        adminUserId: user.userId,
+      });
+
+      mockClerk({
+        userId: user.userId,
+        orgId: org.id,
+        orgRole: "org:member",
+      });
+
+      const response = await connectPOST(connectRequest({}));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain(
+        "Either telegramAuth or connectSignature is required",
+      );
+    });
+  });
+
+  describe("PATCH agentName", () => {
+    it("changes default agent by name for admin", async () => {
+      const { org } = await givenOrgTelegramSetup({ isAdmin: true });
+
+      // Create a second compose to switch to
+      const newAgentName = uniqueId("new-agent");
+      await createTestCompose(newAgentName);
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agentName: newAgentName }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ok).toBe(true);
+
+      // Verify the defaultComposeId was updated
+      const installation = await findTestOrgTelegramInstallation(org.id);
+      expect(installation).toBeDefined();
+      // The old compose was the one from givenOrgTelegramSetup; now it should be different
+      expect(installation!.defaultComposeId).toBeDefined();
+    });
+
+    it("returns 404 when agent name does not exist", async () => {
+      await givenOrgTelegramSetup({ isAdmin: true });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agentName: "nonexistent-agent" }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
     });
   });
 

--- a/turbo/apps/web/app/api/zero/integrations/telegram/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/__tests__/route.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { http as mswHttp, HttpResponse } from "msw";
+import { GET, PATCH, DELETE } from "../route";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import {
+  createTestOrg,
+  createTestOrgTelegramInstallation,
+  findTestOrgTelegramInstallation,
+  findTestTelegramUserLink,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { server } from "../../../../../../src/mocks/server";
+
+const context = testContext();
+
+function telegramOAuthProbe(domainConfigured: boolean) {
+  return mswHttp.head(/oauth\.telegram\.org\/auth/, () =>
+    HttpResponse.text("", {
+      headers: { "content-length": domainConfigured ? "5000" : "100" },
+    }),
+  );
+}
+
+function telegramDeleteWebhook() {
+  return mswHttp.post(/api\.telegram\.org\/bot.*\/deleteWebhook/, () =>
+    HttpResponse.json({ ok: true, result: true }),
+  );
+}
+
+async function givenOrgTelegramSetup(
+  options: {
+    isAdmin?: boolean;
+    withConnection?: boolean;
+    enabled?: boolean;
+  } = {},
+) {
+  const { isAdmin = false, withConnection = true, enabled = true } = options;
+  const user = await context.setupUser();
+  const org = await createTestOrg(uniqueId("org"));
+
+  const { installationId, telegramBotId } =
+    await createTestOrgTelegramInstallation({
+      orgId: org.id,
+      adminUserId: user.userId,
+      vm0UserId: withConnection ? user.userId : undefined,
+      enabled,
+    });
+
+  mockClerk({
+    userId: user.userId,
+    orgId: org.id,
+    orgRole: isAdmin ? "org:admin" : "org:member",
+  });
+
+  server.use(telegramOAuthProbe(true));
+
+  return { user, org, installationId, telegramBotId };
+}
+
+describe("/api/zero/integrations/telegram", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  describe("GET", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockClerk({ userId: null });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns isInstalled=false when no bot is installed for the org", async () => {
+      await context.setupUser();
+      await createTestOrg(uniqueId("org"));
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.isInstalled).toBe(false);
+      expect(data.isConnected).toBe(false);
+    });
+
+    it("returns isConnected=false when user has no connection", async () => {
+      await givenOrgTelegramSetup({ withConnection: false });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.isInstalled).toBe(true);
+      expect(data.isConnected).toBe(false);
+    });
+
+    it("returns connected status with bot info", async () => {
+      const { telegramBotId } = await givenOrgTelegramSetup({
+        withConnection: true,
+      });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.isConnected).toBe(true);
+      expect(data.isInstalled).toBe(true);
+      expect(data.bot.id).toBe(telegramBotId);
+    });
+
+    it("returns isAdmin=true for admin members", async () => {
+      await givenOrgTelegramSetup({ isAdmin: true });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.isAdmin).toBe(true);
+    });
+
+    it("returns isAdmin=false for non-admin members", async () => {
+      await givenOrgTelegramSetup({ isAdmin: false });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.isAdmin).toBe(false);
+    });
+
+    it("returns enabled status", async () => {
+      await givenOrgTelegramSetup({ enabled: false });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.enabled).toBe(false);
+    });
+
+    it("returns environment info when connected", async () => {
+      await givenOrgTelegramSetup();
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+      );
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.environment).toBeDefined();
+      expect(data.environment.requiredSecrets).toBeDefined();
+      expect(data.environment.missingSecrets).toBeDefined();
+    });
+  });
+
+  describe("PATCH", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockClerk({ userId: null });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: false }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 403 when non-admin tries to toggle", async () => {
+      await givenOrgTelegramSetup({ isAdmin: false });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: false }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("toggles enabled state for admin", async () => {
+      const { org } = await givenOrgTelegramSetup({
+        isAdmin: true,
+        enabled: true,
+      });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: false }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ok).toBe(true);
+
+      // Verify in DB
+      const installation = await findTestOrgTelegramInstallation(org.id);
+      expect(installation?.enabled).toBe(false);
+    });
+
+    it("returns 404 when no installation exists", async () => {
+      await context.setupUser();
+      const org = await createTestOrg(uniqueId("org"));
+      mockClerk({
+        userId: (await context.setupUser()).userId,
+        orgId: org.id,
+        orgRole: "org:admin",
+      });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ enabled: false }),
+        },
+      );
+      const response = await PATCH(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+  });
+
+  describe("DELETE (disconnect)", () => {
+    it("returns 401 when not authenticated", async () => {
+      mockClerk({ userId: null });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+        { method: "DELETE" },
+      );
+      const response = await DELETE(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.error.code).toBe("UNAUTHORIZED");
+    });
+
+    it("returns 404 when user has no connection", async () => {
+      await givenOrgTelegramSetup({ withConnection: false });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+        { method: "DELETE" },
+      );
+      const response = await DELETE(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("deletes user link and returns ok", async () => {
+      const { user, installationId } = await givenOrgTelegramSetup();
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram",
+        { method: "DELETE" },
+      );
+      const response = await DELETE(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ok).toBe(true);
+
+      // Verify link was deleted
+      const link = await findTestTelegramUserLink(user.userId, installationId);
+      expect(link).toBeUndefined();
+    });
+  });
+
+  describe("DELETE ?action=uninstall", () => {
+    it("returns 403 when non-admin tries to uninstall", async () => {
+      await givenOrgTelegramSetup({ isAdmin: false });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram?action=uninstall",
+        { method: "DELETE" },
+      );
+      const response = await DELETE(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.error.code).toBe("FORBIDDEN");
+    });
+
+    it("returns 404 when no installation exists", async () => {
+      const user = await context.setupUser();
+      const org = await createTestOrg(uniqueId("org"));
+      mockClerk({
+        userId: user.userId,
+        orgId: org.id,
+        orgRole: "org:admin",
+      });
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram?action=uninstall",
+        { method: "DELETE" },
+      );
+      const response = await DELETE(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error.code).toBe("NOT_FOUND");
+    });
+
+    it("deletes installation and returns ok", async () => {
+      const { org } = await givenOrgTelegramSetup({ isAdmin: true });
+      server.use(telegramDeleteWebhook());
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/integrations/telegram?action=uninstall",
+        { method: "DELETE" },
+      );
+      const response = await DELETE(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ok).toBe(true);
+
+      // Verify installation was deleted
+      const installation = await findTestOrgTelegramInstallation(org.id);
+      expect(installation).toBeUndefined();
+    });
+  });
+});

--- a/turbo/apps/web/app/api/zero/integrations/telegram/auth-callback/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/auth-callback/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/zero/integrations/telegram/auth-callback
+ *
+ * Telegram Login Widget redirect target. Returns a minimal HTML page that
+ * sends the auth data back to the opener window via postMessage and closes
+ * the popup.
+ *
+ * Auth data may arrive as query params OR as a hash fragment (which the
+ * server cannot see), so the page handles both client-side.
+ */
+export async function GET() {
+  const html = `<!DOCTYPE html>
+<html><head><title>Telegram Auth</title></head>
+<body><script>
+(function() {
+  var params = new URLSearchParams(window.location.search);
+  if (!params.get("id")) {
+    params = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+  }
+  var data = {};
+  ["id","first_name","last_name","username","photo_url","auth_date","hash"].forEach(function(k) {
+    var v = params.get(k);
+    if (v !== null) data[k] = v;
+  });
+  if (window.opener && data.id) {
+    window.opener.postMessage(
+      { type: "telegram-auth", data: data },
+      window.location.origin
+    );
+  }
+  window.close();
+})();
+</script></body></html>`;
+
+  return new NextResponse(html, {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}

--- a/turbo/apps/web/app/api/zero/integrations/telegram/connect/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/connect/route.ts
@@ -1,0 +1,204 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { env } from "../../../../../../src/env";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { telegramInstallations } from "../../../../../../src/db/schema/telegram-installation";
+import { telegramUserLinks } from "../../../../../../src/db/schema/telegram-user-link";
+import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
+import {
+  verifyTelegramLogin,
+  telegramAuthSchema,
+} from "../../../../../../src/lib/telegram/verify-login";
+import { verifyConnectSignature } from "../../../../../../src/lib/telegram/connect-token";
+import {
+  ensureOrgAndArtifact,
+  getWorkspaceAgent,
+} from "../../../../../../src/lib/telegram/handlers/shared";
+import {
+  createTelegramClient,
+  sendMessage,
+} from "../../../../../../src/lib/telegram/client";
+import { escapeHtml } from "../../../../../../src/lib/telegram/format";
+import { logger } from "../../../../../../src/lib/logger";
+
+const log = logger("api:zero:telegram:connect");
+
+const connectSignatureSchema = z.object({
+  telegramUserId: z.string().min(1),
+  timestamp: z.number(),
+  signature: z.string().min(1),
+});
+
+const connectBodySchema = z.object({
+  telegramAuth: telegramAuthSchema.optional(),
+  connectSignature: connectSignatureSchema.optional(),
+});
+
+/**
+ * POST /api/zero/integrations/telegram/connect
+ *
+ * Connect user's Telegram identity to the org's bot.
+ * Accepts Telegram Login Widget auth data or connect signature from /connect command.
+ */
+export async function POST(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { userId } = authCtx;
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org } = await resolveOrg(authCtx, orgSlug);
+
+  const parseResult = connectBodySchema.safeParse(await request.json());
+  if (!parseResult.success) {
+    return NextResponse.json(
+      { error: { message: "Invalid request body", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+  const body = parseResult.data;
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const db = globalThis.services.db;
+
+  // Find installation for this org
+  const [installation] = await db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.orgId, org.orgId))
+    .limit(1);
+
+  if (!installation) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "No Telegram bot installed for this organization",
+          code: "NOT_FOUND",
+        },
+      },
+      { status: 404 },
+    );
+  }
+
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+
+  // Verify via Telegram Login Widget
+  if (body.telegramAuth) {
+    if (!verifyTelegramLogin(body.telegramAuth, botToken)) {
+      return NextResponse.json(
+        {
+          error: {
+            message: "Invalid Telegram authorization",
+            code: "BAD_REQUEST",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    const telegramUserId = String(body.telegramAuth.id);
+
+    await db
+      .insert(telegramUserLinks)
+      .values({
+        telegramUserId,
+        installationId: installation.id,
+        vm0UserId: userId,
+      })
+      .onConflictDoUpdate({
+        target: [
+          telegramUserLinks.telegramUserId,
+          telegramUserLinks.installationId,
+        ],
+        set: { vm0UserId: userId, updatedAt: new Date() },
+      });
+    await ensureOrgAndArtifact(userId);
+
+    return NextResponse.json({
+      botUsername: installation.botUsername,
+      telegramUserId,
+    });
+  }
+
+  // Verify via connect signature (from /connect command)
+  if (body.connectSignature) {
+    if (
+      !verifyConnectSignature(
+        installation.id,
+        body.connectSignature.telegramUserId,
+        body.connectSignature.timestamp,
+        body.connectSignature.signature,
+        botToken,
+      )
+    ) {
+      return NextResponse.json(
+        {
+          error: {
+            message:
+              "Invalid or expired connect link. Please use /connect again in Telegram.",
+            code: "BAD_REQUEST",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    const telegramUserId = body.connectSignature.telegramUserId;
+
+    await db
+      .insert(telegramUserLinks)
+      .values({
+        telegramUserId,
+        installationId: installation.id,
+        vm0UserId: userId,
+      })
+      .onConflictDoUpdate({
+        target: [
+          telegramUserLinks.telegramUserId,
+          telegramUserLinks.installationId,
+        ],
+        set: { vm0UserId: userId, updatedAt: new Date() },
+      });
+    await ensureOrgAndArtifact(userId);
+
+    // Send success message in Telegram (non-blocking)
+    const client = createTelegramClient(botToken);
+    const agent = await getWorkspaceAgent(installation.defaultComposeId);
+    const agentName = agent?.name ?? "Agent";
+    sendMessage(
+      client,
+      telegramUserId,
+      `✅ Account connected! 🤖 ${escapeHtml(agentName)} is ready.\n\nSend me a message to get started.`,
+    ).catch((err) => {
+      log.warn("Failed to send connect success message", { err });
+    });
+
+    return NextResponse.json({
+      botUsername: installation.botUsername,
+      telegramUserId,
+    });
+  }
+
+  return NextResponse.json(
+    {
+      error: {
+        message: "Either telegramAuth or connectSignature is required",
+        code: "BAD_REQUEST",
+      },
+    },
+    { status: 400 },
+  );
+}

--- a/turbo/apps/web/app/api/zero/integrations/telegram/install/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/install/route.ts
@@ -1,0 +1,290 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { env } from "../../../../../../src/env";
+import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { telegramInstallations } from "../../../../../../src/db/schema/telegram-installation";
+import { telegramUserLinks } from "../../../../../../src/db/schema/telegram-user-link";
+import { agentComposes } from "../../../../../../src/db/schema/agent-compose";
+import {
+  getMe,
+  setWebhook,
+  setMyCommands,
+} from "../../../../../../src/lib/telegram/client";
+import { encryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
+import { generateCallbackSecret } from "../../../../../../src/lib/callback/hmac";
+import {
+  verifyTelegramLogin,
+  telegramAuthSchema,
+} from "../../../../../../src/lib/telegram/verify-login";
+import { resolveDefaultComposeId } from "../../../../../../src/lib/slack-org/handlers/shared";
+import { getApiUrl } from "../../../../../../src/lib/callback";
+import { ensureOrgAndArtifact } from "../../../../../../src/lib/telegram/handlers/shared";
+import { logger } from "../../../../../../src/lib/logger";
+
+const log = logger("api:zero:telegram:install");
+
+const installBodySchema = z.object({
+  botToken: z.string().min(1),
+  telegramAuth: telegramAuthSchema,
+});
+
+/**
+ * Resolve webhook base URL from env.
+ */
+function getWebhookBaseUrl(): string {
+  const { VM0_TUNNEL_URL, VERCEL_URL } = env();
+  if (VM0_TUNNEL_URL) return VM0_TUNNEL_URL;
+  if (VERCEL_URL) return `https://${VERCEL_URL}`;
+  return getApiUrl();
+}
+
+/**
+ * POST /api/zero/integrations/telegram/install
+ *
+ * Install a Telegram bot for the org. Admin only.
+ * Accepts bot token + Telegram Login Widget auth data.
+ * Creates installation and auto-connects the admin.
+ */
+export async function POST(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { userId } = authCtx;
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org, member } = await resolveOrg(authCtx, orgSlug);
+
+  if (member.role !== "admin") {
+    return NextResponse.json(
+      { error: { message: "Admin access required", code: "FORBIDDEN" } },
+      { status: 403 },
+    );
+  }
+
+  const parseResult = installBodySchema.safeParse(await request.json());
+  if (!parseResult.success) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "botToken and telegramAuth are required",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+  const body = parseResult.data;
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const db = globalThis.services.db;
+
+  // 1. Validate bot token
+  const botInfo = await getMe(body.botToken).catch(() => null);
+  if (!botInfo) {
+    return NextResponse.json(
+      {
+        error: {
+          message:
+            "Invalid bot token. Please verify your token with @BotFather.",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const telegramBotId = String(botInfo.id);
+
+  // 2. Check if org already has a bot
+  const [existingOrgBot] = await db
+    .select({ id: telegramInstallations.id })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.orgId, org.orgId))
+    .limit(1);
+
+  if (existingOrgBot) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "This organization already has a Telegram bot installed.",
+          code: "CONFLICT",
+        },
+      },
+      { status: 409 },
+    );
+  }
+
+  // 3. Check if bot is already registered for another org
+  const [existingBot] = await db
+    .select({
+      id: telegramInstallations.id,
+      orgId: telegramInstallations.orgId,
+    })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.telegramBotId, telegramBotId))
+    .limit(1);
+
+  if (existingBot) {
+    return NextResponse.json(
+      {
+        error: {
+          message:
+            "This bot is already registered. Use /connect in Telegram to link your account.",
+          code: "CONFLICT",
+        },
+      },
+      { status: 409 },
+    );
+  }
+
+  // 4. Verify Telegram Login Widget auth
+  if (!verifyTelegramLogin(body.telegramAuth, body.botToken)) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "Invalid Telegram authorization",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // 5. Resolve default agent
+  const defaultComposeId = await resolveDefaultComposeId(org.orgId);
+  if (!defaultComposeId) {
+    return NextResponse.json(
+      {
+        error: {
+          message:
+            "No default agent configured. Please set a default agent for your organization.",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // Verify agent exists
+  const [compose] = await db
+    .select({ id: agentComposes.id })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, defaultComposeId))
+    .limit(1);
+
+  if (!compose) {
+    return NextResponse.json(
+      { error: { message: "Default agent not found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  // 6. Encrypt token and generate webhook secret
+  const encryptedBotToken = encryptSecretValue(
+    body.botToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const webhookSecret = generateCallbackSecret();
+
+  // 7. Create installation
+  const [installation] = await db
+    .insert(telegramInstallations)
+    .values({
+      telegramBotId,
+      botUsername: botInfo.username,
+      encryptedBotToken,
+      webhookSecret,
+      defaultComposeId,
+      adminUserId: userId,
+      orgId: org.orgId,
+    })
+    .returning();
+
+  if (!installation) {
+    return NextResponse.json(
+      { error: { message: "Failed to create installation", code: "INTERNAL" } },
+      { status: 500 },
+    );
+  }
+
+  // 8. Set webhook
+  const baseUrl = getWebhookBaseUrl();
+  const webhookUrl = `${baseUrl}/api/telegram/webhook/${installation.id}`;
+
+  try {
+    await setWebhook(body.botToken, webhookUrl, webhookSecret);
+  } catch (error) {
+    // Rollback: delete the installation
+    await db
+      .delete(telegramInstallations)
+      .where(eq(telegramInstallations.id, installation.id));
+
+    log.error("Failed to set Telegram webhook", { error });
+    return NextResponse.json(
+      {
+        error: {
+          message: "Failed to register webhook with Telegram",
+          code: "BAD_GATEWAY",
+        },
+      },
+      { status: 502 },
+    );
+  }
+
+  // 9. Register bot commands (best-effort)
+  await setMyCommands(body.botToken, [
+    { command: "new_session", description: "Start a new conversation" },
+    { command: "connect", description: "Connect your VM0 account" },
+    { command: "disconnect", description: "Disconnect your account" },
+    { command: "settings", description: "Open platform settings" },
+    { command: "help", description: "Show available commands" },
+  ]).catch((error) => {
+    log.warn("Failed to register bot commands", { error });
+  });
+
+  // 10. Auto-connect admin (create user link)
+  const telegramUserId = String(body.telegramAuth.id);
+  await db
+    .insert(telegramUserLinks)
+    .values({
+      telegramUserId,
+      installationId: installation.id,
+      vm0UserId: userId,
+    })
+    .onConflictDoUpdate({
+      target: [
+        telegramUserLinks.telegramUserId,
+        telegramUserLinks.installationId,
+      ],
+      set: { vm0UserId: userId, updatedAt: new Date() },
+    });
+  await ensureOrgAndArtifact(userId);
+
+  log.info("Telegram bot installed", {
+    installationId: installation.id,
+    botId: telegramBotId,
+    orgId: org.orgId,
+    adminUserId: userId,
+  });
+
+  return NextResponse.json(
+    {
+      installationId: installation.id,
+      bot: {
+        id: telegramBotId,
+        username: botInfo.username,
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/turbo/apps/web/app/api/zero/integrations/telegram/install/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/install/route.ts
@@ -89,17 +89,32 @@ export async function POST(request: Request) {
   const db = globalThis.services.db;
 
   // 1. Validate bot token
-  const botInfo = await getMe(body.botToken).catch(() => null);
-  if (!botInfo) {
+  let botInfo;
+  try {
+    botInfo = await getMe(body.botToken);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("Telegram API error")) {
+      return NextResponse.json(
+        {
+          error: {
+            message:
+              "Invalid bot token. Please verify your token with @BotFather.",
+            code: "BAD_REQUEST",
+          },
+        },
+        { status: 400 },
+      );
+    }
+    log.error("Failed to validate bot token", { error });
     return NextResponse.json(
       {
         error: {
-          message:
-            "Invalid bot token. Please verify your token with @BotFather.",
-          code: "BAD_REQUEST",
+          message: "Failed to reach Telegram API",
+          code: "BAD_GATEWAY",
         },
       },
-      { status: 400 },
+      { status: 502 },
     );
   }
 

--- a/turbo/apps/web/app/api/zero/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/telegram/route.ts
@@ -1,0 +1,443 @@
+import { NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
+import { z } from "zod";
+import {
+  extractAndGroupVariables,
+  getConnectorProvidedSecretNames,
+} from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { env } from "../../../../../src/env";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { telegramInstallations } from "../../../../../src/db/schema/telegram-installation";
+import { telegramUserLinks } from "../../../../../src/db/schema/telegram-user-link";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../../src/db/schema/agent-compose";
+import { listSecrets } from "../../../../../src/lib/secret/secret-service";
+import { listVariables } from "../../../../../src/lib/variable/variable-service";
+import { listConnectors } from "../../../../../src/lib/connector/connector-service";
+import {
+  getOrgData,
+  getOrgBySlug,
+} from "../../../../../src/lib/org/org-cache-service";
+import { decryptSecretValue } from "../../../../../src/lib/crypto/secrets-encryption";
+import { deleteWebhook } from "../../../../../src/lib/telegram/client";
+import { checkTelegramDomain } from "../../../../../src/lib/telegram/check-domain";
+import { resolveDefaultComposeId } from "../../../../../src/lib/slack-org/handlers/shared";
+import type { AgentComposeYaml } from "../../../../../src/types/agent-compose";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("api:zero:telegram");
+
+/**
+ * GET /api/zero/integrations/telegram
+ *
+ * Returns org-scoped Telegram bot info for the authenticated user,
+ * including bot details, connection status, and environment status.
+ */
+export async function GET(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { userId } = authCtx;
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org, member } = await resolveOrg(authCtx, orgSlug);
+  const isAdmin = member.role === "admin";
+
+  const db = globalThis.services.db;
+
+  // Find the installation for this org
+  const [installation] = await db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.orgId, org.orgId))
+    .limit(1);
+
+  // Check domain configuration for Telegram Login Widget
+  const { NEXT_PUBLIC_APP_URL } = env();
+
+  if (!installation) {
+    // Check domain with a placeholder bot ID — domain config is per-domain, not per-bot
+    // We can only fully check when a bot is installed
+    return NextResponse.json({
+      isConnected: false,
+      isInstalled: false,
+      isAdmin,
+    });
+  }
+
+  // Find user's connection
+  const [userLink] = await db
+    .select()
+    .from(telegramUserLinks)
+    .where(
+      and(
+        eq(telegramUserLinks.vm0UserId, userId),
+        eq(telegramUserLinks.installationId, installation.id),
+      ),
+    )
+    .limit(1);
+
+  const domainConfigured = await checkTelegramDomain(
+    installation.telegramBotId,
+    NEXT_PUBLIC_APP_URL,
+  );
+
+  if (!userLink) {
+    return NextResponse.json({
+      isConnected: false,
+      isInstalled: true,
+      isAdmin,
+      enabled: installation.enabled,
+      bot: {
+        id: installation.telegramBotId,
+        username: installation.botUsername,
+      },
+      domainConfigured,
+    });
+  }
+
+  return getConnectedStatus(
+    org.orgId,
+    userId,
+    member,
+    installation,
+    domainConfigured,
+  );
+}
+
+const patchBodySchema = z.object({
+  enabled: z.boolean().optional(),
+  agentName: z.string().optional(),
+});
+
+/**
+ * PATCH /api/zero/integrations/telegram
+ *
+ * Toggle enabled state and/or change default agent. Admin only.
+ */
+export async function PATCH(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const orgSlug = new URL(request.url).searchParams.get("org");
+  const { org, member } = await resolveOrg(authCtx, orgSlug);
+
+  if (member.role !== "admin") {
+    return NextResponse.json(
+      { error: { message: "Admin access required", code: "FORBIDDEN" } },
+      { status: 403 },
+    );
+  }
+
+  const parseResult = patchBodySchema.safeParse(await request.json());
+  if (!parseResult.success) {
+    return NextResponse.json(
+      { error: { message: "Invalid request body", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+  const body = parseResult.data;
+
+  const db = globalThis.services.db;
+
+  const [installation] = await db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.orgId, org.orgId))
+    .limit(1);
+
+  if (!installation) {
+    return NextResponse.json(
+      { error: { message: "No Telegram bot installed", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  const updates: Record<string, unknown> = { updatedAt: new Date() };
+
+  if (body.enabled !== undefined) {
+    updates.enabled = body.enabled;
+  }
+
+  if (body.agentName) {
+    // Parse org/agentName format
+    const slashIndex = body.agentName.indexOf("/");
+    const agentName =
+      slashIndex === -1 ? body.agentName : body.agentName.slice(slashIndex + 1);
+    const agentOrgSlug =
+      slashIndex === -1 ? null : body.agentName.slice(0, slashIndex);
+
+    let targetOrgId: string;
+    if (agentOrgSlug) {
+      const resolved = await getOrgBySlug(agentOrgSlug);
+      if (!resolved) {
+        return NextResponse.json(
+          { error: { message: "Org not found", code: "BAD_REQUEST" } },
+          { status: 400 },
+        );
+      }
+      targetOrgId = resolved.orgId;
+    } else {
+      targetOrgId = org.orgId;
+    }
+
+    const [compose] = await db
+      .select({ id: agentComposes.id })
+      .from(agentComposes)
+      .where(
+        and(
+          eq(agentComposes.orgId, targetOrgId),
+          eq(agentComposes.name, agentName),
+        ),
+      )
+      .limit(1);
+
+    if (!compose) {
+      return NextResponse.json(
+        { error: { message: "Agent not found", code: "NOT_FOUND" } },
+        { status: 404 },
+      );
+    }
+
+    updates.defaultComposeId = compose.id;
+  }
+
+  await db
+    .update(telegramInstallations)
+    .set(updates)
+    .where(eq(telegramInstallations.id, installation.id));
+
+  return NextResponse.json({ ok: true });
+}
+
+/**
+ * DELETE /api/zero/integrations/telegram
+ *
+ * ?action=uninstall — Admin-only: removes the bot installation and all data.
+ * (default)         — Disconnects the authenticated user's connection.
+ */
+export async function DELETE(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const url = new URL(request.url);
+  const action = url.searchParams.get("action");
+  const orgSlug = url.searchParams.get("org");
+
+  if (action === "uninstall") {
+    return handleUninstall(authCtx, orgSlug);
+  }
+  return handleDisconnect(authCtx, orgSlug);
+}
+
+async function handleUninstall(
+  authCtx: { userId: string },
+  orgSlug: string | null,
+) {
+  const { org, member } = await resolveOrg(authCtx, orgSlug);
+
+  if (member.role !== "admin") {
+    return NextResponse.json(
+      { error: { message: "Admin access required", code: "FORBIDDEN" } },
+      { status: 403 },
+    );
+  }
+
+  const { SECRETS_ENCRYPTION_KEY } = env();
+  const db = globalThis.services.db;
+
+  const [installation] = await db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.orgId, org.orgId))
+    .limit(1);
+
+  if (!installation) {
+    return NextResponse.json(
+      { error: { message: "No Telegram bot installed", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  // Remove webhook from Telegram (best-effort)
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  await deleteWebhook(botToken).catch((error) => {
+    log.warn("Failed to remove Telegram webhook", { error });
+  });
+
+  // Delete installation (cascades to user_links, thread_sessions, messages)
+  await db
+    .delete(telegramInstallations)
+    .where(eq(telegramInstallations.id, installation.id));
+
+  log.info("Telegram bot uninstalled", {
+    installationId: installation.id,
+    orgId: org.orgId,
+    uninstalledBy: authCtx.userId,
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+async function handleDisconnect(
+  authCtx: { userId: string },
+  orgSlug: string | null,
+) {
+  const { userId } = authCtx;
+  const { org } = await resolveOrg(authCtx, orgSlug);
+  const db = globalThis.services.db;
+
+  // Find installation for this org
+  const [installation] = await db
+    .select({ id: telegramInstallations.id })
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.orgId, org.orgId))
+    .limit(1);
+
+  if (!installation) {
+    return NextResponse.json(
+      { error: { message: "No Telegram bot installed", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  const deleted = await db
+    .delete(telegramUserLinks)
+    .where(
+      and(
+        eq(telegramUserLinks.vm0UserId, userId),
+        eq(telegramUserLinks.installationId, installation.id),
+      ),
+    )
+    .returning({ id: telegramUserLinks.id });
+
+  if (deleted.length === 0) {
+    return NextResponse.json(
+      { error: { message: "No Telegram connection found", code: "NOT_FOUND" } },
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}
+
+async function getConnectedStatus(
+  orgId: string,
+  userId: string,
+  member: { role: string },
+  installation: typeof telegramInstallations.$inferSelect,
+  domainConfigured: boolean,
+): Promise<NextResponse> {
+  const db = globalThis.services.db;
+
+  const composeId = await resolveDefaultComposeId(orgId);
+  let defaultAgentName: string | null = null;
+  let agentOrgSlug: string | null = null;
+
+  let requiredSecrets: string[] = [];
+  let requiredVars: string[] = [];
+
+  if (composeId) {
+    const [compose] = await db
+      .select({
+        name: agentComposes.name,
+        orgId: agentComposes.orgId,
+        headVersionId: agentComposes.headVersionId,
+      })
+      .from(agentComposes)
+      .where(eq(agentComposes.id, composeId))
+      .limit(1);
+
+    if (compose) {
+      defaultAgentName = compose.name;
+      agentOrgSlug = (await getOrgData(compose.orgId)).slug;
+
+      if (compose.headVersionId) {
+        const [version] = await db
+          .select({ content: agentComposeVersions.content })
+          .from(agentComposeVersions)
+          .where(eq(agentComposeVersions.id, compose.headVersionId))
+          .limit(1);
+
+        if (version) {
+          const content = version.content as AgentComposeYaml;
+          const grouped = extractAndGroupVariables(content);
+          requiredSecrets = grouped.secrets.map((s) => s.name);
+          requiredVars = grouped.vars.map((v) => v.name);
+        }
+      }
+    }
+  }
+
+  const [userSecrets, userVars, userConnectors] = await Promise.all([
+    listSecrets(orgId, userId),
+    listVariables(orgId, userId),
+    listConnectors(orgId, userId),
+  ]);
+
+  const connectorProvided = getConnectorProvidedSecretNames(
+    userConnectors.map((c) => c.type),
+  );
+  const existingSecretNames = new Set([
+    ...userSecrets.map((s) => s.name),
+    ...connectorProvided,
+  ]);
+  const existingVarNames = new Set(userVars.map((v) => v.name));
+
+  const missingSecrets = requiredSecrets.filter(
+    (name) => !existingSecretNames.has(name),
+  );
+  const missingVars = requiredVars.filter(
+    (name) => !existingVarNames.has(name),
+  );
+
+  return NextResponse.json({
+    isConnected: true,
+    isInstalled: true,
+    isAdmin: member.role === "admin",
+    enabled: installation.enabled,
+    bot: {
+      id: installation.telegramBotId,
+      username: installation.botUsername,
+    },
+    defaultAgentName,
+    agentOrgSlug,
+    domainConfigured,
+    environment: {
+      requiredSecrets,
+      requiredVars,
+      missingSecrets,
+      missingVars,
+    },
+  });
+}

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -2647,6 +2647,104 @@ export async function createTestTelegramInstallation(options?: {
 }
 
 /**
+ * Create an org-scoped Telegram installation.
+ * Uses an existing org (from createTestOrg) and sets up the installation with `orgId`.
+ * Optionally auto-creates a user link.
+ * Returns the installation ID and telegramBotId for assertions.
+ */
+export async function createTestOrgTelegramInstallation(options: {
+  orgId: string;
+  adminUserId: string;
+  vm0UserId?: string;
+  telegramBotId?: string;
+  enabled?: boolean;
+}): Promise<{ installationId: string; telegramBotId: string }> {
+  initServices();
+  const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+
+  const suffix = uniqueId("tg");
+  const telegramBotId = options.telegramBotId ?? suffix;
+
+  // Create agent compose linked to this org
+  const [compose] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({
+      userId: options.adminUserId,
+      orgId: options.orgId,
+      name: uniqueId("compose"),
+    })
+    .returning();
+
+  const [installation] = await globalThis.services.db
+    .insert(telegramInstallations)
+    .values({
+      telegramBotId,
+      botUsername: `bot_${telegramBotId}`,
+      encryptedBotToken: encryptSecretValue(
+        "test-bot-token",
+        SECRETS_ENCRYPTION_KEY,
+      ),
+      webhookSecret: uniqueId("secret"),
+      defaultComposeId: compose!.id,
+      adminUserId: options.adminUserId,
+      orgId: options.orgId,
+      enabled: options.enabled ?? true,
+    })
+    .returning();
+
+  // Auto-create user link if vm0UserId is provided
+  if (options.vm0UserId) {
+    await globalThis.services.db
+      .insert(telegramUserLinks)
+      .values({
+        telegramUserId: suffix,
+        installationId: installation!.id,
+        vm0UserId: options.vm0UserId,
+      })
+      .onConflictDoNothing();
+  }
+
+  return {
+    installationId: installation!.id,
+    telegramBotId,
+  };
+}
+
+/**
+ * Find a Telegram installation by org ID.
+ */
+export async function findTestOrgTelegramInstallation(
+  orgId: string,
+): Promise<typeof telegramInstallations.$inferSelect | undefined> {
+  const [row] = await globalThis.services.db
+    .select()
+    .from(telegramInstallations)
+    .where(eq(telegramInstallations.orgId, orgId))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Find a Telegram user link by user ID and installation ID.
+ */
+export async function findTestTelegramUserLink(
+  vm0UserId: string,
+  installationId: string,
+): Promise<typeof telegramUserLinks.$inferSelect | undefined> {
+  const [row] = await globalThis.services.db
+    .select()
+    .from(telegramUserLinks)
+    .where(
+      and(
+        eq(telegramUserLinks.vm0UserId, vm0UserId),
+        eq(telegramUserLinks.installationId, installationId),
+      ),
+    )
+    .limit(1);
+  return row;
+}
+
+/**
  * Insert test telegram messages with a specific creation date.
  * Used by cleanup cron tests.
  */

--- a/turbo/apps/web/src/db/migrations/0198_telegram_org_integration.sql
+++ b/turbo/apps/web/src/db/migrations/0198_telegram_org_integration.sql
@@ -1,8 +1,4 @@
--- Add org-level integration support to telegram_installations
--- Adds org_id for org-scoped binding and enabled toggle for admin control
-
-ALTER TABLE "telegram_installations" ADD COLUMN "org_id" text;
-ALTER TABLE "telegram_installations" ADD COLUMN "enabled" boolean NOT NULL DEFAULT true;
-
-CREATE INDEX "idx_telegram_installations_org" ON "telegram_installations" USING btree ("org_id");
-CREATE UNIQUE INDEX "idx_telegram_installations_org_unique" ON "telegram_installations" ("org_id") WHERE org_id IS NOT NULL;
+ALTER TABLE "telegram_installations" ADD COLUMN "org_id" text;--> statement-breakpoint
+ALTER TABLE "telegram_installations" ADD COLUMN "enabled" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+CREATE INDEX "idx_telegram_installations_org" ON "telegram_installations" USING btree ("org_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_telegram_installations_org_unique" ON "telegram_installations" USING btree ("org_id") WHERE org_id IS NOT NULL;

--- a/turbo/apps/web/src/db/migrations/0198_telegram_org_integration.sql
+++ b/turbo/apps/web/src/db/migrations/0198_telegram_org_integration.sql
@@ -1,0 +1,8 @@
+-- Add org-level integration support to telegram_installations
+-- Adds org_id for org-scoped binding and enabled toggle for admin control
+
+ALTER TABLE "telegram_installations" ADD COLUMN "org_id" text;
+ALTER TABLE "telegram_installations" ADD COLUMN "enabled" boolean NOT NULL DEFAULT true;
+
+CREATE INDEX "idx_telegram_installations_org" ON "telegram_installations" USING btree ("org_id");
+CREATE UNIQUE INDEX "idx_telegram_installations_org_unique" ON "telegram_installations" ("org_id") WHERE org_id IS NOT NULL;

--- a/turbo/apps/web/src/db/migrations/meta/0198_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0198_snapshot.json
@@ -1,0 +1,6047 @@
+{
+  "id": "0586e462-2c9a-4710-ac5e-ec84eaa6e60b",
+  "prevId": "af3a876b-f839-4ddf-8ecb-5a2dc259047c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_org": {
+          "name": "idx_agent_composes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_org_name": {
+          "name": "idx_agent_composes_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_org_created_idx": {
+          "name": "agent_run_queue_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_schedule_created": {
+          "name": "idx_agent_runs_schedule_created",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_runs_schedule_id_zero_agent_schedules_id_fk": {
+          "name": "agent_runs_schedule_id_zero_agent_schedules_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "zero_agent_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_name": {
+          "name": "memory_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_org": {
+          "name": "idx_agent_sessions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_runs": {
+      "name": "chat_thread_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_runs_unique": {
+          "name": "idx_chat_thread_runs_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_runs_thread": {
+          "name": "idx_chat_thread_runs_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_thread_runs_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_thread_runs_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_thread_runs",
+          "tableTo": "chat_threads",
+          "columnsFrom": ["chat_thread_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_thread_runs_run_id_agent_runs_id_fk": {
+          "name": "chat_thread_runs_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_thread_runs",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_compose_updated": {
+          "name": "idx_chat_threads_user_compose_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_agent_compose_id_agent_composes_id_fk": {
+          "name": "chat_threads_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_snapshot": {
+          "name": "memory_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_type": {
+          "name": "idx_connectors_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_pricing": {
+      "name": "credit_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_token_price": {
+          "name": "cache_creation_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_credit_pricing_model_provider": {
+          "name": "uq_credit_pricing_model_provider",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_usage": {
+      "name": "credit_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_uuid": {
+          "name": "result_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "web_search_requests": {
+          "name": "web_search_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_credit_usage_run_result": {
+          "name": "uq_credit_usage_run_result",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_run_id": {
+          "name": "idx_credit_usage_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_org_status": {
+          "name": "idx_credit_usage_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_org_created": {
+          "name": "idx_credit_usage_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_usage_run_id_agent_runs_id_fk": {
+          "name": "credit_usage_run_id_agent_runs_id_fk",
+          "tableFrom": "credit_usage",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_slug": {
+          "name": "org_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_email_lower_idx": {
+          "name": "email_suppressions_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_agent_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_agent_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cached_at": {
+          "name": "billing_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_org_cache_slug": {
+          "name": "idx_org_cache_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_metadata": {
+      "name": "org_members_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "send_mode": {
+          "name": "send_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enter'"
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "credit_cap": {
+          "name": "credit_cap",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_enabled": {
+          "name": "credit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_metadata_org_id_user_id_pk": {
+          "name": "org_members_metadata_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_metadata": {
+      "name": "org_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_enabled": {
+          "name": "auto_recharge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_threshold": {
+          "name": "auto_recharge_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_amount": {
+          "name": "auto_recharge_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_pending_at": {
+          "name": "auto_recharge_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_stripe_customer": {
+          "name": "uq_org_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_metadata_default_agent_id_agent_composes_id_fk": {
+          "name": "org_metadata_default_agent_id_agent_composes_id_fk",
+          "tableFrom": "org_metadata",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0/default'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_profile_unclaimed_idx": {
+          "name": "runner_job_queue_group_profile_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_path": {
+          "name": "full_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_hash": {
+          "name": "version_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_name": {
+          "name": "idx_skills_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_storage_id": {
+          "name": "idx_skills_storage_id",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_storage_id_storages_id_fk": {
+          "name": "skills_storage_id_storages_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_url_unique": {
+          "name": "skills_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_vm0_user_workspace": {
+          "name": "idx_slack_org_connections_vm0_user_workspace",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": ["slack_workspace_id"],
+          "columnsTo": ["slack_workspace_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_pending_questions": {
+      "name": "slack_org_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_org_pending_questions_run_id": {
+          "name": "idx_slack_org_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_pending_questions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_pending_questions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slack_org_pending_questions_compose_id_agent_composes_id_fk": {
+          "name": "slack_org_pending_questions_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_pending_questions_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_pending_questions_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_thread_sessions": {
+      "name": "slack_org_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_thread_sessions_conn_channel_thread": {
+          "name": "idx_slack_org_thread_sessions_conn_channel_thread",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_thread_sessions_connection": {
+          "name": "idx_slack_org_thread_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_version_lineage": {
+      "name": "storage_version_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storage_version_lineage_storage_version": {
+          "name": "idx_storage_version_lineage_storage_version",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_storage_parent": {
+          "name": "idx_storage_version_lineage_storage_parent",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_run": {
+          "name": "idx_storage_version_lineage_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_version_lineage_storage_id_storages_id_fk": {
+          "name": "storage_version_lineage_storage_id_storages_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_version_lineage_run_id_agent_runs_id_fk": {
+          "name": "storage_version_lineage_run_id_agent_runs_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name_type": {
+          "name": "idx_storages_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_installations_org": {
+          "name": "idx_telegram_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_installations_org_unique": {
+          "name": "idx_telegram_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_bot_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_org_date": {
+          "name": "uq_usage_daily_user_org_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_unsubscribed": {
+          "name": "email_unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_name": {
+          "name": "idx_variables_org_user_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vm0_api_keys": {
+      "name": "vm0_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vm0_api_keys_vendor": {
+          "name": "idx_vm0_api_keys_vendor",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agent_schedules": {
+      "name": "zero_agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_version": {
+          "name": "artifact_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notify_email": {
+          "name": "notify_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_slack": {
+          "name": "notify_slack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agent_schedules_zero_agent": {
+          "name": "idx_zero_agent_schedules_zero_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_org": {
+          "name": "idx_zero_agent_schedules_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_agent_name_org_user": {
+          "name": "idx_zero_agent_schedules_agent_name_org_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_next_run": {
+          "name": "idx_zero_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agent_schedules_agent_id_agent_composes_id_fk": {
+          "name": "zero_agent_schedules_agent_id_agent_composes_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "zero_agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agents": {
+      "name": "zero_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sound": {
+          "name": "sound",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firewall_policies": {
+          "name": "firewall_policies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connectors": {
+          "name": "connectors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agents_org_name": {
+          "name": "idx_zero_agents_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agents_org": {
+          "name": "idx_zero_agents_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agents_id_agent_composes_id_fk": {
+          "name": "zero_agents_id_agent_composes_id_fk",
+          "tableFrom": "zero_agents",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": ["pending", "complete", "expired", "error"]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -1387,6 +1387,13 @@
       "when": 1774828800003,
       "tag": "0197_fk_schedules_email_org_to_composes",
       "breakpoints": true
+    },
+    {
+      "idx": 198,
+      "version": "7",
+      "when": 1774828800004,
+      "tag": "0198_telegram_org_integration",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/telegram-installation.ts
+++ b/turbo/apps/web/src/db/schema/telegram-installation.ts
@@ -1,25 +1,51 @@
-import { pgTable, uuid, varchar, text, timestamp } from "drizzle-orm/pg-core";
+import {
+  pgTable,
+  uuid,
+  varchar,
+  text,
+  timestamp,
+  boolean,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { agentComposes } from "./agent-compose";
 
 /**
  * Telegram Installations table
  * Stores bot-level tokens and default agent for Telegram bot integrations
  * One record per Telegram bot. Each bot has exactly one default agent.
+ * Org:Bot is 1:1 — enforced by a partial unique index on `org_id`.
  */
-export const telegramInstallations = pgTable("telegram_installations", {
-  id: uuid("id").defaultRandom().primaryKey(),
-  telegramBotId: varchar("telegram_bot_id", { length: 255 }).notNull().unique(),
-  botUsername: varchar("bot_username", { length: 255 }),
-  // Bot token encrypted with AES-256-GCM
-  encryptedBotToken: text("encrypted_bot_token").notNull(),
-  // Secret token for webhook verification (X-Telegram-Bot-Api-Secret-Token)
-  webhookSecret: varchar("webhook_secret", { length: 255 }).notNull(),
-  // Bot default agent — always set at registration time
-  defaultComposeId: uuid("default_compose_id")
-    .notNull()
-    .references(() => agentComposes.id, { onDelete: "cascade" }),
-  // Admin: the VM0 user who registered the bot (Clerk user ID)
-  adminUserId: text("admin_user_id").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-});
+export const telegramInstallations = pgTable(
+  "telegram_installations",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    telegramBotId: varchar("telegram_bot_id", { length: 255 })
+      .notNull()
+      .unique(),
+    botUsername: varchar("bot_username", { length: 255 }),
+    // Bot token encrypted with AES-256-GCM
+    encryptedBotToken: text("encrypted_bot_token").notNull(),
+    // Secret token for webhook verification (X-Telegram-Bot-Api-Secret-Token)
+    webhookSecret: varchar("webhook_secret", { length: 255 }).notNull(),
+    // Bot default agent — always set at registration time
+    defaultComposeId: uuid("default_compose_id")
+      .notNull()
+      .references(() => agentComposes.id, { onDelete: "cascade" }),
+    // Admin: the VM0 user who registered the bot (Clerk user ID)
+    adminUserId: text("admin_user_id").notNull(),
+    // Org binding — nullable until admin binds the bot to an org
+    orgId: text("org_id"),
+    // Enable/disable toggle — when disabled, webhook silently drops messages
+    enabled: boolean("enabled").default(true).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("idx_telegram_installations_org").on(table.orgId),
+    uniqueIndex("idx_telegram_installations_org_unique")
+      .on(table.orgId)
+      .where(sql`org_id IS NOT NULL`),
+  ],
+);

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -621,6 +621,12 @@ export {
   type SlackOrgStatus,
 } from "./zero-integrations-slack";
 export {
+  zeroIntegrationsTelegramContract,
+  telegramOrgStatusSchema,
+  type ZeroIntegrationsTelegramContract,
+  type TelegramOrgStatus,
+} from "./zero-integrations-telegram";
+export {
   zeroSlackConnectContract,
   type ZeroSlackConnectContract,
 } from "./zero-slack-connect";

--- a/turbo/packages/core/src/contracts/zero-integrations-telegram.ts
+++ b/turbo/packages/core/src/contracts/zero-integrations-telegram.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const telegramEnvironmentSchema = z.object({
+  requiredSecrets: z.array(z.string()),
+  requiredVars: z.array(z.string()),
+  missingSecrets: z.array(z.string()),
+  missingVars: z.array(z.string()),
+});
+
+const telegramBotSchema = z.object({
+  id: z.string(),
+  username: z.string().nullable(),
+});
+
+const telegramOrgStatusSchema = z.object({
+  isConnected: z.boolean(),
+  isInstalled: z.boolean().optional(),
+  isAdmin: z.boolean(),
+  enabled: z.boolean().optional(),
+  bot: telegramBotSchema.nullable().optional(),
+  defaultAgentName: z.string().nullable().optional(),
+  agentOrgSlug: z.string().nullable().optional(),
+  domainConfigured: z.boolean().optional(),
+  environment: telegramEnvironmentSchema.optional(),
+});
+
+const telegramAuthSchema = z.object({
+  id: z.union([z.string(), z.number()]),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  username: z.string().optional(),
+  photo_url: z.string().optional(),
+  auth_date: z.union([z.string(), z.number()]),
+  hash: z.string(),
+});
+
+const connectSignatureSchema = z.object({
+  telegramUserId: z.string().min(1),
+  timestamp: z.number(),
+  signature: z.string().min(1),
+});
+
+/**
+ * Zero integrations Telegram contract
+ * Manages org-scoped Telegram bot integration.
+ */
+export const zeroIntegrationsTelegramContract = c.router({
+  getStatus: {
+    method: "GET",
+    path: "/api/zero/integrations/telegram",
+    headers: authHeadersSchema,
+    responses: {
+      200: telegramOrgStatusSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Get org-scoped Telegram bot info",
+  },
+  install: {
+    method: "POST",
+    path: "/api/zero/integrations/telegram/install",
+    headers: authHeadersSchema,
+    body: z.object({
+      botToken: z.string().min(1),
+      telegramAuth: telegramAuthSchema,
+    }),
+    responses: {
+      201: z.object({
+        installationId: z.string(),
+        bot: telegramBotSchema,
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      409: apiErrorSchema,
+    },
+    summary: "Install Telegram bot for org (admin only)",
+  },
+  connect: {
+    method: "POST",
+    path: "/api/zero/integrations/telegram/connect",
+    headers: authHeadersSchema,
+    body: z.object({
+      telegramAuth: telegramAuthSchema.optional(),
+      connectSignature: connectSignatureSchema.optional(),
+    }),
+    responses: {
+      200: z.object({
+        botUsername: z.string().nullable(),
+        telegramUserId: z.string(),
+      }),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Connect user Telegram identity to org bot",
+  },
+  update: {
+    method: "PATCH",
+    path: "/api/zero/integrations/telegram",
+    headers: authHeadersSchema,
+    body: z.object({
+      enabled: z.boolean().optional(),
+      agentName: z.string().optional(),
+    }),
+    responses: {
+      200: z.object({ ok: z.boolean() }),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Toggle enabled state or change default agent (admin only)",
+  },
+  disconnect: {
+    method: "DELETE",
+    path: "/api/zero/integrations/telegram",
+    headers: authHeadersSchema,
+    body: c.noBody(),
+    query: z.object({
+      action: z.string().optional(),
+    }),
+    responses: {
+      200: z.object({ ok: z.boolean() }),
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Disconnect user or uninstall Telegram bot",
+  },
+});
+
+export type ZeroIntegrationsTelegramContract =
+  typeof zeroIntegrationsTelegramContract;
+export type TelegramOrgStatus = z.infer<typeof telegramOrgStatusSchema>;
+export { telegramOrgStatusSchema };


### PR DESCRIPTION
## Summary

- Add org-scoped Telegram bot integration on the Works page, mirroring the existing Slack pattern
- Admin can install a bot (bot token + Telegram Login Widget for identity verification), which auto-connects the admin
- Members can connect via Login Widget popup or `/connect` command in Telegram
- Admin has an enable/disable toggle for the bot
- One bot per org enforced via partial unique index on `orgId`
- Feature-gated by existing `TelegramIntegration` flag (staff-only)

### Changes

**Schema & Migration**
- `telegram_installations`: added `org_id` (text, nullable) and `enabled` (boolean, default true) columns
- Partial unique index on `org_id WHERE org_id IS NOT NULL` for 1:1 enforcement

**API Routes** (`/api/zero/integrations/telegram`)
- `GET` — org-scoped status (connection, bot info, environment)
- `POST /install` — admin-only bot installation with webhook setup
- `POST /connect` — user connect via Login Widget or `/connect` signature
- `PATCH` — admin toggle enabled/change default agent
- `DELETE` — disconnect user or `?action=uninstall` for admin

**Platform**
- `zero-telegram.ts` — full ccstate signal layer (state, actions, polling)
- `TelegramCard` component on Works page with install dialog, connect, toggle, disconnect/uninstall
- Updated mock handlers for new endpoints
- Works page setup initializes Telegram alongside Slack

**Webhook**
- Silently returns 200 when bot is disabled (prevents Telegram retry storms)

## Test plan

- [x] 18 integration tests for org-scoped API routes (GET, PATCH, DELETE, uninstall)
- [ ] Verify TelegramCard renders on Works page when feature flag is enabled
- [ ] Test install flow: enter bot token → Telegram Login Widget → auto-connect
- [ ] Test member connect flow via Login Widget popup
- [ ] Test admin toggle enable/disable
- [ ] Test disconnect and uninstall flows
- [ ] Verify webhook returns 200 when bot is disabled

Closes #6767

🤖 Generated with [Claude Code](https://claude.com/claude-code)