### PR TITLE
docs(cli): add after-help examples and notes to all zero commands

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1088,7 +1088,7 @@ jobs:
             -H "Content-Type: application/json")
 
           # Extract user IDs, skipping the persistent e2e test account
-          ids=$(echo "$users" | jq -r '.[] | select(.email_addresses[]?.email_address != "e2e+clerk_test@vm0.ai") | .id' 2>/dev/null || true)
+          ids=$(echo "$users" | jq -r '.[] | select((.email_addresses[]?.email_address != "e2e+clerk_test@vm0.ai") and (.email_addresses[]?.email_address != "e2e_02+clerk_test@vm0.ai")) | .id' 2>/dev/null || true)
 
           if [ -z "$ids" ]; then
             echo "No test accounts to clean up"

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -18,6 +18,14 @@ export const createCommand = new Command()
     "Agent tone: professional, friendly, direct, supportive",
   )
   .option("--instructions-file <path>", "Path to instructions file")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Minimal:               zero agent create --connectors github
+  With display name:     zero agent create --connectors github,linear --display-name "My Agent"
+  With instructions:     zero agent create --connectors github --instructions-file ./instructions.md`,
+  )
   .action(
     withErrorHandler(
       async (options: {

--- a/turbo/apps/cli/src/commands/zero/agent/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/delete.ts
@@ -10,6 +10,16 @@ export const deleteCommand = new Command()
   .description("Delete a zero agent")
   .argument("<agent-id>", "Agent ID")
   .option("-y, --yes", "Skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero agent delete <agent-id>
+  zero agent delete <agent-id> -y
+
+Notes:
+  - Use -y to skip confirmation in non-interactive mode`,
+  )
   .action(
     withErrorHandler(async (agentId: string, options: { yes?: boolean }) => {
       await getZeroAgent(agentId);

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -23,6 +23,19 @@ export const editCommand = new Command()
     "New tone: professional, friendly, direct, supportive",
   )
   .option("--instructions-file <path>", "Path to new instructions file")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Update description:      zero agent edit <agent-id> --description "new role"
+  Update tone:             zero agent edit <agent-id> --sound friendly
+  Update instructions:     zero agent edit <agent-id> --instructions-file ./instructions.md
+  Update yourself:         zero agent edit $ZERO_AGENT_ID --description "new role"
+
+Notes:
+  - At least one option is required
+  - Unspecified fields are preserved (not cleared)`,
+  )
   .action(
     withErrorHandler(
       async (

--- a/turbo/apps/cli/src/commands/zero/agent/index.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/index.ts
@@ -15,7 +15,7 @@ export const zeroAgentCommand = new Command("agent")
   .addHelpText(
     "after",
     `
-Self-management (inside sandbox):
+Examples:
   Your agent ID is in $ZERO_AGENT_ID (or run: zero whoami)
   View your config:      zero agent view $ZERO_AGENT_ID --instructions
   Update description:    zero agent edit $ZERO_AGENT_ID --description "new role"

--- a/turbo/apps/cli/src/commands/zero/agent/list.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/list.ts
@@ -7,6 +7,15 @@ export const listCommand = new Command()
   .name("list")
   .alias("ls")
   .description("List all zero agents")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero agent list
+
+Notes:
+  - Use this to discover teammate agent IDs before delegating with "zero run"`,
+  )
   .action(
     withErrorHandler(async () => {
       const agents = await listZeroAgents();

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -8,6 +8,14 @@ export const viewCommand = new Command()
   .description("View a zero agent")
   .argument("<agent-id>", "Agent ID")
   .option("--instructions", "Also show instructions content")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  View basic info:         zero agent view <agent-id>
+  Include instructions:    zero agent view <agent-id> --instructions
+  View yourself:           zero agent view $ZERO_AGENT_ID --instructions`,
+  )
   .action(
     withErrorHandler(
       async (agentId: string, options: { instructions?: boolean }) => {

--- a/turbo/apps/cli/src/commands/zero/ask-user/index.ts
+++ b/turbo/apps/cli/src/commands/zero/ask-user/index.ts
@@ -4,4 +4,14 @@ import { questionCommand } from "./question";
 export const zeroAskUserCommand = new Command()
   .name("ask-user")
   .description("Ask the user a question and wait for the answer")
-  .addCommand(questionCommand);
+  .addCommand(questionCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero ask-user question "Deploy to production?" --option "Yes" --option "No"
+
+Notes:
+  - The command blocks until the user responds or the timeout expires (default 300s)
+  - The user's answer is printed to stdout for your consumption`,
+  );

--- a/turbo/apps/cli/src/commands/zero/doctor/index.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/index.ts
@@ -4,4 +4,14 @@ import { missingTokenCommand } from "./missing-token";
 export const zeroDoctorCommand = new Command()
   .name("doctor")
   .description("Diagnose runtime issues (missing tokens, connectors)")
-  .addCommand(missingTokenCommand);
+  .addCommand(missingTokenCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Missing an API key?    zero doctor missing-token GITHUB_TOKEN
+
+Notes:
+  - Use this when your task fails due to a missing environment variable
+  - The doctor will identify which connector provides the token and give the user a link to connect it`,
+  );

--- a/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
@@ -9,6 +9,18 @@ export const missingTokenCommand = new Command()
     "Diagnose a missing token and find the connector that provides it",
   )
   .argument("<token-name>", "The environment variable / token name to look up")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero doctor missing-token GITHUB_TOKEN
+  zero doctor missing-token LINEAR_API_KEY
+  zero doctor missing-token NOTION_TOKEN
+
+Notes:
+  - Outputs which connector provides the token and a URL for the user to connect it
+  - Use this to guide the user when a required token is not available in the sandbox`,
+  )
   .action(
     withErrorHandler(async (tokenName: string) => {
       const connectorType = getConnectorTypeForSecretName(tokenName);

--- a/turbo/apps/cli/src/commands/zero/run/continue.ts
+++ b/turbo/apps/cli/src/commands/zero/run/continue.ts
@@ -18,6 +18,17 @@ export const continueCommand = new Command()
     "Override model provider (e.g., anthropic-api-key)",
   )
   .option("--verbose", "Show full tool inputs and outputs")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero run continue <session-id> "now deploy it"
+  zero run continue <session-id> "add tests" --verbose
+
+Notes:
+  - The session ID is printed after a successful "zero run" delegation
+  - Continues the same agent session with full prior context`,
+  )
   .action(
     withErrorHandler(
       async (

--- a/turbo/apps/cli/src/commands/zero/run/index.ts
+++ b/turbo/apps/cli/src/commands/zero/run/index.ts
@@ -6,7 +6,7 @@ mainRunCommand.addCommand(continueCommand);
 mainRunCommand.addHelpText(
   "after",
   `
-Delegation workflow:
+Examples:
   Discover teammates:    zero agent list
   Delegate a task:       zero run <agent-id> "your task"
   Continue delegation:   zero run continue <session-id> "follow up"`,

--- a/turbo/apps/cli/src/commands/zero/run/run.ts
+++ b/turbo/apps/cli/src/commands/zero/run/run.ts
@@ -18,6 +18,18 @@ export const mainRunCommand = new Command()
     "Override model provider (e.g., anthropic-api-key)",
   )
   .option("--verbose", "Show full tool inputs and outputs")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Delegate a task:       zero run <agent-id> "summarize the latest issues"
+  With verbose output:   zero run <agent-id> "fix the bug" --verbose
+
+Notes:
+  - Get agent IDs from "zero agent list"
+  - The command streams events until the delegated run completes
+  - On success, a session ID is printed for follow-up with "zero run continue"`,
+  )
   .action(
     withErrorHandler(
       async (

--- a/turbo/apps/cli/src/commands/zero/schedule/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/delete.ts
@@ -17,6 +17,16 @@ export const deleteCommand = new Command()
     "Schedule name (required when agent has multiple schedules)",
   )
   .option("-y, --yes", "Skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero schedule delete <agent-id>
+  zero schedule delete <agent-id> -n my-schedule -y
+
+Notes:
+  - Use -y to skip confirmation in non-interactive mode`,
+  )
   .action(
     withErrorHandler(
       async (agentName: string, options: { name?: string; yes?: boolean }) => {

--- a/turbo/apps/cli/src/commands/zero/schedule/disable.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/disable.ts
@@ -14,6 +14,13 @@ export const disableCommand = new Command()
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",
   )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero schedule disable <agent-id>
+  zero schedule disable <agent-id> -n my-schedule`,
+  )
   .action(
     withErrorHandler(async (agentName: string, options: { name?: string }) => {
       const resolved = await resolveZeroScheduleByAgent(

--- a/turbo/apps/cli/src/commands/zero/schedule/enable.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/enable.ts
@@ -14,6 +14,13 @@ export const enableCommand = new Command()
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",
   )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero schedule enable <agent-id>
+  zero schedule enable <agent-id> -n my-schedule`,
+  )
   .action(
     withErrorHandler(async (agentName: string, options: { name?: string }) => {
       const resolved = await resolveZeroScheduleByAgent(

--- a/turbo/apps/cli/src/commands/zero/schedule/index.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/index.ts
@@ -27,6 +27,5 @@ Examples:
 
 Notes:
   - setup is idempotent — re-running it with the same agent updates the existing schedule
-  - Schedules are created disabled by default; use --enable or enable separately
-  - Use "zero preference --timezone" to set your default timezone first`,
+  - Schedules are created disabled by default; use --enable or enable separately`,
   );

--- a/turbo/apps/cli/src/commands/zero/schedule/index.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/index.ts
@@ -14,4 +14,19 @@ export const zeroScheduleCommand = new Command()
   .addCommand(statusCommand)
   .addCommand(deleteCommand)
   .addCommand(enableCommand)
-  .addCommand(disableCommand);
+  .addCommand(disableCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Create a daily schedule:   zero schedule setup <agent-id> -f daily -t 09:00 -p "run report"
+  Create a loop schedule:    zero schedule setup <agent-id> -f loop -i 300 -p "poll for updates"
+  Check all schedules:       zero schedule list
+  Pause a schedule:          zero schedule disable <agent-id>
+  Resume a schedule:         zero schedule enable <agent-id>
+
+Notes:
+  - setup is idempotent — re-running it with the same agent updates the existing schedule
+  - Schedules are created disabled by default; use --enable or enable separately
+  - Use "zero preference --timezone" to set your default timezone first`,
+  );

--- a/turbo/apps/cli/src/commands/zero/schedule/list.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/list.ts
@@ -8,6 +8,12 @@ export const listCommand = new Command()
   .name("list")
   .alias("ls")
   .description("List all zero schedules")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero schedule list`,
+  )
   .action(
     withErrorHandler(async () => {
       const result = await listZeroSchedules();

--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -678,6 +678,22 @@ export const setupCommand = new Command()
   .option("--no-notify-email", "Disable email notifications")
   .option("--notify-slack", "Enable Slack notifications (default: true)")
   .option("--no-notify-slack", "Disable Slack notifications")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Daily at 9am:          zero schedule setup <agent-id> -f daily -t 09:00 -p "run report"
+  Weekly on Monday:      zero schedule setup <agent-id> -f weekly -d mon -t 10:00 -p "weekly sync"
+  Monthly on the 1st:    zero schedule setup <agent-id> -f monthly -d 1 -t 08:00 -p "monthly review"
+  One-time:              zero schedule setup <agent-id> -f once -d 2026-04-01 -t 14:00 -p "one-off task"
+  Loop every 5 minutes:  zero schedule setup <agent-id> -f loop -i 300 -p "poll for updates"
+  Create and enable:     zero schedule setup <agent-id> -f daily -t 09:00 -p "run report" --enable
+
+Notes:
+  - Re-running setup with the same agent updates the existing "default" schedule
+  - Use -n to manage multiple named schedules for the same agent
+  - All flags are required in non-interactive mode; interactive mode prompts for missing values`,
+  )
   .action(
     withErrorHandler(async (agentIdentifier: string, options: SetupOptions) => {
       // 1. Resolve agent identifier (UUID or name) to compose ID

--- a/turbo/apps/cli/src/commands/zero/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/status.ts
@@ -110,6 +110,13 @@ export const statusCommand = new Command()
     "-n, --name <schedule-name>",
     "Schedule name (required when agent has multiple schedules)",
   )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero schedule status <agent-id>
+  zero schedule status <agent-id> -n my-schedule`,
+  )
   .action(
     withErrorHandler(async (agentName: string, options: { name?: string }) => {
       const schedule = await resolveZeroScheduleByAgent(

--- a/turbo/apps/cli/src/commands/zero/slack/index.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/index.ts
@@ -4,4 +4,12 @@ import { zeroSlackMessageCommand } from "./message";
 export const zeroSlackCommand = new Command()
   .name("slack")
   .description("Send messages to Slack channels as the bot")
-  .addCommand(zeroSlackMessageCommand);
+  .addCommand(zeroSlackMessageCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Send a message:        zero slack message send -c <channel-id> -t "Hello!"
+  Reply in a thread:     zero slack message send -c <channel-id> --thread <ts> -t "reply"
+  Pipe content:          echo "report" | zero slack message send -c <channel-id>`,
+  );

--- a/turbo/apps/cli/src/commands/zero/slack/index.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/index.ts
@@ -10,6 +10,5 @@ export const zeroSlackCommand = new Command()
     `
 Examples:
   Send a message:        zero slack message send -c <channel-id> -t "Hello!"
-  Reply in a thread:     zero slack message send -c <channel-id> --thread <ts> -t "reply"
-  Pipe content:          echo "report" | zero slack message send -c <channel-id>`,
+  Reply in a thread:     zero slack message send -c <channel-id> --thread <ts> -t "reply"`,
   );

--- a/turbo/apps/cli/src/commands/zero/slack/message/index.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/message/index.ts
@@ -4,4 +4,10 @@ import { sendCommand } from "./send";
 export const zeroSlackMessageCommand = new Command()
   .name("message")
   .description("Manage Slack messages")
-  .addCommand(sendCommand);
+  .addCommand(sendCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero slack message send -c <channel-id> -t "Hello!"`,
+  );

--- a/turbo/apps/cli/src/commands/zero/slack/message/send.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/message/send.ts
@@ -17,12 +17,10 @@ export const sendCommand = new Command()
 Examples:
   Simple message:        zero slack message send -c C01234 -t "Hello!"
   Reply in thread:       zero slack message send -c C01234 --thread 1234567890.123456 -t "reply"
-  Pipe from stdin:       echo "report" | zero slack message send -c C01234
   Rich blocks:           zero slack message send -c C01234 --blocks '[{"type":"section","text":{"type":"mrkdwn","text":"*Bold*"}}]'
 
 Notes:
-  - Either --text or --blocks is required; both can be used together
-  - When --text is omitted, stdin is read automatically if piped`,
+  - Either --text or --blocks is required; both can be used together`,
   )
   .action(
     withErrorHandler(

--- a/turbo/apps/cli/src/commands/zero/slack/message/send.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/message/send.ts
@@ -11,6 +11,19 @@ export const sendCommand = new Command()
   .option("-t, --text <message>", "Message text")
   .option("--thread <ts>", "Thread timestamp for replies")
   .option("--blocks <json>", "Block Kit JSON string")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Simple message:        zero slack message send -c C01234 -t "Hello!"
+  Reply in thread:       zero slack message send -c C01234 --thread 1234567890.123456 -t "reply"
+  Pipe from stdin:       echo "report" | zero slack message send -c C01234
+  Rich blocks:           zero slack message send -c C01234 --blocks '[{"type":"section","text":{"type":"mrkdwn","text":"*Bold*"}}]'
+
+Notes:
+  - Either --text or --blocks is required; both can be used together
+  - When --text is omitted, stdin is read automatically if piped`,
+  )
   .action(
     withErrorHandler(
       async (options: {

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -65,6 +65,16 @@ async function showLocalInfo(): Promise<void> {
 export const zeroWhoamiCommand = new Command()
   .name("whoami")
   .description("Show agent identity, run ID, and capabilities")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero whoami
+
+Notes:
+  - Inside sandbox: shows agent ID, run ID, org ID, and granted capabilities
+  - Your agent ID is also available as $ZERO_AGENT_ID`,
+  )
   .action(
     withErrorHandler(async () => {
       if (isInsideSandbox()) {

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -94,7 +94,7 @@ program
   .addHelpText(
     "after",
     `
-Common scenarios:
+Examples:
   Missing a token?       zero doctor missing-token <TOKEN_NAME>
   Delegate to teammate?  zero run <agent-id> "your task"
   Send a Slack message?  zero slack message send -c <channel> -t "text"

--- a/turbo/apps/platform/package.json
+++ b/turbo/apps/platform/package.json
@@ -33,7 +33,7 @@
     "ccstate-react": "^5.0.0",
     "highlight.js": "^11.11.1",
     "lowlight": "^3.3.0",
-    "path-to-regexp": "^8.3.0",
+    "path-to-regexp": "^8.4.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "signal-timers": "^1.0.4",

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -22,7 +22,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1014.0",
     "@axiomhq/js": "^1.3.1",
     "@axiomhq/logging": "^0.1.6",
-    "@clerk/backend": "^3.2.2",
+    "@clerk/backend": "^3.2.3",
     "@clerk/nextjs": "^6.37.4",
     "@neondatabase/serverless": "^1.0.2",
     "@opentelemetry/api": "^1.9.0",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       path-to-regexp:
-        specifier: ^8.3.0
-        version: 8.3.0
+        specifier: ^8.4.0
+        version: 8.4.0
       react:
         specifier: ^19.1.0
         version: 19.2.1
@@ -361,8 +361,8 @@ importers:
         specifier: ^0.1.6
         version: 0.1.6(@axiomhq/js@1.3.1)
       '@clerk/backend':
-        specifier: ^3.2.2
-        version: 3.2.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^3.2.3
+        version: 3.2.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@clerk/nextjs':
         specifier: ^6.37.4
         version: 6.37.4(next@16.1.7(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -1070,8 +1070,8 @@ packages:
     resolution: {integrity: sha512-4Cg5IUSaSR0ecTk1NGlRpxmXKaCJqrXqS5BppyEPMwYYIrLepJGQMNeTWfVr3n1ffJoXxqLQL6X5ct/P2nLDjQ==}
     engines: {node: '>=18.17.0'}
 
-  '@clerk/backend@3.2.2':
-    resolution: {integrity: sha512-legJnKmsFWicG1jR093aiK/fWS75Xjcm6fu98xbZI0Gu/gfKdQFp4CGd68zmVWMklQo6CWCqGrqkrFKGBBX9EA==}
+  '@clerk/backend@3.2.3':
+    resolution: {integrity: sha512-I3YLnSioYFG+EVFBYm0ilN28+FC8H+hkqMgB5Pdl7AcotQOn3JhiZMqLel2H0P390p8FEJKQNnrvXk3BemeKKQ==}
     engines: {node: '>=20.9.0'}
 
   '@clerk/clerk-js@5.119.0':
@@ -7758,8 +7758,8 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -9875,7 +9875,7 @@ snapshots:
       - react
       - react-dom
 
-  '@clerk/backend@3.2.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+  '@clerk/backend@3.2.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@clerk/shared': 4.3.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       standardwebhooks: 1.0.0
@@ -15388,7 +15388,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       negotiator: 1.0.0
       npm-to-yarn: 3.0.1
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.0
       remark: 15.0.1
       remark-gfm: 4.0.1
       remark-rehype: 11.1.2
@@ -17235,7 +17235,7 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.0: {}
 
   path-type@4.0.0: {}
 


### PR DESCRIPTION
## Summary
- Add consistent `Examples:` and `Notes:` after-help sections to all zero CLI commands (agent, run, schedule, slack, doctor, ask-user, whoami)
- Unify existing help text titles (`Common scenarios:`, `Delegation workflow:`, `Self-management (inside sandbox):`) to `Examples:` for consistency
- Fix schedule subcommand examples to use `<agent-id>` instead of `<agent-name>` to match argument definitions

## Context
The zero CLI is used by agents inside sandbox. The `--help` output serves as a guidance manual for agents to discover how to use commands. Previously, only 4 out of 24 commands had after-help text.

## Test plan
- [ ] `zero agent --help` shows Examples section
- [ ] `zero agent edit --help` shows its own Examples + Notes
- [ ] `zero schedule --help` shows Examples + Notes
- [ ] `zero slack message send --help` shows Examples + Notes
- [ ] `zero doctor --help` shows Examples + Notes
- [ ] `zero whoami --help` shows Examples + Notes
- [ ] Lint passes: `pnpm --filter @vm0/cli lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)