### PR TITLE
fix(ansible): reset ssh connection after group membership change

### DIFF
--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -50,9 +50,17 @@
           - disk
         append: true
       become: true
+      register: group_change
 
     - name: Ensure /dev/kvm is accessible
       file:
         path: /dev/kvm
         mode: '0666'
       become: true
+
+    # When groups change, the current SSH session still has the old group list.
+    # Reset the connection so subsequent playbooks (deploy-runner) pick up the
+    # new membership (e.g. 'disk' group needed to open /dev/loopN).
+    - name: Reset SSH connection to pick up new group membership
+      meta: reset_connection
+      when: group_change.changed


### PR DESCRIPTION
## Summary
- Production deploy failed on `prod-3` with `Permission denied (os error 13)` when opening `/dev/loopN` during snapshot creation
- Root cause: `provision-runner.yml` adds user to `disk` group, but SSH `ControlPersist=3600s` reuses the same connection for `deploy-runner.yml`, so the new group membership is never picked up
- Fix: `meta: reset_connection` after group change forces a new SSH connection with updated groups

## Test plan
- [ ] Verify `meta: reset_connection` only triggers when `group_change.changed` is true
- [ ] Re-run production deploy and confirm snapshot creation succeeds on all hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)