### PR TITLE
fix(ci): always run migrations instead of broken tag detection

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -80,55 +80,15 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Configure Git safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - uses: ./.github/actions/toolchain-init
 
-      - name: Detect migration changes
-        id: detect
-        run: |
-          # Find the most recent web release tag
-          PREV_TAG=$(git tag --list 'web-v*' --sort=-v:refname | head -1)
-          if [ -z "$PREV_TAG" ]; then
-            echo "No previous web release tag found, running migration"
-            echo "needed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "Comparing $PREV_TAG..HEAD for migration changes"
-          if git diff --name-only "$PREV_TAG" HEAD | grep -qE "^turbo/apps/web/src/db/(migrations|schema)/"; then
-            echo "Migration changes detected"
-            echo "needed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No migration changes"
-            echo "needed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Notify Slack - Skipped
-        if: ${{ steps.detect.outputs.needed == 'false' && vars.SLACK_RELEASE_CHANNEL_ID != '' }}
-        uses: slackapi/slack-github-action@v3.0.1
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.CI_SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ vars.SLACK_RELEASE_CHANNEL_ID }}
-            text: "*Database Migration* ⏭️ Skipped (no migration changes)"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "*Database Migration* ⏭️ Skipped (no migration changes)"
-
       - name: Install neonctl
-        if: ${{ steps.detect.outputs.needed == 'true' }}
         run: npm install -g neonctl@2.15.0
 
       - name: Notify Slack - Starting
         id: slack-start
-        if: ${{ steps.detect.outputs.needed == 'true' && vars.SLACK_RELEASE_CHANNEL_ID != '' }}
+        if: ${{ vars.SLACK_RELEASE_CHANNEL_ID != '' }}
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
@@ -144,12 +104,10 @@ jobs:
 
       - name: Record start time
         id: timer
-        if: ${{ steps.detect.outputs.needed == 'true' }}
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
 
       - name: Get Production Database URL
         id: get-db-url
-        if: ${{ steps.detect.outputs.needed == 'true' }}
         run: |
           # Get the main branch database URL (production)
           DATABASE_URL=$(neonctl connection-string production --project-id ${{ vars.NEON_PROJECT_ID }} --database-name neondb --pooled)
@@ -158,7 +116,6 @@ jobs:
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
 
       - name: Run Production Migrations
-        if: ${{ steps.detect.outputs.needed == 'true' }}
         run: |
           cd turbo && pnpm -F web db:migrate
         env:


### PR DESCRIPTION
## Summary

- The `migrate-production` job's detection logic used `git tag --list 'web-v*' --sort=-v:refname | head -1` to find the "previous" tag, but by the time it runs, release-please has already created the new tag — so it compared HEAD to itself and always found no changes, incorrectly skipping migrations.
- Remove the detection logic entirely since Drizzle's `db:migrate` is idempotent (only applies unapplied migrations). The job now always runs migrations when a release is created.
- Also removes the now-unnecessary `fetch-depth: 0` and git safe directory config.

## Test plan

- [ ] Verify workflow YAML syntax is valid
- [ ] Next release triggers migration run unconditionally
- [ ] Slack notifications show "starting → completed" flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)