### PR TITLE
feat(web): redesign global loading screen with avatar and typewriter text

### DIFF
--- a/turbo/apps/platform/index.html
+++ b/turbo/apps/platform/index.html
@@ -64,68 +64,14 @@
     <div id="root">
       <style>
         .sk {
-          display: flex;
           height: 100dvh;
           background: #fdfdfe;
-        }
-        .sk-side {
-          width: 300px;
-          flex-shrink: 0;
-          background: #fafbfc;
-          border-right: 0.7px solid #dce1e8;
-          padding: 16px;
-          display: flex;
-          flex-direction: column;
-          gap: 12px;
-        }
-        .sk-bar {
-          height: 32px;
-          border-radius: 8px;
-          background: #e7ebf0;
-          animation: sk-pulse 2s ease-in-out infinite;
-        }
-        .sk-content {
-          flex: 1;
-          background: #fdfdfe;
-        }
-        @keyframes sk-pulse {
-          0%,
-          100% {
-            opacity: 1;
-          }
-          50% {
-            opacity: 0.4;
-          }
         }
         [data-theme="dark"] .sk {
           background: #19191b;
         }
-        [data-theme="dark"] .sk-side {
-          background: hsl(240 5% 8%);
-          border-color: #292a2e;
-        }
-        [data-theme="dark"] .sk-bar {
-          background: #222325;
-        }
-        [data-theme="dark"] .sk-content {
-          background: #19191b;
-        }
-        @media (max-width: 767px) {
-          .sk-side {
-            display: none;
-          }
-        }
       </style>
-      <div class="sk">
-        <aside class="sk-side">
-          <div class="sk-bar"></div>
-          <div class="sk-bar" style="margin-top: 8px"></div>
-          <div class="sk-bar"></div>
-          <div class="sk-bar"></div>
-          <div class="sk-bar"></div>
-        </aside>
-        <div class="sk-content"></div>
-      </div>
+      <div class="sk"></div>
     </div>
     <script
       src="https://api.dashboard.instatus.com/widget?host=status.vm0.ai&code=02c0ef5a&locale=en"

