### PR TITLE
fix: pass zero-price env var to workflows for billing checkout

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -326,8 +326,7 @@ jobs:
             STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }}
             STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }}
             CLERK_WEBHOOK_SIGNING_SECRET=${{ secrets.CLERK_WEBHOOK_SIGNING_SECRET }}
-            ZERO_PRO_PLAN_PRICE_ID=${{ secrets.ZERO_PRO_PLAN_PRICE_ID }}
-            ZERO_MAX_PLAN_PRICE_ID=${{ secrets.ZERO_MAX_PLAN_PRICE_ID }}
+            ZERO_PRICE=${{ secrets.ZERO_PRICE }}
             NGROK_API_KEY=${{ secrets.NGROK_API_KEY }}
             NGROK_COMPUTER_CONNECTOR_DOMAIN=${{ vars.NGROK_COMPUTER_CONNECTOR_DOMAIN }}
             APP_URL=https://app.vm0.ai

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -662,8 +662,7 @@ jobs:
           STRIPE_OAUTH_CLIENT_SECRET: ${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
-          ZERO_PRO_PLAN_PRICE_ID: ${{ secrets.ZERO_PRO_PLAN_PRICE_ID }}
-          ZERO_MAX_PLAN_PRICE_ID: ${{ secrets.ZERO_MAX_PLAN_PRICE_ID }}
+          ZERO_PRICE: ${{ secrets.ZERO_PRICE }}
           NGROK_API_KEY: ${{ secrets.NGROK_API_KEY }}
           NGROK_COMPUTER_CONNECTOR_DOMAIN: ${{ vars.NGROK_COMPUTER_CONNECTOR_DOMAIN }}
           APP_URL: ${{ needs.prepare.outputs.app-preview-url }}
@@ -867,8 +866,7 @@ jobs:
             STRIPE_OAUTH_CLIENT_SECRET=${{ secrets.STRIPE_OAUTH_CLIENT_SECRET }}
             STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }}
             STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }}
-            ZERO_PRO_PLAN_PRICE_ID=${{ secrets.ZERO_PRO_PLAN_PRICE_ID }}
-            ZERO_MAX_PLAN_PRICE_ID=${{ secrets.ZERO_MAX_PLAN_PRICE_ID }}
+            ZERO_PRICE=${{ secrets.ZERO_PRICE }}
             NGROK_API_KEY=${{ secrets.NGROK_API_KEY }}
             NGROK_COMPUTER_CONNECTOR_DOMAIN=${{ vars.NGROK_COMPUTER_CONNECTOR_DOMAIN }}
             APP_URL=${{ needs.prepare.outputs.app-preview-url }}


### PR DESCRIPTION
## Summary
- Workflows were passing legacy `ZERO_PRO_PLAN_PRICE_ID` / `ZERO_MAX_PLAN_PRICE_ID` env vars, but the billing code reads `ZERO_PRICE` (a JSON map of tier→price IDs)
- This mismatch caused every checkout attempt in production to fail with `"Price not configured for pro tier"` (400)
- Replaced all 3 occurrences (2 in turbo.yml, 1 in release-please.yml) with `ZERO_PRICE`

## Test plan
- [ ] Deploy and verify checkout flow returns a valid Stripe session URL instead of 400
- [ ] Confirm both pro and team tier upgrades work

🤖 Generated with [Claude Code](https://claude.com/claude-code)