### PR TITLE
fix(platform): use stable signal for onboarding intro message

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
@@ -188,7 +188,7 @@ describe("onboarding auto-intro message", () => {
     // Verify the agent run was actually created (intro message was sent)
     await waitFor(
       () => {
-        expect(mock.wasRunCreated()).toBe(true);
+        expect(mock.wasRunCreated()).toBeTruthy();
       },
       { timeout: 10_000 },
     );
@@ -232,7 +232,7 @@ describe("onboarding auto-intro message", () => {
 
     await waitFor(
       () => {
-        expect(mock.wasRunCreated()).toBe(true);
+        expect(mock.wasRunCreated()).toBeTruthy();
       },
       { timeout: 10_000 },
     );
@@ -268,7 +268,7 @@ describe("onboarding auto-intro message", () => {
     // Wait for intro run to start
     await waitFor(
       () => {
-        expect(mock.wasRunCreated()).toBe(true);
+        expect(mock.wasRunCreated()).toBeTruthy();
       },
       { timeout: 10_000 },
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+/**
+ * Mock onboarding as needed for an admin, plus chat lifecycle endpoints.
+ * Returns control object from mockChatLifecycle and a spy for run creation.
+ */
+function mockAdminOnboardingWithChat() {
+  let runCreated = false;
+
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: false,
+        defaultAgentId: null,
+        defaultAgentMetadata: null,
+        defaultAgentSkills: [],
+      });
+    }),
+    http.post("*/api/zero/agents", () => {
+      return HttpResponse.json(
+        { name: "zero", agentId: "new-compose-id" },
+        { status: 201 },
+      );
+    }),
+    http.put("*/api/zero/agents/:name/instructions", () => {
+      return HttpResponse.json({ success: true });
+    }),
+    http.put("*/api/zero/default-agent", () => {
+      return HttpResponse.json({ success: true });
+    }),
+  );
+
+  const ctrl = mockChatLifecycle();
+
+  // Intercept run creation to track whether the intro message was sent
+  server.use(
+    http.post("*/api/zero/runs", async ({ request }) => {
+      runCreated = true;
+      const body = (await request.json()) as { prompt: string };
+      // Verify the auto-intro prompt
+      expect(body.prompt).toBe("Who are you and what can you do?");
+      return HttpResponse.json({ runId: "run-test-1" }, { status: 201 });
+    }),
+  );
+
+  return {
+    ctrl,
+    wasRunCreated: () => runCreated,
+    /** Switch onboarding status to completed (call before clicking "Chat with Zero") */
+    completeOnboarding: () => {
+      server.use(
+        http.get("*/api/zero/onboarding/status", () => {
+          return HttpResponse.json({
+            needsOnboarding: false,
+            isAdmin: true,
+            hasOrg: true,
+            hasDefaultAgent: true,
+            defaultAgentId: "new-compose-id",
+            defaultAgentMetadata: null,
+            defaultAgentSkills: [],
+          });
+        }),
+      );
+    },
+  };
+}
+
+/**
+ * Mock onboarding as needed for a member, plus chat lifecycle endpoints.
+ */
+function mockMemberOnboardingWithChat() {
+  let runCreated = false;
+
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: false,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: "mock-compose-id",
+        defaultAgentMetadata: { displayName: "Zero" },
+        defaultAgentSkills: [],
+      });
+    }),
+    http.post("*/api/zero/onboarding/complete", () => {
+      return HttpResponse.json({ success: true });
+    }),
+  );
+
+  const ctrl = mockChatLifecycle();
+
+  server.use(
+    http.post("*/api/zero/runs", async ({ request }) => {
+      runCreated = true;
+      const body = (await request.json()) as { prompt: string };
+      expect(body.prompt).toBe("Who are you and what can you do?");
+      return HttpResponse.json({ runId: "run-test-1" }, { status: 201 });
+    }),
+  );
+
+  return {
+    ctrl,
+    wasRunCreated: () => runCreated,
+    completeOnboarding: () => {
+      server.use(
+        http.get("*/api/zero/onboarding/status", () => {
+          return HttpResponse.json({
+            needsOnboarding: false,
+            isAdmin: false,
+            hasOrg: true,
+            hasDefaultAgent: true,
+            defaultAgentId: "mock-compose-id",
+            defaultAgentMetadata: { displayName: "Zero" },
+            defaultAgentSkills: [],
+          });
+        }),
+      );
+    },
+  };
+}
+
+/** Walk through onboarding steps up to the "Where would you like to work" step. */
+async function walkToWhereStep(isMember: boolean) {
+  // Step 1: Welcome screen
+  await waitFor(
+    () => {
+      expect(
+        screen.getByText(
+          isMember
+            ? /Meet .+, your new teammate/
+            : /Meet Zero, your new teammate/,
+        ),
+      ).toBeInTheDocument();
+    },
+    { timeout: 5000 },
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+  if (!isMember) {
+    // Admin: step 3 (connectors) → step 4 (where)
+    await waitFor(() => {
+      expect(screen.getByText("Add connector")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "Next" })[0]!);
+  }
+
+  await waitFor(() => {
+    expect(
+      screen.getByText(/Where would you like to work with/),
+    ).toBeInTheDocument();
+  });
+}
+
+describe("onboarding auto-intro message", () => {
+  it("should send intro message after admin completes onboarding via web", async () => {
+    const mock = mockAdminOnboardingWithChat();
+
+    await setupPage({ context, path: "/onboarding" });
+    await walkToWhereStep(false);
+
+    // Switch onboarding status so post-navigate route doesn't redirect back
+    mock.completeOnboarding();
+
+    fireEvent.click(screen.getByRole("button", { name: /Chat with Zero/ }));
+
+    // Verify navigation away from onboarding
+    await waitFor(
+      () => {
+        expect(pathname()).not.toBe("/onboarding");
+      },
+      { timeout: 5000 },
+    );
+
+    // Verify the agent run was actually created (intro message was sent)
+    await waitFor(
+      () => {
+        expect(mock.wasRunCreated()).toBe(true);
+      },
+      { timeout: 10_000 },
+    );
+
+    // The assistant should be in thinking/running state
+    await waitFor(
+      () => {
+        const shimmer = document.querySelector(".zero-shimmer-text");
+        expect(shimmer).toBeInTheDocument();
+      },
+      { timeout: 10_000 },
+    );
+
+    // Complete the run so the test cleans up
+    mock.ctrl.completeRun("I am Zero, your AI teammate.");
+
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText("Send")).toBeInTheDocument();
+      },
+      { timeout: 10_000 },
+    );
+  }, 30_000);
+
+  it("should send intro message after member completes onboarding via web", async () => {
+    const mock = mockMemberOnboardingWithChat();
+
+    await setupPage({ context, path: "/onboarding" });
+    await walkToWhereStep(true);
+
+    mock.completeOnboarding();
+
+    fireEvent.click(screen.getByRole("button", { name: /Chat with Zero/i }));
+
+    await waitFor(
+      () => {
+        expect(pathname()).not.toBe("/onboarding");
+      },
+      { timeout: 5000 },
+    );
+
+    await waitFor(
+      () => {
+        expect(mock.wasRunCreated()).toBe(true);
+      },
+      { timeout: 10_000 },
+    );
+
+    await waitFor(
+      () => {
+        const shimmer = document.querySelector(".zero-shimmer-text");
+        expect(shimmer).toBeInTheDocument();
+      },
+      { timeout: 10_000 },
+    );
+
+    mock.ctrl.completeRun("I am Zero, your AI teammate.");
+
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText("Send")).toBeInTheDocument();
+      },
+      { timeout: 10_000 },
+    );
+  }, 30_000);
+
+  it("should allow follow-up messages after onboarding intro completes", async () => {
+    const mock = mockMemberOnboardingWithChat();
+
+    await setupPage({ context, path: "/onboarding" });
+    await walkToWhereStep(true);
+
+    mock.completeOnboarding();
+
+    fireEvent.click(screen.getByRole("button", { name: /Chat with Zero/i }));
+
+    // Wait for intro run to start
+    await waitFor(
+      () => {
+        expect(mock.wasRunCreated()).toBe(true);
+      },
+      { timeout: 10_000 },
+    );
+
+    // Complete the intro run
+    mock.ctrl.completeRun("I am Zero, your AI teammate.");
+
+    // Wait for the chat to be ready for input
+    const textarea = await waitFor(
+      () => screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      { timeout: 10_000 },
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText("Send")).toBeInTheDocument();
+      },
+      { timeout: 10_000 },
+    );
+
+    // Verify the textarea is interactive (user can type a follow-up)
+    expect(textarea).not.toBeDisabled();
+  }, 30_000);
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -309,7 +309,6 @@ export function ZeroOnboarding({
   const onboardingError = useGet(zeroOnboardingError$);
   const clearOnboardingError = useSet(clearZeroOnboardingError$);
   const reloadBilling = useSet(reloadBillingStatus$);
-  const pageSignal = useGet(pageSignal$);
   const selectedConnectorType = useGet(selectedConnectorType$);
   const setSelected = useSet(setSelectedConnectorType$);
   const slackData = useGet(slackOrgData$);
@@ -365,11 +364,14 @@ export function ZeroOnboarding({
         reloadBilling();
         navigate("/");
         startNewSession();
+        // Use controller.signal instead of pageSignal: navigate("/") aborts
+        // the onboarding page signal via resetRouteSignal$, so pageSignal is
+        // already dead by the time sendMessage runs.
         detach(
           sendMessage(
             "Who are you and what can you do?",
             undefined,
-            pageSignal,
+            controller.signal,
           ),
           Reason.DomCallback,
         );
@@ -616,13 +618,21 @@ export function MemberWelcome({
   };
 
   const handleContinueWeb = () => {
+    const controller = new AbortController();
     detach(
       (async () => {
-        await completeMember(pageSignal);
+        await completeMember(controller.signal);
         navigate("/");
         startNewSession();
+        // Use controller.signal instead of pageSignal: navigate("/") aborts
+        // the onboarding page signal via resetRouteSignal$, so pageSignal is
+        // already dead by the time sendIntro runs.
         detach(
-          sendIntro("Who are you and what can you do?", undefined, pageSignal),
+          sendIntro(
+            "Who are you and what can you do?",
+            undefined,
+            controller.signal,
+          ),
           Reason.DomCallback,
         );
       })(),


### PR DESCRIPTION
## Summary

- Onboarding 完成后点击 "Continue in web" 发送的自动介绍消息没有回复（静默失败）
- 根因：`navigate("/")` 触发 `resetRouteSignal$` abort 掉 onboarding 页面的 page signal，但 `sendMessage()` 仍使用已 abort 的旧 `pageSignal`，导致 `AbortError` 被 `detach()` 静默吞掉
- 修复：在 admin `handleContinueWithWeb` 和 member `handleContinueWeb` 中，用独立的 `AbortController.signal` 替代已失效的 `pageSignal`
- 添加 3 个集成测试验证 onboarding 后自动介绍消息确实被发送并收到回复

## Test plan

- [x] Admin onboarding → "Chat with Zero" → intro message sent and assistant responds
- [x] Member onboarding → "Chat with Zero" → intro message sent and assistant responds
- [x] After intro completes, follow-up messages can be sent normally
- [x] Existing onboarding navigation tests still pass
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)