### PR TITLE
fix: strip markdown from auto-generated chat titles and descriptions

### DIFF
--- a/turbo/apps/web/src/lib/ai/__tests__/lightweight-model.test.ts
+++ b/turbo/apps/web/src/lib/ai/__tests__/lightweight-model.test.ts
@@ -88,6 +88,38 @@ describe("generateChatTitle", () => {
     );
   });
 
+  it("should strip markdown formatting from returned content", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const handler = http.post(OPENROUTER_URL, () => {
+      return HttpResponse.json(openRouterResponse("**Bold** and `code` title"));
+    });
+    server.use(handler.handler);
+
+    const { generateChatTitle } = await import("../lightweight-model");
+
+    const result = await generateChatTitle("Some message");
+
+    expect(result).toBe("Bold and code title");
+  });
+
+  it("should strip heading markers from returned content", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const handler = http.post(OPENROUTER_URL, () => {
+      return HttpResponse.json(openRouterResponse("## Chat Title Here"));
+    });
+    server.use(handler.handler);
+
+    const { generateChatTitle } = await import("../lightweight-model");
+
+    const result = await generateChatTitle("Some message");
+
+    expect(result).toBe("Chat Title Here");
+  });
+
   it("should throw on HTTP error", async () => {
     vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     reloadEnv();

--- a/turbo/apps/web/src/lib/ai/__tests__/lightweight-model.test.ts
+++ b/turbo/apps/web/src/lib/ai/__tests__/lightweight-model.test.ts
@@ -88,36 +88,26 @@ describe("generateChatTitle", () => {
     );
   });
 
-  it("should strip markdown formatting from returned content", async () => {
+  it.each([
+    ["**Bold** and `code` title", "Bold and code title"],
+    ["## Chat Title Here", "Chat Title Here"],
+    ["*Italic* setup guide", "Italic setup guide"],
+    ["__underscored__ text", "underscored text"],
+    ["[Click here](https://example.com) for help", "Click here for help"],
+    ["# **Bold Heading** with `code`", "Bold Heading with code"],
+    ["Plain text without markdown", "Plain text without markdown"],
+  ])("should strip markdown from %j → %j", async (raw, expected) => {
     vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
     reloadEnv();
 
     const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(openRouterResponse("**Bold** and `code` title"));
+      return HttpResponse.json(openRouterResponse(raw));
     });
     server.use(handler.handler);
 
     const { generateChatTitle } = await import("../lightweight-model");
 
-    const result = await generateChatTitle("Some message");
-
-    expect(result).toBe("Bold and code title");
-  });
-
-  it("should strip heading markers from returned content", async () => {
-    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
-    reloadEnv();
-
-    const handler = http.post(OPENROUTER_URL, () => {
-      return HttpResponse.json(openRouterResponse("## Chat Title Here"));
-    });
-    server.use(handler.handler);
-
-    const { generateChatTitle } = await import("../lightweight-model");
-
-    const result = await generateChatTitle("Some message");
-
-    expect(result).toBe("Chat Title Here");
+    expect(await generateChatTitle("msg")).toBe(expected);
   });
 
   it("should throw on HTTP error", async () => {
@@ -187,5 +177,30 @@ describe("generateScheduleDescription", () => {
 
     expect(result).toBe("Runs daily backup for production database");
     expect(handler.mocked).toHaveBeenCalledTimes(1);
+  });
+
+  it("should strip markdown from schedule descriptions", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    reloadEnv();
+
+    const handler = http.post(OPENROUTER_URL, () => {
+      return HttpResponse.json(
+        openRouterResponse("**Daily** `backup` for [prod](https://db.io)"),
+      );
+    });
+    server.use(handler.handler);
+
+    const { generateScheduleDescription } = await import(
+      "../lightweight-model"
+    );
+
+    const result = await generateScheduleDescription(
+      "BackupBot",
+      "Daily Backup",
+      "Every day at 2am",
+      "Back up the production database",
+    );
+
+    expect(result).toBe("Daily backup for prod");
   });
 });

--- a/turbo/apps/web/src/lib/ai/lightweight-model.ts
+++ b/turbo/apps/web/src/lib/ai/lightweight-model.ts
@@ -58,7 +58,26 @@ async function generateText(messages: ChatMessage[]): Promise<string | null> {
     throw new Error("OpenRouter returned empty content");
   }
 
-  return content;
+  return stripMarkdown(content);
+}
+
+/**
+ * Strip common markdown syntax so generated text is always plain text.
+ * Handles bold/italic markers, heading prefixes, inline code, and link syntax.
+ */
+function stripMarkdown(text: string): string {
+  return (
+    text
+      // Bold/italic: **text**, __text__, *text*, _text_
+      .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
+      // Headings: # text
+      .replace(/^#{1,6}\s+/gm, "")
+      // Inline code: `text`
+      .replace(/`([^`]+)`/g, "$1")
+      // Links: [text](url)
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+      .trim()
+  );
 }
 
 /**
@@ -77,7 +96,7 @@ export async function generateChatTitle(
     {
       role: "system",
       content:
-        "Generate a short, descriptive title (max 60 chars) for a chat conversation based on the messages below. Return only the title, no quotes or extra text.",
+        "Generate a short, descriptive title (max 60 chars) for a chat conversation based on the messages below. Return only the title as plain text — no markdown, no quotes, no special formatting.",
     },
     { role: "user", content: userMessage },
   ];
@@ -102,7 +121,7 @@ export async function generateScheduleDescription(
     {
       role: "system",
       content:
-        "Write a one-sentence summary (max 120 chars) for a scheduled task. No quotes or punctuation at end. Return only the summary.",
+        "Write a one-sentence summary (max 120 chars) for a scheduled task as plain text — no markdown, no quotes, no special formatting. Return only the summary.",
     },
     {
       role: "user",


### PR DESCRIPTION
## Summary
- Updated LLM prompts for chat title and schedule description generation to explicitly request plain text output (no markdown)
- Added `stripMarkdown()` safety net in `generateText()` to strip bold/italic markers, heading prefixes, backticks, and link syntax from any generated content
- Both prompt changes and runtime sanitization ensure titles/descriptions are always clean plain text

Closes #6898

## Test plan
- [x] Existing tests pass (10 tests)
- [x] New test: markdown bold/italic + backticks stripped from title
- [x] New test: heading markers stripped from title
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)