### PR TITLE
refactor(platform): remove guest navbar from sidebar layout

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -76,14 +76,6 @@
     0 8px 24px hsl(220 12% 20% / 0.02);
 }
 
-/* Floating nav card (About / Pricing / Sign in): stronger shadow for elevation */
-.zero-app .zero-float-card {
-  box-shadow:
-    0 2px 4px hsl(220 12% 20% / 0.04),
-    0 6px 16px hsl(220 12% 20% / 0.06),
-    0 16px 40px hsl(220 12% 20% / 0.05);
-}
-
 /* Search bar / text input (matches form inputs: white surface in light theme) */
 .zero-app .zero-search-input {
   background-color: hsl(var(--input));

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
-import { Button } from "@vm0/ui";
 import { ZeroSidebar } from "./zero-sidebar.tsx";
 import { user$ } from "../../signals/auth.ts";
 import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
@@ -89,45 +88,7 @@ function SidebarLayoutSkeleton() {
   );
 }
 
-function GuestNavBar() {
-  const setShowAboutPage = useSet(setZeroShowAboutPage$);
-
-  return (
-    <nav
-      className="pointer-events-none absolute right-6 top-6 z-10"
-      aria-label="Site links"
-    >
-      <div className="zero-float-card pointer-events-auto flex items-center gap-4 rounded-xl border border-border bg-card/95 px-4 py-2.5 backdrop-blur-sm">
-        <button
-          type="button"
-          onClick={() => setShowAboutPage(true)}
-          className="text-sm tracking-wide text-foreground hover:text-primary transition-colors duration-200"
-        >
-          About VM0
-        </button>
-        <a
-          href="https://vm0.ai/pricing"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sm tracking-wide text-foreground hover:text-primary transition-colors duration-200"
-        >
-          Pricing
-        </a>
-        <a href="/sign-in">
-          <Button size="sm" className="h-9 rounded-lg px-4 text-sm font-medium">
-            Sign in
-          </Button>
-        </a>
-      </div>
-    </nav>
-  );
-}
-
 export function SidebarLayout({ children }: { children: ReactNode }) {
-  const userLoadable = useLoadable(user$);
-  const isLoggedIn =
-    userLoadable.state === "hasData" && userLoadable.data !== undefined;
-
   const showAboutPage = useGet(zeroShowAboutPage$);
   const setShowAboutPage = useSet(setZeroShowAboutPage$);
 
@@ -145,7 +106,6 @@ export function SidebarLayout({ children }: { children: ReactNode }) {
         />
       )}
       <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">
-        {!isLoggedIn && <GuestNavBar />}
         {showAboutPage ? (
           <ZeroAboutPage onBack={() => setShowAboutPage(false)} />
         ) : (


### PR DESCRIPTION
## Summary
- Remove the `GuestNavBar` component from `sidebar-layout.tsx` that displayed floating navigation (About, Pricing, Sign in) to unauthenticated users
- Remove the associated `.zero-float-card` CSS class from `index.css`
- Clean up the unused `Button` import from `@vm0/ui`

## Test plan
- [ ] Verify authenticated users see no change in sidebar layout behavior
- [ ] Verify unauthenticated users no longer see the floating nav bar
- [ ] Confirm no visual regressions on the zero page

🤖 Generated with [Claude Code](https://claude.com/claude-code)