### PR TITLE
feat(platform): auto-switch tab when connector search matches only one tab

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-add-connection-dialog.test.tsx
@@ -135,6 +135,64 @@ describe("zero add connection dialog", () => {
     expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
   });
 
+  it("auto-switches to connected tab when search matches only connected connectors", async () => {
+    // Hume is connected — "hume" is a unique label with no other connector matching
+    mockConnectors([
+      makeConnector({
+        type: "hume",
+        authMethod: "api-token",
+      }),
+    ]);
+    await renderTeamPage([]);
+
+    await openAddConnectorDialog();
+
+    // Default tab is "Not connected"
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+    // Hume should not be visible on "Not connected" tab
+    expect(screen.queryByText("Hume")).not.toBeInTheDocument();
+
+    // Search for "hume" — only exists in Connected tab
+    const searchInput = screen.getByPlaceholderText("Search...");
+    fireEvent.change(searchInput, { target: { value: "hume" } });
+
+    // Should auto-switch to Connected tab and show Hume
+    await waitFor(() => {
+      expect(screen.getByText("Hume")).toBeInTheDocument();
+    });
+  });
+
+  it("stays on current tab when search matches both tabs", async () => {
+    // Slack is connected; "slack" also matches "Slack Webhook" (not connected)
+    mockConnectors([
+      makeConnector({
+        type: "slack",
+        authMethod: "oauth",
+        oauthScopes: ["channels:read"],
+      }),
+    ]);
+    await renderTeamPage([]);
+
+    await openAddConnectorDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+
+    // Search "slack" matches both "Slack" (connected) and "Slack Webhook" (not connected)
+    const searchInput = screen.getByPlaceholderText("Search...");
+    fireEvent.change(searchInput, { target: { value: "slack" } });
+
+    // Should stay on "Not connected" tab — Slack Webhook is shown (not connected)
+    await waitFor(() => {
+      expect(screen.getByText("Slack Webhook")).toBeInTheDocument();
+    });
+    // Connected "Slack" should not be visible (still on not-connected tab)
+    expect(screen.queryByText(/^Slack$/)).not.toBeInTheDocument();
+  });
+
   it("resets search when dialog is closed and reopened", async () => {
     mockConnectors([]);
     await renderTeamPage([]);

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -652,7 +652,23 @@ function ZeroAddConnectionDialog({
 
   const notConnected = baseFiltered?.filter((item) => !item.connected);
   const connected = baseFiltered?.filter((item) => item.connected);
-  const filteredTypes = tab === "connected" ? connected : notConnected;
+
+  // Auto-switch tab when search matches exist only on the other tab
+  const effectiveTab = (() => {
+    if (!search.trim()) {
+      return tab;
+    }
+    const hasNotConnected = (notConnected?.length ?? 0) > 0;
+    const hasConnected = (connected?.length ?? 0) > 0;
+    if (hasNotConnected && !hasConnected) {
+      return "not-connected";
+    }
+    if (hasConnected && !hasNotConnected) {
+      return "connected";
+    }
+    return tab;
+  })();
+  const filteredTypes = effectiveTab === "connected" ? connected : notConnected;
 
   const notConnectedCount =
     connectorTypes
@@ -697,7 +713,7 @@ function ZeroAddConnectionDialog({
             />
           </div>
           <Tabs
-            value={tab}
+            value={effectiveTab}
             onValueChange={(v) => setTab(v as "not-connected" | "connected")}
           >
             <TabsList className="w-fit">


### PR DESCRIPTION
## Summary

- When searching in the Add Connection dialog, automatically switch to the tab (Connected / Not connected) that has matching results if only one tab matches
- If both tabs have results, stay on the current tab
- If neither has results, stay on the current tab

Closes #6846

## Test plan

- [x] Added test: auto-switches to Connected tab when search matches only connected connectors
- [x] Added test: stays on current tab when search matches both tabs
- [x] Existing tests pass (tab switching, search filtering, dialog reset)
- [x] Lint, type check, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)