### PR TITLE
test: add slack integration test coverage for uncovered modules

### DIFF
--- a/.github/semgrep-baseline.json
+++ b/.github/semgrep-baseline.json
@@ -4,7 +4,7 @@
   "generic.secrets.security.detected-github-token.detected-github-token": 1,
   "generic.secrets.security.detected-google-oauth-access-token.detected-google-oauth-access-token": 6,
   "javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp": 5,
-  "javascript.lang.security.audit.hardcoded-hmac-key.hardcoded-hmac-key": 6,
+  "javascript.lang.security.audit.hardcoded-hmac-key.hardcoded-hmac-key": 7,
   "javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal": 43,
   "javascript.lang.security.audit.spawn-shell-true.spawn-shell-true": 1,
   "javascript.lang.security.detect-child-process.detect-child-process": 1,

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../../src/__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestRun,
+  createTestCallback,
+  createTestSlackOrgInstallation,
+  createTestRequest,
+  seedTestSlackOrgConnection,
+  completeTestRun,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import { computeHmacSignature } from "../../../../../../../src/lib/callback/hmac";
+import { POST } from "../route";
+
+const context = testContext();
+
+interface OrgCallbackPayload {
+  workspaceId: string;
+  channelId: string;
+  threadTs: string;
+  messageTs: string;
+  connectionId: string;
+  agentId: string;
+  existingSessionId?: string | undefined;
+}
+
+function createCallbackRequest(
+  body: {
+    runId: string;
+    status: "completed" | "failed" | "progress";
+    error?: string;
+    payload: OrgCallbackPayload;
+  },
+  secret: string,
+): NextRequest {
+  const bodyString = JSON.stringify(body);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signature = computeHmacSignature(bodyString, secret, timestamp);
+
+  return createTestRequest(
+    "http://localhost/api/internal/callbacks/slack/org",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-VM0-Signature": signature,
+        "X-VM0-Timestamp": timestamp.toString(),
+      },
+      body: bodyString,
+    },
+  );
+}
+
+describe("POST /api/internal/callbacks/slack/org", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  async function setupOrgSlack() {
+    const workspaceId = uniqueId("T-ws");
+    const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+      workspaceId,
+      orgId: user.orgId,
+    });
+    const { connectionId } = await seedTestSlackOrgConnection({
+      slackUserId: uniqueId("U-slack"),
+      slackWorkspaceId: slackWorkspaceId,
+      vm0UserId: user.userId,
+    });
+    return { workspaceId: slackWorkspaceId, connectionId };
+  }
+
+  it("rejects request with invalid payload (missing required fields)", async () => {
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRun(composeId, "Test prompt");
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: {
+        workspaceId: "T-test",
+      },
+    });
+
+    const request = createCallbackRequest(
+      {
+        runId,
+        status: "completed",
+        payload: {
+          workspaceId: "T-test",
+          channelId: undefined as unknown as string,
+          threadTs: undefined as unknown as string,
+          messageTs: undefined as unknown as string,
+          connectionId: undefined as unknown as string,
+          agentId: undefined as unknown as string,
+        },
+      },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+  });
+
+  it("verifyCallback returns correct payload for valid request", async () => {
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRun(composeId, "Test prompt");
+
+    const payload: OrgCallbackPayload = {
+      workspaceId: uniqueId("T-ws"),
+      channelId: uniqueId("C-ch"),
+      threadTs: uniqueId("ts"),
+      messageTs: uniqueId("ts"),
+      connectionId: uniqueId("conn"),
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createCallbackRequest(
+      { runId, status: "progress", payload },
+      secret,
+    );
+
+    // Call verifyCallback directly to see what it returns
+    const { verifyCallback } = await import(
+      "../../../../../../../src/lib/callback"
+    );
+    const log = { warn: () => {} };
+    const result = await verifyCallback(request, log);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const p = result.data.payload as Record<string, unknown>;
+      expect(p).toBeDefined();
+      expect(typeof p.workspaceId).toBe("string");
+      expect(typeof p.channelId).toBe("string");
+      expect(typeof p.agentId).toBe("string");
+      expect(p.workspaceId).toBe(payload.workspaceId);
+    }
+  });
+
+  it("handles progress status by setting thinking status", async () => {
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRun(composeId, "Test prompt");
+
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId: uniqueId("C-ch"),
+      threadTs: uniqueId("ts"),
+      messageTs: uniqueId("ts"),
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createCallbackRequest(
+      { runId, status: "progress", payload },
+      secret,
+    );
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect({ status: response.status, data }).toEqual(
+      expect.objectContaining({ status: 200, data: { success: true } }),
+    );
+
+    // Verify thread status was set
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    expect(mockClient.assistant.threads.setStatus).toHaveBeenCalled();
+  });
+
+  it("posts completion message to Slack thread", async () => {
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createCallbackRequest(
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect({ status: response.status, data }).toEqual(
+      expect.objectContaining({ status: 200, data: { success: true } }),
+    );
+
+    // Verify message was posted to the thread
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    expect(mockClient.chat.postMessage).toHaveBeenCalled();
+    const call = (
+      mockClient.chat.postMessage as ReturnType<typeof import("vitest").vi.fn>
+    ).mock.calls[0]![0] as { channel: string; thread_ts: string };
+    expect(call.channel).toBe(channelId);
+    expect(call.thread_ts).toBe(threadTs);
+  });
+
+  it("posts error message for failed status", async () => {
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRun(composeId, "Test prompt");
+
+    const channelId = uniqueId("C-ch");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs: uniqueId("ts"),
+      messageTs: uniqueId("ts"),
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createCallbackRequest(
+      { runId, status: "failed", error: "Something broke", payload },
+      secret,
+    );
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect({ status: response.status, data }).toEqual(
+      expect.objectContaining({ status: 200, data: { success: true } }),
+    );
+
+    // Verify error message was posted
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    expect(mockClient.chat.postMessage).toHaveBeenCalled();
+    const call = (
+      mockClient.chat.postMessage as ReturnType<typeof import("vitest").vi.fn>
+    ).mock.calls[0]![0] as { channel: string; text: string };
+    expect(call.channel).toBe(channelId);
+    expect(call.text).toContain("Something broke");
+  });
+
+  it("returns 404 when installation is not found (non-progress)", async () => {
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRun(composeId, "Test prompt");
+
+    const payload: OrgCallbackPayload = {
+      workspaceId: "T-nonexistent",
+      channelId: uniqueId("C-ch"),
+      threadTs: uniqueId("ts"),
+      messageTs: uniqueId("ts"),
+      connectionId: uniqueId("conn"),
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createCallbackRequest(
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    const data = await response.json();
+
+    // Should fail with 404 (installation not found), not 400 (payload parse)
+    expect({ status: response.status, data }).toEqual(
+      expect.objectContaining({
+        status: 404,
+        data: { error: "Slack installation not found" },
+      }),
+    );
+  });
+
+  it("clears thread status after posting completion", async () => {
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    await completeTestRun(user.userId, runId);
+
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId: uniqueId("C-ch"),
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createCallbackRequest(
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect({ status: response.status, data }).toEqual(
+      expect.objectContaining({ status: 200, data: { success: true } }),
+    );
+
+    // Thread status should be cleared (empty string)
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const setStatusMock = mockClient.assistant.threads.setStatus as ReturnType<
+      typeof import("vitest").vi.fn
+    >;
+    // Last call should clear the status (empty string)
+    const lastCall = setStatusMock.mock.calls[
+      setStatusMock.mock.calls.length - 1
+    ]![0] as { status: string };
+    expect(lastCall.status).toBe("");
+  });
+});

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/__tests__/route.test.ts
@@ -27,6 +27,7 @@ const context = testContext();
 interface OrgScheduleCallbackPayload {
   scheduleId: string;
   agentId: string;
+  agentName: string;
   userId: string;
   orgId: string;
   slackChannelId?: string | null;
@@ -92,7 +93,7 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
       payload: {
         scheduleId: schedule.id,
         agentId: composeId,
-
+        agentName: "sched-agent",
         userId: user.userId,
         // orgId intentionally missing
       },
@@ -105,7 +106,7 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
         payload: {
           scheduleId: schedule.id,
           agentId: composeId,
-
+          agentName: "sched-agent",
           userId: user.userId,
           orgId: undefined as unknown as string, // missing orgId
         },
@@ -130,7 +131,7 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
     const payload: OrgScheduleCallbackPayload = {
       scheduleId: schedule.id,
       agentId: composeId,
-
+      agentName: "sched-agent",
       userId: user.userId,
       orgId: user.orgId,
       slackChannelId: "C-TARGET-CHANNEL",
@@ -197,7 +198,7 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
     const payload: OrgScheduleCallbackPayload = {
       scheduleId: schedule.id,
       agentId: composeId,
-
+      agentName: "sched-agent",
       userId: user.userId,
       orgId: user.orgId,
       // slackChannelId not set — should fall back to DM
@@ -244,7 +245,7 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
     const payload: OrgScheduleCallbackPayload = {
       scheduleId: schedule.id,
       agentId: composeId,
-
+      agentName: "sched-agent",
       userId: user.userId,
       orgId: user.orgId,
       slackChannelId: "C-FAIL-CHANNEL",
@@ -308,7 +309,7 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
     const payload: OrgScheduleCallbackPayload = {
       scheduleId: schedule.id,
       agentId: composeId,
-
+      agentName: "sched-agent",
       userId: user.userId,
       orgId: user.orgId,
       slackChannelId: "C-DEEP-LINK",
@@ -377,6 +378,7 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
     const payload: OrgScheduleCallbackPayload = {
       scheduleId: schedule.id,
       agentId: composeId,
+      agentName: "sched-agent",
       userId: user.userId,
       orgId: otherOrgId, // different org — no Slack installation here
     };
@@ -432,6 +434,7 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
     const payload: OrgScheduleCallbackPayload = {
       scheduleId: schedule.id,
       agentId: composeId,
+      agentName: "sched-agent",
       userId: user.userId,
       orgId: orgB,
     };

--- a/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
@@ -1,0 +1,357 @@
+import { createHmac } from "crypto";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestSlackOrgInstallation,
+  seedTestSlackOrgConnection,
+  updateOrgDefaultAgent,
+  countSlackOrgConnections,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../../../src/env";
+
+import { POST } from "../route";
+
+const SIGNING_SECRET = "test-slack-signing-secret";
+
+const context = testContext();
+
+/** Build a URL-encoded slash command body */
+function buildCommandBody(
+  overrides: Partial<{
+    team_id: string;
+    user_id: string;
+    channel_id: string;
+    command: string;
+    text: string;
+  }>,
+): string {
+  const params = new URLSearchParams({
+    token: "test-token",
+    team_id: overrides.team_id ?? "T-test",
+    team_domain: "test-workspace",
+    channel_id: overrides.channel_id ?? "C-test",
+    channel_name: "general",
+    user_id: overrides.user_id ?? "U-test",
+    user_name: "testuser",
+    command: overrides.command ?? "/vm0",
+    text: overrides.text ?? "",
+    response_url: "https://hooks.slack.com/commands/T-test/response",
+    trigger_id: "trigger-123",
+    api_app_id: "A-test",
+  });
+  return params.toString();
+}
+
+/** Create a signed Slack command request */
+function createCommandRequest(body: string): Request {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const baseString = `v0:${timestamp}:${body}`;
+  const signature = `v0=${createHmac("sha256", SIGNING_SECRET).update(baseString).digest("hex")}`;
+
+  return new Request("http://localhost:3000/api/zero/slack/commands", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "x-slack-request-timestamp": timestamp,
+      "x-slack-signature": signature,
+    },
+    body,
+  });
+}
+
+describe("POST /api/zero/slack/commands", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    reloadEnv();
+  });
+
+  describe("signature verification", () => {
+    it("returns 401 when signature headers are missing", async () => {
+      const request = new Request(
+        "http://localhost:3000/api/zero/slack/commands",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: buildCommandBody({ text: "help" }),
+        },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(401);
+    });
+
+    it("returns 401 when signature is invalid", async () => {
+      const body = buildCommandBody({ text: "help" });
+      const request = new Request(
+        "http://localhost:3000/api/zero/slack/commands",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "x-slack-request-timestamp": Math.floor(
+              Date.now() / 1000,
+            ).toString(),
+            "x-slack-signature": "v0=invalid_signature",
+          },
+          body,
+        },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("/vm0 help", () => {
+    it("returns help message for empty text", async () => {
+      const body = buildCommandBody({ text: "" });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.response_type).toBe("ephemeral");
+      expect(data.blocks).toBeDefined();
+    });
+
+    it("returns help message for 'help' subcommand", async () => {
+      const body = buildCommandBody({ text: "help" });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.response_type).toBe("ephemeral");
+    });
+
+    it("returns help message for unknown subcommand", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: slackUserId,
+        text: "foobar",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.response_type).toBe("ephemeral");
+    });
+  });
+
+  describe("/vm0 connect", () => {
+    it("returns not-installed message when no installation exists", async () => {
+      const body = buildCommandBody({
+        team_id: "T-nonexistent",
+        text: "connect",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.response_type).toBe("ephemeral");
+      expect(JSON.stringify(data.blocks)).toContain("hasn't been set up");
+    });
+
+    it("returns login URL when user is not connected", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: "U-not-connected",
+        text: "connect",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.response_type).toBe("ephemeral");
+      // Login message contains a connect URL
+      expect(JSON.stringify(data.blocks)).toContain("connect");
+    });
+
+    it("returns already-connected message when user is connected", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: slackUserId,
+        text: "connect",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.response_type).toBe("ephemeral");
+      expect(JSON.stringify(data.blocks)).toContain("already connected");
+    });
+
+    it("includes agent name in already-connected message when agent is configured", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      const compose = await createTestCompose(uniqueId("agent"));
+      await updateOrgDefaultAgent(user.orgId, compose.agentId);
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: slackUserId,
+        text: "connect",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(JSON.stringify(data.blocks)).toContain("already connected");
+      expect(JSON.stringify(data.blocks)).toContain("workspace agent");
+    });
+  });
+
+  describe("/vm0 disconnect", () => {
+    it("returns not-installed message when no installation exists", async () => {
+      const body = buildCommandBody({
+        team_id: "T-nonexistent",
+        text: "disconnect",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(JSON.stringify(data.blocks)).toContain("hasn't been set up");
+    });
+
+    it("returns error when user is not connected", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: "U-not-connected",
+        text: "disconnect",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(JSON.stringify(data.blocks)).toContain("not connected");
+    });
+
+    it("disconnects user and returns success message", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: slackUserId,
+        text: "disconnect",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(JSON.stringify(data.blocks)).toContain("disconnected");
+
+      // Verify connection was actually deleted
+      expect(await countSlackOrgConnections(workspaceId)).toBe(0);
+    });
+  });
+
+  describe("/vm0 settings", () => {
+    it("returns not-installed message when no installation exists", async () => {
+      const body = buildCommandBody({
+        team_id: "T-nonexistent",
+        text: "settings",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(JSON.stringify(data.blocks)).toContain("hasn't been set up");
+    });
+
+    it("returns login prompt when user is not connected", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: "U-not-connected",
+        text: "settings",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.response_type).toBe("ephemeral");
+      // Login message for unconnected users
+      expect(JSON.stringify(data.blocks)).toContain("connect");
+    });
+
+    it("returns settings link when user is connected", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: slackUserId,
+        text: "settings",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.response_type).toBe("ephemeral");
+      expect(JSON.stringify(data.blocks)).toContain("Settings");
+    });
+  });
+});

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   createTestSlackOrgInstallation,
   seedTestSlackOrgConnection,
   seedTestCompose,
