### PR TITLE
feat(cli): add zero ask-user question command

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -21,6 +21,7 @@ describe("zero CLI program", () => {
       "slack",
       "variable",
       "whoami",
+      "ask-user",
     ];
     for (const name of expectedCommands) {
       expect(commandNames).toContain(name);
@@ -46,7 +47,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 10 commands", () => {
-    expect(commandNames).toHaveLength(10);
+  it("should have exactly 11 commands", () => {
+    expect(commandNames).toHaveLength(11);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/ask-user/__tests__/question.test.ts
+++ b/turbo/apps/cli/src/commands/zero/ask-user/__tests__/question.test.ts
@@ -31,14 +31,12 @@ describe("zero ask-user question command", () => {
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
-    vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
   afterEach(() => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
-    vi.useRealTimers();
   });
 
   describe("happy path", () => {
@@ -214,8 +212,6 @@ describe("zero ask-user question command", () => {
       );
     });
 
-    // NOTE: This test must run last because Commander's collectDesc accumulator
-    // mutates the shared default array, which leaks state to subsequent tests.
     it("should error when --desc is provided without matching --option", async () => {
       await expect(async () => {
         await questionCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/ask-user/__tests__/question.test.ts
+++ b/turbo/apps/cli/src/commands/zero/ask-user/__tests__/question.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for zero ask-user question command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { questionCommand } from "../question";
+import chalk from "chalk";
+
+const QUESTION_URL = "http://localhost:3000/api/zero/ask-user/question";
+const ANSWER_URL = "http://localhost:3000/api/zero/ask-user/answer";
+
+const PENDING_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("zero ask-user question command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    vi.useRealTimers();
+  });
+
+  describe("happy path", () => {
+    it("should post question and print answer when answered immediately", async () => {
+      server.use(
+        http.post(QUESTION_URL, () => {
+          return HttpResponse.json({ pendingId: PENDING_ID }, { status: 200 });
+        }),
+        http.get(ANSWER_URL, () => {
+          return HttpResponse.json(
+            { status: "answered", answer: "yes" },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await questionCommand.parseAsync([
+        "node",
+        "cli",
+        "Do you approve?",
+        "--timeout",
+        "5",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith("yes");
+    });
+
+    it("should post question with options and header", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(QUESTION_URL, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ pendingId: PENDING_ID }, { status: 200 });
+        }),
+        http.get(ANSWER_URL, () => {
+          return HttpResponse.json(
+            { status: "answered", answer: "Option A" },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await questionCommand.parseAsync([
+        "node",
+        "cli",
+        "Pick one",
+        "--header",
+        "Choice",
+        "--option",
+        "Option A",
+        "--desc",
+        "First option",
+        "--option",
+        "Option B",
+        "--desc",
+        "Second option",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        questions: [
+          {
+            question: "Pick one",
+            header: "Choice",
+            options: [
+              { label: "Option A", description: "First option" },
+              { label: "Option B", description: "Second option" },
+            ],
+          },
+        ],
+      });
+      expect(mockConsoleLog).toHaveBeenCalledWith("Option A");
+    });
+
+    it("should poll until answer is available", async () => {
+      let pollCount = 0;
+
+      server.use(
+        http.post(QUESTION_URL, () => {
+          return HttpResponse.json({ pendingId: PENDING_ID }, { status: 200 });
+        }),
+        http.get(ANSWER_URL, () => {
+          pollCount++;
+          if (pollCount < 3) {
+            return HttpResponse.json({ status: "pending" }, { status: 200 });
+          }
+          return HttpResponse.json(
+            { status: "answered", answer: "done" },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await questionCommand.parseAsync([
+        "node",
+        "cli",
+        "Are you done?",
+        "--timeout",
+        "10",
+      ]);
+
+      expect(pollCount).toBe(3);
+      expect(mockConsoleLog).toHaveBeenCalledWith("done");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should throw error when question expires", async () => {
+      server.use(
+        http.post(QUESTION_URL, () => {
+          return HttpResponse.json({ pendingId: PENDING_ID }, { status: 200 });
+        }),
+        http.get(ANSWER_URL, () => {
+          return HttpResponse.json({ status: "expired" }, { status: 200 });
+        }),
+      );
+
+      await expect(async () => {
+        await questionCommand.parseAsync([
+          "node",
+          "cli",
+          "Will you respond?",
+          "--timeout",
+          "5",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Question expired before user responded"),
+      );
+    });
+
+    it("should throw error when timeout is reached", async () => {
+      server.use(
+        http.post(QUESTION_URL, () => {
+          return HttpResponse.json({ pendingId: PENDING_ID }, { status: 200 });
+        }),
+        http.get(ANSWER_URL, () => {
+          return HttpResponse.json({ status: "pending" }, { status: 200 });
+        }),
+      );
+
+      await expect(async () => {
+        await questionCommand.parseAsync([
+          "node",
+          "cli",
+          "Will you respond?",
+          "--timeout",
+          "2",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Timed out waiting for user response after 2s"),
+      );
+    });
+
+    it("should error when --timeout is not a positive number", async () => {
+      await expect(async () => {
+        await questionCommand.parseAsync([
+          "node",
+          "cli",
+          "Pick one",
+          "--timeout",
+          "0",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "--timeout must be a positive number of seconds",
+        ),
+      );
+    });
+
+    // NOTE: This test must run last because Commander's collectDesc accumulator
+    // mutates the shared default array, which leaks state to subsequent tests.
+    it("should error when --desc is provided without matching --option", async () => {
+      await expect(async () => {
+        await questionCommand.parseAsync([
+          "node",
+          "cli",
+          "Pick one",
+          "--desc",
+          "orphan description",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--desc must follow an --option flag"),
+      );
+    });
+
+    it("should handle API authentication error", async () => {
+      server.use(
+        http.post(QUESTION_URL, () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await questionCommand.parseAsync([
+          "node",
+          "cli",
+          "Any question",
+          "--timeout",
+          "5",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/ask-user/index.ts
+++ b/turbo/apps/cli/src/commands/zero/ask-user/index.ts
@@ -1,0 +1,7 @@
+import { Command } from "commander";
+import { questionCommand } from "./question";
+
+export const zeroAskUserCommand = new Command()
+  .name("ask-user")
+  .description("Ask the user a question and wait for the answer")
+  .addCommand(questionCommand);

--- a/turbo/apps/cli/src/commands/zero/ask-user/question.ts
+++ b/turbo/apps/cli/src/commands/zero/ask-user/question.ts
@@ -1,0 +1,117 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { postAskUserQuestion, getAskUserAnswer } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+interface OptionItem {
+  label: string;
+  description?: string;
+}
+
+function collectOption(value: string, previous: OptionItem[]): OptionItem[] {
+  previous.push({ label: value });
+  return previous;
+}
+
+function collectDesc(value: string, previous: string[]): string[] {
+  previous.push(value);
+  return previous;
+}
+
+export const questionCommand = new Command()
+  .name("question")
+  .description("Ask the user a question and wait for the answer")
+  .argument("<question>", "The question to ask")
+  .option("--header <text>", "Short label displayed as chip/tag (max 12 chars)")
+  .option(
+    "--option <label>",
+    "Add a choice option (repeatable)",
+    collectOption,
+    [] as OptionItem[],
+  )
+  .option(
+    "--desc <text>",
+    "Description for the preceding --option",
+    collectDesc,
+    [] as string[],
+  )
+  .option("--multi-select", "Allow multiple selections")
+  .option("--timeout <seconds>", "How long to wait for answer", "300")
+  .action(
+    withErrorHandler(
+      async (
+        question: string,
+        options: {
+          header?: string;
+          option: OptionItem[];
+          desc: string[];
+          multiSelect?: boolean;
+          timeout: string;
+        },
+      ) => {
+        // Pair --desc values with --option items
+        for (let i = 0; i < options.desc.length; i++) {
+          const opt = options.option[i];
+          if (!opt) {
+            throw new Error("--desc must follow an --option flag");
+          }
+          opt.description = options.desc[i];
+        }
+
+        const timeoutMs = parseInt(options.timeout, 10) * 1000;
+        if (isNaN(timeoutMs) || timeoutMs <= 0) {
+          throw new Error("--timeout must be a positive number of seconds");
+        }
+
+        // Build question payload
+        const questionItem = {
+          question,
+          header: options.header,
+          options: options.option.length > 0 ? options.option : undefined,
+          multiSelect: options.multiSelect,
+        };
+
+        // Post the question
+        const { pendingId } = await postAskUserQuestion({
+          questions: [questionItem],
+        });
+
+        console.error(
+          chalk.dim(
+            `⏳ Waiting for user response... (pendingId: ${pendingId})`,
+          ),
+        );
+
+        // Poll for answer
+        const deadline = Date.now() + timeoutMs;
+        const pollIntervalMs = 1000;
+
+        while (Date.now() < deadline) {
+          const response = await getAskUserAnswer(pendingId);
+
+          if (response.status === "answered") {
+            // Print answer to stdout (for agent consumption)
+            console.log(response.answer ?? "");
+            return;
+          }
+
+          if (response.status === "expired") {
+            console.error(
+              chalk.red("✗ Question expired before user responded"),
+            );
+            process.exit(1);
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+        }
+
+        // Timeout reached
+        console.error(
+          chalk.red(
+            `✗ Timed out waiting for user response after ${options.timeout}s`,
+          ),
+        );
+        process.exit(1);
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/ask-user/question.ts
+++ b/turbo/apps/cli/src/commands/zero/ask-user/question.ts
@@ -8,14 +8,19 @@ interface OptionItem {
   description?: string;
 }
 
-function collectOption(value: string, previous: OptionItem[]): OptionItem[] {
-  previous.push({ label: value });
-  return previous;
+function collectOption(
+  value: string,
+  previous: OptionItem[] | undefined,
+): OptionItem[] {
+  const list = previous ?? [];
+  list.push({ label: value });
+  return list;
 }
 
-function collectDesc(value: string, previous: string[]): string[] {
-  previous.push(value);
-  return previous;
+function collectDesc(value: string, previous: string[] | undefined): string[] {
+  const list = previous ?? [];
+  list.push(value);
+  return list;
 }
 
 export const questionCommand = new Command()
@@ -23,17 +28,11 @@ export const questionCommand = new Command()
   .description("Ask the user a question and wait for the answer")
   .argument("<question>", "The question to ask")
   .option("--header <text>", "Short label displayed as chip/tag (max 12 chars)")
-  .option(
-    "--option <label>",
-    "Add a choice option (repeatable)",
-    collectOption,
-    [] as OptionItem[],
-  )
+  .option("--option <label>", "Add a choice option (repeatable)", collectOption)
   .option(
     "--desc <text>",
     "Description for the preceding --option",
     collectDesc,
-    [] as string[],
   )
   .option("--multi-select", "Allow multiple selections")
   .option("--timeout <seconds>", "How long to wait for answer", "300")
@@ -43,19 +42,22 @@ export const questionCommand = new Command()
         question: string,
         options: {
           header?: string;
-          option: OptionItem[];
-          desc: string[];
+          option?: OptionItem[];
+          desc?: string[];
           multiSelect?: boolean;
           timeout: string;
         },
       ) => {
+        const optionItems = options.option ?? [];
+        const descItems = options.desc ?? [];
+
         // Pair --desc values with --option items
-        for (let i = 0; i < options.desc.length; i++) {
-          const opt = options.option[i];
+        for (let i = 0; i < descItems.length; i++) {
+          const opt = optionItems[i];
           if (!opt) {
             throw new Error("--desc must follow an --option flag");
           }
-          opt.description = options.desc[i];
+          opt.description = descItems[i];
         }
 
         const timeoutMs = parseInt(options.timeout, 10) * 1000;
@@ -67,7 +69,7 @@ export const questionCommand = new Command()
         const questionItem = {
           question,
           header: options.header,
-          options: options.option.length > 0 ? options.option : undefined,
+          options: optionItems.length > 0 ? optionItems : undefined,
           multiSelect: options.multiSelect,
         };
 

--- a/turbo/apps/cli/src/commands/zero/ask-user/question.ts
+++ b/turbo/apps/cli/src/commands/zero/ask-user/question.ts
@@ -96,22 +96,16 @@ export const questionCommand = new Command()
           }
 
           if (response.status === "expired") {
-            console.error(
-              chalk.red("✗ Question expired before user responded"),
-            );
-            process.exit(1);
+            throw new Error("Question expired before user responded");
           }
 
           await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
         }
 
         // Timeout reached
-        console.error(
-          chalk.red(
-            `✗ Timed out waiting for user response after ${options.timeout}s`,
-          ),
+        throw new Error(
+          `Timed out waiting for user response after ${options.timeout}s`,
         );
-        process.exit(1);
       },
     ),
   );

--- a/turbo/apps/cli/src/lib/api/domains/zero-ask-user.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-ask-user.ts
@@ -1,0 +1,32 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroAskUserQuestionContract,
+  zeroAskUserAnswerContract,
+  type AskUserQuestionBody,
+  type AskUserQuestionResponse,
+  type AskUserAnswerResponse,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function postAskUserQuestion(
+  body: AskUserQuestionBody,
+): Promise<AskUserQuestionResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAskUserQuestionContract, config);
+  const result = await client.postQuestion({ body, headers: {} });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to post question");
+}
+
+export async function getAskUserAnswer(
+  pendingId: string,
+): Promise<AskUserAnswerResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAskUserAnswerContract, config);
+  const result = await client.getAnswer({
+    query: { pendingId },
+    headers: {},
+  });
+  if (result.status === 200) return result.body;
+  handleError(result, "Failed to get answer");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -140,3 +140,6 @@ export {
   type NetworkLogEntry,
   type LogsSearchResponse,
 } from "./domains/logs";
+
+// Domain modules - Zero Ask User
+export { postAskUserQuestion, getAskUserAnswer } from "./domains/zero-ask-user";

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -13,6 +13,7 @@ import { zeroSecretCommand } from "./commands/zero/secret";
 import { zeroSlackCommand } from "./commands/zero/slack";
 import { zeroVariableCommand } from "./commands/zero/variable";
 import { zeroWhoamiCommand } from "./commands/zero/whoami";
+import { zeroAskUserCommand } from "./commands/zero/ask-user";
 import {
   decodeZeroTokenPayload,
   type ZeroTokenPayload,
@@ -29,6 +30,7 @@ const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   doctor: null,
   slack: "slack:write",
   whoami: null,
+  "ask-user": null,
 };
 
 const DEFAULT_COMMANDS: Command[] = [
@@ -42,6 +44,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroSlackCommand,
   zeroVariableCommand,
   zeroWhoamiCommand,
+  zeroAskUserCommand,
 ];
 
 function shouldHideCommand(


### PR DESCRIPTION
## Summary
- Add `zero ask-user question` CLI command that posts a question via API, polls for the user's answer, and prints it to stdout
- Create API domain module with `postAskUserQuestion` and `getAskUserAnswer` functions
- Register ask-user command group in zero.ts with null capability (always visible in sandbox)

## Changes
| Action | File |
|--------|------|
| **Create** | `turbo/apps/cli/src/lib/api/domains/zero-ask-user.ts` |
| **Create** | `turbo/apps/cli/src/commands/zero/ask-user/index.ts` |
| **Create** | `turbo/apps/cli/src/commands/zero/ask-user/question.ts` |
| **Modify** | `turbo/apps/cli/src/lib/api/index.ts` |
| **Modify** | `turbo/apps/cli/src/zero.ts` |
| **Modify** | `turbo/apps/cli/src/__tests__/zero.test.ts` |

## CLI Interface
```bash
zero ask-user question <question> [options]

Options:
  --header <text>       Short label displayed as chip/tag (max 12 chars)
  --option <label>      Add a choice option (repeatable)
  --desc <text>         Description for the preceding --option
  --multi-select        Allow multiple selections
  --timeout <seconds>   How long to wait for answer (default: 300)
```

## Test plan
- [x] All 834 existing CLI tests pass
- [x] TypeScript type checking passes
- [x] Lint passes (oxlint + eslint)
- [x] Knip passes (no unused exports/deps)
- [x] Prettier formatting passes
- [x] Commitlint passes

Closes #6963

🤖 Generated with [Claude Code](https://claude.com/claude-code)