### PR TITLE
fix: restrict billing ui and api access to org admins only

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server.ts";
 import { mockLocation } from "../../../location.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
 import { createPushStateMock } from "../../../../__tests__/page-helper.ts";
@@ -93,6 +95,28 @@ describe("checkSettingsParam$", () => {
     expect(store.get(orgManageDialogOpen$)).toBeFalsy();
     // The param should still be stripped
     expect(store.get(searchParams$).has("settings")).toBeFalsy();
+  });
+
+  it("should redirect non-admin to general tab for admin-only tabs", async () => {
+    const { store, signal } = context;
+    setupAuth(signal);
+    server.use(
+      http.get("*/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "org_1",
+          slug: "user-12345678",
+          name: "User 12345678",
+          role: "member",
+        });
+      }),
+    );
+    createPushStateMock(signal);
+    mockLocation({ pathname: "/", search: "?settings=billing" }, signal);
+
+    await store.set(checkSettingsParam$, signal);
+
+    expect(store.get(orgManageDialogOpen$)).toBeTruthy();
+    expect(store.get(activeTab$)).toBe("general");
   });
 
   it("should preserve other search params when stripping settings", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { mockLocation } from "../../../location.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
 import { createPushStateMock } from "../../../../__tests__/page-helper.ts";
+import { mockUser, clearMockedAuth } from "../../../../__tests__/mock-auth.ts";
 import {
   checkSettingsParam$,
   orgManageDialogOpen$,
@@ -11,9 +12,20 @@ import { searchParams$ } from "../../../route.ts";
 
 const context = testContext();
 
+function setupAuth(signal: AbortSignal) {
+  mockUser(
+    { id: "test-user-123", fullName: "Test User" },
+    { token: "test-token" },
+  );
+  signal.addEventListener("abort", () => {
+    clearMockedAuth();
+  });
+}
+
 describe("checkSettingsParam$", () => {
   it("should open dialog on providers tab when ?settings=providers is present", async () => {
     const { store, signal } = context;
+    setupAuth(signal);
     createPushStateMock(signal);
     mockLocation({ pathname: "/", search: "?settings=providers" }, signal);
 
@@ -27,6 +39,7 @@ describe("checkSettingsParam$", () => {
 
   it("should open dialog on billing tab when ?settings=billing is present", async () => {
     const { store, signal } = context;
+    setupAuth(signal);
     createPushStateMock(signal);
     mockLocation({ pathname: "/", search: "?settings=billing" }, signal);
 
@@ -38,6 +51,7 @@ describe("checkSettingsParam$", () => {
 
   it("should open dialog on usage tab when ?settings=usage is present", async () => {
     const { store, signal } = context;
+    setupAuth(signal);
     createPushStateMock(signal);
     mockLocation({ pathname: "/", search: "?settings=usage" }, signal);
 
@@ -49,6 +63,7 @@ describe("checkSettingsParam$", () => {
 
   it("should map legacy ?settings=credits to usage tab", async () => {
     const { store, signal } = context;
+    setupAuth(signal);
     createPushStateMock(signal);
     mockLocation({ pathname: "/", search: "?settings=credits" }, signal);
 
@@ -82,6 +97,7 @@ describe("checkSettingsParam$", () => {
 
   it("should preserve other search params when stripping settings", async () => {
     const { store, signal } = context;
+    setupAuth(signal);
     createPushStateMock(signal);
     mockLocation(
       { pathname: "/", search: "?settings=providers&other=keep" },

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
@@ -3,6 +3,7 @@ import { clerk$ } from "../../auth.ts";
 import { detach, onRef, Reason } from "../../utils.ts";
 import { searchParams$, updateSearchParams$ } from "../../route.ts";
 import { reloadBillingStatus$ } from "../billing.ts";
+import { isOrgAdmin$ } from "../../org.ts";
 import {
   initProfileName$,
   setActiveTab$,
@@ -46,9 +47,19 @@ export const checkSettingsParam$ = command(
       credits: "usage",
       invoices: "invoices",
     };
+    const ADMIN_ONLY_TABS = new Set<OrgManageTab>([
+      "billing",
+      "usage",
+      "invoices",
+      "providers",
+    ]);
     const tab = settingsTabMap[settingsValue];
     if (tab) {
-      set(setActiveTab$, tab);
+      const isAdmin = await get(isOrgAdmin$);
+      signal.throwIfAborted();
+      const resolvedTab =
+        !isAdmin && ADMIN_ONLY_TABS.has(tab) ? "general" : tab;
+      set(setActiveTab$, resolvedTab);
       await set(setOrgManageDialogOpen$, true, signal);
     }
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
@@ -128,7 +128,7 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
     ...BASE_SIDEBAR_GROUPS.slice(0, 1),
     ...(isAdmin ? [CONFIGURATION_GROUP] : []),
     ...BASE_SIDEBAR_GROUPS.slice(1),
-    BILLING_GROUP,
+    ...(isAdmin ? [BILLING_GROUP] : []),
   ];
 
   const meta = TAB_META[activeTab];

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -95,6 +95,7 @@ import {
   setBillingSubPage$,
 } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
+import { isOrgAdmin$ } from "../../signals/org.ts";
 import { BillingDialog } from "./billing-dialog.tsx";
 import {
   ChatListDialog,
@@ -792,9 +793,16 @@ function SidebarUpgradeCard() {
   const billingLoadable = useLastLoadable(billingStatusAsync$);
   const billing =
     billingLoadable.state === "hasData" ? billingLoadable.data : null;
+  const isAdminLoadable = useLoadable(isOrgAdmin$);
+  const isAdmin =
+    isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
   const setTab = useSet(setActiveTab$);
   const setSubPage = useSet(setBillingSubPage$);
   const openManage = useSet(setOrgManageDialogOpen$);
+
+  if (!isAdmin) {
+    return null;
+  }
 
   if (!billing) {
     return null;

--- a/turbo/apps/web/app/api/zero/billing/checkout/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/checkout/__tests__/route.test.ts
@@ -116,6 +116,29 @@ describe("POST /api/zero/billing/checkout", () => {
     expect(response.status).toBe(400);
   });
 
+  it("returns 403 for non-admin member", async () => {
+    const { userId, orgId } = await context.setupUser({
+      prefix: "member-checkout",
+    });
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/checkout",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tier: "pro",
+          successUrl: "https://app.vm7.ai/billing?billing=success",
+          cancelUrl: "https://app.vm7.ai/billing?billing=canceled",
+        }),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(403);
+  });
+
   it("returns checkout URL on success", async () => {
     stripeMocks.customersCreate.mockResolvedValue({
       id: uniqueId("cus-checkout"),

--- a/turbo/apps/web/app/api/zero/billing/checkout/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/checkout/route.ts
@@ -34,7 +34,13 @@ const router = tsr.router(zeroBillingCheckoutContract, {
     if (isAuthError(authCtx)) return authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only org admins can manage billing",
+      );
+    }
 
     const priceId =
       body.tier === "pro" ? ZERO_PRO_PLAN_PRICE_ID : ZERO_MAX_PLAN_PRICE_ID;

--- a/turbo/apps/web/app/api/zero/billing/invoices/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/invoices/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
   testContext,
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock";
 import { reloadEnv } from "../../../../../../src/env";
 
@@ -51,6 +52,20 @@ describe("GET /api/zero/billing/invoices", () => {
     reloadEnv();
 
     stripeMocks.invoicesList.mockReset();
+  });
+
+  it("returns 403 for non-admin member", async () => {
+    const { userId, orgId } = await context.setupUser({
+      prefix: "member-invoices",
+    });
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/invoices",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(403);
   });
 
   it("returns invoices for org with active subscription", async () => {

--- a/turbo/apps/web/app/api/zero/billing/invoices/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/invoices/route.ts
@@ -3,7 +3,7 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../../src/lib/ts-rest-handler";
-import { zeroBillingInvoicesContract } from "@vm0/core";
+import { zeroBillingInvoicesContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -20,7 +20,13 @@ const router = tsr.router(zeroBillingInvoicesContract, {
     if (isAuthError(authCtx)) return authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only org admins can view invoices",
+      );
+    }
 
     const result = await getOrgInvoices(org.orgId);
 

--- a/turbo/apps/web/app/api/zero/billing/portal/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/portal/__tests__/route.test.ts
@@ -104,6 +104,26 @@ describe("POST /api/zero/billing/portal", () => {
     expect(response.status).toBe(400);
   });
 
+  it("returns 403 for non-admin member", async () => {
+    mockClerk({
+      userId: user.userId,
+      orgId: user.orgId,
+      orgRole: "org:member",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/portal",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ returnUrl: "http://localhost/settings" }),
+      },
+    );
+    const response = await POST(request);
+
+    expect(response.status).toBe(403);
+  });
+
   it("returns portal URL on success", async () => {
     await updateOrgStripeFields(user.orgId, {
       stripeCustomerId: uniqueId("cus-portal"),

--- a/turbo/apps/web/app/api/zero/billing/portal/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/portal/route.ts
@@ -29,7 +29,13 @@ const router = tsr.router(zeroBillingPortalContract, {
     if (isAuthError(authCtx)) return authCtx;
 
     const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only org admins can manage billing",
+      );
+    }
 
     const url = await createBillingPortalSession(org.orgId, body.returnUrl);
 

--- a/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
@@ -100,6 +100,20 @@ describe("GET /api/zero/billing/status", () => {
     expect(data.hasSubscription).toBe(true);
   });
 
+  it("returns 200 for non-admin member", async () => {
+    const { userId, orgId } = await context.setupUser({
+      prefix: "member-status",
+    });
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/billing/status",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+  });
+
   it("returns defaults when org row does not exist", async () => {
     const newOrgId = uniqueId("org-nonexistent");
     mockClerk({


### PR DESCRIPTION
## Summary

- Add admin role checks to billing API endpoints (checkout, portal, invoices) returning 403 for non-admin members, following the existing pattern from auto-recharge
- Hide sidebar upgrade card (`SidebarUpgradeCard`) and billing group in org settings dialog for non-admin members
- Redirect non-admin URL navigation (`?settings=billing/usage/invoices/providers`) to the general tab
- Add test coverage: 403 tests for checkout/portal/invoices and 200 test for status (confirming member access preserved)

## Test plan

- [x] All billing route tests pass (27 tests across 5 test files)
- [x] Lint passes for both web and platform packages
- [x] Knip finds no unused exports/dependencies
- [ ] CI pipeline passes

Closes #6801

🤖 Generated with [Claude Code](https://claude.com/claude-code)