### PR TITLE
fix(chat): insert failed runs at chronological position in message list

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -520,6 +520,7 @@ export const chatSessionSnapshot$ = computed(
       status: string;
       prompt: string;
       error: string | null;
+      createdAt: string;
     }[] = [];
     let isLegacySession = false;
 
@@ -550,6 +551,8 @@ export const chatSessionSnapshot$ = computed(
 
     const resolvedSessionId = isLegacySession ? threadId : latestSessionId;
 
+    // Track createdAt alongside messages for chronological insertion
+    const messageTimestamps: string[] = [];
     const messages: ZeroChatMessage[] = chatMessages.map((m) => {
       const summaries =
         m.summaries && m.summaries.length > 0
@@ -557,6 +560,7 @@ export const chatSessionSnapshot$ = computed(
               TOOL_LABELS[s] ? humanizeToolUse(s, undefined) : s,
             )
           : undefined;
+      messageTimestamps.push(m.createdAt);
       return {
         id: crypto.randomUUID(),
         role: m.role,
@@ -580,9 +584,8 @@ export const chatSessionSnapshot$ = computed(
       const isFailed =
         run.status === "failed" || run.status === "timeout" || isCancelled;
       if (isFailed) {
-        // Failed/cancelled runs are immutable — go to messages
-        messages.push(userMsg);
-        messages.push({
+        // Failed/cancelled runs are immutable — insert at chronological position
+        const assistantMsg: ZeroChatMessage = {
           id: crypto.randomUUID(),
           role: "assistant",
           content: "",
@@ -592,7 +595,17 @@ export const chatSessionSnapshot$ = computed(
             ? "Run cancelled."
             : (run.error ??
               "Something went wrong. Check the activity logs for details."),
-        });
+        };
+        const insertIdx = messageTimestamps.findIndex(
+          (t) => t > run.createdAt,
+        );
+        if (insertIdx === -1) {
+          messages.push(userMsg, assistantMsg);
+          messageTimestamps.push(run.createdAt, run.createdAt);
+        } else {
+          messages.splice(insertIdx, 0, userMsg, assistantMsg);
+          messageTimestamps.splice(insertIdx, 0, run.createdAt, run.createdAt);
+        }
       } else {
         // Active run — goes to activeRunMessages (will be copied to local state)
         activeRunMessages.push(userMsg);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -596,9 +596,7 @@ export const chatSessionSnapshot$ = computed(
             : (run.error ??
               "Something went wrong. Check the activity logs for details."),
         };
-        const insertIdx = messageTimestamps.findIndex(
-          (t) => t > run.createdAt,
-        );
+        const insertIdx = messageTimestamps.findIndex((t) => t > run.createdAt);
         if (insertIdx === -1) {
           messages.push(userMsg, assistantMsg);
           messageTimestamps.push(run.createdAt, run.createdAt);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-ordering.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-message-ordering.test.tsx
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { mockChatLifecycle } from "./chat-test-helpers.ts";
+
+const context = testContext();
+
+describe("chat message ordering", () => {
+  it("should insert failed run at chronological position when subsequent messages exist", async () => {
+    mockChatLifecycle({
+      threadId: "thread-ordering-1",
+      chatMessages: [
+        {
+          role: "user",
+          content: "First message",
+          createdAt: "2026-03-10T00:00:01Z",
+        },
+        {
+          role: "assistant",
+          content: "First reply",
+          createdAt: "2026-03-10T00:00:02Z",
+        },
+        {
+          role: "user",
+          content: "Third message",
+          createdAt: "2026-03-10T00:00:10Z",
+        },
+        {
+          role: "assistant",
+          content: "Third reply",
+          createdAt: "2026-03-10T00:00:11Z",
+        },
+      ],
+      unsavedRuns: [
+        {
+          runId: "failed-run-1",
+          status: "failed",
+          prompt: "Second message",
+          error: "Something went wrong",
+          createdAt: "2026-03-10T00:00:05Z",
+        },
+      ],
+    });
+
+    await setupPage({ context, path: "/chat/thread-ordering-1" });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("First message")).toBeInTheDocument();
+        expect(screen.getByText("First reply")).toBeInTheDocument();
+        expect(screen.getByText("Second message")).toBeInTheDocument();
+        expect(screen.getByText("Third message")).toBeInTheDocument();
+        expect(screen.getByText("Third reply")).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    const firstReply = screen.getByText("First reply");
+    const failedPrompt = screen.getByText("Second message");
+    const thirdMessage = screen.getByText("Third message");
+
+    // Failed run should appear after "First reply"
+    expect(
+      firstReply.compareDocumentPosition(failedPrompt) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // Failed run should appear before "Third message"
+    expect(
+      failedPrompt.compareDocumentPosition(thirdMessage) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  }, 30_000);
+
+  it("should append failed run to bottom when it is the latest message", async () => {
+    mockChatLifecycle({
+      threadId: "thread-ordering-2",
+      chatMessages: [
+        {
+          role: "user",
+          content: "First message",
+          createdAt: "2026-03-10T00:00:01Z",
+        },
+        {
+          role: "assistant",
+          content: "First reply",
+          createdAt: "2026-03-10T00:00:02Z",
+        },
+      ],
+      unsavedRuns: [
+        {
+          runId: "failed-run-2",
+          status: "failed",
+          prompt: "Last message",
+          error: "Something went wrong",
+          createdAt: "2026-03-10T00:00:10Z",
+        },
+      ],
+    });
+
+    await setupPage({ context, path: "/chat/thread-ordering-2" });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("First reply")).toBeInTheDocument();
+        expect(screen.getByText("Last message")).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    const firstReply = screen.getByText("First reply");
+    const lastMessage = screen.getByText("Last message");
+
+    // Failed run should appear after "First reply"
+    expect(
+      firstReply.compareDocumentPosition(lastMessage) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  }, 30_000);
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -69,6 +69,7 @@ export function mockChatLifecycle(options?: {
     status: string;
     prompt: string;
     error: string | null;
+    createdAt?: string;
   }[];
   threadTitle?: string | null;
 }): MockLifecycleControl {

--- a/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
@@ -163,6 +163,7 @@ interface UnsavedRun {
   status: string;
   prompt: string;
   error: string | null;
+  createdAt: string;
 }
 
 export async function getChatThreadMessages(
@@ -262,6 +263,7 @@ export async function getChatThreadMessages(
       status: r.status,
       prompt: r.prompt,
       error: r.error,
+      createdAt: r.createdAt.toISOString(),
     }));
 
   return {

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -27,6 +27,7 @@ const unsavedRunSchema = z.object({
   status: z.string(),
   prompt: z.string(),
   error: z.string().nullable(),
+  createdAt: z.string(),
 });
 
 const chatThreadDetailSchema = z.object({


### PR DESCRIPTION
#6143 — unsaved (failed/cancelled) chat runs always appear at the bottom of the message list, regardless of when they occurred.
                                                                                                                                                                                                                     
  Fix
  Insert failed/cancelled runs at their correct chronological position in the message list instead of always appending them to the end.                                                                              
                                                                                                                                                                                                                     
  - Added `createdAt` field to `UnsavedRun` contract, service, and schema                                                                                                                                            
  - Built a `messageTimestamps` array alongside the message list to track insertion order                                                                                                                            
  - Used `findIndex` to locate the correct insertion point; falls back to append when the run is the latest                                                                                                          
                                                                                                                                                                                                                     
  Testing                                                                                                                                                                                                            
  Added integration tests covering:                                                                                                                                                                                  
  - Failed run with a `createdAt` between existing messages is inserted at the correct position
  - Failed run with the latest `createdAt` is correctly appended to the bottom                                                                                                                                       
  Change is isolated to the chat session snapshot computation and does not affect message parsing or active run handling.