### PR TITLE
fix: correct pricing copy for rollover period and supported llm providers

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -90,7 +90,7 @@ const PLANS = [
       "5 active agents",
       "Unlimited total agents",
       "Bring your own LLM keys",
-      "Credits rollover (3 months)",
+      "Credits rollover (1 month)",
       "Priority support",
     ],
   },

--- a/turbo/apps/web/app/[locale]/pricing/page.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/page.tsx
@@ -569,7 +569,7 @@ export default function PricingPage() {
               />
               <FAQItem
                 question="Can I bring my own model provider?"
-                answer="Yes! All plans support bringing your own LLM API keys (OpenAI, Anthropic, etc.). When using your own keys, no VM0 credits are consumed for model usage."
+                answer="Yes! All plans support bringing your own LLM API keys (Anthropic, etc.). When using your own keys, no VM0 credits are consumed for model usage."
               />
               <FAQItem
                 question="How secure is VM0?"


### PR DESCRIPTION
## Summary
- Fix Max plan credits rollover period from "3 months" to "1 month" in org billing dialog
- Remove OpenAI from supported LLM key providers in pricing page FAQ (only Anthropic is supported)

Fixes #6885

## Test plan
- [ ] Verify org billing dialog shows "Credits rollover (1 month)" for Max plan
- [ ] Verify pricing page FAQ no longer mentions OpenAI

🤖 Generated with [Claude Code](https://claude.com/claude-code)