### PR TITLE
feat(guest-init): use kernel root= boot arg instead of pivot_root

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -14,7 +14,7 @@ This workspace contains Rust crates for the vm0 sandbox runtime — VM orchestra
 | **vsock-host** | Host-side async vsock client (tokio) — connects to guest via Unix domain sockets |
 | **vsock-guest** | Guest-side vsock library — IPC over vsock/Unix sockets, embedded in guest-init as PID 2 |
 | **vsock-test** | Integration tests for vsock — real host + real guest over Unix sockets |
-| **guest-init** | Init process (PID 1) for Firecracker VMs — filesystem setup, mount/pivot_root, signal handling, forks vsock-guest |
+| **guest-init** | Init process (PID 1) for Firecracker VMs — virtual filesystem setup, env config, signal handling, forks vsock-guest |
 | **guest-agent** | Guest orchestrator — CLI execution, heartbeat, telemetry upload, and checkpoint creation inside the VM |
 | **guest-common** | Shared utilities for guest crates — logging macros, telemetry recording, environment accessors |
 | **guest-download** | Downloads and extracts storage archives — parallel downloads (4 concurrent), streaming extraction, retry logic |

--- a/crates/guest-init/Cargo.toml
+++ b/crates/guest-init/Cargo.toml
@@ -6,7 +6,7 @@ description = "Guest init process for Firecracker - filesystem setup, PID 1, and
 
 [dependencies]
 libc.workspace = true
-nix = { workspace = true, features = ["mount", "fs"] }
+nix = { workspace = true, features = ["mount"] }
 vsock-guest.workspace = true
 
 [lints]

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -1,70 +1,25 @@
 //! Filesystem initialization for VM boot.
 //!
-//! This module implements the filesystem initialization in Rust:
-//! 1. Mount ext4 rootfs (writable — COW handled by host dm-snapshot)
-//! 2. Perform pivot_root
-//! 3. Mount virtual filesystems (/proc, /sys)
+//! The kernel mounts the ext4 rootfs via `root=/dev/vda rw` boot arg and
+//! auto-mounts devtmpfs on `/dev` (`CONFIG_DEVTMPFS_MOUNT=y`).
+//!
+//! This module handles the remaining setup:
+//! 1. Mount virtual filesystems (/proc, /sys)
+//! 2. Configure TCP keepalive and environment variables
 
-use nix::mount::{MntFlags, MsFlags, mount, umount2};
-use nix::unistd::{chdir, pivot_root};
+use nix::mount::{MsFlags, mount};
 use std::fs;
-use std::io;
-use std::path::Path;
 
 const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
-/// Initialize filesystem and perform pivot_root.
+/// Initialize virtual filesystems and environment.
 ///
