### PR TITLE
fix: use agent id instead of name in slack /settings command url

### DIFF
--- a/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/__tests__/route.test.ts
@@ -353,5 +353,32 @@ describe("POST /api/zero/slack/commands", () => {
       expect(data.response_type).toBe("ephemeral");
       expect(JSON.stringify(data.blocks)).toContain("Settings");
     });
+
+    it("uses agent UUID in settings URL when agent is configured", async () => {
+      const workspaceId = uniqueId("T-ws");
+      const slackUserId = uniqueId("U-slack");
+      await createTestSlackOrgInstallation({ workspaceId, orgId: user.orgId });
+      await seedTestSlackOrgConnection({
+        slackUserId,
+        slackWorkspaceId: workspaceId,
+        vm0UserId: user.userId,
+      });
+      const compose = await createTestCompose(uniqueId("agent"));
+      await updateOrgDefaultAgent(user.orgId, compose.agentId);
+
+      const body = buildCommandBody({
+        team_id: workspaceId,
+        user_id: slackUserId,
+        text: "settings",
+      });
+      const request = createCommandRequest(body);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      const blocksJson = JSON.stringify(data.blocks);
+      // URL must contain the agent UUID, not the name slug
+      expect(blocksJson).toContain(`/team/${compose.agentId}?tab=connectors`);
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/slack/commands/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/commands/route.ts
@@ -178,17 +178,17 @@ async function handleSettings(
 ): Promise<NextResponse> {
   const appUrl = getAppUrl();
   let agentLabel = "Agent";
-  let agentName: string | undefined;
+  let agentId: string | undefined;
   if (installation.orgId) {
     const composeId = await resolveDefaultComposeId(installation.orgId);
     if (composeId) {
       const agent = await getWorkspaceAgent(composeId);
       agentLabel = agent?.displayName ?? agent?.name ?? agentLabel;
-      agentName = agent?.name;
+      agentId = agent?.id;
     }
   }
-  const settingsPath = agentName
-    ? `/team/${encodeURIComponent(agentName)}?tab=connectors`
+  const settingsPath = agentId
+    ? `/team/${encodeURIComponent(agentId)}?tab=connectors`
     : "/team";
   return ephemeral([
     {


### PR DESCRIPTION
## Summary

- Fix Slack `/settings` command generating connector settings link with `agent.name` (slug string) instead of `agent.id` (UUID)
- The frontend `/team/:id` route requires a UUID for the `/api/zero/agents/:id` API, which validates `z.string().uuid()`
- Changed `handleSettings()` to use `agent.id` instead of `agent.name` for the URL path
- Added test verifying the settings URL contains the agent UUID

## Test plan

- [x] Existing 16 tests pass
- [x] New test verifies settings URL contains agent UUID (not name slug)
- [x] Lint, format, knip all pass

Closes #6951
Closes #6795

🤖 Generated with [Claude Code](https://claude.com/claude-code)