### PR TITLE
chore: remove last vm0_live_ references from codebase

### DIFF
--- a/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
+++ b/turbo/apps/web/__tests__/proxy.sandbox-token.test.ts
@@ -128,15 +128,15 @@ describe("proxy middleware: sandbox token handling", () => {
     expect(capturedClerkRequest!.headers.get("authorization")).toBe(token);
   });
 
-  it("should pass legacy CLI tokens through to Clerk unchanged", async () => {
-    const token = "Bearer vm0_live_abc123def456";
+  it("should pass unknown token formats through to Clerk unchanged", async () => {
+    const token = "Bearer unknown_format_abc123";
     const request = new NextRequest("https://www.vm0.ai/api/runs", {
       headers: { authorization: token },
     });
 
     await middleware(request, createMockEvent());
 
-    // Legacy CLI tokens (vm0_live_) are not self-signed tokens and should pass through
+    // Unknown token formats are not self-signed tokens and should pass through
     expect(capturedClerkRequest).toBeDefined();
     expect(capturedClerkRequest!.headers.get("authorization")).toBe(token);
   });

--- a/turbo/apps/web/src/db/schema/cli-tokens.ts
+++ b/turbo/apps/web/src/db/schema/cli-tokens.ts
@@ -2,7 +2,7 @@ import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
 
 export const cliTokens = pgTable("cli_tokens", {
   id: uuid("id").defaultRandom().primaryKey(),
-  token: text("token").unique().notNull(), // vm0_pat_xxxxx... (JWT) or vm0_live_xxxxx... (legacy opaque)
+  token: text("token").unique().notNull(), // vm0_pat_xxxxx... (JWT)
   userId: text("user_id").notNull(), // Clerk user ID
   name: text("name").notNull(), // User-friendly name
   expiresAt: timestamp("expires_at").notNull(),


### PR DESCRIPTION
## Summary
- Remove legacy opaque token mention (`vm0_live_`) from `cli-tokens.ts` schema comment
- Update proxy middleware test to use generic unknown token format instead of `vm0_live_` prefix
- Cosmetic cleanup from PR #6786

## Verification
- `grep -r vm0_live_` confirms zero remaining references outside CHANGELOG (auto-generated) and `cli-token.test.ts` (tests rejection of old format)
- Lint and type checks pass

## Test plan
- [x] Existing proxy middleware tests pass with updated test data
- [x] No functional changes — comment and test data only

🤖 Generated with [Claude Code](https://claude.com/claude-code)