### PR TITLE
feat: add zero doctor missing-token command

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -14,6 +14,7 @@ describe("zero CLI program", () => {
       "org",
       "agent",
       "connector",
+      "doctor",
       "preference",
       "schedule",
       "secret",
@@ -45,7 +46,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 9 commands", () => {
-    expect(commandNames).toHaveLength(9);
+  it("should have exactly 10 commands", () => {
+    expect(commandNames).toHaveLength(10);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for zero doctor missing-token command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): None (no API calls — purely local mapping)
+ * - Real (internal): All CLI code, connector mappings from @vm0/core
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { missingTokenCommand } from "../missing-token";
+import chalk from "chalk";
+
+describe("zero doctor missing-token command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("known token", () => {
+    it("should output connector name and settings URL", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+
+      await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "GH_TOKEN is provided by the GitHub connector",
+      );
+      expect(logCalls).toContain(
+        "https://app.vm0.ai/team/agent-abc-123?tab=connectors",
+      );
+    });
+
+    it("should include ZERO_AGENT_ID in URL when set", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "test-agent-456");
+
+      await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("/team/test-agent-456?tab=connectors");
+    });
+
+    it("should fall back to generic URL when ZERO_AGENT_ID is not set", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "");
+
+      await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("https://app.vm0.ai/team?tab=connectors");
+    });
+
+    it("should use custom VM0_API_URL", async () => {
+      vi.stubEnv("VM0_API_URL", "https://custom.example.com");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-1");
+
+      await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("https://custom.example.com/team/agent-1");
+    });
+  });
+
+  describe("unknown token", () => {
+    it("should exit with error for unrecognized token", async () => {
+      await expect(async () => {
+        await missingTokenCommand.parseAsync([
+          "node",
+          "cli",
+          "UNKNOWN_FOO_TOKEN",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Unknown token: UNKNOWN_FOO_TOKEN"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/doctor/index.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/index.ts
@@ -1,0 +1,7 @@
+import { Command } from "commander";
+import { missingTokenCommand } from "./missing-token";
+
+export const zeroDoctorCommand = new Command()
+  .name("doctor")
+  .description("Diagnostic tools for troubleshooting agent issues")
+  .addCommand(missingTokenCommand);

--- a/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
@@ -1,0 +1,31 @@
+import { Command } from "commander";
+import { getConnectorTypeForSecretName, CONNECTOR_TYPES } from "@vm0/core";
+import { getApiUrl } from "../../../lib/api/config";
+import { withErrorHandler } from "../../../lib/command";
+
+export const missingTokenCommand = new Command()
+  .name("missing-token")
+  .description(
+    "Diagnose a missing token and find the connector that provides it",
+  )
+  .argument("<token-name>", "The environment variable / token name to look up")
+  .action(
+    withErrorHandler(async (tokenName: string) => {
+      const connectorType = getConnectorTypeForSecretName(tokenName);
+      if (!connectorType) {
+        throw new Error(
+          `Unknown token: ${tokenName} — not managed by any connector`,
+        );
+      }
+
+      const { label } = CONNECTOR_TYPES[connectorType];
+
+      const baseUrl = await getApiUrl();
+      const agentId = process.env.ZERO_AGENT_ID;
+      const path = agentId ? `/team/${agentId}` : "/team";
+      const url = `${baseUrl}${path}?tab=connectors`;
+
+      console.log(`${tokenName} is provided by the ${label} connector.`);
+      console.log(`Ask the user to connect it at: ${url}`);
+    }),
+  );

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -6,6 +6,7 @@ import { configureGlobalProxyFromEnv } from "./lib/network/proxy.js";
 import { zeroOrgCommand } from "./commands/zero/org";
 import { zeroAgentCommand } from "./commands/zero/agent";
 import { zeroConnectorCommand } from "./commands/zero/connector";
+import { zeroDoctorCommand } from "./commands/zero/doctor";
 import { zeroPreferenceCommand } from "./commands/zero/preference";
 import { zeroScheduleCommand } from "./commands/zero/schedule";
 import { zeroSecretCommand } from "./commands/zero/secret";
@@ -25,6 +26,7 @@ import {
 const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   agent: "agent:read",
   schedule: "schedule:read",
+  doctor: null,
   slack: "slack:write",
   whoami: null,
 };
@@ -33,6 +35,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroOrgCommand,
   zeroAgentCommand,
   zeroConnectorCommand,
+  zeroDoctorCommand,
   zeroPreferenceCommand,
   zeroScheduleCommand,
   zeroSecretCommand,


### PR DESCRIPTION
## Summary

- Add `zero doctor missing-token <TOKEN_NAME>` CLI command that maps token names to connectors and provides actionable guidance
- Create new `doctor` command group under the `zero` CLI as the first diagnostic subcommand
- Uses existing `getConnectorTypeForSecretName()` from `@vm0/core` — no duplicated mapping logic

Closes #6847

## Test plan

- [x] `zero doctor missing-token GH_TOKEN` outputs connector name + settings URL
- [x] `zero doctor missing-token UNKNOWN_TOKEN` exits with non-zero code and error message
- [x] URL includes `ZERO_AGENT_ID` when set in environment
- [x] URL falls back to generic `/team` path when `ZERO_AGENT_ID` not set
- [x] Custom `VM0_API_URL` is respected in URL construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)