### PR TITLE
refactor: restructure agent system prompt with agent tools section

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -28,18 +28,15 @@ export const DISALLOWED_CRON_TOOLS = [
 ] as const;
 
 /**
- * Build Zero CLI guidance prompt so sandbox agents know how to use the CLI.
+ * Build Agent Tools prompt so sandbox agents know how to use the Zero CLI.
  * Injected by createZeroRun() for all trigger paths.
  */
-export function buildZeroCliGuidance(): string {
+export function buildAgentToolsPrompt(): string {
   return [
-    "# Zero CLI",
-    "You have access to the Zero CLI for managing platform resources.",
-    "Run commands with: `npx -p @vm0/cli zero <command>`",
-    "Tip: run `alias zero='npx -p @vm0/cli zero'` first, then use `zero <command>` for brevity.",
-    "Run `npx -p @vm0/cli zero --help` to see all available commands.",
-    "Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
-    "For recurring or scheduled tasks, use the zero schedule CLI.",
-    "SLACK_TOKEN is a user token — never use it to send messages. Always use `zero slack message send`, which uses the bot token internally.",
+    "# Agent Tools",
+    "You have access to the Zero CLI for zero platform. Run commands with: `npx -p @vm0/cli zero <command>`",
+    "- Use `zero --help` to see all available commands.",
+    "- Use `zero schedule --help` for recurring or scheduled tasks. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
+    "- Use `zero slack message send` to send messages as bot token. Never use SLACK_TOKEN to send messages — it's a user token.",
   ].join("\n");
 }

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -113,12 +113,12 @@ describe("createZeroRun()", () => {
       expect(run!.appendSystemPrompt).toMatch(/Bot[\s\S]*Custom instructions/);
     });
 
-    it("should inject zero CLI guidance even when no identity metadata exists", async () => {
+    it("should inject agent tools prompt even when no identity metadata exists", async () => {
       const result = await createZeroRun(baseParams());
 
       const run = await findTestRunRecord(result.runId);
       expect(run).toBeDefined();
-      expect(run!.appendSystemPrompt).toContain("Zero CLI");
+      expect(run!.appendSystemPrompt).toContain("# Agent Tools");
       expect(run!.appendSystemPrompt).not.toContain("# Agent Identity");
     });
 

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -3,7 +3,7 @@ import type { TriggerSource, FirewallPolicies } from "@vm0/core";
 import { startRun, type CreateRunResult } from "../run";
 import {
   DISALLOWED_CRON_TOOLS,
-  buildZeroCliGuidance,
+  buildAgentToolsPrompt,
 } from "../integration-context";
 import { formatAgentIdentityPrompt } from "../agent-identity";
 import type { CallbackPayload } from "../callback/callback-payloads";
@@ -61,20 +61,18 @@ export async function createZeroRun(
     firewallPolicies: null,
   };
 
-  // Inject agent identity into appendSystemPrompt
-  let { appendSystemPrompt } = params;
+  // Build agent system prompt: identity + tools first, then trigger context
+  const agentParts: string[] = [];
   if (agent.displayName || agent.description || agent.sound) {
-    const identity = formatAgentIdentityPrompt(agent);
-    appendSystemPrompt = appendSystemPrompt
-      ? `${identity}\n\n${appendSystemPrompt}`
-      : identity;
+    agentParts.push(formatAgentIdentityPrompt(agent));
   }
+  agentParts.push(buildAgentToolsPrompt());
 
-  // Append zero CLI guidance so all trigger paths know how to use the CLI
-  const zeroGuidance = buildZeroCliGuidance();
+  let { appendSystemPrompt } = params;
+  const agentPrompt = agentParts.join("\n\n");
   appendSystemPrompt = appendSystemPrompt
-    ? `${appendSystemPrompt}\n\n${zeroGuidance}`
-    : zeroGuidance;
+    ? `${agentPrompt}\n\n${appendSystemPrompt}`
+    : agentPrompt;
 
   return startRun({
     userId: params.userId,


### PR DESCRIPTION
## Summary
- Rename `buildZeroCliGuidance()` → `buildAgentToolsPrompt()` and restructure the content from a flat "# Zero CLI" section into a concise "# Agent Tools" section with bullet points
- Move Agent Tools to sit right after Agent Identity in the system prompt (instead of being appended at the end), so the agent sees identity + tools as a cohesive block before trigger-specific context
- Simplify the prompt text: remove the alias tip and redundant instructions, keep only the `--help` entry point and gotcha-specific guidance (schedule vs cron, slack bot token)

## Test plan
- [x] Existing `zero-run-service.test.ts` tests pass (22/22)
- [x] Lint and knip pass
- [x] Verified prompt ordering: Agent Identity → Agent Tools → trigger context

🤖 Generated with [Claude Code](https://claude.com/claude-code)