### PR TITLE
fix: remove stale skills from database when deleted from source repo

### DIFF
--- a/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
@@ -21,6 +21,7 @@ import {
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../src/env";
 import { server } from "../../../../../src/mocks/server";
+import { logger } from "../../../../../src/lib/logger";
 
 const context = testContext();
 const cronSecret = "test-cron-secret";
@@ -359,6 +360,127 @@ describe("GET /api/cron/sync-skills", () => {
         description: "Updated slack skill",
       });
       expect(slackSkill!.commitSha).toBe(newCommitSha);
+    });
+  });
+
+  describe("Orphan removal", () => {
+    it("should remove skills deleted from source repo", async () => {
+      // First sync: both slack and github exist
+      const tarball1 = createMockTarball(MOCK_SKILLS);
+      setupMswHandlers(TEST_COMMIT_SHA, tarball1);
+
+      await GET(cronRequest(cronSecret));
+
+      // Verify both skills exist
+      const allSkillsBefore = await findAllTestSkills();
+      expect(allSkillsBefore).toHaveLength(2);
+      const allStoragesBefore = await findTestSystemStorages();
+      expect(allStoragesBefore).toHaveLength(2);
+
+      // Mock listS3Objects to return objects for cleanup
+      context.mocks.s3.listS3Objects.mockResolvedValue([
+        {
+          key: "mock/archive.tar.gz",
+          size: 100,
+          lastModified: new Date(),
+        },
+        {
+          key: "mock/manifest.json",
+          size: 50,
+          lastModified: new Date(),
+        },
+      ]);
+
+      // Second sync: only slack remains (github removed)
+      const newCommitSha = "b".repeat(40);
+      const tarball2 = createMockTarball([MOCK_SKILLS[0]!]);
+      setupMswHandlers(newCommitSha, tarball2);
+
+      const response = await GET(cronRequest(cronSecret));
+      const data = await response.json();
+
+      expect(data.removed).toBe(1);
+      expect(data.synced).toBe(0); // slack unchanged
+      expect(data.skipped).toBe(1); // slack skipped (same hash)
+
+      // Verify github skill is gone
+      const githubSkill = await findTestSkillByUrl(
+        "https://github.com/vm0-ai/vm0-skills/tree/main/github",
+      );
+      expect(githubSkill).toBeNull();
+
+      // Verify slack still exists
+      const slackSkill = await findTestSkillByUrl(
+        "https://github.com/vm0-ai/vm0-skills/tree/main/slack",
+      );
+      expect(slackSkill).not.toBeNull();
+
+      // Verify only 1 skill and 1 storage remain
+      const allSkillsAfter = await findAllTestSkills();
+      expect(allSkillsAfter).toHaveLength(1);
+      const allStoragesAfter = await findTestSystemStorages();
+      expect(allStoragesAfter).toHaveLength(1);
+
+      // Verify S3 cleanup was called
+      expect(context.mocks.s3.listS3Objects).toHaveBeenCalled();
+      expect(context.mocks.s3.deleteS3Objects).toHaveBeenCalledWith(
+        expect.any(String),
+        ["mock/archive.tar.gz", "mock/manifest.json"],
+      );
+    });
+
+    it("should handle S3 cleanup failure gracefully", async () => {
+      // First sync: both skills
+      const tarball1 = createMockTarball(MOCK_SKILLS);
+      setupMswHandlers(TEST_COMMIT_SHA, tarball1);
+      await GET(cronRequest(cronSecret));
+
+      // Make S3 list throw
+      context.mocks.s3.listS3Objects.mockRejectedValue(
+        new Error("S3 connection failed"),
+      );
+
+      // Second sync: github removed
+      const newCommitSha = "b".repeat(40);
+      const tarball2 = createMockTarball([MOCK_SKILLS[0]!]);
+      setupMswHandlers(newCommitSha, tarball2);
+
+      const response = await GET(cronRequest(cronSecret));
+      const data = await response.json();
+
+      // DB cleanup should still succeed despite S3 failure
+      expect(data.removed).toBe(1);
+
+      const allSkills = await findAllTestSkills();
+      expect(allSkills).toHaveLength(1);
+
+      const allStorages = await findTestSystemStorages();
+      expect(allStorages).toHaveLength(1);
+    });
+  });
+
+  describe("SEED_SKILLS validation", () => {
+    it("should emit log.error when SEED_SKILLS references missing skill", async () => {
+      const syncLogger = logger("skills:sync");
+      const errorSpy = vi.spyOn(syncLogger, "error");
+
+      // Sync with skills that don't include all SEED_SKILLS entries
+      // (SEED_SKILLS has 30+ entries, but tarball only has slack + github)
+      const tarball = createMockTarball(MOCK_SKILLS);
+      setupMswHandlers(TEST_COMMIT_SHA, tarball);
+
+      await GET(cronRequest(cronSecret));
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "SEED_SKILLS references skills not found in repository",
+        expect.objectContaining({
+          missingSkills: expect.arrayContaining([
+            expect.stringContaining("vm0-ai/vm0-skills"),
+          ]),
+        }),
+      );
+
+      errorSpy.mockRestore();
     });
   });
 });

