### PR TITLE
docs(cli): add after-help usage examples to ask-user question command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/ask-user/question.ts
+++ b/turbo/apps/cli/src/commands/zero/ask-user/question.ts
@@ -54,14 +54,9 @@ Examples:
       --multi-select \\
       --option "API" --option "Worker" --option "Scheduler"
 
-  Custom timeout (seconds):
-    zero ask-user question "Approve rollback?" --option "Yes" --option "No" --timeout 60
-
 Notes:
   - At least one --option is required
-  - --desc must immediately follow its --option
-  - The answer is printed to stdout; status messages go to stderr
-  - Default timeout is 300 seconds (5 minutes)`,
+  - --desc must immediately follow its --option`,
   )
   .action(
     withErrorHandler(

--- a/turbo/apps/cli/src/commands/zero/ask-user/question.ts
+++ b/turbo/apps/cli/src/commands/zero/ask-user/question.ts
@@ -36,6 +36,33 @@ export const questionCommand = new Command()
   )
   .option("--multi-select", "Allow multiple selections")
   .option("--timeout <seconds>", "How long to wait for answer", "300")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Yes/No confirmation:
+    zero ask-user question "Deploy to production?" --option "Yes" --option "No"
+
+  Options with descriptions:
+    zero ask-user question "Pick a strategy" \\
+      --header "Strategy" \\
+      --option "Fast" --desc "Quick but risky" \\
+      --option "Safe" --desc "Slow but reliable"
+
+  Multi-select:
+    zero ask-user question "Which services to restart?" \\
+      --multi-select \\
+      --option "API" --option "Worker" --option "Scheduler"
+
+  Custom timeout (seconds):
+    zero ask-user question "Approve rollback?" --option "Yes" --option "No" --timeout 60
+
+Notes:
+  - At least one --option is required
+  - --desc must immediately follow its --option
+  - The answer is printed to stdout; status messages go to stderr
+  - Default timeout is 300 seconds (5 minutes)`,
+  )
   .action(
     withErrorHandler(
       async (


### PR DESCRIPTION
## Summary
- Add `addHelpText("after", ...)` to `zero ask-user question` command with practical usage examples
- Agents in sandbox can now learn the command usage via `--help`, covering yes/no confirmation, options with descriptions, multi-select, and custom timeout

## Test plan
- [x] All 9 existing tests pass
- [x] Verified `addHelpText("after", ...)` is standard Commander.js API (returns `this`, supports chaining)
- [x] Consistent with existing patterns in `zero agent`, `zero run`, and root `zero` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)