### PR TITLE
fix(auth): resolve membership role for zero tokens

### DIFF
--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import {
   createTestCompose,
   createTestRunInDb,
   createTestSlackOrgInstallation,
+  insertOrgMembersCacheEntry,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -74,6 +75,11 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
   it("returns 404 when no Slack installation exists for org", async () => {
     mockClerk({ userId: null });
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
     const token = await generateZeroToken(user.userId, "run-1", user.orgId);
 
     const request = createTestRequest(URL, {
@@ -94,6 +100,11 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
   it("sends message successfully and returns Slack response", async () => {
     mockClerk({ userId: null });
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
     const token = await generateZeroToken(user.userId, "run-1", user.orgId);
 
     // Create Slack installation for the user's org
@@ -132,6 +143,11 @@ describe("POST /api/zero/integrations/slack/message", () => {
 
   it("forwards Slack API error with 400 status", async () => {
     mockClerk({ userId: null });
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
     const token = await generateZeroToken(user.userId, "run-1", user.orgId);
 
     await createTestSlackOrgInstallation({ orgId: user.orgId });

--- a/turbo/apps/web/src/lib/auth/__tests__/get-auth-context-zero.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-auth-context-zero.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { auth } from "@clerk/nextjs/server";
+import { getAuthContext } from "../get-auth-context";
+import { generateZeroToken } from "../sandbox-token";
+import { clearOrgMembersCacheEntry } from "../../../__tests__/api-test-helpers";
+import { mockClerk } from "../../../__tests__/clerk-mock";
+import { testContext, type UserContext } from "../../../__tests__/test-helpers";
+
+const context = testContext();
+
+describe("getAuthContext with zero token orgRole", () => {
+  const mockAuth = vi.mocked(auth);
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    mockAuth.mockResolvedValue({
+      userId: null,
+    } as Awaited<ReturnType<typeof auth>>);
+  });
+
+  it("should resolve orgRole as admin for zero token with admin user", async () => {
+    const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+
+    // Mock Clerk to return admin role
+    mockClerk({
+      userId: user.userId,
+      orgId: user.orgId,
+      orgRole: "org:admin",
+      clerkOrgs: [
+        {
+          id: user.orgId,
+          slug: `org-${user.userId}`,
+          name: `org-${user.userId}`,
+          role: "org:admin",
+        },
+      ],
+    });
+    await clearOrgMembersCacheEntry(user.orgId, user.userId);
+
+    const result = await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "agent:read",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe(user.userId);
+    expect(result?.orgId).toBe(user.orgId);
+    expect(result?.orgRole).toBe("admin");
+  });
+
+  it("should resolve orgRole as member for zero token with member user", async () => {
+    const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+
+    mockClerk({
+      userId: user.userId,
+      orgId: user.orgId,
+      orgRole: "org:member",
+      clerkOrgs: [
+        {
+          id: user.orgId,
+          slug: `org-${user.userId}`,
+          name: `org-${user.userId}`,
+          role: "org:member",
+        },
+      ],
+    });
+    await clearOrgMembersCacheEntry(user.orgId, user.userId);
+
+    const result = await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "agent:read",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe(user.userId);
+    expect(result?.orgId).toBe(user.orgId);
+    expect(result?.orgRole).toBe("member");
+  });
+
+  it("should omit orgId when user is no longer an org member", async () => {
+    const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+
+    // Mock Clerk to return no memberships (user was removed from org)
+    mockClerk({ userId: user.userId, clerkOrgs: [] });
+    await clearOrgMembersCacheEntry(user.orgId, user.userId);
+
+    const result = await getAuthContext(`Bearer ${token}`, {
+      requiredCapability: "agent:read",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe(user.userId);
+    expect(result?.orgId).toBeUndefined();
+    expect(result?.orgRole).toBeUndefined();
+  });
+
+  it("should resolve orgRole with acceptAnySandboxCapability", async () => {
+    const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+
+    mockClerk({
+      userId: user.userId,
+      orgId: user.orgId,
+      orgRole: "org:admin",
+      clerkOrgs: [
+        {
+          id: user.orgId,
+          slug: `org-${user.userId}`,
+          name: `org-${user.userId}`,
+          role: "org:admin",
+        },
+      ],
+    });
+    await clearOrgMembersCacheEntry(user.orgId, user.userId);
+
+    const result = await getAuthContext(`Bearer ${token}`, {
+      acceptAnySandboxCapability: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.userId).toBe(user.userId);
+    expect(result?.orgId).toBe(user.orgId);
+    expect(result?.orgRole).toBe("admin");
+    expect(result?.capabilities).toContain("agent:read");
+  });
+});

--- a/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/get-auth-context.spec.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { auth } from "@clerk/nextjs/server";
 import { getAuthContext, getUserId } from "../get-auth-context";
 import { generateSandboxToken, generateZeroToken } from "../sandbox-token";
+import { mockClerk } from "../../../__tests__/clerk-mock";
+import { clearOrgMembersCacheEntry } from "../../../__tests__/api-test-helpers";
+import { testContext } from "../../../__tests__/test-helpers";
+
+const context = testContext();
 
 describe("getUserId", () => {
   const mockAuth = vi.mocked(auth);
@@ -229,6 +234,7 @@ describe("getAuthContext auth() call optimization", () => {
   const mockAuth = vi.mocked(auth);
 
   beforeEach(() => {
+    context.setupMocks();
     mockAuth.mockResolvedValue({
       userId: null,
     } as Awaited<ReturnType<typeof auth>>);
@@ -264,6 +270,11 @@ describe("getAuthContext auth() call optimization", () => {
   });
 
   it("should not call auth() when zero token is provided", async () => {
+    mockClerk({
+      userId: "user-1",
+      clerkOrgs: [{ id: "org-1", slug: "org-1", name: "org-1" }],
+    });
+    await clearOrgMembersCacheEntry("org-1", "user-1");
     const token = await generateZeroToken("user-1", "run-1", "org-1");
     await getAuthContext(`Bearer ${token}`, {
       requiredCapability: "agent:read",
@@ -275,10 +286,16 @@ describe("getAuthContext auth() call optimization", () => {
 describe("getAuthContext with zero token and requiredCapability", () => {
   const mockAuth = vi.mocked(auth);
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    context.setupMocks();
     mockAuth.mockResolvedValue({
       userId: null,
     } as Awaited<ReturnType<typeof auth>>);
+    mockClerk({
+      userId: "user-123",
+      clerkOrgs: [{ id: "org-789", slug: "org-789", name: "org-789" }],
+    });
+    await clearOrgMembersCacheEntry("org-789", "user-123");
   });
 
   it("should accept zero token with matching capability", async () => {
@@ -314,10 +331,16 @@ describe("getAuthContext with zero token and requiredCapability", () => {
 describe("getAuthContext with zero token and acceptAnySandboxCapability", () => {
   const mockAuth = vi.mocked(auth);
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    context.setupMocks();
     mockAuth.mockResolvedValue({
       userId: null,
     } as Awaited<ReturnType<typeof auth>>);
+    mockClerk({
+      userId: "user-123",
+      clerkOrgs: [{ id: "org-789", slug: "org-789", name: "org-789" }],
+    });
+    await clearOrgMembersCacheEntry("org-789", "user-123");
   });
 
   it("should accept zero token on infra routes", async () => {

--- a/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { auth } from "@clerk/nextjs/server";
 import { requireAuth, isAuthError } from "../require-auth";
 import { generateSandboxToken, generateZeroToken } from "../sandbox-token";
+import { mockClerk } from "../../../__tests__/clerk-mock";
+import { clearOrgMembersCacheEntry } from "../../../__tests__/api-test-helpers";
+import { testContext } from "../../../__tests__/test-helpers";
+
+const context = testContext();
 
 describe("requireAuth", () => {
   const mockAuth = vi.mocked(auth);
@@ -137,6 +142,12 @@ describe("requireAuth", () => {
   });
 
   it("should return AuthContext for zero token with matching capability", async () => {
+    context.setupMocks();
+    mockClerk({
+      userId: "user-1",
+      clerkOrgs: [{ id: "org-1", slug: "org-1", name: "org-1" }],
+    });
+    await clearOrgMembersCacheEntry("org-1", "user-1");
     const token = await generateZeroToken("user-1", "run-1", "org-1");
 
     const result = await requireAuth(`Bearer ${token}`, {

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -77,13 +77,13 @@ export async function getAuthContext(
 }
 
 /** Authenticate a sandbox-prefixed token (sandbox or zero scope). */
-function authenticateSandboxToken(
+async function authenticateSandboxToken(
   token: string,
   options?: {
     requiredCapability?: ZeroCapability;
     acceptAnySandboxCapability?: boolean;
   },
-): AuthContext | null {
+): Promise<AuthContext | null> {
   // Without any sandbox opt-in, reject sandbox tokens (existing behavior)
   if (!options?.requiredCapability && !options?.acceptAnySandboxCapability) {
     log.debug("Rejected sandbox JWT token on normal API endpoint");
@@ -99,7 +99,19 @@ function authenticateSandboxToken(
   // Try zero token (scope: "zero")
   const zeroAuth = verifyZeroToken(token);
   if (zeroAuth) {
-    return resolveZeroAuth(zeroAuth, options);
+    const result = resolveZeroAuth(zeroAuth, options);
+    if (result && result.orgId) {
+      const membership = await verifyMembershipCached(
+        result.orgId,
+        result.userId,
+      );
+      if (!membership) {
+        // User no longer a member — omit orgId (same pattern as CLI JWT path)
+        return { userId: result.userId, runId: result.runId };
+      }
+      return { ...result, orgRole: membership.role };
+    }
+    return result;
   }
 
   log.debug("Invalid or expired sandbox/zero token");


### PR DESCRIPTION
## Summary

- Make `authenticateSandboxToken()` async and add `verifyMembershipCached()` call after `resolveZeroAuth()` returns
- Mirrors the existing CLI JWT pattern for consistent org role resolution
- Handles removed-user case by omitting `orgId` from AuthContext (same as CLI JWT behavior)

Fixes #6804

## Test plan

- [x] New integration tests for zero token orgRole (admin/member/removed-user scenarios)
- [x] Existing auth tests updated with Clerk mocks for zero token paths
- [x] All 113 auth tests pass
- [x] Pre-existing test failures verified as unrelated (DELETE agent tests, Slack, skills sync)
- [x] Lint, format, knip, type-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)