### PR TITLE
feat: migrate model preferences from local storage to server

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-user-preferences.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-user-preferences.ts
@@ -11,6 +11,7 @@ let mockPreferences: UserPreferencesResponse = {
   timezone: null,
   pinnedAgentIds: [],
   sendMode: "enter",
+  modelPreferences: {},
 };
 
 export function resetMockUserPreferences(): void {
@@ -18,6 +19,7 @@ export function resetMockUserPreferences(): void {
     timezone: null,
     pinnedAgentIds: [],
     sendMode: "enter",
+    modelPreferences: {},
   };
 }
 
@@ -39,6 +41,9 @@ export const apiUserPreferencesHandlers = [
     }
     if (body.sendMode !== undefined) {
       mockPreferences.sendMode = body.sendMode;
+    }
+    if (body.modelPreferences !== undefined) {
+      mockPreferences.modelPreferences = body.modelPreferences;
     }
 
     return HttpResponse.json(mockPreferences);

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-model-preference.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-model-preference.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
 import { mockLocation, setPathname } from "../../location.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { updatePathname$ } from "../../route.ts";
@@ -21,69 +23,152 @@ describe("zero-model-preference signals", () => {
     expect(context.store.get(selectedModel$)).toBe("openai");
   });
 
-  it("should sync model preference from localStorage for current agent", () => {
-    mockLocation({ pathname: "/talk/my-agent", search: "" }, context.signal);
-    localStorage.setItem("zero.modelProvider.my-agent", "anthropic");
+  it("should sync model preference from server for current agent", async () => {
+    server.use(
+      http.get("*/api/zero/user-preferences", () => {
+        return HttpResponse.json({
+          timezone: null,
+          pinnedAgentIds: [],
+          sendMode: "enter",
+          modelPreferences: { "my-agent": "anthropic" },
+        });
+      }),
+    );
 
-    context.store.set(syncModelPreference$);
+    mockLocation({ pathname: "/talk/my-agent", search: "" }, context.signal);
+
+    await context.store.set(syncModelPreference$);
 
     expect(context.store.get(selectedModel$)).toBe("anthropic");
   });
 
-  it("should sync to 'default' when no localStorage entry exists", () => {
+  it("should sync to 'default' when server has no preference for agent", async () => {
+    server.use(
+      http.get("*/api/zero/user-preferences", () => {
+        return HttpResponse.json({
+          timezone: null,
+          pinnedAgentIds: [],
+          sendMode: "enter",
+          modelPreferences: {},
+        });
+      }),
+    );
+
     mockLocation({ pathname: "/talk/new-agent", search: "" }, context.signal);
-    // Set to something first
     context.store.set(setSelectedModel$, "openai");
 
-    context.store.set(syncModelPreference$);
+    await context.store.set(syncModelPreference$);
 
     expect(context.store.get(selectedModel$)).toBe("default");
   });
 
-  it("should use 'default' key when zeroTalkAgentId is null", () => {
-    mockLocation({ pathname: "/", search: "" }, context.signal);
-    localStorage.setItem("zero.modelProvider.default", "anthropic");
+  it("should use 'default' key when zeroTalkAgentId is null", async () => {
+    server.use(
+      http.get("*/api/zero/user-preferences", () => {
+        return HttpResponse.json({
+          timezone: null,
+          pinnedAgentIds: [],
+          sendMode: "enter",
+          modelPreferences: { default: "anthropic" },
+        });
+      }),
+    );
 
-    context.store.set(syncModelPreference$);
+    mockLocation({ pathname: "/", search: "" }, context.signal);
+
+    await context.store.set(syncModelPreference$);
 
     expect(context.store.get(selectedModel$)).toBe("anthropic");
   });
 
-  it("should persist model preference to localStorage", () => {
+  it("should persist model preference to server via API", async () => {
+    let capturedBody: unknown = null;
+
+    server.use(
+      http.get("*/api/zero/user-preferences", () => {
+        return HttpResponse.json({
+          timezone: null,
+          pinnedAgentIds: [],
+          sendMode: "enter",
+          modelPreferences: {},
+        });
+      }),
+      http.post("*/api/zero/user-preferences", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          timezone: null,
+          pinnedAgentIds: [],
+          sendMode: "enter",
+          modelPreferences: { "my-agent": "openai" },
+        });
+      }),
+    );
+
     mockLocation({ pathname: "/talk/my-agent", search: "" }, context.signal);
     context.store.set(setSelectedModel$, "openai");
 
-    context.store.set(persistModelPreference$);
+    await context.store.set(persistModelPreference$);
 
-    expect(localStorage.getItem("zero.modelProvider.my-agent")).toBe("openai");
+    expect(capturedBody).toStrictEqual({
+      modelPreferences: { "my-agent": "openai" },
+    });
   });
 
-  it("should remove localStorage entry when persisting 'default'", () => {
+  it("should remove agent key from server when persisting 'default'", async () => {
+    let capturedBody: unknown = null;
+
+    server.use(
+      http.get("*/api/zero/user-preferences", () => {
+        return HttpResponse.json({
+          timezone: null,
+          pinnedAgentIds: [],
+          sendMode: "enter",
+          modelPreferences: { "my-agent": "openai" },
+        });
+      }),
+      http.post("*/api/zero/user-preferences", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          timezone: null,
+          pinnedAgentIds: [],
+          sendMode: "enter",
+          modelPreferences: {},
+        });
+      }),
+    );
+
     mockLocation({ pathname: "/talk/my-agent", search: "" }, context.signal);
-    localStorage.setItem("zero.modelProvider.my-agent", "openai");
     context.store.set(setSelectedModel$, "default");
 
-    context.store.set(persistModelPreference$);
+    await context.store.set(persistModelPreference$);
 
-    expect(localStorage.getItem("zero.modelProvider.my-agent")).toBeNull();
+    expect(capturedBody).toStrictEqual({
+      modelPreferences: {},
+    });
   });
 
-  it("should reset model selection when agent changes via sync", () => {
-    // Agent-a has a saved preference; agent-b does not.
-    // Each sync should read localStorage for the current agent.
-    localStorage.setItem("zero.modelProvider.agent-a", "anthropic");
+  it("should reset model selection when agent changes via sync", async () => {
+    server.use(
+      http.get("*/api/zero/user-preferences", () => {
+        return HttpResponse.json({
+          timezone: null,
+          pinnedAgentIds: [],
+          sendMode: "enter",
+          modelPreferences: { "agent-a": "anthropic" },
+        });
+      }),
+    );
 
     // Start on agent-a
     mockLocation({ pathname: "/talk/agent-a", search: "" }, context.signal);
-    context.store.set(syncModelPreference$);
+    await context.store.set(syncModelPreference$);
     expect(context.store.get(selectedModel$)).toBe("anthropic");
 
-    // Navigate to agent-b — use setPathname + updatePathname$ to
-    // both update the override and trigger pathname$ recomputation.
+    // Navigate to agent-b
     setPathname("/talk/agent-b");
     context.store.set(updatePathname$, "/talk/agent-b");
 
-    context.store.set(syncModelPreference$);
+    await context.store.set(syncModelPreference$);
     expect(context.store.get(selectedModel$)).toBe("default");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-model-preference.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-model-preference.test.ts
@@ -37,7 +37,7 @@ describe("zero-model-preference signals", () => {
 
     mockLocation({ pathname: "/talk/my-agent", search: "" }, context.signal);
 
-    await context.store.set(syncModelPreference$);
+    await context.store.set(syncModelPreference$, context.signal);
 
     expect(context.store.get(selectedModel$)).toBe("anthropic");
   });
@@ -57,7 +57,7 @@ describe("zero-model-preference signals", () => {
     mockLocation({ pathname: "/talk/new-agent", search: "" }, context.signal);
     context.store.set(setSelectedModel$, "openai");
 
-    await context.store.set(syncModelPreference$);
+    await context.store.set(syncModelPreference$, context.signal);
 
     expect(context.store.get(selectedModel$)).toBe("default");
   });
@@ -76,7 +76,7 @@ describe("zero-model-preference signals", () => {
 
     mockLocation({ pathname: "/", search: "" }, context.signal);
 
-    await context.store.set(syncModelPreference$);
+    await context.store.set(syncModelPreference$, context.signal);
 
     expect(context.store.get(selectedModel$)).toBe("anthropic");
   });
@@ -107,7 +107,7 @@ describe("zero-model-preference signals", () => {
     mockLocation({ pathname: "/talk/my-agent", search: "" }, context.signal);
     context.store.set(setSelectedModel$, "openai");
 
-    await context.store.set(persistModelPreference$);
+    await context.store.set(persistModelPreference$, context.signal);
 
     expect(capturedBody).toStrictEqual({
       modelPreferences: { "my-agent": "openai" },
@@ -140,7 +140,7 @@ describe("zero-model-preference signals", () => {
     mockLocation({ pathname: "/talk/my-agent", search: "" }, context.signal);
     context.store.set(setSelectedModel$, "default");
 
-    await context.store.set(persistModelPreference$);
+    await context.store.set(persistModelPreference$, context.signal);
 
     expect(capturedBody).toStrictEqual({
       modelPreferences: {},
@@ -161,14 +161,14 @@ describe("zero-model-preference signals", () => {
 
     // Start on agent-a
     mockLocation({ pathname: "/talk/agent-a", search: "" }, context.signal);
-    await context.store.set(syncModelPreference$);
+    await context.store.set(syncModelPreference$, context.signal);
     expect(context.store.get(selectedModel$)).toBe("anthropic");
 
     // Navigate to agent-b
     setPathname("/talk/agent-b");
     context.store.set(updatePathname$, "/talk/agent-b");
 
-    await context.store.set(syncModelPreference$);
+    await context.store.set(syncModelPreference$, context.signal);
     expect(context.store.get(selectedModel$)).toBe("default");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/billing-dialog-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing-dialog-state.ts
@@ -40,3 +40,25 @@ export const setAutoRechargeThreshold$ = command(
 export const setAutoRechargeAmount$ = command(({ set }, amount: string) => {
   set(internalAutoRechargeAmount$, amount);
 });
+
+/** Hydrate auto-recharge form state from server data. */
+export const syncAutoRechargeForm$ = command(
+  (
+    { set },
+    config: {
+      enabled: boolean;
+      threshold: number | null;
+      amount: number | null;
+    },
+  ) => {
+    set(internalAutoRechargeEnabled$, config.enabled);
+    set(
+      internalAutoRechargeThreshold$,
+      config.threshold !== null ? String(config.threshold) : "",
+    );
+    set(
+      internalAutoRechargeAmount$,
+      config.amount !== null ? String(config.amount) : "",
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
@@ -35,6 +35,6 @@ export const setupChatSessionPage$ = command(
       set(updateDocumentTitle$, sessionTitle);
     }
 
-    set(syncModelPreference$);
+    await set(syncModelPreference$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
@@ -35,6 +35,6 @@ export const setupChatSessionPage$ = command(
       set(updateDocumentTitle$, sessionTitle);
     }
 
-    await set(syncModelPreference$);
+    await set(syncModelPreference$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
@@ -22,6 +22,7 @@ export const setOrgManageDialogOpen$ = command(
       await set(initProfileName$, signal);
       set(reloadBillingStatus$);
       const status = await get(billingStatusAsync$);
+      signal.throwIfAborted();
       set(syncAutoRechargeForm$, status.autoRecharge);
     }
     set(internalOrgManageDialogOpen$, open);

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
@@ -2,7 +2,8 @@ import { command, computed, state } from "ccstate";
 import { clerk$ } from "../../auth.ts";
 import { detach, onRef, Reason } from "../../utils.ts";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
-import { reloadBillingStatus$ } from "../billing.ts";
+import { billingStatusAsync$, reloadBillingStatus$ } from "../billing.ts";
+import { syncAutoRechargeForm$ } from "../billing-dialog-state.ts";
 import {
   initProfileName$,
   setActiveTab$,
@@ -16,10 +17,12 @@ export const orgManageDialogOpen$ = computed((get) =>
 );
 
 export const setOrgManageDialogOpen$ = command(
-  async ({ set }, open: boolean, signal: AbortSignal) => {
+  async ({ get, set }, open: boolean, signal: AbortSignal) => {
     if (open) {
       await set(initProfileName$, signal);
       set(reloadBillingStatus$);
+      const status = await get(billingStatusAsync$);
+      set(syncAutoRechargeForm$, status.autoRecharge);
     }
     set(internalOrgManageDialogOpen$, open);
   },

--- a/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
@@ -30,6 +30,6 @@ export const setupTalkPage$ = command(
     set(updateDocumentTitle$, agentName ?? "Agent");
     await set(resolveAgentById$, agentId, signal);
 
-    set(syncModelPreference$);
+    await set(syncModelPreference$);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
@@ -30,6 +30,6 @@ export const setupTalkPage$ = command(
     set(updateDocumentTitle$, agentName ?? "Agent");
     await set(resolveAgentById$, agentId, signal);
 
-    await set(syncModelPreference$);
+    await set(syncModelPreference$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
@@ -3,11 +3,6 @@ import { zeroUserPreferencesContract } from "@vm0/core";
 import { zeroTalkAgentId$ } from "./zero-nav.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { clerk$ } from "../auth.ts";
-import { throwIfAbort } from "../utils.ts";
-import { logger } from "../log.ts";
-
-const L = logger("ZeroModelPreference");
-
 // ---------------------------------------------------------------------------
 // Server-backed model preferences
 // ---------------------------------------------------------------------------
@@ -62,30 +57,26 @@ export const setSelectedModel$ = command(({ set }, value: string) => {
  * Sync model preference from server for the current agent.
  * Called from each route's setup function on navigation.
  */
-export const syncModelPreference$ = command(async ({ get, set }) => {
-  const agentId = get(zeroTalkAgentId$);
-  const key = agentId ?? "default";
-  try {
+export const syncModelPreference$ = command(
+  async ({ get, set }, _signal: AbortSignal) => {
+    const agentId = get(zeroTalkAgentId$);
+    const key = agentId ?? "default";
     const prefs = await get(modelPreferences$);
     const value = prefs[key] ?? "default";
     set(internalSelectedModel$, value);
-  } catch (error) {
-    throwIfAbort(error);
-    L.error("Failed to sync model preference:", error);
-    set(internalSelectedModel$, "default");
-  }
-});
+  },
+);
 
 /**
  * Persist the current model selection to the server.
  * Called before sending a message.
  */
-export const persistModelPreference$ = command(async ({ get, set }) => {
-  const agentId = get(zeroTalkAgentId$);
-  const key = agentId ?? "default";
-  const value = get(internalSelectedModel$);
+export const persistModelPreference$ = command(
+  async ({ get, set }, _signal: AbortSignal) => {
+    const agentId = get(zeroTalkAgentId$);
+    const key = agentId ?? "default";
+    const value = get(internalSelectedModel$);
 
-  try {
     // Read current preferences
     const currentPrefs = await get(modelPreferences$);
 
@@ -100,25 +91,25 @@ export const persistModelPreference$ = command(async ({ get, set }) => {
     // Optimistic update
     set(optimisticModelPreferences$, updated);
 
-    // Persist to server
-    const createClient = get(zeroClient$);
-    const client = createClient(zeroUserPreferencesContract);
-    const result = await client.update({ body: { modelPreferences: updated } });
+    try {
+      // Persist to server
+      const createClient = get(zeroClient$);
+      const client = createClient(zeroUserPreferencesContract);
+      const result = await client.update({
+        body: { modelPreferences: updated },
+      });
 
-    if (result.status !== 200) {
-      L.error("Failed to persist model preference:", result.status);
-      return;
+      if (result.status !== 200) {
+        throw new Error(`Failed to persist model preference: ${result.status}`);
+      }
+
+      // Force JWT refresh so updated membership metadata is available immediately
+      const clerk = await get(clerk$);
+      await clerk.session?.getToken({ skipCache: true });
+
+      set(reloadModelPreferences$, (x) => x + 1);
+    } finally {
+      set(optimisticModelPreferences$, null);
     }
-
-    // Force JWT refresh so updated membership metadata is available immediately
-    const clerk = await get(clerk$);
-    await clerk.session?.getToken({ skipCache: true });
-
-    set(reloadModelPreferences$, (x) => x + 1);
-  } catch (error) {
-    throwIfAbort(error);
-    L.error("Failed to persist model preference:", error);
-  } finally {
-    set(optimisticModelPreferences$, null);
-  }
-});
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
@@ -1,24 +1,48 @@
 import { command, computed, state } from "ccstate";
+import { zeroUserPreferencesContract } from "@vm0/core";
 import { zeroTalkAgentId$ } from "./zero-nav.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { clerk$ } from "../auth.ts";
+import { throwIfAbort } from "../utils.ts";
+import { logger } from "../log.ts";
 
-function readModelPreference(key: string): string {
-  if (typeof window === "undefined") {
-    return "default";
+const L = logger("ZeroModelPreference");
+
+// ---------------------------------------------------------------------------
+// Server-backed model preferences
+// ---------------------------------------------------------------------------
+
+const reloadModelPreferences$ = state(0);
+
+/**
+ * Optimistic override — when set, takes precedence over server value.
+ */
+const optimisticModelPreferences$ = state<Record<string, string> | null>(null);
+
+/**
+ * Model preferences fetched from user preferences API.
+ */
+const serverModelPreferences$ = computed(async (get) => {
+  get(reloadModelPreferences$);
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroUserPreferencesContract);
+  const result = await client.get();
+  if (result.status === 200) {
+    return result.body.modelPreferences;
   }
-  return localStorage.getItem(key) ?? "default";
-}
+  throw new Error(`Failed to fetch user preferences: ${result.status}`);
+});
 
-function writeModelPreference(key: string, value: string) {
-  if (value === "default") {
-    localStorage.removeItem(key);
-  } else {
-    localStorage.setItem(key, value);
+/**
+ * Effective model preferences — optimistic value if set, otherwise server value.
+ */
+const modelPreferences$ = computed((get) => {
+  const optimistic = get(optimisticModelPreferences$);
+  if (optimistic !== null) {
+    return optimistic;
   }
-}
-
-function modelStorageKey(agentId: string | null): string {
-  return `zero.modelProvider.${agentId ?? "default"}`;
-}
+  return get(serverModelPreferences$);
+});
 
 // ---------------------------------------------------------------------------
 // State
@@ -35,23 +59,66 @@ export const setSelectedModel$ = command(({ set }, value: string) => {
 });
 
 /**
- * Sync model preference from localStorage for the current agent.
- * Called from each route's setup function on navigation — eliminates the
- * prevAgentId + queueMicrotask pattern entirely.
+ * Sync model preference from server for the current agent.
+ * Called from each route's setup function on navigation.
  */
-export const syncModelPreference$ = command(({ get, set }) => {
+export const syncModelPreference$ = command(async ({ get, set }) => {
   const agentId = get(zeroTalkAgentId$);
-  const key = modelStorageKey(agentId);
-  set(internalSelectedModel$, readModelPreference(key));
+  const key = agentId ?? "default";
+  try {
+    const prefs = await get(modelPreferences$);
+    const value = prefs[key] ?? "default";
+    set(internalSelectedModel$, value);
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to sync model preference:", error);
+    set(internalSelectedModel$, "default");
+  }
 });
 
 /**
- * Persist the current model selection to localStorage.
+ * Persist the current model selection to the server.
  * Called before sending a message.
  */
-export const persistModelPreference$ = command(({ get }) => {
+export const persistModelPreference$ = command(async ({ get, set }) => {
   const agentId = get(zeroTalkAgentId$);
-  const key = modelStorageKey(agentId);
+  const key = agentId ?? "default";
   const value = get(internalSelectedModel$);
-  writeModelPreference(key, value);
+
+  try {
+    // Read current preferences
+    const currentPrefs = await get(modelPreferences$);
+
+    // Build updated preferences
+    const updated = { ...currentPrefs };
+    if (value === "default") {
+      delete updated[key];
+    } else {
+      updated[key] = value;
+    }
+
+    // Optimistic update
+    set(optimisticModelPreferences$, updated);
+
+    // Persist to server
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroUserPreferencesContract);
+    const result = await client.update({ body: { modelPreferences: updated } });
+
+    if (result.status !== 200) {
+      L.error("Failed to persist model preference:", result.status);
+      return;
+    }
+
+    // Force JWT refresh so updated membership metadata is available immediately
+    const clerk = await get(clerk$);
+    await clerk.session?.getToken({ skipCache: true });
+
+    set(reloadModelPreferences$, (x) => x + 1);
+  } catch (error) {
+    throwIfAbort(error);
+    L.error("Failed to persist model preference:", error);
+  } finally {
+    set(optimisticModelPreferences$, null);
+  }
 });

--- a/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
+++ b/turbo/apps/platform/src/views/preferences-page/__tests__/preferences-page.test.tsx
@@ -15,6 +15,7 @@ function createMockPreferences(
     timezone: "UTC",
     pinnedAgentIds: [],
     sendMode: "enter",
+    modelPreferences: {},
     ...overrides,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -215,4 +215,117 @@ describe("org billing tab - auto-recharge section", () => {
 
     expect(screen.queryByText("Auto-recharge")).not.toBeInTheDocument();
   });
+
+  it("should hydrate form with server auto-recharge config when enabled", async () => {
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: true, threshold: 2000, amount: 5000 },
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    // Switch should be on
+    const toggle = screen.getByRole("switch", {
+      name: /enable auto-recharge/i,
+    });
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("data-state", "checked");
+    });
+
+    // Threshold input should show server value
+    const thresholdInput = screen.getByLabelText(
+      /credit threshold for auto-recharge/i,
+    );
+    expect(thresholdInput).toHaveValue(2000);
+
+    // Amount input should show server value
+    const amountInput = screen.getByLabelText(
+      /auto-recharge credit amount in credits/i,
+    );
+    expect(amountInput).toHaveValue(5000);
+  });
+
+  it("should show switch off when server auto-recharge is disabled", async () => {
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: false, threshold: null, amount: null },
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByRole("switch", {
+      name: /enable auto-recharge/i,
+    });
+    expect(toggle).toHaveAttribute("data-state", "unchecked");
+
+    // Threshold and amount inputs should not be visible when disabled
+    expect(
+      screen.queryByLabelText(/credit threshold for auto-recharge/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should persist auto-recharge config to server on toggle", async () => {
+    let putCalled = false;
+    let putBody: Record<string, unknown> = {};
+    server.use(
+      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
+        putCalled = true;
+        putBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          enabled: putBody.enabled,
+          threshold: putBody.threshold ?? null,
+          amount: putBody.amount ?? null,
+        });
+      }),
+    );
+
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: true, threshold: 2000, amount: 5000 },
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    // Wait for hydration
+    const toggle = screen.getByRole("switch", {
+      name: /enable auto-recharge/i,
+    });
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("data-state", "checked");
+    });
+
+    // Toggle off
+    await act(() => {
+      fireEvent.click(toggle);
+    });
+
+    await waitFor(() => {
+      expect(putCalled).toBeTruthy();
+    });
+    expect(putBody.enabled).toBeFalsy();
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-send-key.test.tsx
@@ -22,10 +22,9 @@ function mockSendMode(mode: "enter" | "cmd-enter") {
     http.get("*/api/zero/user-preferences", () => {
       return HttpResponse.json({
         timezone: null,
-        notifyEmail: false,
-        notifySlack: false,
         pinnedAgentIds: [],
         sendMode: mode,
+        modelPreferences: {},
       });
     }),
   );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
@@ -68,6 +68,7 @@ function mockAPIsWithSubagents({
         timezone: null,
         pinnedAgentIds,
         sendMode: "enter" as const,
+        modelPreferences: {},
       });
     }),
     http.post("*/api/zero/user-preferences", async ({ request }) => {
@@ -76,6 +77,7 @@ function mockAPIsWithSubagents({
         timezone: null,
         pinnedAgentIds: body.pinnedAgentIds ?? pinnedAgentIds,
         sendMode: "enter" as const,
+        modelPreferences: {},
       });
     }),
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -476,7 +476,7 @@ export function ZeroChatComposer({
     if (!trimmed || !!queuedMessage) {
       return;
     }
-    detach(persistSelection(), Reason.DomCallback);
+    detach(persistSelection(new AbortController().signal), Reason.DomCallback);
     onSend(trimmed, buildModelOpts(selectedModel));
   };
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -476,7 +476,7 @@ export function ZeroChatComposer({
     if (!trimmed || !!queuedMessage) {
       return;
     }
-    persistSelection();
+    detach(persistSelection(), Reason.DomCallback);
     onSend(trimmed, buildModelOpts(selectedModel));
   };
 

--- a/turbo/apps/web/app/api/zero/user-preferences/route.ts
+++ b/turbo/apps/web/app/api/zero/user-preferences/route.ts
@@ -34,6 +34,7 @@ const router = tsr.router(zeroUserPreferencesContract, {
         timezone: prefs.timezone,
         pinnedAgentIds: prefs.pinnedAgentIds,
         sendMode: prefs.sendMode,
+        modelPreferences: prefs.modelPreferences,
       },
     };
   },
@@ -52,6 +53,7 @@ const router = tsr.router(zeroUserPreferencesContract, {
         timezone: body.timezone,
         pinnedAgentIds: body.pinnedAgentIds,
         sendMode: body.sendMode,
+        modelPreferences: body.modelPreferences,
       });
 
       return {
@@ -60,6 +62,7 @@ const router = tsr.router(zeroUserPreferencesContract, {
           timezone: prefs.timezone,
           pinnedAgentIds: prefs.pinnedAgentIds,
           sendMode: prefs.sendMode,
+          modelPreferences: prefs.modelPreferences,
         },
       };
     } catch (error) {

--- a/turbo/apps/web/src/db/migrations/0198_add_model_preferences.sql
+++ b/turbo/apps/web/src/db/migrations/0198_add_model_preferences.sql
@@ -1,0 +1,3 @@
+-- Add model_preferences column to org_members_metadata
+-- Stores per-agent model provider preferences as JSON: { "agent-id": "provider-type" }
+ALTER TABLE "org_members_metadata" ADD COLUMN "model_preferences" jsonb DEFAULT '{}'::jsonb;

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -1387,6 +1387,13 @@
       "when": 1774828800003,
       "tag": "0197_fk_schedules_email_org_to_composes",
       "breakpoints": true
+    },
+    {
+      "idx": 198,
+      "version": "7",
+      "when": 1774828800004,
+      "tag": "0198_add_model_preferences",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/org-members-metadata.ts
+++ b/turbo/apps/web/src/db/schema/org-members-metadata.ts
@@ -20,6 +20,9 @@ export const orgMembersMetadata = pgTable(
     timezone: text("timezone"),
     pinnedAgentIds: jsonb("pinned_agent_ids").$type<string[]>().default([]),
     sendMode: text("send_mode").notNull().default("enter"),
+    modelPreferences: jsonb("model_preferences")
+      .$type<Record<string, string>>()
+      .default({}),
     onboardingDone: boolean("onboarding_done").notNull().default(false),
     creditCap: bigint("credit_cap", { mode: "number" }),
     creditEnabled: boolean("credit_enabled").notNull().default(true),

--- a/turbo/apps/web/src/lib/user/user-preferences-service.ts
+++ b/turbo/apps/web/src/lib/user/user-preferences-service.ts
@@ -16,12 +16,30 @@ function toStringArray(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === "string");
 }
 
+/**
+ * Safely extract a Record<string, string> from an unknown jsonb value.
+ * Returns {} if the value is not a valid string-to-string record.
+ */
+function toStringRecord(value: unknown): Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === "string") {
+      result[k] = v;
+    }
+  }
+  return result;
+}
+
 type SendMode = "enter" | "cmd-enter";
 
 interface UserPreferences {
   timezone: string | null;
   pinnedAgentIds: string[];
   sendMode: SendMode;
+  modelPreferences: Record<string, string>;
 }
 
 function parseSendMode(value: unknown): SendMode {
@@ -41,6 +59,7 @@ const DEFAULTS: UserPreferences = {
   timezone: null,
   pinnedAgentIds: [],
   sendMode: "enter",
+  modelPreferences: {},
 };
 
 /**
@@ -69,6 +88,7 @@ export async function getUserPreferences(
       timezone: row.timezone,
       pinnedAgentIds: toStringArray(row.pinnedAgentIds),
       sendMode: parseSendMode(row.sendMode),
+      modelPreferences: toStringRecord(row.modelPreferences),
     };
   }
 
@@ -85,6 +105,7 @@ export async function updateUserPreferences(
     timezone?: string;
     pinnedAgentIds?: string[];
     sendMode?: SendMode;
+    modelPreferences?: Record<string, string>;
   },
 ): Promise<UserPreferences> {
   if (prefs.timezone !== undefined) {
@@ -103,6 +124,10 @@ export async function updateUserPreferences(
         ? prefs.pinnedAgentIds
         : existing.pinnedAgentIds,
     sendMode: prefs.sendMode !== undefined ? prefs.sendMode : existing.sendMode,
+    modelPreferences:
+      prefs.modelPreferences !== undefined
+        ? prefs.modelPreferences
+        : existing.modelPreferences,
   };
 
   const now = new Date();
@@ -114,6 +139,7 @@ export async function updateUserPreferences(
       timezone: merged.timezone,
       pinnedAgentIds: merged.pinnedAgentIds,
       sendMode: merged.sendMode,
+      modelPreferences: merged.modelPreferences,
       createdAt: now,
       updatedAt: now,
     })
@@ -125,6 +151,9 @@ export async function updateUserPreferences(
           pinnedAgentIds: prefs.pinnedAgentIds,
         }),
         ...(prefs.sendMode !== undefined && { sendMode: prefs.sendMode }),
+        ...(prefs.modelPreferences !== undefined && {
+          modelPreferences: prefs.modelPreferences,
+        }),
         updatedAt: now,
       },
     });

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -416,8 +416,10 @@ export {
 export {
   userPreferencesResponseSchema,
   updateUserPreferencesRequestSchema,
+  modelPreferencesSchema,
   type UserPreferencesResponse,
   type UpdateUserPreferencesRequest,
+  type ModelPreferences,
   sendModeSchema,
   type SendMode,
 } from "./zero-user-preferences";

--- a/turbo/packages/core/src/contracts/zero-user-preferences.ts
+++ b/turbo/packages/core/src/contracts/zero-user-preferences.ts
@@ -10,10 +10,14 @@ const c = initContract();
 export const sendModeSchema = z.enum(["enter", "cmd-enter"]);
 export type SendMode = z.infer<typeof sendModeSchema>;
 
+export const modelPreferencesSchema = z.record(z.string(), z.string());
+export type ModelPreferences = z.infer<typeof modelPreferencesSchema>;
+
 export const userPreferencesResponseSchema = z.object({
   timezone: z.string().nullable(),
   pinnedAgentIds: z.array(z.string()),
   sendMode: sendModeSchema,
+  modelPreferences: modelPreferencesSchema,
 });
 
 export type UserPreferencesResponse = z.infer<
@@ -25,12 +29,14 @@ export const updateUserPreferencesRequestSchema = z
     timezone: z.string().min(1).optional(),
     pinnedAgentIds: z.array(z.string()).optional(),
     sendMode: sendModeSchema.optional(),
+    modelPreferences: modelPreferencesSchema.optional(),
   })
   .refine(
     (data) =>
       data.timezone !== undefined ||
       data.pinnedAgentIds !== undefined ||
-      data.sendMode !== undefined,
+      data.sendMode !== undefined ||
+      data.modelPreferences !== undefined,
     {
       message: "At least one preference must be provided",
     },


### PR DESCRIPTION
## Summary
- Migrate per-agent model provider preferences from browser localStorage to the server-backed user preferences API, persisted in the `org_members_metadata` table via a new `model_preferences` jsonb column
- Add `modelPreferences` field to the user preferences contract, API route, and service layer with a DB migration (`0198_add_model_preferences`)
- Implement optimistic updates with server sync and JWT refresh for immediate availability of updated metadata
- Hydrate the auto-recharge form from server billing status when opening the org manage dialog
- Update all related tests to use MSW server mocks instead of localStorage

## Test plan
- [ ] Verify model preference persists across browser sessions and devices
- [ ] Verify selecting "default" removes the agent key from server preferences
- [ ] Verify auto-recharge form shows server values when opening org settings
- [ ] Run existing test suite: `pnpm vitest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)