### PR TITLE
feat(platform): support ?prompt= query param to pre-fill chat input

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/chat-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-page-setup.ts
@@ -1,5 +1,5 @@
 import { command } from "ccstate";
-import { navigateTo$ } from "../route.ts";
+import { navigateTo$, searchParams$ } from "../route.ts";
 import { checkSettingsParam$ } from "./settings/org-manage-dialog.ts";
 import { logger } from "../log.ts";
 import { defaultAgentId$ } from "./zero-agent-name.ts";
@@ -18,13 +18,16 @@ export const setupChatPage$ = command(
 
     await set(checkSettingsParam$, signal);
 
-    // Redirect bare / to /talk/:defaultAgent
+    // Redirect bare / to /talk/:defaultAgent, forwarding ?prompt= if present
     const rawName = await get(defaultAgentId$);
     signal.throwIfAborted();
     if (rawName) {
       L.info("redirecting to /talk/", rawName);
+      const params = get(searchParams$);
+      const prompt = params.get("prompt");
       set(navigateTo$, "/talk/:id", {
         pathParams: { id: rawName },
+        searchParams: prompt ? new URLSearchParams({ prompt }) : undefined,
         replace: true,
       });
     }

--- a/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
@@ -3,10 +3,12 @@ import { createElement } from "react";
 import { ZeroTalkPage } from "../../views/zero-page/zero-talk-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
+import { searchParams$, updateSearchParams$ } from "../route.ts";
 import { syncModelPreference$ } from "./zero-model-preference.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 import { loadInitialData$, resolveAgentById$ } from "./zero-page.ts";
 import { currentAgentDisplayName$, currentAgentId$ } from "./agent.ts";
+import { setChatPageInput$ } from "./zero-chat-page.ts";
 
 export const setupTalkPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -31,5 +33,15 @@ export const setupTalkPage$ = command(
     await set(resolveAgentById$, agentId, signal);
 
     set(syncModelPreference$);
+
+    // Inject ?prompt= into the chat input and clean up the URL
+    const params = get(searchParams$);
+    const prompt = params.get("prompt");
+    if (prompt) {
+      set(setChatPageInput$, prompt);
+      const next = new URLSearchParams(params);
+      next.delete("prompt");
+      set(updateSearchParams$, next);
+    }
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { pathname, search } from "../../../signals/location.ts";
+
+const context = testContext();
+
+const PLACEHOLDER = "Ask me to automate workflows, manage tasks...";
+
+function mockChatAPI() {
+  server.use(
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("prompt query parameter injection", () => {
+  it("should inject ?prompt= into chat input when navigating to /", async () => {
+    mockChatAPI();
+    await setupPage({ context, path: "/?prompt=Hello%20world" });
+
+    // Should redirect to /talk/:id and show the prompt in the input
+    const textarea = await waitFor(
+      () => screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      { timeout: 5000 },
+    );
+
+    expect(textarea).toHaveValue("Hello world");
+  });
+
+  it("should inject ?prompt= into chat input when navigating to /talk/:id", async () => {
+    mockChatAPI();
+    await setupPage({
+      context,
+      path: "/talk/mock-compose-id?prompt=Set%20up%20a%20daily%20report",
+    });
+
+    const textarea = await waitFor(
+      () => screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      { timeout: 5000 },
+    );
+
+    expect(textarea).toHaveValue("Set up a daily report");
+  });
+
+  it("should strip ?prompt= from URL after injection", async () => {
+    mockChatAPI();
+    await setupPage({
+      context,
+      path: "/talk/mock-compose-id?prompt=test",
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // The prompt param should be removed from the URL
+    expect(search()).not.toContain("prompt=");
+  });
+
+  it("should not modify input when no ?prompt= is present", async () => {
+    mockChatAPI();
+    await setupPage({ context, path: "/talk/mock-compose-id" });
+
+    const textarea = await waitFor(
+      () => screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement,
+      { timeout: 5000 },
+    );
+
+    expect(textarea).toHaveValue("");
+  });
+
+  it("should redirect from / to /talk/:id with prompt in URL", async () => {
+    mockChatAPI();
+    await setupPage({ context, path: "/?prompt=hello" });
+
+    await waitFor(
+      () => {
+        expect(pathname()).toMatch(/^\/talk\//);
+      },
+      { timeout: 5000 },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `/?prompt=xx` forwards the param when redirecting to `/talk/:id?prompt=xx`
- `/talk/:id?prompt=xx` injects the prompt text into the chat composer input
- The `?prompt=` param is automatically stripped from the URL after injection
- Enables external links and integrations to pre-populate the chat input box

## Test plan
- [x] 5 integration tests covering both entry points, URL cleanup, and edge cases
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)