### PR TITLE
feat(platform): sort connected connectors before unconnected ones

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { allConnectorTypes$ } from "../settings/connectors.ts";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 
 const context = testContext();
 
@@ -27,5 +30,61 @@ describe("connectors", () => {
       return;
     }
     expect(gmailConnector.connected).toBeFalsy();
+  });
+
+  it("should sort connected connectors before unconnected ones", async () => {
+    server.use(
+      http.get("*/api/zero/connectors", () => {
+        return HttpResponse.json({
+          connectors: [
+            {
+              id: "conn-github",
+              type: "github",
+              authMethod: "oauth",
+              externalId: null,
+              externalUsername: "testuser",
+              externalEmail: null,
+              oauthScopes: ["repo", "project"],
+              needsReconnect: false,
+              createdAt: "2026-01-01T00:00:00Z",
+              updatedAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+          configuredTypes: Object.keys(CONNECTOR_TYPES),
+          connectorProvidedSecretNames: [],
+        });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/",
+      user: {
+        id: "test-user-123",
+        fullName: "Test User",
+        email: "testing@vm0.ai",
+      },
+      featureSwitches: {},
+      withoutRender: true,
+    });
+
+    const connectorTypes = await context.store.get(allConnectorTypes$);
+
+    // Find the first connected and first unconnected
+    const firstConnectedIdx = connectorTypes.findIndex((c) => c.connected);
+    const firstUnconnectedIdx = connectorTypes.findIndex((c) => !c.connected);
+
+    // All connected connectors should appear before all unconnected ones
+    expect(firstConnectedIdx).toBe(0);
+    expect(firstUnconnectedIdx).toBeGreaterThan(0);
+    // Verify no unconnected connector appears before a connected one
+    const allConnectedBeforeUnconnected = connectorTypes.every(
+      (c, i) => c.connected || i >= firstUnconnectedIdx,
+    );
+    expect(allConnectedBeforeUnconnected).toBeTruthy();
+
+    // GitHub should be connected and at position 0
+    expect(connectorTypes[0].type).toBe("github" as ConnectorType);
+    expect(connectorTypes[0].connected).toBeTruthy();
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -52,7 +52,7 @@ export const allConnectorTypes$ = computed(async (get) => {
   const connectorMap = new Map(connectors.map((c) => [c.type, c]));
   const features = await get(featureSwitch$);
 
-  return (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
+  const items = (Object.keys(CONNECTOR_TYPES) as ConnectorType[])
     .filter((type) => {
       const flag = CONNECTOR_TYPES[type].featureFlag;
       const oauthEnabled = !flag || !!features?.[flag];
@@ -88,6 +88,16 @@ export const allConnectorTypes$ = computed(async (get) => {
         needsReconnect: connector?.needsReconnect ?? false,
       };
     });
+
+  // Sort connected connectors to the top of the list
+  items.sort((a, b) => {
+    if (a.connected === b.connected) {
+      return 0;
+    }
+    return a.connected ? -1 : 1;
+  });
+
+  return items;
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
@@ -376,6 +376,42 @@ async function renderTeamPageAsMember(connectors: string[]) {
   await setupPage({ context, path: "/team/zero" });
 }
 
+describe("connector sorting: connected first", () => {
+  it("renders connected connectors before unconnected ones", async () => {
+    // Only github is connected; slack and axiom are not
+    mockConnectors([
+      makeConnector({
+        type: "github",
+        externalUsername: "testuser",
+        oauthScopes: ["repo", "project"],
+      }),
+    ]);
+
+    // Agent has connectors in order: slack, github, axiom
+    // After sorting, github (connected) should appear first
+    await renderTeamPage(["slack", "github", "axiom"]);
+
+    // Wait for all connector cards to render
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Slack")).toBeInTheDocument();
+      expect(screen.getByText("Axiom")).toBeInTheDocument();
+    });
+
+    // Verify order: GitHub (connected) should appear before Slack and Axiom (unconnected)
+    const allCardLabels = screen
+      .getAllByText(/^(GitHub|Slack|Axiom)$/)
+      .map((el) => el.textContent);
+
+    expect(allCardLabels.indexOf("GitHub")).toBeLessThan(
+      allCardLabels.indexOf("Slack"),
+    );
+    expect(allCardLabels.indexOf("GitHub")).toBeLessThan(
+      allCardLabels.indexOf("Axiom"),
+    );
+  });
+});
+
 describe("zero connector card readOnly behavior (member on default agent)", () => {
   it("hides the Add connector button when readOnly", async () => {
     mockConnectors([

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-tab.tsx
@@ -152,9 +152,19 @@ export function ZeroConnectorsTab({
           </>
         )}
 
-        {/* Connector cards — only show connectors that have a matching connector type */}
+        {/* Connector cards — sorted with connected first, then by name */}
         {addedConnectors
           .filter((name) => connectorMap.has(name as ConnectorType))
+          .sort((a, b) => {
+            const aConnected =
+              connectorMap.get(a as ConnectorType)?.connected ?? false;
+            const bConnected =
+              connectorMap.get(b as ConnectorType)?.connected ?? false;
+            if (aConnected === bConnected) {
+              return 0;
+            }
+            return aConnected ? -1 : 1;
+          })
           .map((name) => {
             const connector = connectorMap.get(name as ConnectorType) ?? null;
             const effectiveConnector =

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-tab.tsx
@@ -152,7 +152,7 @@ export function ZeroConnectorsTab({
           </>
         )}
 
-        {/* Connector cards — sorted with connected first, then by name */}
+        {/* Connector cards — sorted with connected first */}
         {addedConnectors
           .filter((name) => connectorMap.has(name as ConnectorType))
           .sort((a, b) => {


### PR DESCRIPTION
## Summary

- Sort connected connectors to the top of the connectors list in both the signal layer (`allConnectorTypes$`) and the agent connectors tab (`ZeroConnectorsTab`)
- Connected connectors now appear before unconnected ones, making it easier for users to find and manage their active connections

Closes #6906

## Test plan

- [x] Signal-level sorting: verified `allConnectorTypes$` returns connected connectors before unconnected ones
- [x] View-level sorting: verified `ZeroConnectorsTab` renders connected connector cards before unconnected ones
- [x] All existing connector tests pass (17/17 card tests, 2/2 signal tests)
- [x] Lint, type check, format, and knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)