### PR TITLE
refactor: remove vm0_secrets/vm0_vars from skill frontmatter and clean up dead code

### DIFF
--- a/turbo/apps/cli/src/commands/compose/__tests__/skill-resolve.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/skill-resolve.test.ts
@@ -72,28 +72,12 @@ vi.mock("child_process", async (importOriginal) => {
 import { spawn } from "child_process";
 const mockSpawn = vi.mocked(spawn);
 
-function createMockSkillDir(
-  destDir: string,
-  skillName: string,
-  frontmatter: { vm0_secrets?: string[]; vm0_vars?: string[] },
-): string {
+function createMockSkillDir(destDir: string, skillName: string): string {
   const skillDir = path.join(destDir, skillName);
   mkdirSync(skillDir, { recursive: true });
 
-  const frontmatterLines: string[] = [];
-  if (frontmatter.vm0_secrets?.length) {
-    frontmatterLines.push(
-      `vm0_secrets: [${frontmatter.vm0_secrets.map((s) => `"${s}"`).join(", ")}]`,
-    );
-  }
-  if (frontmatter.vm0_vars?.length) {
-    frontmatterLines.push(
-      `vm0_vars: [${frontmatter.vm0_vars.map((v) => `"${v}"`).join(", ")}]`,
-    );
-  }
-
   const skillMd = `---
-${frontmatterLines.join("\n")}
+name: ${skillName}
 ---
 
 # ${skillName}
@@ -211,7 +195,7 @@ agents:
             [SLACK_URL]: {
               storageName: "agent-skills@vm0-ai/vm0-skills/tree/main/slack",
               versionHash: "c".repeat(64),
-              frontmatter: { name: "Slack", vm0_secrets: ["SLACK_BOT_TOKEN"] },
+              frontmatter: { name: "Slack" },
             },
           },
           unresolved: [],
@@ -244,7 +228,7 @@ agents:
     );
 
     onGitCheckout = (cwd) => {
-      createMockSkillDir(cwd, "tool", {});
+      createMockSkillDir(cwd, "tool");
     };
 
     server.use(
@@ -281,7 +265,7 @@ agents:
     );
 
     onGitCheckout = (cwd) => {
-      createMockSkillDir(cwd, "tool", {});
+      createMockSkillDir(cwd, "tool");
     };
 
     server.use(
@@ -323,7 +307,7 @@ agents:
     );
 
     onGitCheckout = (cwd) => {
-      createMockSkillDir(cwd, "slack", {});
+      createMockSkillDir(cwd, "slack");
     };
 
     server.use(
@@ -357,7 +341,7 @@ agents:
     );
 
     onGitCheckout = (cwd) => {
-      createMockSkillDir(cwd, "slack", {});
+      createMockSkillDir(cwd, "slack");
     };
 
     server.use(

--- a/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
@@ -97,8 +97,6 @@ const MOCK_SKILLS = [
           "---",
           "name: slack",
           "description: Slack integration skill",
-          "vm0_secrets:",
-          "  - SLACK_TOKEN",
           "---",
           "",
           "# Slack Skill",
@@ -221,7 +219,6 @@ describe("GET /api/cron/sync-skills", () => {
       expect(slackSkill!.frontmatter).toEqual({
         name: "slack",
         description: "Slack integration skill",
-        vm0_secrets: ["SLACK_TOKEN"],
       });
 
       const githubSkill = await findTestSkillByUrl(
@@ -275,9 +272,9 @@ describe("GET /api/cron/sync-skills", () => {
               content: [
                 "---",
                 "name: bad-yaml",
-                "vm0_vars:",
-                "  - GOOD_VAR",
-                "- BAD_VAR",
+                "description:",
+                "  - not_a_string",
+                "- BAD_LINE",
                 "---",
                 "",
                 "# Bad YAML Skill",
@@ -326,9 +323,6 @@ describe("GET /api/cron/sync-skills", () => {
                 "---",
                 "name: slack",
                 "description: Updated slack skill",
-                "vm0_secrets:",
-                "  - SLACK_TOKEN",
-                "  - SLACK_WEBHOOK",
                 "---",
                 "",
                 "# Slack Skill v2",
@@ -363,7 +357,6 @@ describe("GET /api/cron/sync-skills", () => {
       expect(slackSkill!.frontmatter).toEqual({
         name: "slack",
         description: "Updated slack skill",
-        vm0_secrets: ["SLACK_TOKEN", "SLACK_WEBHOOK"],
       });
       expect(slackSkill!.commitSha).toBe(newCommitSha);
     });

--- a/turbo/apps/web/app/api/skills/resolve/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/skills/resolve/__tests__/route.test.ts
@@ -92,9 +92,6 @@ describe("POST /api/skills/resolve", () => {
       );
       expect(data.resolved[skillUrl].versionHash).toBeDefined();
       expect(data.resolved[skillUrl].frontmatter.name).toBe("Slack");
-      expect(data.resolved[skillUrl].frontmatter.vm0_secrets).toEqual([
-        "SLACK_BOT_TOKEN",
-      ]);
       expect(data.unresolved).toEqual([]);
     });
 

--- a/turbo/apps/web/app/api/skills/resolve/route.ts
+++ b/turbo/apps/web/app/api/skills/resolve/route.ts
@@ -56,12 +56,7 @@ const router = tsr.router(skillsResolveContract, {
       resolved[row.url] = {
         storageName: getSkillStorageName(row.fullPath),
         versionHash: row.versionHash,
-        frontmatter: {
-          name: fm.name,
-          description: fm.description,
-          vm0_secrets: fm.vm0_secrets,
-          vm0_vars: fm.vm0_vars,
-        },
+        frontmatter: fm,
       };
     }
 

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -233,8 +233,6 @@ describe("Zero Agents API", () => {
         frontmatter: {
           name: "Slack",
           description: "Slack integration",
-          vm0_secrets: ["SLACK_BOT_TOKEN"],
-          vm0_vars: [],
         },
       });
 
@@ -258,8 +256,6 @@ describe("Zero Agents API", () => {
 
       // Connector-derived: slack environmentMapping → SLACK_TOKEN
       expect(agentEnv.SLACK_TOKEN).toBe("${{ secrets.SLACK_TOKEN }}");
-      // Skill frontmatter vm0_secrets should NOT be injected (removed mergeSkillVariables)
-      expect(agentEnv.SLACK_BOT_TOKEN).toBeUndefined();
       // Base env vars still present
       expect(agentEnv.ZERO_AGENT_ID).toBe("${{ vars.ZERO_AGENT_ID }}");
       expect(agentEnv.ZERO_TOKEN).toBe("${{ secrets.ZERO_TOKEN }}");
@@ -477,8 +473,6 @@ describe("Zero Agents API", () => {
         frontmatter: {
           name: "Slack",
           description: "Slack integration",
-          vm0_secrets: ["SLACK_BOT_TOKEN"],
-          vm0_vars: [],
         },
       });
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3495,8 +3495,6 @@ export async function seedTestSkill(
       frontmatter: {
         name: "Slack",
         description: "Slack integration",
-        vm0_secrets: ["SLACK_BOT_TOKEN"],
-        vm0_vars: [],
       },
       ...overrides,
     })

--- a/turbo/apps/web/src/lib/zero/seed-skills.ts
+++ b/turbo/apps/web/src/lib/zero/seed-skills.ts
@@ -60,8 +60,6 @@ export function buildSeedSkillValues(
       frontmatter: {
         name,
         description: `${name} skill`,
-        vm0_secrets: [] as string[],
-        vm0_vars: [] as string[],
       },
     };
   });

--- a/turbo/packages/core/src/contracts/skills.ts
+++ b/turbo/packages/core/src/contracts/skills.ts
@@ -7,8 +7,6 @@ const c = initContract();
 export const skillFrontmatterSchema = z.object({
   name: z.string().optional(),
   description: z.string().optional(),
-  vm0_secrets: z.array(z.string()).optional(),
-  vm0_vars: z.array(z.string()).optional(),
 });
 
 const resolvedSkillSchema = z.object({

--- a/turbo/packages/core/src/skill-frontmatter.ts
+++ b/turbo/packages/core/src/skill-frontmatter.ts
@@ -1,5 +1,4 @@
 import { parse as parseYaml } from "yaml";
-import { resolveSkillRef, parseGitHubTreeUrl } from "./github-url";
 
 /**
  * Parsed skill frontmatter from SKILL.md
@@ -7,8 +6,6 @@ import { resolveSkillRef, parseGitHubTreeUrl } from "./github-url";
 export interface SkillFrontmatter {
   name?: string;
   description?: string;
-  vm0_secrets?: string[];
-  vm0_vars?: string[];
 }
 
 /**
@@ -41,129 +38,5 @@ export function parseSkillFrontmatter(content: string): SkillFrontmatter {
     name: typeof data.name === "string" ? data.name : undefined,
     description:
       typeof data.description === "string" ? data.description : undefined,
-    vm0_secrets: Array.isArray(data.vm0_secrets)
-      ? data.vm0_secrets.filter((s): s is string => typeof s === "string")
-      : undefined,
-    vm0_vars: Array.isArray(data.vm0_vars)
-      ? data.vm0_vars.filter((s): s is string => typeof s === "string")
-      : undefined,
   };
-}
-
-/**
- * Sync skill-declared environment variables with an agent's environment.
- *
- * - Adds `${{ secrets.X }}` / `${{ vars.X }}` entries for skill-declared vars
- *   that are missing from the environment.
- * - Removes entries that were previously added by skills (detected by the
- *   self-referencing template pattern `KEY = ${{ secrets.KEY }}`) but are no
- *   longer declared by any current skill.
- *
- * @param skills - Array of skill GitHub tree URLs
- * @param environment - Current agent environment (mutated in place)
- */
-export async function mergeSkillEnvironment(
-  skills: string[],
-  environment: Record<string, string>,
-): Promise<void> {
-  const skillDeclared = await collectSkillDeclaredVars(skills);
-
-  // Remove stale skill-added entries that are no longer declared by any skill.
-  // Skill-added entries have a self-referencing template pattern:
-  //   KEY = "${{ secrets.KEY }}" or KEY = "${{ vars.KEY }}"
-  for (const key of Object.keys(environment)) {
-    const value = environment[key];
-    const isSkillAdded =
-      value === `\${{ secrets.${key} }}` || value === `\${{ vars.${key} }}`;
-    if (isSkillAdded && !skillDeclared.has(key)) {
-      delete environment[key];
-    }
-  }
-
-  // Add missing entries for current skills
-  for (const [name, source] of skillDeclared) {
-    if (!(name in environment)) {
-      environment[name] =
-        source === "secret"
-          ? `\${{ secrets.${name} }}`
-          : `\${{ vars.${name} }}`;
-    }
-  }
-}
-
-/**
- * Collect all env var names declared by the given skills.
- * Returns a map of name → "secret" | "var".
- */
-async function collectSkillDeclaredVars(
-  skills: string[],
-): Promise<Map<string, "secret" | "var">> {
-  const declared = new Map<string, "secret" | "var">();
-  const results = await Promise.allSettled(
-    skills.map((url) => fetchSkillMdContent(url)),
-  );
-
-  for (const result of results) {
-    if (result.status !== "fulfilled" || !result.value) {
-      continue;
-    }
-    const fm = parseSkillFrontmatter(result.value);
-    if (fm.vm0_secrets) {
-      for (const name of fm.vm0_secrets) {
-        declared.set(name, "secret");
-      }
-    }
-    if (fm.vm0_vars) {
-      for (const name of fm.vm0_vars) {
-        declared.set(name, "var");
-      }
-    }
-  }
-
-  return declared;
-}
-
-/**
- * Build the raw GitHub URL for a skill's SKILL.md file.
- * Accepts bare skill names (e.g. "slack") or full GitHub tree URLs.
- */
-function buildSkillMdUrl(url: string): string | null {
-  const resolved = resolveSkillRef(url);
-
-  const parsed = parseGitHubTreeUrl(resolved);
-  if (!parsed) {
-    return null;
-  }
-  const pathPrefix = parsed.path ? `${parsed.path}/` : "";
-  return `https://raw.githubusercontent.com/${parsed.owner}/${parsed.repo}/${parsed.branch}/${pathPrefix}SKILL.md`;
-}
-
-/**
- * Fetch the raw SKILL.md content from a GitHub skill URL.
- * Returns null if the URL is invalid or the fetch fails.
- */
-async function fetchSkillMdContent(skillUrl: string): Promise<string | null> {
-  const rawUrl = buildSkillMdUrl(skillUrl);
-  if (!rawUrl) {
-    return null;
-  }
-  const res = await fetch(rawUrl);
-  if (!res.ok) {
-    return null;
-  }
-  return res.text();
-}
-
-/**
- * Fetch and parse SKILL.md frontmatter from a GitHub skill URL.
- * Returns null if the URL is invalid or the fetch fails.
- */
-export async function fetchSkillFrontmatter(
-  skillUrl: string,
-): Promise<SkillFrontmatter | null> {
-  const content = await fetchSkillMdContent(skillUrl);
-  if (!content) {
-    return null;
-  }
-  return parseSkillFrontmatter(content);
 }


### PR DESCRIPTION
## Summary

- Remove `vm0_secrets` and `vm0_vars` from `SkillFrontmatter` interface and `skillFrontmatterSchema`
- Delete 5 dead functions from `skill-frontmatter.ts`: `mergeSkillEnvironment`, `collectSkillDeclaredVars`, `fetchSkillFrontmatter`, `fetchSkillMdContent`, `buildSkillMdUrl`
- Clean up seed skills, API route response, and all test references

**9 files changed, +53 -223 lines** — pure dead-code removal after #6933 and #6934 removed all consumers.

## Parent Epic

#6931

## Test plan

- [x] All existing integration tests updated and passing (core: 353, cli: 834, web: 2475)
- [x] Lint, format, knip all pass
- [x] `grep -r "vm0_secrets\|vm0_vars"` returns no results in source files (only in `instructions-frontmatter.spec.ts` which tests a different module)
- [x] `grep -r "mergeSkillEnvironment\|collectSkillDeclaredVars\|fetchSkillFrontmatter"` returns no results

Closes #6936

🤖 Generated with [Claude Code](https://claude.com/claude-code)