### PR TITLE
fix(e2e): match app url against derived hostname instead of prefix

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -2005,7 +2005,7 @@ jobs:
           check_result "deploy-app" "${{ needs.deploy-app.result }}" "true"
           check_result "build-cli" "${{ needs.build-cli.result }}" "true"
           check_result "build-e2b-template" "${{ needs.build-e2b-template.result }}" "true"
-          check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "informational"
+          check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "true"
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
           check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "true"
           check_result "deploy-runner-start" "${{ needs.deploy-runner-start.result }}" "true"

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -986,8 +986,16 @@ jobs:
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     needs: [prepare]
-    # Deploy if job-ref is set (PR or main), not a release-please commit, and platform changed
-    if: "${{ (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) && needs.prepare.outputs.job-ref != '' && needs.prepare.outputs.platform-changed == 'true' }}"
+    # Deploy if job-ref is set (PR or main), not a release-please commit, and platform/e2e/ci changed
+    if: >-
+      ${{
+        (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+        needs.prepare.outputs.job-ref != '' && (
+          needs.prepare.outputs.platform-changed == 'true' ||
+          needs.prepare.outputs.e2e-changed == 'true' ||
+          needs.prepare.outputs.ci-changed == 'true'
+        )
+      }}
     permissions:
       contents: read
       pull-requests: write
@@ -1039,15 +1047,18 @@ jobs:
     concurrency:
       group: cli-e2e-02-browser-${{ needs.prepare.outputs.job-ref }}
       cancel-in-progress: true
-    needs: [prepare, deploy-web]
+    needs: [prepare, deploy-web, deploy-app]
     if: |
+      always() &&
       (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
         needs.prepare.outputs.ci-changed == 'true' ||
         needs.prepare.outputs.e2e-changed == 'true'
-      )
+      ) &&
+      needs.deploy-web.result == 'success' &&
+      (needs.deploy-app.result == 'success' || needs.deploy-app.result == 'skipped')
     steps:
       - uses: actions/checkout@v6
         with:

--- a/e2e/tests/02-browser/brw-t03-onboarding-chat.bats
+++ b/e2e/tests/02-browser/brw-t03-onboarding-chat.bats
@@ -14,13 +14,16 @@ load '../../helpers/setup'
 load '../../helpers/browser'
 
 # ---------------------------------------------------------------------------
-# url_is_on_app — Check if a URL's hostname starts with "app."
+# url_is_on_app — Check if a URL's hostname matches the APP_URL hostname
+# Compares against the derived APP_URL rather than assuming "app." prefix,
+# so it works for all environments (app.vm7.ai, staging-app.vm6.ai, etc.)
 # ---------------------------------------------------------------------------
 url_is_on_app() {
   local url="$1"
-  local host
-  host=$(echo "$url" | sed -n 's|.*://\([^/:]*\).*|\1|p')
-  [[ "$host" == app.* ]]
+  local url_host app_host
+  url_host=$(echo "$url" | sed -n 's|.*://\([^/:]*\).*|\1|p')
+  app_host=$(echo "$APP_URL" | sed -n 's|.*://\([^/:]*\).*|\1|p')
+  [[ "$url_host" == "$app_host" ]]
 }
 
 setup_file() {


### PR DESCRIPTION
## Summary
- Fix `url_is_on_app` in `brw-t03-onboarding-chat.bats` to compare against the derived `APP_URL` hostname instead of assuming URLs start with `app.`
- This fixes CI failures on staging (`staging-app.vm6.ai`) and PR preview (`pr-123-app.vm0-dev.com`) environments

## Root Cause
The function used `[[ "$host" == app.* ]]` which only matched local dev URLs like `app.vm7.ai`. Staging and preview URLs have prefixes (`staging-app.`, `pr-123-app.`) that don't match this pattern.

The auth and onboarding actually succeeded (confirmed via CI screenshots), but the URL validation incorrectly rejected the hostname.

## Test plan
- [x] Verified via CI artifact screenshots that auth/onboarding succeeded — failure was purely in URL validation
- [ ] CI browser E2E tests pass on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)