### PR TITLE
refactor: remove legacy vm0_live_ opaque cli token support

### DIFF
--- a/turbo/apps/cli/src/commands/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/__tests__/whoami.test.ts
@@ -14,6 +14,15 @@ import * as os from "os";
 import chalk from "chalk";
 import { whoamiCommand } from "../whoami";
 
+function buildFakeCliJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const sig = Buffer.from("fake-signature").toString("base64url");
+  return `vm0_sandbox_${header}.${body}.${sig}`;
+}
+
 // Mock os.homedir to use temp directory for config isolation
 const TEST_HOME = mkdtempSync(path.join(os.tmpdir(), "test-whoami-home-"));
 vi.mock("os", async (importOriginal) => {
@@ -140,8 +149,14 @@ describe("whoami command", () => {
       );
     });
 
-    it("should display active org when VM0_ACTIVE_ORG is set", async () => {
-      vi.stubEnv("VM0_ACTIVE_ORG", "test-org-slug");
+    it("should display active org from CLI JWT token", async () => {
+      const cliJwt = buildFakeCliJwt({
+        scope: "cli",
+        orgId: "test-org-slug",
+        userId: "user-1",
+        tokenId: "tok-1",
+      });
+      vi.stubEnv("VM0_TOKEN", cliJwt);
 
       await runWhoami();
 

--- a/turbo/apps/cli/src/commands/auth/__tests__/setup-token.test.ts
+++ b/turbo/apps/cli/src/commands/auth/__tests__/setup-token.test.ts
@@ -61,7 +61,7 @@ describe("auth setup-token", () => {
       await fs.mkdir(configDir, { recursive: true });
       await fs.writeFile(
         path.join(configDir, "config.json"),
-        JSON.stringify({ token: "vm0_live_test123" }),
+        JSON.stringify({ token: "test_token_abc123" }),
       );
 
       await setupTokenCommand.parseAsync(["node", "cli"]);
@@ -69,7 +69,7 @@ describe("auth setup-token", () => {
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("token exported successfully"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith("vm0_live_test123");
+      expect(mockConsoleLog).toHaveBeenCalledWith("test_token_abc123");
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("export VM0_TOKEN"),
       );
@@ -78,14 +78,14 @@ describe("auth setup-token", () => {
 
   describe("authenticated via environment", () => {
     it("should output token from VM0_TOKEN env var", async () => {
-      vi.stubEnv("VM0_TOKEN", "vm0_live_envtoken456");
+      vi.stubEnv("VM0_TOKEN", "test_token_env456");
 
       await setupTokenCommand.parseAsync(["node", "cli"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("token exported successfully"),
       );
-      expect(mockConsoleLog).toHaveBeenCalledWith("vm0_live_envtoken456");
+      expect(mockConsoleLog).toHaveBeenCalledWith("test_token_env456");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -151,8 +151,14 @@ describe("zero whoami command", () => {
       );
     });
 
-    it("should display active org when set", async () => {
-      vi.stubEnv("VM0_ACTIVE_ORG", "test-org-slug");
+    it("should display active org from CLI JWT token", async () => {
+      const cliJwt = buildZeroToken({
+        scope: "cli",
+        orgId: "test-org-slug",
+        userId: "user-1",
+        tokenId: "tok-1",
+      });
+      vi.stubEnv("VM0_TOKEN", cliJwt);
 
       await runWhoami();
 

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/leave.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/leave.test.ts
@@ -40,6 +40,13 @@ describe("zero org leave command", () => {
   });
 
   it("should leave org and auto-switch to remaining org", async () => {
+    const newJwt = buildFakeCliJwt({
+      scope: "cli",
+      orgId: "org-id-other",
+      userId: "user-1",
+      tokenId: "tok-1",
+    });
+
     server.use(
       http.post("http://localhost:3000/api/zero/org/leave", () => {
         return HttpResponse.json({
@@ -53,6 +60,14 @@ describe("zero org leave command", () => {
             { slug: "another-org", role: "admin" },
           ],
           active: undefined,
+        });
+      }),
+      http.post("http://localhost:3000/api/cli/auth/org", () => {
+        return HttpResponse.json({
+          access_token: newJwt,
+          token_type: "Bearer",
+          expires_in: 7776000,
+          org_slug: "other-org",
         });
       }),
     );

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/list.test.ts
@@ -3,7 +3,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
 import { listCommand } from "../list";
 import { mkdtempSync } from "fs";
-import { mkdir, writeFile, rm } from "fs/promises";
+import { mkdir, rm } from "fs/promises";
 import * as path from "path";
 import * as os from "os";
 import chalk from "chalk";
@@ -44,10 +44,6 @@ describe("zero org list command", () => {
     vi.stubEnv("VM0_TOKEN", cliJwt);
     const configDir = path.join(TEST_HOME, ".vm0");
     await mkdir(configDir, { recursive: true });
-    await writeFile(
-      path.join(configDir, "config.json"),
-      JSON.stringify({ activeOrg: "my-org" }),
-    );
   });
 
   afterEach(async () => {

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/list.test.ts
@@ -14,6 +14,15 @@ vi.mock("os", async (importOriginal) => {
   return { ...original, homedir: () => TEST_HOME };
 });
 
+function buildFakeCliJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const sig = Buffer.from("fake-signature").toString("base64url");
+  return `vm0_sandbox_${header}.${body}.${sig}`;
+}
+
 describe("zero org list command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -26,8 +35,13 @@ describe("zero org list command", () => {
   beforeEach(async () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
-    vi.stubEnv("VM0_TOKEN", "test-token");
-    vi.stubEnv("VM0_ACTIVE_ORG", "my-org");
+    const cliJwt = buildFakeCliJwt({
+      scope: "cli",
+      orgId: "my-org",
+      userId: "user-1",
+      tokenId: "tok-1",
+    });
+    vi.stubEnv("VM0_TOKEN", cliJwt);
     const configDir = path.join(TEST_HOME, ".vm0");
     await mkdir(configDir, { recursive: true });
     await writeFile(

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/set.test.ts
@@ -65,6 +65,13 @@ describe("zero org set command", () => {
   });
 
   it("should update organization with --force", async () => {
+    const newJwt = buildFakeCliJwt({
+      scope: "cli",
+      orgId: "org-id-new",
+      userId: "user-1",
+      tokenId: "tok-1",
+    });
+
     server.use(
       http.get("http://localhost:3000/api/zero/org", () => {
         return HttpResponse.json({
@@ -80,6 +87,14 @@ describe("zero org set command", () => {
           slug: "newslug",
           createdAt: "2024-01-01T00:00:00Z",
           updatedAt: "2024-01-01T00:00:00Z",
+        });
+      }),
+      http.post("http://localhost:3000/api/cli/auth/org", () => {
+        return HttpResponse.json({
+          access_token: newJwt,
+          token_type: "Bearer",
+          expires_in: 7776000,
+          org_slug: "newslug",
         });
       }),
     );

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/use.test.ts
@@ -40,6 +40,13 @@ describe("zero org use command", () => {
   });
 
   it("should switch to a valid organization", async () => {
+    const newJwt = buildFakeCliJwt({
+      scope: "cli",
+      orgId: "org-id-b",
+      userId: "user-1",
+      tokenId: "tok-1",
+    });
+
     server.use(
       http.get("http://localhost:3000/api/zero/org/list", () => {
         return HttpResponse.json({
@@ -48,6 +55,14 @@ describe("zero org use command", () => {
             { slug: "org-b", role: "member" },
           ],
           active: undefined,
+        });
+      }),
+      http.post("http://localhost:3000/api/cli/auth/org", () => {
+        return HttpResponse.json({
+          access_token: newJwt,
+          token_type: "Bearer",
+          expires_in: 7776000,
+          org_slug: "org-b",
         });
       }),
     );

--- a/turbo/apps/cli/src/commands/zero/org/leave.ts
+++ b/turbo/apps/cli/src/commands/zero/org/leave.ts
@@ -1,8 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { leaveZeroOrg, listZeroOrgs, switchZeroOrg } from "../../../lib/api";
-import { saveConfig, getToken } from "../../../lib/api/config";
-import { decodeCliTokenPayload } from "../../../lib/api/cli-token";
+import { saveConfig } from "../../../lib/api/config";
 import { withErrorHandler } from "../../../lib/command";
 
 export const leaveCommand = new Command()
@@ -23,17 +22,11 @@ export const leaveCommand = new Command()
       }
 
       const nextOrg = orgs[0]!.slug;
-      const token = await getToken();
-      if (decodeCliTokenPayload(token)) {
-        // JWT flow: get new token for next org
-        const result = await switchZeroOrg(nextOrg);
-        await saveConfig({
-          token: result.access_token,
-          activeOrg: result.org_slug,
-        });
-      } else {
-        await saveConfig({ activeOrg: nextOrg });
-      }
+      const result = await switchZeroOrg(nextOrg);
+      await saveConfig({
+        token: result.access_token,
+        activeOrg: result.org_slug,
+      });
       console.log(chalk.green(`✓ Left organization. Switched to: ${nextOrg}`));
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/org/leave.ts
+++ b/turbo/apps/cli/src/commands/zero/org/leave.ts
@@ -13,7 +13,7 @@ export const leaveCommand = new Command()
 
       const { orgs } = await listZeroOrgs();
       if (orgs.length === 0) {
-        await saveConfig({ activeOrg: undefined, token: undefined });
+        await saveConfig({ token: undefined });
         console.log(chalk.green("✓ Left organization."));
         console.log(
           chalk.yellow("No remaining organizations. Run: vm0 auth login"),
@@ -25,7 +25,6 @@ export const leaveCommand = new Command()
       const result = await switchZeroOrg(nextOrg);
       await saveConfig({
         token: result.access_token,
-        activeOrg: result.org_slug,
       });
       console.log(chalk.green(`✓ Left organization. Switched to: ${nextOrg}`));
     }),

--- a/turbo/apps/cli/src/commands/zero/org/set.ts
+++ b/turbo/apps/cli/src/commands/zero/org/set.ts
@@ -1,8 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { getZeroOrg, updateZeroOrg, switchZeroOrg } from "../../../lib/api";
-import { saveConfig, getToken } from "../../../lib/api/config";
-import { decodeCliTokenPayload } from "../../../lib/api/cli-token";
+import { saveConfig } from "../../../lib/api/config";
 import { withErrorHandler } from "../../../lib/command";
 
 export const setCommand = new Command()
@@ -29,17 +28,11 @@ export const setCommand = new Command()
 
         const org = await updateZeroOrg({ slug, force: true });
 
-        const token = await getToken();
-        if (decodeCliTokenPayload(token)) {
-          // JWT flow: get new token with updated org context
-          const result = await switchZeroOrg(org.slug);
-          await saveConfig({
-            token: result.access_token,
-            activeOrg: result.org_slug,
-          });
-        } else {
-          await saveConfig({ activeOrg: org.slug });
-        }
+        const result = await switchZeroOrg(org.slug);
+        await saveConfig({
+          token: result.access_token,
+          activeOrg: result.org_slug,
+        });
 
         console.log(chalk.green(`✓ Organization updated to ${org.slug}`));
         console.log();

--- a/turbo/apps/cli/src/commands/zero/org/set.ts
+++ b/turbo/apps/cli/src/commands/zero/org/set.ts
@@ -31,7 +31,6 @@ export const setCommand = new Command()
         const result = await switchZeroOrg(org.slug);
         await saveConfig({
           token: result.access_token,
-          activeOrg: result.org_slug,
         });
 
         console.log(chalk.green(`✓ Organization updated to ${org.slug}`));

--- a/turbo/apps/cli/src/commands/zero/org/use.ts
+++ b/turbo/apps/cli/src/commands/zero/org/use.ts
@@ -1,8 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { listZeroOrgs, switchZeroOrg } from "../../../lib/api";
-import { saveConfig, getToken } from "../../../lib/api/config";
-import { decodeCliTokenPayload } from "../../../lib/api/cli-token";
+import { saveConfig } from "../../../lib/api/config";
 import { withErrorHandler } from "../../../lib/command";
 
 export const useCommand = new Command()
@@ -17,18 +16,11 @@ export const useCommand = new Command()
         throw new Error(`Organization '${slug}' not found or not accessible.`);
       }
 
-      const token = await getToken();
-      if (decodeCliTokenPayload(token)) {
-        // JWT flow: get new token from server
-        const result = await switchZeroOrg(slug);
-        await saveConfig({
-          token: result.access_token,
-          activeOrg: result.org_slug,
-        });
-      } else {
-        // Legacy flow: just update config
-        await saveConfig({ activeOrg: slug });
-      }
+      const result = await switchZeroOrg(slug);
+      await saveConfig({
+        token: result.access_token,
+        activeOrg: result.org_slug,
+      });
       console.log(chalk.green(`✓ Switched to organization: ${slug}`));
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/org/use.ts
+++ b/turbo/apps/cli/src/commands/zero/org/use.ts
@@ -19,7 +19,6 @@ export const useCommand = new Command()
       const result = await switchZeroOrg(slug);
       await saveConfig({
         token: result.access_token,
-        activeOrg: result.org_slug,
       });
       console.log(chalk.green(`✓ Switched to organization: ${slug}`));
     }),

--- a/turbo/apps/cli/src/lib/api/__tests__/cli-token.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/cli-token.test.ts
@@ -31,10 +31,6 @@ describe("decodeCliTokenPayload", () => {
     });
   });
 
-  it("should return undefined for vm0_live_ tokens (old format)", () => {
-    expect(decodeCliTokenPayload("vm0_live_abc123")).toBeUndefined();
-  });
-
   it("should return undefined for zero-scoped tokens", () => {
     const token = buildCliJwt({
       scope: "zero",

--- a/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
+++ b/turbo/apps/cli/src/lib/api/__tests__/config.test.ts
@@ -83,15 +83,6 @@ describe("token resolution", () => {
       return `vm0_sandbox_${header}.${body}.${sig}`;
     }
 
-    async function writeConfigOrg(activeOrg: string): Promise<void> {
-      const configDir = path.join(TEST_HOME, ".vm0");
-      await fs.mkdir(configDir, { recursive: true });
-      await fs.writeFile(
-        path.join(configDir, "config.json"),
-        JSON.stringify({ activeOrg }),
-      );
-    }
-
     it("should return orgId from ZERO_TOKEN when set", async () => {
       vi.stubEnv(
         "ZERO_TOKEN",
@@ -106,35 +97,7 @@ describe("token resolution", () => {
       expect(org).toBe("org-from-jwt");
     });
 
-    it("should prefer ZERO_TOKEN over VM0_ACTIVE_ORG", async () => {
-      vi.stubEnv(
-        "ZERO_TOKEN",
-        buildFakeJwt({ scope: "zero", orgId: "jwt-org", capabilities: [] }),
-      );
-      vi.stubEnv("VM0_ACTIVE_ORG", "env-org");
-
-      const org = await getActiveOrg();
-      expect(org).toBe("jwt-org");
-    });
-
-    it("should fall back to VM0_ACTIVE_ORG when ZERO_TOKEN is absent", async () => {
-      vi.stubEnv("VM0_ACTIVE_ORG", "env-org");
-
-      const org = await getActiveOrg();
-      expect(org).toBe("env-org");
-    });
-
-    it("should fall back to config file when both env vars are absent", async () => {
-      vi.stubEnv("VM0_ACTIVE_ORG", "");
-      await writeConfigOrg("config-org");
-
-      const org = await getActiveOrg();
-      expect(org).toBe("config-org");
-    });
-
-    it("should return undefined when nothing is set", async () => {
-      vi.stubEnv("VM0_ACTIVE_ORG", "");
-
+    it("should return undefined when no JWT token is available", async () => {
       const org = await getActiveOrg();
       expect(org).toBeUndefined();
     });
@@ -144,10 +107,9 @@ describe("token resolution", () => {
         "ZERO_TOKEN",
         buildFakeJwt({ scope: "sandbox", runId: "run-1" }),
       );
-      vi.stubEnv("VM0_ACTIVE_ORG", "fallback-org");
 
       const org = await getActiveOrg();
-      expect(org).toBe("fallback-org");
+      expect(org).toBeUndefined();
     });
 
     it("should ignore compose-job-scoped token", async () => {
@@ -155,26 +117,23 @@ describe("token resolution", () => {
         "ZERO_TOKEN",
         buildFakeJwt({ scope: "compose-job", jobId: "job-1" }),
       );
-      vi.stubEnv("VM0_ACTIVE_ORG", "fallback-org");
 
       const org = await getActiveOrg();
-      expect(org).toBe("fallback-org");
+      expect(org).toBeUndefined();
     });
 
     it("should ignore malformed ZERO_TOKEN", async () => {
       vi.stubEnv("ZERO_TOKEN", "not-a-valid-token");
-      vi.stubEnv("VM0_ACTIVE_ORG", "fallback-org");
 
       const org = await getActiveOrg();
-      expect(org).toBe("fallback-org");
+      expect(org).toBeUndefined();
     });
 
     it("should ignore ZERO_TOKEN with invalid base64 payload", async () => {
       vi.stubEnv("ZERO_TOKEN", "vm0_sandbox_header.!!!invalid!!!.signature");
-      vi.stubEnv("VM0_ACTIVE_ORG", "fallback-org");
 
       const org = await getActiveOrg();
-      expect(org).toBe("fallback-org");
+      expect(org).toBeUndefined();
     });
 
     it("should return orgId from CLI JWT when config token is JWT format", async () => {
@@ -188,19 +147,6 @@ describe("token resolution", () => {
 
       const org = await getActiveOrg();
       expect(org).toBe("cli-org");
-    });
-
-    it("should fall back to config activeOrg when token is vm0_live_ format", async () => {
-      vi.stubEnv("VM0_ACTIVE_ORG", "");
-      const configDir = path.join(TEST_HOME, ".vm0");
-      await fs.mkdir(configDir, { recursive: true });
-      await fs.writeFile(
-        path.join(configDir, "config.json"),
-        JSON.stringify({ token: "vm0_live_abc123", activeOrg: "config-org" }),
-      );
-
-      const org = await getActiveOrg();
-      expect(org).toBe("config-org");
     });
 
     it("should prefer ZERO_TOKEN JWT over CLI JWT", async () => {
@@ -220,8 +166,7 @@ describe("token resolution", () => {
       expect(org).toBe("zero-org");
     });
 
-    it("should prefer CLI JWT over VM0_ACTIVE_ORG env var", async () => {
-      vi.stubEnv("VM0_ACTIVE_ORG", "env-org");
+    it("should return orgId from CLI JWT in config", async () => {
       const cliJwt = buildFakeJwt({
         scope: "cli",
         orgId: "cli-org",

--- a/turbo/apps/cli/src/lib/api/auth.ts
+++ b/turbo/apps/cli/src/lib/api/auth.ts
@@ -131,7 +131,6 @@ export async function authenticate(apiUrl?: string): Promise<void> {
       await saveConfig({
         token: tokenResult.access_token,
         apiUrl: targetApiUrl,
-        ...(tokenResult.org_slug && { activeOrg: tokenResult.org_slug }),
       });
 
       console.log(chalk.green("\nAuthentication successful!"));

--- a/turbo/apps/cli/src/lib/api/config.ts
+++ b/turbo/apps/cli/src/lib/api/config.ts
@@ -80,26 +80,19 @@ export { decodeZeroTokenPayload };
 
 /**
  * Get the active organization for API requests.
- * Priority: ZERO_TOKEN JWT orgId > CLI JWT orgId > VM0_ACTIVE_ORG env var > activeOrg from config file
+ * Priority: ZERO_TOKEN JWT orgId > CLI JWT orgId
  */
 export async function getActiveOrg(): Promise<string | undefined> {
   // Prefer orgId decoded from ZERO_TOKEN JWT (zero agent runs)
   const zeroPayload = decodeZeroTokenPayload();
   if (zeroPayload) return zeroPayload.orgId;
 
-  // Try CLI JWT token (new format: vm0_sandbox_ with scope "cli")
+  // CLI JWT token carries orgId in payload
   const token = await getToken();
   const cliPayload = decodeCliTokenPayload(token);
   if (cliPayload) return cliPayload.orgId;
 
-  // Fall back to VM0_ACTIVE_ORG env var (legacy)
-  if (process.env.VM0_ACTIVE_ORG) {
-    return process.env.VM0_ACTIVE_ORG;
-  }
-
-  // Fall back to config file
-  const config = await loadConfig();
-  return config.activeOrg;
+  return undefined;
 }
 
 export async function clearConfig(): Promise<void> {

--- a/turbo/apps/cli/src/lib/api/config.ts
+++ b/turbo/apps/cli/src/lib/api/config.ts
@@ -8,7 +8,6 @@ import { decodeZeroTokenPayload } from "./zero-token.js";
 interface CliConfig {
   token?: string;
   apiUrl?: string;
-  activeOrg?: string;
 }
 
 // Use functions for lazy evaluation (enables testing with mocked homedir)

--- a/turbo/apps/cli/src/lib/api/core/client-factory.ts
+++ b/turbo/apps/cli/src/lib/api/core/client-factory.ts
@@ -1,7 +1,4 @@
-import { tsRestFetchApi } from "@ts-rest/core";
-import { getApiUrl, getActiveToken, getActiveOrg } from "../config";
-import { decodeCliTokenPayload } from "../cli-token";
-import { decodeZeroTokenPayload } from "../zero-token";
+import { getApiUrl, getActiveToken } from "../config";
 import type { ApiErrorResponse } from "@vm0/core";
 
 /**
@@ -59,39 +56,8 @@ export async function getClientConfig() {
   }
   const baseHeaders = buildHeaders(token);
 
-  // Check if current token is a self-signed JWT with embedded orgId
-  const jwtPayload =
-    decodeCliTokenPayload(token) ?? decodeZeroTokenPayload(token);
-
-  if (jwtPayload) {
-    // JWT tokens carry orgId in payload — server extracts it from authCtx.orgId
-    return { baseUrl, baseHeaders, jsonQuery: false as const };
-  }
-
-  // Legacy opaque tokens: inject ?org= query parameter
-  const activeOrg = await getActiveOrg();
-  if (!activeOrg) {
-    throw new Error(
-      "No active organization configured. Run: zero org use <slug>",
-    );
-  }
-
-  return {
-    baseUrl,
-    baseHeaders,
-    jsonQuery: false as const,
-    api: async (args: Parameters<typeof tsRestFetchApi>[0]) => {
-      const [pathPart, queryPart] = args.path.split("?");
-      const params = new URLSearchParams(queryPart ?? "");
-      if (!params.has("org")) {
-        params.set("org", activeOrg);
-      }
-      args.path = params.toString()
-        ? `${pathPart}?${params.toString()}`
-        : pathPart!;
-      return tsRestFetchApi(args);
-    },
-  };
+  // JWT tokens carry orgId in payload — server extracts it from authCtx.orgId
+  return { baseUrl, baseHeaders, jsonQuery: false as const };
 }
 
 /**

--- a/turbo/apps/cli/src/lib/api/domains/zero-orgs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-orgs.ts
@@ -20,7 +20,7 @@ import {
 import { getToken } from "../config";
 
 /**
- * Get client config that always uses the user token (vm0_live_),
+ * Get client config that always uses the user token,
  * not the org token. Used for org list operations.
  */
 async function getUserTokenClientConfig(): Promise<{

--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -100,15 +100,15 @@ describe("proxy middleware: sandbox token handling", () => {
     expect(capturedClerkRequest!.headers.get("x-vm0-authorization")).toBeNull();
   });
 
-  it("should pass CLI tokens through to Clerk unchanged", async () => {
-    const token = "Bearer vm0_live_abc123def456";
+  it("should pass non-sandbox tokens through to Clerk unchanged", async () => {
+    const token = "Bearer invalid_abc123def456";
     const request = new NextRequest("https://www.vm0.ai/api/runs", {
       headers: { authorization: token },
     });
 
     await middleware(request, createMockEvent());
 
-    // CLI tokens (vm0_live_) are not sandbox tokens and should pass through
+    // Non-sandbox tokens should pass through to Clerk
     expect(capturedClerkRequest).toBeDefined();
     expect(capturedClerkRequest!.headers.get("authorization")).toBe(token);
   });

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -174,7 +174,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              Authorization: "Bearer vm0_live_nonexistent_token",
+              Authorization: "Bearer invalid_nonexistent_token",
             },
             body: JSON.stringify({}),
           },

--- a/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
@@ -88,7 +88,7 @@ describe("POST /api/runners/realtime/token", () => {
       const response = await POST(
         makeRequest(
           { group: "vm0/production" },
-          "Bearer vm0_live_nonexistent_token",
+          "Bearer invalid_nonexistent_token",
         ),
       );
       const data = await response.json();

--- a/turbo/apps/web/src/db/schema/cli-tokens.ts
+++ b/turbo/apps/web/src/db/schema/cli-tokens.ts
@@ -2,7 +2,7 @@ import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 
 export const cliTokens = pgTable("cli_tokens", {
   id: uuid("id").defaultRandom().primaryKey(),
-  token: text("token").unique().notNull(), // vm0_live_xxxxx...
+  token: text("token").unique().notNull(), // vm0_sandbox_<jwt>
   userId: text("user_id").notNull(), // Clerk user ID
   name: text("name").notNull(), // User-friendly name
   expiresAt: timestamp("expires_at").notNull(),

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -128,10 +128,6 @@ describe("sandbox-token", () => {
       expect(isSandboxToken("vm0_sandbox_anything")).toBe(true);
     });
 
-    it("should return false for CLI tokens", () => {
-      expect(isSandboxToken("vm0_live_abc123")).toBe(false);
-    });
-
     it("should return false for raw JWTs without prefix", () => {
       expect(isSandboxToken("a.b.c")).toBe(false);
       expect(isSandboxToken("header.payload.signature")).toBe(false);

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -63,32 +63,6 @@ export async function getAuthContext(
       }
       return authenticateSandboxToken(token, options);
     }
-
-    // Check for CLI token format (vm0_live_)
-    if (token.startsWith("vm0_live_")) {
-      const [tokenRecord] = await globalThis.services.db
-        .select()
-        .from(cliTokens)
-        .where(
-          and(eq(cliTokens.token, token), gt(cliTokens.expiresAt, new Date())),
-        )
-        .limit(1);
-
-      if (!tokenRecord) {
-        return null;
-      }
-
-      // Update last used timestamp (non-blocking)
-      globalThis.services.db
-        .update(cliTokens)
-        .set({ lastUsedAt: new Date() })
-        .where(eq(cliTokens.token, token))
-        .catch((err) => log.error("Failed to update token lastUsedAt:", err));
-
-      return {
-        userId: tokenRecord.userId,
-      };
-    }
   }
 
   // Fall back to Clerk session auth

--- a/turbo/apps/web/src/lib/auth/get-sandbox-auth.ts
+++ b/turbo/apps/web/src/lib/auth/get-sandbox-auth.ts
@@ -38,8 +38,7 @@ export function getSandboxAuthForRun(
 
   const token = authHeader.substring(7); // Remove "Bearer "
 
-  // Only accept JWT tokens (sandbox tokens)
-  // Regular CLI tokens (vm0_live_xxx) are rejected
+  // Only accept JWT tokens with sandbox scope
   if (!isSandboxToken(token)) {
     log.debug("Rejected non-JWT token on webhook endpoint");
     return null;

--- a/turbo/apps/web/src/lib/auth/runner-auth.ts
+++ b/turbo/apps/web/src/lib/auth/runner-auth.ts
@@ -2,12 +2,10 @@
  * Runner authentication module
  *
  * Handles authentication for runner endpoints (poll, claim).
- * Supports official runners (vm0_official_*) and user runners (vm0_live_*).
+ * Supports official runners (vm0_official_*) and user runners (via CLI JWT tokens).
  */
 
-import { eq, and, gt } from "drizzle-orm";
 import { initServices } from "../init-services";
-import { cliTokens } from "../../db/schema/cli-tokens";
 import { isSandboxToken, verifyCliToken } from "./sandbox-token";
 import { resolveCliTokenFromDb } from "./get-auth-context";
 import { logger } from "../logger";
@@ -69,8 +67,8 @@ function validateOfficialRunnerSecret(providedSecret: string): boolean {
  *    - Validated against OFFICIAL_RUNNER_SECRET env var
  *    - Returns { type: 'official-runner' }
  *
- * 2. User runner: Uses `vm0_live_<token>` CLI token format
- *    - Validated against cli_tokens table
+ * 2. User runner: Uses CLI JWT token (`vm0_sandbox_` prefix with scope "cli")
+ *    - Validated via JWT signature + cli_tokens table revocation check
  *    - Returns { type: 'user', userId }
  *
  * @param authHeader - The Authorization header value (optional)
@@ -113,35 +111,6 @@ export async function getRunnerAuth(
     }
 
     log.warn("Invalid official runner secret");
-    return null;
-  }
-
-  // Check for CLI token format (vm0_live_)
-  if (token.startsWith("vm0_live_")) {
-    initServices();
-
-    const [tokenRecord] = await globalThis.services.db
-      .select()
-      .from(cliTokens)
-      .where(
-        and(eq(cliTokens.token, token), gt(cliTokens.expiresAt, new Date())),
-      )
-      .limit(1);
-
-    if (tokenRecord) {
-      // Update last used timestamp (non-blocking)
-      globalThis.services.db
-        .update(cliTokens)
-        .set({ lastUsedAt: new Date() })
-        .where(eq(cliTokens.token, token))
-        .catch((err) => log.error("Failed to update token lastUsedAt:", err));
-
-      return {
-        type: "user",
-        userId: tokenRecord.userId,
-      };
-    }
-
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Remove all `vm0_live_` opaque CLI token code paths from server-side auth (`get-auth-context.ts`, `runner-auth.ts`) and CLI-side (`client-factory.ts`, `config.ts`)
- Simplify `getActiveOrg()` to only decode orgId from JWT tokens (remove `VM0_ACTIVE_ORG` env var and `config.activeOrg` fallbacks)
- Remove legacy `else` branches in org commands (`use`, `leave`, `set`) that handled opaque token flow
- Update stale comments and test fixtures referencing `vm0_live_`

## Test plan

- [x] All 55 directly affected tests pass (auth, config, proxy, runner, org commands, whoami)
- [x] Full test suite passes (only pre-existing failures in unrelated areas)
- [x] Lint passes with 0 warnings
- [x] Knip finds no unused exports/dependencies
- [x] TypeScript types check (pre-existing `@clerk/backend` issue only)
- [x] No remaining `vm0_live_` references in codebase

Closes #6778

🤖 Generated with [Claude Code](https://claude.com/claude-code)