### PR TITLE
fix(platform): add missing org management clerk features

### DIFF
--- a/turbo/apps/platform/src/signals/external/org-domains.ts
+++ b/turbo/apps/platform/src/signals/external/org-domains.ts
@@ -1,0 +1,32 @@
+import { command, computed, state } from "ccstate";
+import { zeroOrgDomainsContract } from "@vm0/core";
+import { org$ } from "../org";
+import { zeroClient$ } from "../api-client";
+
+const domainsVersion$ = state(0);
+
+export const refreshOrgDomains$ = command(({ get, set }) => {
+  set(domainsVersion$, get(domainsVersion$) + 1);
+});
+
+const domainsResponse$ = computed(async (get) => {
+  get(domainsVersion$);
+  const org = await get(org$);
+  if (!org) {
+    return null;
+  }
+
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroOrgDomainsContract);
+  const result = await client.list();
+
+  if (result.status === 200) {
+    return result.body;
+  }
+  return null;
+});
+
+export const orgDomains$ = computed(async (get) => {
+  const response = await get(domainsResponse$);
+  return response?.domains ?? [];
+});

--- a/turbo/apps/platform/src/signals/external/org-members.ts
+++ b/turbo/apps/platform/src/signals/external/org-members.ts
@@ -3,11 +3,12 @@ import {
   zeroOrgMembersContract,
   type OrgMember,
   type OrgPendingInvitation,
+  type OrgMembershipRequest,
 } from "@vm0/core";
 import { org$ } from "../org";
 import { zeroClient$ } from "../api-client";
 
-export type { OrgMember, OrgPendingInvitation };
+export type { OrgMember, OrgPendingInvitation, OrgMembershipRequest };
 
 const orgMembersVersion$ = state(0);
 
