### PR TITLE
fix(auth): reject cli jwt requests when user is no longer an org member

### DIFF
--- a/turbo/apps/web/src/lib/auth/__tests__/get-auth-context-cli.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-auth-context-cli.test.ts
@@ -3,10 +3,12 @@ import { auth } from "@clerk/nextjs/server";
 import { getAuthContext } from "../get-auth-context";
 import { generateCliToken } from "../sandbox-token";
 import {
+  clearOrgMembersCacheEntry,
   createTestCliToken,
   deleteTestCliToken,
   findTestCliToken,
 } from "../../../__tests__/api-test-helpers";
+import { mockClerk } from "../../../__tests__/clerk-mock";
 import { testContext, type UserContext } from "../../../__tests__/test-helpers";
 
 const context = testContext();
@@ -24,13 +26,13 @@ describe("getAuthContext with CLI JWT", () => {
   });
 
   it("should return auth context for valid CLI JWT", async () => {
-    const token = await createTestCliToken(user.userId);
+    const token = await createTestCliToken(user.userId, undefined, user.orgId);
 
     const result = await getAuthContext(`Bearer ${token}`);
 
     expect(result).not.toBeNull();
     expect(result?.userId).toBe(user.userId);
-    expect(result?.orgId).toBe("org_test_default");
+    expect(result?.orgId).toBe(user.orgId);
     expect(result?.capabilities).toBeUndefined();
     expect(result?.runId).toBeUndefined();
   });
@@ -99,5 +101,22 @@ describe("getAuthContext with CLI JWT", () => {
     const result = await getAuthContext(`Bearer ${token}`);
 
     expect(result).toBeNull();
+  });
+
+  it("should omit orgId when user is no longer an org member", async () => {
+    const token = await createTestCliToken(user.userId, undefined, user.orgId);
+
+    // Mock Clerk to return no memberships (user was removed from org)
+    mockClerk({ userId: user.userId, clerkOrgs: [] });
+
+    // Ensure no fresh cache entry exists
+    await clearOrgMembersCacheEntry(user.orgId, user.userId);
+
+    const result = await getAuthContext(`Bearer ${token}`);
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe(user.userId);
+    expect(result?.orgId).toBeUndefined();
+    expect(result?.orgRole).toBeUndefined();
   });
 });

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -51,15 +51,22 @@ export async function getAuthContext(
         const resolved = await resolveCliTokenFromDb(cliAuth);
         if (!resolved) return null;
         // Resolve org role so downstream admin checks work correctly
-        let orgRole: AuthContext["orgRole"];
         if (resolved.orgId) {
           const membership = await verifyMembershipCached(
             resolved.orgId,
             resolved.userId,
           );
-          orgRole = membership?.role;
+          if (!membership) {
+            // User no longer a member — omit orgId to force resolveOrg rejection
+            return { userId: resolved.userId };
+          }
+          return {
+            userId: resolved.userId,
+            orgId: resolved.orgId,
+            orgRole: membership.role,
+          };
         }
-        return { userId: resolved.userId, orgId: resolved.orgId, orgRole };
+        return { userId: resolved.userId, orgId: resolved.orgId };
       }
       return authenticateSandboxToken(token, options);
     }


### PR DESCRIPTION
## Summary

- When a user is removed from an org, their CLI JWT (90-day TTL) still contains the old `orgId`. Previously, `getAuthContext()` kept `orgId` in the AuthContext even when `verifyMembershipCached()` returned `null`, allowing `resolveOrg()` fast path to default removed users to `"member"` role.
- Now `getAuthContext()` omits `orgId` from the AuthContext when membership verification fails, forcing proper rejection downstream.
- Added integration test verifying CLI JWT with revoked membership omits `orgId`.

Closes #6776

## Test plan

- [x] New test: CLI JWT with revoked membership returns auth context without `orgId`
- [x] All 8 existing CLI JWT auth tests pass
- [x] Lint, format, knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)