### PR TITLE
fix: include api-token connectors in firewall resolution

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -1046,11 +1046,12 @@ describe("createRun()", () => {
       expect(result.runId).toBeDefined();
       expect(result.status).toBe("pending");
 
-      // Verify the runner job queue entry contains the injected secret
+      // Figma has a firewall config, so the real token is replaced by a placeholder
+      // (the proxy resolves the real secret at runtime)
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       expect(job!.executionContext.environment).toMatchObject({
-        FIGMA_TOKEN: "figd_test_secret_123",
+        FIGMA_TOKEN: "figd_Vm0PlaceHolder00000000000000000000000000",
       });
     });
 
@@ -1084,11 +1085,12 @@ describe("createRun()", () => {
       expect(result.runId).toBeDefined();
       expect(result.status).toBe("pending");
 
-      // Verify the runner job queue entry contains the injected secret
+      // Productlane has a firewall config, so the real token is replaced by a placeholder
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       expect(job!.executionContext.environment).toMatchObject({
-        PRODUCTLANE_TOKEN: "pl_test_secret_789",
+        PRODUCTLANE_TOKEN:
+          "vm0placeholderProductlaneToken0000000000000000000000a",
       });
     });
 
@@ -1155,6 +1157,41 @@ describe("createRun()", () => {
       expect(job!.executionContext.environment).toMatchObject({
         LINEAR_TOKEN: "lin_api_Vm0PlaceHolder00000000000000000000000000",
       });
+    });
+
+    it("should build firewall for api-token connector", async () => {
+      const compose = await createTestCompose(
+        uniqueId("figma-firewall-agent"),
+        {
+          overrides: {
+            environment: {
+              ANTHROPIC_API_KEY: "test-api-key",
+              FIGMA_TOKEN: "${{ secrets.FIGMA_TOKEN }}",
+            },
+          },
+        },
+      );
+
+      await createTestConnector({
+        type: "figma",
+        authMethod: "api-token",
+        secretName: "FIGMA_TOKEN",
+        accessToken: "figd_test_secret_123",
+      });
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+
+      // Verify firewall is constructed for the api-token connector
+      const firewalls = job!.executionContext.experimentalFirewalls;
+      expect(firewalls).toBeDefined();
+      const figmaFirewall = firewalls!.find((fw) => fw.name === "figma");
+      expect(figmaFirewall).toBeDefined();
+      expect(figmaFirewall!.apis[0]!.base).toBe("https://api.figma.com");
     });
 
     it("should leave Linear token template unresolved when connector not connected", async () => {

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -22,6 +22,7 @@ import {
   type FirewallPolicies,
   getConnectorFirewall,
   isFirewallConnectorType,
+  deriveApiTokenConnectedTypes,
 } from "@vm0/core";
 import { agentComposeVersions } from "../../db/schema/agent-compose";
 import type { AgentComposeYaml } from "../../types/agent-compose";
@@ -44,6 +45,8 @@ import { getOrgDefaultModelProvider } from "../model-provider/model-provider-ser
 import { getVm0ApiKey } from "../vm0-key/vm0-key-service";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { connectors } from "../../db/schema/connector";
+import { secrets as secretsTable } from "../../db/schema/secret";
+import { variables as variablesTable } from "../../db/schema/variable";
 import { PROVIDER_HANDLERS } from "../connector/provider-registry";
 import { refreshConnectorAccessToken } from "../connector/connector-service";
 
@@ -428,18 +431,46 @@ async function resolveConnectorSecrets(
   orgId: string,
   userId: string,
 ): Promise<ConnectorSecretResult> {
-  // Query connected connectors (need type for environmentMapping, authMethod for refresh filter)
-  const userConnectors = await globalThis.services.db
-    .select({ type: connectors.type, authMethod: connectors.authMethod })
-    .from(connectors)
-    .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId)));
+  const db = globalThis.services.db;
+
+  // Query OAuth connectors, user secrets, and user variables in parallel.
+  // User secrets/variables are needed to derive api-token connector types
+  // (these don't have DB records in the connectors table).
+  const [userConnectors, userSecretRows, userVariableRows] = await Promise.all([
+    db
+      .select({ type: connectors.type, authMethod: connectors.authMethod })
+      .from(connectors)
+      .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId))),
+    db
+      .select({ name: secretsTable.name })
+      .from(secretsTable)
+      .where(
+        and(
+          eq(secretsTable.orgId, orgId),
+          eq(secretsTable.userId, userId),
+          eq(secretsTable.type, "user"),
+        ),
+      ),
+    db
+      .select({ name: variablesTable.name })
+      .from(variablesTable)
+      .where(
+        and(eq(variablesTable.orgId, orgId), eq(variablesTable.userId, userId)),
+      ),
+  ]);
+
+  // Derive api-token connector types from user secrets/variables
+  const derivedApiTokenTypes = deriveApiTokenConnectedTypes(
+    new Set(userSecretRows.map((r) => r.name)),
+    new Set(userVariableRows.map((r) => r.name)),
+  );
 
   if (userConnectors.length === 0) {
     return {
       connectorSecrets: undefined,
       injectedEnvVars: undefined,
       secretConnectorMap: undefined,
-      connectorTypes: [],
+      connectorTypes: derivedApiTokenTypes,
     };
   }
 
@@ -449,11 +480,11 @@ async function resolveConnectorSecrets(
       connectorSecrets: undefined,
       injectedEnvVars: undefined,
       secretConnectorMap: undefined,
-      connectorTypes: [],
+      connectorTypes: derivedApiTokenTypes,
     };
   }
 
-  // Parse connector types upfront
+  // Parse connector types upfront (OAuth connectors from DB)
   const validConnectors = userConnectors
     .map((c) => {
       const parsed = connectorTypeSchema.safeParse(c.type);
@@ -534,7 +565,12 @@ async function resolveConnectorSecrets(
       Object.keys(secretConnectorMap).length > 0
         ? secretConnectorMap
         : undefined,
-    connectorTypes: validConnectors.map((c) => c.type),
+    connectorTypes: [
+      ...new Set([
+        ...validConnectors.map((c) => c.type),
+        ...derivedApiTokenTypes,
+      ]),
+    ],
   };
 }
 


### PR DESCRIPTION
## Summary
- API token connectors (e.g. Figma, Gamma, Productlane) were bypassing the firewall because `resolveConnectorSecrets` only queried the `connectors` table, which only has OAuth connector records
- API token connectors are derived from user secrets (no DB record), so they were invisible to the firewall resolution logic
- Now queries user secrets and variables tables in parallel, uses `deriveApiTokenConnectedTypes` to include api-token connectors — matching the pattern already used by `listConnectors` for the frontend

## Root Cause
API token connectors don't write to the `connectors` table. Their existence is inferred from user secrets matching required secret names. The firewall resolution in `build-context.ts` only checked the `connectors` table, so all api-token connector traffic went directly to the API without firewall proxy protection.

Closes #6926

## Test plan
- [x] Updated existing Figma/Productlane api-token tests to expect placeholder tokens (firewall now active)
- [x] Added new test verifying firewall config is constructed for api-token connectors
- [x] All 52 create-run tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)