--- a/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/sync-skills/__tests__/route.test.ts
@@ -379,16 +379,8 @@ describe("GET /api/cron/sync-skills", () => {
 
       // Mock listS3Objects to return objects for cleanup
       context.mocks.s3.listS3Objects.mockResolvedValue([
-        {
-          key: "mock/archive.tar.gz",
-          size: 100,
-          lastModified: new Date(),
-        },
-        {
-          key: "mock/manifest.json",
-          size: 50,
-          lastModified: new Date(),
-        },
+        { key: "mock/archive.tar.gz", size: 100 },
+        { key: "mock/manifest.json", size: 50 },
       ]);
 
       // Second sync: only slack remains (github removed)

--- a/turbo/apps/web/src/lib/skills/sync-skills.ts
+++ b/turbo/apps/web/src/lib/skills/sync-skills.ts
@@ -11,7 +11,7 @@ import { mkdtemp, writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import * as tar from "tar";
-import { eq } from "drizzle-orm";
+import { eq, inArray, like } from "drizzle-orm";
 import {
   SYSTEM_ORG_ID,
   VOLUME_ORG_USER_ID,
@@ -20,6 +20,7 @@ import {
   DEFAULT_SKILLS_REPO,
   DEFAULT_SKILLS_BRANCH,
   parseSkillFrontmatter,
+  resolveSkillRef,
   type SkillFrontmatter,
 } from "@vm0/core";
 import { fetchHeadCommitSha } from "./git-refs";
@@ -28,11 +29,12 @@ import {
   computeSystemSkillHash,
   type FileEntryWithHash,
 } from "../storage/content-hash";
-import { putS3Object } from "../s3/s3-client";
+import { putS3Object, listS3Objects, deleteS3Objects } from "../s3/s3-client";
 import { skills } from "../../db/schema/skill";
 import { storages, storageVersions } from "../../db/schema/storage";
 import { env } from "../../env";
 import { logger } from "../logger";
+import { SEED_SKILLS } from "../zero/seed-skills";
 
 const log = logger("skills:sync");
 
@@ -44,6 +46,8 @@ interface SyncResult {
   skipped: number;
   /** Skills that failed to sync (e.g. bad frontmatter) */
   failed: number;
+  /** Skills removed because they no longer exist in source repo */
+  removed: number;
   /** Total skills found in tarball */
   total: number;
 }
@@ -69,7 +73,14 @@ export async function syncSkills(): Promise<SyncResult> {
     .limit(1);
 
   if (existing?.commitSha === headSha) {
-    return { commitSha: headSha, synced: 0, skipped: 0, failed: 0, total: 0 };
+    return {
+      commitSha: headSha,
+      synced: 0,
+      skipped: 0,
+      failed: 0,
+      removed: 0,
+      total: 0,
+    };
   }
 
   // 3. Download and extract tarball
@@ -108,11 +119,18 @@ export async function syncSkills(): Promise<SyncResult> {
     }
   }
 
+  // 5. Remove orphaned skills (in DB but no longer in tarball)
+  const removed = await removeOrphanedSkills(db, extractedSkills);
+
+  // 6. Validate SEED_SKILLS against tarball
+  validateSeedSkills(extractedSkills);
+
   log.info("Sync completed", {
     commitSha: headSha,
     synced,
     skipped,
     failed,
+    removed,
     total: extractedSkills.length,
   });
 
@@ -121,6 +139,7 @@ export async function syncSkills(): Promise<SyncResult> {
     synced,
     skipped,
     failed,
+    removed,
     total: extractedSkills.length,
   };
 }
@@ -137,7 +156,7 @@ async function syncSingleSkill(
   commitSha: string,
 ): Promise<boolean> {
   const { skillName, files } = extracted;
-  const skillUrl = `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`;
+  const skillUrl = buildSkillUrl(skillName);
   const fullPath = `${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`;
   const storageName = getSkillStorageName(fullPath);
 
@@ -284,6 +303,103 @@ async function syncSingleSkill(
     versionHash: versionHash.slice(0, 8),
   });
   return true;
+}
+
+/**
+ * Build the canonical URL for an official skill.
+ */
+function buildSkillUrl(skillName: string): string {
+  return `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/${skillName}`;
+}
+
+/**
+ * Remove skills from the database that no longer exist in the source repository.
+ *
+ * Deletion order: skills → storages (cascades to storageVersions) → S3 objects.
+ * S3 cleanup is best-effort — errors are logged but do not block the sync.
+ *
+ * @returns Number of orphaned skills removed
+ */
+async function removeOrphanedSkills(
+  db: typeof globalThis.services.db,
+  extractedSkills: ExtractedSkill[],
+): Promise<number> {
+  const tarballUrls = new Set(
+    extractedSkills.map((e) => buildSkillUrl(e.skillName)),
+  );
+
+  // Find all official skills in DB
+  const urlPrefix = `https://github.com/${DEFAULT_SKILLS_OWNER}/${DEFAULT_SKILLS_REPO}/tree/${DEFAULT_SKILLS_BRANCH}/`;
+  const existingSkills = await db
+    .select({ id: skills.id, url: skills.url, storageId: skills.storageId })
+    .from(skills)
+    .where(like(skills.url, `${urlPrefix}%`));
+
+  const orphans = existingSkills.filter((s) => !tarballUrls.has(s.url));
+  if (orphans.length === 0) return 0;
+
+  const orphanIds = orphans.map((o) => o.id);
+  const orphanStorageIds = orphans
+    .map((o) => o.storageId)
+    .filter((id): id is string => id !== null);
+
+  // Get S3 prefixes before deleting DB records
+  let orphanStorages: { id: string; s3Prefix: string }[] = [];
+  if (orphanStorageIds.length > 0) {
+    orphanStorages = await db
+      .select({ id: storages.id, s3Prefix: storages.s3Prefix })
+      .from(storages)
+      .where(inArray(storages.id, orphanStorageIds));
+  }
+
+  // Delete skills first (FK to storages is ON DELETE NO ACTION)
+  await db.delete(skills).where(inArray(skills.id, orphanIds));
+
+  // Delete storages (cascades to storageVersions)
+  if (orphanStorageIds.length > 0) {
+    await db.delete(storages).where(inArray(storages.id, orphanStorageIds));
+  }
+
+  // Best-effort S3 cleanup
+  const bucketName = env().R2_USER_STORAGES_BUCKET_NAME;
+  for (const storage of orphanStorages) {
+    try {
+      const objects = await listS3Objects(bucketName, storage.s3Prefix);
+      if (objects.length > 0) {
+        await deleteS3Objects(
+          bucketName,
+          objects.map((o) => o.key),
+        );
+      }
+    } catch (error) {
+      log.warn("Failed to clean up S3 objects for removed skill", {
+        s3Prefix: storage.s3Prefix,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  log.info("Removed orphaned skills", {
+    removed: orphans.length,
+    skillUrls: orphans.map((o) => o.url),
+  });
+
+  return orphans.length;
+}
+
+/**
+ * Validate that all SEED_SKILLS entries exist in the current tarball.
+ * Emits log.error for any seed skills that reference deleted skills.
+ */
+function validateSeedSkills(extractedSkills: ExtractedSkill[]): void {
+  const tarballNames = new Set(extractedSkills.map((e) => e.skillName));
+  const missingSkills = SEED_SKILLS.filter((name) => !tarballNames.has(name));
+
+  if (missingSkills.length > 0) {
+    log.error("SEED_SKILLS references skills not found in repository", {
+      missingSkills: missingSkills.map((name) => resolveSkillRef(name)),
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #7030

- After syncing skills from the tarball, detect and hard-delete orphaned skill records (present in DB but absent from tarball)
- Clean up the full chain: `skills` → `storages` (cascades to `storageVersions`) → S3 objects
- S3 cleanup is best-effort — failures are logged but do not block sync
- Validate `SEED_SKILLS` against the tarball and emit `log.error` for any seed skills referencing deleted skills
- Add `removed` count to `SyncResult` for observability

## Test plan

- [x] Integration test: skill removed between syncs → DB records + storage cleaned up, `removed: 1`
- [x] Integration test: S3 cleanup failure doesn't block DB cleanup
- [x] Integration test: `SEED_SKILLS` references missing skill → `log.error` emitted
- [x] All 8 existing tests continue to pass (11 total)
- [x] Lint, type check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)