### PR TITLE
fix(platform): always redirect to org selection when no active org

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -12,7 +12,11 @@ interface MockedUser {
 
 let internalMockedUser: MockedUser | null = null;
 let internalMockedSession: { token: string } | null = null;
-let internalMockedOrganization: { id: string; name: string } | null = null;
+let internalMockedOrganization: {
+  id: string;
+  name: string;
+  reload: () => Promise<void>;
+} | null = null;
 let internalMockedInvitations: { id: string }[] = [];
 let internalMockedMemberships: { id: string }[] = [{ id: "org_default" }];
 
@@ -47,7 +51,9 @@ export function mockOrganization(options: {
   memberships?: { id: string }[];
   pendingInvitations?: { id: string }[];
 }) {
-  internalMockedOrganization = options.activeOrg ?? null;
+  internalMockedOrganization = options.activeOrg
+    ? { ...options.activeOrg, reload: () => Promise.resolve() }
+    : null;
   if (options.memberships) {
     internalMockedMemberships = options.memberships;
   }

--- a/turbo/apps/platform/src/__tests__/page-helper.ts
+++ b/turbo/apps/platform/src/__tests__/page-helper.ts
@@ -3,7 +3,7 @@ import { act, render } from "@testing-library/react";
 import type { Store } from "ccstate";
 import { StoreProvider } from "ccstate-react";
 import type { TestContext } from "../signals/__tests__/test-helpers";
-import { clearMockedAuth, mockUser } from "./mock-auth";
+import { clearMockedAuth, mockOrganization, mockUser } from "./mock-auth";
 import { bootstrap$ } from "../signals/bootstrap";
 import { setupRouter } from "../views/main";
 import {
@@ -23,6 +23,10 @@ export async function setupPage(options: {
   path: string;
   user?: { id: string; fullName: string; email?: string } | null;
   session?: { token: string } | null;
+  org?: {
+    activeOrg?: { id: string; name: string } | null;
+    memberships?: { id: string }[];
+  };
   debugLoggers?: string[];
   featureSwitches?: Partial<Record<FeatureSwitchKey, boolean>>;
   withoutRender?: boolean;
@@ -55,6 +59,18 @@ export async function setupPage(options: {
       token: "test-token",
     },
   );
+
+  // Default active org so needsOrgSelection$ doesn't redirect to /select-org.
+  // Tests that explicitly configure org state before calling setupPage can pass
+  // `org` to override this default (or call mockOrganization() before setupPage).
+  if (options.org) {
+    mockOrganization(options.org);
+  } else {
+    mockOrganization({
+      activeOrg: { id: "org_default", name: "Default Org" },
+      memberships: [{ id: "org_default" }],
+    });
+  }
   options.context.signal.addEventListener("abort", () => {
     clearMockedAuth();
   });

--- a/turbo/apps/platform/src/signals/__tests__/needs-org-selection.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/needs-org-selection.test.ts
@@ -1,21 +1,19 @@
 import { describe, it, expect } from "vitest";
 import { testContext } from "./test-helpers.ts";
 import { setupPage } from "../../__tests__/page-helper.ts";
-import { mockOrganization } from "../../__tests__/mock-auth.ts";
 import { pathname$ } from "../route.ts";
 
 const context = testContext();
 
 describe("org selection after auth", () => {
   it("redirects to /select-org when user has multiple orgs and no active org", async () => {
-    mockOrganization({
-      activeOrg: null,
-      memberships: [{ id: "org_1" }, { id: "org_2" }],
-    });
-
     await setupPage({
       context,
       path: "/",
+      org: {
+        activeOrg: null,
+        memberships: [{ id: "org_1" }, { id: "org_2" }],
+      },
       withoutRender: true,
     });
 
@@ -23,15 +21,13 @@ describe("org selection after auth", () => {
   });
 
   it("redirects to /select-org when user has pending invitations and no active org", async () => {
-    mockOrganization({
-      activeOrg: null,
-      memberships: [{ id: "org_1" }],
-      pendingInvitations: [{ id: "inv_1" }],
-    });
-
     await setupPage({
       context,
       path: "/",
+      org: {
+        activeOrg: null,
+        memberships: [{ id: "org_1" }],
+      },
       withoutRender: true,
     });
 
@@ -39,15 +35,13 @@ describe("org selection after auth", () => {
   });
 
   it("redirects to /select-org when user has single org but no active org", async () => {
-    mockOrganization({
-      activeOrg: null,
-      memberships: [{ id: "org_1" }],
-      pendingInvitations: [],
-    });
-
     await setupPage({
       context,
       path: "/",
+      org: {
+        activeOrg: null,
+        memberships: [{ id: "org_1" }],
+      },
       withoutRender: true,
     });
 
@@ -55,14 +49,13 @@ describe("org selection after auth", () => {
   });
 
   it("does not redirect when active org is already set", async () => {
-    mockOrganization({
-      activeOrg: { id: "org_1", name: "My Org" },
-      memberships: [{ id: "org_1" }, { id: "org_2" }],
-    });
-
     await setupPage({
       context,
       path: "/",
+      org: {
+        activeOrg: { id: "org_1", name: "My Org" },
+        memberships: [{ id: "org_1" }, { id: "org_2" }],
+      },
       withoutRender: true,
     });
 
@@ -71,14 +64,13 @@ describe("org selection after auth", () => {
   });
 
   it("does not redirect when already on /select-org", async () => {
-    mockOrganization({
-      activeOrg: null,
-      memberships: [{ id: "org_1" }, { id: "org_2" }],
-    });
-
     await setupPage({
       context,
       path: "/select-org",
+      org: {
+        activeOrg: null,
+        memberships: [{ id: "org_1" }, { id: "org_2" }],
+      },
       withoutRender: true,
     });
 
@@ -87,15 +79,13 @@ describe("org selection after auth", () => {
   });
 
   it("redirects to /select-org when user has no orgs", async () => {
-    mockOrganization({
-      activeOrg: null,
-      memberships: [],
-      pendingInvitations: [],
-    });
-
     await setupPage({
       context,
       path: "/",
+      org: {
+        activeOrg: null,
+        memberships: [],
+      },
       withoutRender: true,
     });
 

--- a/turbo/apps/platform/src/signals/__tests__/needs-org-selection.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/needs-org-selection.test.ts
@@ -38,7 +38,7 @@ describe("org selection after auth", () => {
     expect(context.store.get(pathname$)).toBe("/select-org");
   });
 
-  it("does not redirect when user has single org and no invitations", async () => {
+  it("redirects to /select-org when user has single org but no active org", async () => {
     mockOrganization({
       activeOrg: null,
       memberships: [{ id: "org_1" }],
@@ -51,8 +51,7 @@ describe("org selection after auth", () => {
       withoutRender: true,
     });
 
-    // Home redirects to /talk/:name, not /select-org
-    expect(context.store.get(pathname$)).not.toBe("/select-org");
+    expect(context.store.get(pathname$)).toBe("/select-org");
   });
 
   it("does not redirect when active org is already set", async () => {
@@ -87,7 +86,7 @@ describe("org selection after auth", () => {
     expect(context.store.get(pathname$)).toBe("/select-org");
   });
 
-  it("does not redirect when user has no orgs", async () => {
+  it("redirects to /select-org when user has no orgs", async () => {
     mockOrganization({
       activeOrg: null,
       memberships: [],
@@ -100,7 +99,6 @@ describe("org selection after auth", () => {
       withoutRender: true,
     });
 
-    // Should not redirect to /select-org (normal flow)
-    expect(context.store.get(pathname$)).not.toBe("/select-org");
+    expect(context.store.get(pathname$)).toBe("/select-org");
   });
 });

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -157,18 +157,6 @@ export const needsOrgSelection$ = computed(async (get) => {
     return false;
   }
 
-  // Check membership count (synchronous property on User)
-  if (user.organizationMemberships.length > 1) {
-    return true;
-  }
-
-  // Check pending invitations (async API call)
-  const invitations = await user.getOrganizationInvitations({
-    status: "pending",
-  });
-  if (invitations.total_count > 0) {
-    return true;
-  }
-
-  return false;
+  // No active organization — user must select or create one
+  return true;
 });

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -403,7 +403,7 @@ function DangerZoneSection({
       const result = await client.delete({ body: { slug: org.slug } });
       if (result.status === 200) {
         toast.success("Workspace deleted");
-        window.location.reload();
+        window.location.href = "/select-org";
       } else {
         toast.error(
           extractErrorMessage(result, `Failed to delete (${result.status})`),


### PR DESCRIPTION
## Summary
- Simplify `needsOrgSelection$` to always redirect users to `/select-org` when no active organization is set, removing unnecessary checks for membership count and pending invitations
- Redirect to `/select-org` after workspace deletion instead of reloading the page, ensuring users land on the org selection flow
- Update tests to reflect the corrected redirect behavior

## Test plan
- [ ] Verify users with no active org are redirected to `/select-org` regardless of membership count
- [ ] Verify deleting a workspace redirects to `/select-org`
- [ ] Run existing integration tests: `pnpm vitest apps/platform/src/signals/__tests__/needs-org-selection.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)