### PR TITLE
feat(slack): inject channel id, name, and type into agent system prompt

### DIFF
--- a/turbo/apps/web/app/api/zero/slack/events/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/route.ts
@@ -29,6 +29,7 @@ interface SlackAppMentionEvent {
   text: string;
   ts: string;
   channel: string;
+  channel_type?: string;
   event_ts: string;
   thread_ts?: string;
   files?: SlackFile[];
@@ -93,6 +94,7 @@ function handleEventCallback(payload: SlackEventCallback) {
       handleOrgMention({
         workspaceId: payload.team_id,
         channelId: event.channel,
+        channelType: event.channel_type,
         userId: event.user,
         messageText: event.text,
         messageTs: event.ts,

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -9,11 +9,31 @@ type IntegrationPlatform = "Email" | "GitHub" | "Slack" | "Telegram";
  */
 export function buildIntegrationContext(
   platform: IntegrationPlatform,
-  options?: { botUserId?: string },
+  options?: {
+    botUserId?: string;
+    channelId?: string;
+    channelName?: string;
+    channelType?: "channel" | "dm" | "group_dm";
+  },
 ): string {
   let context = `# Current Integration\nYou are currently running inside: ${platform}`;
   if (options?.botUserId) {
     context += `\nYour bot user ID: ${options.botUserId}`;
+  }
+  if (options?.channelId) {
+    context += `\nChannel ID: ${options.channelId}`;
+  }
+  if (options?.channelName) {
+    context += `\nChannel name: #${options.channelName}`;
+  }
+  if (options?.channelType) {
+    const typeLabel =
+      options.channelType === "dm"
+        ? "Direct message"
+        : options.channelType === "group_dm"
+          ? "Group direct message"
+          : "Channel";
+    context += `\nChannel type: ${typeLabel}`;
   }
   return context;
 }

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -12,7 +12,6 @@ export function buildIntegrationContext(
   options?: {
     botUserId?: string;
     channelId?: string;
-    channelName?: string;
     channelType?: "channel" | "dm" | "group_dm";
   },
 ): string {
@@ -22,9 +21,6 @@ export function buildIntegrationContext(
   }
   if (options?.channelId) {
     context += `\nChannel ID: ${options.channelId}`;
-  }
-  if (options?.channelName) {
-    context += `\nChannel name: #${options.channelName}`;
   }
   if (options?.channelType) {
     const typeLabel =

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -4,6 +4,7 @@ import {
   createSlackClient,
   postMessage,
   setThreadStatus,
+  fetchSlackChannelInfo,
 } from "../../slack/client";
 import {
   buildAgentResponseMessage,
@@ -115,7 +116,10 @@ export async function handleOrgDirectMessage(
   // 4. Show thinking indicator
   await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
 
-  // 5. Enrich message
+  // 5. Fetch channel info for agent context
+  const channelInfo = await fetchSlackChannelInfo(client, context.channelId);
+
+  // 6. Enrich message
   const { prompt: messageContent, userContext } = await enrichMessageContent({
     messageContent: context.messageText,
     files: context.files,
@@ -182,6 +186,9 @@ export async function handleOrgDirectMessage(
     userContext,
     userId: connection.vm0UserId,
     botUserId,
+    channelId: context.channelId,
+    channelName: channelInfo?.name,
+    channelType: channelInfo?.type,
     callbackContext,
   });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -4,7 +4,6 @@ import {
   createSlackClient,
   postMessage,
   setThreadStatus,
-  fetchSlackChannelInfo,
 } from "../../slack/client";
 import {
   buildAgentResponseMessage,
@@ -116,10 +115,7 @@ export async function handleOrgDirectMessage(
   // 4. Show thinking indicator
   await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
 
-  // 5. Fetch channel info for agent context
-  const channelInfo = await fetchSlackChannelInfo(client, context.channelId);
-
-  // 6. Enrich message
+  // 5. Enrich message
   const { prompt: messageContent, userContext } = await enrichMessageContent({
     messageContent: context.messageText,
     files: context.files,
@@ -187,8 +183,7 @@ export async function handleOrgDirectMessage(
     userId: connection.vm0UserId,
     botUserId,
     channelId: context.channelId,
-    channelName: channelInfo?.name,
-    channelType: channelInfo?.type,
+    channelType: "dm",
     callbackContext,
   });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -1,10 +1,6 @@
 import { decryptSecretValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import {
-  createSlackClient,
-  setThreadStatus,
-  fetchSlackChannelInfo,
-} from "../../slack/client";
+import { createSlackClient, setThreadStatus } from "../../slack/client";
 import {
   buildAgentResponseMessage,
   buildLoginPromptMessage,
@@ -32,6 +28,7 @@ const log = logger("slack-org:mention");
 interface OrgMentionContext {
   workspaceId: string;
   channelId: string;
+  channelType?: string;
   userId: string;
   messageText: string;
   messageTs: string;
@@ -115,10 +112,7 @@ export async function handleOrgMention(
   // 4. Show thinking indicator
   await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
 
-  // 5. Fetch channel info for agent context
-  const channelInfo = await fetchSlackChannelInfo(client, context.channelId);
-
-  // 6. Enrich message content
+  // 5. Enrich message content
   const { prompt: messageContent, userContext } = await enrichMessageContent({
     messageContent: context.messageText,
     files: context.files,
@@ -188,8 +182,12 @@ export async function handleOrgMention(
     userId: connection.vm0UserId,
     botUserId,
     channelId: context.channelId,
-    channelName: channelInfo?.name,
-    channelType: channelInfo?.type,
+    channelType:
+      context.channelType === "im"
+        ? "dm"
+        : context.channelType === "mpim"
+          ? "group_dm"
+          : "channel",
     callbackContext,
   });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -1,6 +1,10 @@
 import { decryptSecretValue } from "../../crypto/secrets-encryption";
 import { env } from "../../../env";
-import { createSlackClient, setThreadStatus } from "../../slack/client";
+import {
+  createSlackClient,
+  setThreadStatus,
+  fetchSlackChannelInfo,
+} from "../../slack/client";
 import {
   buildAgentResponseMessage,
   buildLoginPromptMessage,
@@ -111,7 +115,10 @@ export async function handleOrgMention(
   // 4. Show thinking indicator
   await setThreadStatus(client, context.channelId, threadTs, "is thinking...");
 
-  // 5. Enrich message content
+  // 5. Fetch channel info for agent context
+  const channelInfo = await fetchSlackChannelInfo(client, context.channelId);
+
+  // 6. Enrich message content
   const { prompt: messageContent, userContext } = await enrichMessageContent({
     messageContent: context.messageText,
     files: context.files,
@@ -180,6 +187,9 @@ export async function handleOrgMention(
     userContext,
     userId: connection.vm0UserId,
     botUserId,
+    channelId: context.channelId,
+    channelName: channelInfo?.name,
+    channelType: channelInfo?.type,
     callbackContext,
   });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -20,7 +20,6 @@ interface RunAgentParams {
   userId: string;
   botUserId: string;
   channelId?: string;
-  channelName?: string;
   channelType?: "channel" | "dm" | "group_dm";
   callbackContext: SlackOrgCallbackPayload;
 }
@@ -56,7 +55,6 @@ export async function runAgentForSlackOrg(
     userId,
     botUserId,
     channelId,
-    channelName,
     channelType,
     callbackContext,
   } = params;
@@ -64,12 +62,7 @@ export async function runAgentForSlackOrg(
   try {
     // Build system prompt from context parts (agent identity is prepended by startRun)
     const contextParts = [
-      buildIntegrationContext("Slack", {
-        botUserId,
-        channelId,
-        channelName,
-        channelType,
-      }),
+      buildIntegrationContext("Slack", { botUserId, channelId, channelType }),
       threadContext,
       userContext,
     ].filter(Boolean);

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -19,6 +19,9 @@ interface RunAgentParams {
   userContext: string;
   userId: string;
   botUserId: string;
+  channelId?: string;
+  channelName?: string;
+  channelType?: "channel" | "dm" | "group_dm";
   callbackContext: SlackOrgCallbackPayload;
 }
 
@@ -52,13 +55,21 @@ export async function runAgentForSlackOrg(
     userContext,
     userId,
     botUserId,
+    channelId,
+    channelName,
+    channelType,
     callbackContext,
   } = params;
 
   try {
     // Build system prompt from context parts (agent identity is prepended by startRun)
     const contextParts = [
-      buildIntegrationContext("Slack", { botUserId }),
+      buildIntegrationContext("Slack", {
+        botUserId,
+        channelId,
+        channelName,
+        channelType,
+      }),
       threadContext,
       userContext,
     ].filter(Boolean);

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -141,36 +141,6 @@ export async function fetchSlackUserInfoMap(
   return map;
 }
 
-interface SlackChannelInfo {
-  id: string;
-  name?: string;
-  type: "channel" | "dm" | "group_dm";
-}
-
-/**
- * Fetch basic Slack channel info (name, type).
- *
- * @param client - Slack WebClient
- * @param channelId - Slack channel ID
- * @returns Structured channel info, or undefined if lookup fails
- */
-export async function fetchSlackChannelInfo(
-  client: WebClient,
-  channelId: string,
-): Promise<SlackChannelInfo | undefined> {
-  const result = await client.conversations.info({ channel: channelId });
-  if (!result.ok || !result.channel) return undefined;
-
-  const ch = result.channel;
-  const type = ch.is_im ? "dm" : ch.is_mpim ? "group_dm" : "channel";
-
-  return {
-    id: channelId,
-    name: ch.name || undefined,
-    type,
-  };
-}
-
 /**
  * Exchange OAuth code for access token
  *

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -141,6 +141,36 @@ export async function fetchSlackUserInfoMap(
   return map;
 }
 
+interface SlackChannelInfo {
+  id: string;
+  name?: string;
+  type: "channel" | "dm" | "group_dm";
+}
+
+/**
+ * Fetch basic Slack channel info (name, type).
+ *
+ * @param client - Slack WebClient
+ * @param channelId - Slack channel ID
+ * @returns Structured channel info, or undefined if lookup fails
+ */
+export async function fetchSlackChannelInfo(
+  client: WebClient,
+  channelId: string,
+): Promise<SlackChannelInfo | undefined> {
+  const result = await client.conversations.info({ channel: channelId });
+  if (!result.ok || !result.channel) return undefined;
+
+  const ch = result.channel;
+  const type = ch.is_im ? "dm" : ch.is_mpim ? "group_dm" : "channel";
+
+  return {
+    id: channelId,
+    name: ch.name || undefined,
+    type,
+  };
+}
+
 /**
  * Exchange OAuth code for access token
  *


### PR DESCRIPTION
## Summary

- Add `fetchSlackChannelInfo()` to fetch channel metadata (ID, name, type) via Slack `conversations.info` API
- Extend `buildIntegrationContext()` to include channel ID, name, and type in the agent system prompt
- Wire channel info through both mention and direct-message handlers

Fixes the issue where agents couldn't answer "which channel am I in?" because the Slack integration context only contained platform name and bot user ID.

## Test plan

- [ ] Mention the bot in a public channel → agent should know the channel name and ID
- [ ] DM the bot → agent should know it's a direct message (no channel name expected)
- [ ] Mention the bot in a group DM → agent should identify it as a group direct message
- [ ] Verify no regressions in existing Slack integration flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)