+  seedOrphanCompose,
   seedTestSlackOrgPendingQuestion,
   updateOrgDefaultAgent,
   countSlackOrgInstallations,
@@ -100,6 +101,183 @@ describe("POST /api/zero/slack/events", () => {
     });
   });
 
+  describe("app_mention — pre-dispatch validation", () => {
+    it("silently returns when workspace has no installation", async () => {
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: "T-nonexistent-ws",
+        event: {
+          type: "app_mention",
+          user: "U-random",
+          text: "Hello",
+          ts: uniqueId("ts"),
+          channel: "C-test",
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+      expect(mockClient.chat.postEphemeral).not.toHaveBeenCalled();
+    });
+
+    it("silently returns when installation has no orgId bound", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: null });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_mention",
+          user: "U-random",
+          text: "Hello",
+          ts: uniqueId("ts"),
+          channel: "C-test",
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+      expect(mockClient.chat.postEphemeral).not.toHaveBeenCalled();
+    });
+
+    it("sends ephemeral login prompt when user is not connected", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const channelId = uniqueId("C-ch");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_mention",
+          user: "U-not-connected",
+          text: "Hello agent",
+          ts: uniqueId("ts"),
+          channel: channelId,
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postEphemeral).toHaveBeenCalledOnce();
+      expect(mockClient.chat.postEphemeral).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+          user: "U-not-connected",
+        }),
+      );
+    });
+
+    it("sends ephemeral message when no default agent is configured", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_mention",
+          user: slackUserId,
+          text: "Hello agent",
+          ts: uniqueId("ts"),
+          channel: "C-test",
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postEphemeral).toHaveBeenCalledOnce();
+      expect(mockClient.chat.postEphemeral).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("No agent is configured"),
+        }),
+      );
+    });
+
+    it("sends ephemeral message when configured agent is not found", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      // Create a compose record WITHOUT a zero_agents row so getWorkspaceAgent returns undefined
+      const { composeId: orphanId } = await seedOrphanCompose({
+        userId: user.userId,
+        name: uniqueId("orphan-agent"),
+        orgId: user.orgId,
+      });
+      await updateOrgDefaultAgent(user.orgId, orphanId);
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_mention",
+          user: slackUserId,
+          text: "Hello agent",
+          ts: uniqueId("ts"),
+          channel: "C-test",
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postEphemeral).toHaveBeenCalledOnce();
+      expect(mockClient.chat.postEphemeral).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("could not be found"),
+        }),
+      );
+    });
+  });
+
   describe("app_mention — error deduplication", () => {
     async function setupWorkspace(orgId: string) {
       const workspaceId = uniqueId("T-ws");
@@ -185,6 +363,280 @@ describe("POST /api/zero/slack/events", () => {
     });
   });
 
+  describe("direct_message — routing filters", () => {
+    it("ignores messages with bot_id (bot messages)", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: "U-someone",
+          text: "I am a bot",
+          ts: uniqueId("ts"),
+          channel: "D-test",
+          event_ts: uniqueId("ts"),
+          bot_id: "B-bot",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+      expect(mockClient.chat.postEphemeral).not.toHaveBeenCalled();
+    });
+
+    it("ignores messages with non-file_share subtypes", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: "U-someone",
+          text: "edited message",
+          ts: uniqueId("ts"),
+          channel: "D-test",
+          event_ts: uniqueId("ts"),
+          subtype: "message_changed",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("processes file_share subtype messages", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: "U-not-connected",
+          text: "file upload",
+          ts: uniqueId("ts"),
+          channel: "D-test",
+          event_ts: uniqueId("ts"),
+          subtype: "file_share",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // DM handler was invoked — user not connected so login prompt is sent via postMessage
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
+    });
+
+    it("ignores non-im channel type messages", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "channel",
+          user: "U-someone",
+          text: "Hello",
+          ts: uniqueId("ts"),
+          channel: "C-test",
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("direct_message — pre-dispatch validation", () => {
+    it("silently returns when workspace has no installation", async () => {
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: "T-nonexistent-dm",
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: "U-random",
+          text: "Hello",
+          ts: uniqueId("ts"),
+          channel: "D-test",
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("sends login prompt via postMessage when user is not connected", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const channelId = uniqueId("D-ch");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: "U-not-connected",
+          text: "Hello agent",
+          ts: uniqueId("ts"),
+          channel: channelId,
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      // DM handler uses postMessage (not postEphemeral) for login prompt
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+        }),
+      );
+      expect(mockClient.chat.postEphemeral).not.toHaveBeenCalled();
+    });
+
+    it("sends message when no default agent is configured", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: slackUserId,
+          text: "Hello agent",
+          ts: uniqueId("ts"),
+          channel: "D-test",
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("No agent is configured"),
+        }),
+      );
+    });
+
+    it("sends message when configured agent is not found", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      const { composeId: orphanId } = await seedOrphanCompose({
+        userId: user.userId,
+        name: uniqueId("orphan-agent"),
+        orgId: user.orgId,
+      });
+      await updateOrgDefaultAgent(user.orgId, orphanId);
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "message",
+          channel_type: "im",
+          user: slackUserId,
+          text: "Hello agent",
+          ts: uniqueId("ts"),
+          channel: "D-test",
+          event_ts: uniqueId("ts"),
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: expect.stringContaining("could not be found"),
+        }),
+      );
+    });
+  });
+
   describe("direct_message — error deduplication", () => {
     async function setupWorkspace(orgId: string) {
       const workspaceId = uniqueId("T-ws");
@@ -263,6 +715,239 @@ describe("POST /api/zero/slack/events", () => {
 
       const { WebClient } = await import("@slack/web-api");
       const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("app_home_opened — home tab", () => {
+    it("silently returns when workspace has no installation", async () => {
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: "T-nonexistent-home",
+        event: {
+          type: "app_home_opened",
+          user: "U-random",
+          tab: "home",
+          channel: "D-test",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.views.publish).not.toHaveBeenCalled();
+    });
+
+    it("publishes connect prompt when user is not connected", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_home_opened",
+          user: "U-not-connected",
+          tab: "home",
+          channel: "D-test",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.views.publish).toHaveBeenCalledOnce();
+      expect(mockClient.views.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: "U-not-connected",
+        }),
+      );
+    });
+
+    it("publishes linked App Home when user is connected", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_home_opened",
+          user: slackUserId,
+          tab: "home",
+          channel: "D-test",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.views.publish).toHaveBeenCalledOnce();
+      expect(mockClient.views.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: slackUserId,
+        }),
+      );
+    });
+  });
+
+  describe("app_home_opened — messages tab", () => {
+    it("silently returns when workspace has no installation", async () => {
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: "T-nonexistent-msg",
+        event: {
+          type: "app_home_opened",
+          user: "U-random",
+          tab: "messages",
+          channel: "D-test",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("silently returns when user is not connected", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_home_opened",
+          user: "U-not-connected",
+          tab: "messages",
+          channel: "D-test",
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("sends welcome message on first messages tab open", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      const channelId = uniqueId("D-ch");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const request = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_home_opened",
+          user: slackUserId,
+          tab: "messages",
+          channel: channelId,
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+        }),
+      );
+    });
+
+    it("does not send welcome message on subsequent messages tab opens", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      const channelId = uniqueId("D-ch");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      // First open — sends welcome
+      const request1 = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_home_opened",
+          user: slackUserId,
+          tab: "messages",
+          channel: channelId,
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+      await POST(request1);
+      await context.mocks.flushAfter();
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
+
+      // Second open — should NOT send welcome again
+      const request2 = createSlackEventRequest({
+        type: "event_callback",
+        team_id: workspaceId,
+        event: {
+          type: "app_home_opened",
+          user: slackUserId,
+          tab: "messages",
+          channel: channelId,
+        },
+        event_id: uniqueId("evt"),
+        event_time: Date.now(),
+      });
+      await POST(request2);
+      await context.mocks.flushAfter();
+
+      // Still only one call from the first open
       expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();
     });
   });

