### PR TITLE
feat: resolve user mentions in slack context and prompt text

### DIFF
--- a/turbo/apps/web/next-env.d.ts
+++ b/turbo/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
@@ -5,6 +5,7 @@ import {
   buildLogsUrl,
   buildAgentLogsUrl,
   enrichMessageContent,
+  fetchConversationContexts,
 } from "../shared";
 
 describe("buildOrgConnectUrl", () => {
@@ -143,5 +144,204 @@ describe("enrichMessageContent", () => {
     expect(result.prompt).not.toContain("[Slack User]");
     expect(result.prompt).not.toContain("- SENDER:");
     expect(result.prompt).toBe("My message");
+  });
+
+  it("should resolve user mentions in prompt text", async () => {
+    const userDb: Record<string, Record<string, unknown>> = {
+      U123: {
+        id: "U123",
+        profile: { display_name: "Alice", real_name: "Alice A" },
+      },
+      U456: {
+        id: "U456",
+        profile: { display_name: "Bob", real_name: "Bob B" },
+      },
+    };
+    const client = {
+      users: {
+        info: vi.fn().mockImplementation(({ user }: { user: string }) => {
+          const u = userDb[user];
+          return Promise.resolve(u ? { ok: true, user: u } : { ok: false });
+        }),
+      },
+    } as unknown as WebClient;
+
+    const result = await enrichMessageContent({
+      messageContent: "Hey <@U456>, please review this",
+      files: undefined,
+      botToken: "xoxb-test",
+      channelId: "C123",
+      threadTs: "1234567890.001",
+      client,
+      userId: "U123",
+    });
+
+    expect(result.prompt).toContain("@Bob (U456)");
+    expect(result.prompt).not.toContain("<@U456>");
+  });
+});
+
+function createMockConversationClient(opts: {
+  threadMessages?: Record<string, unknown>[];
+  channelMessages?: Record<string, unknown>[];
+}): WebClient {
+  return {
+    conversations: {
+      replies: vi.fn().mockResolvedValue({
+        ok: true,
+        messages: opts.threadMessages ?? [],
+      }),
+      history: vi.fn().mockResolvedValue({
+        ok: true,
+        messages: opts.channelMessages ?? [],
+      }),
+    },
+    users: {
+      info: vi.fn().mockResolvedValue({ ok: false }),
+    },
+  } as unknown as WebClient;
+}
+
+describe("fetchConversationContexts", () => {
+  it("should include channel messages for first session in thread", async () => {
+    const client = createMockConversationClient({
+      threadMessages: [
+        { user: "U100", text: "Thread parent", ts: "100.0" },
+        { user: "U200", text: "Reply", ts: "100.1" },
+      ],
+      channelMessages: [
+        { user: "U300", text: "Channel msg A", ts: "99.1" },
+        { user: "U400", text: "Channel msg B", ts: "99.2" },
+      ],
+    });
+
+    const { executionContext, routingContext } =
+      await fetchConversationContexts(
+        client,
+        "C-chan",
+        "100.0", // threadTs
+        "BBOT",
+        "xoxb-token",
+        undefined, // lastProcessedMessageTs
+        "100.1", // currentMessageTs excluded from context
+        undefined, // no existingSessionId → first session
+      );
+
+    // Should contain both channel and thread sections
+    expect(executionContext).toContain("# Recent Channel Messages");
+    expect(executionContext).toContain("# Slack Thread Context");
+    expect(executionContext).toContain("Channel msg A");
+    expect(executionContext).toContain("Channel msg B");
+    expect(executionContext).toContain("Thread parent");
+    // Current message excluded
+    expect(executionContext).not.toContain("Reply");
+
+    expect(routingContext).toContain("# Recent Channel Messages");
+    expect(routingContext).toContain("# Slack Thread Context");
+  });
+
+  it("should fetch channel messages with latest=threadTs", async () => {
+    const client = createMockConversationClient({
+      threadMessages: [{ user: "U100", text: "Parent", ts: "100.0" }],
+      channelMessages: [{ user: "U300", text: "Before thread", ts: "99.0" }],
+    });
+
+    await fetchConversationContexts(
+      client,
+      "C-chan",
+      "100.0",
+      "BBOT",
+      "xoxb-token",
+      undefined, // lastProcessedMessageTs
+      undefined, // currentMessageTs
+      undefined, // no existingSessionId → first session
+    );
+
+    // conversations.history should be called with latest=threadTs
+    const historyMock = client.conversations.history as ReturnType<
+      typeof vi.fn
+    >;
+    expect(historyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "C-chan", latest: "100.0" }),
+    );
+  });
+
+  it("should NOT include channel messages when session exists", async () => {
+    const client = createMockConversationClient({
+      threadMessages: [
+        { user: "U100", text: "Parent", ts: "100.0" },
+        { user: "U200", text: "Old reply", ts: "100.1" },
+        { user: "U200", text: "New reply", ts: "100.2" },
+      ],
+      channelMessages: [
+        { user: "U300", text: "Should not appear", ts: "99.0" },
+      ],
+    });
+
+    const { executionContext } = await fetchConversationContexts(
+      client,
+      "C-chan",
+      "100.0",
+      "BBOT",
+      "xoxb-token",
+      "100.1", // lastProcessedMessageTs
+      "100.2", // currentMessageTs
+      "session-abc", // existingSessionId → continuing session
+    );
+
+    // Only incremental thread messages, no channel context
+    expect(executionContext).not.toContain("# Recent Channel Messages");
+    expect(executionContext).not.toContain("Should not appear");
+    // conversations.history should not be called at all
+    expect(client.conversations.history).not.toHaveBeenCalled();
+  });
+
+  it("should NOT include channel messages even without lastProcessedMessageTs if session exists", async () => {
+    const client = createMockConversationClient({
+      threadMessages: [{ user: "U100", text: "Parent", ts: "100.0" }],
+      channelMessages: [
+        { user: "U300", text: "Should not appear", ts: "99.0" },
+      ],
+    });
+
+    const { executionContext } = await fetchConversationContexts(
+      client,
+      "C-chan",
+      "100.0",
+      "BBOT",
+      "xoxb-token",
+      undefined, // no lastProcessedMessageTs
+      undefined, // currentMessageTs
+      "session-abc", // existingSessionId → not first session
+    );
+
+    expect(executionContext).not.toContain("# Recent Channel Messages");
+    expect(client.conversations.history).not.toHaveBeenCalled();
+  });
+
+  it("should NOT include channel messages for channel @mention", async () => {
+    const client = createMockConversationClient({
+      channelMessages: [
+        { user: "U100", text: "Msg 1", ts: "1.0" },
+        { user: "U200", text: "Msg 2", ts: "2.0" },
+      ],
+    });
+
+    const { executionContext } = await fetchConversationContexts(
+      client,
+      "C-chan",
+      undefined, // no threadTs → channel mention
+      "BBOT",
+      "xoxb-token",
+      undefined,
+      "2.0",
+    );
+
+    // Single channel section, no duplication
+    expect(executionContext).toContain("# Recent Channel Messages");
+    expect(executionContext).not.toContain("# Slack Thread Context");
+    expect(executionContext).toContain("Msg 1");
+    // conversations.history called once (for channel context), not twice
+    expect(client.conversations.history).toHaveBeenCalledTimes(1);
   });
 });

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -159,6 +159,7 @@ export async function handleOrgDirectMessage(
     botToken,
     lastProcessedMessageTs,
     context.messageTs,
+    existingSessionId,
   );
 
   // 8. Dispatch agent run

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -158,6 +158,7 @@ export async function handleOrgMention(
     botToken,
     lastProcessedMessageTs,
     context.messageTs,
+    existingSessionId,
   );
 
   // 8. Dispatch agent run

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -19,6 +19,7 @@ import {
   formatContextForAgentWithImages,
   formatCurrentMessageFiles,
   extractMentionedUserIds,
+  resolveUserMentions,
   type SlackFile,
 } from "../../slack/context";
 import { validateAgentSession } from "../../run";
