### PR TITLE
fix(web): add --help hints to agent tools prompt for non-trivial commands

### DIFF
--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -58,7 +58,7 @@ export function buildAgentToolsPrompt(): string {
     "- When you need to delegate a task to a teammate agent, use `zero agent list` and `zero run --help`.",
     "- When you need to schedule or manage recurring tasks, use `zero schedule --help`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "- When you need to ask the user a question, use `zero ask-user question --help`.",
-    "- Your replies are automatically sent to the originating thread. Only use `zero slack message send --help` when you need to message a different channel or thread. Never use SLACK_TOKEN to send messages directly — it's a user OAuth token.",
+    "- Your replies are automatically sent to the originating thread. Only use `zero slack message send` when you need to message a different channel or thread. Never use SLACK_TOKEN to send messages directly — it's a user OAuth token.",
     "- When you encounter a missing token or environment variable error, run `zero doctor missing-token <TOKEN_NAME>` to diagnose the issue and get remediation steps for the user.",
     "- When you need to update your own configuration (description, tone, or instructions), use `zero agent edit --help`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",
   ].join("\n");

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -55,11 +55,11 @@ export function buildAgentToolsPrompt(): string {
     "# Agent Tools",
     "You have access to the Zero CLI. Run commands with: `npx -p @vm0/cli zero <command>`",
     "- When you need to discover available commands, run `zero --help`.",
-    "- When you need to delegate a task to a teammate agent, use `zero agent list` and `zero run`.",
-    "- When you need to schedule or manage recurring tasks, use `zero schedule`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
+    "- When you need to delegate a task to a teammate agent, use `zero agent list` and `zero run --help`.",
+    "- When you need to schedule or manage recurring tasks, use `zero schedule --help`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "- When you need to ask the user a question, use `zero ask-user question --help`.",
-    "- Your replies are automatically sent to the originating thread. Only use `zero slack message send` when you need to message a different channel or thread. Never use SLACK_TOKEN to send messages directly — it's a user OAuth token.",
+    "- Your replies are automatically sent to the originating thread. Only use `zero slack message send --help` when you need to message a different channel or thread. Never use SLACK_TOKEN to send messages directly — it's a user OAuth token.",
     "- When you encounter a missing token or environment variable error, run `zero doctor missing-token <TOKEN_NAME>` to diagnose the issue and get remediation steps for the user.",
-    "- When you need to update your own configuration (description, tone, or instructions), use `zero agent edit $ZERO_AGENT_ID`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",
+    "- When you need to update your own configuration (description, tone, or instructions), use `zero agent edit --help`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Add `--help` to CLI commands in agent tools prompt that can't be run directly without knowing flags/args
- Changed: `zero run`, `zero schedule`, `zero slack message send`, `zero agent edit`
- Unchanged (already usable directly): `zero --help`, `zero agent list`, `zero ask-user question --help`, `zero doctor missing-token <TOKEN_NAME>`, `zero agent view $ZERO_AGENT_ID --instructions`

## Test plan
- [x] Verified each command's usability: direct-run vs needs-help
- [x] Pre-commit checks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)