### PR TITLE
fix(billing): address P1 review issues from PR #6760

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -20,6 +20,13 @@ export type BillingTier = "free" | "pro" | "team";
 
 export type BillingStatus = BillingStatusResponse;
 
+export function apiTierToBillingTier(tier: string | undefined): BillingTier {
+  if (tier === "free" || tier === "pro" || tier === "team") {
+    return tier;
+  }
+  return "free";
+}
+
 /** Extract error message from a ts-rest error response body. */
 function getErrorMessage(body: unknown): string | undefined {
   if (typeof body !== "object" || body === null || !("error" in body)) {

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -11,6 +11,7 @@ import { Button, Input, Switch } from "@vm0/ui";
 import { IconCheck } from "@tabler/icons-react";
 import {
   type BillingTier,
+  apiTierToBillingTier,
   billingDialogOpen$,
   billingDialogLoading$,
   billingStatusAsync$,
@@ -357,7 +358,7 @@ export function BillingDialog() {
   const selectedTier = useGet(selectedPlanTier$);
   const setSelectedTier = useSet(setSelectedPlanTier$);
 
-  const currentTier: BillingTier = (status?.tier as BillingTier) ?? "free";
+  const currentTier: BillingTier = apiTierToBillingTier(status?.tier);
 
   const selectedOrder = TIER_ORDER[selectedTier];
   const currentOrder = TIER_ORDER[currentTier];
@@ -365,8 +366,8 @@ export function BillingDialog() {
   const isDowngrade = selectedOrder < currentOrder;
 
   const handleAction = () => {
-    if (isUpgrade) {
-      detach(checkout(selectedTier as "pro" | "team"), Reason.DomCallback);
+    if (isUpgrade && (selectedTier === "pro" || selectedTier === "team")) {
+      detach(checkout(selectedTier), Reason.DomCallback);
     } else if (isDowngrade) {
       detach(downgrade(), Reason.DomCallback);
     }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -12,6 +12,7 @@ import {
   startCheckout$,
   startDowngrade$,
   billingDialogLoading$,
+  apiTierToBillingTier,
   type BillingTier,
 } from "../../../../signals/zero-page/billing.ts";
 import { Button } from "@vm0/ui";
@@ -37,13 +38,6 @@ function tierRank(t: BillingTier): number {
     return 1;
   }
   return 2;
-}
-
-function apiTierToBillingTier(tier: string | undefined): BillingTier {
-  if (tier === "free" || tier === "pro" || tier === "team") {
-    return tier;
-  }
-  return "free";
 }
 
 const PLANS = [
@@ -250,7 +244,10 @@ function PricingPage({
       detach(portal(), Reason.DomCallback);
       return;
     }
-    detach(checkout(planTier as "pro" | "team"), Reason.DomCallback);
+    if (planTier !== "pro" && planTier !== "team") {
+      return;
+    }
+    detach(checkout(planTier), Reason.DomCallback);
   };
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -3,11 +3,13 @@ import { useLoadable, useSet } from "ccstate-react";
 import type { OrgMember, MemberUsage } from "@vm0/core";
 import { IconUsers } from "@tabler/icons-react";
 import { Input, Popover, PopoverAnchor, PopoverContent } from "@vm0/ui";
+import { toast } from "@vm0/ui/components/ui/sonner";
 import { usageMembersAsync$ } from "../../../../signals/usage-page/usage-signals.ts";
 import { orgMembers$ } from "../../../../signals/external/org-members.ts";
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
 import {
   billingStatusAsync$,
+  apiTierToBillingTier,
   type BillingTier,
 } from "../../../../signals/zero-page/billing.ts";
 import { setMemberCreditCap$ } from "../../../../signals/zero-page/member-credit-caps.ts";
@@ -216,13 +218,6 @@ function displayName(m: OrgMember): string {
   return parts.length > 0 ? parts.join(" ") : "";
 }
 
-function apiTierToBillingTier(tier: string | undefined): BillingTier {
-  if (tier === "free" || tier === "pro" || tier === "team") {
-    return tier;
-  }
-  return "free";
-}
-
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
@@ -281,6 +276,7 @@ function InlineCapInput({
         setSaving(false);
       })().catch(() => {
         setSaving(false);
+        toast.error("Failed to update credit cap. Please try again.");
       }),
       Reason.DomCallback,
     );
@@ -298,7 +294,7 @@ function InlineCapInput({
       onKeyDown={(e) => {
         if (e.key === "Enter") {
           commit();
-          (e.target as HTMLInputElement).blur();
+          e.currentTarget.blur();
         }
       }}
       disabled={saving}


### PR DESCRIPTION
## Summary
- Add `toast.error()` in `InlineCapInput` catch block so users see feedback when credit cap save fails (was silently swallowed)
- Replace `as BillingTier` cast with `apiTierToBillingTier()` helper in billing-dialog
- Replace `as "pro" | "team"` casts with proper type narrowing guards in billing-tab and billing-dialog
- Replace `(e.target as HTMLInputElement).blur()` with `e.currentTarget.blur()` for type safety
- Extract shared `apiTierToBillingTier` to `billing.ts` signal module, removing duplicated definitions from org-billing-tab and org-usage-tab

## Context
Follow-up to PR #6760 addressing P1 issues identified in code review:
1. **Silent error swallowing** in `InlineCapInput` -- users had no feedback when cap save failed
2. **Type assertions** (`as` casts) instead of proper type narrowing
3. **Code duplication** of `apiTierToBillingTier` across 2 files

## Test plan
- [x] All existing billing tab tests pass (15/15)
- [x] Type checking passes
- [x] Lint passes (0 errors, 0 warnings)
- [x] Knip reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)