### PR TITLE
fix(web): add next typegen to check-types script to prevent stale validator errors

### DIFF
--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint && eslint . --max-warnings 0",
-    "check-types": "tsc --noEmit",
+    "check-types": "next typegen && tsc --noEmit",
     "db:migrate": "tsx scripts/migrate.ts",
     "db:generate": "drizzle-kit generate",
     "db:dev-seed": "dotenv -e .env.local -- tsx scripts/dev-seed.ts",


### PR DESCRIPTION
## Summary
- Add `next typegen` before `tsc --noEmit` in the web app's `check-types` script
- Prevents stale `.next/types/validator.ts` from causing TS2307 errors when routes are moved/renamed/deleted
- Aligns with the approach already used in `apps/docs` and the official Next.js recommendation

Closes #6848

## Test plan
- [ ] Run `pnpm run check-types` in `apps/web` after deleting `.next/types` — should regenerate and pass
- [ ] Verify CI `check-types` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)