### PR TITLE
feat: add zero run and zero run continue commands

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -17,6 +17,7 @@ function buildCommands(): Command[] {
     new Command("agent"),
     new Command("connector"),
     new Command("preference"),
+    new Command("run"),
     new Command("schedule"),
     new Command("secret"),
     new Command("slack"),
@@ -123,6 +124,7 @@ describe("registerZeroCommands", () => {
       "org",
       "connector",
       "preference",
+      "run",
       "secret",
       "slack",
       "variable",
@@ -172,6 +174,31 @@ describe("registerZeroCommands", () => {
 
     expect(visibleCommandNames(prog)).toContain("slack");
     expect(visibleCommandNames(prog)).toContain("whoami");
+  });
+
+  it("should show run when agent-run:write capability is present", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["agent-run:write"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+
+    expect(visibleCommandNames(prog)).toContain("run");
+    expect(visibleCommandNames(prog)).toContain("whoami");
+  });
+
+  it("should hide run when agent-run:write capability is missing", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["agent:read"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+
+    expect(hiddenCommandNames(prog)).toContain("run");
   });
 
   it("should hide agent when agent:read capability is missing", () => {

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -16,6 +16,7 @@ describe("zero CLI program", () => {
       "connector",
       "doctor",
       "preference",
+      "run",
       "schedule",
       "secret",
       "slack",
@@ -32,7 +33,6 @@ describe("zero CLI program", () => {
     const excludedCommands = [
       "auth",
       "compose",
-      "run",
       "volume",
       "artifact",
       "memory",
@@ -47,7 +47,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 11 commands", () => {
-    expect(commandNames).toHaveLength(11);
+  it("should have exactly 12 commands", () => {
+    expect(commandNames).toHaveLength(12);
   });
 });

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -192,7 +192,7 @@ export function renderRunCreated(response: {
   }
 }
 
-interface PollResult {
+export interface PollResult {
   succeeded: boolean;
   runId: string;
   sessionId?: string;
@@ -202,7 +202,7 @@ interface PollResult {
 /**
  * Options for polling/streaming events
  */
-interface EventRenderingOptions {
+export interface EventRenderingOptions {
   verbose?: boolean;
 }
 

--- a/turbo/apps/cli/src/commands/zero/run/__tests__/continue.test.ts
+++ b/turbo/apps/cli/src/commands/zero/run/__tests__/continue.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for zero run continue command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { continueCommand } from "../continue";
+import chalk from "chalk";
+
+describe("zero run continue command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  const testSessionId = "550e8400-e29b-41d4-a716-446655440000";
+
+  const defaultCreateRunResponse = {
+    runId: "run-123",
+    status: "running",
+    sandboxId: "sbx-456",
+    createdAt: "2025-01-01T00:00:00Z",
+  };
+
+  const defaultGetRunResponse = {
+    runId: "run-123",
+    agentComposeVersionId: null,
+    status: "completed",
+    prompt: "test prompt",
+    appendSystemPrompt: null,
+    result: {
+      agentSessionId: testSessionId,
+      checkpointId: "cp-123",
+    },
+    createdAt: "2025-01-01T00:00:00Z",
+  };
+
+  const defaultEventsResponse = {
+    events: [],
+    hasMore: false,
+    framework: "claude-code",
+  };
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    server.use(
+      http.post("http://localhost:3000/api/zero/runs", () => {
+        return HttpResponse.json(defaultCreateRunResponse, { status: 201 });
+      }),
+      http.get("http://localhost:3000/api/zero/runs/:id", () => {
+        return HttpResponse.json(defaultGetRunResponse);
+      }),
+      http.get(
+        "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+        () => {
+          return HttpResponse.json(defaultEventsResponse);
+        },
+      ),
+    );
+  });
+
+  describe("session ID validation", () => {
+    it("should reject invalid session ID format", async () => {
+      await expect(async () => {
+        await continueCommand.parseAsync([
+          "node",
+          "cli",
+          "invalid-session-id",
+          "test prompt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid session ID format"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("must be a valid UUID"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("successful continue", () => {
+    it("should create a zero run with sessionId and poll to completion", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultCreateRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await continueCommand.parseAsync([
+        "node",
+        "cli",
+        testSessionId,
+        "Continue working on the task",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          sessionId: testSessionId,
+          prompt: "Continue working on the task",
+        }),
+      );
+      // Should not include agentId for continue commands
+      expect(capturedBody).not.toHaveProperty("agentId");
+    });
+
+    it("should pass append-system-prompt option to API", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultCreateRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await continueCommand.parseAsync([
+        "node",
+        "cli",
+        testSessionId,
+        "test prompt",
+        "--append-system-prompt",
+        "Always respond in JSON",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          appendSystemPrompt: "Always respond in JSON",
+        }),
+      );
+    });
+
+    it("should pass model-provider option to API", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultCreateRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await continueCommand.parseAsync([
+        "node",
+        "cli",
+        testSessionId,
+        "test prompt",
+        "--model-provider",
+        "anthropic-api-key",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          modelProvider: "anthropic-api-key",
+        }),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle run preparation failure", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/runs", () => {
+          return HttpResponse.json(
+            {
+              runId: "run-failed",
+              status: "failed",
+              error: "Session not found",
+              createdAt: "2025-01-01T00:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await continueCommand.parseAsync([
+          "node",
+          "cli",
+          testSessionId,
+          "test prompt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Run preparation failed"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Session not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle run failure during polling", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/runs/:id", () => {
+          return HttpResponse.json({
+            ...defaultGetRunResponse,
+            status: "failed",
+            error: "Agent crashed",
+            result: undefined,
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await continueCommand.parseAsync([
+          "node",
+          "cli",
+          testSessionId,
+          "test prompt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle run cancellation during polling", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/runs/:id", () => {
+          return HttpResponse.json({
+            ...defaultGetRunResponse,
+            status: "cancelled",
+            result: undefined,
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await continueCommand.parseAsync([
+          "node",
+          "cli",
+          testSessionId,
+          "test prompt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Run cancelled"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for zero run command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { mainRunCommand } from "../run";
+import chalk from "chalk";
+
+describe("zero run command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  const testAgentId = "550e8400-e29b-41d4-a716-446655440000";
+
+  const defaultCreateRunResponse = {
+    runId: "run-123",
+    status: "running",
+    sandboxId: "sbx-456",
+    createdAt: "2025-01-01T00:00:00Z",
+  };
+
+  const defaultGetRunResponse = {
+    runId: "run-123",
+    agentComposeVersionId: null,
+    status: "completed",
+    prompt: "test prompt",
+    appendSystemPrompt: null,
+    result: {
+      agentSessionId: "session-abc",
+      checkpointId: "cp-123",
+    },
+    createdAt: "2025-01-01T00:00:00Z",
+  };
+
+  const defaultEventsResponse = {
+    events: [],
+    hasMore: false,
+    framework: "claude-code",
+  };
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    server.use(
+      http.post("http://localhost:3000/api/zero/runs", () => {
+        return HttpResponse.json(defaultCreateRunResponse, { status: 201 });
+      }),
+      http.get("http://localhost:3000/api/zero/runs/:id", () => {
+        return HttpResponse.json(defaultGetRunResponse);
+      }),
+      http.get(
+        "http://localhost:3000/api/zero/runs/:id/telemetry/agent",
+        () => {
+          return HttpResponse.json(defaultEventsResponse);
+        },
+      ),
+    );
+  });
+
+  describe("agent ID validation", () => {
+    it("should reject invalid agent ID format", async () => {
+      await expect(async () => {
+        await mainRunCommand.parseAsync([
+          "node",
+          "cli",
+          "invalid-agent-id",
+          "test prompt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid agent ID format"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("must be a valid UUID"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("successful run", () => {
+    it("should create a zero run and poll to completion", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultCreateRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await mainRunCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentId,
+        "Build a hello world app",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          agentId: testAgentId,
+          prompt: "Build a hello world app",
+        }),
+      );
+    });
+
+    it("should pass append-system-prompt option to API", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultCreateRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await mainRunCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentId,
+        "test prompt",
+        "--append-system-prompt",
+        "Always respond in JSON",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          appendSystemPrompt: "Always respond in JSON",
+        }),
+      );
+    });
+
+    it("should pass model-provider option to API", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/runs",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(defaultCreateRunResponse, { status: 201 });
+          },
+        ),
+      );
+
+      await mainRunCommand.parseAsync([
+        "node",
+        "cli",
+        testAgentId,
+        "test prompt",
+        "--model-provider",
+        "anthropic-api-key",
+      ]);
+
+      expect(capturedBody).toEqual(
+        expect.objectContaining({
+          modelProvider: "anthropic-api-key",
+        }),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle run preparation failure", async () => {
+      server.use(
+        http.post("http://localhost:3000/api/zero/runs", () => {
+          return HttpResponse.json(
+            {
+              runId: "run-failed",
+              status: "failed",
+              error: "Agent not found",
+              createdAt: "2025-01-01T00:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await mainRunCommand.parseAsync([
+          "node",
+          "cli",
+          testAgentId,
+          "test prompt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Run preparation failed"),
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Agent not found"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle run failure during polling", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/runs/:id", () => {
+          return HttpResponse.json({
+            ...defaultGetRunResponse,
+            status: "failed",
+            error: "Agent crashed",
+            result: undefined,
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await mainRunCommand.parseAsync([
+          "node",
+          "cli",
+          testAgentId,
+          "test prompt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle run timeout during polling", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/runs/:id", () => {
+          return HttpResponse.json({
+            ...defaultGetRunResponse,
+            status: "timeout",
+            result: undefined,
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await mainRunCommand.parseAsync([
+          "node",
+          "cli",
+          testAgentId,
+          "test prompt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Run timed out"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/run/continue.ts
+++ b/turbo/apps/cli/src/commands/zero/run/continue.ts
@@ -1,0 +1,70 @@
+import { Command } from "commander";
+import { createZeroRun } from "../../../lib/api";
+import { isUUID, renderRunCreated } from "../../run/shared";
+import { withErrorHandler } from "../../../lib/command";
+import { pollZeroEvents, showZeroNextSteps } from "./shared";
+
+export const continueCommand = new Command()
+  .name("continue")
+  .description("Continue a previous delegation from a session")
+  .argument("<session-id>", "Session ID from a previous run")
+  .argument("<prompt>", "Follow-up prompt for the agent")
+  .option(
+    "--append-system-prompt <text>",
+    "Append text to the agent's system prompt",
+  )
+  .option(
+    "--model-provider <type>",
+    "Override model provider (e.g., anthropic-api-key)",
+  )
+  .option("--verbose", "Show full tool inputs and outputs")
+  .action(
+    withErrorHandler(
+      async (
+        sessionId: string,
+        prompt: string,
+        options: {
+          appendSystemPrompt?: string;
+          modelProvider?: string;
+          verbose?: boolean;
+        },
+      ) => {
+        // 1. Validate session-id is a UUID
+        if (!isUUID(sessionId)) {
+          throw new Error(`Invalid session ID format: ${sessionId}`, {
+            cause: new Error("Session ID must be a valid UUID"),
+          });
+        }
+
+        // 2. Create zero run with sessionId (no agentId needed)
+        const response = await createZeroRun({
+          sessionId,
+          prompt,
+          appendSystemPrompt: options.appendSystemPrompt,
+          modelProvider: options.modelProvider,
+        });
+
+        // 3. Check for immediate failure
+        if (response.status === "failed") {
+          throw new Error(
+            "Run preparation failed",
+            response.error ? { cause: new Error(response.error) } : undefined,
+          );
+        }
+
+        // 4. Display run started/queued info
+        renderRunCreated(response);
+
+        // 5. Poll for events
+        const result = await pollZeroEvents(response.runId, {
+          verbose: options.verbose,
+        });
+        if (!result.succeeded) {
+          throw new Error("Run failed");
+        }
+
+        // 6. Show next steps
+        showZeroNextSteps(result);
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/run/index.ts
+++ b/turbo/apps/cli/src/commands/zero/run/index.ts
@@ -1,0 +1,15 @@
+import { mainRunCommand } from "./run";
+import { continueCommand } from "./continue";
+
+mainRunCommand.addCommand(continueCommand);
+
+mainRunCommand.addHelpText(
+  "after",
+  `
+Delegation workflow:
+  Discover teammates:    zero agent list
+  Delegate a task:       zero run <agent-id> "your task"
+  Continue delegation:   zero run continue <session-id> "follow up"`,
+);
+
+export const zeroRunCommand = mainRunCommand;

--- a/turbo/apps/cli/src/commands/zero/run/run.ts
+++ b/turbo/apps/cli/src/commands/zero/run/run.ts
@@ -1,0 +1,72 @@
+import { Command } from "commander";
+import { createZeroRun } from "../../../lib/api";
+import { isUUID, renderRunCreated } from "../../run/shared";
+import { withErrorHandler } from "../../../lib/command";
+import { pollZeroEvents, showZeroNextSteps } from "./shared";
+
+export const mainRunCommand = new Command()
+  .name("run")
+  .description("Delegate a task to a teammate agent")
+  .argument("<agent-id>", "Agent UUID (from `zero agent list`)")
+  .argument("<prompt>", "Task prompt for the agent")
+  .option(
+    "--append-system-prompt <text>",
+    "Append text to the agent's system prompt",
+  )
+  .option(
+    "--model-provider <type>",
+    "Override model provider (e.g., anthropic-api-key)",
+  )
+  .option("--verbose", "Show full tool inputs and outputs")
+  .action(
+    withErrorHandler(
+      async (
+        agentId: string,
+        prompt: string,
+        options: {
+          appendSystemPrompt?: string;
+          modelProvider?: string;
+          verbose?: boolean;
+        },
+      ) => {
+        // 1. Validate agent-id is a UUID
+        if (!isUUID(agentId)) {
+          throw new Error(`Invalid agent ID format: ${agentId}`, {
+            cause: new Error(
+              "Agent ID must be a valid UUID. Use `zero agent list` to find agent IDs.",
+            ),
+          });
+        }
+
+        // 2. Create zero run
+        const response = await createZeroRun({
+          agentId,
+          prompt,
+          appendSystemPrompt: options.appendSystemPrompt,
+          modelProvider: options.modelProvider,
+        });
+
+        // 3. Check for immediate failure
+        if (response.status === "failed") {
+          throw new Error(
+            "Run preparation failed",
+            response.error ? { cause: new Error(response.error) } : undefined,
+          );
+        }
+
+        // 4. Display run started/queued info
+        renderRunCreated(response);
+
+        // 5. Poll for events
+        const result = await pollZeroEvents(response.runId, {
+          verbose: options.verbose,
+        });
+        if (!result.succeeded) {
+          throw new Error("Run failed");
+        }
+
+        // 6. Show next steps
+        showZeroNextSteps(result);
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/run/shared.ts
+++ b/turbo/apps/cli/src/commands/zero/run/shared.ts
@@ -1,0 +1,108 @@
+import chalk from "chalk";
+import { getZeroRunAgentEvents, getZeroRun } from "../../../lib/api";
+import type { RunResult } from "../../../lib/api";
+import { parseEvent } from "../../../lib/events/event-parser-factory";
+import { EventRenderer } from "../../../lib/events/event-renderer";
+
+interface PollResult {
+  succeeded: boolean;
+  runId: string;
+  sessionId?: string;
+  checkpointId?: string;
+}
+
+interface EventRenderingOptions {
+  verbose?: boolean;
+}
+
+/**
+ * Poll for zero run events until run completes.
+ * Uses dual-poll approach: telemetry endpoint for events, getById for status.
+ */
+export async function pollZeroEvents(
+  runId: string,
+  options?: EventRenderingOptions,
+): Promise<PollResult> {
+  const renderer = new EventRenderer({ verbose: options?.verbose });
+
+  let lastSequence = -1;
+  let complete = false;
+  let result: PollResult = { succeeded: true, runId };
+  const pollIntervalMs = 1000;
+
+  while (!complete) {
+    // 1. Fetch events from telemetry endpoint
+    const eventsResponse = await getZeroRunAgentEvents(runId, {
+      since: lastSequence,
+      limit: 100,
+      order: "asc",
+    });
+
+    // 2. Parse and render each event
+    for (const event of eventsResponse.events) {
+      const eventData = event.eventData as Record<string, unknown>;
+      const parsed = parseEvent(eventData);
+      if (parsed) {
+        renderer.render(parsed);
+      }
+    }
+
+    // 3. Track last sequence number for pagination
+    if (eventsResponse.events.length > 0) {
+      lastSequence = Math.max(
+        ...eventsResponse.events.map((e) => e.sequenceNumber),
+      );
+    }
+
+    // 4. Fetch run status separately
+    const runResponse = await getZeroRun(runId);
+    const runStatus = runResponse.status;
+
+    if (runStatus === "completed") {
+      complete = true;
+      EventRenderer.renderRunCompleted(
+        runResponse.result as RunResult | undefined,
+      );
+      result = {
+        succeeded: true,
+        runId,
+        sessionId: runResponse.result?.agentSessionId,
+        checkpointId: runResponse.result?.checkpointId,
+      };
+    } else if (runStatus === "failed") {
+      complete = true;
+      EventRenderer.renderRunFailed(runResponse.error, runId);
+      result = { succeeded: false, runId };
+    } else if (runStatus === "timeout") {
+      complete = true;
+      console.error(chalk.red("\n✗ Run timed out"));
+      result = { succeeded: false, runId };
+    } else if (runStatus === "cancelled") {
+      complete = true;
+      console.error(chalk.yellow("\n✗ Run cancelled"));
+      result = { succeeded: false, runId };
+    }
+
+    if (!complete) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Display next steps after successful zero run
+ */
+export function showZeroNextSteps(result: PollResult): void {
+  const { sessionId } = result;
+
+  console.log();
+
+  if (sessionId) {
+    console.log("  Continue delegation:");
+    console.log(
+      chalk.cyan(`    zero run continue ${sessionId} "your next prompt"`),
+    );
+  }
+}

--- a/turbo/apps/cli/src/commands/zero/run/shared.ts
+++ b/turbo/apps/cli/src/commands/zero/run/shared.ts
@@ -6,6 +6,26 @@ import { EventRenderer } from "../../../lib/events/event-renderer";
 import type { PollResult, EventRenderingOptions } from "../../run/shared";
 
 /**
+ * Safely narrow GetRunResponse.result to RunResult.
+ * GetRunResponse.result has all fields optional (due to .passthrough()),
+ * but RunResult requires checkpointId, agentSessionId, conversationId.
+ * Extra fields (artifact, volumes, memory) are preserved at runtime via passthrough.
+ */
+function toRunResult(result: {
+  output?: string;
+  executionTimeMs?: number;
+  agentSessionId?: string;
+  checkpointId?: string;
+  conversationId?: string;
+}): RunResult | undefined {
+  const { checkpointId, agentSessionId, conversationId } = result;
+  if (!checkpointId || !agentSessionId || !conversationId) {
+    return undefined;
+  }
+  return { checkpointId, agentSessionId, conversationId };
+}
+
+/**
  * Poll for zero run events until run completes.
  * Uses dual-poll approach: telemetry endpoint for events, getById for status.
  */
@@ -51,7 +71,7 @@ export async function pollZeroEvents(
     if (runStatus === "completed") {
       complete = true;
       EventRenderer.renderRunCompleted(
-        runResponse.result as RunResult | undefined,
+        runResponse.result ? toRunResult(runResponse.result) : undefined,
       );
       result = {
         succeeded: true,

--- a/turbo/apps/cli/src/commands/zero/run/shared.ts
+++ b/turbo/apps/cli/src/commands/zero/run/shared.ts
@@ -3,17 +3,7 @@ import { getZeroRunAgentEvents, getZeroRun } from "../../../lib/api";
 import type { RunResult } from "../../../lib/api";
 import { parseEvent } from "../../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../../lib/events/event-renderer";
-
-interface PollResult {
-  succeeded: boolean;
-  runId: string;
-  sessionId?: string;
-  checkpointId?: string;
-}
-
-interface EventRenderingOptions {
-  verbose?: boolean;
-}
+import type { PollResult, EventRenderingOptions } from "../../run/shared";
 
 /**
  * Poll for zero run events until run completes.

--- a/turbo/apps/cli/src/lib/api/domains/zero-runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-runs.ts
@@ -1,0 +1,54 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroRunsMainContract,
+  zeroRunsByIdContract,
+  zeroRunAgentEventsContract,
+  type CreateRunResponse,
+  type GetRunResponse,
+  type AgentEventsResponse,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function createZeroRun(body: {
+  agentId?: string;
+  sessionId?: string;
+  checkpointId?: string;
+  prompt: string;
+  appendSystemPrompt?: string;
+  modelProvider?: string;
+  tools?: string[];
+  settings?: string;
+  checkEnv?: boolean;
+}): Promise<CreateRunResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroRunsMainContract, config);
+  const result = await client.create({ body });
+  if (result.status === 201) return result.body;
+  handleError(result, "Failed to create zero run");
+}
+
+export async function getZeroRun(id: string): Promise<GetRunResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroRunsByIdContract, config);
+  const result = await client.getById({ params: { id } });
+  if (result.status === 200) return result.body;
+  handleError(result, `Failed to get zero run "${id}"`);
+}
+
+export async function getZeroRunAgentEvents(
+  id: string,
+  options?: { since?: number; limit?: number; order?: "asc" | "desc" },
+): Promise<AgentEventsResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroRunAgentEventsContract, config);
+  const result = await client.getAgentEvents({
+    params: { id },
+    query: {
+      since: options?.since,
+      limit: options?.limit ?? 100,
+      order: options?.order ?? "asc",
+    },
+  });
+  if (result.status === 200) return result.body;
+  handleError(result, `Failed to get zero run events for "${id}"`);
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -129,6 +129,13 @@ export {
   resolveZeroScheduleByAgent,
 } from "./domains/zero-schedules";
 
+// Domain modules - Zero Runs
+export {
+  createZeroRun,
+  getZeroRun,
+  getZeroRunAgentEvents,
+} from "./domains/zero-runs";
+
 // Domain modules - Logs
 export {
   getSystemLog,

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -8,6 +8,7 @@ import { zeroAgentCommand } from "./commands/zero/agent";
 import { zeroConnectorCommand } from "./commands/zero/connector";
 import { zeroDoctorCommand } from "./commands/zero/doctor";
 import { zeroPreferenceCommand } from "./commands/zero/preference";
+import { zeroRunCommand } from "./commands/zero/run";
 import { zeroScheduleCommand } from "./commands/zero/schedule";
 import { zeroSecretCommand } from "./commands/zero/secret";
 import { zeroSlackCommand } from "./commands/zero/slack";
@@ -26,6 +27,7 @@ import {
  */
 const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   agent: "agent:read",
+  run: "agent-run:write",
   schedule: "schedule:read",
   doctor: null,
   slack: "slack:write",
@@ -39,6 +41,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroConnectorCommand,
   zeroDoctorCommand,
   zeroPreferenceCommand,
+  zeroRunCommand,
   zeroScheduleCommand,
   zeroSecretCommand,
   zeroSlackCommand,
@@ -93,6 +96,7 @@ program
     `
 Common scenarios:
   Missing a token?       zero doctor missing-token <TOKEN_NAME>
+  Delegate to teammate?  zero run <agent-id> "your task"
   Send a Slack message?  zero slack message send -c <channel> -t "text"
   Set up a schedule?     zero schedule setup <agent-name>
   Update yourself?       zero agent --help

--- a/turbo/package.json
+++ b/turbo/package.json
@@ -48,6 +48,7 @@
       "glob": ">=10.5.0",
       "tar": ">=7.5.7",
       "@isaacs/brace-expansion": ">=5.0.1",
+      "brace-expansion": ">=5.0.5",
       "axios": ">=1.13.5",
       "dompurify": ">=3.3.2",
       "js-yaml": ">=4.1.1",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   glob: '>=10.5.0'
   tar: '>=7.5.7'
   '@isaacs/brace-expansion': '>=5.0.1'
+  brace-expansion: '>=5.0.5'
   axios: '>=1.13.5'
   dompurify: '>=3.3.2'
   js-yaml: '>=4.1.1'
@@ -58,7 +59,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   apps/cli:
     dependencies:
@@ -134,7 +135,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   apps/docs:
     dependencies:
@@ -343,7 +344,7 @@ importers:
         version: 7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   apps/web:
     dependencies:
@@ -542,7 +543,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/core:
     dependencies:
@@ -573,7 +574,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   packages/eslint-config:
     devDependencies:
@@ -728,7 +729,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -5188,8 +5189,8 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -8978,7 +8979,6 @@ packages:
       '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -13790,7 +13790,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -13837,7 +13837,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@4.1.0':
     dependencies:
@@ -14159,7 +14159,7 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -16854,7 +16854,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 
@@ -18678,7 +18678,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -18706,9 +18706,19 @@ snapshots:
       '@vitest/ui': 4.1.0(vitest@4.1.0)
       happy-dom: 20.1.0
     transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.3.0)(@vitest/ui@4.1.0)(happy-dom@20.8.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(msw@2.12.7(@types/node@24.3.0)(typescript@5.9.3))(vite@7.3.1(@types/node@24.3.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -18736,7 +18746,17 @@ snapshots:
       '@vitest/ui': 4.1.0(vitest@4.1.0)
       happy-dom: 20.8.4
     transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vscode-jsonrpc@8.2.0: {}
 


### PR DESCRIPTION
## Summary

- Add `zero run <agent-id> <prompt>` command to delegate tasks to teammate agents from inside sandboxes
- Add `zero run continue <session-id> <prompt>` command to continue a previous delegation session
- Create zero-runs API client with dual-poll event streaming (telemetry endpoint for events, getById for run status)
- Register `run` command with `agent-run:write` capability gating in the zero CLI
- Reuse existing `EventRenderer` and `parseEvent` infrastructure from `vm0 run`

## Test plan

- [x] All 836 CLI tests pass (89 test files)
- [x] New capability visibility tests: `run` visible with `agent-run:write`, hidden without
- [x] Zero CLI test updated: 11 commands, `run` included in expected commands
- [x] TypeScript type check passes
- [x] Lint, format, knip all clean
- [ ] CI pipeline passes
- [ ] Manual verification: `zero run --help` shows command and subcommands

Closes #6984

🤖 Generated with [Claude Code](https://claude.com/claude-code)