### PR TITLE
fix(cli): transform api url to platform url in missing-token command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
@@ -66,14 +66,26 @@ describe("zero doctor missing-token command", () => {
       expect(logCalls).toContain("https://app.vm0.ai/team?tab=connectors");
     });
 
-    it("should use custom VM0_API_URL", async () => {
+    it("should transform www.vm0.ai to app.vm0.ai", async () => {
+      vi.stubEnv("VM0_API_URL", "https://www.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-1");
+
+      await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "https://app.vm0.ai/team/agent-1?tab=connectors",
+      );
+    });
+
+    it("should use custom VM0_API_URL with app prefix", async () => {
       vi.stubEnv("VM0_API_URL", "https://custom.example.com");
       vi.stubEnv("ZERO_AGENT_ID", "agent-1");
 
       await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("https://custom.example.com/team/agent-1");
+      expect(logCalls).toContain("https://app.custom.example.com/team/agent-1");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
@@ -20,10 +20,21 @@ export const missingTokenCommand = new Command()
 
       const { label } = CONNECTOR_TYPES[connectorType];
 
-      const baseUrl = await getApiUrl();
+      const apiUrl = await getApiUrl();
+      const parsed = new URL(apiUrl);
+
+      // Transform API host to platform host: www.vm0.ai → app.vm0.ai
+      const parts = parsed.hostname.split(".");
+      if (parts[0] === "www" || parts[0] === "platform") {
+        parts[0] = "app";
+      } else if (parts[0] !== "app" && parts[0] !== "localhost") {
+        parts.unshift("app");
+      }
+      parsed.hostname = parts.join(".");
+
       const agentId = process.env.ZERO_AGENT_ID;
       const path = agentId ? `/team/${agentId}` : "/team";
-      const url = `${baseUrl}${path}?tab=connectors`;
+      const url = `${parsed.origin}${path}?tab=connectors`;
 
       console.log(`${tokenName} is provided by the ${label} connector.`);
       console.log(`Ask the user to connect it at: ${url}`);


### PR DESCRIPTION
## Summary
- `zero doctor missing-token` was outputting `www.vm0.ai` URLs for the connectors page, but the platform UI lives at `app.vm0.ai`
- Add hostname transformation (`www`/`platform` → `app`) consistent with the existing `logs` command logic

## Test plan
- [x] Added test: `www.vm0.ai` → `app.vm0.ai` transformation
- [x] Updated existing custom URL test to reflect new `app.` prefix behavior
- [x] All 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)