### PR TITLE
docs: update server-side-compose jsdoc to reflect current behavior

### DIFF
--- a/turbo/apps/web/src/lib/compose/server-side-compose.ts
+++ b/turbo/apps/web/src/lib/compose/server-side-compose.ts
@@ -137,8 +137,9 @@ async function upsertComposeRecord(params: {
  * Attempt server-side compose for platform mode.
  *
  * Bypasses the E2B sandbox by resolving skills from the database cache,
- * merging skill variables, expanding firewall configs, uploading instructions,
- * and creating the compose record — all server-side.
+ * injecting connector env vars via buildComposeContent, expanding firewall
+ * configs, uploading instructions, and creating the compose record — all
+ * server-side.
  *
  * @returns Compose result if successful, or `null` if the server-side path
  *          is not possible (e.g., uncached skills) and the caller should


### PR DESCRIPTION
## Summary
- Updated the JSDoc comment on `serverSideCompose()` which still referenced "merging skill variables" — `mergeSkillVariables` was removed
- The comment now reflects that connector env vars are injected by `buildComposeContent`

## Test plan
- [x] Documentation-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)