### PR TITLE
refactor: switch ask-user flow to blocking cli command

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -4,24 +4,15 @@ import { initServices } from "../../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../../src/lib/callback";
 import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
-import { slackOrgPendingQuestions } from "../../../../../../src/db/schema/slack-org-pending-question";
 import { agentSessions } from "../../../../../../src/db/schema/agent-session";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
-import { zeroAgents } from "../../../../../../src/db/schema/zero-agent";
 import {
   createSlackClient,
   postMessage,
   setThreadStatus,
 } from "../../../../../../src/lib/slack/client";
-import {
-  buildAgentResponseMessage,
-  buildAskUserQuestionBlocks,
-} from "../../../../../../src/lib/slack/blocks";
-import type { AskUserQuestion } from "../../../../../../src/lib/slack/blocks";
-import {
-  extractAllRunOutputs,
-  formatAskUserDenials,
-} from "../../../../../../src/lib/run/extract-run-output";
+import { buildAgentResponseMessage } from "../../../../../../src/lib/slack/blocks";
+import { extractAllRunOutputs } from "../../../../../../src/lib/run/extract-run-output";
 import {
   saveThreadSession,
   buildLogsUrl,
@@ -29,11 +20,7 @@ import {
 import { env } from "../../../../../../src/env";
 import type { SlackOrgCallbackPayload } from "../../../../../../src/lib/callback/callback-payloads";
 import { logger } from "../../../../../../src/lib/logger";
-import type { WebClient } from "@slack/web-api";
-import type {
-  PermissionDenial,
-  RunOutput,
-} from "../../../../../../src/lib/run/extract-run-output";
+import type { RunOutput } from "../../../../../../src/lib/run/extract-run-output";
 
 const log = logger("callback:slack-org");
 
@@ -75,68 +62,6 @@ async function findNewSessionId(
     .orderBy(desc(agentSessions.updatedAt))
     .limit(1);
   return newSession?.id;
-}
-
-/**
- * Post an interactive Block Kit card for askUserQuestion denials.
- */
-async function postAskUserInteractiveCard(
-  client: WebClient,
-  resultData: { askUserDenials: PermissionDenial[] },
-  payload: SlackOrgCallbackPayload,
-  runId: string,
-  resolvedSessionId: string | undefined,
-  agentLabel: string,
-): Promise<void> {
-  const allQuestions: AskUserQuestion[] = [];
-  for (const denial of resultData.askUserDenials) {
-    const questions = denial.tool_input?.questions;
-    if (questions) {
-      allQuestions.push(...questions);
-    }
-  }
-
-  if (allQuestions.length === 0) {
-    return;
-  }
-
-  const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
-  const [pending] = await globalThis.services.db
-    .insert(slackOrgPendingQuestions)
-    .values({
-      runId,
-      slackWorkspaceId: payload.workspaceId,
-      slackChannelId: payload.channelId,
-      slackThreadTs: payload.threadTs,
-      connectionId: payload.connectionId,
-      composeId: payload.agentId,
-      agentName: agentLabel,
-      sessionId: resolvedSessionId,
-      questions: allQuestions,
-      expiresAt,
-    })
-    .returning({ id: slackOrgPendingQuestions.id });
-
-  if (!pending) {
-    return;
-  }
-
-  const fallbackText = formatAskUserDenials(resultData.askUserDenials);
-  const cardBlocks = buildAskUserQuestionBlocks(allQuestions, pending.id);
-
-  const cardResult = await postMessage(
-    client,
-    payload.channelId,
-    fallbackText ?? "The agent needs your input.",
-    { threadTs: payload.threadTs, blocks: cardBlocks },
-  );
-
-  if (cardResult.ts) {
-    await globalThis.services.db
-      .update(slackOrgPendingQuestions)
-      .set({ slackMessageTs: cardResult.ts })
-      .where(eq(slackOrgPendingQuestions.id, pending.id));
-  }
 }
 
 function buildResponseText(
@@ -273,20 +198,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   );
   const client = createSlackClient(botToken);
 
-  // Resolve agent display name and slug from zeroAgents
-  const [agentRow] = await globalThis.services.db
-    .select({ displayName: zeroAgents.displayName, name: zeroAgents.name })
-    .from(zeroAgents)
-    .where(eq(zeroAgents.id, payload.agentId))
-    .limit(1);
-  const agentLabel = agentRow?.displayName ?? agentRow?.name ?? "your agent";
-
   const allOutputs = await extractAllRunOutputs(runId, error);
-  const lastOutput = allOutputs[allOutputs.length - 1]!;
-  const hasAskUserDenials = lastOutput.askUserDenials.length > 0;
 
-  // Resolve session before posting interactive card
-  const resolvedSessionId = await saveOrgThreadSession(payload, runId, status);
+  // Resolve session
+  await saveOrgThreadSession(payload, runId, status);
 
   // Post each result as a separate Slack reply (in order)
   for (let i = 0; i < allOutputs.length; i++) {
@@ -301,18 +216,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       threadTs: payload.threadTs,
       blocks: buildAgentResponseMessage(responseText, logsUrl),
     });
-  }
-
-  // Post interactive card for askUserQuestion denials
-  if (hasAskUserDenials) {
-    await postAskUserInteractiveCard(
-      client,
-      lastOutput,
-      payload,
-      runId,
-      resolvedSessionId,
-      agentLabel,
-    );
   }
 
   // Clear assistant thinking status

