### PR TITLE
refactor(platform): remove unused exports and clean up knip ignore patterns

### DIFF
--- a/turbo/apps/platform/src/signals/location.ts
+++ b/turbo/apps/platform/src/signals/location.ts
@@ -1,7 +1,6 @@
 class LocationOverrides {
   pathname: string | undefined = undefined;
   search: string | undefined = undefined;
-  origin: string | undefined = undefined;
   pushState: typeof window.history.pushState | undefined = undefined;
   replaceState: typeof window.history.replaceState | undefined = undefined;
 }
@@ -14,10 +13,6 @@ export const setPathname = (pathname: string) => {
 
 export const setSearch = (search: string) => {
   overrides.search = search;
-};
-
-export const setOrigin = (origin: string) => {
-  overrides.origin = origin;
 };
 
 export function mockLocation(
@@ -45,10 +40,6 @@ export const pathname = () => {
 
 export const search = () => {
   return overrides.search ?? location.search;
-};
-
-export const origin = () => {
-  return overrides.origin ?? location.origin;
 };
 
 export const pushState = (

--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -42,18 +42,10 @@ export const org$ = computed(async (get) => {
 });
 
 /**
- * Whether the current user has an org.
- */
-export const hasOrg$ = computed(async (get) => {
-  const org = await get(org$);
-  return org !== undefined;
-});
-
-/**
  * Current user's role in their org.
  * Defaults to "member" if org is not available.
  */
-export const orgRole$ = computed(async (get) => {
+const orgRole$ = computed(async (get) => {
   const org = await get(org$);
   return org?.role ?? "member";
 });

--- a/turbo/knip.json
+++ b/turbo/knip.json
@@ -44,11 +44,7 @@
       "ignoreDependencies": ["@vm0/typescript-config", "tailwindcss"]
     },
     "apps/platform": {
-      "entry": [
-        "src/main.ts",
-        "src/signals/api-client.ts",
-        "**/*.{test,spec}.ts?(x)"
-      ],
+      "entry": ["src/main.ts", "**/*.{test,spec}.ts?(x)"],
       "project": ["**/*.{ts,tsx}"],
       "ignore": ["custom-eslint/**"],
       "ignoreDependencies": [
@@ -95,16 +91,8 @@
     "**/drizzle.config.ts",
     "**/custom-eslint/**",
     "apps/platform/src/mocks/mock-log-detail-data.ts",
-    "apps/platform/src/signals/location.ts",
-    "apps/platform/src/signals/log.ts",
-    "apps/platform/src/signals/page-signal.ts",
-    "apps/platform/src/signals/utils.ts",
-    "apps/platform/src/signals/org.ts",
-    "apps/platform/src/views/router/link.tsx",
     "apps/platform/src/test/mocks/clerk-react.ts",
     "apps/platform/src/test/mocks/clerk-react-experimental.ts",
-    "apps/web/src/lib/schedule/schedule-service.ts",
-    "apps/web/src/lib/model-provider/model-provider-service.ts",
     "apps/cli/src/lib/utils/paginate.ts",
     "apps/cli/src/commands/cook/cook.ts",
     "apps/web/src/lib/auth/sandbox-token.ts",


### PR DESCRIPTION
## Summary
- Remove unused `origin` and `hasOrg$` exports from platform signals
- Make `orgRole$` private (not exported) since it is only used internally
- Remove stale knip ignore entries for files that are now properly detected
- Remove unnecessary `src/signals/api-client.ts` entry point from knip config

## Test plan
- [x] Knip passes with no issues
- [x] Pre-commit hooks (prettier, knip, commitlint) all pass
- [ ] CI build and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)