### PR TITLE
refactor(platform): unify card shadows and polish background color

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -71,9 +71,7 @@
 .zero-app {
   --zero-card-radius: 0.75rem;
   --zero-card-border: hsl(var(--border));
-  --zero-card-shadow:
-    0 1px 1px hsl(220 12% 20% / 0.02), 0 2px 8px hsl(220 12% 20% / 0.025),
-    0 8px 24px hsl(220 12% 20% / 0.02);
+  --zero-card-shadow: 0 1px 3px hsl(220 12% 20% / 0.08);
 }
 
 /* Search bar / text input (matches form inputs: white surface in light theme) */
@@ -207,6 +205,7 @@
   background-color: hsl(var(--card));
   border: 0.7px solid hsl(var(--gray-400));
   border-radius: var(--zero-card-radius);
+  box-shadow: var(--zero-card-shadow);
   transition: background-color 0.15s;
 }
 .zero-app .zero-card.cursor-pointer {
@@ -260,6 +259,7 @@
   background-color: hsl(var(--card));
   border: 0.7px solid hsl(var(--gray-400));
   border-radius: var(--zero-card-radius);
+  box-shadow: var(--zero-card-shadow);
 }
 
 /* Instructions/content card: uses .zero-card style */
@@ -267,6 +267,7 @@
   background-color: hsl(var(--card));
   border: 0.7px solid hsl(var(--gray-400));
   border-radius: var(--zero-card-radius);
+  box-shadow: var(--zero-card-shadow);
 }
 
 /* Instructions/feature cards: cool gray gradient */
@@ -304,10 +305,7 @@
   background-color: hsl(var(--card));
   border: 0.7px solid hsl(var(--gray-400));
   border-radius: var(--zero-card-radius);
-  box-shadow:
-    0 1px 2px hsl(var(--primary) / 0.04),
-    0 4px 12px hsl(220 20% 40% / 0.06),
-    0 12px 32px hsl(220 20% 40% / 0.04);
+  box-shadow: var(--zero-card-shadow);
 }
 
 /* Chat: outline buttons inside dialogue */
@@ -782,6 +780,7 @@ details[open] > summary > span:first-child {
   border: 0.7px solid hsl(var(--gray-400));
   border-radius: var(--zero-card-radius);
   background-color: hsl(var(--card));
+  box-shadow: var(--zero-card-shadow);
 }
 
 .zero-app .zero-doc-card-content {

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -245,24 +245,22 @@ function CreateTeammateButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       onClick={onClick}
-      className="flex flex-col rounded-[var(--zero-card-radius)] border border-dashed border-[hsl(var(--gray-400))] transition-colors hover:border-[hsl(var(--gray-400))] hover:bg-muted/30 group cursor-pointer text-left"
+      className="flex items-center gap-3 rounded-[var(--zero-card-radius)] border border-dashed border-[hsl(var(--gray-400))] px-4 py-4 transition-colors hover:bg-muted/30 group cursor-pointer text-left"
     >
-      <div className="flex items-center gap-3 px-4 py-3.5">
-        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors">
-          <IconPlus
-            size={18}
-            stroke={2}
-            className="text-foreground/50 group-hover:text-foreground transition-colors"
-          />
-        </span>
-        <span className="text-sm font-medium text-foreground/80 group-hover:text-foreground transition-colors">
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
+        <IconPlus
+          size={18}
+          stroke={2}
+          className="text-foreground/50 group-hover:text-foreground transition-colors"
+        />
+      </span>
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-foreground/80 group-hover:text-foreground transition-colors">
           Create teammate
-        </span>
-      </div>
-      <div className="border-t border-dashed border-[hsl(var(--gray-400))] px-4 py-2.5">
-        <span className="text-xs text-muted-foreground">
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5">
           Add a specialized agent to your team
-        </span>
+        </p>
       </div>
     </button>
   );

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -178,7 +178,7 @@
     /* ===================================
      * Semantic Colors (Light Theme)
      * =================================== */
-    --background: 216 5% 99.5%; /* very subtle cool gray tint */
+    --background: 214 20% 98.5%; /* subtle cool gray, lighter than gray-0 */
     --foreground: var(--gray-950); /* gray-950 */
 
     --card: var(--white); /* white */


### PR DESCRIPTION
## Summary
- Simplify card shadow to single-layer (`0 1px 3px, 8% opacity`) across all card variants
- Apply consistent `--zero-card-shadow` to `zero-card`, `zero-composer`, `zero-card-white`, `zero-card-rectangle`, `zero-doc-card`
- Adjust page background color to subtle cool gray (`98.5%` lightness, same hue as gray scale)
- Fix "Create teammate" button: single-row flex layout with aligned text

## Test plan
- [ ] Cards have subtle uniform shadow across all pages (chat, team, connectors, schedule, activity)
- [ ] Background is slightly off-white, lighter than sidebar
- [ ] "Create teammate" button text is aligned properly
- [ ] Dark mode still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)