### PR TITLE
fix(cli): use agent-id instead of agent-name in schedule setup help text

### DIFF
--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -98,7 +98,7 @@ Common scenarios:
   Missing a token?       zero doctor missing-token <TOKEN_NAME>
   Delegate to teammate?  zero run <agent-id> "your task"
   Send a Slack message?  zero slack message send -c <channel> -t "text"
-  Set up a schedule?     zero schedule setup <agent-name>
+  Set up a schedule?     zero schedule setup <agent-id>
   Update yourself?       zero agent --help
   Check your identity?   zero whoami`,
   );


### PR DESCRIPTION
## Summary

- Fix inconsistent parameter naming in CLI help text
- Change `<agent-name>` to `<agent-id>` in the `schedule setup` example to match the naming convention used by other commands (e.g., `zero run <agent-id>`)

## Test plan

- [ ] Verify `zero --help` shows the updated help text with `<agent-id>`