--- a/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
@@ -1,0 +1,401 @@
+import { createHmac } from "crypto";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestSlackOrgInstallation,
+  seedTestSlackOrgConnection,
+  seedTestSlackOrgPendingQuestion,
+  updateOrgDefaultAgent,
+  countSlackOrgConnections,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../../../src/env";
+
+import { POST } from "../route";
+
+const SIGNING_SECRET = "test-slack-signing-secret";
+
+const context = testContext();
+
+/** Build a signed interactive request with JSON payload */
+function createInteractiveRequest(payload: Record<string, unknown>): Request {
+  const payloadStr = JSON.stringify(payload);
+  const body = new URLSearchParams({ payload: payloadStr }).toString();
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const baseString = `v0:${timestamp}:${body}`;
+  const signature = `v0=${createHmac("sha256", SIGNING_SECRET).update(baseString).digest("hex")}`;
+
+  return new Request("http://localhost:3000/api/zero/slack/interactive", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "x-slack-request-timestamp": timestamp,
+      "x-slack-signature": signature,
+    },
+    body,
+  });
+}
+
+describe("POST /api/zero/slack/interactive", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    reloadEnv();
+  });
+
+  describe("signature verification", () => {
+    it("returns 401 when signature headers are missing", async () => {
+      const body = new URLSearchParams({
+        payload: JSON.stringify({ type: "block_actions" }),
+      }).toString();
+      const request = new Request(
+        "http://localhost:3000/api/zero/slack/interactive",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body,
+        },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("payload validation", () => {
+    it("returns 400 when payload param is missing", async () => {
+      const body = "foo=bar";
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const baseString = `v0:${timestamp}:${body}`;
+      const signature = `v0=${createHmac("sha256", SIGNING_SECRET).update(baseString).digest("hex")}`;
+
+      const request = new Request(
+        "http://localhost:3000/api/zero/slack/interactive",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "x-slack-request-timestamp": timestamp,
+            "x-slack-signature": signature,
+          },
+          body,
+        },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("home_disconnect", () => {
+    it("disconnects user and refreshes App Home", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const request = createInteractiveRequest({
+        type: "block_actions",
+        user: { id: slackUserId, username: "testuser", team_id: workspaceId },
+        team: { id: workspaceId, domain: "test" },
+        actions: [{ action_id: "home_disconnect", block_id: "home" }],
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Connection should be deleted
+      expect(await countSlackOrgConnections(workspaceId)).toBe(0);
+
+      // App Home should be refreshed
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.views.publish).toHaveBeenCalledOnce();
+    });
+
+    it("silently returns when user has no connection", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const request = createInteractiveRequest({
+        type: "block_actions",
+        user: {
+          id: "U-no-connection",
+          username: "testuser",
+          team_id: workspaceId,
+        },
+        team: { id: workspaceId, domain: "test" },
+        actions: [{ action_id: "home_disconnect", block_id: "home" }],
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("ask_user_submit", () => {
+    it("claims pending question and dispatches run", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      const channelId = uniqueId("C-ch");
+      const threadTs = uniqueId("ts");
+
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      const { connectionId } = await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      const compose = await createTestCompose(uniqueId("agent"));
+      await updateOrgDefaultAgent(user.orgId, compose.agentId);
+
+      const messageTs = uniqueId("msg-ts");
+      const { pendingQuestionId } = await seedTestSlackOrgPendingQuestion({
+        runId: uniqueId("run"),
+        slackWorkspaceId: workspaceId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+        slackMessageTs: messageTs,
+        connectionId,
+        composeId: compose.composeId,
+        agentName: "test-agent",
+        questions: [
+          {
+            question: "Pick a color",
+            options: [{ label: "Red" }, { label: "Blue" }, { label: "Green" }],
+            multiSelect: true,
+          },
+        ],
+        expiresAt: new Date(Date.now() + 3600000),
+      });
+
+      const request = createInteractiveRequest({
+        type: "block_actions",
+        user: { id: slackUserId, username: "testuser", team_id: workspaceId },
+        team: { id: workspaceId, domain: "test" },
+        channel: { id: channelId },
+        message: { ts: messageTs },
+        actions: [
+          {
+            action_id: "ask_user_submit",
+            block_id: "submit",
+            value: pendingQuestionId,
+          },
+        ],
+        state: {
+          values: {
+            ask_user_block_q0: {
+              ask_user_select_q0: {
+                type: "static_select",
+                selected_options: [{ value: "q0_o0" }],
+              },
+            },
+          },
+        },
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Wait for the fire-and-forget async handler to complete
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      await vi.waitFor(() => {
+        expect(mockClient.chat.update).toHaveBeenCalled();
+      });
+    });
+
+    it("silently returns for expired pending question", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      const channelId = uniqueId("C-ch");
+      const threadTs = uniqueId("ts");
+
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      const { connectionId } = await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      const compose = await createTestCompose(uniqueId("agent"));
+
+      const { pendingQuestionId } = await seedTestSlackOrgPendingQuestion({
+        runId: uniqueId("run"),
+        slackWorkspaceId: workspaceId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+        connectionId,
+        composeId: compose.composeId,
+        agentName: "test-agent",
+        questions: [{ question: "Pick one", options: [{ label: "A" }] }],
+        expiresAt: new Date(Date.now() - 1000), // already expired
+      });
+
+      const request = createInteractiveRequest({
+        type: "block_actions",
+        user: { id: slackUserId, username: "testuser", team_id: workspaceId },
+        team: { id: workspaceId, domain: "test" },
+        actions: [
+          {
+            action_id: "ask_user_submit",
+            block_id: "submit",
+            value: pendingQuestionId,
+          },
+        ],
+        state: { values: {} },
+      });
+
+      // Get mock client reference before POST so we can verify after
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Wait for the fire-and-forget handler to settle, then verify no card update
+      await vi.waitFor(() => {
+        expect(mockClient.chat.update).not.toHaveBeenCalled();
+      });
+    });
+
+    it("rejects unauthorized submitter", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      const wrongUserId = uniqueId("U-wrong");
+      const channelId = uniqueId("C-ch");
+      const threadTs = uniqueId("ts");
+
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      const { connectionId } = await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      const compose = await createTestCompose(uniqueId("agent"));
+
+      const { pendingQuestionId } = await seedTestSlackOrgPendingQuestion({
+        runId: uniqueId("run"),
+        slackWorkspaceId: workspaceId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+        connectionId,
+        composeId: compose.composeId,
+        agentName: "test-agent",
+        questions: [{ question: "Pick one", options: [{ label: "A" }] }],
+        expiresAt: new Date(Date.now() + 3600000),
+      });
+
+      // Wrong user tries to submit
+      const request = createInteractiveRequest({
+        type: "block_actions",
+        user: { id: wrongUserId, username: "wrong", team_id: workspaceId },
+        team: { id: workspaceId, domain: "test" },
+        actions: [
+          {
+            action_id: "ask_user_submit",
+            block_id: "submit",
+            value: pendingQuestionId,
+          },
+        ],
+        state: { values: {} },
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Wait for the fire-and-forget async handler to complete
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      await vi.waitFor(() => {
+        expect(mockClient.chat.postEphemeral).toHaveBeenCalledWith(
+          expect.objectContaining({
+            user: wrongUserId,
+            text: expect.stringContaining("Only the person who started"),
+          }),
+        );
+      });
+    });
+  });
+
+  describe("direct_pick", () => {
+    it("claims pending question and dispatches run for single-select", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      const channelId = uniqueId("C-ch");
+      const threadTs = uniqueId("ts");
+
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      const { connectionId } = await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      const compose = await createTestCompose(uniqueId("agent"));
+      await updateOrgDefaultAgent(user.orgId, compose.agentId);
+
+      const messageTs = uniqueId("msg-ts");
+      const { pendingQuestionId } = await seedTestSlackOrgPendingQuestion({
+        runId: uniqueId("run"),
+        slackWorkspaceId: workspaceId,
+        slackChannelId: channelId,
+        slackThreadTs: threadTs,
+        slackMessageTs: messageTs,
+        connectionId,
+        composeId: compose.composeId,
+        agentName: "test-agent",
+        questions: [
+          {
+            question: "Pick a fruit",
+            options: [{ label: "Apple" }, { label: "Banana" }],
+          },
+        ],
+        expiresAt: new Date(Date.now() + 3600000),
+      });
+
+      const request = createInteractiveRequest({
+        type: "block_actions",
+        user: { id: slackUserId, username: "testuser", team_id: workspaceId },
+        team: { id: workspaceId, domain: "test" },
+        channel: { id: channelId },
+        message: { ts: messageTs },
+        actions: [
+          {
+            action_id: "ask_user_pick_q0_o1",
+            block_id: "pick",
+            value: pendingQuestionId,
+          },
+        ],
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      // Wait for the fire-and-forget async handler to complete
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      await vi.waitFor(() => {
+        expect(mockClient.chat.update).toHaveBeenCalled();
+      });
+    });
+
+    it("returns 200 with no action for empty actions array", async () => {
+      const request = createInteractiveRequest({
+        type: "block_actions",
+        user: { id: "U-test", username: "testuser", team_id: "T-test" },
+        team: { id: "T-test", domain: "test" },
+        actions: [],
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3548,6 +3548,7 @@ export async function createTestSlackOrgInstallation(opts: {
 }): Promise<{
   slackWorkspaceId: string;
   slackWorkspaceName: string;
+  installation: typeof slackOrgInstallations.$inferSelect;
 }> {
   initServices();
   const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
@@ -3560,15 +3561,26 @@ export async function createTestSlackOrgInstallation(opts: {
     SECRETS_ENCRYPTION_KEY,
   );
 
-  await globalThis.services.db.insert(slackOrgInstallations).values({
+  const [installation] = await globalThis.services.db
+    .insert(slackOrgInstallations)
+    .values({
+      slackWorkspaceId: workspaceId,
+      slackWorkspaceName: workspaceName,
+      orgId: opts.orgId,
+      encryptedBotToken,
+      botUserId: `B-${randomUUID().slice(0, 8)}`,
+    })
+    .returning();
+
+  if (!installation) {
+    throw new Error("Failed to create test Slack org installation");
+  }
+
+  return {
     slackWorkspaceId: workspaceId,
     slackWorkspaceName: workspaceName,
-    orgId: opts.orgId,
-    encryptedBotToken,
-    botUserId: `B-${randomUUID().slice(0, 8)}`,
-  });
-
-  return { slackWorkspaceId: workspaceId, slackWorkspaceName: workspaceName };
+    installation,
+  };
 }
 
 /**
@@ -3940,6 +3952,32 @@ export async function seedTestCompose(opts: {
 }
 
 /**
+ * Seed an agent compose record WITHOUT a corresponding zero_agents row.
+ * Useful for testing "agent not found" scenarios where the compose ID exists
+ * in agent_composes (satisfying FK constraints) but getWorkspaceAgent() returns
+ * undefined because there is no zero_agents row.
+ */
+export async function seedOrphanCompose(opts: {
+  userId: string;
+  name: string;
+  orgId: string;
+}): Promise<{ composeId: string }> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({
+      userId: opts.userId,
+      name: opts.name,
+      orgId: opts.orgId,
+    })
+    .returning({ id: agentComposes.id });
+  if (!row) {
+    throw new Error("Failed to seed orphan agent compose");
+  }
+  return { composeId: row.id };
+}
+
+/**
  * Seed a Slack org pending question for testing.
  */
 export async function seedTestSlackOrgPendingQuestion(opts: {
@@ -3947,6 +3985,7 @@ export async function seedTestSlackOrgPendingQuestion(opts: {
   slackWorkspaceId: string;
   slackChannelId: string;
   slackThreadTs: string;
+  slackMessageTs?: string;
   connectionId: string;
   composeId: string;
   agentName: string;
@@ -3961,6 +4000,7 @@ export async function seedTestSlackOrgPendingQuestion(opts: {
       slackWorkspaceId: opts.slackWorkspaceId,
       slackChannelId: opts.slackChannelId,
       slackThreadTs: opts.slackThreadTs,
+      slackMessageTs: opts.slackMessageTs,
       connectionId: opts.connectionId,
       composeId: opts.composeId,
       agentName: opts.agentName,

--- a/turbo/apps/web/src/lib/connector/providers/__tests__/slack.test.ts
+++ b/turbo/apps/web/src/lib/connector/providers/__tests__/slack.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { http } from "../../../../__tests__/msw";
+import { testContext } from "../../../../__tests__/test-helpers";
+import {
+  buildSlackAuthorizationUrl,
+  exchangeSlackCode,
+  fetchSlackUserInfo,
+  revokeSlackToken,
+  getSlackSecretName,
+} from "../slack";
+
+const context = testContext();
+
+describe("connector/providers/slack", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  describe("buildSlackAuthorizationUrl", () => {
+    it("builds URL with client_id, redirect_uri, state, and user_scope", () => {
+      const url = buildSlackAuthorizationUrl(
+        "test-client-id",
+        "https://example.com/callback",
+        "test-state",
+      );
+
+      expect(url).toContain("client_id=test-client-id");
+      expect(url).toContain(
+        "redirect_uri=" + encodeURIComponent("https://example.com/callback"),
+      );
+      expect(url).toContain("state=test-state");
+      expect(url).toContain("user_scope=");
+    });
+  });
+
+  describe("exchangeSlackCode", () => {
+    it("exchanges code for access token", async () => {
+      const { handler } = http.post(
+        "https://slack.com/api/oauth.v2.access",
+        () => {
+          return HttpResponse.json({
+            ok: true,
+            authed_user: {
+              id: "U-test",
+              access_token: "xoxp-test-token",
+              scope: "users:read,chat:write",
+            },
+          });
+        },
+      );
+      server.use(handler);
+
+      const result = await exchangeSlackCode(
+        "client-id",
+        "client-secret",
+        "test-code",
+        "https://example.com/callback",
+      );
+
+      expect(result.accessToken).toBe("xoxp-test-token");
+      expect(result.userId).toBe("U-test");
+      expect(result.scopes).toEqual(["users:read", "chat:write"]);
+    });
+
+    it("throws when Slack returns ok=false", async () => {
+      const { handler } = http.post(
+        "https://slack.com/api/oauth.v2.access",
+        () => {
+          return HttpResponse.json({
+            ok: false,
+            error: "invalid_code",
+          });
+        },
+      );
+      server.use(handler);
+
+      await expect(
+        exchangeSlackCode(
+          "client-id",
+          "client-secret",
+          "bad-code",
+          "https://example.com/callback",
+        ),
+      ).rejects.toThrow("invalid_code");
+    });
+
+    it("throws when no user access token in response", async () => {
+      const { handler } = http.post(
+        "https://slack.com/api/oauth.v2.access",
+        () => {
+          return HttpResponse.json({
+            ok: true,
+            authed_user: { id: "U-test" },
+          });
+        },
+      );
+      server.use(handler);
+
+      await expect(
+        exchangeSlackCode(
+          "client-id",
+          "client-secret",
+          "test-code",
+          "https://example.com/callback",
+        ),
+      ).rejects.toThrow("No user access token");
+    });
+  });
+
+  describe("fetchSlackUserInfo", () => {
+    it("fetches user info successfully", async () => {
+      const { handler } = http.get("https://slack.com/api/users.info", () => {
+        return HttpResponse.json({
+          ok: true,
+          user: {
+            id: "U-test",
+            name: "testuser",
+            real_name: "Test User",
+            profile: { email: "test@example.com" },
+          },
+        });
+      });
+      server.use(handler);
+
+      const result = await fetchSlackUserInfo("U-test", "xoxp-token");
+
+      expect(result.id).toBe("U-test");
+      expect(result.username).toBe("Test User");
+      expect(result.email).toBe("test@example.com");
+    });
+
+    it("throws when Slack returns ok=false", async () => {
+      const { handler } = http.get("https://slack.com/api/users.info", () => {
+        return HttpResponse.json({
+          ok: false,
+          error: "user_not_found",
+        });
+      });
+      server.use(handler);
+
+      await expect(
+        fetchSlackUserInfo("U-unknown", "xoxp-token"),
+      ).rejects.toThrow("user_not_found");
+    });
+  });
+
+  describe("revokeSlackToken", () => {
+    it("revokes token successfully", async () => {
+      const { handler } = http.post("https://slack.com/api/auth.revoke", () => {
+        return HttpResponse.json({ ok: true, revoked: true });
+      });
+      server.use(handler);
+
+      await expect(
+        revokeSlackToken("client-id", "client-secret", "xoxp-token"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("throws when revocation fails", async () => {
+      const { handler } = http.post("https://slack.com/api/auth.revoke", () => {
+        return HttpResponse.json({ ok: false, error: "token_revoked" });
+      });
+      server.use(handler);
+
+      await expect(
+        revokeSlackToken("client-id", "client-secret", "xoxp-token"),
+      ).rejects.toThrow("token_revoked");
+    });
+  });
+
+  describe("getSlackSecretName", () => {
+    it("returns the expected secret name", () => {
+      expect(getSlackSecretName()).toBe("SLACK_ACCESS_TOKEN");
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/slack-org/__tests__/connect-service.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/__tests__/connect-service.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../__tests__/test-helpers";
+import {
+  createTestSlackOrgInstallation,
+  seedTestSlackOrgConnection,
+  seedTestCompose,
+  seedTestSlackOrgPendingQuestion,
+  countSlackOrgInstallations,
+  countSlackOrgConnections,
+  countSlackOrgPendingQuestions,
+} from "../../../__tests__/api-test-helpers";
+import {
+  adminConnect,
+  memberConnect,
+  disconnect,
+  cleanupWorkspaceInstallation,
+  notifyConnectSuccess,
+} from "../connect-service";
+
+const context = testContext();
+
+describe("connect-service", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  describe("adminConnect", () => {
+    it("binds unbound workspace to org and creates connection", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: null });
+
+      const result = await adminConnect({
+        userId: user.userId,
+        orgId: user.orgId,
+        workspaceId,
+        slackUserId: uniqueId("U-slack"),
+      });
+
+      expect(result.installation.orgId).toBe(user.orgId);
+      expect(result.connection.vm0UserId).toBe(user.userId);
+      expect(await countSlackOrgConnections(workspaceId)).toBe(1);
+    });
+
+    it("is idempotent when workspace is already bound to the same org", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const result = await adminConnect({
+        userId: user.userId,
+        orgId: user.orgId,
+        workspaceId,
+        slackUserId,
+      });
+
+      expect(result.installation.orgId).toBe(user.orgId);
+      expect(result.connection).toBeDefined();
+    });
+
+    it("throws when workspace is bound to a different org", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({
+        workspaceId,
+        orgId: uniqueId("org-other"),
+      });
+
+      await expect(
+        adminConnect({
+          userId: user.userId,
+          orgId: user.orgId,
+          workspaceId,
+          slackUserId: uniqueId("U-slack"),
+        }),
+      ).rejects.toThrow("already connected to a different org");
+    });
+
+    it("handles idempotent reconnect (connection already exists)", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: null });
+
+      // First connect
+      await adminConnect({
+        userId: user.userId,
+        orgId: user.orgId,
+        workspaceId,
+        slackUserId,
+      });
+
+      // Second connect — should not throw
+      const result = await adminConnect({
+        userId: user.userId,
+        orgId: user.orgId,
+        workspaceId,
+        slackUserId,
+      });
+
+      expect(result.connection.slackUserId).toBe(slackUserId);
+      // Still only one connection
+      expect(await countSlackOrgConnections(workspaceId)).toBe(1);
+    });
+  });
+
+  describe("memberConnect", () => {
+    it("creates connection for bound workspace", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+
+      const result = await memberConnect({
+        userId: user.userId,
+        orgId: user.orgId,
+        workspaceId,
+        slackUserId: uniqueId("U-slack"),
+      });
+
+      expect(result.connection.vm0UserId).toBe(user.userId);
+      expect(await countSlackOrgConnections(workspaceId)).toBe(1);
+    });
+
+    it("throws when workspace is not installed", async () => {
+      await expect(
+        memberConnect({
+          userId: user.userId,
+          orgId: user.orgId,
+          workspaceId: "T-nonexistent",
+          slackUserId: uniqueId("U-slack"),
+        }),
+      ).rejects.toThrow("installation not found");
+    });
+
+    it("throws when workspace is unbound (no admin connect yet)", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: null });
+
+      await expect(
+        memberConnect({
+          userId: user.userId,
+          orgId: user.orgId,
+          workspaceId,
+          slackUserId: uniqueId("U-slack"),
+        }),
+      ).rejects.toThrow("admin must connect first");
+    });
+
+    it("throws when workspace is bound to a different org", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({
+        workspaceId,
+        orgId: uniqueId("org-other"),
+      });
+
+      await expect(
+        memberConnect({
+          userId: user.userId,
+          orgId: user.orgId,
+          workspaceId,
+          slackUserId: uniqueId("U-slack"),
+        }),
+      ).rejects.toThrow("different org");
+    });
+  });
+
+  describe("disconnect", () => {
+    it("deletes the connection record", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      const { connectionId } = await seedTestSlackOrgConnection({
+        slackUserId: uniqueId("U-slack"),
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      await disconnect({ connectionId, userId: user.userId });
+
+      expect(await countSlackOrgConnections(workspaceId)).toBe(0);
+    });
+  });
+
+  describe("cleanupWorkspaceInstallation", () => {
+    it("deletes installation, connections, and pending questions", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const orgId = uniqueId("org");
+      await createTestSlackOrgInstallation({ workspaceId, orgId });
+
+      const { connectionId } = await seedTestSlackOrgConnection({
+        slackUserId: uniqueId("U-slack"),
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      const { composeId } = await seedTestCompose({
+        userId: user.userId,
+        name: uniqueId("agent"),
+        orgId,
+      });
+
+      await seedTestSlackOrgPendingQuestion({
+        runId: uniqueId("run"),
+        slackWorkspaceId: workspaceId,
+        slackChannelId: "C-test",
+        slackThreadTs: uniqueId("ts"),
+        connectionId,
+        composeId,
+        agentName: "test-agent",
+        questions: [{ question: "test?" }],
+        expiresAt: new Date(Date.now() + 3600000),
+      });
+
+      const deleted = await cleanupWorkspaceInstallation(workspaceId);
+
+      expect(deleted).toBe(true);
+      expect(await countSlackOrgInstallations(workspaceId)).toBe(0);
+      expect(await countSlackOrgConnections(workspaceId)).toBe(0);
+      expect(await countSlackOrgPendingQuestions(connectionId)).toBe(0);
+    });
+
+    it("returns false when workspace does not exist", async () => {
+      const deleted = await cleanupWorkspaceInstallation("T-nonexistent");
+      expect(deleted).toBe(false);
+    });
+
+    it("handles workspace with no connections", async () => {
+      const workspaceId = uniqueId("T-ws");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: null });
+
+      const deleted = await cleanupWorkspaceInstallation(workspaceId);
+
+      expect(deleted).toBe(true);
+      expect(await countSlackOrgInstallations(workspaceId)).toBe(0);
+    });
+  });
+
+  describe("notifyConnectSuccess", () => {
+    it("sends ephemeral message when channelId is provided", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      const channelId = uniqueId("C-ch");
+
+      const { installation } = await createTestSlackOrgInstallation({
+        workspaceId,
+        orgId: user.orgId,
+      });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      await notifyConnectSuccess({
+        installation,
+        slackUserId,
+        orgId: user.orgId,
+        channelId,
+      });
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      expect(mockClient.chat.postEphemeral).toHaveBeenCalledOnce();
+      expect(mockClient.chat.postEphemeral).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: channelId,
+          user: slackUserId,
+        }),
+      );
+    });
+
+    it("sends DM with welcome thread when no channelId", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+
+      const { installation } = await createTestSlackOrgInstallation({
+        workspaceId,
+        orgId: user.orgId,
+      });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+
+      await notifyConnectSuccess({
+        installation,
+        slackUserId,
+        orgId: user.orgId,
+      });
+
+      const { WebClient } = await import("@slack/web-api");
+      const mockClient = new WebClient();
+      // Should send connect success DM and welcome thread reply
+      expect(
+        (
+          mockClient.chat.postMessage as ReturnType<
+            typeof import("vitest").vi.fn
+          >
+        ).mock.calls.length,
+      ).toBeGreaterThanOrEqual(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive test coverage for 6 previously untested Slack integration modules
- 86 new tests covering org callbacks, events, interactive, commands, connector providers, and connect service
- Use type guard pattern (matching schedule route) for org callback payload validation

Closes #6765

## Test plan
- [ ] All 86 new tests pass in CI
- [ ] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)