### PR TITLE
fix: capitalize initial letter in slack schedule attribution footer

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/__tests__/route.test.ts
@@ -351,7 +351,7 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
 
     const attrText = (contextBlocks[1] as { elements: { text: string }[] })
       .elements[0]!.text;
-    expect(attrText).toContain("triggered by schedule");
+    expect(attrText).toContain("Triggered by schedule");
     expect(attrText).toContain("Daily standup summary");
   });
 
@@ -404,7 +404,7 @@ describe("POST /api/internal/callbacks/slack/org/schedule", () => {
 
     const attrText = (contextBlocks[1] as { elements: { text: string }[] })
       .elements[0]!.text;
-    expect(attrText).toContain("triggered by schedule");
+    expect(attrText).toContain("Triggered by schedule");
     expect(attrText).toContain("Nightly report");
   });
 

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/schedule/route.ts
@@ -84,7 +84,7 @@ async function postScheduleResults(
 
     const triggeredBy =
       isLast && scheduleDescription
-        ? `triggered by schedule "${scheduleDescription}"`
+        ? `Triggered by schedule "${scheduleDescription}"`
         : undefined;
     const blocks = buildAgentResponseMessage(
       rawOutput,
@@ -175,7 +175,7 @@ async function postScheduleFailure(
         failureContent,
         logsUrl,
         scheduleDescription
-          ? `triggered by schedule "${scheduleDescription}"`
+          ? `Triggered by schedule "${scheduleDescription}"`
           : undefined,
       ),
     },

--- a/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/blocks.test.ts
@@ -174,7 +174,7 @@ describe("buildAgentResponseMessage", () => {
     const blocks = buildAgentResponseMessage(
       "Response text",
       "https://app.vm0.ai/activity/run-123",
-      'triggered by schedule "Send a greeting message daily at 9 AM"',
+      'Triggered by schedule "Send a greeting message daily at 9 AM"',
     );
 
     // Should have: markdown, audit context, divider, attribution context
@@ -188,13 +188,13 @@ describe("buildAgentResponseMessage", () => {
     const auditText = (contextBlocks[0] as { elements: { text: string }[] })
       .elements[0]!.text;
     expect(auditText).toContain("Audit");
-    expect(auditText).not.toContain("triggered by");
+    expect(auditText).not.toContain("Triggered by");
 
     // Second context: attribution (after divider)
     const attrText = (contextBlocks[1] as { elements: { text: string }[] })
       .elements[0]!.text;
     expect(attrText).toBe(
-      'triggered by schedule "Send a greeting message daily at 9 AM"',
+      'Triggered by schedule "Send a greeting message daily at 9 AM"',
     );
   });
 


### PR DESCRIPTION
## Summary
- Capitalized "triggered" → "Triggered" in the Slack schedule attribution footer text
- The `triggered by schedule "..."` text in Slack notification messages now reads `Triggered by schedule "..."` for consistent sentence-case formatting
- Updated corresponding tests in route callback and blocks tests

## Test plan
- [x] `blocks.test.ts` — 19 tests pass
- [x] `slack/org/schedule/__tests__/route.test.ts` — 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)