### PR TITLE
feat: add ask-user question and answer api endpoints

### DIFF
--- a/turbo/apps/web/app/api/zero/ask-user/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/ask-user/__tests__/route.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../question/route";
+import { GET } from "../answer/route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestRunInDb,
+  createTestSlackOrgInstallation,
+  createTestSlackOrgConnection,
+  createTestCallback,
+  insertOrgMembersCacheEntry,
+  findTestPendingQuestion,
+  updateTestPendingQuestionAnswer,
+  updateTestPendingQuestionExpiry,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { generateZeroToken } from "../../../../../src/lib/auth/sandbox-token";
+
+const QUESTION_URL = "http://localhost:3000/api/zero/ask-user/question";
+const ANSWER_URL = "http://localhost:3000/api/zero/ask-user/answer";
+
+const context = testContext();
+
+const sampleQuestions = [
+  {
+    question: "What color do you prefer?",
+    options: [{ label: "Red" }, { label: "Blue" }],
+  },
+];
+
+/**
+ * Set up a complete Slack context: installation, connection, compose, run,
+ * callback with Slack payload, and a zero token for authentication.
+ */
+async function setupSlackContext(user: UserContext) {
+  const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+    orgId: user.orgId,
+  });
+  const { connectionId } = await createTestSlackOrgConnection({
+    slackWorkspaceId,
+    vm0UserId: user.userId,
+  });
+  const { composeId } = await createTestCompose(uniqueId("agent"));
+  const { runId } = await createTestRunInDb(user.userId, composeId);
+  await createTestCallback({
+    runId,
+    url: "http://localhost/api/internal/callbacks/slack/org",
+    payload: {
+      workspaceId: slackWorkspaceId,
+      channelId: "C-test-channel",
+      threadTs: "1234567890.000001",
+      messageTs: "1234567890.000002",
+      connectionId,
+      agentId: composeId,
+    },
+  });
+
+  await insertOrgMembersCacheEntry({
+    orgId: user.orgId,
+    userId: user.userId,
+    role: "admin",
+  });
+  mockClerk({ userId: null });
+  const token = await generateZeroToken(user.userId, runId, user.orgId);
+
+  return { token, runId, composeId, slackWorkspaceId, connectionId };
+}
+
+describe("POST /api/zero/ask-user/question", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("returns 401 when no auth token provided", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(QUESTION_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ questions: sampleQuestions }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 200 with pendingId and creates DB record", async () => {
+    const { token } = await setupSlackContext(user);
+
+    const request = createTestRequest(QUESTION_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ questions: sampleQuestions }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.pendingId).toBeDefined();
+    expect(typeof data.pendingId).toBe("string");
+
+    // Verify DB record was created
+    const pending = await findTestPendingQuestion(data.pendingId);
+    expect(pending).toBeDefined();
+    expect(pending!.answer).toBeNull();
+    expect(pending!.answeredAt).toBeNull();
+  });
+
+  it("returns 400 when no Slack callback exists for the run", async () => {
+    // Create a run without a Slack callback
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRunInDb(user.userId, composeId);
+
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
+    mockClerk({ userId: null });
+    const token = await generateZeroToken(user.userId, runId, user.orgId);
+
+    const request = createTestRequest(QUESTION_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ questions: sampleQuestions }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("No Slack thread found");
+  });
+});
+
+describe("GET /api/zero/ask-user/answer", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("returns 401 when no auth token provided", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      `${ANSWER_URL}?pendingId=00000000-0000-0000-0000-000000000000`,
+      { method: "GET" },
+    );
+
+    const response = await GET(request);
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 for non-existent pendingId", async () => {
+    const { token } = await setupSlackContext(user);
+
+    const request = createTestRequest(
+      `${ANSWER_URL}?pendingId=00000000-0000-0000-0000-000000000000`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(request);
+    expect(response.status).toBe(404);
+
+    const data = await response.json();
+    expect(data.error.message).toContain("Pending question not found");
+  });
+
+  it("returns pending status when question not yet answered", async () => {
+    const { token } = await setupSlackContext(user);
+
+    // First create a pending question via POST
+    const postRequest = createTestRequest(QUESTION_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ questions: sampleQuestions }),
+    });
+    const postResponse = await POST(postRequest);
+    const { pendingId } = await postResponse.json();
+
+    // Now poll for answer
+    const getRequest = createTestRequest(
+      `${ANSWER_URL}?pendingId=${pendingId}`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(getRequest);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.status).toBe("pending");
+    expect(data.answer).toBeUndefined();
+  });
+
+  it("returns answered status when question has been answered", async () => {
+    const { token } = await setupSlackContext(user);
+
+    // Create a pending question
+    const postRequest = createTestRequest(QUESTION_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ questions: sampleQuestions }),
+    });
+    const postResponse = await POST(postRequest);
+    const { pendingId } = await postResponse.json();
+
+    // Simulate user answering the question
+    await updateTestPendingQuestionAnswer(pendingId, "Red");
+
+    // Poll for answer
+    const getRequest = createTestRequest(
+      `${ANSWER_URL}?pendingId=${pendingId}`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(getRequest);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.status).toBe("answered");
+    expect(data.answer).toBe("Red");
+  });
+
+  it("returns expired status when question has expired", async () => {
+    const { token } = await setupSlackContext(user);
+
+    // Create a pending question
+    const postRequest = createTestRequest(QUESTION_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ questions: sampleQuestions }),
+    });
+    const postResponse = await POST(postRequest);
+    const { pendingId } = await postResponse.json();
+
+    // Set expiresAt to the past
+    await updateTestPendingQuestionExpiry(
+      pendingId,
+      new Date(Date.now() - 1000),
+    );
+
+    // Poll for answer
+    const getRequest = createTestRequest(
+      `${ANSWER_URL}?pendingId=${pendingId}`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    const response = await GET(getRequest);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.status).toBe("expired");
+  });
+
+  it("returns 404 when pendingId belongs to a different run", async () => {
+    const ctx = await setupSlackContext(user);
+
+    // Create a pending question with the first token
+    const postRequest = createTestRequest(QUESTION_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${ctx.token}`,
+      },
+      body: JSON.stringify({ questions: sampleQuestions }),
+    });
+    const postResponse = await POST(postRequest);
+    const { pendingId } = await postResponse.json();
+
+    // Create a second run under the same compose (reuse existing installation)
+    const { runId: runId2 } = await createTestRunInDb(
+      user.userId,
+      ctx.composeId,
+    );
+    await createTestCallback({
+      runId: runId2,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: {
+        workspaceId: ctx.slackWorkspaceId,
+        channelId: "C-test-channel",
+        threadTs: "1234567890.000003",
+        messageTs: "1234567890.000004",
+        connectionId: ctx.connectionId,
+        agentId: ctx.composeId,
+      },
+    });
+    const token2 = await generateZeroToken(user.userId, runId2, user.orgId);
+
+    // Try to access the pending question with the second token (different runId)
+    const getRequest = createTestRequest(
+      `${ANSWER_URL}?pendingId=${pendingId}`,
+      {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token2}` },
+      },
+    );
+
+    const response = await GET(getRequest);
+    expect(response.status).toBe(404);
+  });
+});

