### PR TITLE
fix(cli): rename schedule help arg from agent-name to agent-id

### DIFF
--- a/turbo/apps/cli/src/commands/zero/schedule/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/delete.ts
@@ -11,7 +11,7 @@ export const deleteCommand = new Command()
   .name("delete")
   .alias("rm")
   .description("Delete a zero schedule")
-  .argument("<agent-name>", "Agent name")
+  .argument("<agent-id>", "Agent ID")
   .option(
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",

--- a/turbo/apps/cli/src/commands/zero/schedule/disable.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/disable.ts
@@ -9,7 +9,7 @@ import { withErrorHandler } from "../../../lib/command";
 export const disableCommand = new Command()
   .name("disable")
   .description("Disable a zero schedule")
-  .argument("<agent-name>", "Agent name")
+  .argument("<agent-id>", "Agent ID")
   .option(
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",

--- a/turbo/apps/cli/src/commands/zero/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/enable.ts
@@ -9,7 +9,7 @@ import { withErrorHandler } from "../../../lib/command";
 export const enableCommand = new Command()
   .name("enable")
   .description("Enable a zero schedule")
-  .argument("<agent-name>", "Agent name")
+  .argument("<agent-id>", "Agent ID")
   .option(
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",

--- a/turbo/apps/cli/src/commands/zero/schedule/list.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/list.ts
@@ -15,7 +15,7 @@ export const listCommand = new Command()
       if (result.schedules.length === 0) {
         console.log(chalk.dim("No schedules found"));
         console.log(
-          chalk.dim("  Create one with: zero schedule setup <agent-name>"),
+          chalk.dim("  Create one with: zero schedule setup <agent-id>"),
         );
         return;
       }

--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -664,7 +664,7 @@ async function handleScheduleEnabling(params: {
 export const setupCommand = new Command()
   .name("setup")
   .description("Create or edit a schedule for a zero agent")
-  .argument("<agent-name>", "Agent name to configure schedule for")
+  .argument("<agent-id>", "Agent ID")
   .option("-n, --name <schedule-name>", 'Schedule name (default: "default")')
   .option("-f, --frequency <type>", "Frequency: daily|weekly|monthly|once|loop")
   .option("-t, --time <HH:MM>", "Time to run (24-hour format)")

--- a/turbo/apps/cli/src/commands/zero/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/status.ts
@@ -105,7 +105,7 @@ function printTimeSchedule(schedule: ScheduleResponse): void {
 export const statusCommand = new Command()
   .name("status")
   .description("Show detailed status of a zero schedule")
-  .argument("<agent-name>", "Agent name")
+  .argument("<agent-id>", "Agent ID")
   .option(
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",


### PR DESCRIPTION
## Summary
- Renamed `<agent-name>` to `<agent-id>` in all `zero schedule` subcommand help text (setup, enable, disable, status, delete, list)
- The previous `<agent-name>` wording misled AI agents into passing the display name instead of the agent ID, since `zero agent list` only shows IDs

## Test plan
- [ ] Run `zero schedule --help` and verify subcommands show `<agent-id>`
- [ ] Run `zero schedule setup --help` and verify argument is `<agent-id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)