@@ -414,16 +415,13 @@ export async function enrichMessageContent(opts: {
     prompt = `${prompt}\n\n${filesText}`;
   }
 
-  // Resolve user mentions and current user info in parallel
+  // Resolve user mentions and current user info
   const mentionedIds = extractMentionedUserIds([{ text: opts.messageContent }]);
   const allIds = [opts.userId, ...mentionedIds];
   const userInfoMap = await fetchSlackUserInfoMap(opts.client, allIds);
 
   // Resolve mentions in prompt text
-  prompt = prompt.replace(/<@(\w+)>/g, (_match, userId: string) => {
-    const info = userInfoMap.get(userId);
-    return info?.name ? `@${info.name} (${userId})` : `<@${userId}>`;
-  });
+  prompt = resolveUserMentions(prompt, userInfoMap);
 
   // Build user context for system prompt
   const currentUser = userInfoMap.get(opts.userId);

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -9,7 +9,6 @@ import { resolveDefaultAgentComposeId } from "../../agent-compose/resolve-defaul
 import { ensureStorageExists } from "../../storage/storage-service";
 import {
   createSlackClient,
-  fetchSlackUserInfo,
   fetchSlackUserInfoMap,
   formatSenderBlock,
 } from "../../slack/client";
@@ -19,6 +18,7 @@ import {
   formatContextForAgent,
   formatContextForAgentWithImages,
   formatCurrentMessageFiles,
+  extractMentionedUserIds,
   type SlackFile,
 } from "../../slack/context";
 import { validateAgentSession } from "../../run";
@@ -241,33 +241,60 @@ export async function fetchConversationContexts(
   botToken: string,
   lastProcessedMessageTs?: string,
   currentMessageTs?: string,
+  existingSessionId?: string,
 ): Promise<{ routingContext: string; executionContext: string }> {
   const imageSessionId = `${channelId}-${threadTs ?? "channel"}`;
   const contextType = threadTs ? "thread" : "channel";
+
+  // First session in a thread (no existing session) — fetch channel messages
+  // around the thread start so the agent has background context.
+  const isFirstThreadSession = Boolean(threadTs && !existingSessionId);
 
   // Fetch all messages once (single Slack API call)
   const allMessages = threadTs
     ? await fetchThreadContext(client, channelId, threadTs)
     : await fetchChannelContext(client, channelId, 10);
 
+  // For first thread mention, fetch the 10 channel messages before the thread
+  const channelMessages = isFirstThreadSession
+    ? await fetchChannelContext(client, channelId, 10, threadTs)
+    : [];
+
   // Exclude the current message (it's already sent as the prompt)
   const contextMessages = currentMessageTs
     ? allMessages.filter((m) => m.ts !== currentMessageTs)
     : allMessages;
 
-  // Resolve user info for all unique user IDs in context messages
-  const userIds = allMessages.flatMap((m) =>
+  // Resolve user info for all senders and mentioned users
+  const allContextMessages = [...channelMessages, ...allMessages];
+  const senderIds = allContextMessages.flatMap((m) =>
     m.user && !m.bot_id ? [m.user] : [],
   );
+  const mentionedIds = extractMentionedUserIds(allContextMessages);
+  const userIds = [...senderIds, ...mentionedIds];
   const userInfoMap = await fetchSlackUserInfoMap(client, userIds);
 
+  // Format channel context prefix (for first thread mention only, text-only)
+  const channelContextPrefix =
+    channelMessages.length > 0
+      ? formatContextForAgent(
+          channelMessages,
+          botUserId,
+          "channel",
+          userInfoMap,
+        )
+      : "";
+
   // Text-only full context for routing (no image uploads needed)
-  const routingContext = formatContextForAgent(
+  const threadRoutingContext = formatContextForAgent(
     contextMessages,
     botUserId,
     contextType,
     userInfoMap,
   );
+  const routingContext = channelContextPrefix
+    ? `${channelContextPrefix}\n\n${threadRoutingContext}`
+    : threadRoutingContext;
 
   // Filter to only new messages for execution context
   const executionMessages = lastProcessedMessageTs
@@ -275,7 +302,7 @@ export async function fetchConversationContexts(
     : contextMessages;
 
   // Format execution context with images (only uploads images for new messages)
-  const executionContext =
+  const threadExecContext =
     executionMessages.length > 0
       ? await formatContextForAgentWithImages(
           executionMessages,
@@ -286,6 +313,9 @@ export async function fetchConversationContexts(
           userInfoMap,
         )
       : "";
+  const executionContext = channelContextPrefix
+    ? `${channelContextPrefix}\n\n${threadExecContext}`
+    : threadExecContext;
 
   return { routingContext, executionContext };
 }
@@ -384,12 +414,22 @@ export async function enrichMessageContent(opts: {
     prompt = `${prompt}\n\n${filesText}`;
   }
 
+  // Resolve user mentions and current user info in parallel
+  const mentionedIds = extractMentionedUserIds([{ text: opts.messageContent }]);
+  const allIds = [opts.userId, ...mentionedIds];
+  const userInfoMap = await fetchSlackUserInfoMap(opts.client, allIds);
+
+  // Resolve mentions in prompt text
+  prompt = prompt.replace(/<@(\w+)>/g, (_match, userId: string) => {
+    const info = userInfoMap.get(userId);
+    return info?.name ? `@${info.name} (${userId})` : `<@${userId}>`;
+  });
+
   // Build user context for system prompt
-  let userContext = "";
-  const userInfo = await fetchSlackUserInfo(opts.client, opts.userId);
-  if (userInfo) {
-    userContext = `# Current User\n${formatSenderBlock(userInfo)}`;
-  }
+  const currentUser = userInfoMap.get(opts.userId);
+  const userContext = currentUser
+    ? `# Current User\n${formatSenderBlock(currentUser)}`
+    : "";
 
   return { prompt, userContext };
 }

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -6,6 +6,7 @@ import {
   formatCurrentMessageFiles,
   extractMessageContent,
   extractTextFromBlocks,
+  extractMentionedUserIds,
 } from "../context";
 import { testContext } from "../../../__tests__/test-helpers";
 import { server } from "../../../mocks/server";
@@ -1624,5 +1625,172 @@ describe("Feature: Format Current Message Files", () => {
       expect(result).toContain("URL: https://slack.com/files/bad.png");
       expect(result).not.toContain("Download: curl");
     });
+  });
+});
+
+describe("Feature: Resolve User Mentions In Context", () => {
+  it("should resolve user mention to name when user info available", () => {
+    const messages = [
+      { user: "U100", text: "Hey <@U200>, can you help?", ts: "1.0" },
+    ];
+    const userInfoMap = new Map([
+      ["U100", { id: "U100", name: "Alice" }],
+      ["U200", { id: "U200", name: "Bob", email: "bob@example.com" }],
+    ]);
+
+    const result = formatContextForAgent(
+      messages,
+      undefined,
+      "thread",
+      userInfoMap,
+    );
+
+    expect(result).toContain("@Bob (U200)");
+    expect(result).not.toContain("<@U200>");
+  });
+
+  it("should keep raw mention when user info not available", () => {
+    const messages = [{ user: "U100", text: "Hey <@U999>", ts: "1.0" }];
+    const userInfoMap = new Map([["U100", { id: "U100", name: "Alice" }]]);
+
+    const result = formatContextForAgent(
+      messages,
+      undefined,
+      "thread",
+      userInfoMap,
+    );
+
+    expect(result).toContain("<@U999>");
+  });
+
+  it("should resolve multiple mentions in one message", () => {
+    const messages = [
+      {
+        user: "U100",
+        text: "CC <@U200> and <@U300>",
+        ts: "1.0",
+      },
+    ];
+    const userInfoMap = new Map([
+      ["U100", { id: "U100", name: "Alice" }],
+      ["U200", { id: "U200", name: "Bob" }],
+      ["U300", { id: "U300", name: "Charlie" }],
+    ]);
+
+    const result = formatContextForAgent(
+      messages,
+      undefined,
+      "thread",
+      userInfoMap,
+    );
+
+    expect(result).toContain("@Bob (U200)");
+    expect(result).toContain("@Charlie (U300)");
+  });
+
+  it("should resolve mentions from rich_text blocks", () => {
+    const messages = [
+      {
+        user: "U100",
+        text: "fallback <@U200>",
+        ts: "1.0",
+        blocks: [
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [
+                  { type: "text", text: "Hey " },
+                  { type: "user", user_id: "U200" },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const userInfoMap = new Map([
+      ["U100", { id: "U100", name: "Alice" }],
+      ["U200", { id: "U200", name: "Bob" }],
+    ]);
+
+    const result = formatContextForAgent(
+      messages,
+      undefined,
+      "thread",
+      userInfoMap,
+    );
+
+    // rich_text produces <@U200> which then gets resolved
+    expect(result).toContain("@Bob (U200)");
+    expect(result).not.toContain("<@U200>");
+  });
+});
+
+describe("Feature: Extract Mentioned User IDs", () => {
+  it("should extract user IDs from rich_text blocks", () => {
+    const messages = [
+      {
+        blocks: [
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [
+                  { type: "user", user_id: "U111" },
+                  { type: "text", text: " and " },
+                  { type: "user", user_id: "U222" },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const ids = extractMentionedUserIds(messages);
+
+    expect(ids).toContain("U111");
+    expect(ids).toContain("U222");
+  });
+
+  it("should extract user IDs from plain text", () => {
+    const messages = [{ text: "Hey <@U333> and <@U444>" }];
+
+    const ids = extractMentionedUserIds(messages);
+
+    expect(ids).toContain("U333");
+    expect(ids).toContain("U444");
+  });
+
+  it("should deduplicate user IDs", () => {
+    const messages = [
+      { text: "<@U100> <@U100>" },
+      {
+        blocks: [
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [{ type: "user", user_id: "U100" }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const ids = extractMentionedUserIds(messages);
+
+    expect(ids).toEqual(["U100"]);
+  });
+
+  it("should return empty array when no mentions", () => {
+    const messages = [{ text: "No mentions here" }];
+
+    expect(extractMentionedUserIds(messages)).toEqual([]);
   });
 });

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -126,10 +126,12 @@ export async function fetchChannelContext(
   client: WebClient,
   channel: string,
   limit = 10,
+  latest?: string,
 ): Promise<SlackMessage[]> {
   const result = await client.conversations.history({
     channel,
     limit,
+    ...(latest && { latest }),
   });
 
   // Reverse to get chronological order (oldest first)
@@ -441,6 +443,49 @@ function formatAttachmentImage(attachment: SlackAttachment): string | null {
 }
 
 /**
+ * Resolve user mentions in text using the user info map.
+ * Replaces `<@U12345>` with `@Name (U12345)` when user info is available.
+ */
+function resolveUserMentions(
+  text: string,
+  userInfoMap?: Map<string, SlackUserInfo>,
+): string {
+  if (!userInfoMap || userInfoMap.size === 0) return text;
+  return text.replace(/<@(\w+)>/g, (_match, userId: string) => {
+    const info = userInfoMap.get(userId);
+    return info?.name ? `@${info.name} (${userId})` : `<@${userId}>`;
+  });
+}
+
+/**
+ * Extract all user IDs mentioned in messages (from rich_text blocks and plain text).
+ */
+export function extractMentionedUserIds(messages: SlackMessage[]): string[] {
+  const ids = new Set<string>();
+  for (const msg of messages) {
+    // From rich_text blocks
+    if (msg.blocks) {
+      for (const block of msg.blocks) {
+        for (const section of block.elements ?? []) {
+          for (const el of section.elements ?? []) {
+            if (el.type === "user" && el.user_id) {
+              ids.add(el.user_id);
+            }
+          }
+        }
+      }
+    }
+    // From plain text fallback
+    if (msg.text) {
+      for (const match of msg.text.matchAll(/<@(\w+)>/g)) {
+        ids.add(match[1]);
+      }
+    }
+  }
+  return [...ids];
+}
+
+/**
  * Format a single message with structured metadata
  */
 function formatMessageWithMetadata(
@@ -452,7 +497,8 @@ function formatMessageWithMetadata(
   const senderId = msg.bot_id ? "BOT" : (msg.user ?? "unknown");
   const userInfo = userInfoMap?.get(senderId);
   const senderBlock = formatSenderBlock(userInfo ?? { id: senderId });
-  const text = extractTextFromBlocks(msg.blocks) ?? msg.text ?? "";
+  const rawText = extractTextFromBlocks(msg.blocks) ?? msg.text ?? "";
+  const text = resolveUserMentions(rawText, userInfoMap);
 
   const parts: string[] = [
     "---",

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -446,7 +446,7 @@ function formatAttachmentImage(attachment: SlackAttachment): string | null {
  * Resolve user mentions in text using the user info map.
  * Replaces `<@U12345>` with `@Name (U12345)` when user info is available.
  */
-function resolveUserMentions(
+export function resolveUserMentions(
   text: string,
   userInfoMap?: Map<string, SlackUserInfo>,
 ): string {
@@ -478,7 +478,8 @@ export function extractMentionedUserIds(messages: SlackMessage[]): string[] {
     // From plain text fallback
     if (msg.text) {
       for (const match of msg.text.matchAll(/<@(\w+)>/g)) {
-        ids.add(match[1]);
+        const userId = match[1];
+        if (userId) ids.add(userId);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Resolve raw `<@U123>` Slack mentions to readable `@Name (U123)` format in both conversation context and prompt text
- Add channel message context for first thread sessions so agents have background context about the channel conversation before the thread started
- Use batch `fetchSlackUserInfoMap` lookups instead of individual `fetchSlackUserInfo` calls for better performance
- Pass `existingSessionId` to `fetchConversationContexts` to determine whether to include channel context (first session only)

## Test plan
- [x] Tests for `resolveUserMentions` in `formatContextForAgent` (single, multiple, missing user info, rich_text blocks)
- [x] Tests for `extractMentionedUserIds` (rich_text blocks, plain text, deduplication, empty)
- [x] Tests for `fetchConversationContexts` (first session with channel context, continuing session without, channel @mention)
- [x] Tests for `enrichMessageContent` mention resolution in prompt text

🤖 Generated with [Claude Code](https://claude.com/claude-code)