### PR TITLE
fix(web): point agents to ask-user question --help for usage guidance

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -57,7 +57,7 @@ export function buildAgentToolsPrompt(): string {
     "- When you need to discover available commands, run `zero --help`.",
     "- When you need to delegate a task to a teammate agent, use `zero agent list` and `zero run`.",
     "- When you need to schedule or manage recurring tasks, use `zero schedule`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
-    "- When you need to ask the user a question, use `zero ask-user question`.",
+    "- When you need to ask the user a question, use `zero ask-user question --help`.",
     "- Your replies are automatically sent to the originating thread. Only use `zero slack message send` when you need to message a different channel or thread. Never use SLACK_TOKEN to send messages directly — it's a user OAuth token.",
     "- When you encounter a missing token or environment variable error, run `zero doctor missing-token <TOKEN_NAME>` to diagnose the issue and get remediation steps for the user.",
     "- When you need to update your own configuration (description, tone, or instructions), use `zero agent edit $ZERO_AGENT_ID`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",


### PR DESCRIPTION
## Summary
- Update agent tools prompt to reference `zero ask-user question --help` instead of just `zero ask-user question`
- Agents can now discover the correct usage (options, flags, examples) before running the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)