### PR TITLE
refactor(platform): align agents list with team compose item type

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/agents-list.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agents-list.ts
@@ -2,7 +2,7 @@ import { command, computed, state } from "ccstate";
 import {
   zeroTeamContract,
   zeroSchedulesMainContract,
-  type ComposeListItem,
+  type TeamComposeItem,
 } from "@vm0/core";
 import { throwIfAbort } from "../utils.ts";
 import { logger } from "../log.ts";
@@ -20,7 +20,7 @@ interface Schedule {
 }
 
 interface AgentsListState {
-  agents: ComposeListItem[];
+  agents: TeamComposeItem[];
   schedules: Schedule[];
   loading: boolean;
   error: string | null;
@@ -49,7 +49,7 @@ export const fetchAgentsList$ = command(async ({ get, set }) => {
       throw new Error(`Failed to fetch agents (${agentsResult.status})`);
     }
 
-    const agents = agentsResult.body as ComposeListItem[];
+    const agents = agentsResult.body;
 
     // Fetch schedules (optional - don't fail if schedules API is unavailable)
     let schedules: Schedule[] = [];

--- a/turbo/apps/platform/src/views/zero-page/__tests__/build-combined-schedule.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/build-combined-schedule.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { buildCombinedSchedule } from "../zero-schedule-page.tsx";
+import type { OrgScheduleEntry } from "../../../signals/zero-page/zero-schedule.ts";
+
+function makeEntry(
+  overrides: Partial<OrgScheduleEntry> = {},
+): OrgScheduleEntry {
+  return {
+    id: "sched-1",
+    time: "Every weekday at 9:00 AM",
+    prompt: "Do something",
+    description: null,
+    enabled: true,
+    notifyEmail: false,
+    notifySlack: false,
+    slackChannelId: null,
+    name: "my-schedule",
+    timezone: "UTC",
+    intervalSeconds: null,
+    agentId: "agent-uuid-1",
+    nextRunAt: null,
+    lastRunAt: null,
+    ...overrides,
+  };
+}
+
+describe("buildCombinedSchedule", () => {
+  it("should use default agent name when entry agentId matches defaultComposeId", () => {
+    const entries = [makeEntry({ agentId: "default-uuid" })];
+    const nameToDisplay = new Map<string, string>();
+    const result = buildCombinedSchedule(
+      entries,
+      "Zero",
+      "default-uuid",
+      nameToDisplay,
+    );
+    expect(result[0].agentLabel).toBe("Zero");
+  });
+
+  it("should resolve agent label from nameToDisplay map keyed by agent id", () => {
+    const entries = [makeEntry({ agentId: "sub-agent-uuid" })];
+    const nameToDisplay = new Map([["sub-agent-uuid", "Research Agent"]]);
+    const result = buildCombinedSchedule(
+      entries,
+      "Zero",
+      "default-uuid",
+      nameToDisplay,
+    );
+    expect(result[0].agentLabel).toBe("Research Agent");
+  });
+
+  it("should fall back to raw agentId when not in nameToDisplay map", () => {
+    const entries = [makeEntry({ agentId: "unknown-uuid" })];
+    const nameToDisplay = new Map([["other-uuid", "Other Agent"]]);
+    const result = buildCombinedSchedule(
+      entries,
+      "Zero",
+      "default-uuid",
+      nameToDisplay,
+    );
+    expect(result[0].agentLabel).toBe("unknown-uuid");
+  });
+
+  it("should handle multiple entries with different agents", () => {
+    const entries = [
+      makeEntry({ id: "s1", agentId: "default-uuid" }),
+      makeEntry({ id: "s2", agentId: "agent-a" }),
+      makeEntry({ id: "s3", agentId: "agent-b" }),
+    ];
+    const nameToDisplay = new Map([
+      ["agent-a", "Alpha Agent"],
+      ["agent-b", "Beta Agent"],
+    ]);
+    const result = buildCombinedSchedule(
+      entries,
+      "Zero",
+      "default-uuid",
+      nameToDisplay,
+    );
+    expect(result[0].agentLabel).toBe("Zero");
+    expect(result[1].agentLabel).toBe("Alpha Agent");
+    expect(result[2].agentLabel).toBe("Beta Agent");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -105,6 +105,97 @@ async function openMenuAndClick(
   fireEvent.click(screen.getByRole("menuitem", { name: action }));
 }
 
+describe("zero schedule page - agent labels", () => {
+  it("should display agent displayName for schedules belonging to sub-agents", async () => {
+    // Mock team API with a sub-agent that has a displayName
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: "mock-compose-id",
+            displayName: "Zero",
+            description: null,
+            sound: null,
+            headVersionId: "v1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "sub-agent-id",
+            displayName: "Research Agent",
+            description: null,
+            sound: null,
+            headVersionId: "v2",
+            updatedAt: "2024-01-02T00:00:00Z",
+          },
+        ]);
+      }),
+      http.get("*/api/zero/schedules", () => {
+        return HttpResponse.json({
+          schedules: [
+            {
+              ...createMockSchedules()[0],
+              agentId: "sub-agent-id",
+            },
+          ],
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+    await renderSchedulePage();
+
+    // The agent column should show "Research Agent" (resolved from displayName by id)
+    await waitFor(() => {
+      expect(screen.getByText("Research Agent")).toBeInTheDocument();
+    });
+  });
+
+  it("should fall back to agent id when displayName is null", async () => {
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: "mock-compose-id",
+            displayName: null,
+            description: null,
+            sound: null,
+            headVersionId: "v1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "no-name-agent",
+            displayName: null,
+            description: null,
+            sound: null,
+            headVersionId: "v2",
+            updatedAt: "2024-01-02T00:00:00Z",
+          },
+        ]);
+      }),
+      http.get("*/api/zero/schedules", () => {
+        return HttpResponse.json({
+          schedules: [
+            {
+              ...createMockSchedules()[0],
+              agentId: "no-name-agent",
+            },
+          ],
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+    await renderSchedulePage();
+
+    // Falls back to raw agent id when displayName is null
+    await waitFor(() => {
+      expect(screen.getByText("no-name-agent")).toBeInTheDocument();
+    });
+  });
+});
+
 describe("zero schedule page - list view", () => {
   it("should render schedule entries with time and prompt", async () => {
     mockScheduleAPI();

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -122,7 +122,7 @@ interface ScheduleFormDialogProps {
   mode: "create" | "edit";
   initialValues?: Partial<ScheduleFormValues>;
   /** When provided, renders an agent selector dropdown. */
-  agents?: { id: string; name: string; displayName?: string | null }[];
+  agents?: { id: string; displayName?: string | null }[];
   /** Error message displayed above the footer. */
   saveError?: string | null;
 }
@@ -696,7 +696,7 @@ function ScheduleFormDialogInner({
                 <SelectContent>
                   {agents.map((a) => (
                     <SelectItem key={a.id} value={a.id}>
-                      {a.displayName ?? a.name}
+                      {a.displayName ?? a.id}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -362,7 +362,6 @@ function AgentCard({
 }: {
   agent: {
     id: string;
-    name: string;
     displayName?: string | null;
     description?: string | null;
   };

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -223,7 +223,6 @@ const SCHEDULE_DETAIL_CONTROL_WIDTH =
 
 type ScheduleAgentOption = {
   id: string;
-  name: string;
   displayName?: string | null;
 };
 
@@ -488,7 +487,7 @@ function ScheduleSettingsForm({
                 <SelectContent>
                   {agents.map((a) => (
                     <SelectItem key={a.id} value={a.id}>
-                      {a.displayName ?? a.name}
+                      {a.displayName ?? a.id}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -985,7 +984,7 @@ export function ZeroScheduleDetailPage() {
   const agentsLoadable = useLoadable(agentsList$);
   const agents = agentsLoadable.state === "hasData" ? agentsLoadable.data : [];
   const nameToDisplay = new Map(
-    agents.filter((a) => a.displayName).map((a) => [a.name, a.displayName!]),
+    agents.filter((a) => a.displayName).map((a) => [a.id, a.displayName!]),
   );
 
   const loaded = useGet(allOrgSchedulesLoaded$);


### PR DESCRIPTION
## Summary
- Replace `ComposeListItem` with `TeamComposeItem` from the zero-team contract in agents list signal
- Remove the unused `name` field from agent interfaces in schedule dialog, jobs page, and schedule detail page
- Fall back to `id` instead of `name` when `displayName` is unavailable

## Test plan
- [ ] Verify agents list loads correctly on the zero page
- [ ] Verify schedule dialog agent selector displays agent names properly
- [ ] Verify schedule detail page agent selector works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)