### PR TITLE
refactor(web): add tooltips to icon-only buttons across platform views

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -23,7 +23,13 @@ import {
   downgradeError$,
   type BillingTier,
 } from "../../../../signals/zero-page/billing.ts";
-import { Button } from "@vm0/ui";
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui";
 import {
   Dialog,
   DialogContent,
@@ -277,14 +283,23 @@ function PricingPage({
   return (
     <div className="flex flex-col gap-5">
       <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={onBack}
-          className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-          aria-label="Back"
-        >
-          <IconArrowLeft size={16} stroke={1.8} />
-        </button>
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onBack}
+                className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                aria-label="Back"
+              >
+                <IconArrowLeft size={16} stroke={1.8} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">Back</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <div>
           <h3 className="text-sm font-medium text-foreground">Compare plans</h3>
           <p className="text-[13px] text-muted-foreground">

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -1,6 +1,12 @@
 import { useLastLoadable } from "ccstate-react";
 import { IconCircleCheck, IconDownload } from "@tabler/icons-react";
-import { cn } from "@vm0/ui";
+import {
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui";
 import { invoicesAsync$ } from "../../../../signals/zero-page/billing.ts";
 
 const cardBorder = { border: "0.7px solid hsl(var(--gray-400))" } as const;
@@ -85,15 +91,24 @@ export function OrgInvoicesTab() {
               </div>
               <div className="flex justify-end">
                 {inv.hostedInvoiceUrl ? (
-                  <a
-                    href={inv.hostedInvoiceUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-                    aria-label="Download invoice"
-                  >
-                    <IconDownload size={14} stroke={1.5} />
-                  </a>
+                  <TooltipProvider delayDuration={200}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <a
+                          href={inv.hostedInvoiceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                          aria-label="Download invoice"
+                        >
+                          <IconDownload size={14} stroke={1.5} />
+                        </a>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        <p className="text-xs">Download invoice</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 ) : (
                   <span className="flex h-7 w-7 items-center justify-center text-muted-foreground/30">
                     <IconDownload size={14} stroke={1.5} />

--- a/turbo/apps/platform/src/views/zero-page/schedule-calendar-view.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-calendar-view.tsx
@@ -4,7 +4,13 @@ import {
   IconChevronRight,
   IconPencil,
 } from "@tabler/icons-react";
-import { cn } from "@vm0/ui";
+import {
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@vm0/ui";
 import {
   Popover,
   PopoverContent,
@@ -162,32 +168,52 @@ export function ScheduleCalendarView<T extends ScheduleEntry>({
           {/* Mobile: single-day view */}
           <div className="md:hidden">
             <div className="flex items-center justify-between bg-muted/50 px-3 py-2 border-b border-border/60">
-              <button
-                type="button"
-                onClick={() =>
-                  setSelectedDay(
-                    (selectedDay - 1 + WEEKDAY_LABELS.length) %
-                      WEEKDAY_LABELS.length,
-                  )
-                }
-                className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                aria-label="Previous day"
-              >
-                <IconChevronLeft size={16} stroke={1.5} />
-              </button>
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setSelectedDay(
+                          (selectedDay - 1 + WEEKDAY_LABELS.length) %
+                            WEEKDAY_LABELS.length,
+                        )
+                      }
+                      className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                      aria-label="Previous day"
+                    >
+                      <IconChevronLeft size={16} stroke={1.5} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p className="text-xs">Previous day</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
               <span className="text-sm font-medium text-muted-foreground">
                 {WEEKDAY_LABELS[selectedDay]}
               </span>
-              <button
-                type="button"
-                onClick={() =>
-                  setSelectedDay((selectedDay + 1) % WEEKDAY_LABELS.length)
-                }
-                className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-                aria-label="Next day"
-              >
-                <IconChevronRight size={16} stroke={1.5} />
-              </button>
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setSelectedDay(
+                          (selectedDay + 1) % WEEKDAY_LABELS.length,
+                        )
+                      }
+                      className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                      aria-label="Next day"
+                    >
+                      <IconChevronRight size={16} stroke={1.5} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p className="text-xs">Next day</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
             {calendarSlots.map((timeLabel, timeIndex) => {
               const cellEntries = getEntriesInCell(

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -196,19 +196,28 @@ export function ZeroChatPage({
         <div className="mx-auto w-full max-w-[900px] flex flex-col items-stretch gap-8 -mt-24">
           <div className="flex items-center gap-4 w-full">
             <div className="relative shrink-0">
-              <button
-                type="button"
-                aria-label="View agent profile"
-                className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent cursor-pointer"
-                onClick={onAvatarClick}
-              >
-                <img
-                  src={zeroAvatarSrc}
-                  alt=""
-                  role="presentation"
-                  className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
-                />
-              </button>
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label="View agent profile"
+                      className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent cursor-pointer"
+                      onClick={onAvatarClick}
+                    >
+                      <img
+                        src={zeroAvatarSrc}
+                        alt=""
+                        role="presentation"
+                        className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
+                      />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p className="text-xs">View agent profile</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
               {showPinPill && (
                 <TooltipProvider delayDuration={200}>
                   <Tooltip>

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -460,18 +460,27 @@ export function ZeroJobDetailPage({
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-6 pb-3">
         <div className="mx-auto max-w-[900px]">
           <div className="flex items-center gap-4">
-            <button
-              type="button"
-              onClick={cycleAvatar}
-              className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              aria-label="Switch avatar"
-            >
-              <img
-                src={currentAvatar}
-                alt={displayName}
-                className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
-              />
-            </button>
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={cycleAvatar}
+                    className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-muted/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    aria-label="Switch avatar"
+                  >
+                    <img
+                      src={currentAvatar}
+                      alt={displayName}
+                      className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
+                    />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p className="text-xs">Switch avatar</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <div className="min-w-0">
               <h1 className="text-xl font-semibold tracking-tight text-foreground">
                 {displayName}

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -145,19 +145,28 @@ export function ZeroSessionChatPage({
       <header className="shrink-0 bg-transparent px-4 sm:px-6 py-3 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div className="relative shrink-0">
-            <button
-              type="button"
-              onClick={onAvatarClick}
-              className="h-8 w-8 shrink-0 overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              aria-label="View agent profile"
-            >
-              <img
-                src={zeroAvatarSrc}
-                alt=""
-                role="presentation"
-                className="h-8 w-8 rounded-full object-cover object-top"
-              />
-            </button>
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onAvatarClick}
+                    className="h-8 w-8 shrink-0 overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    aria-label="View agent profile"
+                  >
+                    <img
+                      src={zeroAvatarSrc}
+                      alt=""
+                      role="presentation"
+                      className="h-8 w-8 rounded-full object-cover object-top"
+                    />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p className="text-xs">View agent profile</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             {showPinPill && (
               <TooltipProvider delayDuration={200}>
                 <Tooltip>
@@ -181,22 +190,40 @@ export function ZeroSessionChatPage({
           <span className="font-semibold text-foreground">{displayName}</span>
         </div>
         <div className="flex items-center gap-0.5">
-          <Link
-            pathname="/team"
-            className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent"
-            aria-label="Sub-agents"
-          >
-            <IconUsers size={18} stroke={1.5} />
-          </Link>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 text-muted-foreground hover:text-foreground"
-            onClick={onNavigateToSchedule}
-            aria-label="Scheduled"
-          >
-            <IconCalendar size={18} stroke={1.5} />
-          </Button>
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Link
+                  pathname="/team"
+                  className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent"
+                  aria-label="Sub-agents"
+                >
+                  <IconUsers size={18} stroke={1.5} />
+                </Link>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p className="text-xs">Agents</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                  onClick={onNavigateToSchedule}
+                  aria-label="Scheduled"
+                >
+                  <IconCalendar size={18} stroke={1.5} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p className="text-xs">Schedule</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </header>
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -542,24 +542,42 @@ function RecentChatSection({
             Chats with {agentLabel}
           </span>
           <div className="flex items-center gap-0.5">
-            <button
-              type="button"
-              onClick={() => setSearchOpen(true)}
-              className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
-              aria-label="Search chats"
-            >
-              <IconSearch size={15} stroke={2.5} />
-            </button>
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={() => setSearchOpen(true)}
+                    className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+                    aria-label="Search chats"
+                  >
+                    <IconSearch size={15} stroke={2.5} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p className="text-xs">Search chats</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             {handleNewChat && (
-              <button
-                type="button"
-                onClick={handleNewChat}
-                disabled={newChatDisabled}
-                className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors disabled:opacity-50 disabled:pointer-events-none"
-                aria-label={`New chat with ${agentLabel}`}
-              >
-                <IconPlus size={15} stroke={2.5} />
-              </button>
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={handleNewChat}
+                      disabled={newChatDisabled}
+                      className="flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors disabled:opacity-50 disabled:pointer-events-none"
+                      aria-label={`New chat with ${agentLabel}`}
+                    >
+                      <IconPlus size={15} stroke={2.5} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p className="text-xs">New chat</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             )}
           </div>
         </div>
@@ -939,14 +957,26 @@ export function ZeroSidebar() {
         <aside className="zero-nav box-border flex h-full w-16 shrink-0 flex-col border-r-[0.7px] border-sidebar-border bg-sidebar px-2 transition-all duration-300">
           {/* Expand — same row pattern as every nav icon (centered in content column) */}
           <div className="flex w-full shrink-0 justify-center pt-3 pb-1">
-            <button
-              type="button"
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
-              onClick={onCollapse}
-              aria-label="Expand sidebar"
-            >
-              <IconLayoutSidebarLeftCollapse size={18} className="rotate-180" />
-            </button>
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                    onClick={onCollapse}
+                    aria-label="Expand sidebar"
+                  >
+                    <IconLayoutSidebarLeftCollapse
+                      size={18}
+                      className="rotate-180"
+                    />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  <p className="text-xs">Expand sidebar</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
 
           {/* Icon-only nav: one centered column; inline-flex links never stretch */}
@@ -1016,14 +1046,23 @@ export function ZeroSidebar() {
             <div className="min-w-0 flex-1">
               <ClerkOrgSwitcher />
             </div>
-            <button
-              type="button"
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
-              onClick={onCollapse}
-              aria-label="Collapse sidebar"
-            >
-              <IconLayoutSidebarLeftCollapse size={18} />
-            </button>
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+                    onClick={onCollapse}
+                    aria-label="Collapse sidebar"
+                  >
+                    <IconLayoutSidebarLeftCollapse size={18} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p className="text-xs">Collapse sidebar</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Add tooltip wrappers to all icon-only buttons that previously had only `aria-label`
- Covers sidebar, chat pages, agent detail, schedule calendar, and settings pages
- Uses consistent `TooltipProvider delayDuration={200}` pattern throughout

### Buttons covered:
- **Sidebar:** Expand/Collapse, Search chats, New chat
- **Chat pages:** View agent profile avatar, Agents link, Schedule button
- **Agent detail:** Switch avatar
- **Schedule calendar:** Previous/Next day navigation
- **Settings:** Back button (billing), Download invoice

## Test plan
- [ ] Hover over each icon button listed above, verify tooltip appears after ~200ms
- [ ] Verify tooltips don't interfere with dropdown menus (three-dot menus excluded)
- [ ] Verify tooltips disappear when clicking the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)