-/// This uses direct syscalls for filesystem initialization.
+/// The kernel has already mounted `/dev/vda` as root (`root=/dev/vda rw`)
+/// and devtmpfs on `/dev` (`CONFIG_DEVTMPFS_MOUNT=y`).
 pub fn init_filesystem() -> Result<(), InitError> {
     eprintln!("[guest-init] Starting filesystem initialization");
 
-    // 1. Mount ext4 rootfs from /dev/vda (writable — COW handled by host dm-snapshot)
-    mount(
-        Some("/dev/vda"),
-        "/mnt/root",
-        Some("ext4"),
-        MsFlags::empty(),
-        None::<&str>,
-    )
-    .map_err(|e| InitError::Mount {
-        target: "/mnt/root".into(),
-        source: e,
-    })?;
-    eprintln!("[guest-init] Mounted ext4 rootfs on /mnt/root");
-
-    // 2. Prepare and perform pivot_root
-    fs::create_dir_all("/mnt/root/oldroot").map_err(|e| InitError::Mkdir {
-        path: "/mnt/root/oldroot".into(),
-        source: e,
-    })?;
-
-    chdir(Path::new("/mnt/root")).map_err(|e| InitError::Chdir {
-        path: "/mnt/root".into(),
-        source: e,
-    })?;
-
-    pivot_root(".", "oldroot").map_err(InitError::PivotRoot)?;
-    eprintln!("[guest-init] pivot_root complete");
-
-    // 3. Move /dev from old root
-    mount(
-        Some("/oldroot/dev"),
-        "/dev",
-        None::<&str>,
-        MsFlags::MS_MOVE,
-        None::<&str>,
-    )
-    .map_err(|e| InitError::MoveMount {
-        from: "/oldroot/dev".into(),
-        to: "/dev".into(),
-        source: e,
-    })?;
-
-    // 4. Unmount old root (lazy unmount, ignore errors)
-    let _ = umount2("/oldroot", MntFlags::MNT_DETACH);
-
-    // 5. Mount virtual filesystems
+    // 1. Mount virtual filesystems
     mount(
         Some("proc"),
         "/proc",
@@ -104,7 +59,7 @@ pub fn init_filesystem() -> Result<(), InitError> {
     })?;
     eprintln!("[guest-init] Virtual filesystems mounted");
 
-    // 6. Set environment variables for the init process (root).
+    // 2. Set environment variables for the init process (root).
     // User commands run via `su - user` which resets env from /etc/passwd,
     // so these only affect root/sudo commands (e.g. clock fix).
     // SAFETY: We are the init process, no other threads are running yet
@@ -137,7 +92,7 @@ pub fn init_filesystem() -> Result<(), InitError> {
         eprintln!("[guest-init] Warning: failed to write /etc/profile.d/vm0-path.sh: {e}");
     }
 
-    // 7. Change to root home directory (init runs as root;
+    // 3. Change to root home directory (init runs as root;
     // `su - user` will cd to /home/user automatically)
     let _ = std::env::set_current_dir("/root");
 
@@ -148,24 +103,7 @@ pub fn init_filesystem() -> Result<(), InitError> {
 /// Errors that can occur during filesystem initialization
 #[derive(Debug)]
 pub enum InitError {
-    Mount {
-        target: String,
-        source: nix::Error,
-    },
-    Mkdir {
-        path: String,
-        source: io::Error,
-    },
-    Chdir {
-        path: String,
-        source: nix::Error,
-    },
-    PivotRoot(nix::Error),
-    MoveMount {
-        from: String,
-        to: String,
-        source: nix::Error,
-    },
+    Mount { target: String, source: nix::Error },
 }
 
 impl std::fmt::Display for InitError {
@@ -173,16 +111,6 @@ impl std::fmt::Display for InitError {
         match self {
             InitError::Mount { target, source } => {
                 write!(f, "Failed to mount {}: {}", target, source)
-            }
-            InitError::Mkdir { path, source } => {
-                write!(f, "Failed to create directory {}: {}", path, source)
-            }
-            InitError::Chdir { path, source } => {
-                write!(f, "Failed to chdir to {}: {}", path, source)
-            }
-            InitError::PivotRoot(e) => write!(f, "Failed to pivot_root: {}", e),
-            InitError::MoveMount { from, to, source } => {
-                write!(f, "Failed to move mount {} to {}: {}", from, to, source)
             }
         }
     }

--- a/crates/guest-init/src/main.rs
+++ b/crates/guest-init/src/main.rs
@@ -14,7 +14,7 @@
 //!   PID 2's children, not PID 1's), there is no ECHILD race condition.
 //!
 //! Startup sequence:
-//! 1. Initialize filesystem (mounts, pivot_root)
+//! 1. Initialize filesystem (mount /proc, /sys, set env vars)
 //! 2. Install PID 1 signal handlers (SIGTERM/SIGINT for shutdown, ignore SIGTTIN/SIGTTOU/SIGPIPE)
 //! 3. Fork child process
 //! 4. Child (PID 2): reset signal handlers to default, run vsock-guest

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -93,9 +93,6 @@ RUN userdel -r node 2>/dev/null || true \
 # NOTE: DNS configuration is handled in build-rootfs.sh after export
 # /etc/resolv.conf is read-only during Docker build
 
-# Create mount point for guest-init pivot_root
-RUN mkdir -p /mnt/root
-
 ENV LANG=C.UTF-8
 
 # Install Chromium and agent-browser CLI for browser automation.

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -199,7 +199,7 @@ mod tests {
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
         assert_eq!(
-            hash, "f4008ac95e23fecd35c28f99ade9729eed9ebe5c060c4a095fa86725cdeec05f",
+            hash, "0451cf520cbe0db285ff4383eae2e8050addc23cd1ec3f6e2f92fa7ce4c1d7a6",
             "snapshot hash changed — this invalidates all cached snapshots"
         );
     }

--- a/crates/sandbox-fc/src/network/guest.rs
+++ b/crates/sandbox-fc/src/network/guest.rs
@@ -45,7 +45,7 @@ pub fn generate_boot_args() -> String {
     format!(
         "console=ttyS0 reboot=k panic=1 pci=off nomodules random.trust_cpu=on \
          quiet loglevel=0 nokaslr audit=0 numa=off mitigations=off noresume \
-         init=/sbin/guest-init {}",
+         root=/dev/vda rootfstype=ext4 rw init=/sbin/guest-init {}",
         generate_guest_network_boot_args(),
     )
 }
@@ -60,6 +60,19 @@ mod tests {
         assert_eq!(
             args,
             "ip=192.168.241.2::192.168.241.1:255.255.255.248:vm0-guest:eth0:off"
+        );
+    }
+
+    #[test]
+    fn boot_args_contains_root_device() {
+        let args = generate_boot_args();
+        assert!(
+            args.contains("root=/dev/vda rootfstype=ext4 rw"),
+            "boot args must specify root device: {args}"
+        );
+        assert!(
+            args.contains("init=/sbin/guest-init"),
+            "boot args must specify init: {args}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Add `root=/dev/vda rootfstype=ext4 rw` to kernel boot args so the kernel mounts the rootfs directly
- Remove redundant mount + pivot_root + move-mount sequence from guest-init (~60 lines deleted)
- Remove `/mnt/root` directory creation from Dockerfile

## Context

After #6521 (dm-snapshot COW), `/dev/vda` is a writable ext4 block device. The kernel's `prepare_namespace()` already mounts it as root when `is_root_device: true`, making guest-init's manual mount + pivot_root redundant (a holdover from the old squashfs+overlayfs architecture).

With explicit `root=/dev/vda rootfstype=ext4 rw`, the kernel mounts ext4 directly and devtmpfs on `/dev` (`CONFIG_DEVTMPFS_MOUNT=y`). Guest-init is simplified from 7 steps to 3: mount /proc + /sys, set env vars, cd /root.

**Note:** Changing boot_args changes `config_hash()` → all cached snapshots are invalidated and must be rebuilt.

Closes #6512

## Test plan
- [x] `cargo check -p guest-init -p sandbox-fc` passes
- [x] 84 sandbox-fc + guest-init tests pass (including new `boot_args_contains_root_device`)
- [ ] CI crates workflow passes (build + clippy + test)
- [ ] E2E verification on metal machine: VM boots, vsock connects, agent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)