### PR TITLE
fix: add s3 cleanup and running-run guard to zero agent delete endpoint

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -16,6 +16,8 @@ import { agentComposes } from "../../../../../src/db/schema/agent-compose";
 import { eq, and } from "drizzle-orm";
 import { buildComposeContent } from "../../../../../src/lib/zero/build-compose-content";
 import { isDefaultAgentCompose } from "../../../../../src/lib/zero/resolve-default-agent";
+import { deleteComposeById } from "../../../../../src/lib/agent-compose/compose-service";
+import { isConflict } from "../../../../../src/lib/errors";
 import { logger } from "../../../../../src/lib/logger";
 
 const log = logger("api:zero-agents:id");
@@ -324,12 +326,23 @@ const router = tsr.router(zeroAgentsByIdContract, {
     );
     if (forbidden) return forbidden;
 
-    // Delete compose and metadata atomically
-    // Deleting agent_composes cascades to zero_agents (FK cascade),
-    // which cascades to schedules and email_thread_sessions.
-    await globalThis.services.db.transaction(async (tx) => {
-      await tx.delete(agentComposes).where(eq(agentComposes.id, params.id));
-    });
+    // Delete compose with full cleanup (cascade + S3 instructions volume)
+    try {
+      await deleteComposeById(agent.id, agent.name, org.orgId);
+    } catch (error) {
+      if (isConflict(error)) {
+        return {
+          status: 409 as const,
+          body: {
+            error: {
+              message: error.message,
+              code: "CONFLICT",
+            },
+          },
+        };
+      }
+      throw error;
+    }
 
     log.info(`Deleted zero agent: ${agent.name}`);
 

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -9,9 +9,13 @@ import {
 import {
   createTestRequest,
   createTestCliToken,
+  createTestCompose,
   createTestRun,
+  createTestRunInDb,
   createTestOrgModelProvider,
   createTestSandboxToken,
+  createTestVolume,
+  findTestStorageByName,
   seedTestSkill,
   seedSeedSkills,
   seedSeedSkillStorages,
@@ -26,6 +30,7 @@ import {
   setDefaultAgentByComposeId,
   clearOrgMembersCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
+import { getInstructionsStorageName } from "@vm0/core";
 import {
   testContext,
   type UserContext,
@@ -831,6 +836,65 @@ describe("Zero Agents API", () => {
         testOrgSlug,
       );
       expect(getResponse.status).toBe(404);
+    });
+
+    it("should clean up instructions storage when agent is deleted", async () => {
+      const agentName = `cleanup-${user.userId.slice(-8)}`;
+      const { composeId } = await createTestCompose(agentName);
+
+      // Create instructions volume for the agent
+      const instructionsName = getInstructionsStorageName(agentName);
+      await createTestVolume(instructionsName);
+
+      // Verify volume exists
+      const storageBefore = await findTestStorageByName(
+        user.orgId,
+        instructionsName,
+      );
+      expect(storageBefore).toBeDefined();
+
+      // Mock S3 listing
+      context.mocks.s3.listS3Objects.mockResolvedValueOnce([
+        {
+          key: `${storageBefore!.s3Prefix}/v1/archive.tar.gz`,
+          size: 1024,
+        },
+      ]);
+
+      // Delete agent via zero agents API
+      const response = await deleteAgent(composeId, testCliToken, testOrgSlug);
+      expect(response.status).toBe(204);
+
+      // Verify instructions storage cleaned up
+      const storageAfter = await findTestStorageByName(
+        user.orgId,
+        instructionsName,
+      );
+      expect(storageAfter).toBeUndefined();
+
+      // Verify S3 cleanup called
+      expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalled();
+    });
+
+    it("should return 409 when agent has running runs", async () => {
+      const created = await (
+        await postAgent({ connectors: [] }, testCliToken, testOrgSlug)
+      ).json();
+
+      // Create a running run for this agent
+      await createTestRunInDb(user.userId, created.agentId, {
+        status: "running",
+      });
+
+      // Try to delete — should get 409
+      const response = await deleteAgent(
+        created.agentId,
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(409);
+      const data = await response.json();
+      expect(data.error.code).toBe("CONFLICT");
     });
 
     it("should return 401 without auth", async () => {

--- a/turbo/apps/web/src/lib/agent-compose/compose-service.ts
+++ b/turbo/apps/web/src/lib/agent-compose/compose-service.ts
@@ -111,29 +111,17 @@ export async function getComposeById(
 }
 
 /**
- * Delete a compose by ID. Verifies ownership, checks for active runs,
- * deletes cascade + S3 instructions storage.
+ * Delete compose by ID with full cleanup. Caller is responsible for auth.
+ * Checks for active runs, deletes cascade + S3 instructions storage.
  *
- * Throws notFound if compose doesn't exist or caller is not the owner.
  * Throws conflict if compose has running/pending runs.
  */
-export async function deleteCompose(
+export async function deleteComposeById(
   composeId: string,
-  userId: string,
+  composeName: string,
+  orgId: string,
 ): Promise<void> {
   const db = globalThis.services.db;
-
-  const [compose] = await db
-    .select()
-    .from(agentComposes)
-    .where(
-      and(eq(agentComposes.id, composeId), eq(agentComposes.userId, userId)),
-    )
-    .limit(1);
-
-  if (!compose) {
-    throw notFound("Agent not found");
-  }
 
   // Check for running/pending runs
   const runningRuns = await db
@@ -159,13 +147,13 @@ export async function deleteCompose(
   await db.delete(agentComposes).where(eq(agentComposes.id, composeId));
 
   // Clean up agent-instructions volume (DB + S3)
-  const storageName = getInstructionsStorageName(compose.name);
+  const storageName = getInstructionsStorageName(composeName);
   const [storage] = await db
     .select({ id: storages.id, s3Prefix: storages.s3Prefix })
     .from(storages)
     .where(
       and(
-        eq(storages.orgId, compose.orgId),
+        eq(storages.orgId, orgId),
         eq(storages.name, storageName),
         eq(storages.type, "volume"),
       ),
@@ -184,6 +172,37 @@ export async function deleteCompose(
       );
     }
   }
+}
+
+/**
+ * Delete a compose by ID. Verifies ownership, then delegates to deleteComposeById.
+ *
+ * Throws notFound if compose doesn't exist or caller is not the owner.
+ * Throws conflict if compose has running/pending runs.
+ */
+export async function deleteCompose(
+  composeId: string,
+  userId: string,
+): Promise<void> {
+  const db = globalThis.services.db;
+
+  const [compose] = await db
+    .select({
+      id: agentComposes.id,
+      name: agentComposes.name,
+      orgId: agentComposes.orgId,
+    })
+    .from(agentComposes)
+    .where(
+      and(eq(agentComposes.id, composeId), eq(agentComposes.userId, userId)),
+    )
+    .limit(1);
+
+  if (!compose) {
+    throw notFound("Agent not found");
+  }
+
+  await deleteComposeById(composeId, compose.name, compose.orgId);
 }
 
 /**

--- a/turbo/packages/core/src/contracts/zero-agents.ts
+++ b/turbo/packages/core/src/contracts/zero-agents.ts
@@ -140,6 +140,7 @@ export const zeroAgentsByIdContract = c.router({
       401: apiErrorSchema,
       403: apiErrorSchema,
       404: apiErrorSchema,
+      409: apiErrorSchema,
     },
     summary: "Delete zero agent by id",
   },


### PR DESCRIPTION
## Summary

- Extract `deleteComposeById()` from `deleteCompose()` so both DELETE endpoints share the same cleanup logic
- The `DELETE /api/zero/agents/:id` endpoint now checks for running/pending runs (409 Conflict) and cleans up S3 instructions volume
- Add 409 response to the ts-rest contract for the zero agents delete endpoint

Closes #6866

## Test plan

- [x] Existing `delete-storage-cleanup.test.ts` passes (compose endpoint path unaffected)
- [x] Existing 44 agent route tests pass (no regressions)
- [x] New test: instructions storage is cleaned up when agent is deleted via `/api/zero/agents/:id`
- [x] New test: 409 returned when agent has running runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)