### PR TITLE
feat: make intervals.icu connector public, remove api-token auth

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -1828,28 +1828,15 @@ const CONNECTOR_TYPES_DEF = {
   },
   "intervals-icu": {
     label: "Intervals.icu",
-    environmentMapping: {
-      INTERVALS_ICU_TOKEN: "$secrets.INTERVALS_ICU_ACCESS_TOKEN",
-    },
-    featureFlag: FeatureSwitchKey.IntervalsIcuConnector,
     helpText:
       "Connect your Intervals.icu account to access training, activity, wellness, and calendar data",
     authMethods: {
       oauth: {
-        label: "OAuth (Recommended)",
+        label: "OAuth",
         helpText: "Sign in with Intervals.icu to grant access.",
         secrets: {
           INTERVALS_ICU_ACCESS_TOKEN: {
             label: "Access Token",
-            required: true,
-          },
-        },
-      },
-      "api-token": {
-        label: "API Key",
-        secrets: {
-          INTERVALS_ICU_TOKEN: {
-            label: "API Key",
             required: true,
           },
         },

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -21,7 +21,6 @@ export enum FeatureSwitchKey {
   NeonConnector = "neonConnector",
   GarminConnectConnector = "garminConnectConnector",
   RedditConnector = "redditConnector",
-  IntervalsIcuConnector = "intervalsIcuConnector",
   SupabaseConnector = "supabaseConnector",
   WebflowConnector = "webflowConnector",
   CloseConnector = "closeConnector",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -160,12 +160,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabledUserHashes: STAFF_USER_HASHES,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
-  [FeatureSwitchKey.IntervalsIcuConnector]: {
-    maintainer: "ethan@vm0.ai",
-    enabled: false,
-    enabledUserHashes: STAFF_USER_HASHES,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
-  },
   [FeatureSwitchKey.SupabaseConnector]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,


### PR DESCRIPTION
## Summary

- Remove `IntervalsIcuConnector` feature flag — connector is now visible to all users
- Remove `IntervalsIcuConnector` from `FeatureSwitchKey` enum
- Remove api-token auth method from intervals-icu connector config; OAuth is now the only supported auth method

## Context

intervals.icu OAuth app has been approved and is live. vm0 launched at https://app.vm0.ai — making this connector available to all users.

## Test plan

- [ ] Verify intervals.icu connector appears in the connector list for a non-staff user
- [ ] Verify OAuth connect flow works end-to-end
- [ ] Verify api-token option no longer appears in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)