### PR TITLE
chore: remove dead ask-user denials extraction code

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -72,9 +72,6 @@ function buildResponseText(
   if (status !== "completed") {
     return `Error: ${error ?? "Agent execution failed."}`;
   }
-  if (resultData && resultData.askUserDenials.length > 0) {
-    return resultData.result ?? "";
-  }
   return resultData?.result ?? "Task completed successfully.";
 }
 

--- a/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/telegram/route.ts
@@ -19,11 +19,7 @@ import {
   buildTelegramResponse,
   buildTelegramErrorResponse,
 } from "../../../../../src/lib/telegram/format";
-import {
-  extractRunOutput,
-  formatAskUserDenials,
-  type RunOutput,
-} from "../../../../../src/lib/run/extract-run-output";
+import { extractRunOutput } from "../../../../../src/lib/run/extract-run-output";
 import {
   saveTelegramThreadSession,
   storeTelegramMessage,
@@ -90,13 +86,9 @@ async function findNewSessionId(
  * Build a plain-text output string from the already-fetched RunOutput,
  * avoiding a redundant Axiom query.
  */
-function buildOutputText(output: RunOutput): string | undefined {
-  if (output.askUserDenials.length > 0) {
-    const formatted = formatAskUserDenials(output.askUserDenials);
-    if (formatted) {
-      return output.result ? `${output.result}\n\n${formatted}` : formatted;
-    }
-  }
+function buildOutputText(output: {
+  result: string | null;
+}): string | undefined {
   return output.result ?? undefined;
 }
 

--- a/turbo/apps/web/src/lib/run/__tests__/extract-run-output.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/extract-run-output.test.ts
@@ -14,7 +14,6 @@ import {
   extractRunOutput,
   extractAllRunOutputs,
   getAllRunOutputTexts,
-  formatAskUserDenials,
 } from "../extract-run-output";
 
 /**
@@ -51,7 +50,6 @@ describe("extractRunOutput", () => {
 
     expect(output).toEqual({
       result: null,
-      askUserDenials: [],
       error: null,
     });
   });
@@ -74,30 +72,6 @@ describe("extractRunOutput", () => {
 
     expect(output.error).toBe("sandbox crashed");
     expect(output.result).toBeNull();
-  });
-
-  it("filters AskUserQuestion denials from permission_denials", async () => {
-    mockQuery.mockResolvedValue(
-      axiomResponse([
-        {
-          eventData: {
-            result: "done",
-            permission_denials: [
-              {
-                tool_name: "AskUserQuestion",
-                tool_input: { questions: [{ question: "Pick one" }] },
-              },
-              { tool_name: "Bash" },
-            ],
-          },
-        },
-      ]),
-    );
-
-    const output = await extractRunOutput("run-1");
-
-    expect(output.askUserDenials).toHaveLength(1);
-    expect(output.askUserDenials[0]!.tool_name).toBe("AskUserQuestion");
   });
 });
 
@@ -184,92 +158,5 @@ describe("getAllRunOutputTexts", () => {
     const texts = await getAllRunOutputTexts("run-1");
 
     expect(texts).toEqual(["first result", "second result"]);
-  });
-
-  it("skips events without result but includes those with denials only", async () => {
-    mockQuery.mockResolvedValue(
-      axiomResponse([
-        { eventData: { result: "ok" } },
-        {
-          eventData: {
-            permission_denials: [
-              {
-                tool_name: "AskUserQuestion",
-                tool_input: { questions: [{ question: "Choose color" }] },
-              },
-            ],
-          },
-        },
-      ]),
-    );
-
-    const texts = await getAllRunOutputTexts("run-1");
-
-    expect(texts).toHaveLength(2);
-    expect(texts[0]).toBe("ok");
-    expect(texts[1]).toContain("Choose color");
-  });
-
-  it("appends formatted denials to result text", async () => {
-    mockQuery.mockResolvedValue(
-      axiomResponse([
-        {
-          eventData: {
-            result: "Need input",
-            permission_denials: [
-              {
-                tool_name: "AskUserQuestion",
-                tool_input: { questions: [{ question: "Yes or no?" }] },
-              },
-            ],
-          },
-        },
-      ]),
-    );
-
-    const texts = await getAllRunOutputTexts("run-1");
-
-    expect(texts).toHaveLength(1);
-    expect(texts[0]).toContain("Need input");
-    expect(texts[0]).toContain("Yes or no?");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// formatAskUserDenials
-// ---------------------------------------------------------------------------
-
-describe("formatAskUserDenials", () => {
-  it("returns undefined for empty denials", () => {
-    expect(formatAskUserDenials([])).toBeUndefined();
-  });
-
-  it("returns undefined when denials have no questions", () => {
-    expect(
-      formatAskUserDenials([{ tool_name: "AskUserQuestion" }]),
-    ).toBeUndefined();
-  });
-
-  it("formats question with options", () => {
-    const result = formatAskUserDenials([
-      {
-        tool_name: "AskUserQuestion",
-        tool_input: {
-          questions: [
-            {
-              question: "Pick a color",
-              options: [
-                { label: "Red", description: "Warm" },
-                { label: "Blue" },
-              ],
-            },
-          ],
-        },
-      },
-    ]);
-
-    expect(result).toContain("Pick a color");
-    expect(result).toContain("Red — Warm");
-    expect(result).toContain("Blue");
   });
 });

--- a/turbo/apps/web/src/lib/run/extract-run-output.ts
+++ b/turbo/apps/web/src/lib/run/extract-run-output.ts
@@ -4,23 +4,9 @@ import { queryAxiom, getDatasetName, DATASETS } from "../axiom";
 // Types
 // ---------------------------------------------------------------------------
 
-interface PermissionDenial {
-  tool_name: string;
-  tool_input?: {
-    questions?: Array<{
-      question: string;
-      header?: string;
-      options?: Array<{ label: string; description?: string }>;
-      multiSelect?: boolean;
-    }>;
-  };
-}
-
 export interface RunOutput {
   /** Raw result text from the agent */
   result: string | null;
-  /** AskUserQuestion permission denials */
-  askUserDenials: PermissionDenial[];
   /** Run error message (if failed) */
   error: string | null;
 }
@@ -32,7 +18,6 @@ export interface RunOutput {
 interface ResultEvent {
   eventData: {
     result?: string;
-    permission_denials?: PermissionDenial[];
   };
 }
 
@@ -82,7 +67,6 @@ export async function extractRunOutput(
   if (!event) {
     return {
       result: null,
-      askUserDenials: [],
       error: error ?? null,
     };
   }
@@ -107,7 +91,6 @@ export async function extractAllRunOutputs(
     return [
       {
         result: null,
-        askUserDenials: [],
         error: error ?? null,
       },
     ];
@@ -120,14 +103,8 @@ function buildRunOutput(event: ResultEvent, error?: string | null): RunOutput {
   const result =
     typeof event.eventData?.result === "string" ? event.eventData.result : null;
 
-  const allDenials = event.eventData?.permission_denials ?? [];
-  const askUserDenials = allDenials.filter(
-    (d) => d.tool_name === "AskUserQuestion",
-  );
-
   return {
     result,
-    askUserDenials,
     error: error ?? null,
   };
 }
@@ -142,17 +119,8 @@ export async function getAllRunOutputTexts(runId: string): Promise<string[]> {
   const texts: string[] = [];
 
   for (const output of outputs) {
-    let text = output.result ?? undefined;
-
-    if (output.askUserDenials.length > 0) {
-      const formatted = formatAskUserDenials(output.askUserDenials);
-      if (formatted) {
-        text = text ? `${text}\n\n${formatted}` : formatted;
-      }
-    }
-
-    if (text) {
-      texts.push(text);
+    if (output.result) {
+      texts.push(output.result);
     }
   }
 
@@ -160,57 +128,13 @@ export async function getAllRunOutputTexts(runId: string): Promise<string[]> {
 }
 
 /**
- * Format AskUserQuestion denials as plain text.
- *
- * Used by non-interactive channels (Slack, Telegram, email) that cannot
- * render interactive question UIs.
- */
-export function formatAskUserDenials(
-  denials: PermissionDenial[],
-): string | undefined {
-  const parts: string[] = [];
-
-  for (const denial of denials) {
-    const questions = denial.tool_input?.questions;
-    if (!questions || questions.length === 0) {
-      continue;
-    }
-
-    for (const q of questions) {
-      parts.push(q.question);
-      if (q.options) {
-        for (const opt of q.options) {
-          const desc = opt.description ? ` — ${opt.description}` : "";
-          parts.push(`  • ${opt.label}${desc}`);
-        }
-      }
-    }
-  }
-
-  if (parts.length === 0) {
-    return undefined;
-  }
-
-  return `The agent needs your input to proceed:\n\n${parts.join("\n")}`;
-}
-
-/**
- * Get formatted run output text (result + formatted denials).
+ * Get formatted run output text (result string).
  *
  * Convenience wrapper for channels that just need a string.
- * Replaces the old `getRunOutput()` function.
  */
 export async function getRunOutputText(
   runId: string,
 ): Promise<string | undefined> {
   const output = await extractRunOutput(runId);
-
-  if (output.askUserDenials.length > 0) {
-    const formatted = formatAskUserDenials(output.askUserDenials);
-    if (formatted) {
-      return output.result ? `${output.result}\n\n${formatted}` : formatted;
-    }
-  }
-
   return output.result ?? undefined;
 }


### PR DESCRIPTION
## Summary

- Removed `PermissionDenial` interface, `askUserDenials` field from `RunOutput`, and `formatAskUserDenials()` function from `extract-run-output.ts`
- Removed dead `askUserDenials` branch in Slack org callback `buildResponseText()`
- Removed `formatAskUserDenials` import and simplified `buildOutputText()` in Telegram callback
- Removed all dead test cases for denials filtering and formatting

After Epic #6872 disabled `AskUserQuestion` via `DISALLOWED_TOOLS`, all `askUserDenials` code paths were dead (always empty array). Net removal of ~200 lines.

Closes #7025

## Test plan

- [x] All remaining extract-run-output tests pass (9/9)
- [x] Lint, knip, prettier all pass
- [x] `grep` confirms zero remaining references to `askUserDenials`, `formatAskUserDenials`, `PermissionDenial`
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)