--- a/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
+++ b/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
@@ -1,93 +1,91 @@
+import { ZERO_AVATARS } from "./zero-avatars.ts";
+
+const LOADING_MESSAGES = [
+  "Warming up the neurons...",
+  "Brewing some ideas...",
+  "Getting things ready...",
+  "Almost there...",
+  "Loading your workspace...",
+  "Tuning the instruments...",
+  "Connecting the dots...",
+  "Spinning up the team...",
+] as const;
+
+/** Pick once at module load so remounts don't flicker. */
+const AVATAR_INDEX = Math.floor(Math.random() * ZERO_AVATARS.length);
+const MSG_INDEX_1 = Math.floor(Math.random() * LOADING_MESSAGES.length);
+const MSG_INDEX_2 = (MSG_INDEX_1 + 1) % LOADING_MESSAGES.length;
+const STATIC_MSG = LOADING_MESSAGES[MSG_INDEX_1];
+const TYPEWRITER_MSG = LOADING_MESSAGES[MSG_INDEX_2];
+const CHAR_COUNT = TYPEWRITER_MSG.length;
+
 /**
- * Skeleton placeholder that approximates the app shell layout
- * (sidebar + content area). Used in two places:
- *  1. Router — while bootstrap is in progress and page$ is still undefined
- *  2. SidebarLayout — while post-route data (agent name) loads
+ * CSS-only typewriter: hidden for the first 800ms (shows static msg),
+ * then types out the second message over 1.5s with a blinking caret.
+ * The static message hides at the same 800ms mark.
+ */
+const skeletonCSS = `
+@keyframes sk-typing {
+  from { width: 0; }
+  to { width: ${CHAR_COUNT}ch; }
+}
+@keyframes sk-blink {
+  0%, 100% { border-color: transparent; }
+  50% { border-color: currentColor; }
+}
+@keyframes sk-hide-static {
+  0%, 99.9% { opacity: 1; }
+  100% { opacity: 0; }
+}
+@keyframes sk-show-typewriter {
+  0%, 99.9% { visibility: hidden; }
+  100% { visibility: visible; }
+}
+`;
+
+/**
+ * Global loading screen shown during app bootstrap.
+ * Shows a static message immediately; if loading takes >800ms,
+ * swaps to a typewriter-animated second message.
  */
 export function AppSkeleton({ visible = true }: { visible?: boolean }) {
   return (
     <div
-      className={`fixed inset-0 z-50 flex bg-background ${
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-background ${
         visible
           ? "opacity-100"
           : "opacity-0 pointer-events-none transition-opacity duration-300"
       }`}
     >
-      {/* Sidebar skeleton */}
-      <aside className="flex h-full w-[300px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar overflow-hidden">
-        {/* Org switcher */}
-        <div className="shrink-0 p-2 pb-1">
-          <div className="rounded-lg p-2">
-            <div className="h-8 w-full rounded-lg bg-muted/50 animate-pulse" />
-          </div>
-        </div>
-        {/* Nav + Recent */}
-        <nav className="flex-1 overflow-y-auto overflow-x-hidden p-2">
-          <div className="flex flex-col gap-1">
-            {["nav-1", "nav-2", "nav-3", "nav-4", "nav-5", "nav-6"].map(
-              (id, i) => (
-                <div
-                  key={id}
-                  className="flex h-8 items-center gap-2 rounded-lg p-2"
-                >
-                  <div className="h-4 w-4 rounded bg-muted/50 animate-pulse shrink-0" />
-                  <div
-                    className="h-3.5 rounded bg-muted/50 animate-pulse"
-                    style={{ width: `${80 + ((i * 37) % 60)}px` }}
-                  />
-                </div>
-              ),
-            )}
-          </div>
-          {/* Recent section */}
-          <div className="mt-4">
-            <div className="h-8 flex items-center px-2">
-              <div className="h-3 w-20 rounded bg-muted/30 animate-pulse" />
-            </div>
-            <div className="flex flex-col gap-1">
-              {["recent-1", "recent-2", "recent-3"].map((id, i) => (
-                <div key={id} className="flex h-8 items-center rounded-lg p-2">
-                  <div
-                    className="h-3.5 rounded bg-muted/40 animate-pulse"
-                    style={{ width: `${100 + ((i * 43) % 80)}px` }}
-                  />
-                </div>
-              ))}
-            </div>
-          </div>
-        </nav>
-        {/* Footer */}
-        <div className="p-2">
-          <div className="flex flex-col gap-1">
-            <div className="flex h-8 items-center gap-2 rounded-lg p-2">
-              <div className="h-4 w-4 rounded bg-muted/50 animate-pulse shrink-0" />
-              <div className="h-3.5 w-28 rounded bg-muted/50 animate-pulse" />
-            </div>
-            {/* Account */}
-            <div className="mt-2 pt-1">
-              <div className="rounded-lg p-2">
-                <div className="flex items-center gap-2">
-                  <div className="h-8 w-8 shrink-0 rounded-xl bg-muted/50 animate-pulse" />
-                  <div className="flex-1 min-w-0">
-                    <div className="h-3.5 w-24 rounded bg-muted/50 animate-pulse" />
-                    <div className="h-3 w-32 rounded bg-muted/30 animate-pulse mt-1" />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </aside>
-      {/* Content skeleton */}
-      <div className="flex flex-1 flex-col min-w-0 zero-workspace-bg">
-        <div className="shrink-0 px-6 pt-6 pb-5">
-          <div className="h-6 w-40 rounded bg-muted/50 animate-pulse mb-2" />
-          <div className="h-4 w-64 rounded bg-muted/30 animate-pulse" />
-        </div>
-        <div className="flex-1 px-6">
-          <div className="mx-auto max-w-[900px]">
-            <div className="h-48 rounded-xl bg-muted/20 animate-pulse" />
-          </div>
+      <style>{skeletonCSS}</style>
+      <div className="flex flex-col items-center gap-5">
+        <img
+          src={ZERO_AVATARS[AVATAR_INDEX]}
+          alt=""
+          role="presentation"
+          className="h-16 w-16 rounded-full object-cover object-top"
+        />
+        <div className="relative h-6">
+          {/* Static message: visible immediately, hides at 800ms */}
+          <p
+            className="text-base font-medium text-foreground/70 whitespace-nowrap"
+            style={{
+              animation: "sk-hide-static 800ms forwards",
+            }}
+          >
+            {STATIC_MSG}
+          </p>
+          {/* Typewriter message: appears at 800ms, types over 1.5s */}
+          <p
+            className="absolute inset-0 text-base font-medium text-foreground/70 overflow-hidden whitespace-nowrap border-r-2 border-current"
+            style={{
+              visibility: "hidden",
+              width: 0,
+              animation: `sk-show-typewriter 800ms forwards, sk-typing 1.5s steps(${CHAR_COUNT}) 800ms forwards, sk-blink 0.6s step-end 800ms infinite`,
+            }}
+          >
+            {TYPEWRITER_MSG}
+          </p>
         </div>
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -11,6 +11,7 @@ import {
   setZeroSidebarCollapsed$,
 } from "../../signals/zero-page/zero-nav.ts";
 import { ZeroAboutPage } from "./zero-about-page.tsx";
+import { AppSkeleton } from "./app-skeleton.tsx";
 
 function SidebarLayoutSkeleton() {
   const userLoadable = useLoadable(user$);
@@ -20,73 +21,7 @@ function SidebarLayoutSkeleton() {
   const agentNameReady = agentNameLoadable.state === "hasData";
   const visible = isLoggedIn && !agentNameReady;
 
-  return (
-    <div
-      className={`fixed inset-0 z-50 flex bg-background ${
-        visible
-          ? "opacity-100"
-          : "opacity-0 pointer-events-none transition-opacity duration-300"
-      }`}
-    >
-      {/* Sidebar skeleton */}
-      <aside className="flex h-full w-[300px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar overflow-hidden">
-        <div className="shrink-0 p-2 pb-1">
-          <div className="rounded-lg p-2">
-            <div className="h-8 w-full rounded-lg bg-muted/50 animate-pulse" />
-          </div>
-        </div>
-        <nav className="flex-1 overflow-y-auto overflow-x-hidden p-2">
-          <div className="flex flex-col gap-1">
-            {["nav-1", "nav-2", "nav-3", "nav-4", "nav-5", "nav-6"].map(
-              (id, i) => (
-                <div
-                  key={id}
-                  className="flex h-8 items-center gap-2 rounded-lg p-2"
-                >
-                  <div className="h-4 w-4 rounded bg-muted/50 animate-pulse shrink-0" />
-                  <div
-                    className="h-3.5 rounded bg-muted/50 animate-pulse"
-                    style={{ width: `${80 + ((i * 37) % 60)}px` }}
-                  />
-                </div>
-              ),
-            )}
-          </div>
-        </nav>
-        <div className="p-2">
-          <div className="flex flex-col gap-1">
-            <div className="flex h-8 items-center gap-2 rounded-lg p-2">
-              <div className="h-4 w-4 rounded bg-muted/50 animate-pulse shrink-0" />
-              <div className="h-3.5 w-28 rounded bg-muted/50 animate-pulse" />
-            </div>
-            <div className="mt-2 pt-1">
-              <div className="rounded-lg p-2">
-                <div className="flex items-center gap-2">
-                  <div className="h-8 w-8 shrink-0 rounded-xl bg-muted/50 animate-pulse" />
-                  <div className="flex-1 min-w-0">
-                    <div className="h-3.5 w-24 rounded bg-muted/50 animate-pulse" />
-                    <div className="h-3 w-32 rounded bg-muted/30 animate-pulse mt-1" />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </aside>
-      {/* Content skeleton */}
-      <div className="flex flex-1 flex-col min-w-0 zero-workspace-bg">
-        <div className="shrink-0 px-6 pt-6 pb-5">
-          <div className="h-6 w-40 rounded bg-muted/50 animate-pulse mb-2" />
-          <div className="h-4 w-64 rounded bg-muted/30 animate-pulse" />
-        </div>
-        <div className="flex-1 px-6">
-          <div className="mx-auto max-w-[900px]">
-            <div className="h-48 rounded-xl bg-muted/20 animate-pulse" />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  return <AppSkeleton visible={visible} />;
 }
 
 function GuestNavBar() {


### PR DESCRIPTION
## Summary
- Replace skeleton sidebar+content loading screen with a centered avatar + message
- Random avatar and fun loading message picked once at module load (no flicker on remount)
- Static text shown immediately; if loading takes >800ms, a second message appears with typewriter animation
- Simplify `index.html` pre-JS placeholder to plain background (no skeleton bars)
- Deduplicate `SidebarLayoutSkeleton` by reusing `AppSkeleton`

## Test plan
- [ ] Hard refresh — verify centered avatar + static message appears (no skeleton sidebar)
- [ ] Throttle network to Slow 3G — verify typewriter animation kicks in after ~800ms
- [ ] Verify no avatar flickering between different images
- [ ] Verify dark mode background matches correctly
- [ ] Verify loading screen fades out smoothly when app is ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)