### PR TITLE
fix: expand firewall placeholders to cover raw oauth names and aliases

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -1119,11 +1119,48 @@ describe("createRun()", () => {
       expect(result.runId).toBeDefined();
       expect(result.status).toBe("pending");
 
-      // Verify the runner job queue entry contains the injected secret
+      // GH_TOKEN is an alias for GITHUB_TOKEN — both are covered by the
+      // GitHub firewall placeholder, so the real token is replaced.
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
       expect(job!.executionContext.environment).toMatchObject({
-        GH_TOKEN: "ghp_oauth_test_456",
+        GH_TOKEN: "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",
+      });
+    });
+
+    it("should replace raw oauth secret name with placeholder when connector has firewall", async () => {
+      // GITHUB_ACCESS_TOKEN is the raw OAuth secret name — a compose
+      // referencing it directly must still get a placeholder, not the
+      // real token, because it maps to the same credential.
+      const compose = await createTestCompose(
+        uniqueId("oauth-raw-secret-agent"),
+        {
+          overrides: {
+            environment: {
+              ANTHROPIC_API_KEY: "test-api-key",
+              GITHUB_ACCESS_TOKEN: "${{ secrets.GITHUB_ACCESS_TOKEN }}",
+            },
+          },
+        },
+      );
+
+      await createTestConnector({
+        type: "github",
+        authMethod: "oauth",
+        accessToken: "ghp_raw_secret_test_999",
+      });
+
+      const result = await createRun(
+        baseParams({ agentComposeVersionId: compose.versionId }),
+      );
+
+      expect(result.runId).toBeDefined();
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      // Raw secret name gets the same placeholder as the mapped env var
+      expect(job!.executionContext.environment).toMatchObject({
+        GITHUB_ACCESS_TOKEN: "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",
       });
     });
 

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -68,6 +68,15 @@ function buildFirewallPlaceholders(
       placeholders[secretName] =
         fw.placeholders?.[secretName] ?? `VM0_PLACEHOLDER_${secretName}`;
     }
+    // Connector firewalls carry expanded placeholders that cover raw OAuth
+    // secret names and aliased env vars beyond what auth templates reference.
+    if (fw.placeholders) {
+      for (const [key, value] of Object.entries(fw.placeholders)) {
+        if (!placeholders[key]) {
+          placeholders[key] = value;
+        }
+      }
+    }
   }
   return Object.keys(placeholders).length > 0 ? placeholders : undefined;
 }

--- a/turbo/packages/core/src/contracts/__tests__/firewall-secret-consistency.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-secret-consistency.test.ts
@@ -31,8 +31,12 @@ describe("firewall secret name consistency", () => {
       const hasMapping = Object.keys(mapping).length > 0;
 
       if (hasMapping) {
-        for (const envVar of Object.keys(mapping)) {
+        for (const [envVar, valueRef] of Object.entries(mapping)) {
           connectorSecretNames.add(envVar);
+          // Also allow the raw secret name (e.g. GITHUB_ACCESS_TOKEN)
+          if (valueRef.startsWith("$secrets.")) {
+            connectorSecretNames.add(valueRef.slice("$secrets.".length));
+          }
         }
       } else {
         // API-token path: use authMethods secrets directly

--- a/turbo/packages/core/src/firewalls/index.ts
+++ b/turbo/packages/core/src/firewalls/index.ts
@@ -8,6 +8,7 @@
 
 import type { FirewallConfig } from "../contracts/firewalls";
 import type { ConnectorType } from "../contracts/connectors";
+import { getConnectorEnvironmentMapping } from "../contracts/connectors";
 import { agentmailFirewall } from "./agentmail.generated";
 import { ahrefsFirewall } from "./ahrefs.generated";
 import { airtableFirewall } from "./airtable.generated";
@@ -220,6 +221,59 @@ const CONNECTOR_FIREWALLS = {
   zeptomail: zeptomailFirewall,
 } as const satisfies Partial<Record<ConnectorType, FirewallConfig>>;
 
+/**
+ * Expand firewall placeholders to cover all secret names related to the
+ * connector.  For each existing placeholder key, find related names via
+ * environmentMapping (raw OAuth secret names and sibling aliases) and assign
+ * the same placeholder value.
+ */
+function expandPlaceholders(
+  firewall: FirewallConfig,
+  connectorType: ConnectorType,
+): FirewallConfig {
+  if (!firewall.placeholders) return firewall;
+
+  const mapping = getConnectorEnvironmentMapping(connectorType);
+  if (Object.keys(mapping).length === 0) return firewall;
+
+  const expanded: Record<string, string> = { ...firewall.placeholders };
+
+  for (const [key, placeholderValue] of Object.entries(firewall.placeholders)) {
+    // key is a mapped env var (e.g. GITHUB_TOKEN)
+    // → add the raw secret name and any sibling aliases
+    const valueRef = mapping[key];
+    if (valueRef?.startsWith("$secrets.")) {
+      const rawName = valueRef.slice("$secrets.".length);
+      if (!expanded[rawName]) {
+        expanded[rawName] = placeholderValue;
+      }
+      for (const [envVar, ref] of Object.entries(mapping)) {
+        if (ref === valueRef && !expanded[envVar]) {
+          expanded[envVar] = placeholderValue;
+        }
+      }
+    }
+
+    // key is a raw secret name → add all env vars that reference it
+    const rawRef = `$secrets.${key}`;
+    for (const [envVar, ref] of Object.entries(mapping)) {
+      if (ref === rawRef && !expanded[envVar]) {
+        expanded[envVar] = placeholderValue;
+      }
+    }
+  }
+
+  return { ...firewall, placeholders: expanded };
+}
+
+// Pre-compute expanded placeholders at module load time.
+const EXPANDED_CONNECTOR_FIREWALLS = Object.fromEntries(
+  Object.entries(CONNECTOR_FIREWALLS).map(([type, firewall]) => [
+    type,
+    expandPlaceholders(firewall, type as ConnectorType),
+  ]),
+) as typeof CONNECTOR_FIREWALLS;
+
 /** Connector types that have a firewall config (subset of ConnectorType). */
 export type FirewallConnectorType = keyof typeof CONNECTOR_FIREWALLS;
 
@@ -289,9 +343,9 @@ export function isFirewallConnectorType(
   return type in CONNECTOR_FIREWALLS;
 }
 
-/** Get the firewall config for a connector type. */
+/** Get the firewall config for a connector type (placeholders pre-expanded). */
 export function getConnectorFirewall(
   type: FirewallConnectorType,
 ): FirewallConfig {
-  return CONNECTOR_FIREWALLS[type];
+  return EXPANDED_CONNECTOR_FIREWALLS[type];
 }


### PR DESCRIPTION
## Summary

- Firewall placeholder replacement only covered secret names in auth templates (e.g. `GITHUB_TOKEN`). Raw OAuth names (`GITHUB_ACCESS_TOKEN`) and aliased env vars (`GH_TOKEN`) leaked real tokens to the sandbox.
- Pre-compute expanded placeholders at module load time via `expandPlaceholders()` in `getConnectorFirewall`, deriving related names from `environmentMapping`.
- `buildFirewallPlaceholders` now spreads all `fw.placeholders` keys so extra names reach `processSecretValues`.

## Test plan

- [x] Existing GH_TOKEN test updated to expect placeholder instead of real token
- [x] New test: raw OAuth secret name (`GITHUB_ACCESS_TOKEN`) replaced with placeholder
- [x] Firewall secret consistency tests updated and passing (104 tests)
- [x] All 157 tests pass

Closes #6941

🤖 Generated with [Claude Code](https://claude.com/claude-code)