### PR TITLE
fix: clarify slack token type in agent context

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -40,7 +40,6 @@ export function buildZeroCliGuidance(): string {
     "Run `npx -p @vm0/cli zero --help` to see all available commands.",
     "Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "For recurring or scheduled tasks, use the zero schedule CLI.",
-    "Never use the user's Slack token to send messages as the user's identity.",
-    "Use `zero slack message send` to send Slack messages as the bot user.",
+    "SLACK_TOKEN is a user token — never use it to send messages. Always use `zero slack message send`, which uses the bot token internally.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Replace two vague Slack instructions with a single clear line that explicitly identifies `SLACK_TOKEN` as a user token and directs agents to use `zero slack message send` (bot token) instead
- Follows up on #6815 — agents were still calling Slack API directly with the user token because the instruction didn't clarify token types

## Test plan
- [ ] Verify agent context includes the updated instruction
- [ ] Confirm agents use `zero slack message send` instead of direct Slack API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)