### PR TITLE
refactor(web): simplify agent tools prompt

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -55,10 +55,10 @@ export function buildAgentToolsPrompt(): string {
     "# Agent Tools",
     "You have access to the Zero CLI. Run commands with: `npx -p @vm0/cli zero <command>`",
     "- When you need to discover available commands, run `zero --help`.",
-    '- When you need to delegate a task to a teammate agent, first discover teammates with `zero agent list`, then run `zero run <agent-id> "your task description"`. To continue a previous delegation, use `zero run continue <session-id> "follow-up prompt"`.',
+    "- When you need to delegate a task to a teammate agent, use `zero agent list` and `zero run`.",
     "- When you need to schedule or manage recurring tasks, use `zero schedule`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
-    '- When you need to ask the user a question, use `zero ask-user question` with at least one `--option` flag. Do NOT use the AskUserQuestion tool — it is not available. Example: `zero ask-user question "Pick one" --option "Yes" --option "No"`',
-    "- When you need to send a Slack message, use `zero slack message send`. Never use SLACK_TOKEN directly — it's a user token.",
+    "- When you need to ask the user a question, use `zero ask-user question`.",
+    "- Your replies are automatically sent to the originating thread. Only use `zero slack message send` when you need to message a different channel or thread. Never use SLACK_TOKEN to send messages directly — it's a user OAuth token.",
     "- When you encounter a missing token or environment variable error, run `zero doctor missing-token <TOKEN_NAME>` to diagnose the issue and get remediation steps for the user.",
     "- When you need to update your own configuration (description, tone, or instructions), use `zero agent edit $ZERO_AGENT_ID`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",
   ].join("\n");


### PR DESCRIPTION
## Summary
- Shorten delegation instruction to reference `zero agent list` and `zero run` instead of spelling out full usage
- Simplify ask-user instruction, let agents discover usage themselves
- Clarify Slack behavior: replies auto-send to originating thread, `zero slack message send` only needed for different channels/threads. Explicitly note SLACK_TOKEN is a user OAuth token.

## Test plan
- [ ] Verify agent runs still receive the correct tools prompt
- [ ] Confirm agents can discover command usage via `--help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)