### PR TITLE
fix: suppress npm upgrade notices in sandbox environment

### DIFF
--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -195,7 +195,10 @@ pub fn init_filesystem() -> Result<(), InitError> {
     // PATH goes in /etc/profile.d/ because Debian's /etc/profile overrides
     // PATH from /etc/environment, omitting sbin dirs for non-root users.
     // Scripts in /etc/profile.d/ run after /etc/profile, so our PATH wins.
-    if let Err(e) = fs::write("/etc/environment", "LANG=C.UTF-8\n") {
+    if let Err(e) = fs::write(
+        "/etc/environment",
+        "LANG=C.UTF-8\nNPM_CONFIG_UPDATE_NOTIFIER=false\n",
+    ) {
         eprintln!("[guest-init] Warning: failed to write /etc/environment: {e}");
     }
     if let Err(e) = fs::write(


### PR DESCRIPTION
## Summary
- Set `NPM_CONFIG_UPDATE_NOTIFIER=false` in `/etc/environment` inside the VM sandbox
- Prevents npm from printing upgrade notices when agents run `npx` commands
- Written by `guest-init` alongside the existing `LANG=C.UTF-8`

Closes #6970

## Test plan
- [x] `cargo check -p guest-init` passes
- [x] cargo-clippy passes
- [ ] Deploy and verify `npx -p @vm0/cli zero doctor` no longer shows npm upgrade notices

🤖 Generated with [Claude Code](https://claude.com/claude-code)