--- a/turbo/apps/web/app/api/zero/ask-user/answer/route.ts
+++ b/turbo/apps/web/app/api/zero/ask-user/answer/route.ts
@@ -1,0 +1,80 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroAskUserAnswerContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { slackOrgPendingQuestions } from "../../../../../src/db/schema/slack-org-pending-question";
+import { eq } from "drizzle-orm";
+
+const router = tsr.router(zeroAskUserAnswerContract, {
+  getAnswer: async ({ query, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "slack:write",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+
+    const { runId } = authCtx;
+    if (!runId) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "No run context available", code: "UNAUTHORIZED" },
+        },
+      };
+    }
+
+    // Look up pending question
+    const [pending] = await globalThis.services.db
+      .select()
+      .from(slackOrgPendingQuestions)
+      .where(eq(slackOrgPendingQuestions.id, query.pendingId))
+      .limit(1);
+
+    // Return 404 for not found or ownership mismatch (avoid information leakage)
+    if (!pending || pending.runId !== runId) {
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            message: "Pending question not found",
+            code: "NOT_FOUND",
+          },
+        },
+      };
+    }
+
+    // Check answer status
+    if (pending.answeredAt && pending.answer !== null) {
+      return {
+        status: 200 as const,
+        body: { status: "answered" as const, answer: pending.answer },
+      };
+    }
+
+    if (pending.expiresAt < new Date()) {
+      return {
+        status: 200 as const,
+        body: { status: "expired" as const },
+      };
+    }
+
+    return {
+      status: 200 as const,
+      body: { status: "pending" as const },
+    };
+  },
+});
+
+const handler = createHandler(zeroAskUserAnswerContract, router, {
+  errorHandler: createSafeErrorHandler("ask-user-answer"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/ask-user/question/route.ts
+++ b/turbo/apps/web/app/api/zero/ask-user/question/route.ts
@@ -1,0 +1,189 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroAskUserQuestionContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { agentRunCallbacks } from "../../../../../src/db/schema/agent-run-callback";
+import { slackOrgInstallations } from "../../../../../src/db/schema/slack-org-installation";
+import { slackOrgPendingQuestions } from "../../../../../src/db/schema/slack-org-pending-question";
+import { zeroAgents } from "../../../../../src/db/schema/zero-agent";
+import { decryptSecretValue } from "../../../../../src/lib/crypto/secrets-encryption";
+import {
+  createSlackClient,
+  postMessage,
+} from "../../../../../src/lib/slack/client";
+import { buildAskUserQuestionBlocks } from "../../../../../src/lib/slack/blocks";
+import { eq } from "drizzle-orm";
+
+interface SlackOrgPayload {
+  workspaceId: string;
+  channelId: string;
+  threadTs: string;
+  messageTs: string;
+  connectionId: string;
+  agentId: string;
+  existingSessionId?: string;
+}
+
+function parseSlackPayload(payload: unknown): SlackOrgPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  if (
+    typeof p.workspaceId !== "string" ||
+    typeof p.channelId !== "string" ||
+    typeof p.threadTs !== "string" ||
+    typeof p.messageTs !== "string" ||
+    typeof p.connectionId !== "string" ||
+    typeof p.agentId !== "string"
+  ) {
+    return null;
+  }
+  return p as unknown as SlackOrgPayload;
+}
+
+const router = tsr.router(zeroAskUserQuestionContract, {
+  postQuestion: async ({ body, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "slack:write",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+
+    const { runId } = authCtx;
+    if (!runId) {
+      return {
+        status: 400 as const,
+        body: {
+          error: { message: "No run context available", code: "BAD_REQUEST" },
+        },
+      };
+    }
+
+    // Resolve Slack thread from callback payload
+    const callbacks = await globalThis.services.db
+      .select({ payload: agentRunCallbacks.payload })
+      .from(agentRunCallbacks)
+      .where(eq(agentRunCallbacks.runId, runId))
+      .limit(1);
+
+    const slackPayload = callbacks[0]
+      ? parseSlackPayload(callbacks[0].payload)
+      : null;
+
+    if (!slackPayload) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "No Slack thread found for this run",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
+    }
+
+    // Look up Slack installation for the workspace
+    const [installation] = await globalThis.services.db
+      .select()
+      .from(slackOrgInstallations)
+      .where(
+        eq(slackOrgInstallations.slackWorkspaceId, slackPayload.workspaceId),
+      )
+      .limit(1);
+
+    if (!installation) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "No Slack installation found for workspace",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
+    }
+
+    // Resolve agent name for display
+    const [agent] = await globalThis.services.db
+      .select({ name: zeroAgents.name })
+      .from(zeroAgents)
+      .where(eq(zeroAgents.id, slackPayload.agentId))
+      .limit(1);
+    const agentName = agent?.name ?? "Agent";
+
+    // Decrypt bot token and create Slack client
+    const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+    const botToken = decryptSecretValue(
+      installation.encryptedBotToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    const client = createSlackClient(botToken);
+
+    // Insert pending question record
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    const [pending] = await globalThis.services.db
+      .insert(slackOrgPendingQuestions)
+      .values({
+        runId,
+        slackWorkspaceId: slackPayload.workspaceId,
+        slackChannelId: slackPayload.channelId,
+        slackThreadTs: slackPayload.threadTs,
+        connectionId: slackPayload.connectionId,
+        composeId: slackPayload.agentId,
+        agentName,
+        sessionId: slackPayload.existingSessionId ?? null,
+        questions: body.questions,
+        expiresAt,
+      })
+      .returning({ id: slackOrgPendingQuestions.id });
+
+    if (!pending) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "Failed to create pending question",
+            code: "BAD_REQUEST",
+          },
+        },
+      };
+    }
+
+    // Build Block Kit card and post to Slack thread
+    const fallbackText = body.questions.map((q) => q.question).join("\n");
+    const blocks = buildAskUserQuestionBlocks(body.questions, pending.id);
+
+    const cardResult = await postMessage(
+      client,
+      slackPayload.channelId,
+      fallbackText || "The agent needs your input.",
+      { threadTs: slackPayload.threadTs, blocks },
+    );
+
+    // Store message timestamp for future card updates
+    if (cardResult.ts) {
+      await globalThis.services.db
+        .update(slackOrgPendingQuestions)
+        .set({ slackMessageTs: cardResult.ts })
+        .where(eq(slackOrgPendingQuestions.id, pending.id));
+    }
+
+    return {
+      status: 200 as const,
+      body: { pendingId: pending.id },
+    };
+  },
+});
+
+const handler = createHandler(zeroAskUserQuestionContract, router, {
+  errorHandler: createSafeErrorHandler("ask-user-question"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -4719,3 +4719,44 @@ export async function getTestComposeVersionContent(
     .limit(1);
   return (row?.content as Record<string, unknown>) ?? null;
 }
+
+/**
+ * Update a pending question record to simulate a user answering.
+ */
+export async function updateTestPendingQuestionAnswer(
+  pendingId: string,
+  answer: string,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(slackOrgPendingQuestions)
+    .set({ answer, answeredAt: new Date() })
+    .where(eq(slackOrgPendingQuestions.id, pendingId));
+}
+
+/**
+ * Update a pending question record's expiration to simulate expiry.
+ */
+export async function updateTestPendingQuestionExpiry(
+  pendingId: string,
+  expiresAt: Date,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(slackOrgPendingQuestions)
+    .set({ expiresAt })
+    .where(eq(slackOrgPendingQuestions.id, pendingId));
+}
+
+/**
+ * Find a pending question record by ID.
+ */
+export async function findTestPendingQuestion(pendingId: string) {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select()
+    .from(slackOrgPendingQuestions)
+    .where(eq(slackOrgPendingQuestions.id, pendingId))
+    .limit(1);
+  return row;
+}


### PR DESCRIPTION
## Summary

- Add `POST /api/zero/ask-user/question` endpoint that resolves the Slack thread from the run's callback payload, creates a pending question record, and posts a Block Kit interactive card to the Slack thread
- Add `GET /api/zero/ask-user/answer` endpoint that polls pending question status (pending/answered/expired) with runId ownership validation
- Add integration tests covering auth, happy path, and error cases for both endpoints
- Add test helpers for pending question state mutations

This is the server-side backbone of the new blocking ask-user flow (epic #6872), implementing the contracts defined in #6961.

Closes #6962

## Test plan

- [x] 9 integration tests all passing
- [x] POST /question returns 200 with pendingId and creates DB record
- [x] POST /question returns 401 without auth token
- [x] POST /question returns 400 when no Slack callback exists for the run
- [x] GET /answer returns pending/answered/expired status correctly
- [x] GET /answer returns 404 for non-existent or wrong-run pendingId
- [x] GET /answer returns 401 without auth token
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)