### PR TITLE
fix(cli): lazy-load ngrok to prevent glibc crash at startup

### DIFF
--- a/turbo/apps/cli/src/lib/computer/ngrok.ts
+++ b/turbo/apps/cli/src/lib/computer/ngrok.ts
@@ -1,7 +1,11 @@
+// Dynamic import is intentional: @ngrok/ngrok contains native binaries that
+// crash on systems with GLIBC version mismatches. Lazy-loading ensures the
+// crash only affects the command that needs ngrok, not the entire CLI.
+// See: https://github.com/vm0-ai/vm0/issues/6825
 async function loadNgrok(): Promise<typeof import("@ngrok/ngrok")> {
   try {
     const mod = await import("@ngrok/ngrok");
-    return mod.default ?? mod;
+    return mod.default;
   } catch (cause) {
     throw new Error(
       "Failed to load ngrok tunnel module. " +

--- a/turbo/apps/cli/src/lib/computer/ngrok.ts
+++ b/turbo/apps/cli/src/lib/computer/ngrok.ts
@@ -1,4 +1,16 @@
-import ngrok from "@ngrok/ngrok";
+async function loadNgrok(): Promise<typeof import("@ngrok/ngrok")> {
+  try {
+    const mod = await import("@ngrok/ngrok");
+    return mod.default ?? mod;
+  } catch (cause) {
+    throw new Error(
+      "Failed to load ngrok tunnel module. " +
+        "This may be caused by a system library (GLIBC) incompatibility. " +
+        "See: https://github.com/vm0-ai/vm0/issues/6825",
+      { cause },
+    );
+  }
+}
 
 export async function startNgrokTunnels(
   ngrokToken: string,
@@ -6,6 +18,8 @@ export async function startNgrokTunnels(
   webdavPort: number,
   cdpPort: number,
 ): Promise<void> {
+  const ngrok = await loadNgrok();
+
   await ngrok.forward({
     addr: `localhost:${webdavPort}`,
     authtoken: ngrokToken,
@@ -20,5 +34,6 @@ export async function startNgrokTunnels(
 }
 
 export async function stopNgrokTunnels(): Promise<void> {
+  const ngrok = await loadNgrok();
   await ngrok.kill();
 }


### PR DESCRIPTION
## Summary

- Convert `@ngrok/ngrok` from static import to dynamic `await import()` in `src/lib/computer/ngrok.ts`
- The native module was eagerly loaded at CLI startup via the shared chunk's static ESM imports, causing a fatal GLIBC crash on systems with library version mismatches (CentOS)
- Now the native module only loads when the `connector connect computer` command is invoked

## Root Cause

The `@ngrok/ngrok` x64-gnu binary links against `librt.so.1`. On systems with mismatched GLIBC versions (e.g., CentOS 7 with Node.js bundling newer GLIBC), `librt.so.1` fails to resolve `__clock_nanosleep@GLIBC_PRIVATE` → crash. Since tsup bundles everything into one shared chunk with static imports, this crashed ALL CLI commands — not just tunneling.

## Test plan

- [x] Build output verified: `@ngrok/ngrok` no longer appears as static import in shared chunk
- [x] Dynamic `import("@ngrok/ngrok")` appears inside `loadNgrok()` function body only
- [x] All 839 CLI tests pass
- [x] Type checking passes
- [x] Lint passes (0 warnings, 0 errors)
- [x] Knip passes (no unused exports/deps)
- [x] Format produces no changes

Closes #6825

🤖 Generated with [Claude Code](https://claude.com/claude-code)