### PR TITLE
docs: add computed best practices to ccstate skill

### DIFF
--- a/.claude/skills/ccstate/SKILL.md
+++ b/.claude/skills/ccstate/SKILL.md
@@ -429,3 +429,157 @@ After refactoring each file:
 5. `pnpm check-types` has no new errors
 6. `pnpm knip` has no unused exports (newly-internal signals should lose `export`)
 7. Existing tests still pass
+
+## Computed Best Practices
+
+### Golden Rule
+
+**If a state's correct value depends on another state, it is derived state — use `computed`, not `state` + `command` manual maintenance.**
+
+"Depends on" includes:
+
+- Value can be **synchronously calculated** from another state (e.g., `doubled = count * 2`)
+- Value needs to be **asynchronously loaded** based on another state (e.g., `tasks = fetch(workspaceId)`)
+- Value is only **valid when another state meets a condition** (e.g., `editing` is only true when `workspaceId` matches)
+
+Whenever A changes and B's correct value should change too, B is derived from A — whether it's calculated, fetched, or only exists when A is valid.
+
+### How to Decide: Should a State Exist?
+
+Ask two questions:
+
+1. **Can its value be derived from other states?** (sync calculation / async load / conditional filter) → Yes, use `computed`
+2. **Does its value come from external input and cannot be derived from any other state?** (user action / route param / unpredictable event) → Yes, use `state`
+
+If the answer is 1, but you used `state` + `command` for manual maintenance — that's an anti-pattern.
+
+### Anti-Patterns
+
+#### Anti-pattern 1: Manually Synchronizing Multiple States
+
+**Symptom**: A command sets multiple states that have a computational relationship.
+
+```typescript
+// ❌
+const count$ = state(0)
+const doubled$ = state(0)
+
+const increment$ = command(({ get, set }) => {
+    const n = get(count$) + 1
+    set(count$, n)
+    set(doubled$, n * 2)  // doubled depends on count
+})
+
+// ✅
+const count$ = state(0)
+const doubled$ = computed((get) => get(count$) * 2)
+```
+
+#### Anti-pattern 2: Pure Calculation in Command Then Store
+
+**Symptom**: Command contains pure calculation logic (no side effects), result is set to another state.
+
+```typescript
+// ❌
+const firstName$ = state('')
+const lastName$ = state('')
+const fullName$ = state('')
+
+const updateFullName$ = command(({ get, set }) => {
+    set(fullName$, `${get(firstName$)} ${get(lastName$)}`)
+})
+
+// ✅
+const fullName$ = computed((get) => `${get(firstName$)} ${get(lastName$)}`)
+```
+
+#### Anti-pattern 3: Manual Reset of States on Context Switch
+
+**Symptom**: A "context ID" (e.g., workspaceId) exists, a group of states depend on it, and switching requires resetting each one.
+
+```typescript
+// ❌ Typical: cleanupWorkspace$ with 15 lines of manual resets
+const cleanupWorkspace$ = command(({ set }) => {
+    set(resetWsFileTreeState$)
+    set(resetWsMarkdownEdit$)
+    set(resetWsCsvEdit$)
+    // ... every new workspace-level state requires a new line
+})
+
+// ✅ These states' correct values depend on workspaceId — express as computed
+
+// API data: async computed, auto re-fetches when workspaceId changes
+const repoTrees$ = computed(async (get, { signal }) => {
+    const wsId = await get(activeWorkspaceId$)
+    if (!wsId) return []
+    return await fetchTrees(wsId, signal)
+})
+
+// Interaction state: workspaceSession, auto returns null when wsId doesn't match
+const mdEdit = workspaceSession<MdEditSession>()
+export const wsMarkdownEditing$ = computed((get) => get(mdEdit.session$) !== null)
+
+// No cleanup needed, no reset needed
+```
+
+#### Anti-pattern 4: Formatted/Transformed Results Stored as State
+
+**Symptom**: States named `xxxFormatted$`, `xxxDisplay$` whose values are transformations of a source state.
+
+```typescript
+// ❌
+const timestamp$ = state(Date.now())
+const formattedDate$ = state('')
+
+const updateTimestamp$ = command(({ set }, ts: number) => {
+    set(timestamp$, ts)
+    set(formattedDate$, new Date(ts).toISOString())
+})
+
+// ✅
+const formattedDate$ = computed((get) => new Date(get(timestamp$)).toISOString())
+```
+
+#### Anti-pattern 5: Boolean Flag Combination Logic Stored as State
+
+**Symptom**: Multiple boolean states have logical relationships, command sets one flag based on another.
+
+```typescript
+// ❌
+const isLoading$ = state(false)
+const hasError$ = state(false)
+const canSubmit$ = state(true)
+
+const setLoading$ = command(({ set }, loading: boolean) => {
+    set(isLoading$, loading)
+    set(canSubmit$, !loading)  // canSubmit depends on isLoading
+})
+
+// ✅
+const canSubmit$ = computed((get) => !get(isLoading$) && !get(hasError$))
+```
+
+### Correct Usage of State
+
+```typescript
+// User input — cannot be derived from other states
+const userInput$ = state('')
+
+// User selection — unpredictable event
+const selectedItems$ = state<Set<string>>(new Set())
+
+// Route parameter — from external source
+const currentWorkspaceId$ = state<string | undefined>(undefined)
+```
+
+### Code Review Checklist
+
+- Is each `state` a source of truth? Can its value be derived from other states?
+- Does a command set multiple related states simultaneously? If so, one of them should be a `computed`
+- Is there a reset/cleanup list? If so, the states being reset are likely derived from a context ID
+- Does a command contain pure calculation logic (no side effects)? If so, extract to `computed`
+- Is an AbortSignal passed solely to update derived data? If so, use `computed` instead
+
+### One-Line Summary
+
+**If A changes and B should change too, B should be a `computed` of A — whether B is calculated, fetched, or only exists when A is valid.**


### PR DESCRIPTION
## Summary
- Add "Computed Best Practices" section to the ccstate skill documentation
- Documents the golden rule: derived state should use `computed`, not `state` + `command`
- Covers 5 anti-patterns with before/after code examples and a code review checklist

## Test plan
- [x] Documentation-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)