@@ -37,6 +38,11 @@ export const orgMembers$ = computed(async (get) => {
 export const orgPendingInvitations$ = computed(async (get) => {
   const response = await get(orgMembersResponse$);
   return response?.pendingInvitations ?? [];
+});
+
+export const orgMembershipRequests$ = computed(async (get) => {
+  const response = await get(orgMembersResponse$);
+  return response?.membershipRequests ?? [];
 });
 
 export const refreshOrgMembers$ = command(({ get, set }) => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
@@ -9,6 +9,7 @@ export type OrgManageTab =
   | "general"
   | "providers"
   | "members"
+  | "domains"
   | "billing"
   | "usage"
   | "invoices";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-members-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-members-dialog.test.tsx
@@ -4,33 +4,45 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
+import type { OrgMember } from "../../../signals/external/org-members.ts";
 
 const context = testContext();
 
-function mockMembersAPI() {
+const adminMember: OrgMember = {
+  userId: "test-user-123",
+  email: "admin@example.com",
+  firstName: "Admin",
+  lastName: "User",
+  imageUrl: "",
+  role: "admin",
+  joinedAt: "2026-01-01T00:00:00Z",
+};
+
+const regularMember: OrgMember = {
+  userId: "user-member",
+  email: "member@example.com",
+  firstName: "Regular",
+  lastName: "Member",
+  imageUrl: "",
+  role: "member",
+  joinedAt: "2026-02-01T00:00:00Z",
+};
+
+const secondAdmin: OrgMember = {
+  userId: "user-admin-2",
+  email: "admin2@example.com",
+  firstName: "Second",
+  lastName: "Admin",
+  imageUrl: "",
+  role: "admin",
+  joinedAt: "2026-01-15T00:00:00Z",
+};
+
+function mockMembersAPI(members: OrgMember[] = [adminMember, regularMember]) {
   server.use(
     http.get("*/api/zero/org/members", () => {
       return HttpResponse.json({
-        members: [
-          {
-            userId: "test-user-123",
-            email: "admin@example.com",
-            firstName: "Admin",
-            lastName: "User",
-            imageUrl: "",
-            role: "admin",
-            joinedAt: "2026-01-01T00:00:00Z",
-          },
-          {
-            userId: "user-member",
-            email: "member@example.com",
-            firstName: "Regular",
-            lastName: "Member",
-            imageUrl: "",
-            role: "member",
-            joinedAt: "2026-02-01T00:00:00Z",
-          },
-        ],
+        members,
         pendingInvitations: [],
       });
     }),
@@ -142,7 +154,7 @@ describe("org members - invite dialog loading state", () => {
     ).toBeInTheDocument();
   });
 
-  it("should disable input and cancel button during invite", async () => {
+  it("should disable input and cancel during invite", async () => {
     let resolveInvite: (() => void) | null = null;
 
     mockMembersAPI();
@@ -186,5 +198,38 @@ describe("org members - invite dialog loading state", () => {
         screen.queryByRole("heading", { name: "Invite member" }),
       ).not.toBeInTheDocument();
     });
+  });
+});
+
+describe("org members - sole admin self-demote protection", () => {
+  it("should not show self-demote menu when user is the only admin", async () => {
+    mockMembersAPI([adminMember, regularMember]);
+
+    await renderMembersTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("admin@example.com")).toBeInTheDocument();
+    });
+
+    // The admin row for the current user should exist but have no action menu
+    const adminRow = screen.getByText("Admin User").closest("[class*=grid]")!;
+    const menuButton = adminRow.querySelector("button[class*=rounded-md]");
+    expect(menuButton).toBeNull();
+  });
+
+  it("should show self-demote menu when multiple admins exist", async () => {
+    mockMembersAPI([adminMember, secondAdmin, regularMember]);
+
+    await renderMembersTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("admin@example.com")).toBeInTheDocument();
+    });
+
+    // The current user's admin row should have an action menu button
+    const youBadge = screen.getByText("You");
+    const adminRow = youBadge.closest("[class*=grid]")!;
+    const menuButton = adminRow.querySelector("button");
+    expect(menuButton).not.toBeNull();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-members-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-members-dialog.test.tsx
@@ -8,7 +8,7 @@ import type { OrgMember } from "../../../signals/external/org-members.ts";
 
 const context = testContext();
 
-const adminMember: OrgMember = {
+const adminMember = {
   userId: "test-user-123",
   email: "admin@example.com",
   firstName: "Admin",
@@ -16,9 +16,9 @@ const adminMember: OrgMember = {
   imageUrl: "",
   role: "admin",
   joinedAt: "2026-01-01T00:00:00Z",
-};
+} as const satisfies OrgMember;
 
-const regularMember: OrgMember = {
+const regularMember = {
   userId: "user-member",
   email: "member@example.com",
   firstName: "Regular",
@@ -26,9 +26,9 @@ const regularMember: OrgMember = {
   imageUrl: "",
   role: "member",
   joinedAt: "2026-02-01T00:00:00Z",
-};
+} as const satisfies OrgMember;
 
-const secondAdmin: OrgMember = {
+const secondAdmin = {
   userId: "user-admin-2",
   email: "admin2@example.com",
   firstName: "Second",
@@ -36,7 +36,7 @@ const secondAdmin: OrgMember = {
   imageUrl: "",
   role: "admin",
   joinedAt: "2026-01-15T00:00:00Z",
-};
+} as const satisfies OrgMember;
 
 function mockMembersAPI(members: OrgMember[] = [adminMember, regularMember]) {
   server.use(

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-api-error.ts
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-api-error.ts
@@ -1,0 +1,26 @@
+/**
+ * Extract an error message from a ts-rest API response.
+ * All org management contracts return `{ error: { message: string } }` for
+ * 400 / 401 / 403 / 500 status codes. This helper narrows the response and
+ * returns the message so callers don't repeat the status-check boilerplate.
+ */
+export function extractApiErrorMessage(
+  result: { status: number; body: unknown },
+  fallback: string,
+): string {
+  if (
+    (result.status === 400 ||
+      result.status === 401 ||
+      result.status === 403 ||
+      result.status === 500) &&
+    typeof result.body === "object" &&
+    result.body !== null &&
+    "error" in result.body
+  ) {
+    const error = (result.body as { error: { message: string } }).error;
+    if (typeof error?.message === "string") {
+      return error.message;
+    }
+  }
+  return `${fallback} (${result.status})`;
+}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-domains-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-domains-tab.tsx
@@ -57,10 +57,7 @@ export function OrgDomainsTab() {
       return;
     }
     const msg =
-      result.status === 400 ||
-      result.status === 401 ||
-      result.status === 403 ||
-      result.status === 500
+      result.status === 401 || result.status === 403 || result.status === 500
         ? result.body.error.message
         : undefined;
     toast.error(msg ?? `Failed to add domain (${result.status})`);
@@ -76,10 +73,7 @@ export function OrgDomainsTab() {
       return;
     }
     const msg =
-      result.status === 400 ||
-      result.status === 401 ||
-      result.status === 403 ||
-      result.status === 500
+      result.status === 401 || result.status === 403 || result.status === 500
         ? result.body.error.message
         : undefined;
     toast.error(msg ?? `Failed to remove domain (${result.status})`);

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-domains-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-domains-tab.tsx
@@ -6,6 +6,9 @@ import {
   IconCircleCheck,
   IconAlertCircle,
   IconWorldWww,
+  IconDots,
+  IconShieldCheck,
+  IconShieldOff,
 } from "@tabler/icons-react";
 import {
   cn,
@@ -17,16 +20,44 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
 } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { zeroOrgDomainsContract, type OrgDomain } from "@vm0/core";
+import {
+  zeroOrgDomainsContract,
+  type OrgDomain,
+  type OrgEnrollmentMode,
+} from "@vm0/core";
 import { zeroClient$ } from "../../../../signals/api-client.ts";
 import {
   orgDomains$,
   refreshOrgDomains$,
 } from "../../../../signals/external/org-domains.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ENROLLMENT_MODE_LABELS: Record<OrgEnrollmentMode, string> = {
+  manual_invitation: "Manual invitation",
+  automatic_invitation: "Automatic invitation",
+  automatic_suggestion: "Automatic suggestion",
+};
+
+const ENROLLMENT_MODE_DESCRIPTIONS: Record<OrgEnrollmentMode, string> = {
+  manual_invitation: "Only invited users can join",
+  automatic_invitation: "Users with matching email are auto-invited",
+  automatic_suggestion: "Users with matching email are suggested to join",
+};
 
 // ---------------------------------------------------------------------------
 // Components
@@ -37,7 +68,8 @@ function formatDate(iso: string): string {
   return `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
 }
 
-const ROW_GRID = "grid grid-cols-[1fr_6rem_6rem_2rem] gap-x-4 items-center";
+const ROW_GRID =
+  "grid grid-cols-[1fr_10rem_6rem_6rem_2rem] gap-x-4 items-center";
 
 export function OrgDomainsTab() {
   const domainsLoadable = useLoadable(orgDomains$);
@@ -48,9 +80,9 @@ export function OrgDomainsTab() {
     domainsLoadable.state === "hasData" ? domainsLoadable.data : [];
   const isLoading = domainsLoadable.state === "loading";
 
-  const handleAdd = async (name: string) => {
+  const handleAdd = async (name: string, enrollmentMode: OrgEnrollmentMode) => {
     const client = createClient(zeroOrgDomainsContract);
-    const result = await client.add({ body: { name } });
+    const result = await client.add({ body: { name, enrollmentMode } });
     if (result.status === 200) {
       toast.success(`Domain ${name} added`);
       refresh();
@@ -80,6 +112,22 @@ export function OrgDomainsTab() {
     throw new Error(msg ?? `Failed to remove domain (${result.status})`);
   };
 
+  const handleSetVerified = async (domainId: string, verified: boolean) => {
+    const client = createClient(zeroOrgDomainsContract);
+    const result = await client.setVerified({ body: { domainId, verified } });
+    if (result.status === 200) {
+      toast.success(verified ? "Domain verified" : "Domain unverified");
+      refresh();
+      return;
+    }
+    const msg =
+      result.status === 401 || result.status === 403 || result.status === 500
+        ? result.body.error.message
+        : undefined;
+    toast.error(msg ?? `Failed to update domain (${result.status})`);
+    throw new Error(msg ?? `Failed to update domain (${result.status})`);
+  };
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-end">
@@ -97,6 +145,7 @@ export function OrgDomainsTab() {
           )}
         >
           <div>Domain</div>
+          <div>Enrollment</div>
           <div>Added</div>
           <div>Status</div>
           <div />
@@ -127,7 +176,11 @@ export function OrgDomainsTab() {
           domains.map((domain, i) => (
             <div key={domain.id}>
               {i > 0 && <div className="h-px bg-border/40 mx-5" />}
-              <DomainRow domain={domain} onRemove={handleRemove} />
+              <DomainRow
+                domain={domain}
+                onRemove={handleRemove}
+                onSetVerified={handleSetVerified}
+              />
             </div>
           ))}
       </div>
@@ -138,10 +191,12 @@ export function OrgDomainsTab() {
 function AddDomainDialog({
   onAdd,
 }: {
-  onAdd: (name: string) => Promise<void>;
+  onAdd: (name: string, enrollmentMode: OrgEnrollmentMode) => Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
+  const [enrollmentMode, setEnrollmentMode] =
+    useState<OrgEnrollmentMode>("manual_invitation");
   const [adding, setAdding] = useState(false);
 
   const trimmed = name.trim().toLowerCase();
@@ -153,10 +208,11 @@ function AddDomainDialog({
   const handleAdd = () => {
     setAdding(true);
     detach(
-      onAdd(trimmed).then(
+      onAdd(trimmed, enrollmentMode).then(
         () => {
           setOpen(false);
           setName("");
+          setEnrollmentMode("manual_invitation");
           setAdding(false);
         },
         (error: unknown) => {
@@ -192,12 +248,46 @@ function AddDomainDialog({
             Add a domain to enable domain-based membership management.
           </DialogDescription>
         </DialogHeader>
-        <Input
-          placeholder="example.com"
-          value={name}
-          disabled={adding}
-          onChange={(e) => setName(e.target.value)}
-        />
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Domain</label>
+            <Input
+              placeholder="example.com"
+              value={name}
+              disabled={adding}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Enrollment mode</label>
+            <Select
+              value={enrollmentMode}
+              onValueChange={(v) => setEnrollmentMode(v as OrgEnrollmentMode)}
+              disabled={adding}
+            >
+              <SelectTrigger>
+                <span>{ENROLLMENT_MODE_LABELS[enrollmentMode]}</span>
+              </SelectTrigger>
+              <SelectContent>
+                {(
+                  Object.entries(ENROLLMENT_MODE_LABELS) as [
+                    OrgEnrollmentMode,
+                    string,
+                  ][]
+                ).map(([mode, label]) => (
+                  <SelectItem key={mode} value={mode}>
+                    <div className="flex flex-col">
+                      <span>{label}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {ENROLLMENT_MODE_DESCRIPTIONS[mode]}
+                      </span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
         <DialogFooter>
           <Button
             variant="outline"
@@ -219,12 +309,15 @@ function AddDomainDialog({
 function DomainRow({
   domain,
   onRemove,
+  onSetVerified,
 }: {
   domain: OrgDomain;
   onRemove: (domainId: string) => Promise<void>;
+  onSetVerified: (domainId: string, verified: boolean) => Promise<void>;
 }) {
-  const [open, setOpen] = useState(false);
+  const [removeOpen, setRemoveOpen] = useState(false);
   const [removing, setRemoving] = useState(false);
+  const [settingVerified, setSettingVerified] = useState(false);
   const isVerified = domain.verification.status === "verified";
 
   const handleRemove = () => {
@@ -232,7 +325,7 @@ function DomainRow({
     detach(
       onRemove(domain.id).then(
         () => {
-          setOpen(false);
+          setRemoveOpen(false);
           setRemoving(false);
         },
         (error: unknown) => {
@@ -246,20 +339,38 @@ function DomainRow({
     );
   };
 
+  const handleSetVerified = (verified: boolean) => {
+    setSettingVerified(true);
+    detach(
+      onSetVerified(domain.id, verified).then(
+        () => setSettingVerified(false),
+        (error: unknown) => {
+          setSettingVerified(false);
+          const message =
+            error instanceof Error ? error.message : "Failed to update domain";
+          toast.error(message);
+        },
+      ),
+      Reason.DomCallback,
+    );
+  };
+
   return (
     <div className={cn(ROW_GRID, "py-3 px-5")}>
       <div className="flex items-center gap-3 min-w-0">
         <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground">
           <IconWorldWww size={16} stroke={1.5} />
         </div>
-        <div className="min-w-0">
-          <p className="text-sm font-medium text-foreground truncate">
-            {domain.name}
-          </p>
-          <p className="text-[12px] text-muted-foreground">
-            {domain.enrollmentMode.replace(/_/g, " ")}
-          </p>
-        </div>
+        <p className="text-sm font-medium text-foreground truncate">
+          {domain.name}
+        </p>
+      </div>
+      <div className="text-[13px] text-muted-foreground">
+        {domain.enrollmentMode
+          ? (ENROLLMENT_MODE_LABELS[
+              domain.enrollmentMode as OrgEnrollmentMode
+            ] ?? domain.enrollmentMode.replace(/_/g, " "))
+          : "—"}
       </div>
       <div className="text-[13px] text-muted-foreground tabular-nums">
         {formatDate(domain.createdAt)}
@@ -285,18 +396,41 @@ function DomainRow({
       </div>
       <div className="flex justify-end">
         <Dialog
-          open={open}
+          open={removeOpen}
           onOpenChange={(v) => {
-            if (!removing) {
-              setOpen(v);
-            }
+            if (!removing) setRemoveOpen(v);
           }}
         >
-          <DialogTrigger asChild>
-            <button className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors">
-              <IconTrash size={14} stroke={1.5} />
-            </button>
-          </DialogTrigger>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted transition-colors"
+                disabled={settingVerified}
+              >
+                <IconDots size={14} stroke={1.5} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => handleSetVerified(!isVerified)}
+                disabled={settingVerified}
+              >
+                {isVerified ? (
+                  <IconShieldOff size={14} stroke={1.5} className="mr-2" />
+                ) : (
+                  <IconShieldCheck size={14} stroke={1.5} className="mr-2" />
+                )}
+                {isVerified ? "Unverify" : "Verify"}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                onClick={() => setRemoveOpen(true)}
+              >
+                <IconTrash size={14} stroke={1.5} className="mr-2" />
+                Remove
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Remove domain?</DialogTitle>
@@ -309,7 +443,7 @@ function DomainRow({
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => setOpen(false)}
+                onClick={() => setRemoveOpen(false)}
                 disabled={removing}
               >
                 Cancel
@@ -335,12 +469,10 @@ function DomainRowSkeleton() {
     <div className={cn(ROW_GRID, "py-3 px-5 animate-pulse")}>
       <div className="flex items-center gap-3">
         <div className="h-8 w-8 shrink-0 rounded-lg bg-muted/50" />
-        <div className="flex flex-col gap-1">
-          <div className="h-4 w-32 rounded bg-muted/50" />
-          <div className="h-3 w-20 rounded bg-muted/30" />
-        </div>
+        <div className="h-4 w-32 rounded bg-muted/50" />
       </div>
-      <div className="h-4 w-20 rounded bg-muted/30" />
+      <div className="h-4 w-24 rounded bg-muted/30" />
+      <div className="h-4 w-16 rounded bg-muted/30" />
       <div className="h-5 w-16 rounded bg-muted/30" />
       <div />
     </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-domains-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-domains-tab.tsx
@@ -42,22 +42,23 @@ import {
   refreshOrgDomains$,
 } from "../../../../signals/external/org-domains.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
+import { extractApiErrorMessage } from "./org-api-error.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const ENROLLMENT_MODE_LABELS: Record<OrgEnrollmentMode, string> = {
+const ENROLLMENT_MODE_LABELS = {
   manual_invitation: "Manual invitation",
   automatic_invitation: "Automatic invitation",
   automatic_suggestion: "Automatic suggestion",
-};
+} as const satisfies Record<OrgEnrollmentMode, string>;
 
-const ENROLLMENT_MODE_DESCRIPTIONS: Record<OrgEnrollmentMode, string> = {
+const ENROLLMENT_MODE_DESCRIPTIONS = {
   manual_invitation: "Only invited users can join",
   automatic_invitation: "Users with matching email are auto-invited",
   automatic_suggestion: "Users with matching email are suggested to join",
-};
+} as const satisfies Record<OrgEnrollmentMode, string>;
 
 // ---------------------------------------------------------------------------
 // Components
@@ -88,12 +89,7 @@ export function OrgDomainsTab() {
       refresh();
       return;
     }
-    const msg =
-      result.status === 401 || result.status === 403 || result.status === 500
-        ? result.body.error.message
-        : undefined;
-    toast.error(msg ?? `Failed to add domain (${result.status})`);
-    throw new Error(msg ?? `Failed to add domain (${result.status})`);
+    throw new Error(extractApiErrorMessage(result, "Failed to add domain"));
   };
 
   const handleRemove = async (domainId: string) => {
@@ -104,12 +100,7 @@ export function OrgDomainsTab() {
       refresh();
       return;
     }
-    const msg =
-      result.status === 401 || result.status === 403 || result.status === 500
-        ? result.body.error.message
-        : undefined;
-    toast.error(msg ?? `Failed to remove domain (${result.status})`);
-    throw new Error(msg ?? `Failed to remove domain (${result.status})`);
+    throw new Error(extractApiErrorMessage(result, "Failed to remove domain"));
   };
 
   const handleSetVerified = async (domainId: string, verified: boolean) => {
@@ -120,12 +111,7 @@ export function OrgDomainsTab() {
       refresh();
       return;
     }
-    const msg =
-      result.status === 401 || result.status === 403 || result.status === 500
-        ? result.body.error.message
-        : undefined;
-    toast.error(msg ?? `Failed to update domain (${result.status})`);
-    throw new Error(msg ?? `Failed to update domain (${result.status})`);
+    throw new Error(extractApiErrorMessage(result, "Failed to update domain"));
   };
 
   return (
@@ -366,11 +352,8 @@ function DomainRow({
         </p>
       </div>
       <div className="text-[13px] text-muted-foreground">
-        {domain.enrollmentMode
-          ? (ENROLLMENT_MODE_LABELS[
-              domain.enrollmentMode as OrgEnrollmentMode
-            ] ?? domain.enrollmentMode.replace(/_/g, " "))
-          : "—"}
+        {ENROLLMENT_MODE_LABELS[domain.enrollmentMode as OrgEnrollmentMode] ??
+          domain.enrollmentMode.replace(/_/g, " ")}
       </div>
       <div className="text-[13px] text-muted-foreground tabular-nums">
         {formatDate(domain.createdAt)}
@@ -398,7 +381,9 @@ function DomainRow({
         <Dialog
           open={removeOpen}
           onOpenChange={(v) => {
-            if (!removing) setRemoveOpen(v);
+            if (!removing) {
+              setRemoveOpen(v);
+            }
           }}
         >
           <DropdownMenu>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-domains-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-domains-tab.tsx
@@ -1,0 +1,354 @@
+import { useState } from "react";
+import { useGet, useLoadable, useSet } from "ccstate-react";
+import {
+  IconPlus,
+  IconTrash,
+  IconCircleCheck,
+  IconAlertCircle,
+  IconWorldWww,
+} from "@tabler/icons-react";
+import {
+  cn,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Input,
+} from "@vm0/ui";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { zeroOrgDomainsContract, type OrgDomain } from "@vm0/core";
+import { zeroClient$ } from "../../../../signals/api-client.ts";
+import {
+  orgDomains$,
+  refreshOrgDomains$,
+} from "../../../../signals/external/org-domains.ts";
+import { detach, Reason } from "../../../../signals/utils.ts";
+
+// ---------------------------------------------------------------------------
+// Components
+// ---------------------------------------------------------------------------
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return `${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}`;
+}
+
+const ROW_GRID = "grid grid-cols-[1fr_6rem_6rem_2rem] gap-x-4 items-center";
+
+export function OrgDomainsTab() {
+  const domainsLoadable = useLoadable(orgDomains$);
+  const createClient = useGet(zeroClient$);
+  const refresh = useSet(refreshOrgDomains$);
+
+  const domains =
+    domainsLoadable.state === "hasData" ? domainsLoadable.data : [];
+  const isLoading = domainsLoadable.state === "loading";
+
+  const handleAdd = async (name: string) => {
+    const client = createClient(zeroOrgDomainsContract);
+    const result = await client.add({ body: { name } });
+    if (result.status === 200) {
+      toast.success(`Domain ${name} added`);
+      refresh();
+      return;
+    }
+    const msg =
+      result.status === 400 ||
+      result.status === 401 ||
+      result.status === 403 ||
+      result.status === 500
+        ? result.body.error.message
+        : undefined;
+    toast.error(msg ?? `Failed to add domain (${result.status})`);
+    throw new Error(msg ?? `Failed to add domain (${result.status})`);
+  };
+
+  const handleRemove = async (domainId: string) => {
+    const client = createClient(zeroOrgDomainsContract);
+    const result = await client.remove({ body: { domainId } });
+    if (result.status === 200) {
+      toast.success("Domain removed");
+      refresh();
+      return;
+    }
+    const msg =
+      result.status === 400 ||
+      result.status === 401 ||
+      result.status === 403 ||
+      result.status === 500
+        ? result.body.error.message
+        : undefined;
+    toast.error(msg ?? `Failed to remove domain (${result.status})`);
+    throw new Error(msg ?? `Failed to remove domain (${result.status})`);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-end">
+        <AddDomainDialog onAdd={handleAdd} />
+      </div>
+
+      <div
+        className="overflow-hidden rounded-xl bg-card"
+        style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+      >
+        <div
+          className={cn(
+            ROW_GRID,
+            "sticky top-0 z-10 px-5 py-2.5 text-[13px] font-medium text-foreground bg-card",
+          )}
+        >
+          <div>Domain</div>
+          <div>Added</div>
+          <div>Status</div>
+          <div />
+        </div>
+        <div className="h-px bg-border/40 mx-5" />
+
+        {isLoading && (
+          <>
+            <DomainRowSkeleton />
+            <DomainRowSkeleton />
+          </>
+        )}
+
+        {!isLoading && domains.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-12 gap-2">
+            <IconWorldWww
+              size={24}
+              stroke={1.2}
+              className="text-muted-foreground/40"
+            />
+            <span className="text-sm text-muted-foreground">
+              No domains configured
+            </span>
+          </div>
+        )}
+
+        {!isLoading &&
+          domains.map((domain, i) => (
+            <div key={domain.id}>
+              {i > 0 && <div className="h-px bg-border/40 mx-5" />}
+              <DomainRow domain={domain} onRemove={handleRemove} />
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+function AddDomainDialog({
+  onAdd,
+}: {
+  onAdd: (name: string) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  const trimmed = name.trim().toLowerCase();
+  const isValid =
+    /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(
+      trimmed,
+    );
+
+  const handleAdd = () => {
+    setAdding(true);
+    detach(
+      onAdd(trimmed).then(
+        () => {
+          setOpen(false);
+          setName("");
+          setAdding(false);
+        },
+        (error: unknown) => {
+          setAdding(false);
+          const message =
+            error instanceof Error ? error.message : "Failed to add domain";
+          toast.error(message);
+        },
+      ),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!adding) {
+          setOpen(v);
+        }
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button size="sm" className="gap-1.5 rounded-lg">
+          <IconPlus size={14} stroke={2} />
+          Add domain
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add domain</DialogTitle>
+          <DialogDescription>
+            Add a domain to enable domain-based membership management.
+          </DialogDescription>
+        </DialogHeader>
+        <Input
+          placeholder="example.com"
+          value={name}
+          disabled={adding}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <DialogFooter>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setOpen(false)}
+            disabled={adding}
+          >
+            Cancel
+          </Button>
+          <Button size="sm" disabled={!isValid || adding} onClick={handleAdd}>
+            {adding ? "Adding..." : "Add domain"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DomainRow({
+  domain,
+  onRemove,
+}: {
+  domain: OrgDomain;
+  onRemove: (domainId: string) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [removing, setRemoving] = useState(false);
+  const isVerified = domain.verification.status === "verified";
+
+  const handleRemove = () => {
+    setRemoving(true);
+    detach(
+      onRemove(domain.id).then(
+        () => {
+          setOpen(false);
+          setRemoving(false);
+        },
+        (error: unknown) => {
+          setRemoving(false);
+          const message =
+            error instanceof Error ? error.message : "Failed to remove domain";
+          toast.error(message);
+        },
+      ),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <div className={cn(ROW_GRID, "py-3 px-5")}>
+      <div className="flex items-center gap-3 min-w-0">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/50 text-muted-foreground">
+          <IconWorldWww size={16} stroke={1.5} />
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">
+            {domain.name}
+          </p>
+          <p className="text-[12px] text-muted-foreground">
+            {domain.enrollmentMode.replace(/_/g, " ")}
+          </p>
+        </div>
+      </div>
+      <div className="text-[13px] text-muted-foreground tabular-nums">
+        {formatDate(domain.createdAt)}
+      </div>
+      <div>
+        <span
+          className={cn(
+            "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium",
+            isVerified ? "text-green-600" : "text-amber-600",
+          )}
+          style={{
+            border: "0.7px solid hsl(var(--gray-400))",
+            backgroundColor: "hsl(var(--gray-0))",
+          }}
+        >
+          {isVerified ? (
+            <IconCircleCheck size={12} stroke={1.8} />
+          ) : (
+            <IconAlertCircle size={12} stroke={1.8} />
+          )}
+          {isVerified ? "Verified" : "Unverified"}
+        </span>
+      </div>
+      <div className="flex justify-end">
+        <Dialog
+          open={open}
+          onOpenChange={(v) => {
+            if (!removing) {
+              setOpen(v);
+            }
+          }}
+        >
+          <DialogTrigger asChild>
+            <button className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors">
+              <IconTrash size={14} stroke={1.5} />
+            </button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Remove domain?</DialogTitle>
+              <DialogDescription>
+                The domain {domain.name} will be removed from this workspace.
+                Any domain-based membership rules will stop working.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setOpen(false)}
+                disabled={removing}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={removing}
+                onClick={handleRemove}
+              >
+                {removing ? "Removing..." : "Remove"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </div>
+  );
+}
+
+function DomainRowSkeleton() {
+  return (
+    <div className={cn(ROW_GRID, "py-3 px-5 animate-pulse")}>
+      <div className="flex items-center gap-3">
+        <div className="h-8 w-8 shrink-0 rounded-lg bg-muted/50" />
+        <div className="flex flex-col gap-1">
+          <div className="h-4 w-32 rounded bg-muted/50" />
+          <div className="h-3 w-20 rounded bg-muted/30" />
+        </div>
+      </div>
+      <div className="h-4 w-20 rounded bg-muted/30" />
+      <div className="h-5 w-16 rounded bg-muted/30" />
+      <div />
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
@@ -14,11 +14,13 @@ import {
   IconCreditCard,
   IconCoins,
   IconFileInvoice,
+  IconWorldWww,
 } from "@tabler/icons-react";
 
 import { OrgGeneralTab } from "./org-general-tab.tsx";
 import { OrgProvidersTab } from "./org-providers-tab.tsx";
 import { OrgMembersTab } from "./org-members-tab.tsx";
+import { OrgDomainsTab } from "./org-domains-tab.tsx";
 import { OrgBillingTab } from "./org-billing-tab.tsx";
 import { OrgUsageTab } from "./org-usage-tab.tsx";
 import { OrgInvoicesTab } from "./org-invoices-tab.tsx";
@@ -50,6 +52,10 @@ const TAB_META = {
   members: {
     title: "Members",
     description: "Manage who has access to this workspace.",
+  },
+  domains: {
+    title: "Domains",
+    description: "Manage verified domains for your workspace.",
   },
   billing: {
     title: "Billing",
@@ -88,6 +94,11 @@ const CONFIGURATION_GROUP = {
       label: "Model Providers",
       icon: IconCpu as NavIcon,
     },
+    {
+      id: "domains",
+      label: "Domains",
+      icon: IconWorldWww as NavIcon,
+    },
   ],
 } as const satisfies SidebarGroup;
 
@@ -106,6 +117,7 @@ const TAB_COMPONENTS = {
   general: () => <OrgGeneralTab />,
   providers: () => <OrgProvidersTab />,
   members: () => <OrgMembersTab />,
+  domains: () => <OrgDomainsTab />,
   billing: () => <OrgBillingTab />,
   usage: () => <OrgUsageTab />,
   invoices: () => <OrgInvoicesTab />,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -46,6 +46,7 @@ import { isOrgAdmin$, refreshOrg$ } from "../../../../signals/org.ts";
 import { user$, clerk$ } from "../../../../signals/auth.ts";
 import { zeroClient$ } from "../../../../signals/api-client.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
+import { extractApiErrorMessage } from "./org-api-error.ts";
 import {
   memberSearch$,
   setMemberSearch$,
@@ -125,15 +126,7 @@ export function OrgMembersTab() {
       refreshMembers();
       return;
     }
-    const msg =
-      result.status === 400 ||
-      result.status === 401 ||
-      result.status === 403 ||
-      result.status === 500
-        ? result.body.error.message
-        : undefined;
-    toast.error(msg ?? `Failed to invite (${result.status})`);
-    throw new Error(msg ?? `Failed to invite (${result.status})`);
+    throw new Error(extractApiErrorMessage(result, "Failed to invite"));
   };
 
   const handleRoleChange = async (email: string, role: OrgRole) => {
@@ -149,15 +142,7 @@ export function OrgMembersTab() {
       refreshOrg();
       return;
     }
-    const msg =
-      result.status === 400 ||
-      result.status === 401 ||
-      result.status === 403 ||
-      result.status === 500
-        ? result.body.error.message
-        : undefined;
-    toast.error(msg ?? `Failed to update role (${result.status})`);
-    throw new Error(msg ?? `Failed to update role (${result.status})`);
+    throw new Error(extractApiErrorMessage(result, "Failed to update role"));
   };
 
   const handleRemove = async (email: string) => {
@@ -168,15 +153,7 @@ export function OrgMembersTab() {
       refreshMembers();
       return;
     }
-    const msg =
-      result.status === 400 ||
-      result.status === 401 ||
-      result.status === 403 ||
-      result.status === 500
-        ? result.body.error.message
-        : undefined;
-    toast.error(msg ?? `Failed to remove member (${result.status})`);
-    throw new Error(msg ?? `Failed to remove member (${result.status})`);
+    throw new Error(extractApiErrorMessage(result, "Failed to remove member"));
   };
 
   const handleRevokeInvitation = async (invitationId: string) => {
@@ -187,15 +164,9 @@ export function OrgMembersTab() {
       refreshMembers();
       return;
     }
-    const msg =
-      result.status === 400 ||
-      result.status === 401 ||
-      result.status === 403 ||
-      result.status === 500
-        ? result.body.error.message
-        : undefined;
-    toast.error(msg ?? `Failed to revoke invitation (${result.status})`);
-    throw new Error(msg ?? `Failed to revoke invitation (${result.status})`);
+    throw new Error(
+      extractApiErrorMessage(result, "Failed to revoke invitation"),
+    );
   };
 
   const handleAcceptRequest = async (requestId: string) => {
@@ -206,15 +177,7 @@ export function OrgMembersTab() {
       refreshMembers();
       return;
     }
-    const msg =
-      result.status === 400 ||
-      result.status === 401 ||
-      result.status === 403 ||
-      result.status === 500
-        ? result.body.error.message
-        : undefined;
-    toast.error(msg ?? `Failed to accept request (${result.status})`);
-    throw new Error(msg ?? `Failed to accept request (${result.status})`);
+    throw new Error(extractApiErrorMessage(result, "Failed to accept request"));
   };
 
   const handleRejectRequest = async (requestId: string) => {
@@ -225,15 +188,7 @@ export function OrgMembersTab() {
       refreshMembers();
       return;
     }
-    const msg =
-      result.status === 400 ||
-      result.status === 401 ||
-      result.status === 403 ||
-      result.status === 500
-        ? result.body.error.message
-        : undefined;
-    toast.error(msg ?? `Failed to reject request (${result.status})`);
-    throw new Error(msg ?? `Failed to reject request (${result.status})`);
+    throw new Error(extractApiErrorMessage(result, "Failed to reject request"));
   };
 
   return (

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -6,6 +6,9 @@ import {
   IconDots,
   IconPlus,
   IconClock,
+  IconCheck,
+  IconX,
+  IconUserPlus,
 } from "@tabler/icons-react";
 import {
   cn,
@@ -27,14 +30,17 @@ import { toast } from "@vm0/ui/components/ui/sonner";
 import {
   zeroOrgMembersContract,
   zeroOrgInviteContract,
+  zeroOrgMembershipRequestsContract,
   type OrgRole,
 } from "@vm0/core";
 import {
   orgMembers$,
   orgPendingInvitations$,
+  orgMembershipRequests$,
   refreshOrgMembers$,
   type OrgMember,
   type OrgPendingInvitation,
+  type OrgMembershipRequest,
 } from "../../../../signals/external/org-members.ts";
 import { isOrgAdmin$, refreshOrg$ } from "../../../../signals/org.ts";
 import { user$, clerk$ } from "../../../../signals/auth.ts";
@@ -64,6 +70,7 @@ function formatDate(iso: string): string {
 export function OrgMembersTab() {
   const membersLoadable = useLoadable(orgMembers$);
   const pendingLoadable = useLoadable(orgPendingInvitations$);
+  const requestsLoadable = useLoadable(orgMembershipRequests$);
   const userLoadable = useLoadable(user$);
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
@@ -80,6 +87,8 @@ export function OrgMembersTab() {
     membersLoadable.state === "hasData" ? membersLoadable.data : [];
   const pendingInvitations =
     pendingLoadable.state === "hasData" ? pendingLoadable.data : [];
+  const membershipRequests =
+    requestsLoadable.state === "hasData" ? requestsLoadable.data : [];
   const currentUserId =
     userLoadable.state === "hasData" ? userLoadable.data?.id : undefined;
   const isLoading = membersLoadable.state === "loading";
@@ -168,6 +177,63 @@ export function OrgMembersTab() {
     throw new Error(msg ?? `Failed to remove member (${result.status})`);
   };
 
+  const handleRevokeInvitation = async (invitationId: string) => {
+    const client = createClient(zeroOrgInviteContract);
+    const result = await client.revoke({ body: { invitationId } });
+    if (result.status === 200) {
+      toast.success("Invitation revoked");
+      refreshMembers();
+      return;
+    }
+    const msg =
+      result.status === 400 ||
+      result.status === 401 ||
+      result.status === 403 ||
+      result.status === 500
+        ? result.body.error.message
+        : undefined;
+    toast.error(msg ?? `Failed to revoke invitation (${result.status})`);
+    throw new Error(msg ?? `Failed to revoke invitation (${result.status})`);
+  };
+
+  const handleAcceptRequest = async (requestId: string) => {
+    const client = createClient(zeroOrgMembershipRequestsContract);
+    const result = await client.accept({ body: { requestId } });
+    if (result.status === 200) {
+      toast.success("Membership request accepted");
+      refreshMembers();
+      return;
+    }
+    const msg =
+      result.status === 400 ||
+      result.status === 401 ||
+      result.status === 403 ||
+      result.status === 500
+        ? result.body.error.message
+        : undefined;
+    toast.error(msg ?? `Failed to accept request (${result.status})`);
+    throw new Error(msg ?? `Failed to accept request (${result.status})`);
+  };
+
+  const handleRejectRequest = async (requestId: string) => {
+    const client = createClient(zeroOrgMembershipRequestsContract);
+    const result = await client.reject({ body: { requestId } });
+    if (result.status === 200) {
+      toast.success("Membership request rejected");
+      refreshMembers();
+      return;
+    }
+    const msg =
+      result.status === 400 ||
+      result.status === 401 ||
+      result.status === 403 ||
+      result.status === 500
+        ? result.body.error.message
+        : undefined;
+    toast.error(msg ?? `Failed to reject request (${result.status})`);
+    throw new Error(msg ?? `Failed to reject request (${result.status})`);
+  };
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center gap-3">
@@ -212,7 +278,8 @@ export function OrgMembersTab() {
 
         {!isLoading &&
           filtered.length === 0 &&
-          filteredPending.length === 0 && (
+          filteredPending.length === 0 &&
+          membershipRequests.length === 0 && (
             <div className="flex items-center justify-center py-12">
               <span className="text-sm text-muted-foreground">
                 {search.trim() ? "No members found" : "No members"}
@@ -220,10 +287,34 @@ export function OrgMembersTab() {
             </div>
           )}
 
+        {!isLoading && membershipRequests.length > 0 && (
+          <>
+            <div className="px-5 pt-3 pb-1">
+              <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                <IconUserPlus size={13} stroke={1.8} />
+                Join requests
+              </span>
+            </div>
+            {membershipRequests.map((req, i) => (
+              <div key={req.id}>
+                {i > 0 && <div className="h-0 zero-border-t mx-5" />}
+                <MembershipRequestRow
+                  request={req}
+                  onAccept={handleAcceptRequest}
+                  onReject={handleRejectRequest}
+                />
+              </div>
+            ))}
+            <div className="h-0 zero-border-t mx-5" />
+          </>
+        )}
+
         {!isLoading &&
           filtered.map((m, i) => (
             <div key={m.userId}>
-              {i > 0 && <div className="h-0 zero-border-t mx-5" />}
+              {(i > 0 || membershipRequests.length > 0) && (
+                <div className="h-0 zero-border-t mx-5" />
+              )}
               <MemberRow
                 member={m}
                 isCurrentUser={m.userId === currentUserId}
@@ -236,11 +327,17 @@ export function OrgMembersTab() {
 
         {!isLoading &&
           filteredPending.map((inv, i) => (
-            <div key={inv.email}>
-              {(i > 0 || filtered.length > 0) && (
+            <div key={inv.id}>
+              {(i > 0 ||
+                filtered.length > 0 ||
+                membershipRequests.length > 0) && (
                 <div className="h-0 zero-border-t mx-5" />
               )}
-              <PendingInvitationRow invitation={inv} />
+              <PendingInvitationRow
+                invitation={inv}
+                isAdmin={isAdmin}
+                onRevoke={handleRevokeInvitation}
+              />
             </div>
           ))}
       </div>
@@ -597,10 +694,37 @@ function MemberActions({
 
 function PendingInvitationRow({
   invitation,
+  isAdmin,
+  onRevoke,
 }: {
   invitation: OrgPendingInvitation;
+  isAdmin: boolean;
+  onRevoke: (invitationId: string) => Promise<void>;
 }) {
   const initial = invitation.email.charAt(0).toUpperCase();
+  const [open, setOpen] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+
+  const handleRevoke = () => {
+    setRevoking(true);
+    detach(
+      onRevoke(invitation.id).then(
+        () => {
+          setOpen(false);
+          setRevoking(false);
+        },
+        (error: unknown) => {
+          setRevoking(false);
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Failed to revoke invitation";
+          toast.error(message);
+        },
+      ),
+      Reason.DomCallback,
+    );
+  };
 
   return (
     <div className={cn(ROW_GRID, "py-3 px-5")}>
@@ -621,7 +745,156 @@ function PendingInvitationRow({
           Pending
         </span>
       </div>
-      <div />
+      <div className="flex justify-end">
+        {isAdmin && (
+          <Dialog
+            open={open}
+            onOpenChange={(v) => {
+              if (!revoking) {
+                setOpen(v);
+              }
+            }}
+          >
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/50 transition-colors">
+                  <IconDots size={15} stroke={1.5} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DialogTrigger asChild>
+                  <DropdownMenuItem className="text-destructive focus:text-destructive">
+                    Revoke invitation
+                  </DropdownMenuItem>
+                </DialogTrigger>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Revoke invitation?</DialogTitle>
+                <DialogDescription>
+                  The invitation to {invitation.email} will be cancelled. They
+                  will no longer be able to join using this invitation.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setOpen(false)}
+                  disabled={revoking}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  disabled={revoking}
+                  onClick={handleRevoke}
+                >
+                  {revoking ? "Revoking..." : "Revoke"}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MembershipRequestRow({
+  request,
+  onAccept,
+  onReject,
+}: {
+  request: OrgMembershipRequest;
+  onAccept: (requestId: string) => Promise<void>;
+  onReject: (requestId: string) => Promise<void>;
+}) {
+  const name = [request.firstName, request.lastName].filter(Boolean).join(" ");
+  const initial = (name || request.email).charAt(0).toUpperCase();
+  const [loading, setLoading] = useState(false);
+
+  const handleAccept = () => {
+    setLoading(true);
+    detach(
+      onAccept(request.id).then(
+        () => setLoading(false),
+        (error: unknown) => {
+          setLoading(false);
+          const message =
+            error instanceof Error ? error.message : "Failed to accept request";
+          toast.error(message);
+        },
+      ),
+      Reason.DomCallback,
+    );
+  };
+
+  const handleReject = () => {
+    setLoading(true);
+    detach(
+      onReject(request.id).then(
+        () => setLoading(false),
+        (error: unknown) => {
+          setLoading(false);
+          const message =
+            error instanceof Error ? error.message : "Failed to reject request";
+          toast.error(message);
+        },
+      ),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <div className={cn(ROW_GRID, "py-3 px-5")}>
+      <div className="flex items-center gap-3 min-w-0">
+        <MemberAvatar
+          imageUrl={request.imageUrl}
+          initial={initial}
+          name={name || request.email}
+        />
+        <div className="min-w-0">
+          {name && (
+            <span className="text-sm font-medium text-foreground truncate block">
+              {name}
+            </span>
+          )}
+          <p className="text-[13px] text-muted-foreground truncate">
+            {request.email}
+          </p>
+        </div>
+      </div>
+      <div className="text-[13px] text-muted-foreground tabular-nums">
+        {formatDate(request.createdAt)}
+      </div>
+      <div>
+        <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
+          <IconUserPlus size={12} stroke={1.8} className="text-blue-500" />
+          Request
+        </span>
+      </div>
+      <div className="flex justify-end gap-1">
+        <button
+          className="flex h-7 w-7 items-center justify-center rounded-md text-green-600 hover:bg-green-50 dark:hover:bg-green-950/30 transition-colors disabled:opacity-50"
+          onClick={handleAccept}
+          disabled={loading}
+          title="Accept request"
+        >
+          <IconCheck size={15} stroke={2} />
+        </button>
+        <button
+          className="flex h-7 w-7 items-center justify-center rounded-md text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50"
+          onClick={handleReject}
+          disabled={loading}
+          title="Reject request"
+        >
+          <IconX size={15} stroke={2} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -93,6 +93,8 @@ export function OrgMembersTab() {
     userLoadable.state === "hasData" ? userLoadable.data?.id : undefined;
   const isLoading = membersLoadable.state === "loading";
 
+  const adminCount = members.filter((m) => m.role === "admin").length;
+
   const filtered = (() => {
     if (!search.trim()) {
       return members;
@@ -319,6 +321,7 @@ export function OrgMembersTab() {
                 member={m}
                 isCurrentUser={m.userId === currentUserId}
                 isAdmin={isAdmin}
+                isOnlyAdmin={adminCount < 2}
                 onRoleChange={handleRoleChange}
                 onRemove={handleRemove}
               />
@@ -445,19 +448,22 @@ function MemberRow({
   member,
   isCurrentUser,
   isAdmin,
+  isOnlyAdmin,
   onRoleChange,
   onRemove,
 }: {
   member: OrgMember;
   isCurrentUser: boolean;
   isAdmin: boolean;
+  isOnlyAdmin: boolean;
   onRoleChange: (email: string, role: OrgRole) => Promise<void>;
   onRemove: (email: string) => Promise<void>;
 }) {
   const name = displayName(member);
   const initial = (name || member.email).charAt(0).toUpperCase();
   const canManage = isAdmin && !isCurrentUser;
-  const canSelfDemote = isAdmin && isCurrentUser && member.role === "admin";
+  const canSelfDemote =
+    isAdmin && isCurrentUser && member.role === "admin" && !isOnlyAdmin;
 
   return (
     <div className={cn(ROW_GRID, "py-3 px-5")}>

--- a/turbo/apps/web/app/api/zero/org/domains/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { GET, POST, DELETE } from "../route";
+import { GET, POST, DELETE, PATCH } from "../route";
 import {
   createTestRequest,
   createTestOrg,
@@ -173,6 +173,78 @@ describe("DELETE /api/zero/org/domains", () => {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ domainId: "domain_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("PATCH /api/zero/org/domains (setVerified)", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should verify a domain for an admin", async () => {
+    const userId = uniqueId("dom-verify");
+    const { slug } = await setupOrg(userId);
+
+    const response = await PATCH(
+      createTestRequest(domainsUrl(slug), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domainId: "domain_test123", verified: true }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toBe("Domain verified");
+  });
+
+  it("should unverify a domain for an admin", async () => {
+    const userId = uniqueId("dom-unverify");
+    const { slug } = await setupOrg(userId);
+
+    const response = await PATCH(
+      createTestRequest(domainsUrl(slug), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domainId: "domain_test123", verified: false }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toBe("Domain unverified");
+  });
+
+  it("should return 403 when caller is not an admin", async () => {
+    const userId = uniqueId("dom-verify-403");
+    const slug = uniqueId("dom-verify-member");
+    const orgId = `org_mock_${userId}`;
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+    await createTestOrg(slug);
+
+    const response = await PATCH(
+      createTestRequest(domainsUrl(slug), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domainId: "domain_test123", verified: true }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await PATCH(
+      createTestRequest(domainsUrl("any-org"), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domainId: "domain_test123", verified: true }),
       }),
     );
 

--- a/turbo/apps/web/app/api/zero/org/domains/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/__tests__/route.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET, POST, DELETE } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("dom");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function domainsUrl(slug: string): string {
+  return `http://localhost:3000/api/zero/org/domains?org=${slug}`;
+}
+
+describe("GET /api/zero/org/domains", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return domain list for an admin", async () => {
+    const userId = uniqueId("dom-get");
+    const { slug } = await setupOrg(userId);
+
+    const response = await GET(createTestRequest(domainsUrl(slug)));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.domains).toBeInstanceOf(Array);
+  });
+
+  it("should return 403 when caller is not an admin", async () => {
+    const userId = uniqueId("dom-get-403");
+    const slug = uniqueId("dom-member");
+    const orgId = `org_mock_${userId}`;
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+    await createTestOrg(slug);
+
+    const response = await GET(createTestRequest(domainsUrl(slug)));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(createTestRequest(domainsUrl("any-org")));
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("POST /api/zero/org/domains", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should add a domain for an admin", async () => {
+    const userId = uniqueId("dom-add");
+    const { slug } = await setupOrg(userId);
+
+    const response = await POST(
+      createTestRequest(domainsUrl(slug), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "example.com" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toContain("example.com");
+  });
+
+  it("should return 403 when caller is not an admin", async () => {
+    const userId = uniqueId("dom-add-403");
+    const slug = uniqueId("dom-add-member");
+    const orgId = `org_mock_${userId}`;
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+    await createTestOrg(slug);
+
+    const response = await POST(
+      createTestRequest(domainsUrl(slug), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "example.com" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(
+      createTestRequest(domainsUrl("any-org"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "example.com" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("DELETE /api/zero/org/domains", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should remove a domain for an admin", async () => {
+    const userId = uniqueId("dom-del");
+    const { slug } = await setupOrg(userId);
+
+    const response = await DELETE(
+      createTestRequest(domainsUrl(slug), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domainId: "domain_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toBe("Domain removed");
+  });
+
+  it("should return 403 when caller is not an admin", async () => {
+    const userId = uniqueId("dom-del-403");
+    const slug = uniqueId("dom-del-member");
+    const orgId = `org_mock_${userId}`;
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+    await createTestOrg(slug);
+
+    const response = await DELETE(
+      createTestRequest(domainsUrl(slug), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domainId: "domain_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await DELETE(
+      createTestRequest(domainsUrl("any-org"), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ domainId: "domain_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/org/domains/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/__tests__/route.test.ts
@@ -74,7 +74,10 @@ describe("POST /api/zero/org/domains", () => {
       createTestRequest(domainsUrl(slug), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: "example.com" }),
+        body: JSON.stringify({
+          name: "example.com",
+          enrollmentMode: "manual_invitation",
+        }),
       }),
     );
 
@@ -94,7 +97,10 @@ describe("POST /api/zero/org/domains", () => {
       createTestRequest(domainsUrl(slug), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: "example.com" }),
+        body: JSON.stringify({
+          name: "example.com",
+          enrollmentMode: "manual_invitation",
+        }),
       }),
     );
 
@@ -108,7 +114,10 @@ describe("POST /api/zero/org/domains", () => {
       createTestRequest(domainsUrl("any-org"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: "example.com" }),
+        body: JSON.stringify({
+          name: "example.com",
+          enrollmentMode: "manual_invitation",
+        }),
       }),
     );
 

--- a/turbo/apps/web/app/api/zero/org/domains/route.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/route.ts
@@ -15,11 +15,7 @@ import {
   addOrgDomain,
   removeOrgDomain,
 } from "../../../../../src/lib/org/org-member-service";
-import {
-  isBadRequest,
-  isForbidden,
-  isNotFound,
-} from "../../../../../src/lib/errors";
+import { isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroOrgDomainsContract, {
   list: async ({ headers }, { request }) => {
@@ -56,9 +52,6 @@ const router = tsr.router(zeroOrgDomainsContract, {
         body: { message: `Domain ${body.name} added` },
       };
     } catch (error) {
-      if (isBadRequest(error)) {
-        return createErrorResponse("BAD_REQUEST", "Invalid request");
-      }
       if (isForbidden(error)) {
         return createErrorResponse("FORBIDDEN", "Access denied");
       }
@@ -81,14 +74,8 @@ const router = tsr.router(zeroOrgDomainsContract, {
         body: { message: "Domain removed" },
       };
     } catch (error) {
-      if (isBadRequest(error)) {
-        return createErrorResponse("BAD_REQUEST", "Invalid request");
-      }
       if (isForbidden(error)) {
         return createErrorResponse("FORBIDDEN", "Access denied");
-      }
-      if (isNotFound(error)) {
-        return createErrorResponse("NOT_FOUND", "Resource not found");
       }
       throw error;
     }

--- a/turbo/apps/web/app/api/zero/org/domains/route.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/route.ts
@@ -14,6 +14,7 @@ import {
   getOrgDomains,
   addOrgDomain,
   removeOrgDomain,
+  setOrgDomainVerified,
 } from "../../../../../src/lib/org/org-member-service";
 import { isForbidden } from "../../../../../src/lib/errors";
 
@@ -46,7 +47,12 @@ const router = tsr.router(zeroOrgDomainsContract, {
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
       const { org, member } = await resolveOrg(authCtx, orgSlug);
-      await addOrgDomain(org.orgId, member.role, body.name);
+      await addOrgDomain(
+        org.orgId,
+        member.role,
+        body.name,
+        body.enrollmentMode,
+      );
       return {
         status: 200 as const,
         body: { message: `Domain ${body.name} added` },
@@ -80,10 +86,38 @@ const router = tsr.router(zeroOrgDomainsContract, {
       throw error;
     }
   },
+  setVerified: async ({ headers, body }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      await setOrgDomainVerified(
+        org.orgId,
+        member.role,
+        body.domainId,
+        body.verified,
+      );
+      return {
+        status: 200 as const,
+        body: {
+          message: body.verified ? "Domain verified" : "Domain unverified",
+        },
+      };
+    } catch (error) {
+      if (isForbidden(error)) {
+        return createErrorResponse("FORBIDDEN", "Access denied");
+      }
+      throw error;
+    }
+  },
 });
 
 const handler = createHandler(zeroOrgDomainsContract, router, {
   errorHandler: createSafeErrorHandler("zero-org-domains"),
 });
 
-export { handler as GET, handler as POST, handler as DELETE };
+export { handler as GET, handler as POST, handler as DELETE, handler as PATCH };

--- a/turbo/apps/web/app/api/zero/org/domains/route.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/route.ts
@@ -3,7 +3,7 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../../src/lib/ts-rest-handler";
-import { zeroOrgInviteContract, createErrorResponse } from "@vm0/core";
+import { zeroOrgDomainsContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -11,8 +11,9 @@ import {
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import {
-  inviteMember,
-  revokeInvitation,
+  getOrgDomains,
+  addOrgDomain,
+  removeOrgDomain,
 } from "../../../../../src/lib/org/org-member-service";
 import {
   isBadRequest,
@@ -20,8 +21,8 @@ import {
   isNotFound,
 } from "../../../../../src/lib/errors";
 
-const router = tsr.router(zeroOrgInviteContract, {
-  invite: async ({ headers, body }, { request }) => {
+const router = tsr.router(zeroOrgDomainsContract, {
+  list: async ({ headers }, { request }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -30,10 +31,29 @@ const router = tsr.router(zeroOrgInviteContract, {
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
       const { org, member } = await resolveOrg(authCtx, orgSlug);
-      await inviteMember(authCtx.userId, org.orgId, member.role, body.email);
+      const result = await getOrgDomains(org.orgId, member.role);
+      return { status: 200 as const, body: result };
+    } catch (error) {
+      if (isForbidden(error)) {
+        return createErrorResponse("FORBIDDEN", "Access denied");
+      }
+      throw error;
+    }
+  },
+
+  add: async ({ headers, body }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      await addOrgDomain(org.orgId, member.role, body.name);
       return {
         status: 200 as const,
-        body: { message: `Invitation sent to ${body.email}` },
+        body: { message: `Domain ${body.name} added` },
       };
     } catch (error) {
       if (isBadRequest(error)) {
@@ -42,14 +62,11 @@ const router = tsr.router(zeroOrgInviteContract, {
       if (isForbidden(error)) {
         return createErrorResponse("FORBIDDEN", "Access denied");
       }
-      if (isNotFound(error)) {
-        return createErrorResponse("NOT_FOUND", "Resource not found");
-      }
       throw error;
     }
   },
 
-  revoke: async ({ headers, body }, { request }) => {
+  remove: async ({ headers, body }, { request }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -58,10 +75,10 @@ const router = tsr.router(zeroOrgInviteContract, {
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
       const { org, member } = await resolveOrg(authCtx, orgSlug);
-      await revokeInvitation(org.orgId, member.role, body.invitationId);
+      await removeOrgDomain(org.orgId, member.role, body.domainId);
       return {
         status: 200 as const,
-        body: { message: "Invitation revoked" },
+        body: { message: "Domain removed" },
       };
     } catch (error) {
       if (isBadRequest(error)) {
@@ -78,8 +95,8 @@ const router = tsr.router(zeroOrgInviteContract, {
   },
 });
 
-const handler = createHandler(zeroOrgInviteContract, router, {
-  errorHandler: createSafeErrorHandler("zero-org-invite"),
+const handler = createHandler(zeroOrgDomainsContract, router, {
+  errorHandler: createSafeErrorHandler("zero-org-domains"),
 });
 
-export { handler as POST, handler as DELETE };
+export { handler as GET, handler as POST, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { DELETE } from "../route";
+import { POST, DELETE } from "../route";
 import {
   createTestRequest,
   createTestOrg,
@@ -23,6 +23,61 @@ async function setupOrg(userId: string) {
 function inviteUrl(slug: string): string {
   return `http://localhost:3000/api/zero/org/invite?org=${slug}`;
 }
+
+describe("POST /api/zero/org/invite (invite)", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should invite a member for an admin", async () => {
+    const userId = uniqueId("inv-ok");
+    const { slug } = await setupOrg(userId);
+
+    const response = await POST(
+      createTestRequest(inviteUrl(slug), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "newuser@example.com" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toContain("newuser@example.com");
+  });
+
+  it("should return 403 when caller is not an admin", async () => {
+    const userId = uniqueId("inv-403");
+    const slug = uniqueId("inv-member");
+    const orgId = `org_mock_${userId}`;
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+    await createTestOrg(slug);
+
+    const response = await POST(
+      createTestRequest(inviteUrl(slug), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "newuser@example.com" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(
+      createTestRequest(inviteUrl("any-org"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "newuser@example.com" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
 
 describe("DELETE /api/zero/org/invite (revoke)", () => {
   beforeEach(() => {

--- a/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { DELETE } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("inv");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function inviteUrl(slug: string): string {
+  return `http://localhost:3000/api/zero/org/invite?org=${slug}`;
+}
+
+describe("DELETE /api/zero/org/invite (revoke)", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should revoke an invitation for an admin", async () => {
+    const userId = uniqueId("rev-ok");
+    const { slug } = await setupOrg(userId);
+
+    const response = await DELETE(
+      createTestRequest(inviteUrl(slug), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ invitationId: "inv_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toBe("Invitation revoked");
+  });
+
+  it("should return 403 when caller is not an admin", async () => {
+    const userId = uniqueId("rev-403");
+    const slug = uniqueId("inv-member");
+    const orgId = `org_mock_${userId}`;
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+    await createTestOrg(slug);
+
+    const response = await DELETE(
+      createTestRequest(inviteUrl(slug), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ invitationId: "inv_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await DELETE(
+      createTestRequest(inviteUrl("any-org"), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ invitationId: "inv_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 404 when org not found", async () => {
+    const userId = uniqueId("rev-nf");
+    mockClerk({ userId, orgId: `org_mock_${userId}`, orgRole: "org:admin" });
+
+    const response = await DELETE(
+      createTestRequest(inviteUrl("nonexistent-org-slug"), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ invitationId: "inv_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/turbo/apps/web/app/api/zero/org/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/members/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { server } from "../../../../../../src/mocks/server";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("mem");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function membersUrl(slug: string): string {
+  return `http://localhost:3000/api/zero/org/members?org=${slug}`;
+}
+
+describe("GET /api/zero/org/members", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return members list for an admin", async () => {
+    const userId = uniqueId("mem-get");
+    const { slug, orgId } = await setupOrg(userId);
+
+    server.use(
+      http.get(
+        `https://api.clerk.com/v1/organizations/${orgId}/membership_requests`,
+        () => HttpResponse.json({ data: [] }),
+      ),
+    );
+
+    const response = await GET(createTestRequest(membersUrl(slug)));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.members).toBeInstanceOf(Array);
+    expect(data.role).toBe("admin");
+    expect(data.membershipRequests).toBeInstanceOf(Array);
+  });
+
+  it("should include membership requests when pending requests exist", async () => {
+    const userId = uniqueId("mem-mreq");
+    const { slug, orgId } = await setupOrg(userId);
+    const requestUserId = `req-user-${userId}`;
+
+    server.use(
+      http.get(
+        `https://api.clerk.com/v1/organizations/${orgId}/membership_requests`,
+        () =>
+          HttpResponse.json({
+            data: [
+              {
+                id: "req_test_1",
+                public_user_data: { user_id: requestUserId },
+                created_at: Date.now(),
+              },
+            ],
+          }),
+      ),
+    );
+
+    const response = await GET(createTestRequest(membersUrl(slug)));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.membershipRequests).toBeInstanceOf(Array);
+    expect(data.membershipRequests).toHaveLength(1);
+    expect(data.membershipRequests[0].id).toBe("req_test_1");
+    expect(data.membershipRequests[0].userId).toBe(requestUserId);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(createTestRequest(membersUrl("any-org")));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 404 when org not found", async () => {
+    const userId = uniqueId("mem-nf");
+    mockClerk({ userId, orgId: `org_mock_${userId}`, orgRole: "org:admin" });
+
+    const response = await GET(
+      createTestRequest(membersUrl("nonexistent-org-slug")),
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/turbo/apps/web/app/api/zero/org/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/members/__tests__/route.test.ts
@@ -100,4 +100,25 @@ describe("GET /api/zero/org/members", () => {
 
     expect(response.status).toBe(404);
   });
+
+  it("should not expose pendingInvitations or membershipRequests to non-admin members", async () => {
+    const userId = uniqueId("mem-nonadmin");
+    const slug = uniqueId("mem-nonadmin");
+    const orgId = `org_mock_${userId}`;
+    mockClerk({
+      userId,
+      orgId,
+      orgRole: "org:member",
+      clerkOrgs: [{ id: orgId, slug, name: slug, role: "org:member" }],
+    });
+    await createTestOrg(slug);
+
+    const response = await GET(createTestRequest(membersUrl(slug)));
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.role).toBe("member");
+    expect(data.pendingInvitations).toEqual([]);
+    expect(data.membershipRequests).toEqual([]);
+  });
 });

--- a/turbo/apps/web/app/api/zero/org/membership-requests/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/membership-requests/__tests__/route.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { POST, DELETE } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { server } from "../../../../../../src/mocks/server";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("mreq");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function membershipRequestsUrl(slug: string): string {
+  return `http://localhost:3000/api/zero/org/membership-requests?org=${slug}`;
+}
+
+describe("POST /api/zero/org/membership-requests (accept)", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should accept a membership request for an admin", async () => {
+    const userId = uniqueId("mreq-acc");
+    const { orgId, slug } = await setupOrg(userId);
+
+    server.use(
+      http.post(
+        `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/req_test123/accept`,
+        () => HttpResponse.json({}),
+      ),
+    );
+
+    const response = await POST(
+      createTestRequest(membershipRequestsUrl(slug), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId: "req_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toBe("Membership request accepted");
+  });
+
+  it("should return 403 when caller is not an admin", async () => {
+    const userId = uniqueId("mreq-acc-403");
+    const slug = uniqueId("mreq-member");
+    const orgId = `org_mock_${userId}`;
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+    await createTestOrg(slug);
+
+    const response = await POST(
+      createTestRequest(membershipRequestsUrl(slug), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId: "req_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(
+      createTestRequest(membershipRequestsUrl("any-org"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId: "req_test123" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("DELETE /api/zero/org/membership-requests (reject)", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should reject a membership request for an admin", async () => {
+    const userId = uniqueId("mreq-rej");
+    const { orgId, slug } = await setupOrg(userId);
+
+    server.use(
+      http.post(
+        `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/req_test456/reject`,
+        () => HttpResponse.json({}),
+      ),
+    );
+
+    const response = await DELETE(
+      createTestRequest(membershipRequestsUrl(slug), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId: "req_test456" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toBe("Membership request rejected");
+  });
+
+  it("should return 403 when caller is not an admin", async () => {
+    const userId = uniqueId("mreq-rej-403");
+    const slug = uniqueId("mreq-rej-member");
+    const orgId = `org_mock_${userId}`;
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+    await createTestOrg(slug);
+
+    const response = await DELETE(
+      createTestRequest(membershipRequestsUrl(slug), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId: "req_test456" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await DELETE(
+      createTestRequest(membershipRequestsUrl("any-org"), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId: "req_test456" }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/org/membership-requests/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/membership-requests/__tests__/route.test.ts
@@ -55,6 +55,28 @@ describe("POST /api/zero/org/membership-requests (accept)", () => {
     expect(data.message).toBe("Membership request accepted");
   });
 
+  it("should return 400 when Clerk API rejects the accept request", async () => {
+    const userId = uniqueId("mreq-acc-fail");
+    const { orgId, slug } = await setupOrg(userId);
+
+    server.use(
+      http.post(
+        `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/req_invalid/accept`,
+        () => HttpResponse.json({ error: "Not found" }, { status: 404 }),
+      ),
+    );
+
+    const response = await POST(
+      createTestRequest(membershipRequestsUrl(slug), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId: "req_invalid" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
   it("should return 403 when caller is not an admin", async () => {
     const userId = uniqueId("mreq-acc-403");
     const slug = uniqueId("mreq-member");
@@ -115,6 +137,28 @@ describe("DELETE /api/zero/org/membership-requests (reject)", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.message).toBe("Membership request rejected");
+  });
+
+  it("should return 400 when Clerk API rejects the reject request", async () => {
+    const userId = uniqueId("mreq-rej-fail");
+    const { orgId, slug } = await setupOrg(userId);
+
+    server.use(
+      http.post(
+        `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/req_invalid/reject`,
+        () => HttpResponse.json({ error: "Not found" }, { status: 404 }),
+      ),
+    );
+
+    const response = await DELETE(
+      createTestRequest(membershipRequestsUrl(slug), {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId: "req_invalid" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
   });
 
   it("should return 403 when caller is not an admin", async () => {

--- a/turbo/apps/web/app/api/zero/org/membership-requests/route.ts
+++ b/turbo/apps/web/app/api/zero/org/membership-requests/route.ts
@@ -17,35 +17,9 @@ import {
   acceptMembershipRequest,
   rejectMembershipRequest,
 } from "../../../../../src/lib/org/org-member-service";
-import {
-  isBadRequest,
-  isForbidden,
-  isNotFound,
-} from "../../../../../src/lib/errors";
+import { isBadRequest, isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroOrgMembershipRequestsContract, {
-  list: async ({ headers }, { request }) => {
-    initServices();
-
-    const authCtx = await requireAuth(headers.authorization);
-    if (isAuthError(authCtx)) return authCtx;
-
-    try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      await resolveOrg(authCtx, orgSlug);
-      // Membership requests are already returned in the members endpoint
-      return {
-        status: 200 as const,
-        body: { message: "Use GET /api/zero/org/members for full data" },
-      };
-    } catch (error) {
-      if (isForbidden(error)) {
-        return createErrorResponse("FORBIDDEN", "Access denied");
-      }
-      throw error;
-    }
-  },
-
   accept: async ({ headers, body }, { request }) => {
     initServices();
 
@@ -66,9 +40,6 @@ const router = tsr.router(zeroOrgMembershipRequestsContract, {
       }
       if (isForbidden(error)) {
         return createErrorResponse("FORBIDDEN", "Access denied");
-      }
-      if (isNotFound(error)) {
-        return createErrorResponse("NOT_FOUND", "Resource not found");
       }
       throw error;
     }
@@ -95,9 +66,6 @@ const router = tsr.router(zeroOrgMembershipRequestsContract, {
       if (isForbidden(error)) {
         return createErrorResponse("FORBIDDEN", "Access denied");
       }
-      if (isNotFound(error)) {
-        return createErrorResponse("NOT_FOUND", "Resource not found");
-      }
       throw error;
     }
   },
@@ -107,4 +75,4 @@ const handler = createHandler(zeroOrgMembershipRequestsContract, router, {
   errorHandler: createSafeErrorHandler("zero-org-membership-requests"),
 });
 
-export { handler as GET, handler as POST, handler as DELETE };
+export { handler as POST, handler as DELETE };

--- a/turbo/apps/web/app/api/zero/org/membership-requests/route.ts
+++ b/turbo/apps/web/app/api/zero/org/membership-requests/route.ts
@@ -3,7 +3,10 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../../src/lib/ts-rest-handler";
-import { zeroOrgInviteContract, createErrorResponse } from "@vm0/core";
+import {
+  zeroOrgMembershipRequestsContract,
+  createErrorResponse,
+} from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -11,8 +14,8 @@ import {
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import {
-  inviteMember,
-  revokeInvitation,
+  acceptMembershipRequest,
+  rejectMembershipRequest,
 } from "../../../../../src/lib/org/org-member-service";
 import {
   isBadRequest,
@@ -20,8 +23,30 @@ import {
   isNotFound,
 } from "../../../../../src/lib/errors";
 
-const router = tsr.router(zeroOrgInviteContract, {
-  invite: async ({ headers, body }, { request }) => {
+const router = tsr.router(zeroOrgMembershipRequestsContract, {
+  list: async ({ headers }, { request }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    try {
+      const orgSlug = new URL(request.url).searchParams.get("org");
+      await resolveOrg(authCtx, orgSlug);
+      // Membership requests are already returned in the members endpoint
+      return {
+        status: 200 as const,
+        body: { message: "Use GET /api/zero/org/members for full data" },
+      };
+    } catch (error) {
+      if (isForbidden(error)) {
+        return createErrorResponse("FORBIDDEN", "Access denied");
+      }
+      throw error;
+    }
+  },
+
+  accept: async ({ headers, body }, { request }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -30,10 +55,10 @@ const router = tsr.router(zeroOrgInviteContract, {
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
       const { org, member } = await resolveOrg(authCtx, orgSlug);
-      await inviteMember(authCtx.userId, org.orgId, member.role, body.email);
+      await acceptMembershipRequest(org.orgId, member.role, body.requestId);
       return {
         status: 200 as const,
-        body: { message: `Invitation sent to ${body.email}` },
+        body: { message: "Membership request accepted" },
       };
     } catch (error) {
       if (isBadRequest(error)) {
@@ -49,7 +74,7 @@ const router = tsr.router(zeroOrgInviteContract, {
     }
   },
 
-  revoke: async ({ headers, body }, { request }) => {
+  reject: async ({ headers, body }, { request }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -58,10 +83,10 @@ const router = tsr.router(zeroOrgInviteContract, {
     try {
       const orgSlug = new URL(request.url).searchParams.get("org");
       const { org, member } = await resolveOrg(authCtx, orgSlug);
-      await revokeInvitation(org.orgId, member.role, body.invitationId);
+      await rejectMembershipRequest(org.orgId, member.role, body.requestId);
       return {
         status: 200 as const,
-        body: { message: "Invitation revoked" },
+        body: { message: "Membership request rejected" },
       };
     } catch (error) {
       if (isBadRequest(error)) {
@@ -78,8 +103,8 @@ const router = tsr.router(zeroOrgInviteContract, {
   },
 });
 
-const handler = createHandler(zeroOrgInviteContract, router, {
-  errorHandler: createSafeErrorHandler("zero-org-invite"),
+const handler = createHandler(zeroOrgMembershipRequestsContract, router, {
+  errorHandler: createSafeErrorHandler("zero-org-membership-requests"),
 });
 
-export { handler as POST, handler as DELETE };
+export { handler as GET, handler as POST, handler as DELETE };

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -121,16 +121,49 @@ export function mockClerk(options: {
         emailAddresses: [{ id: "email_1", emailAddress: email }],
         primaryEmailAddressId: "email_1",
       }),
-      getUserList: vi.fn().mockImplementation(({ emailAddress }) => {
-        // Return user if email matches, empty array otherwise
-        const queryEmail = emailAddress?.[0];
-        if (queryEmail === email && options.userId) {
-          return Promise.resolve({
-            data: [{ id: options.userId }],
-          });
-        }
-        return Promise.resolve({ data: [] });
-      }),
+      getUserList: vi
+        .fn()
+        .mockImplementation(
+          ({
+            emailAddress,
+            userId: userIdQuery,
+          }: {
+            emailAddress?: string[];
+            userId?: string[];
+          }) => {
+            // Return user if email matches
+            const queryEmail = emailAddress?.[0];
+            if (queryEmail === email && options.userId) {
+              return Promise.resolve({
+                data: [
+                  {
+                    id: options.userId,
+                    emailAddresses: [{ id: "email_1", emailAddress: email }],
+                    primaryEmailAddressId: "email_1",
+                    firstName: null,
+                    lastName: null,
+                    imageUrl: "",
+                  },
+                ],
+              });
+            }
+            // Return matching users when queried by userId array
+            if (userIdQuery && userIdQuery.length > 0 && options.userId) {
+              const matchedUsers = userIdQuery
+                .filter((uid) => uid === options.userId)
+                .map((uid) => ({
+                  id: uid,
+                  emailAddresses: [{ id: "email_1", emailAddress: email }],
+                  primaryEmailAddressId: "email_1",
+                  firstName: null,
+                  lastName: null,
+                  imageUrl: "",
+                }));
+              return Promise.resolve({ data: matchedUsers });
+            }
+            return Promise.resolve({ data: [] });
+          },
+        ),
       getOrganizationMembershipList: vi
         .fn()
         .mockImplementation(({ userId: queryUserId }: { userId: string }) => {
@@ -252,6 +285,7 @@ export function mockClerk(options: {
               slug,
               name: org.name,
               publicMetadata: {},
+              createdAt: Date.now(),
             });
           },
         ),

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -265,6 +265,12 @@ export function mockClerk(options: {
         }),
       updateOrganizationMetadata: vi.fn().mockResolvedValue({}),
       updateOrganizationMembershipMetadata: vi.fn().mockResolvedValue({}),
+      getOrganizationInvitationList: vi.fn().mockResolvedValue({ data: [] }),
+      createOrganizationInvitation: vi.fn().mockResolvedValue({}),
+      revokeOrganizationInvitation: vi.fn().mockResolvedValue({}),
+      getOrganizationDomainList: vi.fn().mockResolvedValue({ data: [] }),
+      createOrganizationDomain: vi.fn().mockResolvedValue({}),
+      deleteOrganizationDomain: vi.fn().mockResolvedValue({}),
     },
   } as unknown as Awaited<ReturnType<typeof clerkClient>>);
 }

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -305,6 +305,7 @@ export function mockClerk(options: {
       getOrganizationDomainList: vi.fn().mockResolvedValue({ data: [] }),
       createOrganizationDomain: vi.fn().mockResolvedValue({}),
       deleteOrganizationDomain: vi.fn().mockResolvedValue({}),
+      updateOrganizationDomain: vi.fn().mockResolvedValue({}),
     },
   } as unknown as Awaited<ReturnType<typeof clerkClient>>);
 }

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -574,7 +574,18 @@ export async function deleteOrg(
  * List domains for an org.
  * Requires admin role.
  */
-export async function getOrgDomains(orgId: string, role: OrgRole) {
+export async function getOrgDomains(
+  orgId: string,
+  role: OrgRole,
+): Promise<{
+  domains: Array<{
+    id: string;
+    name: string;
+    enrollmentMode: string;
+    verification: { status: string; strategy: string };
+    createdAt: string;
+  }>;
+}> {
   if (role !== "admin") {
     throw forbidden("Only admins can manage domains");
   }

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -3,7 +3,7 @@ import { clerkClient } from "@clerk/nextjs/server";
 import { z } from "zod";
 import { badRequest, forbidden, notFound } from "../errors";
 import { logger } from "../logger";
-import type { OrgRole } from "@vm0/core";
+import type { OrgRole, OrgEnrollmentMode } from "@vm0/core";
 import { slackOrgConnections } from "../../db/schema/slack-org-connection";
 import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
 import { slackOrgPendingQuestions } from "../../db/schema/slack-org-pending-question";
@@ -19,6 +19,26 @@ const CLERK_API_BASE = "https://api.clerk.com/v1";
  * The backend SDK doesn't expose membership request methods yet,
  * so we call the REST API directly and validate the response shape at runtime.
  */
+/**
+ * Zod schema for Clerk domain REST API response.
+ * The SDK may return camelCase or snake_case depending on the version,
+ * so we parse both forms to be safe.
+ */
+const clerkDomainDataSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  enrollment_mode: z.string().optional(),
+  enrollmentMode: z.string().optional(),
+  created_at: z.number().optional(),
+  createdAt: z.number().optional(),
+  verification: z
+    .object({
+      status: z.string(),
+      strategy: z.string(),
+    })
+    .optional(),
+});
+
 const membershipRequestDataSchema = z.object({
   id: z.string(),
   public_user_data: z.object({ user_id: z.string().optional() }).optional(),
@@ -46,6 +66,10 @@ async function fetchMembershipRequests(
     },
   );
   if (res.status === 404) {
+    log.warn(
+      "Membership requests endpoint returned 404 — feature may be disabled for org",
+      { orgId },
+    );
     return [];
   }
   if (!res.ok) {
@@ -607,19 +631,18 @@ export async function getOrgDomains(
 
   return {
     domains: domains.data.map((d) => {
-      // Clerk returns raw snake_case JSON from getOrganizationDomainList
-      const raw = d as unknown as Record<string, unknown>;
+      const parsed = clerkDomainDataSchema.parse(d);
       const enrollmentMode =
-        (raw.enrollment_mode as string | undefined) ?? d.enrollmentMode;
-      const createdAtMs = (raw.created_at as number | undefined) ?? d.createdAt;
+        parsed.enrollment_mode ?? parsed.enrollmentMode ?? "";
+      const createdAtMs = parsed.created_at ?? parsed.createdAt;
       return {
-        id: d.id,
-        name: d.name,
+        id: parsed.id,
+        name: parsed.name,
         enrollmentMode,
-        verification: d.verification
+        verification: parsed.verification
           ? {
-              status: d.verification.status,
-              strategy: d.verification.strategy,
+              status: parsed.verification.status,
+              strategy: parsed.verification.strategy,
             }
           : { status: "unverified", strategy: "email_code" },
         createdAt: createdAtMs
@@ -638,10 +661,7 @@ export async function addOrgDomain(
   orgId: string,
   role: OrgRole,
   domainName: string,
-  enrollmentMode:
-    | "manual_invitation"
-    | "automatic_invitation"
-    | "automatic_suggestion",
+  enrollmentMode: OrgEnrollmentMode,
 ) {
   if (role !== "admin") {
     throw forbidden("Only admins can add domains");

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -45,6 +45,9 @@ async function fetchMembershipRequests(
       headers: { Authorization: `Bearer ${secretKey}` },
     },
   );
+  if (res.status === 404) {
+    return [];
+  }
   if (!res.ok) {
     throw new Error(
       `Failed to fetch membership requests for org ${orgId}: HTTP ${res.status}`,
@@ -603,15 +606,27 @@ export async function getOrgDomains(
   });
 
   return {
-    domains: domains.data.map((d) => ({
-      id: d.id,
-      name: d.name,
-      enrollmentMode: d.enrollmentMode,
-      verification: d.verification
-        ? { status: d.verification.status, strategy: d.verification.strategy }
-        : { status: "unverified", strategy: "email_code" },
-      createdAt: new Date(d.createdAt).toISOString(),
-    })),
+    domains: domains.data.map((d) => {
+      // Clerk returns raw snake_case JSON from getOrganizationDomainList
+      const raw = d as unknown as Record<string, unknown>;
+      const enrollmentMode =
+        (raw.enrollment_mode as string | undefined) ?? d.enrollmentMode;
+      const createdAtMs = (raw.created_at as number | undefined) ?? d.createdAt;
+      return {
+        id: d.id,
+        name: d.name,
+        enrollmentMode,
+        verification: d.verification
+          ? {
+              status: d.verification.status,
+              strategy: d.verification.strategy,
+            }
+          : { status: "unverified", strategy: "email_code" },
+        createdAt: createdAtMs
+          ? new Date(createdAtMs).toISOString()
+          : new Date(0).toISOString(),
+      };
+    }),
   };
 }
 
@@ -623,6 +638,10 @@ export async function addOrgDomain(
   orgId: string,
   role: OrgRole,
   domainName: string,
+  enrollmentMode:
+    | "manual_invitation"
+    | "automatic_invitation"
+    | "automatic_suggestion",
 ) {
   if (role !== "admin") {
     throw forbidden("Only admins can add domains");
@@ -632,7 +651,7 @@ export async function addOrgDomain(
   await client.organizations.createOrganizationDomain({
     organizationId: orgId,
     name: domainName,
-    enrollmentMode: "manual_invitation",
+    enrollmentMode,
   });
 
   log.debug("Domain added", { orgId, domainName });
@@ -658,6 +677,30 @@ export async function removeOrgDomain(
   });
 
   log.debug("Domain removed", { orgId, domainId });
+}
+
+/**
+ * Verify or unverify a domain for an org.
+ * Requires admin role.
+ */
+export async function setOrgDomainVerified(
+  orgId: string,
+  role: OrgRole,
+  domainId: string,
+  verified: boolean,
+) {
+  if (role !== "admin") {
+    throw forbidden("Only admins can manage domains");
+  }
+
+  const client = await clerkClient();
+  await client.organizations.updateOrganizationDomain({
+    organizationId: orgId,
+    domainId,
+    verified,
+  });
+
+  log.debug("Domain verification updated", { orgId, domainId, verified });
 }
 
 /**

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -15,11 +15,6 @@ const log = logger("service:org-member");
 const CLERK_API_BASE = "https://api.clerk.com/v1";
 
 /**
- * Zod schema for Clerk membership request REST API response.
- * The backend SDK doesn't expose membership request methods yet,
- * so we call the REST API directly and validate the response shape at runtime.
- */
-/**
  * Zod schema for Clerk domain REST API response.
  * The SDK may return camelCase or snake_case depending on the version,
  * so we parse both forms to be safe.
@@ -39,6 +34,11 @@ const clerkDomainDataSchema = z.object({
     .optional(),
 });
 
+/**
+ * Zod schema for Clerk membership request REST API response.
+ * The backend SDK doesn't expose membership request methods yet,
+ * so we call the REST API directly and validate the response shape at runtime.
+ */
 const membershipRequestDataSchema = z.object({
   id: z.string(),
   public_user_data: z.object({ user_id: z.string().optional() }).optional(),

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -22,21 +22,27 @@ interface MembershipRequestData {
   created_at: number;
 }
 
-async function getClerkSecretKey(): Promise<string> {
+function getClerkSecretKey(): string {
   return globalThis.services.env.CLERK_SECRET_KEY;
 }
 
 async function fetchMembershipRequests(
   orgId: string,
 ): Promise<MembershipRequestData[]> {
-  const secretKey = await getClerkSecretKey();
+  const secretKey = getClerkSecretKey();
   const res = await fetch(
     `https://api.clerk.com/v1/organizations/${orgId}/membership_requests?status=pending`,
     {
       headers: { Authorization: `Bearer ${secretKey}` },
     },
   );
-  if (!res.ok) return [];
+  if (!res.ok) {
+    log.debug("Failed to fetch membership requests", {
+      orgId,
+      status: res.status,
+    });
+    return [];
+  }
   const body = (await res.json()) as { data: MembershipRequestData[] };
   return body.data ?? [];
 }
@@ -297,7 +303,7 @@ export async function acceptMembershipRequest(
     throw forbidden("Only admins can accept membership requests");
   }
 
-  const secretKey = await getClerkSecretKey();
+  const secretKey = getClerkSecretKey();
   const res = await fetch(
     `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/${requestId}/accept`,
     {
@@ -327,7 +333,7 @@ export async function rejectMembershipRequest(
     throw forbidden("Only admins can reject membership requests");
   }
 
-  const secretKey = await getClerkSecretKey();
+  const secretKey = getClerkSecretKey();
   const res = await fetch(
     `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/${requestId}/reject`,
     {

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -12,6 +12,36 @@ import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
 const log = logger("service:org-member");
 
 /**
+ * Membership request data shape from Clerk REST API.
+ * The backend SDK doesn't expose membership request methods yet,
+ * so we call the REST API directly.
+ */
+interface MembershipRequestData {
+  id: string;
+  public_user_data?: { user_id?: string };
+  created_at: number;
+}
+
+async function getClerkSecretKey(): Promise<string> {
+  return globalThis.services.env.CLERK_SECRET_KEY;
+}
+
+async function fetchMembershipRequests(
+  orgId: string,
+): Promise<MembershipRequestData[]> {
+  const secretKey = await getClerkSecretKey();
+  const res = await fetch(
+    `https://api.clerk.com/v1/organizations/${orgId}/membership_requests?status=pending`,
+    {
+      headers: { Authorization: `Bearer ${secretKey}` },
+    },
+  );
+  if (!res.ok) return [];
+  const body = (await res.json()) as { data: MembershipRequestData[] };
+  return body.data ?? [];
+}
+
+/**
  * Require a user to be a member of an org, or throw 403.
  * Verifies membership via Clerk API using the org ID directly.
  */
@@ -124,21 +154,84 @@ export async function getOrgMembers(
     ? mapClerkRole(callerMembership.role)
     : "member";
 
-  // Only expose pending invitations to admins
+  // Only expose pending invitations and membership requests to admins
   const pendingInvitations =
     callerRole === "admin"
       ? invitations.data.map((inv) => ({
+          id: inv.id,
           email: inv.emailAddress,
           role: mapClerkRole(inv.role),
           createdAt: new Date(inv.createdAt).toISOString(),
         }))
       : [];
 
+  // Fetch membership requests (only for admins)
+  let membershipRequests: Array<{
+    id: string;
+    userId: string;
+    email: string;
+    firstName: string | null;
+    lastName: string | null;
+    imageUrl: string;
+    createdAt: string;
+  }> = [];
+
+  if (callerRole === "admin") {
+    const requestsData = await fetchMembershipRequests(orgId);
+
+    if (requestsData.length > 0) {
+      const requestUserIds = requestsData
+        .map((r: MembershipRequestData) => r.public_user_data?.user_id)
+        .filter((id: string | undefined): id is string => Boolean(id));
+
+      const requestUserMap = new Map<
+        string,
+        {
+          email: string;
+          firstName: string | null;
+          lastName: string | null;
+          imageUrl: string;
+        }
+      >();
+      if (requestUserIds.length > 0) {
+        const requestUsers = await client.users.getUserList({
+          userId: requestUserIds,
+        });
+        for (const user of requestUsers.data) {
+          const primaryEmail = user.emailAddresses.find(
+            (e) => e.id === user.primaryEmailAddressId,
+          );
+          requestUserMap.set(user.id, {
+            email: primaryEmail?.emailAddress ?? "",
+            firstName: user.firstName,
+            lastName: user.lastName,
+            imageUrl: user.imageUrl,
+          });
+        }
+      }
+
+      membershipRequests = requestsData.map((req: MembershipRequestData) => {
+        const uid = req.public_user_data?.user_id ?? "";
+        const profile = requestUserMap.get(uid);
+        return {
+          id: req.id,
+          userId: uid,
+          email: profile?.email ?? "",
+          firstName: profile?.firstName ?? null,
+          lastName: profile?.lastName ?? null,
+          imageUrl: profile?.imageUrl ?? "",
+          createdAt: new Date(req.created_at).toISOString(),
+        };
+      });
+    }
+  }
+
   return {
     slug: orgSlug,
     role: callerRole,
     members,
     pendingInvitations,
+    membershipRequests,
     createdAt: createdAt.toISOString(),
   };
 }
@@ -166,6 +259,88 @@ export async function inviteMember(
   });
 
   log.debug("Invitation sent", { orgId, email });
+}
+
+/**
+ * Revoke a pending invitation.
+ * Requires admin role.
+ */
+export async function revokeInvitation(
+  orgId: string,
+  role: OrgRole,
+  invitationId: string,
+) {
+  if (role !== "admin") {
+    throw forbidden("Only admins can revoke invitations");
+  }
+
+  const client = await clerkClient();
+  await client.organizations.revokeOrganizationInvitation({
+    organizationId: orgId,
+    invitationId,
+  });
+
+  log.debug("Invitation revoked", { orgId, invitationId });
+}
+
+/**
+ * Accept a membership request.
+ * Requires admin role.
+ * Uses Clerk REST API directly since the backend SDK doesn't expose this method.
+ */
+export async function acceptMembershipRequest(
+  orgId: string,
+  role: OrgRole,
+  requestId: string,
+) {
+  if (role !== "admin") {
+    throw forbidden("Only admins can accept membership requests");
+  }
+
+  const secretKey = await getClerkSecretKey();
+  const res = await fetch(
+    `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/${requestId}/accept`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${secretKey}` },
+    },
+  );
+
+  if (!res.ok) {
+    throw badRequest("Failed to accept membership request");
+  }
+
+  log.debug("Membership request accepted", { orgId, requestId });
+}
+
+/**
+ * Reject a membership request.
+ * Requires admin role.
+ * Uses Clerk REST API directly since the backend SDK doesn't expose this method.
+ */
+export async function rejectMembershipRequest(
+  orgId: string,
+  role: OrgRole,
+  requestId: string,
+) {
+  if (role !== "admin") {
+    throw forbidden("Only admins can reject membership requests");
+  }
+
+  const secretKey = await getClerkSecretKey();
+  const res = await fetch(
+    `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/${requestId}/reject`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${secretKey}` },
+    },
+  );
+
+  if (!res.ok) {
+    throw badRequest("Failed to reject membership request");
+  }
+
+  log.debug("Membership request rejected", { orgId, requestId });
 }
 
 /**
@@ -387,6 +562,78 @@ export async function deleteOrg(
   await client.organizations.deleteOrganization(orgId);
 
   log.debug("Organization deleted", { orgId, callerUserId });
+}
+
+/**
+ * List domains for an org.
+ * Requires admin role.
+ */
+export async function getOrgDomains(orgId: string, role: OrgRole) {
+  if (role !== "admin") {
+    throw forbidden("Only admins can manage domains");
+  }
+
+  const client = await clerkClient();
+  const domains = await client.organizations.getOrganizationDomainList({
+    organizationId: orgId,
+  });
+
+  return {
+    domains: domains.data.map((d) => ({
+      id: d.id,
+      name: d.name,
+      enrollmentMode: d.enrollmentMode,
+      verification: d.verification
+        ? { status: d.verification.status, strategy: d.verification.strategy }
+        : { status: "unverified", strategy: "email_code" },
+      createdAt: new Date(d.createdAt).toISOString(),
+    })),
+  };
+}
+
+/**
+ * Add a domain to an org.
+ * Requires admin role.
+ */
+export async function addOrgDomain(
+  orgId: string,
+  role: OrgRole,
+  domainName: string,
+) {
+  if (role !== "admin") {
+    throw forbidden("Only admins can add domains");
+  }
+
+  const client = await clerkClient();
+  await client.organizations.createOrganizationDomain({
+    organizationId: orgId,
+    name: domainName,
+    enrollmentMode: "manual_invitation",
+  });
+
+  log.debug("Domain added", { orgId, domainName });
+}
+
+/**
+ * Remove a domain from an org.
+ * Requires admin role.
+ */
+export async function removeOrgDomain(
+  orgId: string,
+  role: OrgRole,
+  domainId: string,
+) {
+  if (role !== "admin") {
+    throw forbidden("Only admins can remove domains");
+  }
+
+  const client = await clerkClient();
+  await client.organizations.deleteOrganizationDomain({
+    organizationId: orgId,
+    domainId,
+  });
+
+  log.debug("Domain removed", { orgId, domainId });
 }
 
 /**

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -1,5 +1,6 @@
 import { eq, and, inArray } from "drizzle-orm";
 import { clerkClient } from "@clerk/nextjs/server";
+import { z } from "zod";
 import { badRequest, forbidden, notFound } from "../errors";
 import { logger } from "../logger";
 import type { OrgRole } from "@vm0/core";
@@ -11,16 +12,24 @@ import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
 
 const log = logger("service:org-member");
 
+const CLERK_API_BASE = "https://api.clerk.com/v1";
+
 /**
- * Membership request data shape from Clerk REST API.
+ * Zod schema for Clerk membership request REST API response.
  * The backend SDK doesn't expose membership request methods yet,
- * so we call the REST API directly.
+ * so we call the REST API directly and validate the response shape at runtime.
  */
-interface MembershipRequestData {
-  id: string;
-  public_user_data?: { user_id?: string };
-  created_at: number;
-}
+const membershipRequestDataSchema = z.object({
+  id: z.string(),
+  public_user_data: z.object({ user_id: z.string().optional() }).optional(),
+  created_at: z.number(),
+});
+
+const clerkMembershipRequestsResponseSchema = z.object({
+  data: z.array(membershipRequestDataSchema),
+});
+
+type MembershipRequestData = z.infer<typeof membershipRequestDataSchema>;
 
 function getClerkSecretKey(): string {
   return globalThis.services.env.CLERK_SECRET_KEY;
@@ -31,20 +40,18 @@ async function fetchMembershipRequests(
 ): Promise<MembershipRequestData[]> {
   const secretKey = getClerkSecretKey();
   const res = await fetch(
-    `https://api.clerk.com/v1/organizations/${orgId}/membership_requests?status=pending`,
+    `${CLERK_API_BASE}/organizations/${orgId}/membership_requests?status=pending`,
     {
       headers: { Authorization: `Bearer ${secretKey}` },
     },
   );
   if (!res.ok) {
-    log.debug("Failed to fetch membership requests", {
-      orgId,
-      status: res.status,
-    });
-    return [];
+    throw new Error(
+      `Failed to fetch membership requests for org ${orgId}: HTTP ${res.status}`,
+    );
   }
-  const body = (await res.json()) as { data: MembershipRequestData[] };
-  return body.data ?? [];
+  const body = clerkMembershipRequestsResponseSchema.parse(await res.json());
+  return body.data;
 }
 
 /**
@@ -305,7 +312,7 @@ export async function acceptMembershipRequest(
 
   const secretKey = getClerkSecretKey();
   const res = await fetch(
-    `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/${requestId}/accept`,
+    `${CLERK_API_BASE}/organizations/${orgId}/membership_requests/${requestId}/accept`,
     {
       method: "POST",
       headers: { Authorization: `Bearer ${secretKey}` },
@@ -335,7 +342,7 @@ export async function rejectMembershipRequest(
 
   const secretKey = getClerkSecretKey();
   const res = await fetch(
-    `https://api.clerk.com/v1/organizations/${orgId}/membership_requests/${requestId}/reject`,
+    `${CLERK_API_BASE}/organizations/${orgId}/membership_requests/${requestId}/reject`,
     {
       method: "POST",
       headers: { Authorization: `Bearer ${secretKey}` },

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -457,7 +457,9 @@ export {
   type RevokeInvitationRequest,
   type MembershipRequestAction,
   type AddDomainRequest,
+  type OrgEnrollmentMode,
   type DomainActionRequest,
+  type DomainVerifyRequest,
   type OrgMessageResponse,
 } from "./org-members";
 export {

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -432,18 +432,32 @@ export {
   orgRoleSchema,
   orgMemberSchema,
   orgPendingInvitationSchema,
+  orgMembershipRequestSchema,
+  orgDomainSchema,
   orgMembersResponseSchema,
+  orgDomainsResponseSchema,
   inviteOrgMemberRequestSchema,
   removeOrgMemberRequestSchema,
   updateOrgMemberRoleRequestSchema,
+  revokeInvitationRequestSchema,
+  membershipRequestActionSchema,
+  addDomainRequestSchema,
+  domainActionRequestSchema,
   orgMessageResponseSchema,
   type OrgRole,
   type OrgMember,
   type OrgPendingInvitation,
+  type OrgMembershipRequest,
+  type OrgDomain,
   type OrgMembersResponse,
+  type OrgDomainsResponse,
   type InviteOrgMemberRequest,
   type RemoveOrgMemberRequest,
   type UpdateOrgMemberRoleRequest,
+  type RevokeInvitationRequest,
+  type MembershipRequestAction,
+  type AddDomainRequest,
+  type DomainActionRequest,
   type OrgMessageResponse,
 } from "./org-members";
 export {
@@ -510,9 +524,15 @@ export { zeroOrgListContract, type ZeroOrgListContract } from "./zero-org-list";
 export {
   zeroOrgMembersContract,
   zeroOrgInviteContract,
+  zeroOrgMembershipRequestsContract,
   type ZeroOrgMembersContract,
   type ZeroOrgInviteContract,
+  type ZeroOrgMembershipRequestsContract,
 } from "./zero-org-members";
+export {
+  zeroOrgDomainsContract,
+  type ZeroOrgDomainsContract,
+} from "./zero-org-domains";
 export {
   zeroComposesMainContract,
   zeroComposesByIdContract,

--- a/turbo/packages/core/src/contracts/org-members.ts
+++ b/turbo/packages/core/src/contracts/org-members.ts
@@ -115,7 +115,7 @@ export type UpdateOrgMemberRoleRequest = z.infer<
 export const orgDomainSchema = z.object({
   id: z.string(),
   name: z.string(),
-  enrollmentMode: z.string().optional(),
+  enrollmentMode: z.string(),
   verification: z.object({
     status: z.string(),
     strategy: z.string(),

--- a/turbo/packages/core/src/contracts/org-members.ts
+++ b/turbo/packages/core/src/contracts/org-members.ts
@@ -115,7 +115,7 @@ export type UpdateOrgMemberRoleRequest = z.infer<
 export const orgDomainSchema = z.object({
   id: z.string(),
   name: z.string(),
-  enrollmentMode: z.string(),
+  enrollmentMode: z.string().optional(),
   verification: z.object({
     status: z.string(),
     strategy: z.string(),
@@ -135,18 +135,35 @@ export type OrgDomainsResponse = z.infer<typeof orgDomainsResponseSchema>;
 /**
  * Add domain request schema
  */
+const orgEnrollmentModeSchema = z.enum([
+  "manual_invitation",
+  "automatic_invitation",
+  "automatic_suggestion",
+]);
+export type OrgEnrollmentMode = z.infer<typeof orgEnrollmentModeSchema>;
+
 export const addDomainRequestSchema = z.object({
   name: z.string(),
+  enrollmentMode: orgEnrollmentModeSchema,
 });
 export type AddDomainRequest = z.infer<typeof addDomainRequestSchema>;
 
 /**
- * Domain action request schema (for delete/verify)
+ * Domain action request schema (for delete)
  */
 export const domainActionRequestSchema = z.object({
   domainId: z.string(),
 });
 export type DomainActionRequest = z.infer<typeof domainActionRequestSchema>;
+
+/**
+ * Domain verify/unverify request schema
+ */
+export const domainVerifyRequestSchema = z.object({
+  domainId: z.string(),
+  verified: z.boolean(),
+});
+export type DomainVerifyRequest = z.infer<typeof domainVerifyRequestSchema>;
 
 /**
  * Simple message response schema

--- a/turbo/packages/core/src/contracts/org-members.ts
+++ b/turbo/packages/core/src/contracts/org-members.ts
@@ -24,11 +24,46 @@ export type OrgMember = z.infer<typeof orgMemberSchema>;
  * Pending invitation schema
  */
 export const orgPendingInvitationSchema = z.object({
+  id: z.string(),
   email: z.string(),
   role: orgRoleSchema,
   createdAt: z.string(),
 });
 export type OrgPendingInvitation = z.infer<typeof orgPendingInvitationSchema>;
+
+/**
+ * Membership request schema
+ */
+export const orgMembershipRequestSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  email: z.string(),
+  firstName: z.string().nullable(),
+  lastName: z.string().nullable(),
+  imageUrl: z.string(),
+  createdAt: z.string(),
+});
+export type OrgMembershipRequest = z.infer<typeof orgMembershipRequestSchema>;
+
+/**
+ * Revoke invitation request schema
+ */
+export const revokeInvitationRequestSchema = z.object({
+  invitationId: z.string(),
+});
+export type RevokeInvitationRequest = z.infer<
+  typeof revokeInvitationRequestSchema
+>;
+
+/**
+ * Membership request action schema
+ */
+export const membershipRequestActionSchema = z.object({
+  requestId: z.string(),
+});
+export type MembershipRequestAction = z.infer<
+  typeof membershipRequestActionSchema
+>;
 
 /**
  * Org members response schema (status + members list)
@@ -38,6 +73,7 @@ export const orgMembersResponseSchema = z.object({
   role: orgRoleSchema,
   members: z.array(orgMemberSchema),
   pendingInvitations: z.array(orgPendingInvitationSchema).optional(),
+  membershipRequests: z.array(orgMembershipRequestSchema).optional(),
   createdAt: z.string(),
 });
 export type OrgMembersResponse = z.infer<typeof orgMembersResponseSchema>;
@@ -72,6 +108,45 @@ export const updateOrgMemberRoleRequestSchema = z.object({
 export type UpdateOrgMemberRoleRequest = z.infer<
   typeof updateOrgMemberRoleRequestSchema
 >;
+
+/**
+ * Org domain schema
+ */
+export const orgDomainSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  enrollmentMode: z.string(),
+  verification: z.object({
+    status: z.string(),
+    strategy: z.string(),
+  }),
+  createdAt: z.string(),
+});
+export type OrgDomain = z.infer<typeof orgDomainSchema>;
+
+/**
+ * Org domains response schema
+ */
+export const orgDomainsResponseSchema = z.object({
+  domains: z.array(orgDomainSchema),
+});
+export type OrgDomainsResponse = z.infer<typeof orgDomainsResponseSchema>;
+
+/**
+ * Add domain request schema
+ */
+export const addDomainRequestSchema = z.object({
+  name: z.string(),
+});
+export type AddDomainRequest = z.infer<typeof addDomainRequestSchema>;
+
+/**
+ * Domain action request schema (for delete/verify)
+ */
+export const domainActionRequestSchema = z.object({
+  domainId: z.string(),
+});
+export type DomainActionRequest = z.infer<typeof domainActionRequestSchema>;
 
 /**
  * Simple message response schema

--- a/turbo/packages/core/src/contracts/zero-org-domains.ts
+++ b/turbo/packages/core/src/contracts/zero-org-domains.ts
@@ -1,0 +1,58 @@
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import {
+  orgDomainsResponseSchema,
+  addDomainRequestSchema,
+  domainActionRequestSchema,
+  orgMessageResponseSchema,
+} from "./org-members";
+
+const c = initContract();
+
+/**
+ * Zero contract for /api/zero/org/domains
+ */
+export const zeroOrgDomainsContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/org/domains",
+    headers: authHeadersSchema,
+    responses: {
+      200: orgDomainsResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List org domains (zero proxy)",
+  },
+  add: {
+    method: "POST",
+    path: "/api/zero/org/domains",
+    headers: authHeadersSchema,
+    body: addDomainRequestSchema,
+    responses: {
+      200: orgMessageResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Add a domain to the org (zero proxy)",
+  },
+  remove: {
+    method: "DELETE",
+    path: "/api/zero/org/domains",
+    headers: authHeadersSchema,
+    body: domainActionRequestSchema,
+    responses: {
+      200: orgMessageResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Remove a domain from the org (zero proxy)",
+  },
+});
+
+export type ZeroOrgDomainsContract = typeof zeroOrgDomainsContract;

--- a/turbo/packages/core/src/contracts/zero-org-domains.ts
+++ b/turbo/packages/core/src/contracts/zero-org-domains.ts
@@ -32,7 +32,6 @@ export const zeroOrgDomainsContract = c.router({
     body: addDomainRequestSchema,
     responses: {
       200: orgMessageResponseSchema,
-      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       500: apiErrorSchema,
@@ -46,7 +45,6 @@ export const zeroOrgDomainsContract = c.router({
     body: domainActionRequestSchema,
     responses: {
       200: orgMessageResponseSchema,
-      400: apiErrorSchema,
       401: apiErrorSchema,
       403: apiErrorSchema,
       500: apiErrorSchema,

--- a/turbo/packages/core/src/contracts/zero-org-domains.ts
+++ b/turbo/packages/core/src/contracts/zero-org-domains.ts
@@ -4,6 +4,7 @@ import {
   orgDomainsResponseSchema,
   addDomainRequestSchema,
   domainActionRequestSchema,
+  domainVerifyRequestSchema,
   orgMessageResponseSchema,
 } from "./org-members";
 
@@ -50,6 +51,19 @@ export const zeroOrgDomainsContract = c.router({
       500: apiErrorSchema,
     },
     summary: "Remove a domain from the org (zero proxy)",
+  },
+  setVerified: {
+    method: "PATCH",
+    path: "/api/zero/org/domains",
+    headers: authHeadersSchema,
+    body: domainVerifyRequestSchema,
+    responses: {
+      200: orgMessageResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Verify or unverify a domain (zero proxy)",
   },
 });
 

--- a/turbo/packages/core/src/contracts/zero-org-members.ts
+++ b/turbo/packages/core/src/contracts/zero-org-members.ts
@@ -104,18 +104,6 @@ export type ZeroOrgInviteContract = typeof zeroOrgInviteContract;
  * Zero contract for /api/zero/org/membership-requests
  */
 export const zeroOrgMembershipRequestsContract = c.router({
-  list: {
-    method: "GET",
-    path: "/api/zero/org/membership-requests",
-    headers: authHeadersSchema,
-    responses: {
-      200: orgMessageResponseSchema,
-      401: apiErrorSchema,
-      403: apiErrorSchema,
-      500: apiErrorSchema,
-    },
-    summary: "List pending membership requests (zero proxy)",
-  },
   accept: {
     method: "POST",
     path: "/api/zero/org/membership-requests",

--- a/turbo/packages/core/src/contracts/zero-org-members.ts
+++ b/turbo/packages/core/src/contracts/zero-org-members.ts
@@ -5,6 +5,8 @@ import {
   inviteOrgMemberRequestSchema,
   removeOrgMemberRequestSchema,
   updateOrgMemberRoleRequestSchema,
+  revokeInvitationRequestSchema,
+  membershipRequestActionSchema,
   orgMessageResponseSchema,
 } from "./org-members";
 
@@ -80,6 +82,69 @@ export const zeroOrgInviteContract = c.router({
     },
     summary: "Invite a member to the org (zero proxy)",
   },
+  revoke: {
+    method: "DELETE",
+    path: "/api/zero/org/invite",
+    headers: authHeadersSchema,
+    body: revokeInvitationRequestSchema,
+    responses: {
+      200: orgMessageResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Revoke a pending invitation (zero proxy)",
+  },
 });
 
 export type ZeroOrgInviteContract = typeof zeroOrgInviteContract;
+
+/**
+ * Zero contract for /api/zero/org/membership-requests
+ */
+export const zeroOrgMembershipRequestsContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/org/membership-requests",
+    headers: authHeadersSchema,
+    responses: {
+      200: orgMessageResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "List pending membership requests (zero proxy)",
+  },
+  accept: {
+    method: "POST",
+    path: "/api/zero/org/membership-requests",
+    headers: authHeadersSchema,
+    body: membershipRequestActionSchema,
+    responses: {
+      200: orgMessageResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Accept a membership request (zero proxy)",
+  },
+  reject: {
+    method: "DELETE",
+    path: "/api/zero/org/membership-requests",
+    headers: authHeadersSchema,
+    body: membershipRequestActionSchema,
+    responses: {
+      200: orgMessageResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Reject a membership request (zero proxy)",
+  },
+});
+
+export type ZeroOrgMembershipRequestsContract =
+  typeof zeroOrgMembershipRequestsContract;


### PR DESCRIPTION
## Summary

Closes #7046

- **Revoke invitations**: Admins can now revoke pending invitations via a dropdown menu with confirmation dialog on each pending invitation row
- **Membership request approval**: Join requests are displayed in a dedicated section with accept/reject buttons, using Clerk REST API directly (SDK doesn't expose these methods yet)
- **Invitation management**: Pending invitations now show actionable controls (previously just a status badge with no actions)
- **Domain verification management**: New "Domains" tab under Configuration (admin-only) to list, add, and remove organization domains

## Changes

### Contracts (`@vm0/core`)
- Added `id` field to `orgPendingInvitationSchema` for revocation
- Added `orgMembershipRequestSchema`, `orgDomainSchema` with response/request schemas
- Added `zeroOrgInviteContract.revoke` (DELETE), `zeroOrgMembershipRequestsContract` (GET/POST/DELETE), `zeroOrgDomainsContract` (GET/POST/DELETE)

### Backend (`web`)
- `org-member-service.ts`: Added `revokeInvitation`, `acceptMembershipRequest`, `rejectMembershipRequest`, `getOrgDomains`, `addOrgDomain`, `removeOrgDomain`
- Membership requests use Clerk REST API directly since `@clerk/backend@2.31.0` doesn't expose these methods
- Updated `getOrgMembers` to return membership requests for admins
- New API routes: `/api/zero/org/invite` (DELETE), `/api/zero/org/membership-requests`, `/api/zero/org/domains`

### Frontend (`platform`)
- `org-members-tab.tsx`: Added revoke action to `PendingInvitationRow`, new `MembershipRequestRow` with accept/reject buttons, join requests section header
- `org-domains-tab.tsx`: New tab component with domain list, add dialog, remove with confirmation
- `org-manage-dialog.tsx`: Registered "Domains" tab under Configuration group
- New signals: `org-domains.ts` for domain state, `orgMembershipRequests$` in `org-members.ts`

## Test plan

- [ ] Verify pending invitations show revoke action (admin only)
- [ ] Verify revoking an invitation removes it from the list
- [ ] Verify membership requests appear when org has pending join requests
- [ ] Verify accept/reject buttons work on membership requests
- [ ] Verify Domains tab appears under Configuration for admins
- [ ] Verify adding/removing domains works
- [ ] Verify non-admin users don't see admin-only controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)