### PR TITLE
refactor: derive compose env vars from connector environment mapping

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -29,6 +29,7 @@ import {
   insertTestSlackOrgPendingQuestion,
   setDefaultAgentByComposeId,
   clearOrgMembersCacheEntry,
+  getTestComposeVersionContent,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { getInstructionsStorageName } from "@vm0/core";
 import {
@@ -224,7 +225,7 @@ describe("Zero Agents API", () => {
       expect(data.sound).toBe("professional");
     });
 
-    it("should create an agent with cached connectors", async () => {
+    it("should create an agent with cached connectors and inject connector env vars", async () => {
       await seedTestSkill({
         url: "https://github.com/vm0-ai/vm0-skills/tree/main/slack",
         name: "slack",
@@ -246,6 +247,22 @@ describe("Zero Agents API", () => {
       expect(response.status).toBe(201);
       const data = await response.json();
       expect(data.connectors).toStrictEqual(["slack"]);
+
+      // Verify compose environment contains connector-derived env vars
+      const content = await getTestComposeVersionContent(data.agentId);
+      const agents = content?.agents as Record<
+        string,
+        { environment: Record<string, string> }
+      >;
+      const agentEnv = Object.values(agents)[0]!.environment;
+
+      // Connector-derived: slack environmentMapping → SLACK_TOKEN
+      expect(agentEnv.SLACK_TOKEN).toBe("${{ secrets.SLACK_TOKEN }}");
+      // Skill frontmatter vm0_secrets should NOT be injected (removed mergeSkillVariables)
+      expect(agentEnv.SLACK_BOT_TOKEN).toBeUndefined();
+      // Base env vars still present
+      expect(agentEnv.ZERO_AGENT_ID).toBe("${{ vars.ZERO_AGENT_ID }}");
+      expect(agentEnv.ZERO_TOKEN).toBe("${{ secrets.ZERO_TOKEN }}");
     });
 
     it("should return 422 when connector skills are not cached", async () => {

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -4699,3 +4699,25 @@ export async function insertTestSlackOrgPendingQuestionNoSession(params: {
     expiresAt: new Date(Date.now() + 3600000),
   });
 }
+
+/**
+ * Read the head compose version content for a compose record.
+ * Returns the resolved compose content stored in the version.
+ */
+export async function getTestComposeVersionContent(
+  composeId: string,
+): Promise<Record<string, unknown> | null> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({
+      content: agentComposeVersions.content,
+    })
+    .from(agentComposeVersions)
+    .innerJoin(
+      agentComposes,
+      eq(agentComposes.headVersionId, agentComposeVersions.id),
+    )
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  return (row?.content as Record<string, unknown>) ?? null;
+}

--- a/turbo/apps/web/src/lib/compose/server-side-compose.ts
+++ b/turbo/apps/web/src/lib/compose/server-side-compose.ts
@@ -4,7 +4,6 @@ import {
   AGENT_NAME_REGEX,
   isSupportedFramework,
   expandFirewallConfigs,
-  type SkillFrontmatter,
   type SupportedFramework,
 } from "@vm0/core";
 import type { AgentComposeYaml } from "../../types/agent-compose";
@@ -66,29 +65,6 @@ function extractAgentConfig(content: Record<string, unknown>): AgentConfig {
     framework,
     agent,
   };
-}
-
-/**
- * Merge skill variables from cached frontmatter into the environment.
- * Does not overwrite existing entries.
- */
-function mergeSkillVariables(
-  environment: Record<string, string>,
-  cachedSkills: { frontmatter: unknown }[],
-): void {
-  for (const skill of cachedSkills) {
-    const fm = skill.frontmatter as SkillFrontmatter | null;
-    for (const name of fm?.vm0_secrets ?? []) {
-      if (!(name in environment)) {
-        environment[name] = `\${{ secrets.${name} }}`;
-      }
-    }
-    for (const name of fm?.vm0_vars ?? []) {
-      if (!(name in environment)) {
-        environment[name] = `\${{ vars.${name} }}`;
-      }
-    }
-  }
 }
 
 /**
@@ -205,11 +181,10 @@ export async function serverSideCompose(params: {
     }
   }
 
-  // 3. Merge skill variables from cached frontmatter
+  // 3. Use environment as-is (connector env vars already injected by buildComposeContent)
   const environment: Record<string, string> = {
     ...((agent.environment ?? {}) as Record<string, string>),
   };
-  mergeSkillVariables(environment, cachedSkills);
 
   // 4. Expand firewall configs (mutates in-place, so deep-clone first)
   const contentCopy = structuredClone(content);

--- a/turbo/apps/web/src/lib/compose/server-side-compose.ts
+++ b/turbo/apps/web/src/lib/compose/server-side-compose.ts
@@ -166,10 +166,10 @@ export async function serverSideCompose(params: {
   const agentSkills = (agent.skills ?? []) as string[];
   const resolvedSkillUrls = agentSkills.map(resolveSkillRef);
 
-  let cachedSkills: { frontmatter: unknown }[] = [];
+  let cachedSkills: { url: string }[] = [];
   if (resolvedSkillUrls.length > 0) {
     cachedSkills = await db
-      .select({ frontmatter: skills.frontmatter })
+      .select({ url: skills.url })
       .from(skills)
       .where(inArray(skills.url, resolvedSkillUrls));
 

--- a/turbo/apps/web/src/lib/zero/build-compose-content.ts
+++ b/turbo/apps/web/src/lib/zero/build-compose-content.ts
@@ -1,4 +1,9 @@
-import { resolveSkillRef, getInstructionsFilename } from "@vm0/core";
+import {
+  resolveSkillRef,
+  getInstructionsFilename,
+  getConnectorEnvironmentMapping,
+  connectorTypeSchema,
+} from "@vm0/core";
 import { SEED_SKILLS } from "./seed-skills";
 
 /**
@@ -6,7 +11,8 @@ import { SEED_SKILLS } from "./seed-skills";
  *
  * Merges SEED_SKILLS with user connectors (deduplicated) and maps
  * to GitHub skill URLs. Produces compose content with hardcoded
- * defaults per issue #5548.
+ * defaults per issue #5548. Injects connector environment variables
+ * from each connector's environmentMapping.
  */
 export function buildComposeContent(
   agentName: string,
@@ -15,13 +21,30 @@ export function buildComposeContent(
   const merged = [...new Set([...SEED_SKILLS, ...connectors])];
   const skills = merged.map((c) => resolveSkillRef(c));
 
+  const environment: Record<string, string> = {
+    ZERO_AGENT_ID: "${{ vars.ZERO_AGENT_ID }}",
+    ZERO_TOKEN: "${{ secrets.ZERO_TOKEN }}",
+  };
+
+  // Inject env vars from connector environmentMappings
+  for (const connector of connectors) {
+    const parsed = connectorTypeSchema.safeParse(connector);
+    if (!parsed.success) continue;
+    const mapping = getConnectorEnvironmentMapping(parsed.data);
+    for (const [envVar, valueRef] of Object.entries(mapping)) {
+      if (envVar in environment) continue;
+      if (valueRef.startsWith("$secrets.")) {
+        environment[envVar] = `\${{ secrets.${envVar} }}`;
+      } else if (valueRef.startsWith("$vars.")) {
+        environment[envVar] = `\${{ vars.${envVar} }}`;
+      }
+    }
+  }
+
   const agentDef: Record<string, unknown> = {
     framework: "claude-code",
     instructions: getInstructionsFilename("claude-code"),
-    environment: {
-      ZERO_AGENT_ID: "${{ vars.ZERO_AGENT_ID }}",
-      ZERO_TOKEN: "${{ secrets.ZERO_TOKEN }}",
-    },
+    environment,
     volumes: [],
   };
 


### PR DESCRIPTION
## Summary

- Update `buildComposeContent()` to inject connector environment variables from `getConnectorEnvironmentMapping()`, replacing skill frontmatter-based injection
- Delete `mergeSkillVariables()` from `server-side-compose.ts` — compose env vars are now derived from connector types, not skill frontmatter `vm0_secrets`/`vm0_vars`
- Add test verifying compose environment contains connector-derived env vars (e.g., `SLACK_TOKEN`) and does NOT contain old frontmatter-based vars (e.g., `SLACK_BOT_TOKEN`)

## Test plan

- [x] All 46 zero agent tests pass
- [x] Updated test verifies connector-derived env vars in compose environment
- [x] Updated test confirms skill frontmatter `vm0_secrets` no longer drive env injection
- [x] Lint passes with 0 warnings
- [x] Knip finds no unused exports
- [x] No type errors in changed files

Closes #6934

🤖 Generated with [Claude Code](https://claude.com/claude-code)