### PR TITLE
fix(web): align schedule page spacing with logs and fix sidebar x button color

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -3,8 +3,6 @@ import { useGet, useSet, useLoadable, useLastLoadable } from "ccstate-react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { IconList, IconLayoutGrid, IconPlus } from "@tabler/icons-react";
 import {
-  Card,
-  CardContent,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -589,41 +587,39 @@ export function ZeroSchedulePage() {
 
       <main className="flex-1 overflow-auto px-4 sm:px-6 pt-4 pb-8">
         <div className="mx-auto max-w-[900px]">
-          <Card className="zero-card">
-            <CardContent className="py-5 flex flex-col gap-6">
-              {isInitialLoading ? (
-                scheduleViewMode === "calendar" ? (
-                  <ScheduleCalendarSkeleton />
-                ) : (
-                  <ScheduleListSkeleton />
-                )
-              ) : scheduleViewMode === "list" ? (
-                <ScheduleListView
-                  entries={combinedSchedule}
-                  togglingIds={togglingIds}
-                  runningIds={runningIds}
-                  getAgentLabel={(e) => e.agentLabel}
-                  onEdit={openScheduleDetail}
-                  onToggle={(entry, enabled) => {
-                    handleToggle(entry, enabled).catch(() => {});
-                  }}
-                  onDelete={handleDelete}
-                  onNew={() => setCreateOpen(true)}
-                  onRunNow={(entry) => {
-                    handleRunNow(entry).catch(() => {});
-                  }}
-                  onOpenDetails={openScheduleDetail}
-                />
+          <div className="zero-card overflow-hidden px-4 sm:px-7 pb-3">
+            {isInitialLoading ? (
+              scheduleViewMode === "calendar" ? (
+                <ScheduleCalendarSkeleton />
               ) : (
-                <ScheduleCalendarView
-                  entries={combinedSchedule}
-                  agentOrder={agentOrder}
-                  getAgentLabel={(e) => e.agentLabel}
-                  onEdit={openScheduleDetail}
-                />
-              )}
-            </CardContent>
-          </Card>
+                <ScheduleListSkeleton />
+              )
+            ) : scheduleViewMode === "list" ? (
+              <ScheduleListView
+                entries={combinedSchedule}
+                togglingIds={togglingIds}
+                runningIds={runningIds}
+                getAgentLabel={(e) => e.agentLabel}
+                onEdit={openScheduleDetail}
+                onToggle={(entry, enabled) => {
+                  handleToggle(entry, enabled).catch(() => {});
+                }}
+                onDelete={handleDelete}
+                onNew={() => setCreateOpen(true)}
+                onRunNow={(entry) => {
+                  handleRunNow(entry).catch(() => {});
+                }}
+                onOpenDetails={openScheduleDetail}
+              />
+            ) : (
+              <ScheduleCalendarView
+                entries={combinedSchedule}
+                agentOrder={agentOrder}
+                getAgentLabel={(e) => e.agentLabel}
+                onEdit={openScheduleDetail}
+              />
+            )}
+          </div>
         </div>
       </main>
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -764,7 +764,7 @@ function TalkToSection({
                         }}
                         className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 ${
                           isPrimarySelected
-                            ? "text-sidebar-primary/80 hover:text-white hover:bg-white/20"
+                            ? "text-slate-500 hover:text-slate-900 hover:bg-slate-300"
                             : "text-sidebar-foreground/80 hover:text-foreground hover:bg-sidebar-foreground/10"
                         }`}
                         aria-label="Remove from list"


### PR DESCRIPTION
## Summary
- **Schedule page spacing:** Replace `Card > CardContent(py-5)` wrapper with `div.zero-card(px-4 sm:px-7 pb-3)` to match activity logs page layout
- **Sidebar X button color:** Fix pinned agent remove button showing white on light `bg-slate-200` selected background — change from `hover:text-white` to `text-slate-500 hover:text-slate-900 hover:bg-slate-300`

## Test plan
- [ ] Open schedule page, verify table spacing matches activity logs page
- [ ] Select a pinned agent in sidebar, hover over the X button — verify it's visible (not white) on the selected background

🤖 Generated with [Claude Code](https://claude.com/claude-code)