### PR TITLE
fix: update gamma connector help text with correct API key URL

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -1622,7 +1622,7 @@ const CONNECTOR_TYPES_DEF = {
       "api-token": {
         label: "API Key",
         helpText:
-          "1. Log in to [Gamma](https://gamma.app) (requires Pro, Ultra, Teams, or Business plan)\n2. Go to **Settings and Members > API key** tab\n3. Click **Create API key**\n4. Copy the key (it is only shown once)",
+          "1. Log in to [Gamma](https://gamma.app)\n2. Go to [API Keys](https://gamma.app/settings/api-keys) (Settings > API Keys)\n3. Click **Create API key**\n4. Copy the key (it is only shown once)",
         secrets: {
           GAMMA_TOKEN: {
             label: "API Key",


### PR DESCRIPTION
## Summary

- Update the Gamma connector's API key help text to reference the correct navigation path (Settings > API Keys) instead of the incorrect "Settings and Members > API key"
- Add a direct link to the API keys page at https://gamma.app/settings/api-keys for improved UX
- Remove the plan requirement note from step 1 as it was inaccurate

Closes #7015

## Test plan

- [ ] Verify type checking passes (`pnpm check-types` in the core package)
- [ ] Verify the help text renders correctly in the connector setup UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)