### PR TITLE
feat(platform): add dedicated /ideas route for ideas & use cases page

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -21,6 +21,7 @@ import { setupUsagePage$ } from "./usage-page/usage-page-setup.ts";
 import { setupChatSessionPage$ } from "./zero-page/chat-session-page-setup.ts";
 import { setupInternalConnectorLogos$ } from "./internal-connector-logos-setup.ts";
 import { setupOnboardingPage$ } from "./onboarding-page/onboarding-page-setup.ts";
+import { setupIdeationPage$ } from "./zero-page/ideation-page-setup.ts";
 
 /**
  * Catch-all fallback — redirects unknown paths to /.
@@ -88,6 +89,10 @@ const ROUTE_CONFIG = [
   {
     path: "/usage",
     setup: setupAuthPageWrapper(setupUsagePage$),
+  },
+  {
+    path: "/ideas",
+    setup: setupAuthPageWrapper(setupIdeationPage$),
   },
   {
     path: "/onboarding",

--- a/turbo/apps/platform/src/signals/zero-page/ideation-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/ideation-page-setup.ts
@@ -1,0 +1,20 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroIdeationPage } from "../../views/zero-page/zero-ideation-page.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { onboardGuard$ } from "./onboard-guard.ts";
+import { loadInitialData$ } from "./zero-page.ts";
+
+export const setupIdeationPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroIdeationPage));
+    set(updateDocumentTitle$, "Ideas & Use Cases");
+
+    await set(loadInitialData$, signal);
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -8,6 +8,7 @@ import type {
 function isValidTab(tab: string): tab is ZeroNavId {
   return (
     tab === "chat" ||
+    tab === "ideas" ||
     tab === "schedule" ||
     tab === "team" ||
     tab === "activity" ||
@@ -80,6 +81,8 @@ export const setZeroActiveId$ = command(({ set }, id: ZeroNavId) => {
     set(navigateTo$, "/");
   } else if (id === "team") {
     set(navigateTo$, "/team");
+  } else if (id === "ideas") {
+    set(navigateTo$, "/ideas");
   } else {
     set(navigateTo$, "/:tab", { pathParams: { tab: id } });
   }

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -15,6 +15,7 @@ export type RoutePath =
   | "/preferences"
   | "/usage"
   | "/works"
+  | "/ideas"
   | "/onboarding"
   | "/__internal-connector-logos"
   | `/projects/${string}`;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import { act, screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { getCategories } from "../zero-ideation-data.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+function mockChatAPI() {
+  server.use(
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+async function renderIdeationPage() {
+  mockChatAPI();
+  await setupPage({ context, path: "/ideas" });
+}
+
+describe("ideation page - direct route rendering", () => {
+  it("should render the ideation page when navigating to /ideas", async () => {
+    await renderIdeationPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Ideas & Use Cases" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(/Click any card to start a conversation/),
+    ).toBeInTheDocument();
+  });
+
+  it("should set document title", async () => {
+    await renderIdeationPage();
+
+    await waitFor(() => {
+      expect(document.title).toBe("Ideas & Use Cases | VM0");
+    });
+  });
+
+  it("should render breadcrumb with Chat link", async () => {
+    await renderIdeationPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Chat").closest("button")).toBeInTheDocument();
+    });
+
+    // Breadcrumb text (non-heading) should also be present
+    const breadcrumbNav = screen.getByRole("navigation");
+    expect(breadcrumbNav).toHaveTextContent("Ideas & Use Cases");
+  });
+});
+
+describe("ideation page - category tabs", () => {
+  const categories = getCategories().slice(0, 5);
+
+  it("should render All tab and each category tab", async () => {
+    await renderIdeationPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+    });
+
+    for (const category of categories) {
+      expect(
+        screen.getByRole("button", { name: category.title }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("should show all category headings when All tab is active", async () => {
+    await renderIdeationPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: categories[0].title }),
+      ).toBeInTheDocument();
+    });
+
+    for (const category of categories) {
+      expect(
+        screen.getByRole("heading", { name: category.title }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("should filter to a single category when its tab is clicked", async () => {
+    await renderIdeationPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "GitHub" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "GitHub" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "GitHub" }),
+      ).toBeInTheDocument();
+    });
+
+    // Other categories should not be visible
+    expect(
+      screen.queryByRole("heading", { name: "Reports" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show all categories again when All tab is clicked after filtering", async () => {
+    await renderIdeationPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "GitHub" }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "GitHub" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Reports" }),
+      ).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Reports" }),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("ideation page - search", () => {
+  it("should render search input", async () => {
+    await renderIdeationPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("searchbox", { name: "Search use cases" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should filter use cases by title", async () => {
+    await renderIdeationPage();
+
+    const searchInput = await waitFor(() =>
+      screen.getByRole("searchbox", { name: "Search use cases" }),
+    );
+
+    fireEvent.change(searchInput, { target: { value: "Daily standup" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Daily standup report")).toBeInTheDocument();
+    });
+
+    // Unrelated use cases should not be visible
+    expect(screen.queryByText("Batch-create issues")).not.toBeInTheDocument();
+  });
+
+  it("should show empty message when no use cases match", async () => {
+    await renderIdeationPage();
+
+    const searchInput = await waitFor(() =>
+      screen.getByRole("searchbox", { name: "Search use cases" }),
+    );
+
+    fireEvent.change(searchInput, {
+      target: { value: "xyznonexistentquery" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No use cases match your search."),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("ideation page - use case cards", () => {
+  it("should render use case cards with title and description", async () => {
+    await renderIdeationPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Daily standup report")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Morning metrics become a slide deck posted to Slack"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("ideation page - navigation", () => {
+  it("should navigate to / when a use case card is clicked", async () => {
+    await renderIdeationPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Daily standup report")).toBeInTheDocument();
+    });
+
+    await act(() => {
+      fireEvent.click(screen.getByText("Daily standup report"));
+    });
+
+    await waitFor(() => {
+      expect(pathname()).not.toBe("/ideas");
+    });
+  });
+
+  it("should navigate to / when Chat breadcrumb is clicked", async () => {
+    await renderIdeationPage();
+
+    const chatBreadcrumb = await waitFor(
+      () => screen.getByText("Chat").closest("button")!,
+    );
+
+    await act(() => {
+      fireEvent.click(chatBreadcrumb!);
+    });
+
+    await waitFor(() => {
+      expect(pathname()).not.toBe("/ideas");
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -21,8 +21,9 @@ import {
   setChatPageInput$,
   chatPageTaglineIndex$,
 } from "../../signals/zero-page/zero-chat-page.ts";
-import { ZeroIdeationPage, getRandomPrompts } from "./zero-ideation-page.tsx";
+import { getRandomPrompts } from "./zero-ideation-page.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import { navigateTo$ } from "../../signals/route.ts";
 import zeroAvatarImg from "./assets/avatar_0.png";
 
 function getTagline(
@@ -156,8 +157,8 @@ export function ZeroChatPage({
   const setInput = useSet(setChatPageInput$);
   const taglineIndex = useGet(chatPageTaglineIndex$);
   const tagline = getTagline(displayName, userName, taglineIndex);
-  const [showIdeation, setShowIdeation] = useState(false);
   const [suggestedPrompts] = useState(() => getRandomPrompts(2));
+  const navigate = useSet(navigateTo$);
 
   // Pin pill
   const currentChatAgentId = useGet(zeroChatAgentId$);
@@ -180,18 +181,6 @@ export function ZeroChatPage({
     setInput("");
     onSendMessage?.(text, opts);
   };
-
-  if (showIdeation) {
-    return (
-      <ZeroIdeationPage
-        onBack={() => setShowIdeation(false)}
-        onSelectPrompt={(prompt) => {
-          setInput(prompt);
-          setShowIdeation(false);
-        }}
-      />
-    );
-  }
 
   // Landing page: full content (title, triggers, composer, actions, prompts)
   return (
@@ -294,7 +283,7 @@ export function ZeroChatPage({
             <button
               type="button"
               className="zero-card cursor-pointer p-4 text-left flex flex-col relative group hover:bg-muted/30 transition-colors"
-              onClick={() => setShowIdeation(true)}
+              onClick={() => navigate("/ideas")}
             >
               <IconArrowUpRight
                 size={14}

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useSet } from "ccstate-react";
 import {
   IconArrowUpRight,
   IconMessageCircle,
@@ -7,21 +8,17 @@ import {
 import { Card, CardContent, cn, Input } from "@vm0/ui";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { getCategories } from "./zero-ideation-data.ts";
+import { setChatPageInput$ } from "../../signals/zero-page/zero-chat-page.ts";
+import { navigateTo$ } from "../../signals/route.ts";
 
 export { getRandomPrompts } from "./zero-ideation-data.ts";
 
-interface ZeroIdeationPageProps {
-  onBack: () => void;
-  onSelectPrompt: (prompt: string) => void;
-}
-
-export function ZeroIdeationPage({
-  onBack,
-  onSelectPrompt,
-}: ZeroIdeationPageProps) {
+export function ZeroIdeationPage() {
   const categories = getCategories().slice(0, 5);
   const [activeTab, setActiveTab] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
+  const setInput = useSet(setChatPageInput$);
+  const navigate = useSet(navigateTo$);
 
   const baseCategories =
     activeTab === "all"
@@ -42,12 +39,21 @@ export function ZeroIdeationPage({
           }))
           .filter((c) => c.cases.length > 0);
 
+  const handleSelectPrompt = (prompt: string) => {
+    setInput(prompt);
+    navigate("/");
+  };
+
+  const handleBack = () => {
+    navigate("/");
+  };
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <nav className="flex shrink-0 items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
         <button
           type="button"
-          onClick={onBack}
+          onClick={handleBack}
           className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-muted hover:text-foreground transition-colors cursor-pointer"
         >
           <IconMessageCircle size={14} stroke={1.5} className="shrink-0" />
@@ -142,7 +148,7 @@ export function ZeroIdeationPage({
                         <Card
                           key={useCase.title}
                           className="zero-card cursor-pointer hover:bg-muted/30 transition-colors"
-                          onClick={() => onSelectPrompt(useCase.prompt)}
+                          onClick={() => handleSelectPrompt(useCase.prompt)}
                         >
                           <CardContent className="p-4 group relative">
                             <IconArrowUpRight

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -96,6 +96,7 @@ export { AGENT_AVATARS, useAgentAvatar } from "./zero-sidebar-shared.tsx";
 
 export type ZeroNavId =
   | "chat"
+  | "ideas"
   | "schedule"
   | "team"
   | "activity"


### PR DESCRIPTION
## Summary

- Adds a dedicated `/ideas` route for the Ideas & Use Cases page, replacing the inline overlay that was rendered via local React state within the chat page
- The page now supports browser navigation (back/forward), refresh, bookmarking, URL sharing, and direct navigation
- Clicking a use case card navigates back to chat with the selected prompt pre-filled in the composer

## Changes

- **New file**: `ideation-page-setup.ts` — route setup signal for `/ideas`
- **`bootstrap.ts`**: Register `/ideas` route in `ROUTE_CONFIG`
- **`route.ts` (types)**: Add `/ideas` to `RoutePath` union
- **`zero-nav.ts`**: Add `"ideas"` to `isValidTab` and `setZeroActiveId$`
- **`zero-sidebar.tsx`**: Add `"ideas"` to `ZeroNavId` type
- **`zero-ideation-page.tsx`**: Remove callback props, use route navigation internally
- **`zero-chat-page.tsx`**: Navigate to `/ideas` instead of toggling local state

## Test plan

- [x] Existing 16 chat page tests pass (including ideation navigation tests)
- [x] TypeScript type check passes
- [x] Lint passes (0 warnings, 0 errors)
- [x] Knip passes (no unused code)
- [ ] Manual: Navigate to `/ideas` directly — page renders correctly
- [ ] Manual: Click "Ideas & use cases" card on chat landing — navigates to `/ideas`
- [ ] Manual: Click a use case card — navigates back to chat with prompt pre-filled
- [ ] Manual: Click "Chat" breadcrumb — navigates back to chat
- [ ] Manual: Browser back/forward works between chat and ideas page
- [ ] Manual: Refresh on `/ideas` preserves the page
- [ ] Manual: Copy `/ideas` URL and open in new tab — page loads correctly

Closes #6817

🤖 Generated with [Claude Code](https://claude.com/claude-code)