### PR TITLE
refactor(web): extract api-token connector type derivation into shared function

### DIFF
--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -37,6 +37,38 @@ function getSecretNameForConnector(type: ConnectorType): string {
 }
 
 /**
+ * Derive api-token connector types from user secrets and variables.
+ * API-token connectors don't have DB records — their existence is inferred
+ * from matching user secrets/variables.
+ */
+export async function getApiTokenConnectorTypes(
+  orgId: string,
+  userId: string,
+): Promise<ConnectorType[]> {
+  const db = globalThis.services.db;
+  const [userSecretRows, userVariableRows] = await Promise.all([
+    db
+      .select({ name: secrets.name })
+      .from(secrets)
+      .where(
+        and(
+          eq(secrets.orgId, orgId),
+          eq(secrets.userId, userId),
+          eq(secrets.type, "user"),
+        ),
+      ),
+    db
+      .select({ name: variables.name })
+      .from(variables)
+      .where(and(eq(variables.orgId, orgId), eq(variables.userId, userId))),
+  ]);
+  return deriveApiTokenConnectedTypes(
+    new Set(userSecretRows.map((r) => r.name)),
+    new Set(userVariableRows.map((r) => r.name)),
+  );
+}
+
+/**
  * List all connectors for an org.
  * Returns OAuth connectors from DB plus derived api-token connectors
  * based on user secrets that match api-token required secret names.
@@ -47,8 +79,8 @@ export async function listConnectors(
 ): Promise<ConnectorResponse[]> {
   const db = globalThis.services.db;
 
-  // Query OAuth connectors from DB, user secret names, and variable names in parallel
-  const [dbResult, userSecretRows, userVariableRows] = await Promise.all([
+  // Query OAuth connectors from DB and derive api-token types in parallel
+  const [dbResult, derivedTypes] = await Promise.all([
     db
       .select({
         id: connectors.id,
@@ -65,20 +97,7 @@ export async function listConnectors(
       .from(connectors)
       .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId)))
       .orderBy(connectors.type),
-    db
-      .select({ name: secrets.name })
-      .from(secrets)
-      .where(
-        and(
-          eq(secrets.orgId, orgId),
-          eq(secrets.userId, userId),
-          eq(secrets.type, "user"),
-        ),
-      ),
-    db
-      .select({ name: variables.name })
-      .from(variables)
-      .where(and(eq(variables.orgId, orgId), eq(variables.userId, userId))),
+    getApiTokenConnectorTypes(orgId, userId),
   ]);
 
   const dbConnectors: ConnectorResponse[] = dbResult.map((row) => ({
@@ -93,14 +112,6 @@ export async function listConnectors(
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
   }));
-
-  // Derive api-token connected types from user secrets and variables
-  const userSecretNames = new Set(userSecretRows.map((r) => r.name));
-  const userVariableNames = new Set(userVariableRows.map((r) => r.name));
-  const derivedTypes = deriveApiTokenConnectedTypes(
-    userSecretNames,
-    userVariableNames,
-  );
 
   // DB record takes precedence over derived
   const dbTypeSet = new Set(dbConnectors.map((c) => c.type));

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -22,7 +22,6 @@ import {
   type FirewallPolicies,
   getConnectorFirewall,
   isFirewallConnectorType,
-  deriveApiTokenConnectedTypes,
 } from "@vm0/core";
 import { agentComposeVersions } from "../../db/schema/agent-compose";
 import type { AgentComposeYaml } from "../../types/agent-compose";
@@ -45,10 +44,11 @@ import { getOrgDefaultModelProvider } from "../model-provider/model-provider-ser
 import { getVm0ApiKey } from "../vm0-key/vm0-key-service";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { connectors } from "../../db/schema/connector";
-import { secrets as secretsTable } from "../../db/schema/secret";
-import { variables as variablesTable } from "../../db/schema/variable";
 import { PROVIDER_HANDLERS } from "../connector/provider-registry";
-import { refreshConnectorAccessToken } from "../connector/connector-service";
+import {
+  getApiTokenConnectorTypes,
+  refreshConnectorAccessToken,
+} from "../connector/connector-service";
 
 const log = logger("run:build-context");
 
@@ -433,37 +433,14 @@ async function resolveConnectorSecrets(
 ): Promise<ConnectorSecretResult> {
   const db = globalThis.services.db;
 
-  // Query OAuth connectors, user secrets, and user variables in parallel.
-  // User secrets/variables are needed to derive api-token connector types
-  // (these don't have DB records in the connectors table).
-  const [userConnectors, userSecretRows, userVariableRows] = await Promise.all([
+  // Query OAuth connectors and derive api-token types in parallel.
+  const [userConnectors, derivedApiTokenTypes] = await Promise.all([
     db
       .select({ type: connectors.type, authMethod: connectors.authMethod })
       .from(connectors)
       .where(and(eq(connectors.orgId, orgId), eq(connectors.userId, userId))),
-    db
-      .select({ name: secretsTable.name })
-      .from(secretsTable)
-      .where(
-        and(
-          eq(secretsTable.orgId, orgId),
-          eq(secretsTable.userId, userId),
-          eq(secretsTable.type, "user"),
-        ),
-      ),
-    db
-      .select({ name: variablesTable.name })
-      .from(variablesTable)
-      .where(
-        and(eq(variablesTable.orgId, orgId), eq(variablesTable.userId, userId)),
-      ),
+    getApiTokenConnectorTypes(orgId, userId),
   ]);
-
-  // Derive api-token connector types from user secrets/variables
-  const derivedApiTokenTypes = deriveApiTokenConnectedTypes(
-    new Set(userSecretRows.map((r) => r.name)),
-    new Set(userVariableRows.map((r) => r.name)),
-  );
 
   if (userConnectors.length === 0) {
     return {


### PR DESCRIPTION
## Summary
- Extract `getApiTokenConnectorTypes()` from duplicated logic in `connector-service.ts` and `build-context.ts`
- Both files had identical patterns: query user secrets/variables → build Sets → call `deriveApiTokenConnectedTypes`
- The new shared function lives in `connector-service.ts` and is reused by both callers

## Test plan
- [ ] `pnpm check-types` passes
- [ ] `pnpm knip` finds no issues
- [ ] Existing connector tests pass (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)