### PR TITLE
fix: add email verification to clerk test user cleanup and stale job

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -318,6 +318,78 @@ jobs:
           echo "Cleaned: $CLEANED"
           echo "Failures: $FAILED"
 
+  cleanup-clerk-test-users:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Find recently closed PRs
+        id: prs
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const since = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 100
+            });
+            const recent = pulls
+              .filter(pr => pr.closed_at && pr.closed_at >= since)
+              .map(pr => pr.number);
+            console.log(`Found ${recent.length} PRs closed since ${since}: ${recent.join(', ')}`);
+            core.setOutput('numbers', JSON.stringify(recent));
+            core.setOutput('has-prs', recent.length > 0 ? 'true' : 'false');
+
+      - name: Delete stale Clerk test users for closed PRs
+        if: steps.prs.outputs.has-prs == 'true'
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          PR_NUMBERS: ${{ steps.prs.outputs.numbers }}
+          DRY_RUN: ${{ env.DRY_RUN }}
+        run: |
+          set -eu
+
+          DELETED=0
+          SKIPPED=0
+
+          for PR_NUMBER in $(echo "$PR_NUMBERS" | jq -r '.[]'); do
+            JOB_REF="pr-${PR_NUMBER}"
+            echo "--- Searching for test users matching ${JOB_REF}+clerk_test ---"
+
+            USERS=$(curl -sS -X GET "https://api.clerk.com/v1/users?query=${JOB_REF}%2Bclerk_test&limit=100" \
+              -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+              -H "Content-Type: application/json")
+
+            echo "$USERS" | jq -c '.[]' 2>/dev/null | while read -r user; do
+              USER_ID=$(echo "$user" | jq -r '.id')
+              EMAIL=$(echo "$user" | jq -r '.email_addresses[0].email_address // "unknown"')
+
+              # Verify email actually matches this PR (Clerk query is fuzzy)
+              if [[ "$EMAIL" != "${JOB_REF}+clerk_test@"* ]]; then
+                echo "Skipping $USER_ID ($EMAIL) — does not match ${JOB_REF}"
+                continue
+              fi
+
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "[DRY-RUN] Would delete $USER_ID ($EMAIL)"
+              else
+                echo "Deleting $USER_ID ($EMAIL)"
+                curl -sS -X DELETE "https://api.clerk.com/v1/users/${USER_ID}" \
+                  -H "Authorization: Bearer ${CLERK_SECRET_KEY}" || true
+              fi
+              DELETED=$((DELETED + 1))
+            done
+          done
+
+          echo ""
+          echo "=== Clerk Test User Cleanup Summary ==="
+          echo "Deleted: $DELETED"
+          echo "Skipped: $SKIPPED"
+
   cleanup-git-branches:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -364,13 +364,14 @@ jobs:
               -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
               -H "Content-Type: application/json")
 
-            echo "$USERS" | jq -c '.[]' 2>/dev/null | while read -r user; do
+            while read -r user; do
               USER_ID=$(echo "$user" | jq -r '.id')
               EMAIL=$(echo "$user" | jq -r '.email_addresses[0].email_address // "unknown"')
 
               # Verify email actually matches this PR (Clerk query is fuzzy)
               if [[ "$EMAIL" != "${JOB_REF}+clerk_test@"* ]]; then
                 echo "Skipping $USER_ID ($EMAIL) — does not match ${JOB_REF}"
+                SKIPPED=$((SKIPPED + 1))
                 continue
               fi
 
@@ -378,11 +379,13 @@ jobs:
                 echo "[DRY-RUN] Would delete $USER_ID ($EMAIL)"
               else
                 echo "Deleting $USER_ID ($EMAIL)"
