### PR TITLE
test(e2e): add browser test for pro plan upgrade flow

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1066,6 +1066,11 @@ jobs:
           node-version: 22
       - name: Install E2E dependencies
         run: npm install -g agent-browser@0.22.0
+      - name: Install Stripe CLI
+        run: |
+          curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | sudo tee /usr/share/keyrings/stripe.gpg >/dev/null
+          echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | sudo tee /etc/apt/sources.list.d/stripe.list
+          sudo apt-get update -qq && sudo apt-get install -y -qq stripe
       - name: Run browser E2E tests
         run: |
           BATS_TEST_TIMEOUT=180 ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/02-browser/*.bats
@@ -1073,6 +1078,7 @@ jobs:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
       - name: Upload auth screenshots
         if: always()
         uses: actions/upload-artifact@v7

--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -250,6 +250,26 @@ create_clerk_user_and_token() {
 
   export CLERK_USER_ID="$user_id"
 
+  # Create a Clerk organization for the user so they have exactly one org on
+  # sign-in. Clerk auto-activates the org when the user has only one, which
+  # avoids the "Select an Organization" blocker in the E2E flow.
+  local org_response
+  org_response=$(curl -sS -X POST \
+    "https://api.clerk.com/v1/organizations" \
+    -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "{\"name\": \"E2E Org\", \"created_by\": \"${user_id}\"}")
+
+  local org_id
+  org_id=$(echo "$org_response" | jq -r '.id // empty' 2>/dev/null)
+  if [[ -z "$org_id" ]]; then
+    echo "Failed to create Clerk org for user ${user_id}" >&2
+    echo "API response: ${org_response}" >&2
+    return 1
+  fi
+
+  export CLERK_ORG_ID="$org_id"
+
   # Create sign-in token
   local token_response
   token_response=$(curl -sS -X POST \

--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -219,6 +219,73 @@ create_clerk_sign_in_token() {
 }
 
 # ---------------------------------------------------------------------------
+# create_clerk_user_and_token — Create a fresh Clerk user and sign-in token
+# Creates a new user with a random email, then generates a sign-in token.
+# Requires CLERK_SECRET_KEY. Exports SIGN_IN_TOKEN and CLERK_USER_ID.
+# ---------------------------------------------------------------------------
+create_clerk_user_and_token() {
+  if [[ -z "${CLERK_SECRET_KEY:-}" ]]; then
+    echo "CLERK_SECRET_KEY is required but not set" >&2
+    return 1
+  fi
+
+  local email
+  email="$(generate_test_email)"
+
+  # Create user via Clerk Backend API
+  local create_response
+  create_response=$(curl -sS -X POST \
+    "https://api.clerk.com/v1/users" \
+    -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "{\"email_address\": [\"${email}\"], \"skip_password_requirement\": true}")
+
+  local user_id
+  user_id=$(echo "$create_response" | jq -e -r '.id' 2>/dev/null)
+  if [[ -z "$user_id" || "$user_id" == "null" ]]; then
+    echo "Failed to create Clerk user for ${email}" >&2
+    echo "API response: ${create_response}" >&2
+    return 1
+  fi
+
+  export CLERK_USER_ID="$user_id"
+
+  # Create sign-in token
+  local token_response
+  token_response=$(curl -sS -X POST \
+    "https://api.clerk.com/v1/sign_in_tokens" \
+    -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "{\"user_id\": \"${user_id}\", \"expires_in_seconds\": 300}")
+
+  local token
+  token=$(echo "$token_response" | jq -e -r '.token' 2>/dev/null)
+  if [[ -z "$token" || "$token" == "null" ]]; then
+    echo "Failed to create sign-in token" >&2
+    echo "API response: ${token_response}" >&2
+    return 1
+  fi
+
+  export SIGN_IN_TOKEN="$token"
+  export E2E_ACCOUNT="$email"
+}
+
+# ---------------------------------------------------------------------------
+# delete_clerk_user — Delete a Clerk user by ID
+# Usage: delete_clerk_user <user_id>
+# ---------------------------------------------------------------------------
+delete_clerk_user() {
+  local user_id="$1"
+  if [[ -z "$user_id" || -z "${CLERK_SECRET_KEY:-}" ]]; then
+    return 0
+  fi
+  curl -sS -X DELETE \
+    "https://api.clerk.com/v1/users/${user_id}" \
+    -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+    > /dev/null 2>&1 || true
+}
+
+# ---------------------------------------------------------------------------
 # derive_app_url — Derive platform app URL from VM0_API_URL
 # Local:  https://www.vm7.ai:8443  → https://app.vm7.ai:8443
 # CI:     https://pr-123-www.vm0-dev.com → https://pr-123-app.vm0-dev.com

--- a/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
+++ b/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
@@ -1,0 +1,447 @@
+#!/usr/bin/env bats
+# brw-t07-upgrade-pro.bats — Verify Pro plan upgrade flow via Stripe checkout
+#
+# Tests the full user flow: sign in via Clerk token → complete onboarding →
+# click "Get Pro" → fill Stripe test card → subscribe → verify Pro plan active.
+#
+# Uses Stripe CLI to forward webhooks to the local dev server so that
+# checkout.session.completed and invoice.paid events are processed correctly.
+#
+# Required env vars:
+#   VM0_API_URL          — Target web app URL (e.g., https://www.vm7.ai:8443)
+#   STRIPE_SECRET_KEY    — Stripe test-mode secret key (sk_test_...)
+#   CLERK_SECRET_KEY     — Clerk Backend API key (for creating sign-in tokens)
+
+load '../../helpers/setup'
+load '../../helpers/browser'
+
+# ---------------------------------------------------------------------------
+# File-level setup: start Stripe webhook forwarding, init browser
+# ---------------------------------------------------------------------------
+setup_file() {
+  # Close any existing agent-browser daemon so we start with a clean session
+  agent-browser close 2>/dev/null || true
+  sleep 1
+
+  browser_setup
+
+  if [[ -z "${STRIPE_SECRET_KEY:-}" ]]; then
+    echo "STRIPE_SECRET_KEY is required but not set" >&2
+    return 1
+  fi
+
+  if ! command -v stripe &>/dev/null; then
+    echo "stripe CLI is not installed" >&2
+    return 1
+  fi
+
+  APP_URL="$(derive_app_url)"
+  export APP_URL
+
+  # Create a fresh Clerk user and sign-in token (ensures clean Free tier state)
+  create_clerk_user_and_token
+
+  # Start Stripe webhook forwarding in background
+  # In CI, forward to the preview deployment; locally, forward to localhost
+  local webhook_url
+  if [[ "$VM0_API_URL" == *"localhost"* ]] || [[ "$VM0_API_URL" == *"vm7.ai"* ]]; then
+    webhook_url="http://localhost:3000/api/webhooks/stripe"
+  else
+    webhook_url="${VM0_API_URL}/api/webhooks/stripe"
+  fi
+  echo "# Stripe webhook forward target: $webhook_url" >&3
+  export STRIPE_WEBHOOK_LOG="/tmp/stripe-webhook-forward.log"
+  stripe listen \
+    --api-key "$STRIPE_SECRET_KEY" \
+    --forward-to "$webhook_url" \
+    --events checkout.session.completed,invoice.paid,customer.subscription.updated,customer.subscription.deleted \
+    > "$STRIPE_WEBHOOK_LOG" 2>&1 &
+  export STRIPE_LISTEN_PID=$!
+
+  # Wait for stripe listen to be ready (look for "Ready!" in output)
+  local ready=false
+  for _i in $(seq 1 30); do
+    if grep -qi "ready" "$STRIPE_WEBHOOK_LOG" 2>/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ "$ready" != "true" ]]; then
+    echo "# WARNING: stripe listen may not be ready yet" >&3
+    cat "$STRIPE_WEBHOOK_LOG" >&3 2>/dev/null || true
+  fi
+
+  echo "# Upgrade Pro flow verification via agent-browser" >&3
+  echo "#   Web URL: $VM0_API_URL" >&3
+  echo "#   App URL: $APP_URL" >&3
+  echo "#   Stripe webhook PID: $STRIPE_LISTEN_PID" >&3
+}
+
+# ---------------------------------------------------------------------------
+# File-level teardown: stop Stripe forwarding, kill browser
+# ---------------------------------------------------------------------------
+teardown_file() {
+  # Stop stripe listen
+  if [[ -n "${STRIPE_LISTEN_PID:-}" ]]; then
+    kill "$STRIPE_LISTEN_PID" 2>/dev/null || true
+    wait "$STRIPE_LISTEN_PID" 2>/dev/null || true
+  fi
+  pkill -f 'stripe listen' 2>/dev/null || true
+
+  # Clean up the test Clerk user
+  delete_clerk_user "${CLERK_USER_ID:-}"
+
+  browser_teardown
+}
+
+# ===========================================================================
+# Test 1: Sign in via Clerk token on the app domain
+# ===========================================================================
+@test "sign in via token" {
+  echo "# Signing in via token on $APP_URL..." >&3
+  agent-browser open "${APP_URL}/sign-in-token?token=${SIGN_IN_TOKEN}" --ignore-https-errors
+  agent-browser wait 5000
+
+  # Wait for token auth to complete — may land on app page or Clerk org creation
+  local auth_complete=false
+  for _i in $(seq 1 30); do
+    local snap
+    snap=$(full_snapshot)
+    # Org creation page = auth succeeded, user needs to create org first
+    if contains "$snap" "Select an Organization\|Create Organization"; then
+      auth_complete=true
+      break
+    fi
+    # Normal redirect = already has an org
+    local current_url
+    current_url=$(agent-browser get url 2>/dev/null || true)
+    if url_is_on_app "$current_url" && [[ ! "$current_url" =~ sign-in-token ]]; then
+      auth_complete=true
+      break
+    fi
+    sleep 1
+  done
+
+  assert [ "$auth_complete" = "true" ]
+  dismiss_cookie_banner
+  step_screenshot "after-sign-in"
+  echo "# Authentication complete!" >&3
+}
+
+# ===========================================================================
+# Test 2: Complete onboarding
+# ===========================================================================
+@test "complete onboarding" {
+  echo "# Waiting for onboarding..." >&3
+  agent-browser wait 3000
+
+  local snap
+  local needs_onboarding=false
+
+  for _i in $(seq 1 20); do
+    snap=$(full_snapshot)
+    # Handle Clerk "Create Organization" page (appears for fresh users)
+    if contains "$snap" "Select an Organization\|Create Organization"; then
+      echo "# Creating Clerk organization..." >&3
+      agent-browser find placeholder "Organization name" fill "E2E Pro Test"
+      agent-browser wait 500
+      agent-browser find text "Create organization" click
+      agent-browser wait 5000
+      snap=$(full_snapshot)
+    fi
+    if contains "$snap" "Name your workspace\|Choose your tools\|Connect your apps\|Where would you like to work"; then
+      needs_onboarding=true
+      break
+    fi
+    if contains "$snap" "Ask me to automate workflows"; then
+      echo "# Already onboarded" >&3
+      break
+    fi
+    sleep 1
+  done
+
+  if [[ "$needs_onboarding" != "true" ]]; then
+    echo "# Skipping onboarding: user already onboarded" >&3
+    skip "User already onboarded"
+  fi
+
+  # Step 1: Name workspace
+  if contains "$snap" "Name your workspace"; then
+    echo "# Step 1: Naming workspace..." >&3
+    agent-browser find placeholder "e.g. Acme Corp" fill "Pro Upgrade Test"
+    agent-browser wait 500
+    agent-browser find text "Next" click
+    agent-browser wait 2000
+    snap=$(full_snapshot)
+  fi
+
+  # Step 2: Choose tools (skip)
+  if contains "$snap" "Choose your tools"; then
+    echo "# Step 2: Choosing tools (skip)..." >&3
+    agent-browser find text "Next" click
+    agent-browser wait 2000
+    snap=$(full_snapshot)
+  fi
+
+  # Step 3: Connect apps (skip)
+  if contains "$snap" "Connect your apps"; then
+    echo "# Step 3: Connect apps (skip)..." >&3
+    agent-browser find text "Next" click
+    agent-browser wait 2000
+    snap=$(full_snapshot)
+  fi
+
+  # Step 4: Where to work
+  if contains "$snap" "Where would you like to work\|Continue in web"; then
+    echo "# Step 4: Continue in web..." >&3
+    agent-browser find text "Continue in web" click
+    agent-browser wait 8000
+  fi
+
+  step_screenshot "onboarding-done"
+  echo "# Onboarding complete!" >&3
+}
+
+# ===========================================================================
+# Test 3: Verify chat page loads and Get Pro button exists
+# ===========================================================================
+@test "verify chat page with Get Pro button" {
+  echo "# Waiting for chat page..." >&3
+
+  local chat_loaded=false
+  for _i in $(seq 1 30); do
+    local snap
+    snap=$(full_snapshot)
+    if contains "$snap" "Ask me to automate workflows"; then
+      chat_loaded=true
+      break
+    fi
+    sleep 1
+  done
+  assert [ "$chat_loaded" = "true" ]
+
+  # Verify "Get Pro" button is visible in sidebar
+  local snap_i
+  snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
+  assert [ "$(contains "$snap_i" "Get Pro" && echo "yes" || echo "no")" = "yes" ]
+  step_screenshot "chat-with-get-pro"
+  echo "# Chat page loaded with Get Pro button" >&3
+}
+
+# ===========================================================================
+# Test 4: Click Get Pro and navigate to Stripe checkout
+# ===========================================================================
+@test "open billing and click Upgrade to Pro" {
+  echo "# Clicking Get Pro..." >&3
+
+  # Click "Get Pro" button in sidebar
+  local snap_i ref
+  snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
+  ref=$(echo "$snap_i" | grep -E 'button "Get Pro' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  assert [ -n "$ref" ]
+  agent-browser click "$ref"
+  agent-browser wait 3000
+
+  # Verify Compare plans dialog
+  wait_for_text "Compare plans" 10
+  step_screenshot "compare-plans"
+
+  # Click "Upgrade to Pro" — scroll into view first as it may be below the fold
+  snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
+  ref=$(echo "$snap_i" | grep -E 'button "Upgrade to Pro"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  assert [ -n "$ref" ]
+  agent-browser scrollintoview "$ref" 2>/dev/null || true
+  agent-browser wait 500
+  agent-browser click "$ref"
+
+  # Wait for Stripe checkout page to load (redirect can take 10-20s)
+  echo "# Waiting for Stripe checkout page..." >&3
+  local stripe_loaded=false
+  for _i in $(seq 1 30); do
+    local snap
+    snap=$(full_snapshot)
+    if contains "$snap" "Subscribe to Pro Plan\|subscribe.*pro\|Stripe\|checkout"; then
+      stripe_loaded=true
+      break
+    fi
+    sleep 2
+  done
+  step_screenshot "stripe-checkout"
+
+  assert [ "$stripe_loaded" = "true" ]
+  echo "# Stripe checkout page loaded" >&3
+}
+
+# ===========================================================================
+# Test 5: Fill Stripe test card and subscribe
+# ===========================================================================
+@test "fill Stripe test card and subscribe" {
+  echo "# Filling Stripe checkout form..." >&3
+
+  local snap_i ref
+
+  # Fill email
+  snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
+  ref=$(echo "$snap_i" | grep -E 'textbox "Email"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  assert [ -n "$ref" ]
+  agent-browser fill "$ref" "$E2E_ACCOUNT"
+  agent-browser wait 500
+
+  # Select Card payment method — use "Pay with card" button which reliably expands the form
+  ref=$(echo "$snap_i" | grep -E 'button "Pay with card"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  if [[ -n "$ref" ]]; then
+    agent-browser click "$ref"
+    agent-browser wait 2000
+  else
+    # Fallback: click radio
+    ref=$(echo "$snap_i" | grep -E 'radio "Card"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+    if [[ -n "$ref" ]]; then
+      agent-browser click "$ref"
+      agent-browser wait 2000
+    fi
+  fi
+
+  # Wait for card form fields to appear
+  local card_form_ready=false
+  for _i in $(seq 1 10); do
+    snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
+    if echo "$snap_i" | grep -q 'textbox "Card number"'; then
+      card_form_ready=true
+      break
+    fi
+    sleep 1
+  done
+  assert [ "$card_form_ready" = "true" ]
+  echo "# Card form expanded" >&3
+
+  # Fill card details — Stripe test card 4242 4242 4242 4242
+  ref=$(echo "$snap_i" | grep -E 'textbox "Card number"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  agent-browser fill "$ref" "4242424242424242"
+  agent-browser wait 300
+
+  ref=$(echo "$snap_i" | grep -E 'textbox "Expiration"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  agent-browser fill "$ref" "12/30"
+  agent-browser wait 300
+
+  ref=$(echo "$snap_i" | grep -E 'textbox "CVC"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  agent-browser fill "$ref" "123"
+  agent-browser wait 300
+
+  ref=$(echo "$snap_i" | grep -E 'textbox "Cardholder name"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  agent-browser fill "$ref" "E2E Test User"
+  agent-browser wait 300
+
+  # Fill ZIP code
+  ref=$(echo "$snap_i" | grep -E 'textbox "ZIP"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  if [[ -n "$ref" ]]; then
+    agent-browser fill "$ref" "10001"
+    agent-browser wait 300
+  fi
+
+  # Fill phone number — required when "Save my information" is checked
+  # Use agent-browser find which is more reliable than snapshot grep for this field
+  echo "# Filling phone number..." >&3
+  if agent-browser find placeholder "Phone number" fill "2125551234" 2>/dev/null; then
+    echo "# Phone number filled via placeholder" >&3
+  elif agent-browser find label "Phone number" fill "2125551234" 2>/dev/null; then
+    echo "# Phone number filled via label" >&3
+  else
+    # Last resort: find by ref in full snapshot
+    local full_snap
+    full_snap=$(agent-browser snapshot 2>/dev/null || true)
+    ref=$(echo "$full_snap" | grep 'textbox "Phone number"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+    if [[ -n "$ref" ]]; then
+      agent-browser fill "$ref" "2125551234"
+      echo "# Phone number filled via ref" >&3
+    else
+      echo "# WARNING: Could not find phone number field" >&3
+    fi
+  fi
+  agent-browser wait 300
+
+  step_screenshot "stripe-form-filled"
+
+  # Click Subscribe — scroll into view first as it may be below the fold
+  echo "# Clicking Subscribe..." >&3
+  snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
+  ref=$(echo "$snap_i" | grep -E 'button "Subscribe"' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  assert [ -n "$ref" ]
+  agent-browser scrollintoview "$ref" 2>/dev/null || true
+  agent-browser wait 500
+  agent-browser click "$ref"
+
+  # Wait briefly and check if payment is processing
+  agent-browser wait 5000
+  step_screenshot "after-subscribe-click"
+
+  # Wait for payment processing and redirect back to app
+  echo "# Waiting for payment to process..." >&3
+  local redirected=false
+  for _i in $(seq 1 60); do
+    local current_url
+    current_url=$(agent-browser get url 2>/dev/null || true)
+    if url_is_on_app "$current_url"; then
+      redirected=true
+      break
+    fi
+    sleep 1
+  done
+  assert [ "$redirected" = "true" ]
+
+  step_screenshot "after-payment"
+  echo "# Payment complete, redirected back to app!" >&3
+}
+
+# ===========================================================================
+# Test 6: Verify Pro plan is active
+# ===========================================================================
+@test "verify Pro plan is active" {
+  echo "# Waiting for app to load after upgrade..." >&3
+  agent-browser wait 5000
+
+  # Wait for sidebar to show "Get Team" (indicates Pro is active)
+  local pro_active=false
+  for _i in $(seq 1 30); do
+    local snap
+    snap=$(full_snapshot)
+    if contains "$snap" "Get Team"; then
+      pro_active=true
+      break
+    fi
+    sleep 1
+  done
+  step_screenshot "pro-active-sidebar"
+
+  # Also verify via billing settings
+  echo "# Opening billing settings to confirm..." >&3
+  local snap_i ref
+  snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
+  ref=$(echo "$snap_i" | grep -E 'button "Get Team' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  if [[ -n "$ref" ]]; then
+    agent-browser click "$ref"
+    agent-browser wait 3000
+  fi
+
+  # Check billing page shows PRO as current plan
+  local billing_confirmed=false
+  for _i in $(seq 1 10); do
+    snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
+    # The PRO column should have a disabled "Current plan" button
+    if echo "$snap_i" | grep -q 'button "Current plan".*disabled'; then
+      local snap
+      snap=$(full_snapshot)
+      if contains "$snap" "PRO"; then
+        billing_confirmed=true
+        break
+      fi
+    fi
+    sleep 1
+  done
+  step_screenshot "billing-pro-confirmed"
+
+  assert [ "$pro_active" = "true" ]
+  assert [ "$billing_confirmed" = "true" ]
+  echo "# Pro plan upgrade verified!" >&3
+}

--- a/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
+++ b/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
@@ -217,11 +217,18 @@ teardown_file() {
 @test "verify chat page with Get Pro button" {
   echo "# Waiting for chat page..." >&3
 
+  # Give the page additional time to fully load after navigation in the previous test
+  agent-browser wait 5000
+
   local chat_loaded=false
-  for _i in $(seq 1 30); do
+  for _i in $(seq 1 60); do
     local snap
     snap=$(full_snapshot)
     if contains "$snap" "Ask me to automate workflows"; then
+      chat_loaded=true
+      break
+    fi
+    if contains "$snap" "Ideas.*use cases\|Browse use cases"; then
       chat_loaded=true
       break
     fi

--- a/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
+++ b/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
@@ -140,15 +140,18 @@ teardown_file() {
   local snap
   local needs_onboarding=false
 
+  local org_created=false
   for _i in $(seq 1 20); do
     snap=$(full_snapshot)
     # Handle Clerk "Create Organization" page (appears for fresh users)
-    if contains "$snap" "Select an Organization\|Create Organization"; then
+    # Only attempt org creation once to avoid retry loops if the page lingers
+    if [[ "$org_created" != "true" ]] && contains "$snap" "Select an Organization\|Create Organization"; then
       echo "# Creating Clerk organization..." >&3
       agent-browser find placeholder "Organization name" fill "E2E Pro Test"
       agent-browser wait 500
       agent-browser find text "Create organization" click
-      agent-browser wait 5000
+      org_created=true
+      agent-browser wait 8000
       snap=$(full_snapshot)
     fi
     if contains "$snap" "Name your workspace\|Choose your tools\|Connect your apps\|Where would you like to work"; then

--- a/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
+++ b/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
@@ -140,20 +140,10 @@ teardown_file() {
   local snap
   local needs_onboarding=false
 
-  local org_created=false
-  for _i in $(seq 1 20); do
+  # The test user was created with a Clerk org via API, so Clerk auto-activates
+  # the org on sign-in. We only need to wait for the app's onboarding wizard.
+  for _i in $(seq 1 30); do
     snap=$(full_snapshot)
-    # Handle Clerk "Create Organization" page (appears for fresh users)
-    # Only attempt org creation once to avoid retry loops if the page lingers
-    if [[ "$org_created" != "true" ]] && contains "$snap" "Select an Organization\|Create Organization"; then
-      echo "# Creating Clerk organization..." >&3
-      agent-browser find placeholder "Organization name" fill "E2E Pro Test"
-      agent-browser wait 500
-      agent-browser find text "Create organization" click
-      org_created=true
-      agent-browser wait 8000
-      snap=$(full_snapshot)
-    fi
     if contains "$snap" "Name your workspace\|Choose your tools\|Connect your apps\|Where would you like to work"; then
       needs_onboarding=true
       break
@@ -165,28 +155,8 @@ teardown_file() {
     sleep 1
   done
 
-  # After org creation the app redirects to onboarding, but the redirect may not
-  # have completed within the detection loop above. If we created an org but did
-  # not yet see the onboarding wizard, give the app extra time and check again.
-  if [[ "$org_created" == "true" && "$needs_onboarding" != "true" ]]; then
-    echo "# Org was just created — waiting for onboarding redirect..." >&3
-    for _i in $(seq 1 60); do
-      snap=$(full_snapshot)
-      if contains "$snap" "Name your workspace\|Choose your tools\|Connect your apps\|Where would you like to work"; then
-        needs_onboarding=true
-        break
-      fi
-      if contains "$snap" "Ask me to automate workflows\|Ideas.*use cases\|Browse use cases"; then
-        echo "# Already onboarded (post-org-creation check)" >&3
-        break
-      fi
-      sleep 1
-    done
-  fi
-
   if [[ "$needs_onboarding" != "true" ]]; then
     echo "# Skipping onboarding steps: navigating directly to chat page" >&3
-    # Ensure the browser is on the chat page before subsequent tests depend on it
     agent-browser open "$APP_URL" --ignore-https-errors
     agent-browser wait 5000
     step_screenshot "onboarding-skipped"
@@ -236,49 +206,9 @@ teardown_file() {
 @test "verify chat page with Get Pro button" {
   echo "# Waiting for chat page..." >&3
 
-  # Give the page additional time to fully load after navigation in the previous test
   agent-browser wait 5000
 
-  # If the platform redirected to the onboarding wizard (fresh user), complete it first.
-  # This can happen when org creation in the previous test succeeds but the onboarding
-  # page was not yet ready during the detection loop.
   local snap
-  snap=$(full_snapshot)
-  if contains "$snap" "Name your workspace\|Choose your tools\|Connect your apps\|Where would you like to work"; then
-    echo "# Onboarding wizard detected in test 16 — completing it now..." >&3
-
-    if contains "$snap" "Name your workspace"; then
-      echo "# Onboarding step 1: naming workspace..." >&3
-      agent-browser find placeholder "e.g. Acme Corp" fill "Pro Upgrade Test"
-      agent-browser wait 500
-      agent-browser find text "Next" click
-      agent-browser wait 2000
-      snap=$(full_snapshot)
-    fi
-
-    if contains "$snap" "Choose your tools"; then
-      echo "# Onboarding step 2: choosing tools (skip)..." >&3
-      agent-browser find text "Next" click
-      agent-browser wait 2000
-      snap=$(full_snapshot)
-    fi
-
-    if contains "$snap" "Connect your apps"; then
-      echo "# Onboarding step 3: connect apps (skip)..." >&3
-      agent-browser find text "Next" click
-      agent-browser wait 2000
-      snap=$(full_snapshot)
-    fi
-
-    if contains "$snap" "Where would you like to work\|Continue in web"; then
-      echo "# Onboarding step 4: continue in web..." >&3
-      agent-browser find text "Continue in web" click
-      agent-browser wait 8000
-    fi
-
-    echo "# Onboarding complete (from test 16), waiting for chat page..." >&3
-  fi
-
   local chat_loaded=false
   local onboarding_completed_in_loop=false
   for _i in $(seq 1 90); do

--- a/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
+++ b/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
@@ -165,6 +165,25 @@ teardown_file() {
     sleep 1
   done
 
+  # After org creation the app redirects to onboarding, but the redirect may not
+  # have completed within the detection loop above. If we created an org but did
+  # not yet see the onboarding wizard, give the app extra time and check again.
+  if [[ "$org_created" == "true" && "$needs_onboarding" != "true" ]]; then
+    echo "# Org was just created — waiting for onboarding redirect..." >&3
+    for _i in $(seq 1 20); do
+      snap=$(full_snapshot)
+      if contains "$snap" "Name your workspace\|Choose your tools\|Connect your apps\|Where would you like to work"; then
+        needs_onboarding=true
+        break
+      fi
+      if contains "$snap" "Ask me to automate workflows"; then
+        echo "# Already onboarded (post-org-creation check)" >&3
+        break
+      fi
+      sleep 1
+    done
+  fi
+
   if [[ "$needs_onboarding" != "true" ]]; then
     echo "# Skipping onboarding steps: navigating directly to chat page" >&3
     # Ensure the browser is on the chat page before subsequent tests depend on it

--- a/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
+++ b/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
@@ -220,9 +220,48 @@ teardown_file() {
   # Give the page additional time to fully load after navigation in the previous test
   agent-browser wait 5000
 
+  # If the platform redirected to the onboarding wizard (fresh user), complete it first.
+  # This can happen when org creation in the previous test succeeds but the onboarding
+  # page was not yet ready during the detection loop.
+  local snap
+  snap=$(full_snapshot)
+  if contains "$snap" "Name your workspace\|Choose your tools\|Connect your apps\|Where would you like to work"; then
+    echo "# Onboarding wizard detected in test 16 — completing it now..." >&3
+
+    if contains "$snap" "Name your workspace"; then
+      echo "# Onboarding step 1: naming workspace..." >&3
+      agent-browser find placeholder "e.g. Acme Corp" fill "Pro Upgrade Test"
+      agent-browser wait 500
+      agent-browser find text "Next" click
+      agent-browser wait 2000
+      snap=$(full_snapshot)
+    fi
+
+    if contains "$snap" "Choose your tools"; then
+      echo "# Onboarding step 2: choosing tools (skip)..." >&3
+      agent-browser find text "Next" click
+      agent-browser wait 2000
+      snap=$(full_snapshot)
+    fi
+
+    if contains "$snap" "Connect your apps"; then
+      echo "# Onboarding step 3: connect apps (skip)..." >&3
+      agent-browser find text "Next" click
+      agent-browser wait 2000
+      snap=$(full_snapshot)
+    fi
+
+    if contains "$snap" "Where would you like to work\|Continue in web"; then
+      echo "# Onboarding step 4: continue in web..." >&3
+      agent-browser find text "Continue in web" click
+      agent-browser wait 8000
+    fi
+
+    echo "# Onboarding complete (from test 16), waiting for chat page..." >&3
+  fi
+
   local chat_loaded=false
   for _i in $(seq 1 60); do
-    local snap
     snap=$(full_snapshot)
     if contains "$snap" "Ask me to automate workflows"; then
       chat_loaded=true

--- a/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
+++ b/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
@@ -166,8 +166,12 @@ teardown_file() {
   done
 
   if [[ "$needs_onboarding" != "true" ]]; then
-    echo "# Skipping onboarding: user already onboarded" >&3
-    skip "User already onboarded"
+    echo "# Skipping onboarding steps: navigating directly to chat page" >&3
+    # Ensure the browser is on the chat page before subsequent tests depend on it
+    agent-browser open "$APP_URL" --ignore-https-errors
+    agent-browser wait 5000
+    step_screenshot "onboarding-skipped"
+    return 0
   fi
 
   # Step 1: Name workspace

--- a/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
+++ b/e2e/tests/02-browser/brw-t07-upgrade-pro.bats
@@ -170,13 +170,13 @@ teardown_file() {
   # not yet see the onboarding wizard, give the app extra time and check again.
   if [[ "$org_created" == "true" && "$needs_onboarding" != "true" ]]; then
     echo "# Org was just created — waiting for onboarding redirect..." >&3
-    for _i in $(seq 1 20); do
+    for _i in $(seq 1 60); do
       snap=$(full_snapshot)
       if contains "$snap" "Name your workspace\|Choose your tools\|Connect your apps\|Where would you like to work"; then
         needs_onboarding=true
         break
       fi
-      if contains "$snap" "Ask me to automate workflows"; then
+      if contains "$snap" "Ask me to automate workflows\|Ideas.*use cases\|Browse use cases"; then
         echo "# Already onboarded (post-org-creation check)" >&3
         break
       fi
@@ -280,7 +280,8 @@ teardown_file() {
   fi
 
   local chat_loaded=false
-  for _i in $(seq 1 60); do
+  local onboarding_completed_in_loop=false
+  for _i in $(seq 1 90); do
     snap=$(full_snapshot)
     if contains "$snap" "Ask me to automate workflows"; then
       chat_loaded=true
@@ -289,6 +290,34 @@ teardown_file() {
     if contains "$snap" "Ideas.*use cases\|Browse use cases"; then
       chat_loaded=true
       break
+    fi
+    # Handle onboarding wizard appearing mid-loop (post-org-creation redirect can be slow)
+    if [[ "$onboarding_completed_in_loop" != "true" ]] && contains "$snap" "Name your workspace\|Choose your tools\|Connect your apps\|Where would you like to work"; then
+      echo "# Onboarding wizard detected in chat polling loop — completing it..." >&3
+      if contains "$snap" "Name your workspace"; then
+        agent-browser find placeholder "e.g. Acme Corp" fill "Pro Upgrade Test"
+        agent-browser wait 500
+        agent-browser find text "Next" click
+        agent-browser wait 2000
+        snap=$(full_snapshot)
+      fi
+      if contains "$snap" "Choose your tools"; then
+        agent-browser find text "Next" click
+        agent-browser wait 2000
+        snap=$(full_snapshot)
+      fi
+      if contains "$snap" "Connect your apps"; then
+        agent-browser find text "Next" click
+        agent-browser wait 2000
+        snap=$(full_snapshot)
+      fi
+      if contains "$snap" "Where would you like to work\|Continue in web"; then
+        agent-browser find text "Continue in web" click
+        agent-browser wait 8000
+      fi
+      onboarding_completed_in_loop=true
+      echo "# Onboarding completed in loop, continuing to wait for chat page..." >&3
+      continue
     fi
     sleep 1
   done


### PR DESCRIPTION
## Summary
- Add E2E browser test (`brw-t07-upgrade-pro.bats`) that verifies the full Pro plan upgrade flow: Clerk sign-in, onboarding, Stripe checkout with test card, and Pro plan verification
- Add `create_clerk_user_and_token` and `delete_clerk_user` helpers to `browser.bash` for creating fresh test users
- Install Stripe CLI in CI workflow and pass `STRIPE_SECRET_KEY` to browser E2E jobs

## Test plan
- [ ] CI browser E2E job runs successfully with Stripe CLI installed
- [ ] Test creates a fresh Clerk user, completes onboarding, upgrades to Pro via Stripe test card, and verifies Pro plan is active
- [ ] Test cleans up Clerk user on teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)