### PR TITLE
refactor(platform): resolve schedule agent label from server-side displayName

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -382,6 +382,7 @@ export interface OrgScheduleEntry {
   timezone: string;
   intervalSeconds: number | null;
   agentId: string;
+  displayName: string | null;
   nextRunAt: string | null;
   lastRunAt: string | null;
 }
@@ -412,6 +413,7 @@ export const allOrgScheduleEntries$ = computed((get) => {
         timezone: s.timezone,
         intervalSeconds: s.intervalSeconds,
         agentId: s.agentId,
+        displayName: s.displayName,
         nextRunAt: s.nextRunAt,
         lastRunAt: s.lastRunAt,
       }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/build-combined-schedule.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/build-combined-schedule.test.ts
@@ -18,6 +18,7 @@ function makeEntry(
     timezone: "UTC",
     intervalSeconds: null,
     agentId: "agent-uuid-1",
+    displayName: null,
     nextRunAt: null,
     lastRunAt: null,
     ...overrides,
@@ -25,58 +26,33 @@ function makeEntry(
 }
 
 describe("buildCombinedSchedule", () => {
-  it("should use default agent name when entry agentId matches defaultComposeId", () => {
-    const entries = [makeEntry({ agentId: "default-uuid" })];
-    const nameToDisplay = new Map<string, string>();
-    const result = buildCombinedSchedule(
-      entries,
-      "Zero",
-      "default-uuid",
-      nameToDisplay,
-    );
+  it("should use displayName as agentLabel when set", () => {
+    const entries = [makeEntry({ displayName: "Zero" })];
+    const result = buildCombinedSchedule(entries);
     expect(result[0].agentLabel).toBe("Zero");
   });
 
-  it("should resolve agent label from nameToDisplay map keyed by agent id", () => {
-    const entries = [makeEntry({ agentId: "sub-agent-uuid" })];
-    const nameToDisplay = new Map([["sub-agent-uuid", "Research Agent"]]);
-    const result = buildCombinedSchedule(
-      entries,
-      "Zero",
-      "default-uuid",
-      nameToDisplay,
-    );
-    expect(result[0].agentLabel).toBe("Research Agent");
-  });
-
-  it("should fall back to raw agentId when not in nameToDisplay map", () => {
-    const entries = [makeEntry({ agentId: "unknown-uuid" })];
-    const nameToDisplay = new Map([["other-uuid", "Other Agent"]]);
-    const result = buildCombinedSchedule(
-      entries,
-      "Zero",
-      "default-uuid",
-      nameToDisplay,
-    );
+  it("should fall back to agentId when displayName is null", () => {
+    const entries = [makeEntry({ agentId: "unknown-uuid", displayName: null })];
+    const result = buildCombinedSchedule(entries);
     expect(result[0].agentLabel).toBe("unknown-uuid");
   });
 
   it("should handle multiple entries with different agents", () => {
     const entries = [
-      makeEntry({ id: "s1", agentId: "default-uuid" }),
-      makeEntry({ id: "s2", agentId: "agent-a" }),
-      makeEntry({ id: "s3", agentId: "agent-b" }),
+      makeEntry({ id: "s1", agentId: "default-uuid", displayName: "Zero" }),
+      makeEntry({
+        id: "s2",
+        agentId: "agent-a",
+        displayName: "Alpha Agent",
+      }),
+      makeEntry({
+        id: "s3",
+        agentId: "agent-b",
+        displayName: "Beta Agent",
+      }),
     ];
-    const nameToDisplay = new Map([
-      ["agent-a", "Alpha Agent"],
-      ["agent-b", "Beta Agent"],
-    ]);
-    const result = buildCombinedSchedule(
-      entries,
-      "Zero",
-      "default-uuid",
-      nameToDisplay,
-    );
+    const result = buildCombinedSchedule(entries);
     expect(result[0].agentLabel).toBe("Zero");
     expect(result[1].agentLabel).toBe("Alpha Agent");
     expect(result[2].agentLabel).toBe("Beta Agent");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-page.test.tsx
@@ -12,7 +12,7 @@ function createMockSchedules() {
     {
       id: "sched-1",
       agentId: "mock-compose-id",
-      agentName: "zero",
+      displayName: "Zero",
       orgSlug: "test",
       name: "morning-briefing",
       triggerType: "cron",
@@ -33,7 +33,7 @@ function createMockSchedules() {
     {
       id: "sched-2",
       agentId: "mock-compose-id",
-      agentName: "zero",
+      displayName: "Zero",
       orgSlug: "test",
       name: "check-inbox",
       triggerType: "loop",
@@ -54,7 +54,7 @@ function createMockSchedules() {
     {
       id: "sched-disabled",
       agentId: "mock-compose-id",
-      agentName: "zero",
+      displayName: "Zero",
       orgSlug: "test",
       name: "disabled-schedule",
       triggerType: "cron",
@@ -135,6 +135,7 @@ describe("zero schedule page - agent labels", () => {
             {
               ...createMockSchedules()[0],
               agentId: "sub-agent-id",
+              displayName: "Research Agent",
             },
           ],
         });
@@ -145,7 +146,7 @@ describe("zero schedule page - agent labels", () => {
     );
     await renderSchedulePage();
 
-    // The agent column should show "Research Agent" (resolved from displayName by id)
+    // The agent column should show "Research Agent" (from schedule displayName)
     await waitFor(() => {
       expect(screen.getByText("Research Agent")).toBeInTheDocument();
     });
@@ -179,6 +180,7 @@ describe("zero schedule page - agent labels", () => {
             {
               ...createMockSchedules()[0],
               agentId: "no-name-agent",
+              displayName: null,
             },
           ],
         });

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -32,9 +32,7 @@ import { Switch } from "@vm0/ui/components/ui/switch";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import { Link } from "../router/link.tsx";
 import { navigateTo$, pathParams$ } from "../../signals/route.ts";
-import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import { agentsList$ } from "../../signals/zero-page/agents-list.ts";
-import { zeroOnboardingStatus$ } from "../../signals/zero-page/zero-onboarding.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   allOrgScheduleEntries$,
@@ -967,25 +965,12 @@ export function ZeroScheduleDetailPage() {
       ? String(params.scheduleId)
       : null;
 
-  const displayNameLoadable = useLoadable(agentDisplayName$);
-  const displayName =
-    displayNameLoadable.state === "hasData" ? displayNameLoadable.data : "Zero";
-
-  const statusLoadable = useLoadable(zeroOnboardingStatus$);
-  const defaultComposeId =
-    statusLoadable.state === "hasData"
-      ? statusLoadable.data.defaultAgentId
-      : null;
-
   const entriesLoadable = useLastLoadable(allOrgScheduleEntries$);
   const entries: OrgScheduleEntry[] =
     entriesLoadable.state === "hasData" ? entriesLoadable.data : [];
 
   const agentsLoadable = useLoadable(agentsList$);
   const agents = agentsLoadable.state === "hasData" ? agentsLoadable.data : [];
-  const nameToDisplay = new Map(
-    agents.filter((a) => a.displayName).map((a) => [a.id, a.displayName!]),
-  );
 
   const loaded = useGet(allOrgSchedulesLoaded$);
   const slackReady = useGet(slackOrgInitialized$);
@@ -999,12 +984,7 @@ export function ZeroScheduleDetailPage() {
   const [saving, setSaving] = useState(false);
   const [toggling, setToggling] = useState(false);
   const [running, setRunning] = useState(false);
-  const combinedSchedule = buildCombinedSchedule(
-    entries,
-    displayName,
-    defaultComposeId,
-    nameToDisplay,
-  );
+  const combinedSchedule = buildCombinedSchedule(entries);
 
   if (!scheduleId) {
     return <ScheduleNotFound />;

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -31,7 +31,6 @@ import {
 } from "./schedule-dialog.tsx";
 import { ScheduleCalendarView } from "./schedule-calendar-view.tsx";
 import { ScheduleListView } from "./schedule-list-view.tsx";
-import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 import { agentsList$ } from "../../signals/zero-page/agents-list.ts";
 import { COMMON_TIMEZONES } from "../../signals/zero-page/cron.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -57,9 +56,6 @@ export type CombinedEntry = ScheduleEntry & {
 
 export function buildCombinedSchedule(
   entries: OrgScheduleEntry[],
-  agentName: string,
-  defaultComposeId: string | null,
-  nameToDisplay: Map<string, string>,
 ): CombinedEntry[] {
   return entries.map((e) => ({
     id: e.id,
@@ -72,10 +68,7 @@ export function buildCombinedSchedule(
     slackChannelId: e.slackChannelId,
     name: e.name,
     intervalSeconds: e.intervalSeconds,
-    agentLabel:
-      e.agentId === defaultComposeId
-        ? agentName
-        : (nameToDisplay.get(e.agentId) ?? e.agentId),
+    agentLabel: e.displayName ?? e.agentId,
     agentId: e.agentId,
     timezone: e.timezone,
     nextRunAt: e.nextRunAt,
@@ -397,10 +390,6 @@ function ScheduleCalendarSkeleton() {
 // ---------------------------------------------------------------------------
 
 export function ZeroSchedulePage() {
-  const displayNameLoadable = useLoadable(agentDisplayName$);
-  const displayName =
-    displayNameLoadable.state === "hasData" ? displayNameLoadable.data : "Zero";
-
   const statusLoadable = useLoadable(zeroOnboardingStatus$);
   const defaultComposeId =
     statusLoadable.state === "hasData"
@@ -413,9 +402,6 @@ export function ZeroSchedulePage() {
 
   const agentsLoadable = useLoadable(agentsList$);
   const agents = agentsLoadable.state === "hasData" ? agentsLoadable.data : [];
-  const nameToDisplay = new Map(
-    agents.filter((a) => a.displayName).map((a) => [a.id, a.displayName!]),
-  );
   const loaded = useGet(allOrgSchedulesLoaded$);
   const isInitialLoading = !loaded;
 
@@ -437,12 +423,7 @@ export function ZeroSchedulePage() {
     null,
   );
 
-  const combinedSchedule = buildCombinedSchedule(
-    entries,
-    displayName,
-    defaultComposeId,
-    nameToDisplay,
-  );
+  const combinedSchedule = buildCombinedSchedule(entries);
 
   const agentOrder = [
     ...new Set(combinedSchedule.map((e) => e.agentLabel)),

--- a/turbo/apps/web/src/lib/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/schedule/schedule-service.ts
@@ -2,6 +2,7 @@ import { eq, and, lte, inArray, desc } from "drizzle-orm";
 import { Cron } from "croner";
 import { zeroAgentSchedules } from "../../db/schema/zero-agent-schedule";
 import { agentComposes } from "../../db/schema/agent-compose";
+import { zeroAgents } from "../../db/schema/zero-agent";
 import { slackOrgConnections } from "../../db/schema/slack-org-connection";
 import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
 import { agentRuns } from "../../db/schema/agent-run";
@@ -26,7 +27,7 @@ const log = logger("service:schedule");
 export interface ScheduleResponse {
   id: string;
   agentId: string;
-  agentName: string;
+  displayName: string | null;
   orgSlug: string;
   userId: string;
   name: string;
@@ -120,7 +121,7 @@ function calculateNextRun(
  */
 function toResponse(
   schedule: typeof zeroAgentSchedules.$inferSelect,
-  agentName: string,
+  displayName: string | null,
   orgSlug: string,
 ): ScheduleResponse {
   // Extract secret names from encrypted secrets (values are never returned)
@@ -138,7 +139,7 @@ function toResponse(
   return {
     id: schedule.id,
     agentId: schedule.agentId,
-    agentName,
+    displayName,
     orgSlug,
     userId: schedule.userId,
     name: schedule.name,
@@ -186,12 +187,17 @@ async function verifyScheduleOwnership(
   name: string,
 ): Promise<{
   schedule: typeof zeroAgentSchedules.$inferSelect;
-  agentName: string;
+  displayName: string | null;
   orgSlug: string;
 }> {
   const [agent] = await globalThis.services.db
-    .select({ id: agentComposes.id, name: agentComposes.name })
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      displayName: zeroAgents.displayName,
+    })
     .from(agentComposes)
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(eq(agentComposes.id, agentId))
     .limit(1);
 
@@ -217,7 +223,7 @@ async function verifyScheduleOwnership(
     throw notFound(`Schedule '${name}' not found`);
   }
 
-  return { schedule, agentName: agent.name, orgSlug };
+  return { schedule, displayName: agent.displayName ?? null, orgSlug };
 }
 
 /**
@@ -408,8 +414,13 @@ export async function deploySchedule(
   log.debug(`Deploying schedule ${request.name} for agent ${request.agentId}`);
 
   const [agent] = await globalThis.services.db
-    .select({ id: agentComposes.id, name: agentComposes.name })
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      displayName: zeroAgents.displayName,
+    })
     .from(agentComposes)
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(eq(agentComposes.id, request.agentId))
     .limit(1);
 
@@ -474,6 +485,7 @@ export async function deploySchedule(
     .limit(1);
 
   const { triggerType, nextRunAt } = resolveTrigger(request);
+  const displayName = agent.displayName ?? null;
 
   if (existing) {
     const updated = await updateExistingSchedule(
@@ -484,7 +496,7 @@ export async function deploySchedule(
     );
     log.debug(`Updated schedule ${request.name} (${existing.id})`);
     return {
-      schedule: toResponse(updated, agent.name, orgSlug),
+      schedule: toResponse(updated, displayName, orgSlug),
       created: false,
     };
   }
@@ -499,7 +511,7 @@ export async function deploySchedule(
   );
   log.debug(`Created schedule ${request.name} (${created.id})`);
   return {
-    schedule: toResponse(created, agent.name, orgSlug),
+    schedule: toResponse(created, displayName, orgSlug),
     created: true,
   };
 }
@@ -530,11 +542,15 @@ export async function listSchedules(
     return [];
   }
 
-  // Load agent compose data for all schedules
+  // Load agent compose data (with displayName) for all schedules
   const agentIds = [...new Set(userSchedules.map((s) => s.agentId))];
   const agentRows = await globalThis.services.db
-    .select({ id: agentComposes.id, name: agentComposes.name })
+    .select({
+      id: agentComposes.id,
+      displayName: zeroAgents.displayName,
+    })
     .from(agentComposes)
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
     .where(inArray(agentComposes.id, agentIds));
   const agentMap = new Map(agentRows.map((r) => [r.id, r]));
 
@@ -554,7 +570,7 @@ export async function listSchedules(
     .map((schedule) => {
       const agent = agentMap.get(schedule.agentId)!;
       const orgSlug = orgDataMap.get(schedule.orgId)?.slug ?? "";
-      return toResponse(schedule, agent.name, orgSlug);
+      return toResponse(schedule, agent.displayName ?? null, orgSlug);
     });
 }
 
@@ -569,14 +585,14 @@ export async function getScheduleByName(
 ): Promise<ScheduleResponse> {
   log.debug(`Getting schedule ${name} for agent ${agentId}`);
 
-  const { schedule, agentName, orgSlug } = await verifyScheduleOwnership(
+  const { schedule, displayName, orgSlug } = await verifyScheduleOwnership(
     userId,
     orgId,
     agentId,
     name,
   );
 
-  return toResponse(schedule, agentName, orgSlug);
+  return toResponse(schedule, displayName, orgSlug);
 }
 
 /**
@@ -659,7 +675,7 @@ export async function enableSchedule(
 ): Promise<ScheduleResponse> {
   log.debug(`Enabling schedule ${name} for agent ${agentId}`);
 
-  const { schedule, agentName, orgSlug } = await verifyScheduleOwnership(
+  const { schedule, displayName, orgSlug } = await verifyScheduleOwnership(
     userId,
     orgId,
     agentId,
@@ -703,7 +719,7 @@ export async function enableSchedule(
 
   log.debug(`Enabled schedule ${name}`);
 
-  return toResponse(updated, agentName, orgSlug);
+  return toResponse(updated, displayName, orgSlug);
 }
 
 /**
@@ -717,7 +733,7 @@ export async function disableSchedule(
 ): Promise<ScheduleResponse> {
   log.debug(`Disabling schedule ${name} for agent ${agentId}`);
 
-  const { schedule, agentName, orgSlug } = await verifyScheduleOwnership(
+  const { schedule, displayName, orgSlug } = await verifyScheduleOwnership(
     userId,
     orgId,
     agentId,
@@ -740,7 +756,7 @@ export async function disableSchedule(
 
   log.debug(`Disabled schedule ${name}`);
 
-  return toResponse(updated, agentName, orgSlug);
+  return toResponse(updated, displayName, orgSlug);
 }
 
 /**

--- a/turbo/packages/core/src/contracts/zero-schedules.ts
+++ b/turbo/packages/core/src/contracts/zero-schedules.ts
@@ -10,6 +10,7 @@ const c = initContract();
 export const scheduleResponseSchema = z.object({
   id: z.string().uuid(),
   agentId: z.string().uuid(),
+  displayName: z.string().nullable(),
   orgSlug: z.string(),
   userId: z.string(),
   name: z.string(),


### PR DESCRIPTION
## Summary

- Add `displayName` to schedule API response by joining `zero_agents` table server-side
- Remove dead `agentName` field from `ScheduleResponse` (was stripped by Zod contract, no client ever read it)
- Simplify `buildCombinedSchedule()` — remove `nameToDisplay` map, `agentName`, and `defaultComposeId` parameters
- Each schedule entry is now self-contained: `agentLabel = e.displayName ?? e.agentId`

Closes #6830

## Test plan

- [x] `buildCombinedSchedule` unit tests updated and passing
- [x] Platform integration test updated for new mock shape
- [x] Type check passing (core, platform, cli)
- [x] Lint clean
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)