### PR TITLE
fix: persist chat summaries with structured metadata for consistent display

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -30,6 +30,7 @@ import {
   chatThreadRunsContract,
   zeroSessionsByIdContract,
   type ChatThreadListItem,
+  type SummaryEntry,
 } from "@vm0/core";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
 
@@ -531,7 +532,7 @@ export const chatSessionSnapshot$ = computed(
       content: string;
       runId?: string;
       error?: string;
-      summaries?: string[];
+      summaries?: SummaryEntry[];
       createdAt: string;
     }[] = [];
     let latestSessionId: string | null = null;
@@ -573,9 +574,15 @@ export const chatSessionSnapshot$ = computed(
     const messages: ZeroChatMessage[] = chatMessages.map((m) => {
       const summaries =
         m.summaries && m.summaries.length > 0
-          ? m.summaries.map((s) =>
-              TOOL_LABELS[s] ? humanizeToolUse(s, undefined) : s,
-            )
+          ? m.summaries.map((s) => {
+              if (typeof s === "string") {
+                return TOOL_LABELS[s] ? humanizeToolUse(s, undefined) : s;
+              }
+              if (s.kind === "tool") {
+                return humanizeToolUse(s.name, s.input);
+              }
+              return s.text;
+            })
           : undefined;
       return {
         id: crypto.randomUUID(),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -2,6 +2,7 @@ import { fireEvent } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import type { AgentEvent } from "../../../signals/zero-page/log-types.ts";
+import type { SummaryEntry } from "@vm0/core";
 
 export const PLACEHOLDER = "Ask me to automate workflows, manage tasks...";
 
@@ -61,7 +62,7 @@ export function mockChatLifecycle(options?: {
     content: string;
     runId?: string;
     error?: string;
-    summaries?: string[];
+    summaries?: SummaryEntry[];
     createdAt: string;
   }[];
   unsavedRuns?: {

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -234,7 +234,7 @@ export function ZeroSessionChatPage({
         </main>
 
         {/* Composer — sticky inside the scroll container so it aligns with messages */}
-        <footer className="relative sticky bottom-0 shrink-0 px-4 sm:px-6 pt-3 pb-8 bg-[hsl(var(--background))]">
+        <footer className="relative sticky bottom-0 z-10 shrink-0 px-4 sm:px-6 pt-3 pb-8 bg-[hsl(var(--background))]">
           <div className="pointer-events-none absolute inset-x-0 -top-5 h-5 bg-gradient-to-t from-[hsl(var(--background))] to-transparent" />
           <div className="mx-auto max-w-[900px]">
             <ZeroChatComposer

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -631,7 +631,11 @@ describe("POST /api/webhooks/agent/complete", () => {
         role: string;
         content: string;
         runId?: string;
-        summaries?: string[];
+        summaries?: Array<
+          | string
+          | { kind: "tool"; name: string }
+          | { kind: "text"; text: string }
+        >;
       };
       const chatMessages = (await getSessionChatMessages(
         checkpointData.agentSessionId,
@@ -641,8 +645,11 @@ describe("POST /api/webhooks/agent/complete", () => {
       const assistantMsg = chatMessages.find((m) => m.role === "assistant");
       expect(assistantMsg).toBeDefined();
       expect(assistantMsg!.content).toBe("Done. Created 3 files.");
-      // Last text event is skipped — only tool_use names are extracted
-      expect(assistantMsg!.summaries).toEqual(["Bash", "Read"]);
+      // Last text event is skipped — only tool_use entries are extracted
+      expect(assistantMsg!.summaries).toEqual([
+        { kind: "tool", name: "Bash" },
+        { kind: "tool", name: "Read" },
+      ]);
     });
 
     it("should extract text summaries when events have no tool_use", async () => {
@@ -717,7 +724,11 @@ describe("POST /api/webhooks/agent/complete", () => {
 
       type StoredMessage = {
         role: string;
-        summaries?: string[];
+        summaries?: Array<
+          | string
+          | { kind: "tool"; name: string }
+          | { kind: "text"; text: string }
+        >;
       };
       const chatMessages = (await getSessionChatMessages(
         checkpointData.agentSessionId,
@@ -726,7 +737,9 @@ describe("POST /api/webhooks/agent/complete", () => {
       const assistantMsg = chatMessages.find((m) => m.role === "assistant");
       expect(assistantMsg).toBeDefined();
       // First text event included, last text event skipped
-      expect(assistantMsg!.summaries).toEqual(["Let me check the logs first"]);
+      expect(assistantMsg!.summaries).toEqual([
+        { kind: "text", text: "Let me check the logs first" },
+      ]);
     });
 
     it("should truncate text summaries exceeding 80 characters", async () => {
@@ -802,7 +815,11 @@ describe("POST /api/webhooks/agent/complete", () => {
 
       type StoredMessage = {
         role: string;
-        summaries?: string[];
+        summaries?: Array<
+          | string
+          | { kind: "tool"; name: string }
+          | { kind: "text"; text: string }
+        >;
       };
       const chatMessages = (await getSessionChatMessages(
         checkpointData.agentSessionId,
@@ -811,8 +828,13 @@ describe("POST /api/webhooks/agent/complete", () => {
       const assistantMsg = chatMessages.find((m) => m.role === "assistant");
       expect(assistantMsg).toBeDefined();
       expect(assistantMsg!.summaries).toHaveLength(1);
-      expect(assistantMsg!.summaries![0]!.length).toBe(81); // 80 chars + "…"
-      expect(assistantMsg!.summaries![0]!.endsWith("…")).toBe(true);
+      const entry = assistantMsg!.summaries![0] as {
+        kind: "text";
+        text: string;
+      };
+      expect(entry.kind).toBe("text");
+      expect(entry.text.length).toBe(81); // 80 chars + "…"
+      expect(entry.text.endsWith("…")).toBe(true);
     });
 
     it("should not include summaries when Axiom returns no message events", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -546,6 +546,344 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(chatMessages[0]!.role).toBe("user");
       expect(chatMessages[0]!.content).toBe("Test prompt");
     });
+
+    it("should persist summaries extracted from Axiom events", async () => {
+      // Create checkpoint (which creates a session)
+      const checkpointRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "test-session-summaries",
+            cliAgentSessionHistory: JSON.stringify({ type: "test" }),
+            artifactSnapshot: {
+              artifactName: "test-artifact",
+              artifactVersion: "v1",
+            },
+          }),
+        },
+      );
+      const checkpointResponse = await checkpointWebhook(checkpointRequest);
+      expect(checkpointResponse.status).toBe(200);
+      const checkpointData = (await checkpointResponse.json()) as {
+        agentSessionId: string;
+      };
+
+      // First Axiom call: extractRunOutput — returns the result text
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        { eventData: { result: "Done. Created 3 files." } },
+      ]);
+      // Second Axiom call: extractSummariesFromAxiom — returns message events
+      // with tool_use blocks and a final text block (which should be skipped)
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventData: {
+            message: {
+              content: [{ type: "tool_use", name: "Bash" }],
+            },
+          },
+        },
+        {
+          eventData: {
+            message: {
+              content: [{ type: "tool_use", name: "Read" }],
+            },
+          },
+        },
+        {
+          eventData: {
+            message: {
+              content: [{ type: "text", text: "Done. Created 3 files." }],
+            },
+          },
+        },
+      ]);
+
+      // Complete the run
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await context.mocks.flushAfter();
+
+      // Verify summaries are persisted on the assistant message
+      type StoredMessage = {
+        role: string;
+        content: string;
+        runId?: string;
+        summaries?: string[];
+      };
+      const chatMessages = (await getSessionChatMessages(
+        checkpointData.agentSessionId,
+      )) as StoredMessage[];
+      expect(chatMessages.length).toBeGreaterThanOrEqual(2);
+
+      const assistantMsg = chatMessages.find((m) => m.role === "assistant");
+      expect(assistantMsg).toBeDefined();
+      expect(assistantMsg!.content).toBe("Done. Created 3 files.");
+      // Last text event is skipped — only tool_use names are extracted
+      expect(assistantMsg!.summaries).toEqual(["Bash", "Read"]);
+    });
+
+    it("should extract text summaries when events have no tool_use", async () => {
+      const checkpointRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "test-session-text-summaries",
+            cliAgentSessionHistory: JSON.stringify({ type: "test" }),
+            artifactSnapshot: {
+              artifactName: "test-artifact",
+              artifactVersion: "v1",
+            },
+          }),
+        },
+      );
+      const checkpointResponse = await checkpointWebhook(checkpointRequest);
+      expect(checkpointResponse.status).toBe(200);
+      const checkpointData = (await checkpointResponse.json()) as {
+        agentSessionId: string;
+      };
+
+      // First Axiom call: extractRunOutput
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        { eventData: { result: "Analysis complete." } },
+      ]);
+      // Second Axiom call: extractSummariesFromAxiom — text-only events
+      // Last text event should be skipped, earlier ones included
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventData: {
+            message: {
+              content: [{ type: "text", text: "Let me check the logs first" }],
+            },
+          },
+        },
+        {
+          eventData: {
+            message: {
+              content: [{ type: "text", text: "Analysis complete." }],
+            },
+          },
+        },
+      ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await context.mocks.flushAfter();
+
+      type StoredMessage = {
+        role: string;
+        summaries?: string[];
+      };
+      const chatMessages = (await getSessionChatMessages(
+        checkpointData.agentSessionId,
+      )) as StoredMessage[];
+
+      const assistantMsg = chatMessages.find((m) => m.role === "assistant");
+      expect(assistantMsg).toBeDefined();
+      // First text event included, last text event skipped
+      expect(assistantMsg!.summaries).toEqual(["Let me check the logs first"]);
+    });
+
+    it("should truncate text summaries exceeding 80 characters", async () => {
+      const checkpointRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "test-session-truncate",
+            cliAgentSessionHistory: JSON.stringify({ type: "test" }),
+            artifactSnapshot: {
+              artifactName: "test-artifact",
+              artifactVersion: "v1",
+            },
+          }),
+        },
+      );
+      const checkpointResponse = await checkpointWebhook(checkpointRequest);
+      expect(checkpointResponse.status).toBe(200);
+      const checkpointData = (await checkpointResponse.json()) as {
+        agentSessionId: string;
+      };
+
+      const longText = "x".repeat(100);
+
+      // First Axiom call: extractRunOutput
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        { eventData: { result: "Done." } },
+      ]);
+      // Second Axiom call: extractSummariesFromAxiom — one long text, then final text
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        {
+          eventData: {
+            message: {
+              content: [{ type: "text", text: longText }],
+            },
+          },
+        },
+        {
+          eventData: {
+            message: {
+              content: [{ type: "text", text: "Done." }],
+            },
+          },
+        },
+      ]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await context.mocks.flushAfter();
+
+      type StoredMessage = {
+        role: string;
+        summaries?: string[];
+      };
+      const chatMessages = (await getSessionChatMessages(
+        checkpointData.agentSessionId,
+      )) as StoredMessage[];
+
+      const assistantMsg = chatMessages.find((m) => m.role === "assistant");
+      expect(assistantMsg).toBeDefined();
+      expect(assistantMsg!.summaries).toHaveLength(1);
+      expect(assistantMsg!.summaries![0]!.length).toBe(81); // 80 chars + "…"
+      expect(assistantMsg!.summaries![0]!.endsWith("…")).toBe(true);
+    });
+
+    it("should not include summaries when Axiom returns no message events", async () => {
+      const checkpointRequest = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/checkpoints",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            cliAgentType: "claude-code",
+            cliAgentSessionId: "test-session-no-summaries",
+            cliAgentSessionHistory: JSON.stringify({ type: "test" }),
+            artifactSnapshot: {
+              artifactName: "test-artifact",
+              artifactVersion: "v1",
+            },
+          }),
+        },
+      );
+      const checkpointResponse = await checkpointWebhook(checkpointRequest);
+      expect(checkpointResponse.status).toBe(200);
+      const checkpointData = (await checkpointResponse.json()) as {
+        agentSessionId: string;
+      };
+
+      // First Axiom call: extractRunOutput — returns result
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+        { eventData: { result: "All good." } },
+      ]);
+      // Second Axiom call: extractSummariesFromAxiom — no events
+      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([]);
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 0,
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await context.mocks.flushAfter();
+
+      type StoredMessage = {
+        role: string;
+        content: string;
+        summaries?: string[];
+      };
+      const chatMessages = (await getSessionChatMessages(
+        checkpointData.agentSessionId,
+      )) as StoredMessage[];
+
+      const assistantMsg = chatMessages.find((m) => m.role === "assistant");
+      expect(assistantMsg).toBeDefined();
+      expect(assistantMsg!.content).toBe("All good.");
+      // summaries should be undefined (not included when empty)
+      expect(assistantMsg!.summaries).toBeUndefined();
+    });
   });
 
   describe("Title Regeneration", () => {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -34,6 +34,7 @@ import {
   DATASETS,
 } from "../../../../../src/lib/axiom";
 import { after } from "next/server";
+import type { SummaryEntry } from "@vm0/core";
 
 const log = logger("webhook:complete");
 
@@ -44,39 +45,53 @@ interface AxiomEventContent {
   input?: Record<string, unknown>;
 }
 
+function summarizeContentBlock(
+  block: AxiomEventContent,
+  skipText: boolean,
+): SummaryEntry | null {
+  if (block.type === "tool_use" && block.name) {
+    return {
+      kind: "tool",
+      name: block.name,
+      ...(block.input ? { input: block.input } : {}),
+    };
+  }
+  if (!skipText && block.type === "text" && block.text) {
+    const line = block.text.split("\n")[0] ?? "";
+    return {
+      kind: "text",
+      text: line.length > 80 ? line.slice(0, 80) + "…" : line,
+    };
+  }
+  return null;
+}
+
+function findLastTextEventIndex(
+  events: Array<{ eventData: { message?: { content?: AxiomEventContent[] } } }>,
+): number {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const content = events[i]?.eventData?.message?.content ?? [];
+    if (content.some((b) => b.type === "text" && b.text)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 function extractSummariesFromEvents(
   events: Array<{
     eventData: { message?: { content?: AxiomEventContent[] } };
   }>,
-): string[] {
-  let lastTextIdx = -1;
-  for (let i = events.length - 1; i >= 0; i--) {
-    const event = events[i];
-    if (!event) {
-      continue;
-    }
-    const content = event.eventData?.message?.content ?? [];
-    if (content.some((b) => b.type === "text" && b.text)) {
-      lastTextIdx = i;
-      break;
-    }
-  }
+): SummaryEntry[] {
+  const lastTextIdx = findLastTextEventIndex(events);
+  const summaries: SummaryEntry[] = [];
 
-  const summaries: string[] = [];
   for (let i = 0; i < events.length; i++) {
-    const event = events[i];
-    if (!event) {
-      continue;
-    }
-    const content = event.eventData?.message?.content ?? [];
+    const content = events[i]?.eventData?.message?.content ?? [];
     for (const block of content) {
-      if (block.type === "tool_use" && block.name) {
-        summaries.push(block.name);
-        break;
-      }
-      if (i !== lastTextIdx && block.type === "text" && block.text) {
-        const line = block.text.split("\n")[0] ?? "";
-        summaries.push(line.length > 80 ? line.slice(0, 80) + "…" : line);
+      const entry = summarizeContentBlock(block, i === lastTextIdx);
+      if (entry) {
+        summaries.push(entry);
         break;
       }
     }
@@ -84,11 +99,13 @@ function extractSummariesFromEvents(
   return summaries;
 }
 
-async function extractSummariesFromAxiom(runId: string): Promise<string[]> {
+async function extractSummariesFromAxiom(
+  runId: string,
+): Promise<SummaryEntry[]> {
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
 | where runId == "${runId}"
-| where eventType == "message"
+| where eventType == "assistant"
 | order by sequenceNumber asc
 | limit 200`;
 
@@ -120,7 +137,7 @@ async function persistChatMessages(
     role: "user" | "assistant";
     content: string;
     runId?: string;
-    summaries?: string[];
+    summaries?: SummaryEntry[];
   }> = [{ role: "user", content: prompt }];
 
   if (output.result) {

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -123,7 +123,11 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
         role: "assistant",
         content: "Here are the changed files.",
         runId,
-        summaries: ["Bash", "Read", "Grep"],
+        summaries: [
+          { kind: "tool", name: "Bash" },
+          { kind: "tool", name: "Read", input: { file_path: "src/index.ts" } },
+          { kind: "tool", name: "Grep" },
+        ],
       },
     ]);
 
@@ -156,7 +160,11 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     expect(assistantMsg).toBeDefined();
     expect(assistantMsg.content).toBe("Here are the changed files.");
     expect(assistantMsg.runId).toBe(runId);
-    expect(assistantMsg.summaries).toEqual(["Bash", "Read", "Grep"]);
+    expect(assistantMsg.summaries).toEqual([
+      { kind: "tool", name: "Bash" },
+      { kind: "tool", name: "Read", input: { file_path: "src/index.ts" } },
+      { kind: "tool", name: "Grep" },
+    ]);
   });
 
   it("should not return thread owned by another user", async () => {

--- a/turbo/apps/web/src/db/schema/agent-session.ts
+++ b/turbo/apps/web/src/db/schema/agent-session.ts
@@ -9,6 +9,7 @@ import {
 } from "drizzle-orm/pg-core";
 import { agentComposes } from "./agent-compose";
 import { conversations } from "./conversation";
+import type { SummaryEntry } from "@vm0/core";
 
 /**
  * Stored chat message for server-side persistence.
@@ -18,7 +19,7 @@ export interface StoredChatMessage {
   role: "user" | "assistant";
   content: string;
   runId?: string;
-  summaries?: string[];
+  summaries?: SummaryEntry[];
   createdAt: string;
 }
 

--- a/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
@@ -8,7 +8,7 @@ import {
   agentComposeVersions,
 } from "../../db/schema/agent-compose";
 import { conversations } from "../../db/schema/conversation";
-import { extractAndGroupVariables } from "@vm0/core";
+import { extractAndGroupVariables, type SummaryEntry } from "@vm0/core";
 import { notFound, forbidden } from "../errors";
 import type {
   AgentSessionData,
@@ -179,7 +179,7 @@ export async function appendChatMessages(
     role: "user" | "assistant";
     content: string;
     runId?: string;
-    summaries?: string[];
+    summaries?: SummaryEntry[];
   }>,
 ): Promise<void> {
   const now = new Date().toISOString();

--- a/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
@@ -3,6 +3,7 @@ import { chatThreads, chatThreadRuns } from "../../db/schema/chat-thread";
 import { agentRuns } from "../../db/schema/agent-run";
 import { agentSessions } from "../../db/schema/agent-session";
 import { notFound } from "../errors";
+import type { SummaryEntry } from "@vm0/core";
 
 /**
  * Create a new chat thread.
@@ -174,7 +175,7 @@ export async function getChatThreadMessages(
     content: string;
     runId?: string;
     error?: string;
-    summaries?: string[];
+    summaries?: SummaryEntry[];
     createdAt: string;
   }>;
   latestSessionId: string | null;
@@ -215,7 +216,7 @@ export async function getChatThreadMessages(
     role: "user" | "assistant";
     content: string;
     runId?: string;
-    summaries?: string[];
+    summaries?: SummaryEntry[];
     createdAt: string;
   };
   let messages: StoredMessage[] = [];

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -13,12 +13,29 @@ const chatThreadListItemSchema = z.object({
   updatedAt: z.string(),
 });
 
+const toolSummaryEntrySchema = z.object({
+  kind: z.literal("tool"),
+  name: z.string(),
+  input: z.record(z.string(), z.unknown()).optional(),
+});
+
+const textSummaryEntrySchema = z.object({
+  kind: z.literal("text"),
+  text: z.string(),
+});
+
+const summaryEntrySchema = z.union([
+  z.string(),
+  toolSummaryEntrySchema,
+  textSummaryEntrySchema,
+]);
+
 const storedChatMessageSchema = z.object({
   role: z.enum(["user", "assistant"]),
   content: z.string(),
   runId: z.string().optional(),
   error: z.string().optional(),
-  summaries: z.array(z.string()).optional(),
+  summaries: z.array(summaryEntrySchema).optional(),
   createdAt: z.string(),
 });
 
@@ -120,7 +137,8 @@ export type ChatThreadsContract = typeof chatThreadsContract;
 export type ChatThreadByIdContract = typeof chatThreadByIdContract;
 export type ChatThreadRunsContract = typeof chatThreadRunsContract;
 
-export { chatThreadListItemSchema, chatThreadDetailSchema };
+export { chatThreadListItemSchema, chatThreadDetailSchema, summaryEntrySchema };
 
+export type SummaryEntry = z.infer<typeof summaryEntrySchema>;
 export type ChatThreadListItem = z.infer<typeof chatThreadListItemSchema>;
 export type ChatThreadDetail = z.infer<typeof chatThreadDetailSchema>;

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -289,6 +289,8 @@ export {
   chatThreadRunsContract,
   chatThreadListItemSchema,
   chatThreadDetailSchema,
+  summaryEntrySchema,
+  type SummaryEntry,
   type ChatThreadsContract,
   type ChatThreadByIdContract,
   type ChatThreadRunsContract,

--- a/turbo/packages/core/src/contracts/sessions.ts
+++ b/turbo/packages/core/src/contracts/sessions.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
+import { summaryEntrySchema } from "./chat-threads";
 
 const c = initContract();
 
@@ -11,7 +12,7 @@ const storedChatMessageSchema = z.object({
   role: z.enum(["user", "assistant"]),
   content: z.string(),
   runId: z.string().optional(),
-  summaries: z.array(z.string()).optional(),
+  summaries: z.array(summaryEntrySchema).optional(),
   createdAt: z.string(),
 });
 


### PR DESCRIPTION
## Summary
- Fix Axiom eventType filter: `"message"` → `"assistant"` — summaries were never extracted because Claude Code events don't use `"message"` type
- Store structured `SummaryEntry` objects (tool name + input) instead of raw tool names, so the frontend can humanize consistently after page refresh
- Add backward-compatible union schema (`string | ToolEntry | TextEntry`) so old session data still validates

### Before
Live: "Reading zero-chat.ts" → After refresh: "Peeking at a file..."

### After
Live: "Reading zero-chat.ts" → After refresh: "Reading zero-chat.ts"

Closes #6842

## Files changed
- `packages/core/src/contracts/chat-threads.ts` — `SummaryEntry` union schema
- `packages/core/src/contracts/sessions.ts` — reuse shared schema
- `apps/web/app/api/webhooks/agent/complete/route.ts` — fix eventType + return structured entries
- `apps/web/src/db/schema/agent-session.ts` — `StoredChatMessage.summaries` type
- `apps/web/src/lib/agent-session/agent-session-service.ts` — service type alignment
- `apps/web/src/lib/chat-thread/chat-thread-service.ts` — service type alignment
- `apps/platform/src/signals/zero-page/zero-chat.ts` — handle both old/new formats

## Test plan
- [x] `pnpm vitest run apps/web/app/api/webhooks/agent/complete` — 28 tests pass
- [x] `pnpm vitest run apps/web/app/api/zero/chat-threads` — 21 tests pass
- [x] `pnpm vitest run apps/platform/src/views/zero-page/__tests__/chat` — 23 tests pass
- [x] `pnpm check-types` — all packages pass
- [x] `pnpm turbo run lint` — no errors
- [x] `pnpm knip` — no unused exports
- [ ] Manual: send a message in chat, refresh, verify summaries display with correct labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)