### PR TITLE
feat: add plan selection step to downgrade flow

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-billing.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-billing.ts
@@ -53,6 +53,13 @@ export const apiBillingHandlers = [
     });
   }),
 
+  http.post("*/api/zero/billing/downgrade", () => {
+    return HttpResponse.json({
+      success: true,
+      effectiveDate: null,
+    });
+  }),
+
   http.get("*/api/zero/billing/auto-recharge", () => {
     return HttpResponse.json(mockBillingStatus.autoRecharge);
   }),

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -5,6 +5,7 @@ import {
   zeroBillingPortalContract,
   zeroBillingAutoRechargeContract,
   zeroBillingInvoicesContract,
+  zeroBillingDowngradeContract,
   type BillingStatusResponse,
 } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
@@ -48,6 +49,8 @@ const internalDialogOpen$ = state(false);
 const internalCheckoutLoading$ = state(false);
 const internalPortalLoading$ = state(false);
 const billingReload$ = state(0);
+const internalDowngradeDialogOpen$ = state(false);
+const internalDowngradeLoading$ = state(false);
 
 // ---------------------------------------------------------------------------
 // Selectors
@@ -55,7 +58,16 @@ const billingReload$ = state(0);
 
 export const billingDialogOpen$ = computed((get) => get(internalDialogOpen$));
 export const billingDialogLoading$ = computed(
-  (get) => get(internalCheckoutLoading$) || get(internalPortalLoading$),
+  (get) =>
+    get(internalCheckoutLoading$) ||
+    get(internalPortalLoading$) ||
+    get(internalDowngradeLoading$),
+);
+export const downgradeDialogOpen$ = computed((get) =>
+  get(internalDowngradeDialogOpen$),
+);
+export const downgradeLoading$ = computed((get) =>
+  get(internalDowngradeLoading$),
 );
 
 /**
@@ -131,6 +143,40 @@ export const startDowngrade$ = command(
     } else {
       log.error("Portal redirect failed", getErrorMessage(result.body));
       set(internalPortalLoading$, false);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Downgrade dialog commands
+// ---------------------------------------------------------------------------
+
+export const openDowngradeDialog$ = command(({ set }) => {
+  set(internalDowngradeDialogOpen$, true);
+});
+
+export const closeDowngradeDialog$ = command(({ set }) => {
+  set(internalDowngradeDialogOpen$, false);
+});
+
+export const confirmDowngrade$ = command(
+  async ({ get, set }, targetTier: "free" | "pro", _signal: AbortSignal) => {
+    set(internalDowngradeLoading$, true);
+
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroBillingDowngradeContract);
+    const result = await client.create({
+      body: { targetTier },
+    });
+
+    set(internalDowngradeLoading$, false);
+
+    if (result.status === 200) {
+      set(internalDowngradeDialogOpen$, false);
+      // Reload billing status to reflect the change
+      set(billingReload$, (x) => x + 1);
+    } else {
+      log.error("Downgrade failed", getErrorMessage(result.body));
     }
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -51,6 +51,7 @@ const internalPortalLoading$ = state(false);
 const billingReload$ = state(0);
 const internalDowngradeDialogOpen$ = state(false);
 const internalDowngradeLoading$ = state(false);
+const internalDowngradeError$ = state<string | null>(null);
 
 // ---------------------------------------------------------------------------
 // Selectors
@@ -69,6 +70,7 @@ export const downgradeDialogOpen$ = computed((get) =>
 export const downgradeLoading$ = computed((get) =>
   get(internalDowngradeLoading$),
 );
+export const downgradeError$ = computed((get) => get(internalDowngradeError$));
 
 /**
  * Async computed signal that fetches billing status on first access.
@@ -152,6 +154,7 @@ export const startDowngrade$ = command(
 // ---------------------------------------------------------------------------
 
 export const openDowngradeDialog$ = command(({ set }) => {
+  set(internalDowngradeError$, null);
   set(internalDowngradeDialogOpen$, true);
 });
 
@@ -162,6 +165,7 @@ export const closeDowngradeDialog$ = command(({ set }) => {
 export const confirmDowngrade$ = command(
   async ({ get, set }, targetTier: "free" | "pro", _signal: AbortSignal) => {
     set(internalDowngradeLoading$, true);
+    set(internalDowngradeError$, null);
 
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingDowngradeContract);
@@ -176,7 +180,10 @@ export const confirmDowngrade$ = command(
       // Reload billing status to reflect the change
       set(billingReload$, (x) => x + 1);
     } else {
-      log.error("Downgrade failed", getErrorMessage(result.body));
+      const message =
+        getErrorMessage(result.body) ?? "Failed to downgrade plan";
+      log.error("Downgrade failed", message);
+      set(internalDowngradeError$, message);
     }
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-billing-tab.test.tsx
@@ -331,3 +331,242 @@ describe("org billing tab - auto-recharge section", () => {
     });
   });
 });
+
+describe("org billing tab - downgrade flow", () => {
+  it("should show Downgrade button for paid tier (pro)", async () => {
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: /Downgrade/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should show Downgrade button for team tier", async () => {
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "team",
+      credits: 120_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Team plan")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: /Downgrade/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should not show Downgrade button for free tier", async () => {
+    mockAPIs();
+    setMockBillingStatus({ tier: "free", credits: 10_000 });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Free plan")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole("button", { name: /Downgrade/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should open downgrade dialog on Downgrade button click for pro user", async () => {
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    await act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /Downgrade/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Downgrade plan")).toBeInTheDocument();
+    });
+
+    // Pro user should see "Downgrade to Free?" confirmation
+    expect(
+      screen.getByText("Are you sure you want to downgrade to Free?"),
+    ).toBeInTheDocument();
+  });
+
+  it("should open downgrade dialog with plan selection for team user", async () => {
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "team",
+      credits: 120_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Team plan")).toBeInTheDocument();
+    });
+
+    await act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /Downgrade/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Downgrade plan")).toBeInTheDocument();
+    });
+
+    // Team user should see plan selection options
+    expect(
+      screen.getByText("Choose which plan to downgrade to."),
+    ).toBeInTheDocument();
+  });
+
+  it("should call downgrade API with correct targetTier on confirm", async () => {
+    let capturedBody: unknown = null;
+    server.use(
+      http.post("*/api/zero/billing/downgrade", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ success: true, effectiveDate: null });
+      }),
+    );
+
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    await act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /Downgrade/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Downgrade plan")).toBeInTheDocument();
+    });
+
+    await act(() => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /Downgrade to Free/i }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(capturedBody).toStrictEqual({ targetTier: "free" });
+    });
+  });
+
+  it("should close dialog on cancel without calling API", async () => {
+    let apiCalled = false;
+    server.use(
+      http.post("*/api/zero/billing/downgrade", () => {
+        apiCalled = true;
+        return HttpResponse.json({ success: true, effectiveDate: null });
+      }),
+    );
+
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    await act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /Downgrade/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Downgrade plan")).toBeInTheDocument();
+    });
+
+    await act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Downgrade plan")).not.toBeInTheDocument();
+    });
+
+    expect(apiCalled).toBeFalsy();
+  });
+
+  it("should route pricing page downgrade through dialog", async () => {
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+
+    await openBillingTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pro plan")).toBeInTheDocument();
+    });
+
+    // Navigate to pricing page
+    await act(() => {
+      fireEvent.click(screen.getByText("Compare all plans"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Compare plans")).toBeInTheDocument();
+    });
+
+    // Click "Manage subscription" (the downgrade button on pricing page for free tier)
+    const manageButtons = screen.getAllByRole("button", {
+      name: /Manage subscription/i,
+    });
+    expect(manageButtons.length).toBeGreaterThanOrEqual(1);
+
+    await act(() => {
+      fireEvent.click(manageButtons[0]!);
+    });
+
+    // Should open downgrade dialog instead of redirecting to Stripe
+    await waitFor(() => {
+      expect(screen.getByText("Downgrade plan")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -18,7 +18,7 @@ import {
   billingStatusAsync$,
   closeBillingDialog$,
   startCheckout$,
-  startDowngrade$,
+  openDowngradeDialog$,
   saveAutoRecharge$,
   autoRechargeConfig$,
 } from "../../signals/zero-page/billing.ts";
@@ -375,7 +375,7 @@ export function BillingDialog() {
     statusLoadable.state === "hasData" ? statusLoadable.data : null;
   const close = useSet(closeBillingDialog$);
   const checkout = useSet(startCheckout$);
-  const downgrade = useSet(startDowngrade$);
+  const openDowngrade = useSet(openDowngradeDialog$);
   const selectedTier = useGet(selectedPlanTier$);
   const setSelectedTier = useSet(setSelectedPlanTier$);
 
@@ -390,7 +390,7 @@ export function BillingDialog() {
     if (isUpgrade && (selectedTier === "pro" || selectedTier === "team")) {
       detach(checkout(selectedTier, pageSignal), Reason.DomCallback);
     } else if (isDowngrade) {
-      detach(downgrade(pageSignal), Reason.DomCallback);
+      openDowngrade();
     }
   };
 
@@ -429,7 +429,7 @@ export function BillingDialog() {
                 ? "Redirecting..."
                 : isUpgrade
                   ? `Upgrade to ${selectedTier.charAt(0).toUpperCase() + selectedTier.slice(1)}`
-                  : "Manage subscription"}
+                  : "Downgrade"}
             </Button>
           </div>
         )}

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -27,7 +27,7 @@ import {
   setSelectedPlanTier$,
 } from "../../signals/zero-page/billing-dialog-state.ts";
 
-export const PLANS = [
+const PLANS = [
   {
     tier: "free" as const,
     name: "Free",

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -27,7 +27,7 @@ import {
   setSelectedPlanTier$,
 } from "../../signals/zero-page/billing-dialog-state.ts";
 
-const PLANS = [
+export const PLANS = [
   {
     tier: "free" as const,
     name: "Free",

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -41,28 +41,6 @@ import {
   setBillingSubPage$,
 } from "../../../../signals/zero-page/settings/org-manage-tabs-state.ts";
 
-function getPlanPrice(tier: string): string {
-  const plan = PLANS.find((p) => p.tier === tier);
-  return plan ? `${plan.price}${plan.period}` : "";
-}
-
-const proPlanPrice = getPlanPrice("pro");
-const freePlanPrice = getPlanPrice("free");
-
-const sectionCardStyle = {
-  border: "0.7px solid hsl(var(--gray-400))",
-} as const;
-
-function tierRank(t: BillingTier): number {
-  if (t === "free") {
-    return 0;
-  }
-  if (t === "pro") {
-    return 1;
-  }
-  return 2;
-}
-
 const PLANS = [
   {
     tier: "free" as const,
@@ -117,6 +95,28 @@ const PLANS = [
     ],
   },
 ] as const;
+
+function getPlanPrice(tier: string): string {
+  const plan = PLANS.find((p) => p.tier === tier);
+  return plan ? `${plan.price}${plan.period}` : "";
+}
+
+const proPlanPrice = getPlanPrice("pro");
+const freePlanPrice = getPlanPrice("free");
+
+const sectionCardStyle = {
+  border: "0.7px solid hsl(var(--gray-400))",
+} as const;
+
+function tierRank(t: BillingTier): number {
+  if (t === "free") {
+    return 0;
+  }
+  if (t === "pro") {
+    return 1;
+  }
+  return 2;
+}
 
 function planButtonLabel(
   plan: (typeof PLANS)[number],

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -20,6 +20,7 @@ import {
   confirmDowngrade$,
   downgradeDialogOpen$,
   downgradeLoading$,
+  downgradeError$,
   type BillingTier,
 } from "../../../../signals/zero-page/billing.ts";
 import { Button } from "@vm0/ui";
@@ -34,11 +35,19 @@ import planFreeImg from "./assets/plan-free.webp";
 import planProImg from "./assets/plan-pro.webp";
 import planTeamImg from "./assets/plan-team.webp";
 import { detach, Reason } from "../../../../signals/utils.ts";
-import { AutoRechargeSection } from "../../billing-dialog.tsx";
+import { AutoRechargeSection, PLANS } from "../../billing-dialog.tsx";
 import {
   billingSubPage$,
   setBillingSubPage$,
 } from "../../../../signals/zero-page/settings/org-manage-tabs-state.ts";
+
+function getPlanPrice(tier: string): string {
+  const plan = PLANS.find((p) => p.tier === tier);
+  return plan ? `${plan.price}${plan.period}` : "";
+}
+
+const proPlanPrice = getPlanPrice("pro");
+const freePlanPrice = getPlanPrice("free");
 
 const sectionCardStyle = {
   border: "0.7px solid hsl(var(--gray-400))",
@@ -307,6 +316,7 @@ function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
   const pageSignal = useGet(pageSignal$);
   const open = useGet(downgradeDialogOpen$);
   const loading = useGet(downgradeLoading$);
+  const error = useGet(downgradeError$);
   const close = useSet(closeDowngradeDialog$);
   const confirm = useSet(confirmDowngrade$);
   const [selectedTarget, setSelectedTarget] = useState<"free" | "pro">("free");
@@ -345,7 +355,7 @@ function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
                   Pro
                 </span>
                 <span className="ml-2 text-sm text-muted-foreground">
-                  $40/month
+                  {proPlanPrice}
                 </span>
               </div>
             </button>
@@ -363,12 +373,14 @@ function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
                   Free
                 </span>
                 <span className="ml-2 text-sm text-muted-foreground">
-                  $0/month
+                  {freePlanPrice}
                 </span>
               </div>
             </button>
           </div>
         )}
+
+        {error && <p className="text-sm text-destructive mt-2">{error}</p>}
 
         <div className="flex justify-end gap-2 mt-4">
           <Button variant="outline" onClick={() => close()} disabled={loading}>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useGet, useSet, useLoadable } from "ccstate-react";
 import {
   IconExternalLink,
@@ -14,9 +15,21 @@ import {
   startDowngrade$,
   billingDialogLoading$,
   apiTierToBillingTier,
+  openDowngradeDialog$,
+  closeDowngradeDialog$,
+  confirmDowngrade$,
+  downgradeDialogOpen$,
+  downgradeLoading$,
   type BillingTier,
 } from "../../../../signals/zero-page/billing.ts";
 import { Button } from "@vm0/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@vm0/ui/components/ui/dialog";
 import planFreeImg from "./assets/plan-free.webp";
 import planProImg from "./assets/plan-pro.webp";
 import planTeamImg from "./assets/plan-team.webp";
@@ -236,14 +249,14 @@ function PricingPage({
   const pageSignal = useGet(pageSignal$);
   const loading = useGet(billingDialogLoading$);
   const checkout = useSet(startCheckout$);
-  const portal = useSet(startDowngrade$);
+  const openDowngrade = useSet(openDowngradeDialog$);
 
   const handlePlanAction = (planTier: BillingTier) => {
     if (planTier === currentTier) {
       return;
     }
     if (planTier === "free" || tierRank(planTier) < tierRank(currentTier)) {
-      detach(portal(pageSignal), Reason.DomCallback);
+      openDowngrade();
       return;
     }
     if (planTier !== "pro" && planTier !== "team") {
@@ -290,12 +303,99 @@ function formatTierLabel(tier: BillingTier): string {
   return tier.charAt(0).toUpperCase() + tier.slice(1);
 }
 
+function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
+  const pageSignal = useGet(pageSignal$);
+  const open = useGet(downgradeDialogOpen$);
+  const loading = useGet(downgradeLoading$);
+  const close = useSet(closeDowngradeDialog$);
+  const confirm = useSet(confirmDowngrade$);
+  const [selectedTarget, setSelectedTarget] = useState<"free" | "pro">("free");
+
+  const isTeam = currentTier === "team";
+
+  const handleConfirm = () => {
+    detach(confirm(selectedTarget, pageSignal), Reason.DomCallback);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && close()}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle>Downgrade plan</DialogTitle>
+          <DialogDescription>
+            {isTeam
+              ? "Choose which plan to downgrade to."
+              : "Are you sure you want to downgrade to Free?"}
+          </DialogDescription>
+        </DialogHeader>
+
+        {isTeam && (
+          <div className="flex flex-col gap-2 mt-2">
+            <button
+              type="button"
+              onClick={() => setSelectedTarget("pro")}
+              className={`flex items-center justify-between rounded-lg border p-3 text-left transition-colors ${
+                selectedTarget === "pro"
+                  ? "border-primary ring-2 ring-primary/20"
+                  : "border-border hover:border-muted-foreground/30"
+              }`}
+            >
+              <div>
+                <span className="text-sm font-semibold text-foreground">
+                  Pro
+                </span>
+                <span className="ml-2 text-sm text-muted-foreground">
+                  $40/month
+                </span>
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setSelectedTarget("free")}
+              className={`flex items-center justify-between rounded-lg border p-3 text-left transition-colors ${
+                selectedTarget === "free"
+                  ? "border-primary ring-2 ring-primary/20"
+                  : "border-border hover:border-muted-foreground/30"
+              }`}
+            >
+              <div>
+                <span className="text-sm font-semibold text-foreground">
+                  Free
+                </span>
+                <span className="ml-2 text-sm text-muted-foreground">
+                  $0/month
+                </span>
+              </div>
+            </button>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 mt-4">
+          <Button variant="outline" onClick={() => close()} disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={loading}
+          >
+            {loading
+              ? "Downgrading..."
+              : `Downgrade to ${formatTierLabel(selectedTarget)}`}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function OrgBillingTab() {
   const pricingOpen = useGet(billingSubPage$);
   const setBillingSubPage = useSet(setBillingSubPage$);
   const setPricingOpen = (v: boolean) => setBillingSubPage(v);
   const pageSignal = useGet(pageSignal$);
   const reloadBilling = useSet(reloadBillingStatus$);
+  const openDowngrade = useSet(openDowngradeDialog$);
   const portal = useSet(startDowngrade$);
   const statusLoadable = useLoadable(billingStatusAsync$);
   const loading = useGet(billingDialogLoading$);
@@ -313,16 +413,19 @@ export function OrgBillingTab() {
       ? `Renews ${new Date(periodEnd).toLocaleDateString()}`
       : null;
 
-  const openPortal = () => {
-    detach(portal(pageSignal), Reason.DomCallback);
+  const handleDowngrade = () => {
+    openDowngrade();
   };
 
   if (pricingOpen) {
     return (
-      <PricingPage
-        currentTier={currentTier}
-        onBack={() => setPricingOpen(false)}
-      />
+      <>
+        <PricingPage
+          currentTier={currentTier}
+          onBack={() => setPricingOpen(false)}
+        />
+        <DowngradeConfirmDialog currentTier={currentTier} />
+      </>
     );
   }
 
@@ -396,7 +499,7 @@ export function OrgBillingTab() {
                       className="rounded-lg h-8 text-xs"
                       style={sectionCardStyle}
                       disabled={loading}
-                      onClick={openPortal}
+                      onClick={handleDowngrade}
                     >
                       Downgrade
                     </Button>
@@ -421,7 +524,9 @@ export function OrgBillingTab() {
                       className="shrink-0 rounded-lg h-8 text-xs gap-1.5"
                       style={sectionCardStyle}
                       disabled={loading}
-                      onClick={openPortal}
+                      onClick={() =>
+                        detach(portal(pageSignal), Reason.DomCallback)
+                      }
                     >
                       Manage
                       <IconExternalLink size={13} stroke={1.5} />
@@ -461,6 +566,8 @@ export function OrgBillingTab() {
           variant="settings"
         />
       )}
+
+      <DowngradeConfirmDialog currentTier={currentTier} />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -35,7 +35,7 @@ import planFreeImg from "./assets/plan-free.webp";
 import planProImg from "./assets/plan-pro.webp";
 import planTeamImg from "./assets/plan-team.webp";
 import { detach, Reason } from "../../../../signals/utils.ts";
-import { AutoRechargeSection, PLANS } from "../../billing-dialog.tsx";
+import { AutoRechargeSection } from "../../billing-dialog.tsx";
 import {
   billingSubPage$,
   setBillingSubPage$,

--- a/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/stripe/__tests__/route.test.ts
@@ -20,6 +20,8 @@ import { reloadEnv } from "../../../../../src/env";
 // Mock stripe module (external dependency)
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
+  subscriptionsUpdate: vi.fn(),
+  subscriptionsCancel: vi.fn(),
   invoicesRetrieve: vi.fn(),
   invoicesList: vi.fn(),
   customersCreate: vi.fn(),
@@ -31,7 +33,11 @@ const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
 vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
-      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      subscriptions: {
+        retrieve: stripeMocks.subscriptionsRetrieve,
+        update: stripeMocks.subscriptionsUpdate,
+        cancel: stripeMocks.subscriptionsCancel,
+      },
       invoices: {
         retrieve: stripeMocks.invoicesRetrieve,
         list: stripeMocks.invoicesList,
@@ -436,6 +442,30 @@ describe("POST /api/webhooks/stripe", () => {
       const billing = await getOrgBillingFields(user.orgId);
       expect(billing?.subscriptionStatus).toBe("past_due");
       expect(billing?.tier).toBe("team");
+    });
+
+    it("downgrades tier from team to pro when price changes", async () => {
+      const cusId = uniqueId("cus-downgrade");
+      const subId = uniqueId("sub-downgrade");
+
+      await updateOrgStripeFields(user.orgId, {
+        stripeCustomerId: cusId,
+        stripeSubscriptionId: subId,
+        subscriptionStatus: "active",
+        tier: "team",
+      });
+
+      const response = await sendWebhookEvent("customer.subscription.updated", {
+        id: subId,
+        status: "active",
+        items: { data: [{ price: { id: TEST_PRICE_PRO } }] },
+      });
+
+      expect(response.status).toBe(200);
+
+      const billing = await getOrgBillingFields(user.orgId);
+      expect(billing?.tier).toBe("pro");
+      expect(billing?.subscriptionStatus).toBe("active");
     });
   });
 

--- a/turbo/apps/web/app/api/zero/billing/checkout/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/checkout/__tests__/route.test.ts
@@ -10,6 +10,8 @@ import { reloadEnv } from "../../../../../../src/env";
 
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
+  subscriptionsUpdate: vi.fn(),
+  subscriptionsCancel: vi.fn(),
   invoicesRetrieve: vi.fn(),
   invoicesList: vi.fn(),
   customersCreate: vi.fn(),
@@ -21,7 +23,11 @@ const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
 vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
-      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      subscriptions: {
+        retrieve: stripeMocks.subscriptionsRetrieve,
+        update: stripeMocks.subscriptionsUpdate,
+        cancel: stripeMocks.subscriptionsCancel,
+      },
       invoices: {
         retrieve: stripeMocks.invoicesRetrieve,
         list: stripeMocks.invoicesList,

--- a/turbo/apps/web/app/api/zero/billing/downgrade/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/downgrade/__tests__/route.test.ts
@@ -170,7 +170,7 @@ describe("POST /api/zero/billing/downgrade", () => {
     });
   });
 
-  it("downgrades pro to free via subscription cancel", async () => {
+  it("downgrades pro to free via cancel at period end", async () => {
     const subId = uniqueId("sub-pro-free");
     const periodEnd = new Date(Date.now() + 30 * 86400 * 1000);
     await updateOrgStripeFields(user.orgId, {
@@ -180,7 +180,7 @@ describe("POST /api/zero/billing/downgrade", () => {
       currentPeriodEnd: periodEnd,
     });
 
-    stripeMocks.subscriptionsCancel.mockResolvedValue({ id: subId });
+    stripeMocks.subscriptionsUpdate.mockResolvedValue({ id: subId });
 
     const request = createDowngradeRequest({ targetTier: "free" });
     const response = await POST(request);
@@ -190,10 +190,12 @@ describe("POST /api/zero/billing/downgrade", () => {
     expect(data.success).toBe(true);
     expect(data.effectiveDate).toBe(periodEnd.toISOString());
 
-    expect(stripeMocks.subscriptionsCancel).toHaveBeenCalledWith(subId);
+    expect(stripeMocks.subscriptionsUpdate).toHaveBeenCalledWith(subId, {
+      cancel_at_period_end: true,
+    });
   });
 
-  it("downgrades team to free via subscription cancel", async () => {
+  it("downgrades team to free via cancel at period end", async () => {
     const subId = uniqueId("sub-team-free");
     const periodEnd = new Date(Date.now() + 30 * 86400 * 1000);
     await updateOrgStripeFields(user.orgId, {
@@ -203,7 +205,7 @@ describe("POST /api/zero/billing/downgrade", () => {
       currentPeriodEnd: periodEnd,
     });
 
-    stripeMocks.subscriptionsCancel.mockResolvedValue({ id: subId });
+    stripeMocks.subscriptionsUpdate.mockResolvedValue({ id: subId });
 
     const request = createDowngradeRequest({ targetTier: "free" });
     const response = await POST(request);
@@ -213,6 +215,8 @@ describe("POST /api/zero/billing/downgrade", () => {
     expect(data.success).toBe(true);
     expect(data.effectiveDate).toBe(periodEnd.toISOString());
 
-    expect(stripeMocks.subscriptionsCancel).toHaveBeenCalledWith(subId);
+    expect(stripeMocks.subscriptionsUpdate).toHaveBeenCalledWith(subId, {
+      cancel_at_period_end: true,
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/billing/downgrade/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/downgrade/__tests__/route.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  updateOrgStripeFields,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock";
+import { reloadEnv } from "../../../../../../src/env";
+
+const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
+  subscriptionsRetrieve: vi.fn(),
+  subscriptionsUpdate: vi.fn(),
+  subscriptionsCancel: vi.fn(),
+  invoicesRetrieve: vi.fn(),
+  invoicesList: vi.fn(),
+  customersCreate: vi.fn(),
+  checkoutSessionsCreate: vi.fn(),
+  billingPortalSessionsCreate: vi.fn(),
+  constructEvent: vi.fn(),
+}));
+
+vi.mock("stripe", () => ({
+  default: function MockStripe() {
+    return {
+      subscriptions: {
+        retrieve: stripeMocks.subscriptionsRetrieve,
+        update: stripeMocks.subscriptionsUpdate,
+        cancel: stripeMocks.subscriptionsCancel,
+      },
+      invoices: {
+        retrieve: stripeMocks.invoicesRetrieve,
+        list: stripeMocks.invoicesList,
+      },
+      customers: { create: stripeMocks.customersCreate },
+      checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+      billingPortal: {
+        sessions: { create: stripeMocks.billingPortalSessionsCreate },
+      },
+      webhooks: { constructEvent: stripeMocks.constructEvent },
+    };
+  },
+}));
+
+import { POST } from "../route";
+
+const TEST_PRICE_PRO = "price_test_pro";
+const TEST_PRICE_TEAM = "price_test_team";
+
+const context = testContext();
+
+function createDowngradeRequest(
+  body: Record<string, unknown>,
+): ReturnType<typeof createTestRequest> {
+  return createTestRequest("http://localhost:3000/api/zero/billing/downgrade", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/zero/billing/downgrade", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+    vi.stubEnv("ZERO_PRO_PLAN_PRICE_ID", TEST_PRICE_PRO);
+    vi.stubEnv("ZERO_MAX_PLAN_PRICE_ID", TEST_PRICE_TEAM);
+    reloadEnv();
+
+    stripeMocks.subscriptionsRetrieve.mockReset();
+    stripeMocks.subscriptionsUpdate.mockReset();
+    stripeMocks.subscriptionsCancel.mockReset();
+  });
+
+  it("returns 503 when STRIPE_SECRET_KEY is not configured", async () => {
+    vi.stubEnv("STRIPE_SECRET_KEY", "");
+    reloadEnv();
+
+    const request = createDowngradeRequest({ targetTier: "free" });
+    const response = await POST(request);
+
+    expect(response.status).toBe(503);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createDowngradeRequest({ targetTier: "free" });
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin member", async () => {
+    const { userId, orgId } = await context.setupUser({
+      prefix: "member-downgrade",
+    });
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+
+    const request = createDowngradeRequest({ targetTier: "free" });
+    const response = await POST(request);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 for invalid targetTier", async () => {
+    const request = createDowngradeRequest({ targetTier: "team" });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 500 when org has no subscription", async () => {
+    const request = createDowngradeRequest({ targetTier: "free" });
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+  });
+
+  it("returns 500 when target tier is same or higher", async () => {
+    const subId = uniqueId("sub-same");
+    await updateOrgStripeFields(user.orgId, {
+      stripeSubscriptionId: subId,
+      tier: "pro",
+      subscriptionStatus: "active",
+    });
+
+    const request = createDowngradeRequest({ targetTier: "pro" });
+    const response = await POST(request);
+
+    expect(response.status).toBe(500);
+  });
+
+  it("downgrades team to pro via subscription update", async () => {
+    const subId = uniqueId("sub-team-pro");
+    await updateOrgStripeFields(user.orgId, {
+      stripeSubscriptionId: subId,
+      tier: "team",
+      subscriptionStatus: "active",
+    });
+
+    stripeMocks.subscriptionsRetrieve.mockResolvedValue({
+      id: subId,
+      items: { data: [{ id: "si_item_1", price: { id: TEST_PRICE_TEAM } }] },
+    });
+    stripeMocks.subscriptionsUpdate.mockResolvedValue({
+      id: subId,
+      items: { data: [{ id: "si_item_1", price: { id: TEST_PRICE_PRO } }] },
+    });
+
+    const request = createDowngradeRequest({ targetTier: "pro" });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.effectiveDate).toBeNull();
+
+    expect(stripeMocks.subscriptionsUpdate).toHaveBeenCalledWith(subId, {
+      items: [{ id: "si_item_1", price: TEST_PRICE_PRO }],
+      proration_behavior: "always_invoice",
+    });
+  });
+
+  it("downgrades pro to free via subscription cancel", async () => {
+    const subId = uniqueId("sub-pro-free");
+    const periodEnd = new Date(Date.now() + 30 * 86400 * 1000);
+    await updateOrgStripeFields(user.orgId, {
+      stripeSubscriptionId: subId,
+      tier: "pro",
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+    });
+
+    stripeMocks.subscriptionsCancel.mockResolvedValue({ id: subId });
+
+    const request = createDowngradeRequest({ targetTier: "free" });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.effectiveDate).toBe(periodEnd.toISOString());
+
+    expect(stripeMocks.subscriptionsCancel).toHaveBeenCalledWith(subId);
+  });
+
+  it("downgrades team to free via subscription cancel", async () => {
+    const subId = uniqueId("sub-team-free");
+    const periodEnd = new Date(Date.now() + 30 * 86400 * 1000);
+    await updateOrgStripeFields(user.orgId, {
+      stripeSubscriptionId: subId,
+      tier: "team",
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+    });
+
+    stripeMocks.subscriptionsCancel.mockResolvedValue({ id: subId });
+
+    const request = createDowngradeRequest({ targetTier: "free" });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.effectiveDate).toBe(periodEnd.toISOString());
+
+    expect(stripeMocks.subscriptionsCancel).toHaveBeenCalledWith(subId);
+  });
+});

--- a/turbo/apps/web/app/api/zero/billing/downgrade/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/downgrade/route.ts
@@ -1,0 +1,51 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroBillingDowngradeContract, createErrorResponse } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { env } from "../../../../../src/env";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { downgradeSubscription } from "../../../../../src/lib/billing/billing-service";
+
+const router = tsr.router(zeroBillingDowngradeContract, {
+  create: async ({ body, headers }, { request }) => {
+    initServices();
+
+    const { STRIPE_SECRET_KEY } = env();
+
+    if (!STRIPE_SECRET_KEY) {
+      return createErrorResponse(
+        "PROVIDER_UNAVAILABLE",
+        "Billing not configured",
+      );
+    }
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const orgSlug = new URL(request.url).searchParams.get("org");
+    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only org admins can manage billing",
+      );
+    }
+
+    const result = await downgradeSubscription(org.orgId, body.targetTier);
+
+    return { status: 200 as const, body: result };
+  },
+});
+
+const handler = createHandler(zeroBillingDowngradeContract, router, {
+  errorHandler: createSafeErrorHandler("zero-billing-downgrade"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/zero/billing/invoices/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/invoices/__tests__/route.test.ts
@@ -13,6 +13,8 @@ import { reloadEnv } from "../../../../../../src/env";
 
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
+  subscriptionsUpdate: vi.fn(),
+  subscriptionsCancel: vi.fn(),
   invoicesRetrieve: vi.fn(),
   invoicesList: vi.fn(),
   customersCreate: vi.fn(),
@@ -24,7 +26,11 @@ const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
 vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
-      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      subscriptions: {
+        retrieve: stripeMocks.subscriptionsRetrieve,
+        update: stripeMocks.subscriptionsUpdate,
+        cancel: stripeMocks.subscriptionsCancel,
+      },
       invoices: {
         retrieve: stripeMocks.invoicesRetrieve,
         list: stripeMocks.invoicesList,

--- a/turbo/apps/web/app/api/zero/billing/portal/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/portal/__tests__/route.test.ts
@@ -14,6 +14,8 @@ import { reloadEnv } from "../../../../../../src/env";
 
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
+  subscriptionsUpdate: vi.fn(),
+  subscriptionsCancel: vi.fn(),
   invoicesRetrieve: vi.fn(),
   invoicesList: vi.fn(),
   customersCreate: vi.fn(),
@@ -25,7 +27,11 @@ const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
 vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
-      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      subscriptions: {
+        retrieve: stripeMocks.subscriptionsRetrieve,
+        update: stripeMocks.subscriptionsUpdate,
+        cancel: stripeMocks.subscriptionsCancel,
+      },
       invoices: {
         retrieve: stripeMocks.invoicesRetrieve,
         list: stripeMocks.invoicesList,

--- a/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
@@ -12,6 +12,8 @@ import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock"
 
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
+  subscriptionsUpdate: vi.fn(),
+  subscriptionsCancel: vi.fn(),
   invoicesRetrieve: vi.fn(),
   invoicesList: vi.fn(),
   customersCreate: vi.fn(),
@@ -23,7 +25,11 @@ const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
 vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
-      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      subscriptions: {
+        retrieve: stripeMocks.subscriptionsRetrieve,
+        update: stripeMocks.subscriptionsUpdate,
+        cancel: stripeMocks.subscriptionsCancel,
+      },
       invoices: {
         retrieve: stripeMocks.invoicesRetrieve,
         list: stripeMocks.invoicesList,

--- a/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/members/__tests__/route.test.ts
@@ -13,6 +13,8 @@ import type { StripeMockFns } from "../../../../../../src/__tests__/stripe-mock"
 
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
+  subscriptionsUpdate: vi.fn(),
+  subscriptionsCancel: vi.fn(),
   invoicesRetrieve: vi.fn(),
   invoicesList: vi.fn(),
   customersCreate: vi.fn(),
@@ -24,7 +26,11 @@ const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
 vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
-      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      subscriptions: {
+        retrieve: stripeMocks.subscriptionsRetrieve,
+        update: stripeMocks.subscriptionsUpdate,
+        cancel: stripeMocks.subscriptionsCancel,
+      },
       invoices: {
         retrieve: stripeMocks.invoicesRetrieve,
         list: stripeMocks.invoicesList,

--- a/turbo/apps/web/src/__tests__/stripe-mock.ts
+++ b/turbo/apps/web/src/__tests__/stripe-mock.ts
@@ -13,6 +13,8 @@ import type { Mock } from "vitest";
  *
  * const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
  *   subscriptionsRetrieve: vi.fn(),
+ *   subscriptionsUpdate: vi.fn(),
+ *   subscriptionsCancel: vi.fn(),
  *   invoicesRetrieve: vi.fn(),
  *   invoicesList: vi.fn(),
  *   customersCreate: vi.fn(),
@@ -24,7 +26,7 @@ import type { Mock } from "vitest";
  * vi.mock("stripe", () => ({
  *   default: function MockStripe() {
  *     return {
- *       subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+ *       subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve, update: stripeMocks.subscriptionsUpdate, cancel: stripeMocks.subscriptionsCancel },
  *       invoices: { retrieve: stripeMocks.invoicesRetrieve, list: stripeMocks.invoicesList },
  *       customers: { create: stripeMocks.customersCreate },
  *       checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
@@ -37,6 +39,8 @@ import type { Mock } from "vitest";
  */
 export interface StripeMockFns {
   subscriptionsRetrieve: Mock;
+  subscriptionsUpdate: Mock;
+  subscriptionsCancel: Mock;
   invoicesRetrieve: Mock;
   invoicesList: Mock;
   customersCreate: Mock;

--- a/turbo/apps/web/src/lib/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/billing/billing-service.ts
@@ -427,7 +427,9 @@ export async function downgradeSubscription(
 
   if (targetTier === "free") {
     // Cancel at period end
-    await stripe.subscriptions.cancel(org.stripeSubscriptionId);
+    await stripe.subscriptions.update(org.stripeSubscriptionId, {
+      cancel_at_period_end: true,
+    });
     const effectiveDate = org.currentPeriodEnd
       ? org.currentPeriodEnd.toISOString()
       : null;

--- a/turbo/apps/web/src/lib/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/billing/billing-service.ts
@@ -377,6 +377,95 @@ export async function handleSubscriptionDeleted(
   });
 }
 
+// ---------------------------------------------------------------------------
+// Tier ranking for downgrade validation
+// ---------------------------------------------------------------------------
+
+const TIER_RANK: Record<OrgTier, number> = {
+  free: 0,
+  pro: 1,
+  team: 2,
+};
+
+/**
+ * Downgrade a subscription to a lower tier.
+ *
+ * - Team -> Pro: updates the subscription's price via Stripe API (immediate).
+ * - Paid -> Free: cancels the subscription at period end.
+ *
+ * Returns `{ success, effectiveDate }` where effectiveDate is non-null only
+ * for cancellations (the date access ends).
+ */
+export async function downgradeSubscription(
+  orgId: string,
+  targetTier: "free" | "pro",
+): Promise<{ success: boolean; effectiveDate: string | null }> {
+  const db = globalThis.services.db;
+
+  const [org] = await db
+    .select({
+      tier: orgMetadata.tier,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+      currentPeriodEnd: orgMetadata.currentPeriodEnd,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  if (!org?.stripeSubscriptionId) {
+    throw new Error("Org has no active subscription");
+  }
+
+  const currentTier = org.tier as OrgTier;
+  if (TIER_RANK[targetTier] >= TIER_RANK[currentTier]) {
+    throw new Error(
+      `Cannot downgrade from ${currentTier} to ${targetTier}: target tier is same or higher`,
+    );
+  }
+
+  const stripe = getStripe();
+
+  if (targetTier === "free") {
+    // Cancel at period end
+    await stripe.subscriptions.cancel(org.stripeSubscriptionId);
+    const effectiveDate = org.currentPeriodEnd
+      ? org.currentPeriodEnd.toISOString()
+      : null;
+    log.info("subscription cancellation initiated", {
+      orgId,
+      targetTier,
+      effectiveDate,
+    });
+    return { success: true, effectiveDate };
+  }
+
+  // Team -> Pro: update subscription price
+  const subscription = await stripe.subscriptions.retrieve(
+    org.stripeSubscriptionId,
+  );
+  const currentItem = subscription.items.data[0];
+  if (!currentItem) {
+    throw new Error("Subscription has no items");
+  }
+
+  const proPriceId = env().ZERO_PRO_PLAN_PRICE_ID;
+  if (!proPriceId) {
+    throw new Error("Pro plan price ID not configured");
+  }
+
+  await stripe.subscriptions.update(org.stripeSubscriptionId, {
+    items: [{ id: currentItem.id, price: proPriceId }],
+    proration_behavior: "always_invoice",
+  });
+
+  log.info("subscription downgraded", {
+    orgId,
+    from: currentTier,
+    to: targetTier,
+  });
+  return { success: true, effectiveDate: null };
+}
+
 /**
  * Create a Stripe Billing Portal session for managing subscriptions.
  * Returns the portal URL.

--- a/turbo/apps/web/src/lib/org/__tests__/org-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-cache-service.test.ts
@@ -22,6 +22,8 @@ import {
 // Mock stripe module (external dependency)
 const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
   subscriptionsRetrieve: vi.fn(),
+  subscriptionsUpdate: vi.fn(),
+  subscriptionsCancel: vi.fn(),
   invoicesRetrieve: vi.fn(),
   invoicesList: vi.fn(),
   customersCreate: vi.fn(),
@@ -33,7 +35,11 @@ const stripeMocks = vi.hoisted<StripeMockFns>(() => ({
 vi.mock("stripe", () => ({
   default: function MockStripe() {
     return {
-      subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+      subscriptions: {
+        retrieve: stripeMocks.subscriptionsRetrieve,
+        update: stripeMocks.subscriptionsUpdate,
+        cancel: stripeMocks.subscriptionsCancel,
+      },
       invoices: {
         retrieve: stripeMocks.invoicesRetrieve,
         list: stripeMocks.invoicesList,

--- a/turbo/apps/web/src/lib/org/__tests__/org-external-cleanup.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-external-cleanup.test.ts
@@ -17,11 +17,13 @@ import { cleanupOrgExternalServices } from "../org-external-cleanup";
 // --- Stripe mock (external dependency — allowed) ---
 
 const stripeMocks = vi.hoisted<
-  Pick<StripeMockFns, "subscriptionsRetrieve"> & {
-    subscriptionsCancel: ReturnType<typeof vi.fn>;
-  }
+  Pick<
+    StripeMockFns,
+    "subscriptionsRetrieve" | "subscriptionsUpdate" | "subscriptionsCancel"
+  >
 >(() => ({
   subscriptionsRetrieve: vi.fn(),
+  subscriptionsUpdate: vi.fn(),
   subscriptionsCancel: vi.fn(),
 }));
 

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -588,11 +588,13 @@ export {
   zeroBillingPortalContract,
   zeroBillingAutoRechargeContract,
   zeroBillingInvoicesContract,
+  zeroBillingDowngradeContract,
   type ZeroBillingStatusContract,
   type ZeroBillingCheckoutContract,
   type ZeroBillingPortalContract,
   type ZeroBillingAutoRechargeContract,
   type ZeroBillingInvoicesContract,
+  type ZeroBillingDowngradeContract,
   // Inferred types
   type BillingStatusResponse,
   type AutoRechargeConfig,
@@ -600,6 +602,7 @@ export {
   type PortalResponse,
   type BillingInvoice,
   type BillingInvoicesResponse,
+  type DowngradeResponse,
 } from "./zero-billing";
 export {
   zeroUsageMembersContract,

--- a/turbo/packages/core/src/contracts/zero-billing.ts
+++ b/turbo/packages/core/src/contracts/zero-billing.ts
@@ -211,6 +211,7 @@ export const zeroBillingDowngradeContract = c.router({
       400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
+      500: apiErrorSchema,
       503: apiErrorSchema,
     },
     summary: "Downgrade subscription to a lower tier",

--- a/turbo/packages/core/src/contracts/zero-billing.ts
+++ b/turbo/packages/core/src/contracts/zero-billing.ts
@@ -184,6 +184,41 @@ export const zeroBillingInvoicesContract = c.router({
 
 export type ZeroBillingInvoicesContract = typeof zeroBillingInvoicesContract;
 
+// ---------------------------------------------------------------------------
+// Downgrade
+// ---------------------------------------------------------------------------
+
+const downgradeRequestSchema = z.object({
+  targetTier: z.enum(["free", "pro"]),
+});
+
+const downgradeResponseSchema = z.object({
+  success: z.boolean(),
+  effectiveDate: z.string().nullable(),
+});
+
+/**
+ * Zero contract for POST /api/zero/billing/downgrade
+ */
+export const zeroBillingDowngradeContract = c.router({
+  create: {
+    method: "POST",
+    path: "/api/zero/billing/downgrade",
+    headers: authHeadersSchema,
+    body: downgradeRequestSchema,
+    responses: {
+      200: downgradeResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      503: apiErrorSchema,
+    },
+    summary: "Downgrade subscription to a lower tier",
+  },
+});
+
+export type ZeroBillingDowngradeContract = typeof zeroBillingDowngradeContract;
+
 // Inferred types from Zod schemas
 export type BillingStatusResponse = z.infer<typeof billingStatusResponseSchema>;
 export type AutoRechargeConfig = z.infer<typeof autoRechargeSchema>;
@@ -193,3 +228,4 @@ export type BillingInvoice = z.infer<typeof invoiceSchema>;
 export type BillingInvoicesResponse = z.infer<
   typeof billingInvoicesResponseSchema
 >;
+export type DowngradeResponse = z.infer<typeof downgradeResponseSchema>;


### PR DESCRIPTION
## Summary
- Add `POST /api/zero/billing/downgrade` endpoint that handles Team-to-Pro (subscription update) and Paid-to-Free (subscription cancel at period end) downgrades server-side via Stripe API
- Replace Stripe Billing Portal redirect with in-app `DowngradeConfirmDialog` that shows tier-aware UI (Pro users: simple free confirmation; Team users: plan selection between Pro and Free)
- Update `BillingDialog` and `PricingPage` to route downgrade actions through the new dialog instead of Stripe portal
- Extend `StripeMockFns` interface with `subscriptionsUpdate` and `subscriptionsCancel` across all billing test files
- Add `zeroBillingDowngradeContract` to `@vm0/core` contracts

## Test plan
- [x] 9 backend integration tests for downgrade route (auth guards, validation, Team->Pro, Pro->Free, Team->Free)
- [x] 1 webhook test for Team-to-Pro via `customer.subscription.updated`
- [x] 8 frontend integration tests for downgrade dialog flow (visibility, open/close, API calls, pricing page routing)
- [x] All 72 billing-related tests pass
- [x] Lint, type check, knip all pass

Closes #6860

🤖 Generated with [Claude Code](https://claude.com/claude-code)