### PR TITLE
fix: add z-index to sticky chat composer to prevent content overlap

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -234,7 +234,7 @@ export function ZeroSessionChatPage({
         </main>
 
         {/* Composer — sticky inside the scroll container so it aligns with messages */}
-        <footer className="relative sticky bottom-0 shrink-0 px-4 sm:px-6 pt-3 pb-8 bg-[hsl(var(--background))]">
+        <footer className="relative sticky bottom-0 z-10 shrink-0 px-4 sm:px-6 pt-3 pb-8 bg-[hsl(var(--background))]">
           <div className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
           <div className="mx-auto max-w-[900px]">
             <ZeroChatComposer


### PR DESCRIPTION
## Summary
- Add `z-10` to the sticky chat composer footer so scrolled content (tool use blocks, code blocks, timeline elements) no longer overlaps the input area

Closes #6219

## Test plan
- [ ] Open a chat with tool use blocks or long code blocks
- [ ] Scroll so content passes behind the composer
- [ ] Verify the composer stays on top of all scrolled content

🤖 Generated with [Claude Code](https://claude.com/claude-code)