-                curl -sS -X DELETE "https://api.clerk.com/v1/users/${USER_ID}" \
-                  -H "Authorization: Bearer ${CLERK_SECRET_KEY}" || true
+                if ! curl -sS -X DELETE "https://api.clerk.com/v1/users/${USER_ID}" \
+                  -H "Authorization: Bearer ${CLERK_SECRET_KEY}"; then
+                  echo "::warning::Failed to delete user $USER_ID ($EMAIL)"
+                fi
               fi
               DELETED=$((DELETED + 1))
-            done
+            done < <(echo "$USERS" | jq -c '.[]' 2>/dev/null)
           done
 
           echo ""

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -109,16 +109,21 @@ jobs:
           USERS=$(curl -sS -X GET "https://api.clerk.com/v1/users?query=${JOB_REF}%2Bclerk_test&limit=100" \
             -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
             -H "Content-Type: application/json")
-          USER_IDS=$(echo "$USERS" | jq -r '.[].id // empty' 2>/dev/null || true)
-          if [[ -z "$USER_IDS" ]]; then
-            echo "No test users found to clean up"
-          else
-            for uid in $USER_IDS; do
-              echo "Deleting user $uid"
-              curl -sS -X DELETE "https://api.clerk.com/v1/users/${uid}" \
-                -H "Authorization: Bearer ${CLERK_SECRET_KEY}" || true
-            done
-          fi
+
+          echo "$USERS" | jq -c '.[]' 2>/dev/null | while read -r user; do
+            USER_ID=$(echo "$user" | jq -r '.id')
+            EMAIL=$(echo "$user" | jq -r '.email_addresses[0].email_address // "unknown"')
+
+            # Verify email actually matches this PR (Clerk query is fuzzy)
+            if [[ "$EMAIL" != "${JOB_REF}+clerk_test@"* ]]; then
+              echo "Skipping $USER_ID ($EMAIL) — does not match ${JOB_REF}"
+              continue
+            fi
+
+            echo "Deleting $USER_ID ($EMAIL)"
+            curl -sS -X DELETE "https://api.clerk.com/v1/users/${USER_ID}" \
+              -H "Authorization: Bearer ${CLERK_SECRET_KEY}" || true
+          done
 
   cleanup-deployments:
     # Skip for release-please PRs (only version bumps and changelogs)

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -110,7 +110,7 @@ jobs:
             -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
             -H "Content-Type: application/json")
 
-          echo "$USERS" | jq -c '.[]' 2>/dev/null | while read -r user; do
+          while read -r user; do
             USER_ID=$(echo "$user" | jq -r '.id')
             EMAIL=$(echo "$user" | jq -r '.email_addresses[0].email_address // "unknown"')
 
@@ -121,9 +121,11 @@ jobs:
             fi
 
             echo "Deleting $USER_ID ($EMAIL)"
-            curl -sS -X DELETE "https://api.clerk.com/v1/users/${USER_ID}" \
-              -H "Authorization: Bearer ${CLERK_SECRET_KEY}" || true
-          done
+            if ! curl -sS -X DELETE "https://api.clerk.com/v1/users/${USER_ID}" \
+              -H "Authorization: Bearer ${CLERK_SECRET_KEY}"; then
+              echo "::warning::Failed to delete user $USER_ID ($EMAIL)"
+            fi
+          done < <(echo "$USERS" | jq -c '.[]' 2>/dev/null)
 
   cleanup-deployments:
     # Skip for release-please PRs (only version bumps and changelogs)


### PR DESCRIPTION
## Summary
- Add email prefix matching before deleting Clerk test users to prevent accidental deletion caused by Clerk's fuzzy search API
- Add a dedicated `cleanup-clerk-test-users` job to the `cleanup-stale.yml` workflow that cleans up test users from recently closed PRs
- Improve logging in both workflows by showing email addresses during cleanup

## Test plan
- [ ] Verify `cleanup-stale.yml` workflow syntax is valid
- [ ] Verify `cleanup.yml` workflow syntax is valid
- [ ] Confirm email prefix check correctly filters out non-matching users

🤖 Generated with [Claude Code](https://claude.com/claude-code)