### PR TITLE
refactor(cli): add agent self-update guidance to zero --help and system prompt

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/index.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/index.ts
@@ -11,4 +11,14 @@ export const zeroAgentCommand = new Command("agent")
   .addCommand(editCommand)
   .addCommand(viewCommand)
   .addCommand(listCommand)
-  .addCommand(deleteCommand);
+  .addCommand(deleteCommand)
+  .addHelpText(
+    "after",
+    `
+Self-management (inside sandbox):
+  Your agent ID is in $ZERO_AGENT_ID (or run: zero whoami)
+  View your config:      zero agent view $ZERO_AGENT_ID --instructions
+  Update description:    zero agent edit $ZERO_AGENT_ID --description "new role"
+  Update tone:           zero agent edit $ZERO_AGENT_ID --sound friendly
+  Update instructions:   zero agent edit $ZERO_AGENT_ID --instructions-file <path>`,
+  );

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -92,6 +92,7 @@ Common scenarios:
   Missing a token?       zero doctor missing-token <TOKEN_NAME>
   Send a Slack message?  zero slack message send -c <channel> -t "text"
   Set up a schedule?     zero schedule setup <agent-name>
+  Update yourself?       zero agent --help
   Check your identity?   zero whoami`,
   );
 

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -39,5 +39,6 @@ export function buildAgentToolsPrompt(): string {
     "- When you need to schedule or manage recurring tasks, use `zero schedule`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "- When you need to send a Slack message, use `zero slack message send`. Never use SLACK_TOKEN directly — it's a user token.",
     "- When you encounter a missing token or environment variable error, run `zero doctor missing-token <TOKEN_NAME>` to diagnose the issue and get remediation steps for the user.",
+    "- When you need to update your own configuration (description, tone, or instructions), use `zero agent edit $ZERO_AGENT_ID`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Add "Update yourself?" scenario to `zero --help` common scenarios, pointing to `zero agent --help`
- Add self-management afterhelp block to `zero agent --help` with `view`/`edit` examples using `$ZERO_AGENT_ID`
- Add when-do guidance in `buildAgentToolsPrompt()` so sandbox agents know how to update their own configuration

## Test plan
- [x] All existing zero CLI and agent command tests pass (21/21)
- [x] Lint, type check, format, knip all pass
- [x] No existing E2E tests assert on help text content — no breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)