### PR TITLE
fix(platform): extend table row hover to card edges

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
@@ -55,7 +55,7 @@ function LogRow({
     <Link
       pathname="/activity/:runId"
       options={{ pathParams: { runId: entry.id } }}
-      className="block py-3 transition-colors hover:bg-muted/50 cursor-pointer border-b border-border/40 last:border-b-0 no-underline text-inherit"
+      className="block px-5 py-3 transition-colors hover:bg-muted/50 cursor-pointer border-b border-border/40 last:border-b-0 no-underline text-inherit"
     >
       <div className={cn(gridClassName)}>
         <div className="min-w-0 truncate text-left text-sm font-medium text-foreground">
@@ -116,7 +116,7 @@ function SkeletonRows({
   return (
     <div className="divide-y divide-border/40">
       {Array.from({ length: count }, (_, i) => (
-        <div key={i} className={cn(gridClassName, "py-3")}>
+        <div key={i} className={cn(gridClassName, "px-5 py-3")}>
           <div className="h-4 w-20 rounded bg-muted/50 animate-pulse" />
           {showSource && (
             <div className="h-4 w-12 rounded bg-muted/50 animate-pulse" />
@@ -174,7 +174,7 @@ export function LogTable({
           <div
             className={cn(
               gridClassName,
-              "sticky top-0 z-10 py-3 text-sm font-medium text-muted-foreground bg-card border-b border-border/40",
+              "sticky top-0 z-10 px-5 py-3 text-sm font-medium text-muted-foreground bg-card border-b border-border/40",
             )}
           >
             <div className="text-left">Agent</div>

--- a/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
@@ -232,8 +232,8 @@ export function ScheduleListView<T extends ScheduleEntry>({
   const showAgent = !!getAgentLabel;
 
   return (
-    <div className="w-full overflow-x-auto -mx-1">
-      <table className="w-full text-sm border-collapse">
+    <div className="w-full overflow-x-auto">
+      <table className="w-full text-sm border-collapse [&_tr>:first-child]:pl-5 [&_tr>:last-child]:pr-5">
         <thead>
           <tr className="border-b border-border/40 bg-card text-left text-sm text-muted-foreground">
             {showAgent && (

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -170,7 +170,7 @@ export function ZeroActivityPage() {
       {/* Scrollable table area */}
       <div className="flex-1 min-h-0 overflow-auto px-4 sm:px-6 pt-4">
         <div className="mx-auto max-w-[900px]">
-          <div className="zero-card overflow-hidden px-4 sm:px-7 pb-3">
+          <div className="zero-card overflow-hidden pb-3">
             <LogTable
               logs={logs}
               isLoading={isLoading}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -749,7 +749,7 @@ function ScheduleRunHistoryTab() {
 
       {/* Table */}
       <Card className="zero-card overflow-hidden">
-        <CardContent className="px-4 sm:px-7 pb-3 pt-0">
+        <CardContent className="pb-3 pt-0 px-0">
           <LogTable
             logs={logs}
             isLoading={isLoading}

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -587,7 +587,7 @@ export function ZeroSchedulePage() {
 
       <main className="flex-1 overflow-auto px-4 sm:px-6 pt-4 pb-8">
         <div className="mx-auto max-w-[900px]">
-          <div className="zero-card overflow-hidden px-4 sm:px-7 pb-3">
+          <div className="zero-card overflow-hidden pb-3">
             {isInitialLoading ? (
               scheduleViewMode === "calendar" ? (
                 <ScheduleCalendarSkeleton />


### PR DESCRIPTION
## Summary
- Move horizontal padding from card wrapper into table rows so hover background extends to card edges
- Affects Activity log table (`LogTable`) and Schedule list table (`ScheduleListView`)
- Previously hover highlight was flush with text; now it covers the full row width with padding

## Test plan
- [ ] Activity page: hover a log row — background should extend to card edges
- [ ] Schedule page (list view): hover a schedule row — same behavior
- [ ] Schedule detail page: history table rows should also have full-width hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)