### PR TITLE
fix(cli): resolve schedule commands agent lookup by uuid

### DIFF
--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/delete.test.ts
@@ -93,6 +93,39 @@ describe("zero schedule delete command", () => {
       expect(logCalls).toContain("Schedule");
       expect(logCalls).toContain("deleted");
     });
+
+    it("should delete when agent identifier is a UUID", async () => {
+      const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidCompose = { ...mockCompose, id: testUuid };
+      const uuidSchedule = { ...mockSchedule, agentId: testUuid };
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/composes/:id",
+          ({ params }) => {
+            if (params.id !== testUuid) {
+              return HttpResponse.json(
+                { error: { message: "Not found", code: "NOT_FOUND" } },
+                { status: 404 },
+              );
+            }
+            return HttpResponse.json(uuidCompose);
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [uuidSchedule] });
+        }),
+        http.delete("http://localhost:3000/api/zero/schedules/default", () => {
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      await deleteCommand.parseAsync(["node", "cli", testUuid, "--yes"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Schedule");
+      expect(logCalls).toContain("deleted");
+    });
   });
 
   describe("error handling", () => {

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/disable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/disable.test.ts
@@ -98,6 +98,46 @@ describe("zero schedule disable command", () => {
       expect(logCalls).toContain("Schedule");
       expect(logCalls).toContain("disabled");
     });
+
+    it("should disable a schedule when agent identifier is a UUID", async () => {
+      const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidCompose = { ...mockCompose, id: testUuid };
+      const uuidSchedule = {
+        ...mockSchedule,
+        agentId: testUuid,
+        enabled: true,
+      };
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/composes/:id",
+          ({ params }) => {
+            if (params.id !== testUuid) {
+              return HttpResponse.json(
+                { error: { message: "Not found", code: "NOT_FOUND" } },
+                { status: 404 },
+              );
+            }
+            return HttpResponse.json(uuidCompose);
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [uuidSchedule] });
+        }),
+        http.post(
+          "http://localhost:3000/api/zero/schedules/default/disable",
+          () => {
+            return HttpResponse.json({ ...uuidSchedule, enabled: false });
+          },
+        ),
+      );
+
+      await disableCommand.parseAsync(["node", "cli", testUuid]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Schedule");
+      expect(logCalls).toContain("disabled");
+    });
   });
 
   describe("error handling", () => {

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/enable.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/enable.test.ts
@@ -96,6 +96,42 @@ describe("zero schedule enable command", () => {
       expect(logCalls).toContain("Schedule");
       expect(logCalls).toContain("enabled");
     });
+
+    it("should enable a schedule when agent identifier is a UUID", async () => {
+      const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidCompose = { ...mockCompose, id: testUuid };
+      const uuidSchedule = { ...mockSchedule, agentId: testUuid };
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/composes/:id",
+          ({ params }) => {
+            if (params.id !== testUuid) {
+              return HttpResponse.json(
+                { error: { message: "Not found", code: "NOT_FOUND" } },
+                { status: 404 },
+              );
+            }
+            return HttpResponse.json(uuidCompose);
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [uuidSchedule] });
+        }),
+        http.post(
+          "http://localhost:3000/api/zero/schedules/default/enable",
+          () => {
+            return HttpResponse.json(uuidSchedule);
+          },
+        ),
+      );
+
+      await enableCommand.parseAsync(["node", "cli", testUuid]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Schedule");
+      expect(logCalls).toContain("enabled");
+    });
   });
 
   describe("error handling", () => {

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/setup.test.ts
@@ -164,6 +164,50 @@ describe("zero schedule setup command", () => {
       expect(logCalls).toContain("Schedule");
       expect(logCalls).toContain("created");
     });
+
+    it("should create schedule when agent identifier is a UUID", async () => {
+      const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidCompose = { ...mockCompose, id: testUuid, name: "uuid-agent" };
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/composes/:id",
+          ({ params }) => {
+            if (params.id !== testUuid) {
+              return HttpResponse.json(
+                { error: { message: "Not found", code: "NOT_FOUND" } },
+                { status: 404 },
+              );
+            }
+            return HttpResponse.json(uuidCompose);
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+        http.post("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json(mockDeployResponse, { status: 201 });
+        }),
+      );
+
+      await setupCommand.parseAsync([
+        "node",
+        "cli",
+        testUuid,
+        "--frequency",
+        "daily",
+        "--time",
+        "09:00",
+        "--timezone",
+        "UTC",
+        "--prompt",
+        "run daily check",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Schedule");
+      expect(logCalls).toContain("created");
+    });
   });
 
   describe("error handling", () => {

--- a/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/__tests__/status.test.ts
@@ -121,6 +121,36 @@ describe("zero schedule status command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("0 9 * * 1");
     });
+
+    it("should display schedule when agent identifier is a UUID", async () => {
+      const testUuid = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidCompose = { ...mockCompose, id: testUuid };
+      const uuidSchedule = { ...mockSchedule, agentId: testUuid };
+
+      server.use(
+        http.get(
+          "http://localhost:3000/api/agent/composes/:id",
+          ({ params }) => {
+            if (params.id !== testUuid) {
+              return HttpResponse.json(
+                { error: { message: "Not found", code: "NOT_FOUND" } },
+                { status: 404 },
+              );
+            }
+            return HttpResponse.json(uuidCompose);
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [uuidSchedule] });
+        }),
+      );
+
+      await statusCommand.parseAsync(["node", "cli", testUuid]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("0 9 * * *");
+      expect(logCalls).toContain("run daily check");
+    });
   });
 
   describe("error handling", () => {

--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -17,7 +17,7 @@ import {
   type ScheduleFrequency,
 } from "../../../lib/domain/schedule-utils";
 import {
-  getComposeByName,
+  resolveCompose,
   deployZeroSchedule,
   listZeroSchedules,
   enableZeroSchedule,
@@ -679,11 +679,11 @@ export const setupCommand = new Command()
   .option("--notify-slack", "Enable Slack notifications (default: true)")
   .option("--no-notify-slack", "Disable Slack notifications")
   .action(
-    withErrorHandler(async (agentName: string, options: SetupOptions) => {
-      // 1. Resolve agent name to compose ID
-      const compose = await getComposeByName(agentName);
+    withErrorHandler(async (agentIdentifier: string, options: SetupOptions) => {
+      // 1. Resolve agent identifier (UUID or name) to compose ID
+      const compose = await resolveCompose(agentIdentifier);
       if (!compose) {
-        throw new Error(`Agent not found: ${agentName}`);
+        throw new Error(`Agent not found: ${agentIdentifier}`);
       }
       const agentId = compose.id;
       const scheduleName = options.name || "default";
@@ -694,6 +694,7 @@ export const setupCommand = new Command()
         scheduleName,
       );
 
+      const agentName = compose.name;
       console.log(
         chalk.dim(
           existingSchedule

--- a/turbo/apps/cli/src/lib/api/domains/composes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/composes.ts
@@ -35,6 +35,30 @@ export async function getComposeByName(
   handleError(result, `Compose not found: ${name}`);
 }
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolve an agent identifier to a compose.
+ * Accepts either a UUID (compose ID) or a human-readable compose name.
+ * UUID is tried first; if the identifier is not a UUID, falls back to name lookup.
+ */
+export async function resolveCompose(
+  identifier: string,
+  org?: string,
+): Promise<GetComposeResponse | null> {
+  if (UUID_PATTERN.test(identifier)) {
+    const config = await getClientConfig();
+    const client = initClient(composesByIdContract, config);
+    const result = await client.getById({ params: { id: identifier } });
+    if (result.status === 200) {
+      return result.body;
+    }
+    return null;
+  }
+  return getComposeByName(identifier, org);
+}
+
 export async function getComposeById(id: string): Promise<GetComposeResponse> {
   const config = await getClientConfig();
   const client = initClient(composesByIdContract, config);

--- a/turbo/apps/cli/src/lib/api/domains/composes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/composes.ts
@@ -48,13 +48,11 @@ export async function resolveCompose(
   org?: string,
 ): Promise<GetComposeResponse | null> {
   if (UUID_PATTERN.test(identifier)) {
-    const config = await getClientConfig();
-    const client = initClient(composesByIdContract, config);
-    const result = await client.getById({ params: { id: identifier } });
-    if (result.status === 200) {
-      return result.body;
+    try {
+      return await getComposeById(identifier);
+    } catch {
+      return null;
     }
-    return null;
   }
   return getComposeByName(identifier, org);
 }

--- a/turbo/apps/cli/src/lib/api/domains/composes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/composes.ts
@@ -6,7 +6,11 @@ import {
   agentComposeApiContentSchema,
 } from "@vm0/core";
 import type { z } from "zod";
-import { getClientConfig, handleError } from "../core/client-factory";
+import {
+  ApiRequestError,
+  getClientConfig,
+  handleError,
+} from "../core/client-factory";
 import type {
   GetComposeResponse,
   CreateComposeResponse,
@@ -50,8 +54,11 @@ export async function resolveCompose(
   if (UUID_PATTERN.test(identifier)) {
     try {
       return await getComposeById(identifier);
-    } catch {
-      return null;
+    } catch (error) {
+      if (error instanceof ApiRequestError && error.status === 404) {
+        return null;
+      }
+      throw error;
     }
   }
   return getComposeByName(identifier, org);

--- a/turbo/apps/cli/src/lib/api/domains/zero-schedules.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-schedules.ts
@@ -10,7 +10,7 @@ import type {
   ScheduleListResponse,
   DeployScheduleResponse,
 } from "@vm0/core";
-import { getComposeByName } from "./composes";
+import { resolveCompose } from "./composes";
 
 /**
  * Deploy zero schedule (create or update)
@@ -127,7 +127,7 @@ export async function disableZeroSchedule(params: {
 }
 
 /**
- * Resolve a zero schedule by agent name using the list API.
+ * Resolve a zero schedule by agent identifier (UUID or name) using the list API.
  * Searches across all user's schedules and finds by agentId.
  *
  * Returns the full ScheduleResponse so callers can access any field.
@@ -137,12 +137,12 @@ export async function disableZeroSchedule(params: {
  * @throws Error if agent has no schedule or disambiguation is needed
  */
 export async function resolveZeroScheduleByAgent(
-  agentName: string,
+  agentIdentifier: string,
   scheduleName?: string,
 ): Promise<ScheduleResponse> {
-  const compose = await getComposeByName(agentName);
+  const compose = await resolveCompose(agentIdentifier);
   if (!compose) {
-    throw new Error(`Agent not found: ${agentName}`);
+    throw new Error(`Agent not found: ${agentIdentifier}`);
   }
 
   const { schedules } = await listZeroSchedules();
@@ -150,7 +150,7 @@ export async function resolveZeroScheduleByAgent(
   const agentSchedules = schedules.filter((s) => s.agentId === compose.id);
 
   if (agentSchedules.length === 0) {
-    throw new Error(`No schedule found for agent "${agentName}"`);
+    throw new Error(`No schedule found for agent "${agentIdentifier}"`);
   }
 
   if (scheduleName) {
@@ -158,7 +158,7 @@ export async function resolveZeroScheduleByAgent(
     if (!match) {
       const available = agentSchedules.map((s) => s.name).join(", ");
       throw new Error(
-        `Schedule "${scheduleName}" not found for agent "${agentName}". Available schedules: ${available}`,
+        `Schedule "${scheduleName}" not found for agent "${agentIdentifier}". Available schedules: ${available}`,
       );
     }
     return match;
@@ -170,6 +170,6 @@ export async function resolveZeroScheduleByAgent(
 
   const available = agentSchedules.map((s) => s.name).join(", ");
   throw new Error(
-    `Agent "${agentName}" has multiple schedules. Use --name to specify which one: ${available}`,
+    `Agent "${agentIdentifier}" has multiple schedules. Use --name to specify which one: ${available}`,
   );
 }

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -10,6 +10,7 @@ export { ApiRequestError } from "./core/client-factory";
 export {
   getComposeByName,
   getComposeById,
+  resolveCompose,
   getComposeVersion,
   createOrUpdateCompose,
 } from "./domains/composes";


### PR DESCRIPTION
## Summary

- All 5 schedule subcommands (`setup`, `status`, `enable`, `disable`, `delete`) used `getComposeByName()` to resolve the agent argument, which only matches compose **names** — not UUIDs
- Since `zero agent list` displays agent IDs as UUIDs, users would copy the UUID and pass it to schedule commands, always getting "Agent not found"
- Added `resolveCompose()` helper to `composes.ts` that checks if the identifier is a UUID first (via `getComposeById`), falling back to name lookup — matching the existing pattern in `run.ts`
- Updated `setup.ts` and `resolveZeroScheduleByAgent()` (shared by status/enable/disable/delete) to use the new resolver

Closes #6999

## Test plan

- [x] Added UUID-based agent resolution test for `schedule setup`
- [x] Added UUID-based agent resolution test for `schedule enable`
- [x] Added UUID-based agent resolution test for `schedule disable`
- [x] Added UUID-based agent resolution test for `schedule delete`
- [x] Added UUID-based agent resolution test for `schedule status`
- [x] All existing name-based tests still pass (backward compatibility)
- [x] Lint passes
- [x] Type-check passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)