### PR TITLE
feat: add agent trigger source, sessionId inference, and agent tools prompt for zero run

### DIFF
--- a/e2e/tests/03-runner/t12-vm0-env-expansion.bats
+++ b/e2e/tests/03-runner/t12-vm0-env-expansion.bats
@@ -2,22 +2,37 @@
 
 load '../../helpers/setup'
 
-setup() {
-    # Create unique volume for this test
-    create_test_volume "e2e-vol-t12"
+# ============================================================================
+# File-level setup: create volume, compose config, and artifact ONCE.
+# ============================================================================
 
+setup_file() {
     export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
-    export SECRET_VALUE="secret-value-${UNIQUE_ID}"
-    export VAR_VALUE="var-value-${UNIQUE_ID}"
-    export ARTIFACT_NAME="e2e-env-test-${UNIQUE_ID}"
-    export AGENT_NAME="vm0-env-expansion-${UNIQUE_ID}"
-    export TEST_ARTIFACT_DIR="$(mktemp -d)"
-    export TEST_ENV_DIR="$(mktemp -d)"
-    export TEST_CONFIG="$TEST_ARTIFACT_DIR/vm0-env-expansion.yaml"
-}
+    export TEST_DIR="$(mktemp -d)"
 
-# Helper to create config dynamically
-create_env_expansion_config() {
+    # Create volume once
+    export VOLUME_NAME="e2e-vol-t12-${UNIQUE_ID}"
+    mkdir -p "$TEST_DIR/$VOLUME_NAME"
+    cd "$TEST_DIR/$VOLUME_NAME"
+    cat > CLAUDE.md << 'VOLEOF'
+This is a test file for the volume.
+VOLEOF
+    $VM0_CLI volume init --name "$VOLUME_NAME" >/dev/null
+    $VM0_CLI volume push >/dev/null
+    cd - >/dev/null
+
+    # Create artifact once
+    export ARTIFACT_NAME="e2e-env-test-${UNIQUE_ID}"
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null 2>&1
+    echo "test content" > test.txt
+    $VM0_CLI artifact push >/dev/null 2>&1
+    cd - >/dev/null
+
+    # Create compose config once
+    export AGENT_NAME="vm0-env-expansion-${UNIQUE_ID}"
+    export TEST_CONFIG="$TEST_DIR/vm0-env-expansion.yaml"
     cat > "$TEST_CONFIG" <<EOF
 version: "1.0"
 
@@ -37,57 +52,38 @@ volumes:
     name: $VOLUME_NAME
     version: latest
 EOF
+    $VM0_CLI compose "$TEST_CONFIG" >/dev/null
 }
 
-teardown() {
-    # Clean up temporary directories
-    if [ -n "$TEST_ARTIFACT_DIR" ] && [ -d "$TEST_ARTIFACT_DIR" ]; then
-        rm -rf "$TEST_ARTIFACT_DIR"
+teardown_file() {
+    # Clean up shared test directory
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
     fi
-    if [ -n "$TEST_ENV_DIR" ] && [ -d "$TEST_ENV_DIR" ]; then
-        rm -rf "$TEST_ENV_DIR"
-    fi
-    # Clean up test volume
-    cleanup_test_volume
-}
-
-# Helper to create artifact for tests
-setup_artifact() {
-    # Create config dynamically (each test needs its own due to parallel execution)
-    create_env_expansion_config
-    mkdir -p "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
-    cd "$TEST_ARTIFACT_DIR/$ARTIFACT_NAME"
-    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null 2>&1
-    echo "test content" > test.txt
-    $VM0_CLI artifact push >/dev/null 2>&1
 }
 
 # Environment variable expansion tests with --secrets flag
 
 @test "vm0 run expands vars and secrets via --secrets flag" {
-    echo "# Step 1: Create and push artifact"
-    setup_artifact
+    local secret_value="secret-value-${UNIQUE_ID}"
+    local var_value="var-value-${UNIQUE_ID}"
 
-    echo "# Step 2: Build the compose"
-    run $VM0_CLI compose "$TEST_CONFIG"
-    assert_success
-
-    echo "# Step 3: Run with --vars and --secrets flags"
+    echo "# Running with --vars and --secrets flags"
     run $VM0_CLI run "$AGENT_NAME" \
-        --vars "testVar=${VAR_VALUE}" \
-        --secrets "TEST_SECRET=${SECRET_VALUE}" \
+        --vars "testVar=${var_value}" \
+        --secrets "TEST_SECRET=${secret_value}" \
         --artifact-name "$ARTIFACT_NAME" \
         --verbose \
         "echo VAR=\$TEST_VAR && echo SECRET=\$TEST_SECRET"
     assert_success
 
-    echo "# Step 4: Verify vars are expanded"
-    assert_output --partial "VAR=${VAR_VALUE}"
+    echo "# Verify vars are expanded"
+    assert_output --partial "VAR=${var_value}"
 
-    echo "# Step 5: Verify secrets are masked in output"
+    echo "# Verify secrets are masked in output"
     # The secret value should be replaced with *** for security
     assert_output --partial "SECRET=***"
-    refute_output --partial "SECRET=${SECRET_VALUE}"
+    refute_output --partial "SECRET=${secret_value}"
 }
 
 # Note: The following tests have been moved to Route Integration tests

--- a/e2e/tests/03-runner/t29-zero-secret.bats
+++ b/e2e/tests/03-runner/t29-zero-secret.bats
@@ -6,14 +6,94 @@ load '../../helpers/setup'
 # Validation tests (help text, name validation, error handling) are in unit tests:
 # turbo/apps/cli/src/commands/zero/secret/__tests__/*.test.ts
 
+# ============================================================================
+# File-level setup: create volume, compose config, and artifact ONCE for all
+# heavy (vm0 run) tests. Lightweight CRUD tests don't need these resources.
+# ============================================================================
+
+setup_file() {
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export TEST_DIR="$(mktemp -d)"
+
+    # Create volume once for all vm0 run tests
+    export VOLUME_NAME="e2e-vol-secret-${UNIQUE_ID}"
+    mkdir -p "$TEST_DIR/$VOLUME_NAME"
+    cd "$TEST_DIR/$VOLUME_NAME"
+    cat > CLAUDE.md << 'VOLEOF'
+This is a test file for the volume.
+VOLEOF
+    $VM0_CLI volume init --name "$VOLUME_NAME" >/dev/null
+    $VM0_CLI volume push >/dev/null
+    cd - >/dev/null
+
+    # Create artifact once
+    export ARTIFACT_NAME="e2e-secret-art-${UNIQUE_ID}"
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null 2>&1
+    echo "test content" > test.txt
+    $VM0_CLI artifact push >/dev/null 2>&1
+    cd - >/dev/null
+
+    # Create compose config for single-secret masking test
+    export AGENT_MASK="e2e-secret-mask-${UNIQUE_ID}"
+    export CONFIG_MASK="$TEST_DIR/mask.yaml"
+    cat > "$CONFIG_MASK" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_MASK}:
+    description: "E2E test agent for secret masking"
+    framework: claude-code
+    working_dir: /home/user/workspace
+    environment:
+      MY_SECRET: "\${{ secrets.MY_SECRET }}"
+    volumes:
+      - claude-files:/home/user/.claude
+volumes:
+  claude-files:
+    name: $VOLUME_NAME
+    version: latest
+EOF
+    $VM0_CLI compose "$CONFIG_MASK" >/dev/null
+
+    # Create compose config for multi-secret masking test
+    export AGENT_MULTI="e2e-secret-multi-${UNIQUE_ID}"
+    export CONFIG_MULTI="$TEST_DIR/multi.yaml"
+    cat > "$CONFIG_MULTI" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_MULTI}:
+    description: "E2E test agent for multiple secrets"
+    framework: claude-code
+    working_dir: /home/user/workspace
+    environment:
+      API_KEY: "\${{ secrets.API_KEY }}"
+      CLI_SECRET: "\${{ secrets.CLI_SECRET }}"
+    volumes:
+      - claude-files:/home/user/.claude
+volumes:
+  claude-files:
+    name: $VOLUME_NAME
+    version: latest
+EOF
+    $VM0_CLI compose "$CONFIG_MULTI" >/dev/null
+}
+
 # Generate unique secret name for each test run to avoid conflicts
 setup() {
     export TEST_SECRET_NAME="E2E_TEST_SECRET_$(date +%s%3N)_$RANDOM"
 }
 
 teardown() {
-    # Clean up test secret if it exists
-    $ZERO_CLI secret delete -y "$TEST_SECRET_NAME" 2>/dev/null || true
+    # Filesystem-only cleanup — no API calls during per-test teardown
+    :
+}
+
+teardown_file() {
+    # Clean up shared test directory
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
 }
 
 @test "zero secret --help shows command description" {
@@ -29,6 +109,9 @@ teardown() {
     run $ZERO_CLI secret set "$TEST_SECRET_NAME" --body "test-secret-value"
     assert_success
     assert_output --partial "Secret \"$TEST_SECRET_NAME\" saved"
+
+    # Clean up inline since teardown no longer does API calls
+    $ZERO_CLI secret delete -y "$TEST_SECRET_NAME" 2>/dev/null || true
 }
 
 @test "zero secret list shows created secret" {
@@ -41,6 +124,8 @@ teardown() {
     assert_output --partial "$TEST_SECRET_NAME"
     assert_output --partial "E2E test"
     assert_output --partial "secret(s)"
+
+    $ZERO_CLI secret delete -y "$TEST_SECRET_NAME" 2>/dev/null || true
 }
 
 @test "zero secret ls works as alias for list" {
@@ -51,6 +136,8 @@ teardown() {
     run $ZERO_CLI secret ls
     assert_success
     assert_output --partial "$TEST_SECRET_NAME"
+
+    $ZERO_CLI secret delete -y "$TEST_SECRET_NAME" 2>/dev/null || true
 }
 
 @test "zero secret set updates existing secret" {
@@ -65,6 +152,8 @@ teardown() {
     # Verify description was updated
     run $ZERO_CLI secret list
     assert_output --partial "Updated"
+
+    $ZERO_CLI secret delete -y "$TEST_SECRET_NAME" 2>/dev/null || true
 }
 
 @test "zero secret delete removes secret" {
@@ -84,7 +173,8 @@ teardown() {
 
 # ============================================================================
 # Secret Masking Tests
-# These tests verify that secret values are masked in agent output
+# These tests verify that secret values are masked in agent output.
+# Heavy setup (volume, compose, artifact) is shared via setup_file().
 # ============================================================================
 
 @test "vm0 run masks secret values in output" {
@@ -92,51 +182,13 @@ teardown() {
         skip "VM0_API_URL not set"
     fi
 
-    # Create unique identifiers for this test
-    local unique_id="$(date +%s%3N)-$RANDOM"
-    local secret_value="secret-${unique_id}"
-    local artifact_name="e2e-secret-mask-${unique_id}"
-    local agent_name="e2e-secret-mask-${unique_id}"
-    local test_artifact_dir="$(mktemp -d)"
-    local test_config="$(mktemp --suffix=.yaml)"
+    local secret_value="secret-${UNIQUE_ID}"
 
-    # Create test volume
-    create_test_volume "e2e-vol-secret-mask"
-
-    # Step 1: Create config that uses a secret
-    cat > "$test_config" <<EOF
-version: "1.0"
-agents:
-  ${agent_name}:
-    description: "E2E test agent for secret masking"
-    framework: claude-code
-    working_dir: /home/user/workspace
-    environment:
-      MY_SECRET: "\${{ secrets.MY_SECRET }}"
-    volumes:
-      - claude-files:/home/user/.claude
-volumes:
-  claude-files:
-    name: $VOLUME_NAME
-    version: latest
-EOF
-
-    # Step 2: Create artifact
-    mkdir -p "$test_artifact_dir/$artifact_name"
-    cd "$test_artifact_dir/$artifact_name"
-    $VM0_CLI artifact init --name "$artifact_name" >/dev/null 2>&1
-    echo "test content" > test.txt
-    $VM0_CLI artifact push >/dev/null 2>&1
-
-    # Step 3: Build the compose
-    run $VM0_CLI compose "$test_config"
-    assert_success
-
-    # Step 4: Run agent with secret provided via CLI
+    # Run agent with secret provided via CLI
     echo "# Running agent that echoes secret value..."
-    run $VM0_CLI run "$agent_name" \
+    run $VM0_CLI run "$AGENT_MASK" \
         --secrets "MY_SECRET=${secret_value}" \
-        --artifact-name "$artifact_name" \
+        --artifact-name "$ARTIFACT_NAME" \
         "echo SECRET=\$MY_SECRET"
 
     echo "# Output:"
@@ -147,11 +199,6 @@ EOF
     # Verify secret value is masked
     assert_output --partial "SECRET=***"
     refute_output --partial "SECRET=${secret_value}"
-
-    # Cleanup
-    rm -rf "$test_artifact_dir"
-    rm -f "$test_config"
-    cleanup_test_volume
 }
 
 @test "vm0 run masks multiple CLI secrets in output" {
@@ -159,54 +206,15 @@ EOF
         skip "VM0_API_URL not set"
     fi
 
-    # Create unique identifiers for this test
-    local unique_id="$(date +%s%3N)-$RANDOM"
-    local secret1_value="secret1-${unique_id}"
-    local secret2_value="secret2-${unique_id}"
-    local artifact_name="e2e-secret-multi-${unique_id}"
-    local agent_name="e2e-secret-multi-${unique_id}"
-    local test_artifact_dir="$(mktemp -d)"
-    local test_config="$(mktemp --suffix=.yaml)"
+    local secret1_value="secret1-${UNIQUE_ID}"
+    local secret2_value="secret2-${UNIQUE_ID}"
 
-    # Create test volume
-    create_test_volume "e2e-vol-secret-multi"
-
-    # Step 1: Create config that uses multiple secrets
-    cat > "$test_config" <<EOF
-version: "1.0"
-agents:
-  ${agent_name}:
-    description: "E2E test agent for multiple secrets"
-    framework: claude-code
-    working_dir: /home/user/workspace
-    environment:
-      API_KEY: "\${{ secrets.API_KEY }}"
-      CLI_SECRET: "\${{ secrets.CLI_SECRET }}"
-    volumes:
-      - claude-files:/home/user/.claude
-volumes:
-  claude-files:
-    name: $VOLUME_NAME
-    version: latest
-EOF
-
-    # Step 2: Create artifact
-    mkdir -p "$test_artifact_dir/$artifact_name"
-    cd "$test_artifact_dir/$artifact_name"
-    $VM0_CLI artifact init --name "$artifact_name" >/dev/null 2>&1
-    echo "test content" > test.txt
-    $VM0_CLI artifact push >/dev/null 2>&1
-
-    # Step 3: Build the compose
-    run $VM0_CLI compose "$test_config"
-    assert_success
-
-    # Step 4: Run agent with multiple CLI secrets
+    # Run agent with multiple CLI secrets
     echo "# Running agent with multiple CLI secrets..."
-    run $VM0_CLI run "$agent_name" \
+    run $VM0_CLI run "$AGENT_MULTI" \
         --secrets "API_KEY=${secret1_value}" \
         --secrets "CLI_SECRET=${secret2_value}" \
-        --artifact-name "$artifact_name" \
+        --artifact-name "$ARTIFACT_NAME" \
         "echo API_KEY=\$API_KEY && echo CLI_SECRET=\$CLI_SECRET"
 
     echo "# Output:"
@@ -221,9 +229,4 @@ EOF
     # Neither actual value should appear
     refute_output --partial "${secret1_value}"
     refute_output --partial "${secret2_value}"
-
-    # Cleanup
-    rm -rf "$test_artifact_dir"
-    rm -f "$test_config"
-    cleanup_test_volume
 }

--- a/e2e/tests/03-runner/t31-zero-variable.bats
+++ b/e2e/tests/03-runner/t31-zero-variable.bats
@@ -6,14 +6,94 @@ load '../../helpers/setup'
 # Validation tests (help text, name validation, error handling) are in unit tests:
 # turbo/apps/cli/src/commands/zero/variable/__tests__/*.test.ts
 
+# ============================================================================
+# File-level setup: create volume, compose config, and artifact ONCE for all
+# heavy (vm0 run) tests. Lightweight CRUD tests don't need these resources.
+# ============================================================================
+
+setup_file() {
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export TEST_DIR="$(mktemp -d)"
+
+    # Create volume once for all vm0 run tests
+    export VOLUME_NAME="e2e-vol-var-${UNIQUE_ID}"
+    mkdir -p "$TEST_DIR/$VOLUME_NAME"
+    cd "$TEST_DIR/$VOLUME_NAME"
+    cat > CLAUDE.md << 'VOLEOF'
+This is a test file for the volume.
+VOLEOF
+    $VM0_CLI volume init --name "$VOLUME_NAME" >/dev/null
+    $VM0_CLI volume push >/dev/null
+    cd - >/dev/null
+
+    # Create artifact once
+    export ARTIFACT_NAME="e2e-var-art-${UNIQUE_ID}"
+    mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
+    cd "$TEST_DIR/$ARTIFACT_NAME"
+    $VM0_CLI artifact init --name "$ARTIFACT_NAME" >/dev/null 2>&1
+    echo "test content" > test.txt
+    $VM0_CLI artifact push >/dev/null 2>&1
+    cd - >/dev/null
+
+    # Create compose configs for both vm0 run tests
+    export AGENT_EXPAND="e2e-var-expand-${UNIQUE_ID}"
+    export CONFIG_EXPAND="$TEST_DIR/expand.yaml"
+    cat > "$CONFIG_EXPAND" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_EXPAND}:
+    description: "E2E test agent for variable expansion"
+    framework: claude-code
+    working_dir: /home/user/workspace
+    environment:
+      MY_VAR: "\${{ vars.TEST_VAR }}"
+    volumes:
+      - claude-files:/home/user/.claude
+volumes:
+  claude-files:
+    name: $VOLUME_NAME
+    version: latest
+EOF
+    $VM0_CLI compose "$CONFIG_EXPAND" >/dev/null
+
+    export AGENT_OVERRIDE="e2e-var-override-${UNIQUE_ID}"
+    export CONFIG_OVERRIDE="$TEST_DIR/override.yaml"
+    cat > "$CONFIG_OVERRIDE" <<EOF
+version: "1.0"
+agents:
+  ${AGENT_OVERRIDE}:
+    description: "E2E test agent for variable override"
+    framework: claude-code
+    working_dir: /home/user/workspace
+    environment:
+      MY_VAR: "\${{ vars.TEST_VAR }}"
+    volumes:
+      - claude-files:/home/user/.claude
+volumes:
+  claude-files:
+    name: $VOLUME_NAME
+    version: latest
+EOF
+    $VM0_CLI compose "$CONFIG_OVERRIDE" >/dev/null
+}
+
 # Generate unique variable name for each test run to avoid conflicts
 setup() {
     export TEST_VAR_NAME="E2E_TEST_VAR_$(date +%s%3N)_$RANDOM"
 }
 
 teardown() {
-    # Clean up test variable if it exists
-    $ZERO_CLI variable delete -y "$TEST_VAR_NAME" 2>/dev/null || true
+    # Filesystem-only cleanup — no API calls during per-test teardown
+    :
+}
+
+teardown_file() {
+    # Clean up the variable used by vm0 run tests (single API call, once)
+    $ZERO_CLI variable delete -y "TEST_VAR" 2>/dev/null || true
+    # Clean up shared test directory
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
 }
 
 @test "zero variable --help shows command description" {
@@ -29,6 +109,9 @@ teardown() {
     run $ZERO_CLI variable set "$TEST_VAR_NAME" "test-variable-value"
     assert_success
     assert_output --partial "Variable \"$TEST_VAR_NAME\" saved"
+
+    # Clean up inline since teardown no longer does API calls
+    $ZERO_CLI variable delete -y "$TEST_VAR_NAME" 2>/dev/null || true
 }
 
 @test "zero variable list shows created variable with value" {
@@ -42,6 +125,8 @@ teardown() {
     assert_output --partial "my-test-value"
     assert_output --partial "E2E test"
     assert_output --partial "variable(s)"
+
+    $ZERO_CLI variable delete -y "$TEST_VAR_NAME" 2>/dev/null || true
 }
 
 @test "zero variable ls works as alias for list" {
@@ -53,6 +138,8 @@ teardown() {
     assert_success
     assert_output --partial "$TEST_VAR_NAME"
     assert_output --partial "alias-test-value"
+
+    $ZERO_CLI variable delete -y "$TEST_VAR_NAME" 2>/dev/null || true
 }
 
 @test "zero variable set updates existing variable" {
@@ -68,6 +155,8 @@ teardown() {
     run $ZERO_CLI variable list
     assert_output --partial "updated-value"
     assert_output --partial "Updated"
+
+    $ZERO_CLI variable delete -y "$TEST_VAR_NAME" 2>/dev/null || true
 }
 
 @test "zero variable delete removes variable" {
@@ -87,7 +176,8 @@ teardown() {
 
 # ============================================================================
 # Variable Expansion Tests
-# These tests verify that variable values are expanded in agent environment
+# These tests verify that variable values are expanded in agent environment.
+# Heavy setup (volume, compose, artifact) is shared via setup_file().
 # ============================================================================
 
 @test "vm0 run expands server-stored variables" {
@@ -95,53 +185,15 @@ teardown() {
         skip "VM0_API_URL not set"
     fi
 
-    # Create unique identifiers for this test
-    local unique_id="$(date +%s%3N)-$RANDOM"
-    local var_value="var-value-${unique_id}"
-    local artifact_name="e2e-var-expand-${unique_id}"
-    local agent_name="e2e-var-expand-${unique_id}"
-    local test_artifact_dir="$(mktemp -d)"
-    local test_config="$(mktemp --suffix=.yaml)"
+    local var_value="var-value-${UNIQUE_ID}"
 
-    # Create test volume
-    create_test_volume "e2e-vol-var-expand"
+    # Set a server-stored variable
+    $ZERO_CLI variable set "TEST_VAR" "$var_value"
 
-    # Step 1: Create a server-stored variable
-    $ZERO_CLI variable set "$TEST_VAR_NAME" "$var_value"
-
-    # Step 2: Create config that uses the variable
-    cat > "$test_config" <<EOF
-version: "1.0"
-agents:
-  ${agent_name}:
-    description: "E2E test agent for variable expansion"
-    framework: claude-code
-    working_dir: /home/user/workspace
-    environment:
-      MY_VAR: "\${{ vars.$TEST_VAR_NAME }}"
-    volumes:
-      - claude-files:/home/user/.claude
-volumes:
-  claude-files:
-    name: $VOLUME_NAME
-    version: latest
-EOF
-
-    # Step 3: Create artifact
-    mkdir -p "$test_artifact_dir/$artifact_name"
-    cd "$test_artifact_dir/$artifact_name"
-    $VM0_CLI artifact init --name "$artifact_name" >/dev/null 2>&1
-    echo "test content" > test.txt
-    $VM0_CLI artifact push >/dev/null 2>&1
-
-    # Step 4: Build the compose
-    run $VM0_CLI compose "$test_config"
-    assert_success
-
-    # Step 5: Run agent that echoes the variable value
+    # Run agent that echoes the variable value
     echo "# Running agent that echoes variable value..."
-    run $VM0_CLI run "$agent_name" \
-        --artifact-name "$artifact_name" \
+    run $VM0_CLI run "$AGENT_EXPAND" \
+        --artifact-name "$ARTIFACT_NAME" \
         "echo MY_VAR=\$MY_VAR"
 
     echo "# Output:"
@@ -151,11 +203,6 @@ EOF
 
     # Verify variable value is expanded (NOT masked like secrets)
     assert_output --partial "MY_VAR=${var_value}"
-
-    # Cleanup
-    rm -rf "$test_artifact_dir"
-    rm -f "$test_config"
-    cleanup_test_volume
 }
 
 @test "vm0 run CLI vars override server-stored variables" {
@@ -163,55 +210,17 @@ EOF
         skip "VM0_API_URL not set"
     fi
 
-    # Create unique identifiers for this test
-    local unique_id="$(date +%s%3N)-$RANDOM"
-    local server_value="server-value-${unique_id}"
-    local cli_value="cli-value-${unique_id}"
-    local artifact_name="e2e-var-override-${unique_id}"
-    local agent_name="e2e-var-override-${unique_id}"
-    local test_artifact_dir="$(mktemp -d)"
-    local test_config="$(mktemp --suffix=.yaml)"
+    local server_value="server-value-${UNIQUE_ID}"
+    local cli_value="cli-value-${UNIQUE_ID}"
 
-    # Create test volume
-    create_test_volume "e2e-vol-var-override"
+    # Set a server-stored variable
+    $ZERO_CLI variable set "TEST_VAR" "$server_value"
 
-    # Step 1: Create a server-stored variable
-    $ZERO_CLI variable set "$TEST_VAR_NAME" "$server_value"
-
-    # Step 2: Create config that uses the variable
-    cat > "$test_config" <<EOF
-version: "1.0"
-agents:
-  ${agent_name}:
-    description: "E2E test agent for variable override"
-    framework: claude-code
-    working_dir: /home/user/workspace
-    environment:
-      MY_VAR: "\${{ vars.$TEST_VAR_NAME }}"
-    volumes:
-      - claude-files:/home/user/.claude
-volumes:
-  claude-files:
-    name: $VOLUME_NAME
-    version: latest
-EOF
-
-    # Step 3: Create artifact
-    mkdir -p "$test_artifact_dir/$artifact_name"
-    cd "$test_artifact_dir/$artifact_name"
-    $VM0_CLI artifact init --name "$artifact_name" >/dev/null 2>&1
-    echo "test content" > test.txt
-    $VM0_CLI artifact push >/dev/null 2>&1
-
-    # Step 4: Build the compose
-    run $VM0_CLI compose "$test_config"
-    assert_success
-
-    # Step 5: Run agent with CLI --vars to override server value
+    # Run agent with CLI --vars to override server value
     echo "# Running agent with CLI var override..."
-    run $VM0_CLI run "$agent_name" \
-        --vars "$TEST_VAR_NAME=$cli_value" \
-        --artifact-name "$artifact_name" \
+    run $VM0_CLI run "$AGENT_OVERRIDE" \
+        --vars "TEST_VAR=$cli_value" \
+        --artifact-name "$ARTIFACT_NAME" \
         "echo MY_VAR=\$MY_VAR"
 
     echo "# Output:"
@@ -222,9 +231,4 @@ EOF
     # Verify CLI value is used (overrides server-stored value)
     assert_output --partial "MY_VAR=${cli_value}"
     refute_output --partial "MY_VAR=${server_value}"
-
-    # Cleanup
-    rm -rf "$test_artifact_dir"
-    rm -f "$test_config"
-    cleanup_test_volume
 }

--- a/e2e/tests/03-runner/t31-zero-variable.bats
+++ b/e2e/tests/03-runner/t31-zero-variable.bats
@@ -35,6 +35,10 @@ VOLEOF
     $VM0_CLI artifact push >/dev/null 2>&1
     cd - >/dev/null
 
+    # Each vm0 run test gets its own unique variable name to avoid race conditions
+    export VAR_NAME_EXPAND="TEST_VAR_EXPAND_${UNIQUE_ID}"
+    export VAR_NAME_OVERRIDE="TEST_VAR_OVERRIDE_${UNIQUE_ID}"
+
     # Create compose configs for both vm0 run tests
     export AGENT_EXPAND="e2e-var-expand-${UNIQUE_ID}"
     export CONFIG_EXPAND="$TEST_DIR/expand.yaml"
@@ -46,7 +50,7 @@ agents:
     framework: claude-code
     working_dir: /home/user/workspace
     environment:
-      MY_VAR: "\${{ vars.TEST_VAR }}"
+      MY_VAR: "\${{ vars.${VAR_NAME_EXPAND} }}"
     volumes:
       - claude-files:/home/user/.claude
 volumes:
@@ -66,7 +70,7 @@ agents:
     framework: claude-code
     working_dir: /home/user/workspace
     environment:
-      MY_VAR: "\${{ vars.TEST_VAR }}"
+      MY_VAR: "\${{ vars.${VAR_NAME_OVERRIDE} }}"
     volumes:
       - claude-files:/home/user/.claude
 volumes:
@@ -88,8 +92,9 @@ teardown() {
 }
 
 teardown_file() {
-    # Clean up the variable used by vm0 run tests (single API call, once)
-    $ZERO_CLI variable delete -y "TEST_VAR" 2>/dev/null || true
+    # Clean up variables used by vm0 run tests (one API call each, once)
+    $ZERO_CLI variable delete -y "$VAR_NAME_EXPAND" 2>/dev/null || true
+    $ZERO_CLI variable delete -y "$VAR_NAME_OVERRIDE" 2>/dev/null || true
     # Clean up shared test directory
     if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
         rm -rf "$TEST_DIR"
@@ -187,8 +192,8 @@ teardown_file() {
 
     local var_value="var-value-${UNIQUE_ID}"
 
-    # Set a server-stored variable
-    $ZERO_CLI variable set "TEST_VAR" "$var_value"
+    # Set a server-stored variable (unique name per test to avoid races)
+    $ZERO_CLI variable set "$VAR_NAME_EXPAND" "$var_value"
 
     # Run agent that echoes the variable value
     echo "# Running agent that echoes variable value..."
@@ -213,13 +218,13 @@ teardown_file() {
     local server_value="server-value-${UNIQUE_ID}"
     local cli_value="cli-value-${UNIQUE_ID}"
 
-    # Set a server-stored variable
-    $ZERO_CLI variable set "TEST_VAR" "$server_value"
+    # Set a server-stored variable (unique name per test to avoid races)
+    $ZERO_CLI variable set "$VAR_NAME_OVERRIDE" "$server_value"
 
     # Run agent with CLI --vars to override server value
     echo "# Running agent with CLI var override..."
     run $VM0_CLI run "$AGENT_OVERRIDE" \
-        --vars "TEST_VAR=$cli_value" \
+        --vars "$VAR_NAME_OVERRIDE=$cli_value" \
         --artifact-name "$ARTIFACT_NAME" \
         "echo MY_VAR=\$MY_VAR"
 

--- a/e2e/tests/03-runner/t31-zero-variable.bats
+++ b/e2e/tests/03-runner/t31-zero-variable.bats
@@ -35,9 +35,12 @@ VOLEOF
     $VM0_CLI artifact push >/dev/null 2>&1
     cd - >/dev/null
 
-    # Each vm0 run test gets its own unique variable name to avoid race conditions
-    export VAR_NAME_EXPAND="TEST_VAR_EXPAND_${UNIQUE_ID}"
-    export VAR_NAME_OVERRIDE="TEST_VAR_OVERRIDE_${UNIQUE_ID}"
+    # Each vm0 run test gets its own unique variable name to avoid race conditions.
+    # Variable names must contain only uppercase letters, numbers, and underscores,
+    # so replace the hyphen in UNIQUE_ID with an underscore.
+    local var_safe_id="${UNIQUE_ID//-/_}"
+    export VAR_NAME_EXPAND="TEST_VAR_EXPAND_${var_safe_id}"
+    export VAR_NAME_OVERRIDE="TEST_VAR_OVERRIDE_${var_safe_id}"
 
     # Create compose configs for both vm0 run tests
     export AGENT_EXPAND="e2e-var-expand-${UNIQUE_ID}"

--- a/turbo/apps/platform/src/signals/zero-page/log-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/log-types.ts
@@ -13,6 +13,7 @@ export const TRIGGER_SOURCE_LABELS: Readonly<Record<TriggerSource, string>> = {
   telegram: "Telegram",
   github: "GitHub",
   cli: "CLI",
+  agent: "Agent",
 };
 
 // List response - contains basic fields for list display

--- a/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/__tests__/route.test.ts
@@ -1,9 +1,24 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../route";
-import { createTestRequest } from "../../../../../src/__tests__/api-test-helpers";
-import { testContext } from "../../../../../src/__tests__/test-helpers";
+import {
+  createTestRequest,
+  createTestCompose,
+  getTestZeroAgentId,
+  createTestSessionWithConversation,
+  findTestZeroRun,
+  insertOrgDefaultModelProvider,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
+import {
+  generateSandboxToken,
+  generateZeroToken,
+} from "../../../../../src/lib/auth/sandbox-token";
+import { reloadEnv } from "../../../../../src/env";
 
 const context = testContext();
 
@@ -35,5 +50,137 @@ describe("POST /api/zero/runs", () => {
 
     const data = await response.json();
     expect(data.error.message).toContain("agent-run:write");
+  });
+
+  describe("sessionId inference", () => {
+    let user: UserContext;
+    let agentId: string;
+
+    beforeEach(async () => {
+      user = await context.setupUser();
+      const compose = await createTestCompose(uniqueId("session-agent"));
+      agentId = await getTestZeroAgentId(user.orgId, compose.name);
+      vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
+      reloadEnv();
+    });
+
+    it("should infer agentId from sessionId when agentId is not provided", async () => {
+      await insertOrgDefaultModelProvider(user.orgId, "anthropic-api-key");
+      const session = await createTestSessionWithConversation(
+        user.userId,
+        agentId,
+      );
+
+      const response = await POST(
+        createTestRequest(URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            sessionId: session.id,
+            prompt: "test delegation",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.runId).toBeTruthy();
+    });
+
+    it("should return 404 when sessionId does not match any session", async () => {
+      mockClerk({ userId: null });
+      const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+
+      const response = await POST(
+        createTestRequest(URL, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            sessionId: "00000000-0000-0000-0000-000000000000",
+            prompt: "test prompt",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(404);
+      const data = await response.json();
+      expect(data.error.message).toBe("Session not found");
+    });
+
+    it("should return 400 when neither agentId nor sessionId is provided", async () => {
+      const response = await POST(
+        createTestRequest(URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            prompt: "test prompt",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.error.message).toBe("agentId is required");
+    });
+  });
+
+  describe("triggerSource", () => {
+    let user: UserContext;
+    let agentId: string;
+
+    beforeEach(async () => {
+      user = await context.setupUser();
+      const compose = await createTestCompose(uniqueId("trigger-agent"));
+      agentId = await getTestZeroAgentId(user.orgId, compose.name);
+      vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
+      reloadEnv();
+    });
+
+    it("should set triggerSource to 'agent' for ZERO_TOKEN callers", async () => {
+      mockClerk({ userId: null });
+      const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+
+      const response = await POST(
+        createTestRequest(URL, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            agentId,
+            prompt: "delegated task",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      const zeroRun = await findTestZeroRun(data.runId);
+      expect(zeroRun).toBeDefined();
+      expect(zeroRun!.triggerSource).toBe("agent");
+    });
+
+    it("should set triggerSource to 'web' for Clerk JWT callers", async () => {
+      const response = await POST(
+        createTestRequest(URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentId,
+            prompt: "web task",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      const zeroRun = await findTestZeroRun(data.runId);
+      expect(zeroRun).toBeDefined();
+      expect(zeroRun!.triggerSource).toBe("web");
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -14,6 +14,7 @@ import { createZeroRun } from "../../../../src/lib/zero/zero-run-service";
 import { isApiError } from "../../../../src/lib/errors";
 import { isRunDispatchError } from "../../../../src/lib/run";
 import { zeroAgents } from "../../../../src/db/schema/zero-agent";
+import { agentSessions } from "../../../../src/db/schema/agent-session";
 
 /**
  * Translate createZeroRun() errors into API response format.
@@ -58,7 +59,30 @@ const router = tsr.router(zeroRunsMainContract, {
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const agentId = body.agentId;
+      let agentId = body.agentId;
+
+      // Infer agentId from session when not provided directly
+      if (!agentId && body.sessionId) {
+        const [session] = await globalThis.services.db
+          .select({ agentComposeId: agentSessions.agentComposeId })
+          .from(agentSessions)
+          .where(eq(agentSessions.id, body.sessionId))
+          .limit(1);
+
+        if (!session) {
+          return {
+            status: 404 as const,
+            body: {
+              error: {
+                message: "Session not found",
+                code: "NOT_FOUND" as const,
+              },
+            },
+          };
+        }
+        agentId = session.agentComposeId;
+      }
+
       if (!agentId) {
         return {
           status: 400 as const,
@@ -94,7 +118,7 @@ const router = tsr.router(zeroRunsMainContract, {
         sessionId: body.sessionId,
         appendSystemPrompt: body.appendSystemPrompt,
         modelProvider: body.modelProvider,
-        triggerSource: "web",
+        triggerSource: authCtx.runId ? "agent" : "web",
       });
 
       return {

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -52,6 +52,7 @@ export function buildAgentToolsPrompt(): string {
     "# Agent Tools",
     "You have access to the Zero CLI. Run commands with: `npx -p @vm0/cli zero <command>`",
     "- When you need to discover available commands, run `zero --help`.",
+    '- When you need to delegate a task to a teammate agent, first discover teammates with `zero agent list`, then run `zero run <agent-id> "your task description"`. To continue a previous delegation, use `zero run continue <session-id> "follow-up prompt"`.',
     "- When you need to schedule or manage recurring tasks, use `zero schedule`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "- When you need to send a Slack message, use `zero slack message send`. Never use SLACK_TOKEN directly — it's a user token.",
     "- When you encounter a missing token or environment variable error, run `zero doctor missing-token <TOKEN_NAME>` to diagnose the issue and get remediation steps for the user.",

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -169,6 +169,7 @@ describe("createZeroRun()", () => {
       "slack",
       "email",
       "github",
+      "agent",
     ];
 
     for (const triggerSource of triggerSources) {

--- a/turbo/packages/core/src/contracts/logs.ts
+++ b/turbo/packages/core/src/contracts/logs.ts
@@ -47,6 +47,7 @@ export const triggerSourceSchema = z.enum([
   "telegram",
   "github",
   "cli",
+  "agent",
 ]);
 
 export type TriggerSource = z.infer<typeof triggerSourceSchema>;


### PR DESCRIPTION
## Summary

Closes #6983 — Part of Epic #6978

- Add `"agent"` to `triggerSourceSchema` for runs triggered by agents inside sandbox
- Infer `agentId` from `sessionId` in `POST /api/zero/runs` when `agentId` is not provided
- Set `triggerSource` dynamically based on auth context (`"agent"` for ZERO_TOKEN, `"web"` for Clerk JWT)
- Document `zero run` and `zero agent list` in the agent tools prompt for delegation
- Add `"Agent"` label to the platform trigger source display map

## Test plan

- [x] `triggerSource "agent"` stored correctly on `zero_runs` record
- [x] `sessionId` → `agentId` inference succeeds (happy path with conversation)
- [x] Returns 404 when `sessionId` does not match any session
- [x] Returns 400 when neither `agentId` nor `sessionId` is provided
- [x] `triggerSource = "agent"` for ZERO_TOKEN callers
- [x] `triggerSource = "web"` for Clerk JWT callers
- [x] All existing tests pass (69 related tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)