### PR TITLE
fix: wrap cli command example in backticks to prevent markdown parsing

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -35,7 +35,7 @@ export function buildZeroCliGuidance(): string {
   return [
     "# Zero CLI",
     "You have access to the Zero CLI for managing platform resources.",
-    "Run commands with: npx -p @vm0/cli zero <command>",
+    "Run commands with: `npx -p @vm0/cli zero <command>`",
     "Tip: run `alias zero='npx -p @vm0/cli zero'` first, then use `zero <command>` for brevity.",
     "Run `npx -p @vm0/cli zero --help` to see all available commands.",
     "Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",


### PR DESCRIPTION
## Summary
- The bare `<command>` in `buildZeroCliGuidance()` was parsed as an HTML element by `rehype-raw`, causing all subsequent system prompt content to be silently dropped in the activity page
- Wrapping the command example in backticks makes it inline code, preventing HTML parsing

## Related
- #6770 (systemic Markdown rendering fix tracked separately)

## Test plan
- [ ] Verify system prompt on activity page displays full content without truncation
- [ ] Confirm the CLI guidance text renders correctly with `<command>` shown as inline code

🤖 Generated with [Claude Code](https://claude.com/claude-code)