### PR TITLE
fix(platform): retain active agent when navigating between pages

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-detail-page-setup.ts
@@ -4,7 +4,8 @@ import { ZeroActivityDetailPageWrapper } from "../../views/activity-page/zero-ac
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
 import { setupActivityLogLoop$ } from "./activity-signals.ts";
 
 export const setupActivityDetailPage$ = command(
@@ -12,13 +13,14 @@ export const setupActivityDetailPage$ = command(
     set(updatePage$, createElement(ZeroActivityDetailPageWrapper));
     set(updateDocumentTitle$, "Activity");
 
+    await set(initZeroOnboarding$, signal);
     if (await set(onboardGuard$, signal)) {
       return;
     }
 
     await Promise.all([
-      set(switchActiveAgent$, null, signal),
       set(setupActivityLogLoop$, signal),
+      set(fetchZeroSessionList$, signal),
     ]);
     signal.throwIfAborted();
   },

--- a/turbo/apps/platform/src/signals/activity-page/activity-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-page-setup.ts
@@ -4,7 +4,8 @@ import { ZeroActivityPageWrapper } from "../../views/activity-page/zero-activity
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
 import { initZeroActivity$, refreshZeroActivity$ } from "./activity-signals.ts";
 
 export const setupActivityPage$ = command(
@@ -12,13 +13,16 @@ export const setupActivityPage$ = command(
     set(updatePage$, createElement(ZeroActivityPageWrapper));
     set(updateDocumentTitle$, "Activity");
     set(refreshZeroActivity$);
-    await set(initZeroActivity$, signal);
+    await Promise.all([
+      set(initZeroOnboarding$, signal),
+      set(initZeroActivity$, signal),
+    ]);
     signal.throwIfAborted();
 
     if (await set(onboardGuard$, signal)) {
       return;
     }
 
-    await set(switchActiveAgent$, null, signal);
+    await set(fetchZeroSessionList$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/preferences-page/preferences-page-setup.ts
+++ b/turbo/apps/platform/src/signals/preferences-page/preferences-page-setup.ts
@@ -4,16 +4,20 @@ import { ZeroPreferencesPageWrapper } from "../../views/preferences-page/zero-pr
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
 
 export const setupPreferencesPage$ = command(
   async ({ set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroPreferencesPageWrapper));
     set(updateDocumentTitle$, "Preferences");
+    await set(initZeroOnboarding$, signal);
+    signal.throwIfAborted();
+
     if (await set(onboardGuard$, signal)) {
       return;
     }
 
-    await set(switchActiveAgent$, null, signal);
+    await set(fetchZeroSessionList$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/queue-page/queue-page-setup.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-page-setup.ts
@@ -5,16 +5,20 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { detach, Reason } from "../utils.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
 import { startQueuePolling$ } from "./queue-signals.ts";
 
 export const setupQueuePage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(ZeroQueuePage));
   set(updateDocumentTitle$, "Queue");
+  await set(initZeroOnboarding$, signal);
+  signal.throwIfAborted();
+
   if (await set(onboardGuard$, signal)) {
     return;
   }
 
-  await set(switchActiveAgent$, null, signal);
+  await set(fetchZeroSessionList$, signal);
   detach(set(startQueuePolling$, signal), Reason.Entrance);
 });

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-detail-page-setup.ts
@@ -3,7 +3,8 @@ import { createElement } from "react";
 import { ZeroScheduleDetailPageWrapper } from "../../views/schedule-page/zero-schedule-detail-page-wrapper.tsx";
 import { updatePage$ } from "../react-router.ts";
 import { pathParams$ } from "../route.ts";
-import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
 import { fetchAllOrgSchedules$ } from "../zero-page/zero-schedule.ts";
 import { fetchSlackChannels$ } from "../zero-page/slack-channels.ts";
 import { initSlackOrg$ } from "../zero-page/zero-slack.ts";
@@ -30,10 +31,12 @@ export const setupScheduleDetailPage$ = command(
 
     detach(set(fetchAllOrgSchedules$, signal), Reason.Entrance);
     await Promise.all([
+      set(initZeroOnboarding$, signal),
       set(initSlackOrg$, signal),
       set(fetchSlackChannels$, signal),
     ]);
     signal.throwIfAborted();
-    await set(switchActiveAgent$, null, signal);
+
+    await set(fetchZeroSessionList$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-page-setup.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-page-setup.ts
@@ -4,7 +4,8 @@ import { ZeroSchedulePageWrapper } from "../../views/schedule-page/zero-schedule
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
 import { fetchAllOrgSchedules$ } from "../zero-page/zero-schedule.ts";
 import { initSlackOrg$ } from "../zero-page/zero-slack.ts";
 import { Reason, detach } from "../utils.ts";
@@ -14,13 +15,16 @@ export const setupSchedulePage$ = command(
     set(updatePage$, createElement(ZeroSchedulePageWrapper));
     set(updateDocumentTitle$, "Schedule");
     detach(set(fetchAllOrgSchedules$, signal), Reason.Entrance);
-    await set(initSlackOrg$, signal);
+    await Promise.all([
+      set(initZeroOnboarding$, signal),
+      set(initSlackOrg$, signal),
+    ]);
     signal.throwIfAborted();
 
     if (await set(onboardGuard$, signal)) {
       return;
     }
 
-    await set(switchActiveAgent$, null, signal);
+    await set(fetchZeroSessionList$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/team-page/team-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/team-page/team-detail-page-setup.ts
@@ -7,7 +7,8 @@ import { pathParams$ } from "../route.ts";
 import { agents$ } from "../zero-page/agents-list.ts";
 import { fetchZeroJobData$ } from "../zero-page/zero-job-detail.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
 import { initSlackOrg$ } from "../zero-page/zero-slack.ts";
 
 export const setupTeamDetailPage$ = command(
@@ -18,6 +19,7 @@ export const setupTeamDetailPage$ = command(
     const agentId = params?.agentId ?? null;
     set(updateDocumentTitle$, "Team");
     await Promise.all([
+      set(initZeroOnboarding$, signal),
       set(initSlackOrg$, signal),
       agentId ? set(fetchZeroJobData$, agentId, signal) : Promise.resolve(),
     ]);
@@ -37,6 +39,6 @@ export const setupTeamDetailPage$ = command(
       set(updateDocumentTitle$, displayName);
     }
 
-    await set(switchActiveAgent$, null, signal);
+    await set(fetchZeroSessionList$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/team-page/team-page-setup.ts
+++ b/turbo/apps/platform/src/signals/team-page/team-page-setup.ts
@@ -4,14 +4,18 @@ import { ZeroTeamPage } from "../../views/team-page/zero-team-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
 
 export const setupTeamPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(ZeroTeamPage));
   set(updateDocumentTitle$, "Team");
+  await set(initZeroOnboarding$, signal);
+  signal.throwIfAborted();
+
   if (await set(onboardGuard$, signal)) {
     return;
   }
 
-  await set(switchActiveAgent$, null, signal);
+  await set(fetchZeroSessionList$, signal);
 });

--- a/turbo/apps/platform/src/signals/usage-page/usage-page-setup.ts
+++ b/turbo/apps/platform/src/signals/usage-page/usage-page-setup.ts
@@ -4,14 +4,18 @@ import { ZeroUsagePageWrapper } from "../../views/usage-page/zero-usage-page-wra
 import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
 
 export const setupUsagePage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(ZeroUsagePageWrapper));
   set(updateDocumentTitle$, "Usage");
+  await set(initZeroOnboarding$, signal);
+  signal.throwIfAborted();
+
   if (await set(onboardGuard$, signal)) {
     return;
   }
 
-  await set(switchActiveAgent$, null, signal);
+  await set(fetchZeroSessionList$, signal);
 });

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -5,7 +5,8 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { detach, Reason } from "../utils.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
-import { switchActiveAgent$ } from "../zero-page/zero-chat.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
 import {
   initSlackOrg$,
   pollSlackConnection$,
@@ -14,7 +15,10 @@ import {
 export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
   set(updatePage$, createElement(ZeroWorksPageWrapper));
   set(updateDocumentTitle$, "Works");
-  await set(initSlackOrg$, signal);
+  await Promise.all([
+    set(initZeroOnboarding$, signal),
+    set(initSlackOrg$, signal),
+  ]);
   signal.throwIfAborted();
   detach(set(pollSlackConnection$, signal), Reason.Entrance);
 
@@ -22,5 +26,5 @@ export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
     return;
   }
 
-  await set(switchActiveAgent$, null, signal);
+  await set(fetchZeroSessionList$, signal);
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -260,3 +260,14 @@ export const completeZeroOnboarding$ = command(
 export const dismissZeroOnboarding$ = command(({ set }) => {
   set(userStep$, "done");
 });
+
+/**
+ * Initialize onboarding status by eagerly loading it.
+ * Called on page setup so onboarding data is ready before onboardGuard$ checks it.
+ */
+export const initZeroOnboarding$ = command(
+  async ({ get }, signal: AbortSignal) => {
+    await get(zeroOnboardingStatus$);
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-to-activity-agent-retention.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-to-activity-agent-retention.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+function mockTwoAgents() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: false,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: "agent-foo-id",
+        defaultAgentMetadata: { displayName: "foo" },
+        defaultAgentSkills: [],
+      });
+    }),
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: "agent-foo-id",
+          displayName: "foo",
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "agent-bar-id",
+          displayName: "bar",
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_2",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("talk to activity agent retention", () => {
+  it("should retain non-default agent in sidebar after navigating from /talk/:agentId to /activity", async () => {
+    mockTwoAgents();
+
+    // Navigate to non-default agent (bar)
+    await setupPage({ context, path: "/talk/agent-bar-id" });
+
+    // Wait for sidebar to show "bar" as the active chat agent
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText("New chat with bar")).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    // Click the "Activity logs" nav tab in the sidebar
+    const activityNavLink = screen.getByRole("link", {
+      name: "Activity logs",
+    });
+    fireEvent.click(activityNavLink);
+
+    // Wait for navigation to /activity to complete
+    await waitFor(
+      () => {
+        expect(pathname()).toBe("/activity");
+      },
+      { timeout: 5000 },
+    );
+
+    // After navigating to /activity, the sidebar should still show "chat with bar"
+    // (the last visited agent), not "chat with foo" (the default agent)
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText("New chat with bar")).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

- Remove `switchActiveAgent$` calls from all page setup signals (activity, preferences, queue, schedule, team, usage, works pages) so navigating between pages no longer resets the active agent to `null`
- Add integration test verifying that the sidebar retains the last selected non-default agent after navigating from `/talk/:agentId` to `/activity`

## Test plan

- [ ] Navigate to a non-default agent's chat page (`/talk/agent-bar-id`)
- [ ] Verify the sidebar shows "bar" as the active agent
- [ ] Click "Activity logs" nav tab to navigate to `/activity`
- [ ] Verify the sidebar still shows "bar" (not reset to default agent "foo")

🤖 Generated with [Claude Code](https://claude.com/claude-code)