### PR TITLE
refactor: remove vm0 skill from seed skills list

### DIFF
--- a/turbo/apps/web/src/lib/zero/seed-skills.ts
+++ b/turbo/apps/web/src/lib/zero/seed-skills.ts
@@ -8,7 +8,6 @@ import type { skills } from "../../db/schema/skill";
  * These live server-side only so the frontend never sends stale seed skills.
  */
 export const SEED_SKILLS: readonly string[] = [
-  "vm0",
   "deep-dive",
   "account-reconciliation",
   "analysis-qa",


### PR DESCRIPTION
## Summary
- Remove the `vm0` skill from `SEED_SKILLS` in `seed-skills.ts`, so it is no longer bundled by default into every zero agent compose

## Test plan
- [ ] Verify new agent creation no longer includes the `vm0` skill
- [ ] Verify existing seed skills still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)