--- a/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/__tests__/route.test.ts
@@ -142,7 +142,7 @@ describe("POST /api/zero/slack/interactive", () => {
   });
 
   describe("ask_user_submit", () => {
-    it("claims pending question and dispatches run", async () => {
+    it("claims pending question and writes answer to DB", async () => {
       const workspaceId = uniqueId("T-ws");
       const slackUserId = uniqueId("U-slack");
       const channelId = uniqueId("C-ch");
@@ -326,7 +326,7 @@ describe("POST /api/zero/slack/interactive", () => {
   });
 
   describe("direct_pick", () => {
-    it("claims pending question and dispatches run for single-select", async () => {
+    it("claims pending question and writes answer for single-select", async () => {
       const workspaceId = uniqueId("T-ws");
       const slackUserId = uniqueId("U-slack");
       const channelId = uniqueId("C-ch");

--- a/turbo/apps/web/app/api/zero/slack/interactive/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/interactive/route.ts
@@ -14,16 +14,12 @@ import { decryptSecretValue } from "../../../../../src/lib/crypto/secrets-encryp
 import {
   createSlackClient,
   updateMessage,
-  setThreadStatus,
 } from "../../../../../src/lib/slack/client";
 import {
   buildAskUserAnsweredBlocks,
   buildErrorMessage,
 } from "../../../../../src/lib/slack/blocks";
 import type { AskUserQuestion } from "../../../../../src/lib/slack/blocks";
-import { runAgentForSlackOrg } from "../../../../../src/lib/slack-org/handlers/run-agent";
-import type { SlackOrgCallbackPayload } from "../../../../../src/lib/callback/callback-payloads";
-import { getWorkspaceAgent } from "../../../../../src/lib/slack-org/handlers/shared";
 import { refreshOrgAppHome } from "../../../../../src/lib/slack-org/handlers/app-home";
 import { disconnect } from "../../../../../src/lib/slack-org/connect-service";
 import { logger } from "../../../../../src/lib/logger";
@@ -460,7 +456,8 @@ async function handleAskUserSubmit(
 }
 
 /**
- * Shared post-submit logic: update the card, set thinking status, dispatch run.
+ * Shared post-submit logic: update the card and write the answer to DB.
+ * The running agent picks up the answer via polling (GET /api/zero/ask-user/answer).
  */
 async function finishSubmit(
   payload: SlackInteractivePayload,
@@ -495,17 +492,9 @@ async function finishSubmit(
   );
   const client = createSlackClient(botToken);
 
-  // Resolve display name for user-visible blocks
-  const agentInfo = await getWorkspaceAgent(claimed.composeId);
-  const agentLabel = agentInfo?.displayName ?? claimed.agentName;
-
   // Replace interactive card with answered summary
   if (claimed.slackMessageTs) {
-    const answeredBlocks = buildAskUserAnsweredBlocks(
-      questions,
-      answers,
-      agentLabel,
-    );
+    const answeredBlocks = buildAskUserAnsweredBlocks(questions, answers);
     await updateMessage(
       client,
       claimed.slackChannelId,
@@ -515,74 +504,13 @@ async function finishSubmit(
     );
   }
 
-  // Set thinking status
-  try {
-    await setThreadStatus(
-      client,
-      claimed.slackChannelId,
-      claimed.slackThreadTs,
-      "is thinking...",
-    );
-  } catch (err) {
-    log.debug("Failed to set thread status", { error: err });
-  }
+  // Write answer to DB for CLI polling
+  await globalThis.services.db
+    .update(slackOrgPendingQuestions)
+    .set({ answer: answerPrompt })
+    .where(eq(slackOrgPendingQuestions.id, pendingId));
 
-  // Look up connection to get userId for the run
-  const [connection] = await globalThis.services.db
-    .select()
-    .from(slackOrgConnections)
-    .where(eq(slackOrgConnections.id, claimed.connectionId))
-    .limit(1);
-
-  if (!connection) {
-    log.error("Connection not found for pending question", { pendingId });
-    await updateCardWithError(
-      claimed.slackChannelId,
-      claimed.slackMessageTs,
-      claimed.slackWorkspaceId,
-      "Your Zero account connection was not found. Please reconnect your account.",
-    );
-    return;
-  }
-
-  // Dispatch new agent run with the user's answer
-  const callbackContext: SlackOrgCallbackPayload = {
-    workspaceId: claimed.slackWorkspaceId,
-    channelId: claimed.slackChannelId,
-    threadTs: claimed.slackThreadTs,
-    messageTs: claimed.slackThreadTs,
-    connectionId: claimed.connectionId,
-    agentId: claimed.composeId,
-    existingSessionId: claimed.sessionId ?? undefined,
-  };
-
-  if (!agentInfo) {
-    log.error("Zero agent not found for compose", {
-      composeId: claimed.composeId,
-    });
-    await updateCardWithError(
-      claimed.slackChannelId,
-      claimed.slackMessageTs,
-      claimed.slackWorkspaceId,
-      "The agent could not be found. Please contact your org admin.",
-    );
-    return;
-  }
-
-  await runAgentForSlackOrg({
-    composeId: claimed.composeId,
-    agentId: agentInfo.agentId,
-    agentName: claimed.agentName,
-    sessionId: claimed.sessionId ?? undefined,
-    prompt: answerPrompt,
-    threadContext: "",
-    userContext: "",
-    userId: connection.vm0UserId,
-    botUserId: installation.botUserId,
-    callbackContext,
-  });
-
-  log.debug("askUserQuestion answer dispatched", {
+  log.debug("askUserQuestion answer persisted", {
     pendingId,
     answerPrompt,
   });

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -56,6 +56,7 @@ export function buildAgentToolsPrompt(): string {
     "You have access to the Zero CLI. Run commands with: `npx -p @vm0/cli zero <command>`",
     "- When you need to discover available commands, run `zero --help`.",
     "- When you need to schedule or manage recurring tasks, use `zero schedule`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
+    "- When you need to ask the user a question, use `zero ask-user question`. Do NOT use the AskUserQuestion tool — it is not available.",
     "- When you need to send a Slack message, use `zero slack message send`. Never use SLACK_TOKEN directly — it's a user token.",
     "- When you encounter a missing token or environment variable error, run `zero doctor missing-token <TOKEN_NAME>` to diagnose the issue and get remediation steps for the user.",
     "- When you need to update your own configuration (description, tone, or instructions), use `zero agent edit $ZERO_AGENT_ID`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",

--- a/turbo/apps/web/src/lib/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/run/extract-run-output.ts
@@ -4,7 +4,7 @@ import { queryAxiom, getDatasetName, DATASETS } from "../axiom";
 // Types
 // ---------------------------------------------------------------------------
 
-export interface PermissionDenial {
+interface PermissionDenial {
   tool_name: string;
   tool_input?: {
     questions?: Array<{

--- a/turbo/apps/web/src/lib/slack/__tests__/ask-user-blocks.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/ask-user-blocks.test.ts
@@ -160,12 +160,12 @@ describe("buildAskUserAnsweredBlocks", () => {
     answers.set(0, ["React"]);
     answers.set(1, ["TS", "JS"]);
 
-    const blocks = buildAskUserAnsweredBlocks(questions, answers, "my-agent");
+    const blocks = buildAskUserAnsweredBlocks(questions, answers);
 
     // Context header
     expect(blocks[0]).toMatchObject({
       type: "context",
-      elements: [{ type: "mrkdwn", text: expect.stringContaining("my-agent") }],
+      elements: [{ type: "mrkdwn", text: expect.stringContaining("Answered") }],
     });
 
     // First question answer
@@ -182,7 +182,7 @@ describe("buildAskUserAnsweredBlocks", () => {
     const questions: AskUserQuestion[] = [{ question: "Framework?" }];
     const answers = new Map<number, string[]>();
 
-    const blocks = buildAskUserAnsweredBlocks(questions, answers, "agent");
+    const blocks = buildAskUserAnsweredBlocks(questions, answers);
 
     const q1 = blocks[1] as SectionBlock;
     expect(q1.text?.text).toContain("_No selection_");

--- a/turbo/apps/web/src/lib/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/slack/blocks.ts
@@ -612,7 +612,6 @@ export function buildAskUserQuestionBlocks(
 export function buildAskUserAnsweredBlocks(
   questions: AskUserQuestion[],
   answers: Map<number, string[]>,
-  agentName: string,
 ): (Block | KnownBlock)[] {
   const blocks: (Block | KnownBlock)[] = [
     {
@@ -620,7 +619,7 @@ export function buildAskUserAnsweredBlocks(
       elements: [
         {
           type: "mrkdwn",
-          text: `:white_check_mark: *Answered — ${agentName} is continuing...*`,
+          text: `:white_check_mark: *Answered*`,
         },
       ],
     },


### PR DESCRIPTION
## Summary

Part of Epic #6872 — replaces the AskUserQuestion run-restart cycle with a blocking `zero ask-user question` CLI command.

- Simplifies `finishSubmit()` in Slack interactive handler to write answer to DB instead of dispatching a new agent run
- Adds agent tools prompt instructing agents to use `zero ask-user question` instead of the disabled AskUserQuestion tool
- Removes dead ask-user denial handling from Slack org callback (no longer needed since AskUserQuestion is disabled)
- Simplifies `buildAskUserAnsweredBlocks` by removing `agentName` parameter (agent no longer restarts)
- Unexports `PermissionDenial` type (no longer consumed externally)

Closes #6964

## Test plan

- [x] Existing ask-user-blocks tests updated and passing
- [x] Interactive route test descriptions updated to reflect new flow
- [x] Lint passes
- [x] Knip passes (no unused exports/imports)
- [ ] CI pipeline (build, lint, test, e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)