### PR TITLE
fix: prevent agent from sending slack messages as user identity

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -40,6 +40,7 @@ export function buildZeroCliGuidance(): string {
     "Run `npx -p @vm0/cli zero --help` to see all available commands.",
     "Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "For recurring or scheduled tasks, use the zero schedule CLI.",
+    "Never use the user's Slack token to send messages as the user's identity.",
     "Use `zero slack message send` to send Slack messages as the bot user.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Add instruction in agent context to never use user's Slack token to send messages as the user's identity
- Ensures agents always use the bot user via `zero slack message send`

## Test plan
- [ ] Verify the integration context includes the new instruction
- [ ] Confirm agents use bot token instead of user token for Slack messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)