### PR TITLE
refactor(platform): replace inline border styles with reusable css utilities

### DIFF
--- a/turbo/apps/platform/src/views/components/pagination.tsx
+++ b/turbo/apps/platform/src/views/components/pagination.tsx
@@ -102,8 +102,7 @@ export function Pagination({
         <Button
           variant="outline"
           size="icon"
-          className={cn("h-8 w-8 border-0 bg-card", buttonClassName)}
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          className={cn("h-8 w-8 bg-card", buttonClassName)}
           onClick={onBackTwoPages}
           disabled={!canGoBackTwo}
         >
@@ -113,8 +112,7 @@ export function Pagination({
         <Button
           variant="outline"
           size="icon"
-          className={cn("h-8 w-8 border-0 bg-card", buttonClassName)}
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          className={cn("h-8 w-8 bg-card", buttonClassName)}
           onClick={onPrevPage}
           disabled={!hasPrev}
         >
@@ -124,8 +122,7 @@ export function Pagination({
         <Button
           variant="outline"
           size="icon"
-          className={cn("h-8 w-8 border-0 bg-card", buttonClassName)}
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          className={cn("h-8 w-8 bg-card", buttonClassName)}
           onClick={onNextPage}
           disabled={!hasNext || isLoading}
         >
@@ -135,8 +132,7 @@ export function Pagination({
         <Button
           variant="outline"
           size="icon"
-          className={cn("h-8 w-8 border-0 bg-card", buttonClassName)}
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          className={cn("h-8 w-8 bg-card", buttonClassName)}
           onClick={onForwardTwoPages}
           disabled={!hasNext || isLoading}
         >

--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -117,6 +117,29 @@
   border-color: hsl(var(--primary));
 }
 
+/* Reusable 0.7px border utilities — replaces inline style={{ border: "0.7px solid ..." }} */
+.zero-border {
+  border: 0.7px solid hsl(var(--gray-400));
+}
+.zero-border-t {
+  border-top: 0.7px solid hsl(var(--gray-400));
+}
+.zero-border-r {
+  border-right: 0.7px solid hsl(var(--gray-300));
+}
+.zero-border-dashed {
+  border: 0.7px dashed hsl(var(--gray-400));
+}
+.zero-border-dashed-t {
+  border-top: 0.7px dashed hsl(var(--gray-400));
+}
+
+/* Role / status badge: pill with 0.7px border on neutral background */
+.zero-badge {
+  border: 0.7px solid hsl(var(--gray-400));
+  background-color: hsl(var(--gray-0));
+}
+
 /* Zero chip-style gray (tone options, skill tags, Add skill) */
 .zero-app .zero-chip {
   background-color: hsl(var(--gray-50));
@@ -852,6 +875,17 @@ details[open] > summary > span:first-child {
 
 .tiptap:focus {
   outline: none;
+}
+
+/* Dashed vertical connector line for tool-call timelines */
+.zero-dashed-line {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent,
+    transparent 2px,
+    hsl(var(--border) / 0.6) 2px,
+    hsl(var(--border) / 0.6) 5px
+  );
 }
 
 /* Sheet / side drawer animations */

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -193,8 +193,7 @@ export function AutoRechargeSection({
     }
   };
 
-  const inputRowClass =
-    "h-9 w-[200px] shrink-0 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))]";
+  const inputRowClass = "h-9 w-[200px] shrink-0";
 
   if (variant === "settings") {
     return (
@@ -236,7 +235,7 @@ export function AutoRechargeSection({
           </div>
           {displayEnabled && (
             <>
-              <div className="h-px bg-border/40 mx-5" />
+              <div className="h-0 zero-border-t mx-5" />
               <div className="flex items-center justify-between gap-4 px-5 py-4">
                 <div className="min-w-0">
                   <p className="text-sm font-medium text-foreground">
@@ -259,7 +258,7 @@ export function AutoRechargeSection({
                   aria-label="Credit threshold for auto-recharge"
                 />
               </div>
-              <div className="h-px bg-border/40 mx-5" />
+              <div className="h-0 zero-border-t mx-5" />
               <div className="flex items-center justify-between gap-4 px-5 py-4">
                 <div className="min-w-0 flex flex-col gap-1">
                   <span className="text-xl font-semibold tabular-nums tracking-tight text-foreground">
@@ -328,14 +327,13 @@ export function AutoRechargeSection({
             <span className="text-xs text-muted-foreground">
               When credits drop below
             </span>
-            <input
+            <Input
               key={`dialog-threshold-${threshold}`}
               id={thresholdId}
               type="number"
               min={1}
               defaultValue={threshold}
               placeholder="e.g. 1000"
-              className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground"
             />
           </label>
 
@@ -344,7 +342,7 @@ export function AutoRechargeSection({
               Recharge amount
             </span>
             <div className="flex items-center gap-2">
-              <input
+              <Input
                 key={`dialog-amount-${amount}`}
                 id={amountId}
                 type="number"
@@ -352,7 +350,7 @@ export function AutoRechargeSection({
                 step={CREDITS_PER_DOLLAR}
                 defaultValue={amount}
                 placeholder="e.g. 10000"
-                className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground flex-1"
+                className="flex-1"
               />
               <span className="text-xs text-muted-foreground whitespace-nowrap">
                 = ${dollarAmount}

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
@@ -55,7 +55,7 @@ function LogRow({
     <Link
       pathname="/activity/:runId"
       options={{ pathParams: { runId: entry.id } }}
-      className="block py-3 transition-colors hover:bg-muted/50 cursor-pointer border-b border-border/40 last:border-b-0 no-underline text-inherit"
+      className="block px-5 py-3 transition-colors hover:bg-muted/50 cursor-pointer border-b border-border/40 last:border-b-0 no-underline text-inherit"
     >
       <div className={cn(gridClassName)}>
         <div className="min-w-0 truncate text-left text-sm font-medium text-foreground">
@@ -116,7 +116,7 @@ function SkeletonRows({
   return (
     <div className="divide-y divide-border/40">
       {Array.from({ length: count }, (_, i) => (
-        <div key={i} className={cn(gridClassName, "py-3")}>
+        <div key={i} className={cn(gridClassName, "px-5 py-3")}>
           <div className="h-4 w-20 rounded bg-muted/50 animate-pulse" />
           {showSource && (
             <div className="h-4 w-12 rounded bg-muted/50 animate-pulse" />
@@ -174,7 +174,7 @@ export function LogTable({
           <div
             className={cn(
               gridClassName,
-              "sticky top-0 z-10 py-3 text-sm font-medium text-muted-foreground bg-card border-b border-border/40",
+              "sticky top-0 z-10 px-5 py-3 text-sm font-medium text-muted-foreground bg-card border-b border-border/40",
             )}
           >
             <div className="text-left">Agent</div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -110,10 +110,6 @@ function getPlanPrice(tier: string): string {
 const proPlanPrice = getPlanPrice("pro");
 const freePlanPrice = getPlanPrice("free");
 
-const sectionCardStyle = {
-  border: "0.7px solid hsl(var(--gray-400))",
-} as const;
-
 function tierRank(t: BillingTier): number {
   if (t === "free") {
     return 0;
@@ -155,21 +151,9 @@ function PlanCard({
   const label = planButtonLabel(plan, currentTier);
 
   return (
-    <div
-      className="relative flex flex-col rounded-xl transition-transform duration-200 hover:-translate-y-0.5"
-      style={{
-        border: "0.7px solid hsl(var(--gray-400))",
-        padding: "28px 24px",
-      }}
-    >
+    <div className="relative flex flex-col rounded-xl transition-transform duration-200 hover:-translate-y-0.5 zero-border px-6 py-7">
       {"badge" in plan && plan.badge && (
-        <span
-          className="absolute top-3 right-3 inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground"
-          style={{
-            border: "0.7px solid hsl(var(--gray-400))",
-            backgroundColor: "hsl(var(--gray-0))",
-          }}
-        >
+        <span className="absolute top-3 right-3 inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
           <IconCrown size={12} stroke={1.8} className="text-amber-500" />
           {plan.badge}
         </span>
@@ -184,10 +168,7 @@ function PlanCard({
         />
       )}
 
-      <h3
-        className="text-sm font-semibold uppercase tracking-wider"
-        style={{ color: "#ed4e01", fontFamily: "var(--font-mono, monospace)" }}
-      >
+      <h3 className="text-sm font-semibold uppercase tracking-wider text-primary font-mono">
         {plan.name}
       </h3>
 
@@ -238,12 +219,7 @@ function PlanCard({
                 : "outline"
           }
           size="sm"
-          className="w-full rounded-lg h-9 text-xs"
-          style={
-            !("primary" in plan && plan.primary) && !isCurrent
-              ? sectionCardStyle
-              : undefined
-          }
+          className="w-full h-9 text-xs"
           disabled={loading || isCurrent}
           onClick={() => onAction(plan.tier)}
         >
@@ -451,8 +427,7 @@ function PlanActionButtons({
         <Button
           variant="outline"
           size="sm"
-          className="rounded-lg h-8 text-xs"
-          style={sectionCardStyle}
+          className="h-8 text-xs"
           disabled={loading}
           onClick={onDowngrade}
         >
@@ -510,10 +485,7 @@ export function OrgBillingTab() {
     <div className="flex flex-col gap-8">
       <section className="flex flex-col gap-3">
         <h3 className="text-sm font-medium text-foreground">Plan</h3>
-        <div
-          className="overflow-hidden rounded-xl bg-card"
-          style={sectionCardStyle}
-        >
+        <div className="overflow-hidden rounded-xl bg-card zero-border">
           {statusLoading && !status ? (
             <div className="flex items-center justify-between gap-4 px-5 py-4">
               <div className="min-w-0">
@@ -530,8 +502,6 @@ export function OrgBillingTab() {
               <Button
                 size="sm"
                 variant="outline"
-                className="rounded-lg"
-                style={sectionCardStyle}
                 onClick={() => reloadBilling()}
               >
                 Retry
@@ -559,7 +529,7 @@ export function OrgBillingTab() {
               </div>
               {isCancelling && periodEnd && (
                 <>
-                  <div className="h-px bg-border/40 mx-5" />
+                  <div className="h-0 zero-border-t mx-5" />
                   <div className="px-5 py-3">
                     <p className="text-[13px] text-amber-600 dark:text-amber-400">
                       Your {formatTierLabel(currentTier)} plan has been
@@ -571,7 +541,7 @@ export function OrgBillingTab() {
               )}
               {isPaid && (
                 <>
-                  <div className="h-px bg-border/40 mx-5" />
+                  <div className="h-0 zero-border-t mx-5" />
                   <div className="flex items-center justify-between gap-4 px-5 py-4">
                     <div className="min-w-0">
                       <p className="text-sm font-medium text-foreground">
@@ -584,8 +554,7 @@ export function OrgBillingTab() {
                     <Button
                       variant="outline"
                       size="sm"
-                      className="shrink-0 rounded-lg h-8 text-xs gap-1.5"
-                      style={sectionCardStyle}
+                      className="shrink-0 h-8 text-xs gap-1.5"
                       disabled={loading}
                       onClick={() =>
                         detach(portal(pageSignal), Reason.DomCallback)
@@ -597,7 +566,7 @@ export function OrgBillingTab() {
                   </div>
                 </>
               )}
-              <div className="h-px bg-border/40" />
+              <div className="h-0 zero-border-t" />
               <button
                 type="button"
                 className="flex w-full items-center justify-between gap-4 px-5 py-3 text-left transition-colors bg-muted/20 hover:bg-muted/35"

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -275,7 +275,7 @@ function ProfileSection({
             </button>
           </div>
         </div>
-        <div className="h-px bg-border/40 mx-5" />
+        <div className="h-0 zero-border-t mx-5" />
         {/* Name row */}
         <div className="flex items-center justify-between gap-4 px-5 py-4">
           <div className="min-w-0">
@@ -290,7 +290,7 @@ function ProfileSection({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="Workspace name"
-              className="h-9 w-[220px] shrink-0 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))]"
+              className="w-[220px] shrink-0"
             />
           ) : (
             <span className="text-sm text-foreground shrink-0">
@@ -298,7 +298,7 @@ function ProfileSection({
             </span>
           )}
         </div>
-        <div className="h-px bg-border/40 mx-5" />
+        <div className="h-0 zero-border-t mx-5" />
         {/* Slug row */}
         <div className="flex items-center justify-between gap-4 px-5 py-4">
           <div className="min-w-0">
@@ -313,7 +313,7 @@ function ProfileSection({
               value={slug}
               onChange={(e) => setSlug(e.target.value)}
               placeholder="organization-slug"
-              className="h-9 w-[220px] shrink-0 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))]"
+              className="w-[220px] shrink-0"
             />
           ) : (
             <span className="text-sm text-foreground shrink-0">
@@ -473,7 +473,7 @@ function DangerZoneSection({
         )}
         {isAdmin && (
           <>
-            {canLeave && <div className="h-px bg-border/40 mx-5" />}
+            {canLeave && <div className="h-0 zero-border-t mx-5" />}
             {/* Delete workspace */}
             <div className="flex items-center justify-between gap-4 px-5 py-4">
               <div className="min-w-0">
@@ -575,7 +575,7 @@ function GeneralTabSkeleton() {
             </div>
             <div className="h-9 w-9 shrink-0 rounded-lg bg-muted/50 animate-pulse" />
           </div>
-          <div className="h-px bg-border/40 mx-5" />
+          <div className="h-0 zero-border-t mx-5" />
           {/* Name row */}
           <div className="flex items-center justify-between gap-4 px-5 py-4">
             <div className="min-w-0">
@@ -584,7 +584,7 @@ function GeneralTabSkeleton() {
             </div>
             <div className="h-9 w-[220px] shrink-0 rounded-lg bg-muted/30 animate-pulse" />
           </div>
-          <div className="h-px bg-border/40 mx-5" />
+          <div className="h-0 zero-border-t mx-5" />
           {/* Slug row */}
           <div className="flex items-center justify-between gap-4 px-5 py-4">
             <div className="min-w-0">

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -60,24 +60,18 @@ export function OrgInvoicesTab() {
           <div className="text-left">Amount</div>
           <div />
         </div>
-        <div className="h-px bg-border/40 mx-4" />
+        <div className="h-0 zero-border-t mx-4" />
 
         {invoices.map((inv, i) => (
           <div key={inv.id}>
-            {i > 0 && <div className="h-px bg-border/40 mx-4" />}
+            {i > 0 && <div className="h-0 zero-border-t mx-4" />}
             <div className={cn(ROW_GRID, "px-4 py-3")}>
               <div className="flex items-center gap-3 min-w-0">
                 <span className="text-sm font-medium text-foreground truncate">
                   {inv.number ?? inv.id}
                 </span>
                 {inv.status && (
-                  <span
-                    className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground"
-                    style={{
-                      border: "0.7px solid hsl(var(--gray-400))",
-                      backgroundColor: "hsl(var(--gray-0))",
-                    }}
-                  >
+                  <span className="inline-flex items-center gap-1 rounded-lg px-2 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
                     <IconCircleCheck size={12} className="text-green-600" />
                     {inv.status.charAt(0).toUpperCase() + inv.status.slice(1)}
                   </span>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
@@ -137,14 +137,7 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="flex flex-col max-w-[960px] h-[85vh] p-0 gap-0 overflow-hidden"
-        style={{
-          border: "0.7px solid hsl(var(--gray-400))",
-          borderRadius: "0.75rem",
-          backgroundColor: "hsl(var(--card))",
-        }}
-      >
+      <DialogContent className="flex flex-col max-w-[960px] h-[85vh] p-0 gap-0 overflow-hidden zero-border rounded-xl bg-card">
         <DialogTitle className="sr-only">Workspace settings</DialogTitle>
         <DialogDescription className="sr-only">
           Manage your workspace profile, members, integrations, and billing.
@@ -152,13 +145,7 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
 
         <div className="flex h-full">
           {/* Sidebar nav — mirrors zero-sidebar.tsx styling */}
-          <nav
-            className="w-52 shrink-0 p-3 pt-3 pb-4 flex flex-col gap-4 overflow-y-auto"
-            style={{
-              borderRight: "0.7px solid hsl(var(--gray-300))",
-              backgroundColor: "hsl(var(--gray-0))",
-            }}
-          >
+          <nav className="w-52 shrink-0 p-3 pt-3 pb-4 flex flex-col gap-4 overflow-y-auto zero-border-r bg-[hsl(var(--gray-0))]">
             {sidebarGroups.map((group) => (
               <div key={group.label} className="shrink-0">
                 <div className="h-7 flex items-center pl-2">
@@ -204,10 +191,7 @@ export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
           </nav>
 
           {/* Content area */}
-          <div
-            className="flex-1 min-w-0 flex flex-col overflow-hidden"
-            style={{ backgroundColor: "rgb(254, 254, 254)" }}
-          >
+          <div className="flex-1 min-w-0 flex flex-col overflow-hidden bg-[rgb(254,254,254)]">
             {!hideHeader && (
               <header className="shrink-0 px-10 pt-8 pb-1">
                 <h2 className="text-xl font-semibold tracking-tight text-foreground">

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tabler/icons-react";
 import {
   cn,
+  Input,
   Button,
   Dialog,
   DialogContent,
@@ -17,7 +18,6 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-  Input,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -177,21 +177,18 @@ export function OrgMembersTab() {
             stroke={1.5}
             className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground/60"
           />
-          <input
+          <Input
             type="text"
             placeholder="Search"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="h-9 w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input pl-9 pr-3 text-sm text-foreground outline-none placeholder:text-muted-foreground/50 transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10"
+            className="pl-9"
           />
         </div>
         {isAdmin && <InviteDialog onInvite={handleInvite} />}
       </div>
 
-      <div
-        className="overflow-hidden rounded-xl bg-card"
-        style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-      >
+      <div className="overflow-hidden rounded-xl bg-card zero-border">
         <div
           className={cn(
             ROW_GRID,
@@ -203,7 +200,7 @@ export function OrgMembersTab() {
           <div>Role</div>
           <div />
         </div>
-        <div className="h-px bg-border/40 mx-5" />
+        <div className="h-0 zero-border-t mx-5" />
 
         {isLoading && (
           <>
@@ -226,7 +223,7 @@ export function OrgMembersTab() {
         {!isLoading &&
           filtered.map((m, i) => (
             <div key={m.userId}>
-              {i > 0 && <div className="h-px bg-border/40 mx-5" />}
+              {i > 0 && <div className="h-0 zero-border-t mx-5" />}
               <MemberRow
                 member={m}
                 isCurrentUser={m.userId === currentUserId}
@@ -241,7 +238,7 @@ export function OrgMembersTab() {
           filteredPending.map((inv, i) => (
             <div key={inv.email}>
               {(i > 0 || filtered.length > 0) && (
-                <div className="h-px bg-border/40 mx-5" />
+                <div className="h-0 zero-border-t mx-5" />
               )}
               <PendingInvitationRow invitation={inv} />
             </div>
@@ -393,13 +390,7 @@ function MemberRow({
         {formatDate(member.joinedAt)}
       </div>
       <div>
-        <span
-          className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground"
-          style={{
-            border: "0.7px solid hsl(var(--gray-400))",
-            backgroundColor: "hsl(var(--gray-0))",
-          }}
-        >
+        <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
           <IconShieldCheck
             size={12}
             stroke={1.8}
@@ -625,13 +616,7 @@ function PendingInvitationRow({
         {formatDate(invitation.createdAt)}
       </div>
       <div>
-        <span
-          className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground"
-          style={{
-            border: "0.7px solid hsl(var(--gray-400))",
-            backgroundColor: "hsl(var(--gray-0))",
-          }}
-        >
+        <span className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-muted-foreground zero-badge">
           <IconClock size={12} stroke={1.8} className="text-amber-500" />
           Pending
         </span>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-providers-tab.tsx
@@ -2,6 +2,7 @@ import { useGet, useSet, useLoadable } from "ccstate-react";
 import { IconPlus, IconDotsVertical } from "@tabler/icons-react";
 import { MODEL_PROVIDER_TYPES } from "@vm0/core";
 import {
+  cn,
   Button,
   DropdownMenu,
   DropdownMenuTrigger,
@@ -57,13 +58,7 @@ function ProviderListSection({ isAdmin }: { isAdmin: boolean }) {
           <button
             type="button"
             onClick={() => setAddDialogOpen(true)}
-            className="flex flex-col transition-colors hover:bg-muted/30 group"
-            style={{
-              border: "0.7px dashed hsl(var(--gray-400))",
-              borderRadius: "0.75rem",
-              boxShadow:
-                "0 1px 1px hsl(220 12% 20% / 0.02), 0 2px 8px hsl(220 12% 20% / 0.025), 0 8px 24px hsl(220 12% 20% / 0.02)",
-            }}
+            className="flex flex-col transition-colors hover:bg-muted/30 group zero-border-dashed rounded-xl shadow-[var(--zero-card-shadow)]"
           >
             <div className="flex h-14 items-center gap-2.5 px-5">
               <span className="flex h-7 w-7 shrink-0 items-center justify-center">
@@ -77,10 +72,7 @@ function ProviderListSection({ isAdmin }: { isAdmin: boolean }) {
                 Add provider
               </span>
             </div>
-            <div
-              className="flex h-11 items-center px-5"
-              style={{ borderTop: "0.7px dashed hsl(var(--gray-400))" }}
-            >
+            <div className="flex h-11 items-center px-5 zero-border-dashed-t">
               <span className="text-xs text-muted-foreground/70">
                 Browse supported providers
               </span>
@@ -114,14 +106,10 @@ function ProviderListSection({ isAdmin }: { isAdmin: boolean }) {
                       }
                     : undefined
                 }
-                className={isAdmin ? "cursor-pointer" : ""}
-                style={{
-                  border: "0.7px solid hsl(var(--gray-400))",
-                  borderRadius: "0.75rem",
-                  backgroundColor: "hsl(var(--card))",
-                  boxShadow:
-                    "0 1px 1px hsl(220 12% 20% / 0.02), 0 2px 8px hsl(220 12% 20% / 0.025), 0 8px 24px hsl(220 12% 20% / 0.02)",
-                }}
+                className={cn(
+                  "zero-card shadow-[var(--zero-card-shadow)]",
+                  isAdmin && "cursor-pointer",
+                )}
               >
                 <div className="flex h-14 items-center gap-2.5 px-5">
                   <span className="flex h-7 w-7 shrink-0 items-center justify-center">
@@ -132,8 +120,7 @@ function ProviderListSection({ isAdmin }: { isAdmin: boolean }) {
                   </span>
                 </div>
                 <div
-                  className="flex h-11 items-center justify-between pl-5 pr-2"
-                  style={{ borderTop: "0.7px solid hsl(var(--gray-400))" }}
+                  className="flex h-11 items-center justify-between pl-5 pr-2 zero-border-t"
                   onClick={isAdmin ? (e) => e.stopPropagation() : undefined}
                 >
                   <span className="flex items-center gap-2 text-xs text-muted-foreground truncate">
@@ -190,21 +177,12 @@ function ProviderListSection({ isAdmin }: { isAdmin: boolean }) {
 
 function ProviderSkeleton() {
   return (
-    <div
-      className="flex flex-col bg-card animate-pulse"
-      style={{
-        border: "0.7px solid hsl(var(--gray-400))",
-        borderRadius: "0.75rem",
-      }}
-    >
+    <div className="flex flex-col bg-card animate-pulse zero-border rounded-xl">
       <div className="flex h-14 items-center gap-2.5 px-5">
         <span className="h-7 w-7 shrink-0 rounded-lg bg-muted/50" />
         <span className="h-4 w-24 rounded bg-muted/50" />
       </div>
-      <div
-        className="flex h-11 items-center px-5"
-        style={{ borderTop: "0.7px solid hsl(var(--gray-400))" }}
-      >
+      <div className="flex h-11 items-center px-5 zero-border-t">
         <span className="h-3 w-16 rounded bg-muted/30" />
       </div>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -16,16 +16,6 @@ import {
 import { setMemberCreditCap$ } from "../../../../signals/zero-page/member-credit-caps.ts";
 import { detach, Reason } from "../../../../signals/utils.ts";
 
-const sectionCardStyle = {
-  border: "0.7px solid hsl(var(--gray-400))",
-} as const;
-
-const cardBoxStyle = {
-  ...sectionCardStyle,
-  borderRadius: "0.75rem",
-  backgroundColor: "hsl(var(--card))",
-} as const;
-
 // ---------------------------------------------------------------------------
 // Credit balance bar (moved from billing tab)
 // ---------------------------------------------------------------------------
@@ -264,13 +254,13 @@ function InlineCapInput({
 
 function LoadingSkeleton() {
   return (
-    <div className="flex flex-col" style={cardBoxStyle}>
+    <div className="flex flex-col rounded-xl bg-card zero-border">
       <div className="flex items-center gap-3 px-5 py-4">
         <span className="h-7 w-7 shrink-0 rounded-lg bg-muted/50 animate-pulse" />
         <span className="h-4 w-32 rounded bg-muted/50 animate-pulse" />
         <span className="ml-auto h-4 w-16 rounded bg-muted/30 animate-pulse" />
       </div>
-      <div className="h-px bg-border/40 mx-5" />
+      <div className="h-0 zero-border-t mx-5" />
       <div className="flex items-center gap-3 px-5 py-4">
         <span className="h-7 w-7 shrink-0 rounded-lg bg-muted/50 animate-pulse" />
         <span className="h-4 w-40 rounded bg-muted/40 animate-pulse" />
@@ -336,10 +326,7 @@ export function OrgUsageTab() {
       {/* Credit balance */}
       <section className="flex flex-col gap-3">
         <h3 className="text-sm font-medium text-foreground">Credit balance</h3>
-        <div
-          className="overflow-hidden rounded-xl bg-card"
-          style={sectionCardStyle}
-        >
+        <div className="overflow-hidden rounded-xl bg-card zero-border">
           {billingLoading && !billing ? (
             <div className="px-5 py-4 space-y-2">
               <div className="h-4 w-48 rounded bg-muted/50 animate-pulse" />
@@ -381,25 +368,16 @@ export function OrgUsageTab() {
         {usageLoading && !usageData ? (
           <LoadingSkeleton />
         ) : usageError ? (
-          <div
-            className="rounded-xl bg-card px-5 py-8 text-center text-sm text-muted-foreground"
-            style={sectionCardStyle}
-          >
+          <div className="rounded-xl bg-card px-5 py-8 text-center text-sm text-muted-foreground zero-border">
             Failed to load usage. Please try again later.
           </div>
         ) : !period ? (
-          <div
-            className="rounded-xl bg-card px-5 py-8 text-center text-sm text-muted-foreground"
-            style={sectionCardStyle}
-          >
+          <div className="rounded-xl bg-card px-5 py-8 text-center text-sm text-muted-foreground zero-border">
             No active billing period. Credit usage by member is available on
             paid plans.
           </div>
         ) : members.length === 0 ? (
-          <div
-            className="flex flex-col items-center gap-2 rounded-xl bg-card px-5 py-10 text-center"
-            style={sectionCardStyle}
-          >
+          <div className="flex flex-col items-center gap-2 rounded-xl bg-card px-5 py-10 text-center zero-border">
             <IconUsers
               size={20}
               stroke={1.5}
@@ -410,10 +388,7 @@ export function OrgUsageTab() {
             </p>
           </div>
         ) : (
-          <div
-            className="overflow-hidden rounded-xl bg-card"
-            style={sectionCardStyle}
-          >
+          <div className="overflow-hidden rounded-xl bg-card zero-border">
             {/* Header */}
             <div className="grid grid-cols-[1fr_7rem_6rem_5.5rem] gap-x-4 items-center px-5 py-2.5 text-[13px] font-medium text-foreground">
               <span>Member</span>
@@ -433,7 +408,7 @@ export function OrgUsageTab() {
 
               return (
                 <div key={member.userId}>
-                  <div className="h-px bg-border/40 mx-5" />
+                  <div className="h-0 zero-border-t mx-5" />
                   <div className="grid grid-cols-[1fr_7rem_6rem_5.5rem] gap-x-4 items-center px-5 py-3">
                     <div className="flex items-center gap-3 min-w-0">
                       <MemberAvatar

--- a/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/add-connection-dialog.tsx
@@ -1,5 +1,7 @@
 import { useLastResolved, useGet, useSet } from "ccstate-react";
 import { IconSearch, IconPlus } from "@tabler/icons-react";
+import { Input } from "@vm0/ui/components/ui/input";
+import { Button } from "@vm0/ui/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -140,22 +142,21 @@ function ApiTokenForm({
           <label className="text-sm font-medium text-foreground">
             {secretConfig.label}
           </label>
-          <input
+          <Input
             type="password"
             placeholder={secretConfig.placeholder}
             value={secretValues[name] ?? ""}
             onChange={(e) => setFormValue(type, name, e.target.value)}
-            className="rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </div>
       ))}
-      <button
+      <Button
         onClick={handleSubmit}
         disabled={!allFilled || submitting}
-        className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+        className="w-full"
       >
         {submitting ? "Saving..." : "Save"}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -188,7 +189,8 @@ function ConnectModalContent({
   return (
     <div className="flex flex-col gap-4">
       {hasOAuth && (
-        <button
+        <Button
+          variant="outline"
           onClick={() =>
             detach(
               (async () => {
@@ -200,16 +202,16 @@ function ConnectModalContent({
               Reason.DomCallback,
             )
           }
-          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+          className="w-full"
         >
           Sign in with {config.label}
-        </button>
+        </Button>
       )}
 
       {hasOAuth && hasApiToken && (
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
-            <span className="w-full border-t border-border" />
+            <span className="w-full zero-border-t" />
           </div>
           <div className="relative flex justify-center text-xs">
             <span className="bg-background px-2 text-muted-foreground">or</span>
@@ -338,7 +340,7 @@ function ConnectorCard({
 
   return (
     <div
-      className={`flex min-w-0 flex-col gap-3 rounded-xl border border-border bg-card p-4${clickable ? " cursor-pointer transition-colors hover:bg-muted/50" : ""}`}
+      className={`flex min-w-0 flex-col gap-3 rounded-xl zero-border bg-card p-4${clickable ? " cursor-pointer transition-colors hover:bg-muted/50" : ""}`}
       onClick={clickable ? handleCardClick : undefined}
       role={clickable ? "button" : undefined}
       tabIndex={clickable ? 0 : undefined}
@@ -415,7 +417,7 @@ function CustomAPITabContent({
         <button
           type="button"
           onClick={onAddSecret}
-          className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:bg-muted/50"
+          className="flex flex-col gap-3 rounded-xl zero-border bg-card p-4 text-left transition-colors hover:bg-muted/50"
         >
           <div className="flex items-center gap-3">
             <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-muted">
@@ -432,7 +434,7 @@ function CustomAPITabContent({
         <button
           type="button"
           onClick={onAddVariable}
-          className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:bg-muted/50"
+          className="flex flex-col gap-3 rounded-xl zero-border bg-card p-4 text-left transition-colors hover:bg-muted/50"
         >
           <div className="flex items-center gap-3">
             <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-muted">
@@ -483,7 +485,7 @@ function ConnectorGrid({
         : types.slice(0, 6).map((type) => (
             <div
               key={type}
-              className="flex min-w-0 flex-col gap-3 rounded-xl border border-border bg-card p-4 animate-pulse"
+              className="flex min-w-0 flex-col gap-3 rounded-xl zero-border bg-card p-4 animate-pulse"
             >
               <div className="flex min-w-0 items-center gap-3">
                 <div className="h-5 w-5 rounded bg-muted" />
@@ -704,12 +706,12 @@ function ZeroAddConnectionDialog({
               stroke={1.5}
               className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
             />
-            <input
+            <Input
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search..."
-              className="w-full rounded-lg border border-border bg-background py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20"
+              className="pl-9"
             />
           </div>
           <Tabs

--- a/turbo/apps/platform/src/views/zero-page/components/settings/firewall-permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/firewall-permissions-dialog.tsx
@@ -94,10 +94,7 @@ function PolicyPill({
   onChange: (p: PermissionPolicy) => void;
 }) {
   return (
-    <span
-      className="inline-flex shrink-0 rounded-md overflow-hidden text-xs font-medium"
-      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-    >
+    <span className="inline-flex shrink-0 rounded-md overflow-hidden text-xs font-medium zero-border">
       {POLICY_OPTIONS.map((opt, idx) => (
         <button
           key={opt.value}
@@ -219,10 +216,7 @@ export function FirewallPermissionsDrawer({
               <span className="text-xs font-medium text-foreground">
                 Select all ({permissions.length})
               </span>
-              <span
-                className="inline-flex shrink-0 rounded-md overflow-hidden text-xs font-medium"
-                style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-              >
+              <span className="inline-flex shrink-0 rounded-md overflow-hidden text-xs font-medium zero-border">
                 {POLICY_OPTIONS.map((opt, idx) => (
                   <button
                     key={opt.value}

--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
@@ -31,7 +31,7 @@ function ProviderCardInDialog({
     <button
       type="button"
       onClick={onAdd}
-      className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:bg-muted/50"
+      className="flex flex-col gap-3 rounded-xl zero-border bg-card p-4 text-left transition-colors hover:bg-muted/50"
       data-testid={`org-provider-card-${type}`}
     >
       <div className="flex items-center gap-3">
@@ -50,7 +50,7 @@ function ProviderCardInDialog({
         </div>
       )}
       <div className="mt-auto">
-        <span className="w-full h-8 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-[hsl(var(--gray-50))] px-3 text-sm font-medium text-foreground hover:bg-[hsl(var(--gray-100))] transition-colors text-center flex items-center justify-center">
+        <span className="w-full h-8 rounded-lg zero-chip px-3 text-sm font-medium text-foreground transition-colors text-center flex items-center justify-center">
           Add
         </span>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
@@ -65,10 +65,7 @@ export function TimezoneSettings() {
       <p className="text-sm text-muted-foreground">
         Sets the TZ environment variable for your agent sandbox at runtime.
       </p>
-      <div
-        className="flex items-center gap-4 bg-card p-4 rounded-xl"
-        style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-      >
+      <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
             <IconClock

--- a/turbo/apps/platform/src/views/zero-page/schedule-calendar-view.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-calendar-view.tsx
@@ -164,7 +164,7 @@ export function ScheduleCalendarView<T extends ScheduleEntry>({
         <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           Week view
         </h3>
-        <div className="rounded-xl border border-border/70 bg-muted/20 overflow-hidden">
+        <div className="rounded-xl zero-border bg-muted/20 overflow-hidden">
           {/* Mobile: single-day view */}
           <div className="md:hidden">
             <div className="flex items-center justify-between bg-muted/50 px-3 py-2 border-b border-border/60">

--- a/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-dialog.tsx
@@ -140,8 +140,7 @@ function ConfirmCloseOverlay({
 }) {
   return createPortal(
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center"
-      style={{ pointerEvents: "auto" }}
+      className="fixed inset-0 z-[100] flex items-center justify-center pointer-events-auto"
       role="alertdialog"
       aria-modal="true"
       aria-labelledby="confirm-close-title"
@@ -718,7 +717,7 @@ function ScheduleFormDialogInner({
               onChange={(e) => setPrompt(e.target.value)}
               placeholder="Describe your task and instruction"
               rows={5}
-              className="w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-primary/20 resize-y min-h-[120px]"
+              className="w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 resize-y min-h-[120px]"
             />
           </div>
 

--- a/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
@@ -232,8 +232,8 @@ export function ScheduleListView<T extends ScheduleEntry>({
   const showAgent = !!getAgentLabel;
 
   return (
-    <div className="w-full overflow-x-auto -mx-1">
-      <table className="w-full text-sm border-collapse">
+    <div className="w-full overflow-x-auto">
+      <table className="w-full text-sm border-collapse [&_tr>:first-child]:pl-5 [&_tr>:last-child]:pr-5">
         <thead>
           <tr className="border-b border-border/40 bg-card text-left text-sm text-muted-foreground">
             {showAgent && (

--- a/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
@@ -185,13 +185,13 @@ export function TiptapInstructionsEditor({
 
   return (
     <div
-      className={`relative rounded-lg border border-border/60 bg-transparent transition-colors focus-within:border-border ${disabled ? "opacity-60 pointer-events-none" : ""}`}
+      className={`relative rounded-xl zero-border bg-transparent transition-colors focus-within:border-primary ${disabled ? "opacity-60 pointer-events-none" : ""}`}
     >
       {editor && (
         <BubbleMenu
           editor={editor}
           updateDelay={0}
-          className="z-50 flex items-center gap-1 rounded-lg border border-border bg-popover px-1.5 py-1 shadow-lg"
+          className="z-50 flex items-center gap-1 rounded-lg zero-border bg-popover px-1.5 py-1 shadow-lg"
         >
           <ToolbarButton
             onAction={() => editor.chain().focus().toggleBold().run()}
@@ -288,7 +288,7 @@ export function TiptapInstructionsEditor({
         </BubbleMenu>
       )}
       <EditorContent editor={editor} />
-      <p className="mx-4 border-t border-border/40 pt-2 pb-3 text-xs text-muted-foreground">
+      <p className="mx-4 zero-border-t pt-2 pb-3 text-xs text-muted-foreground">
         {footerHint}
       </p>
     </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-account-page.tsx
@@ -46,10 +46,7 @@ function AppearanceSettings() {
       <p className="text-sm text-muted-foreground">
         Choose how the interface looks.
       </p>
-      <div
-        className="flex items-center gap-4 bg-card p-4 rounded-xl"
-        style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-      >
+      <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
             <IconPalette
@@ -71,9 +68,8 @@ function AppearanceSettings() {
               key={value}
               type="button"
               onClick={() => setTheme(value)}
-              style={{ borderWidth: "0.7px" }}
               className={cn(
-                "flex items-center gap-2 rounded-lg border px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                "flex items-center gap-2 rounded-lg border border-[0.7px] px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 currentPref === value
                   ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
                   : "zero-chip text-muted-foreground hover:text-foreground",
@@ -110,10 +106,7 @@ function SendModeSettings() {
       <p className="text-sm text-muted-foreground">
         Choose how to send messages in chat.
       </p>
-      <div
-        className="flex items-center gap-4 bg-card p-4 rounded-xl"
-        style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-      >
+      <div className="flex items-center gap-4 bg-card p-4 rounded-xl zero-border">
         <div className="shrink-0">
           <div className="flex h-7 w-7 items-center justify-center">
             <IconKeyboard
@@ -140,9 +133,8 @@ function SendModeSettings() {
               type="button"
               disabled={saving !== null}
               onClick={() => handleChange(value)}
-              style={{ borderWidth: "0.7px" }}
               className={cn(
-                "flex items-center gap-2 rounded-lg border px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                "flex items-center gap-2 rounded-lg border border-[0.7px] px-3.5 py-2 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 (saving === value ? true : saving === null && current === value)
                   ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
                   : "zero-chip text-muted-foreground hover:text-foreground",

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -346,15 +346,13 @@ export function ZeroActivityDetailPage() {
                   </span>
                 </div>
                 <div className="flex items-center gap-2 sm:gap-3">
-                  <div className="zero-search-input relative flex h-9 flex-1 sm:flex-none items-center rounded-lg border transition-colors focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
-                    <div className="pl-2">
-                      <IconSearch className="h-4 w-4 text-muted-foreground" />
-                    </div>
+                  <div className="relative flex-1 sm:flex-none sm:w-44">
+                    <IconSearch className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                     <Input
                       placeholder="Search steps"
                       value={stepSearch}
                       onChange={(e) => setStepSearch(e.target.value)}
-                      className="h-full w-full sm:w-44 border-0 text-sm focus:border-0 focus:ring-0 pl-2 pr-3 bg-transparent"
+                      className="pl-9"
                     />
                   </div>
                 </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -170,7 +170,7 @@ export function ZeroActivityPage() {
       {/* Scrollable table area */}
       <div className="flex-1 min-h-0 overflow-auto px-4 sm:px-6 pt-4">
         <div className="mx-auto max-w-[900px]">
-          <div className="zero-card overflow-hidden px-4 sm:px-7 pb-3">
+          <div className="zero-card overflow-hidden pb-3">
             <LogTable
               logs={logs}
               isLoading={isLoading}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -166,10 +166,7 @@ function ConnectorTriggerIcons({
     <span className="flex items-center -space-x-1.5">
       {connected.map((c) => (
         <span key={c.type} className="relative shrink-0">
-          <span
-            className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-background"
-            style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-          >
+          <span className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-background zero-border">
             <ConnectorIcon type={c.type as ConnectorType} size={16} />
           </span>
         </span>
@@ -285,10 +282,7 @@ function ConnectorsPopoverButton({
       <PopoverContent side="top" align="start" className="w-64 p-0 rounded-lg">
         {hasAgentConnectors && (
           <TooltipProvider delayDuration={400}>
-            <div
-              className="max-h-[200px] overflow-y-auto py-1 pl-1"
-              style={{ scrollbarWidth: "thin" }}
-            >
+            <div className="max-h-[200px] overflow-y-auto py-1 pl-1">
               <div className="px-2 pt-1 pb-1">
                 <span className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
                   Connectors used by {displayName}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -231,7 +231,7 @@ export function ZeroChatPage({
                       <button
                         type="button"
                         onClick={handlePin}
-                        className="absolute -top-0.5 -right-0.5 flex h-6 w-6 items-center justify-center rounded-full border-[0.7px] border-[hsl(var(--gray-400))] bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground hover:shadow-md cursor-pointer"
+                        className="absolute -top-0.5 -right-0.5 flex h-6 w-6 items-center justify-center rounded-full zero-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground hover:shadow-md cursor-pointer"
                         aria-label="Pin to sidebar"
                       >
                         <IconPin size={12} stroke={2} />

--- a/turbo/apps/platform/src/views/zero-page/zero-connector-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connector-card.tsx
@@ -183,10 +183,7 @@ export function ZeroConnectorCard({
   const isPolling = pollingType === name;
 
   return (
-    <div
-      className="flex flex-col rounded-[var(--zero-card-radius)] bg-card shadow-[var(--zero-card-shadow)]"
-      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-    >
+    <div className="flex flex-col rounded-xl bg-card shadow-[var(--zero-card-shadow)] zero-border">
       <div className="flex h-14 items-center gap-2.5 px-5">
         <span className="flex h-5 w-5 shrink-0 items-center justify-center">
           {name in CONNECTOR_TYPES ? (

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-tab.tsx
@@ -138,7 +138,7 @@ export function ZeroConnectorsTab({
             {Array.from({ length: 3 }, (_, i) => (
               <div
                 key={i}
-                className="flex flex-col rounded-[var(--zero-card-radius)] border border-border/50 bg-card animate-pulse"
+                className="flex flex-col rounded-xl zero-border bg-card animate-pulse"
               >
                 <div className="flex h-14 items-center gap-2.5 px-5">
                   <span className="h-5 w-5 shrink-0 rounded-lg bg-muted/50" />

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -245,7 +245,7 @@ function CreateTeammateButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-[hsl(var(--gray-400))] transition-colors hover:border-[hsl(var(--gray-400))] hover:bg-muted/30 group cursor-pointer text-left"
+      className="flex flex-col rounded-xl border border-dashed border-[hsl(var(--gray-400))] transition-colors hover:border-[hsl(var(--gray-400))] hover:bg-muted/30 group cursor-pointer text-left"
     >
       <div className="flex items-center gap-3 px-4 py-3.5">
         <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors">

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -100,10 +100,9 @@ function OnboardingConnectorCard({
       type="button"
       onClick={onClick}
       disabled={isPolling}
-      className={`flex items-center gap-3 rounded-xl px-4 py-3.5 transition-colors focus:outline-none ${
+      className={`flex items-center gap-3 rounded-xl px-4 py-3.5 transition-colors focus:outline-none zero-border ${
         isPolling ? "bg-yellow-500/5" : "hover:bg-muted/30 cursor-pointer"
       }`}
-      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
     >
       <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted/40 overflow-hidden">
         <ConnectorIcon type={type} size={20} />
@@ -255,8 +254,7 @@ function ConnectStepContent({
             return (
               <div
                 key={type}
-                className="flex items-center gap-4 rounded-xl px-5 py-4"
-                style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+                className="flex items-center gap-4 rounded-xl px-5 py-4 zero-border"
               >
                 <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted/40 overflow-hidden">
                   <ConnectorIcon type={type} size={20} />
@@ -341,8 +339,7 @@ function WhereToWorkContent({
           type="button"
           onClick={onAddToSlack}
           disabled={saving}
-          className="flex items-center gap-4 rounded-xl bg-card px-6 py-6 text-left transition-colors hover:bg-muted/30 disabled:opacity-50"
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          className="flex items-center gap-4 rounded-xl bg-card px-6 py-6 text-left transition-colors hover:bg-muted/30 disabled:opacity-50 zero-border"
         >
           <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted/40 overflow-hidden">
             <img src={slackIcon} alt="" className="h-6 w-6" />
@@ -361,8 +358,7 @@ function WhereToWorkContent({
           type="button"
           onClick={onContinueWeb}
           disabled={saving}
-          className="flex items-center gap-4 rounded-xl bg-card px-6 py-6 text-left transition-colors hover:bg-muted/30 disabled:opacity-50"
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          className="flex items-center gap-4 rounded-xl bg-card px-6 py-6 text-left transition-colors hover:bg-muted/30 disabled:opacity-50 zero-border"
         >
           <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg overflow-hidden">
             <img
@@ -561,9 +557,8 @@ function OrbitIllustration({
         return (
           <div
             key={type}
-            className="absolute z-10 flex h-11 w-11 items-center justify-center rounded-xl bg-background shadow-sm transition-all duration-500 ease-out"
+            className="absolute z-10 flex h-11 w-11 items-center justify-center rounded-xl bg-background shadow-sm transition-all duration-500 ease-out zero-border"
             style={{
-              border: "0.7px solid hsl(var(--gray-400))",
               top: `calc(50% + ${y}px - 22px)`,
               left: `calc(50% + ${x}px - 22px)`,
             }}
@@ -582,9 +577,8 @@ function OrbitIllustration({
         return (
           <div
             key={type}
-            className="absolute z-10 flex h-10 w-10 items-center justify-center rounded-xl bg-background shadow-sm transition-all duration-500 ease-out"
+            className="absolute z-10 flex h-10 w-10 items-center justify-center rounded-xl bg-background shadow-sm transition-all duration-500 ease-out zero-border"
             style={{
-              border: "0.7px solid hsl(var(--gray-400))",
               top: `calc(50% + ${y}px - 20px)`,
               left: `calc(50% + ${x}px - 20px)`,
             }}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -749,7 +749,7 @@ function ScheduleRunHistoryTab() {
 
       {/* Table */}
       <Card className="zero-card overflow-hidden">
-        <CardContent className="px-4 sm:px-7 pb-3 pt-0">
+        <CardContent className="pb-3 pt-0 px-0">
           <LogTable
             logs={logs}
             isLoading={isLoading}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -587,7 +587,7 @@ export function ZeroSchedulePage() {
 
       <main className="flex-1 overflow-auto px-4 sm:px-6 pt-4 pb-8">
         <div className="mx-auto max-w-[900px]">
-          <div className="zero-card overflow-hidden px-4 sm:px-7 pb-3">
+          <div className="zero-card overflow-hidden pb-3">
             {isInitialLoading ? (
               scheduleViewMode === "calendar" ? (
                 <ScheduleCalendarSkeleton />

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -350,7 +350,7 @@ function ScheduleCalendarSkeleton() {
   return (
     <section className="flex flex-col gap-2">
       <Skeleton className="h-4 w-20" />
-      <div className="rounded-xl border border-border/70 bg-muted/20 overflow-hidden">
+      <div className="rounded-xl zero-border bg-muted/20 overflow-hidden">
         <div className="grid grid-cols-8">
           <div className="bg-muted/50 p-2 border-b border-r border-border/60 h-9" />
           {WEEKDAY_LABELS.map((d) => (

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -168,7 +168,7 @@ export function ZeroSessionChatPage({
                     <button
                       type="button"
                       onClick={handlePin}
-                      className="absolute -top-0.5 -right-0.5 flex h-5 w-5 items-center justify-center rounded-full border-[0.7px] border-[hsl(var(--gray-400))] bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground hover:shadow-md cursor-pointer"
+                      className="absolute -top-0.5 -right-0.5 flex h-5 w-5 items-center justify-center rounded-full zero-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground hover:shadow-md cursor-pointer"
                       aria-label="Pin to sidebar"
                     >
                       <IconPin size={10} stroke={2} />
@@ -488,13 +488,7 @@ function RunActivityLine() {
           className="absolute left-[5.5px] top-[6px] bottom-[6px] pointer-events-none"
           aria-hidden
         >
-          <div
-            className="w-px h-full bg-border/60"
-            style={{
-              backgroundImage:
-                "repeating-linear-gradient(to bottom, transparent, transparent 2px, hsl(var(--border) / 0.6) 2px, hsl(var(--border) / 0.6) 5px)",
-            }}
-          />
+          <div className="w-px h-full bg-border/60 zero-dashed-line" />
         </div>
       )}
       {items.map((summary, idx) => {
@@ -578,13 +572,7 @@ function CollapsibleTimeline({
               className="absolute left-[5.5px] top-[6px] bottom-[6px] pointer-events-none"
               aria-hidden
             >
-              <div
-                className="w-px h-full"
-                style={{
-                  backgroundImage:
-                    "repeating-linear-gradient(to bottom, transparent, transparent 2px, hsl(var(--border) / 0.6) 2px, hsl(var(--border) / 0.6) 5px)",
-                }}
-              />
+              <div className="w-px h-full zero-dashed-line" />
             </div>
           )}
           {items.map((summary, idx) => (

--- a/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-settings-tab.tsx
@@ -280,7 +280,7 @@ export function ZeroSettingsTab({
                   value={agentName}
                   onChange={(e) => setAgentName(e.target.value)}
                   placeholder="What should we call them?"
-                  className="h-9 w-full zero-form-border"
+                  className="h-9 w-full"
                   aria-label="Name"
                 />
               </div>
@@ -298,7 +298,7 @@ export function ZeroSettingsTab({
                   onChange={(e) => setDesc(e.target.value)}
                   placeholder="What does this agent do?"
                   rows={3}
-                  className="zero-form-border w-full rounded-lg bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:ring-[3px] focus:ring-primary/10 resize-y min-h-[72px]"
+                  className="w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 resize-y min-h-[72px]"
                   aria-label="Description"
                 />
               </div>
@@ -324,9 +324,8 @@ export function ZeroSettingsTab({
                       key={opt}
                       type="button"
                       onClick={() => setTone(opt)}
-                      style={{ borderWidth: "0.7px" }}
                       className={cn(
-                        "w-full min-w-0 rounded-lg border px-3 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                        "w-full min-w-0 rounded-lg border border-[0.7px] px-3 py-2.5 text-sm font-medium transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                         tone === opt
                           ? "border-primary/40 bg-primary/10 text-primary dark:border-primary/50 dark:bg-primary/15"
                           : "zero-chip text-muted-foreground hover:text-foreground",
@@ -337,8 +336,7 @@ export function ZeroSettingsTab({
                   ))}
                 </div>
                 <div
-                  className="rounded-lg bg-muted/30 px-3 py-2 w-full"
-                  style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+                  className="rounded-lg bg-muted/30 px-3 py-2 w-full zero-border"
                   key={tone}
                 >
                   <p className="text-xs text-muted-foreground italic min-h-[1.25rem] leading-relaxed">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -33,6 +33,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  Input,
   Button,
 } from "@vm0/ui";
 import {
@@ -404,28 +405,26 @@ export function ChatListDialog({
           </p>
         </DialogHeader>
 
-        {/* Search — same pattern as zero-activity-detail-page (zero-search-input) */}
+        {/* Search */}
         <div className="px-5 pb-3">
-          <div className="zero-search-input relative flex h-10 w-full items-center rounded-lg border transition-colors focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/20">
-            <div className="pl-2.5 shrink-0">
-              <IconSearch
-                size={16}
-                stroke={2}
-                className="text-muted-foreground"
-              />
-            </div>
-            <input
+          <div className="relative w-full">
+            <IconSearch
+              size={16}
+              stroke={2}
+              className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+            />
+            <Input
               type="text"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search agents..."
-              className="h-full min-w-0 flex-1 border-0 bg-transparent py-2 pl-2 pr-2 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-0"
+              className={`pl-9 ${query ? "pr-9" : ""}`}
             />
             {query && (
               <button
                 type="button"
                 onClick={() => setQuery("")}
-                className="mr-1.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                className="absolute right-1.5 top-1/2 -translate-y-1/2 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
                 aria-label="Clear search"
               >
                 <IconX size={14} stroke={2} />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -290,8 +290,7 @@ function AccountDropdown({
         side="top"
         align="start"
         sideOffset={8}
-        className="w-[240px] rounded-lg"
-        style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+        className="w-[240px]"
       >
         {/* Current account header */}
         {current && (
@@ -314,10 +313,7 @@ function AccountDropdown({
                 </div>
               </div>
             </div>
-            <DropdownMenuSeparator
-              className="h-0 bg-transparent"
-              style={{ borderTop: "0.7px solid hsl(var(--gray-400))" }}
-            />
+            <DropdownMenuSeparator />
           </>
         )}
 
@@ -333,10 +329,7 @@ function AccountDropdown({
           />
           <span>Preferences</span>
         </DropdownMenuItem>
-        <DropdownMenuSeparator
-          className="h-0 bg-transparent"
-          style={{ borderTop: "0.7px solid hsl(var(--gray-400))" }}
-        />
+        <DropdownMenuSeparator />
 
         {/* Account management group */}
         {hasOthers ? (
@@ -354,10 +347,7 @@ function AccountDropdown({
                 className="text-muted-foreground"
               />
             </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent
-              className="w-[220px] rounded-lg"
-              style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-            >
+            <DropdownMenuSubContent className="w-[220px]">
               {others.map((account) => (
                 <DropdownMenuItem
                   key={account.sessionId}
@@ -379,10 +369,7 @@ function AccountDropdown({
                   </div>
                 </DropdownMenuItem>
               ))}
-              <DropdownMenuSeparator
-                className="h-0 bg-transparent"
-                style={{ borderTop: "0.7px solid hsl(var(--gray-400))" }}
-              />
+              <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={handleAddAccount}
                 className="gap-3 px-3 py-2.5 rounded-lg"
@@ -503,8 +490,7 @@ function RecentChatSection({
     <div className="mt-4 flex flex-col min-h-0 flex-1">
       {searchOpen ? (
         <div
-          className="shrink-0 flex h-8 items-center gap-2 rounded-lg bg-sidebar-accent/60 pl-2 pr-2"
-          style={{ border: "0.7px solid hsl(var(--gray-400))" }}
+          className="shrink-0 flex h-8 items-center gap-2 rounded-lg bg-sidebar-accent/60 pl-2 pr-2 zero-border"
           onBlur={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget)) {
               setSearchOpen(false);
@@ -842,13 +828,7 @@ function SidebarUpgradeCard() {
     <button
       type="button"
       onClick={handleClick}
-      className="flex w-full items-center gap-3 rounded-lg p-2.5 text-left transition-colors hover:bg-muted/30"
-      style={{
-        border: "0.7px solid hsl(var(--gray-300))",
-        backgroundColor: "hsl(var(--card))",
-        boxShadow:
-          "0 1px 2px hsl(220 12% 20% / 0.04), 0 4px 12px hsl(220 12% 20% / 0.03)",
-      }}
+      className="flex w-full items-center gap-3 rounded-lg p-2.5 text-left transition-colors hover:bg-muted/30 zero-card shadow-[0_1px_2px_hsl(220_12%_20%/0.04),0_4px_12px_hsl(220_12%_20%/0.03)]"
     >
       <div className="min-w-0 flex-1">
         <p className="text-sm font-medium text-foreground">Get {next.label}</p>

--- a/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-slack-connect-page.tsx
@@ -59,7 +59,7 @@ export function ZeroSlackConnectPage() {
   return (
     <div className="zero-app flex h-dvh w-full bg-background zero-workspace-bg">
       <div className="flex flex-1 items-center justify-center p-4">
-        <div className="zero-card w-full max-w-sm rounded-xl border border-border bg-card p-5 sm:p-8 flex flex-col items-center gap-6">
+        <div className="zero-card w-full max-w-sm p-5 sm:p-8 flex flex-col items-center gap-6">
           <PageContent
             effectiveStatus={eStatus}
             effectiveError={eError}

--- a/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
@@ -15,7 +15,7 @@ export function ZeroUnsavedBar({
 }: ZeroUnsavedBarProps) {
   return createPortal(
     <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4">
-      <div className="zero-card flex max-w-md items-center justify-between gap-4 rounded-xl border border-border bg-card px-5 py-4 shadow-lg">
+      <div className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg">
         <div className="flex items-center gap-2 text-sm text-foreground">
           <IconPencil
             size={18}

--- a/turbo/packages/ui/src/components/ui/button.tsx
+++ b/turbo/packages/ui/src/components/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90 active:bg-destructive/80",
         outline:
-          "border border-border bg-background hover:bg-gray-50 active:bg-gray-100 text-foreground",
+          "border-[0.7px] border-[hsl(var(--gray-400))] bg-background hover:bg-gray-50 active:bg-gray-100 text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 active:bg-secondary/70",
         ghost: "text-primary hover:bg-accent active:bg-accent/80",

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90vh] overflow-y-auto dialog-scrollable translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90vh] overflow-y-auto dialog-scrollable translate-x-[-50%] translate-y-[-50%] gap-4 border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-xl",
         className,
       )}
       {...props}

--- a/turbo/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/turbo/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -20,7 +20,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-card p-1 text-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}
@@ -50,7 +50,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    className={cn("-mx-1 my-1 h-0 border-0 zero-border-t", className)}
     {...props}
   />
 ));
@@ -82,7 +82,7 @@ const DropdownMenuSubContent = React.forwardRef<
     <DropdownMenuPrimitive.SubContent
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-card p-1 text-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/turbo/packages/ui/src/components/ui/input.tsx
+++ b/turbo/packages/ui/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
+          "flex h-9 w-full rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground placeholder:text-sm placeholder:text-muted-foreground outline-none transition-colors focus:border-primary focus:ring-[3px] focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
           type === "password" && "font-mono tracking-wider",
           className,
         )}

--- a/turbo/packages/ui/src/components/ui/popover.tsx
+++ b/turbo/packages/ui/src/components/ui/popover.tsx
@@ -23,7 +23,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-lg border border-border bg-card p-4 text-foreground outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-4 text-foreground outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       style={{

--- a/turbo/packages/ui/src/components/ui/select.tsx
+++ b/turbo/packages/ui/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-start gap-2 rounded-lg border border-border bg-input px-3 py-2 text-sm text-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:text-left [&>span]:w-full",
+      "flex h-9 w-full items-center justify-start gap-2 rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-input px-3 py-2 text-sm text-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 [&>span]:text-left [&>span]:w-full",
       className,
     )}
     {...props}
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-card text-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-card text-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,
@@ -146,7 +146,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    className={cn("-mx-1 my-1 h-0 border-0 zero-border-t", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Summary

- Extract repeated inline border/divider patterns into reusable CSS utility classes in `index.css`
- Replace inline border styles across 30+ platform view files with the new utility classes
- Move horizontal padding from card wrappers into table/row components for consistent alignment
- Clean up redundant Tailwind classes in UI component library (button, dialog, dropdown, input, popover, select)

## Test plan

- [ ] Verify all pages render correctly with no visual regressions (borders, dividers, spacing)
- [ ] Check schedule, activity, settings, onboarding, and chat pages
- [ ] Confirm table padding alignment is consistent across log tables and schedule lists