### PR TITLE
feat: add e2e browser test for clerk token-based auth

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1055,6 +1055,7 @@ jobs:
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
       - name: Upload auth screenshots
         if: always()
         uses: actions/upload-artifact@v7

--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -157,6 +157,52 @@ generate_password() {
 }
 
 # ---------------------------------------------------------------------------
+# create_clerk_sign_in_token — Create a Clerk sign-in token for e2e test user
+# Requires CLERK_SECRET_KEY. Exports SIGN_IN_TOKEN on success.
+# ---------------------------------------------------------------------------
+create_clerk_sign_in_token() {
+  if [[ -z "${CLERK_SECRET_KEY:-}" ]]; then
+    echo "CLERK_SECRET_KEY is required but not set" >&2
+    return 1
+  fi
+
+  local email="e2e+clerk_test@vm0.ai"
+
+  # Resolve user ID from email
+  local users_response
+  users_response=$(curl -sS -X GET \
+    "https://api.clerk.com/v1/users?email_address[]=${email}" \
+    -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+    -H "Content-Type: application/json")
+
+  local user_id
+  user_id=$(echo "$users_response" | jq -e -r '.[0].id' 2>/dev/null)
+  if [[ -z "$user_id" || "$user_id" == "null" ]]; then
+    echo "Failed to resolve user ID for ${email}" >&2
+    echo "API response: ${users_response}" >&2
+    return 1
+  fi
+
+  # Create sign-in token
+  local token_response
+  token_response=$(curl -sS -X POST \
+    "https://api.clerk.com/v1/sign_in_tokens" \
+    -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "{\"user_id\": \"${user_id}\", \"expires_in_seconds\": 300}")
+
+  local token
+  token=$(echo "$token_response" | jq -e -r '.token' 2>/dev/null)
+  if [[ -z "$token" || "$token" == "null" ]]; then
+    echo "Failed to create sign-in token" >&2
+    echo "API response: ${token_response}" >&2
+    return 1
+  fi
+
+  export SIGN_IN_TOKEN="$token"
+}
+
+# ---------------------------------------------------------------------------
 # browser_teardown — Kill agent-browser and any spawned browser processes
 # Call this in teardown_file() to prevent bats from hanging.
 # ---------------------------------------------------------------------------

--- a/e2e/tests/02-browser/brw-t02-token-auth.bats
+++ b/e2e/tests/02-browser/brw-t02-token-auth.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# brw-t02-token-auth.bats — Verify Clerk token-based auth reaches app homepage
+#
+# Required env vars:
+#   VM0_API_URL        — Target site URL
+#   CLERK_SECRET_KEY   — Clerk Backend API key (for creating sign-in tokens)
+
+load '../../helpers/setup'
+load '../../helpers/browser'
+
+setup_file() {
+  browser_setup
+  create_clerk_sign_in_token
+
+  echo "# Token-based auth verification via agent-browser" >&3
+  echo "#   URL:   $VM0_API_URL" >&3
+}
+
+teardown_file() {
+  browser_teardown
+}
+
+@test "sign in via Clerk token and reach app homepage" {
+  # Navigate to sign-in-token page with the token
+  echo "# Navigating to sign-in-token page" >&3
+  agent-browser open "${VM0_API_URL}/sign-in-token?token=${SIGN_IN_TOKEN}" --ignore-https-errors
+  agent-browser wait 3000
+  step_screenshot "sign-in-token-page"
+
+  # Wait for redirect chain to complete (/sign-in-token -> / -> /en)
+  echo "# Waiting for redirect to complete..." >&3
+  local redirect_complete=false
+  for i in $(seq 1 20); do
+    local current_url
+    current_url=$(agent-browser get url 2>/dev/null || true)
+    if [[ -n "$current_url" && ! "$current_url" =~ sign-in-token ]]; then
+      redirect_complete=true
+      break
+    fi
+    sleep 1
+  done
+  step_screenshot "after-redirect"
+  assert [ "$redirect_complete" = "true" ]
+
+  # Dismiss cookie banner if present
+  dismiss_cookie_banner
+
+  # Wait for page content to load and verify signed-in state
+  echo "# Verifying authenticated homepage..." >&3
+  local signed_in=false
+  for i in $(seq 1 10); do
+    local snap
+    snap=$(full_snapshot)
+    if contains "$snap" "Open app"; then
+      signed_in=true
+      break
+    fi
+    sleep 1
+  done
+  step_screenshot "homepage-final"
+
+  # Assert signed-in state
+  assert [ "$signed_in" = "true" ]
+
+  # Assert URL does not contain sign-in-token (redirect completed)
+  local final_url
+  final_url=$(agent-browser get url 2>/dev/null || true)
+  [[ ! "$final_url" =~ sign-in-token ]]
+}


### PR DESCRIPTION
## Summary
- Add `create_clerk_sign_in_token()` helper function to `e2e/helpers/browser.bash` that creates a Clerk sign-in token via the Backend API
- Create `brw-t02-token-auth.bats` test that authenticates via token-based auth and verifies the user reaches the authenticated homepage
- Add `CLERK_SECRET_KEY` to the `cli-e2e-02-browser` CI job environment

## Test plan
- [ ] CI `cli-e2e-02-browser` job passes with the new test
- [ ] Token-based auth test successfully creates a sign-in token, navigates to `/sign-in-token`, and verifies redirect to authenticated homepage showing "Open app"

Closes #6958

🤖 Generated with [Claude Code](https://claude.com/claude-code)