### PR TITLE
fix(platform): initialize sentry synchronously to capture bootstrap errors

### DIFF
--- a/turbo/apps/platform/src/lib/sentry.ts
+++ b/turbo/apps/platform/src/lib/sentry.ts
@@ -1,61 +1,54 @@
 import * as Sentry from "@sentry/react";
 
-// Defer Sentry initialization off the critical path to reduce TBT.
-// Sentry APIs (captureException, setUser, etc.) are safe no-ops before init.
-export function deferSentryInit(): void {
-  const init = () => {
-    Sentry.init({
-      dsn: import.meta.env.VITE_SENTRY_DSN,
+// Initialize Sentry synchronously so that global error/unhandledrejection
+// handlers are installed before the app bootstraps. Errors during bootstrap
+// (route resolution, signal evaluation) would be missed with deferred init.
+export function initSentry(): void {
+  Sentry.init({
+    dsn: import.meta.env.VITE_SENTRY_DSN,
 
-      // Only enable when DSN is configured
-      enabled: !!import.meta.env.VITE_SENTRY_DSN,
+    // Only enable when DSN is configured
+    enabled: !!import.meta.env.VITE_SENTRY_DSN,
 
-      // Set environment (Vercel provides VITE_VERCEL_ENV in builds)
-      environment: import.meta.env.VITE_VERCEL_ENV,
+    // Set environment (Vercel provides VITE_VERCEL_ENV in builds)
+    environment: import.meta.env.VITE_VERCEL_ENV,
 
-      // Set app tag to identify this app in Sentry
-      initialScope: {
-        tags: {
-          app: "platform",
-        },
+    // Set app tag to identify this app in Sentry
+    initialScope: {
+      tags: {
+        app: "platform",
       },
+    },
 
-      // Disable tracing - only error tracking is needed
-      tracesSampleRate: 0,
+    // Disable tracing - only error tracking is needed
+    tracesSampleRate: 0,
 
-      // Filter out expected errors
-      beforeSend(event) {
-        // Filter out 4xx client errors that are expected
-        const statusCode = event.contexts?.response?.status_code;
-        if (
-          typeof statusCode === "number" &&
-          statusCode >= 400 &&
-          statusCode < 500
-        ) {
-          return null;
-        }
-        return event;
-      },
+    // Filter out expected errors
+    beforeSend(event) {
+      // Filter out 4xx client errors that are expected
+      const statusCode = event.contexts?.response?.status_code;
+      if (
+        typeof statusCode === "number" &&
+        statusCode >= 400 &&
+        statusCode < 500
+      ) {
+        return null;
+      }
+      return event;
+    },
 
-      // Ignore common client-side errors
-      ignoreErrors: [
-        // Network errors
-        "Failed to fetch",
-        "NetworkError",
-        "Load failed",
-        // User navigation
-        "AbortError",
-        // Browser extensions
-        "ResizeObserver loop",
-      ],
-    });
-  };
-
-  if (typeof requestIdleCallback === "function") {
-    requestIdleCallback(init, { timeout: 3000 });
-  } else {
-    window.setTimeout(init, 100);
-  }
+    // Ignore common client-side errors
+    ignoreErrors: [
+      // Network errors
+      "Failed to fetch",
+      "NetworkError",
+      "Load failed",
+      // User navigation
+      "AbortError",
+      // Browser extensions
+      "ResizeObserver loop",
+    ],
+  });
 }
 
 export function setSentryUser(userId: string) {

--- a/turbo/apps/platform/src/main.ts
+++ b/turbo/apps/platform/src/main.ts
@@ -1,5 +1,5 @@
 // lighthouse-ci: trigger platform-changed detection
-import { deferSentryInit, Sentry } from "./lib/sentry.ts";
+import { initSentry, Sentry } from "./lib/sentry.ts";
 import "./polyfill.ts";
 import { createRoot } from "react-dom/client";
 import { appStore, AppStoreProvider } from "./signals/app-store.ts";
@@ -9,8 +9,8 @@ import { initTheme$ } from "./signals/theme.ts";
 import { detach, Reason } from "./signals/utils.ts";
 import { setupRouter } from "./views/main.tsx";
 
-// Kick off deferred Sentry initialization via requestIdleCallback
-deferSentryInit();
+// Initialize Sentry before bootstrap so errors during startup are captured
+initSentry();
 
 setLogErrorHandler((loggerName, args) => {
   const error = args.find((a): a is Error => a instanceof Error);


### PR DESCRIPTION
## Summary
- Replace deferred Sentry initialization (`requestIdleCallback`/`setTimeout`) with synchronous `initSentry()` call
- Ensures Sentry's global error and `unhandledrejection` handlers are installed before the app bootstraps
- Fixes missed error capture for errors during startup (route resolution, signal evaluation)

## Test plan
- [ ] Verify Sentry initialization occurs before app bootstrap in dev
- [ ] Confirm errors thrown during startup are captured by Sentry
- [ ] Check that Sentry still functions correctly for runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)