### PR TITLE
refactor(sandbox): introduce sandbox runtime trait and internalize shared resources

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1634,7 +1634,6 @@ dependencies = [
  "ably-subscriber",
  "async-trait",
  "base64",
- "block-cow",
  "chrono",
  "clap",
  "flate2",

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 
 [dependencies]
 ably-subscriber = { workspace = true }
-block-cow = { workspace = true }
 sandbox = { workspace = true }
 sandbox-fc = { workspace = true }
 

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -3,8 +3,7 @@ use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use clap::Args;
-use sandbox::{ExecRequest, ExecResult, SandboxConfig, SandboxFactory};
-use sandbox_fc::FirecrackerFactory;
+use sandbox::{ExecRequest, ExecResult, SandboxConfig, SandboxFactory, SandboxRuntime};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -85,18 +84,19 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     let proxy_ms = t.elapsed().as_millis();
     info!(proxy_ms, port = mitm.port(), "proxy ready");
 
-    // 3. Factory init (with proxy port)
-    let fc_config =
-        runner_config.firecracker_config(&args.profile, &default_profile, &home, Some(mitm.port()));
+    // 3. Factory init (with proxy port) via sandbox runtime
+    let factory_config = runner_config.factory_config(&args.profile, &default_profile, &home);
 
     let t = Instant::now();
-    let base_cache = std::sync::Arc::new(std::sync::Mutex::new(block_cow::BaseLoopCache::new()));
-    let mut factory = FirecrackerFactory::new(fc_config, None, base_cache).await?;
-    factory.startup().await?;
+    let mut runtime = sandbox_fc::FirecrackerRuntime::new(sandbox::RuntimeConfig {
+        proxy_port: Some(mitm.port()),
+    })
+    .await?;
+    let mut factory = runtime.create_factory(factory_config).await?;
     let factory_ms = t.elapsed().as_millis();
     info!(factory_ms, "factory ready");
 
-    // 4. Create + run sandbox — always shutdown factory and proxy afterwards
+    // 4. Create + run sandbox — always shutdown factory and runtime afterwards
     let sandbox_config = SandboxConfig {
         id: Uuid::new_v4(),
         resources: sandbox::ResourceLimits {
@@ -104,9 +104,11 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
             memory_mb: default_profile.memory_mb,
         },
     };
-    let (result, timing) = run_sandbox(&args, &factory, &mitm, sandbox_config, is_snapshot).await;
+    let (result, timing) = run_sandbox(&args, &*factory, &mitm, sandbox_config, is_snapshot).await;
     let total_ms = total.elapsed().as_millis();
+    // Shutdown factory first (releases COW pool, base loop handle), then runtime.
     factory.shutdown().await;
+    runtime.shutdown().await;
     if let Err(e) = mitm.stop().await {
         warn!(error = %e, "proxy stop failed");
     }
@@ -166,7 +168,7 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
 /// Caller is responsible for `factory.shutdown()`.
 async fn run_sandbox(
     args: &BenchmarkArgs,
-    factory: &FirecrackerFactory,
+    factory: &dyn SandboxFactory,
     mitm: &proxy::MitmProxy,
     sandbox_config: SandboxConfig,
     is_snapshot: bool,

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -560,6 +560,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 }
 
 /// A sandbox factory shared across concurrent job executors.
+///
+/// Uses `Arc<Box<...>>` instead of `Arc<dyn ...>` because `Arc::try_unwrap`
+/// requires a sized type — `dyn SandboxFactory` is unsized, but `Box<dyn
+/// SandboxFactory>` is sized, allowing `try_unwrap` at shutdown.
 type SharedFactory = Arc<Box<dyn SandboxFactory>>;
 
 /// Per-job profile parameters resolved from the profile config.

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Args;
-use sandbox::SandboxFactory;
-use sandbox_fc::FirecrackerFactory;
+use sandbox::{SandboxFactory, SandboxRuntime};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -210,14 +209,12 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         }
     };
 
-    // Build per-profile netns pool (shared).
-    let netns_pool = sandbox_fc::NetnsPool::create(sandbox_fc::NetnsPoolConfig {
+    // Build sandbox runtime with shared resources (netns pool, base loop cache).
+    let runtime = sandbox_fc::FirecrackerRuntime::new(sandbox::RuntimeConfig {
         proxy_port: Some(mitm.port()),
     })
     .await
-    .map_err(|e| RunnerError::Internal(format!("netns pool: {e}")))?;
-    let shared_netns = Arc::new(tokio::sync::Mutex::new(netns_pool));
-    let shared_base_cache = Arc::new(std::sync::Mutex::new(block_cow::BaseLoopCache::new()));
+    .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;
 
     let mut status = StatusTracker::new(paths.status(), estimated_capacity);
     status.set_proxy_port(mitm.port()).await;
@@ -265,10 +262,8 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
         name,
         group: group_name,
         profiles: runner_config.profiles,
-        shared_netns,
-        shared_base_cache,
+        runtime,
         home,
-        proxy_port: mitm.port(),
         budget,
         status,
         mitm,
@@ -291,10 +286,8 @@ struct RunConfig {
     name: String,
     group: String,
     profiles: std::collections::BTreeMap<String, ProfileConfig>,
-    shared_netns: Arc<tokio::sync::Mutex<sandbox_fc::NetnsPool>>,
-    shared_base_cache: Arc<std::sync::Mutex<block_cow::BaseLoopCache>>,
+    runtime: sandbox_fc::FirecrackerRuntime,
     home: HomePaths,
-    proxy_port: u16,
     budget: Arc<ResourceBudget>,
     status: Arc<StatusTracker>,
     mitm: proxy::MitmProxy,
@@ -319,10 +312,8 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         name,
         group,
         profiles,
-        shared_netns,
-        shared_base_cache,
+        mut runtime,
         home,
-        proxy_port,
         budget,
         status,
         mut mitm,
@@ -338,37 +329,26 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         kmsg_handle,
     } = config;
 
-    // Build per-profile factories with shared netns pool.
-    let mut factories: BTreeMap<String, Arc<FirecrackerFactory>> = BTreeMap::new();
+    // Build per-profile factories via the sandbox runtime.
+    let mut factories: BTreeMap<String, (SharedFactory, bool)> = BTreeMap::new();
     for (profile_name, profile_config) in &profiles {
-        let fc_config = config::RunnerConfig::build_firecracker_config(
+        let factory_config = config::RunnerConfig::build_factory_config(
             &firecracker,
             &base_dir,
             profile_name,
             profile_config,
             &home,
-            Some(proxy_port),
         );
-        let factory_result = async {
-            let mut factory = FirecrackerFactory::new(
-                fc_config,
-                Some(Arc::clone(&shared_netns)),
-                Arc::clone(&shared_base_cache),
-            )
-            .await?;
-            factory.startup().await?;
-            Ok::<_, sandbox::SandboxError>(factory)
-        }
-        .await;
+        let use_snapshot = factory_config.snapshot.is_some();
+        let factory_result = runtime.create_factory(factory_config).await;
         let factory = match factory_result {
             Ok(f) => f,
             Err(e) => {
-                // Clean up already-started factories before propagating.
-                shutdown_factories(&mut factories, &shared_netns, &shared_base_cache).await;
+                shutdown_factories(&mut factories, &mut runtime).await;
                 return Err(e.into());
             }
         };
-        factories.insert(profile_name.clone(), Arc::new(factory));
+        factories.insert(profile_name.clone(), (Arc::new(factory), use_snapshot));
         info!(profile = %profile_name, "factory started");
     }
 
@@ -471,7 +451,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let job_vcpu = profile_config.vcpu;
                 let job_memory = profile_config.memory_mb;
                 // Look up factory for this profile.
-                let Some(factory) = factories.get(&profile_name) else {
+                let Some((factory, use_snapshot)) = factories.get(&profile_name) else {
                     warn!(run_id = %run_id, profile = %profile_name, "no factory for profile, skipping");
                     continue;
                 };
@@ -506,7 +486,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 let job_profile = JobProfile {
                     vcpu: job_vcpu,
                     memory_mb: job_memory,
-                    use_snapshot: factory.has_snapshot(),
+                    use_snapshot: *use_snapshot,
                     factory: Arc::clone(factory),
                     cancel: job_cancel,
                 };
@@ -562,7 +542,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     }
 
     info!("shutting down factories");
-    shutdown_factories(&mut factories, &shared_netns, &shared_base_cache).await;
+    shutdown_factories(&mut factories, &mut runtime).await;
 
     // Stop proxy after all jobs have drained and factory is shut down.
     if let Err(e) = mitm.stop().await {
@@ -579,44 +559,31 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     Ok(())
 }
 
+/// A sandbox factory shared across concurrent job executors.
+type SharedFactory = Arc<Box<dyn SandboxFactory>>;
+
 /// Per-job profile parameters resolved from the profile config.
 struct JobProfile {
     vcpu: u32,
     memory_mb: u32,
     use_snapshot: bool,
-    factory: Arc<FirecrackerFactory>,
+    factory: SharedFactory,
     cancel: CancellationToken,
 }
 
-/// Shut down all factories and clean up shared pools.
+/// Shut down all factories, then release shared runtime resources.
 async fn shutdown_factories(
-    factories: &mut BTreeMap<String, Arc<FirecrackerFactory>>,
-    shared_netns: &Arc<tokio::sync::Mutex<sandbox_fc::NetnsPool>>,
-    shared_base_cache: &Arc<std::sync::Mutex<block_cow::BaseLoopCache>>,
+    factories: &mut BTreeMap<String, (SharedFactory, bool)>,
+    runtime: &mut sandbox_fc::FirecrackerRuntime,
 ) {
-    for (name, factory) in std::mem::take(factories) {
+    for (name, (factory, _)) in std::mem::take(factories) {
         match Arc::try_unwrap(factory) {
             Ok(mut f) => f.shutdown().await,
             Err(_) => warn!(profile = %name, "factory still referenced at shutdown"),
         }
     }
-    // Clean up shared netns pool after all factories released their references.
-    // Cannot try_unwrap here because the caller still holds a reference;
-    // lock and clean up in-place instead.
-    let mut pool = shared_netns.lock().await;
-    if let Err(e) = pool.cleanup().await {
-        warn!(error = %e, "failed to cleanup shared netns pool");
-    }
-    drop(pool);
-
-    // Clean up base image pool — detach any remaining loop devices.
-    // Each factory.shutdown() releases its own reference, but if a factory
-    // was still referenced (Arc::try_unwrap failed), its base handle leaks.
-    // This is the safety net.
-    shared_base_cache
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .cleanup();
+    // Clean up shared resources (netns pool, base loop cache).
+    runtime.shutdown().await;
 }
 
 /// Spawn a job executor task.
@@ -657,7 +624,7 @@ fn spawn_job(
         // still reports completion and releases budget.
         let cancel = job_cancel.clone();
         let inner = tokio::spawn(async move {
-            executor::execute_job(factory.as_ref(), context, &exec_config, &params, cancel).await
+            executor::execute_job(&**factory, context, &exec_config, &params, cancel).await
         });
 
         let (exit_code, err) = match inner.await {

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -199,52 +199,50 @@ impl RunnerConfig {
         resolve(&mut self.firecracker.kernel);
     }
 
-    /// Build a `sandbox_fc::FirecrackerConfig` for a given profile.
+    /// Build a [`sandbox::FactoryConfig`] for a given profile.
     ///
     /// Resolves rootfs and snapshot paths from the profile's hashes
     /// using the standard content-addressed storage layout.
-    pub fn firecracker_config(
+    pub fn factory_config(
         &self,
         profile_name: &str,
         profile: &ProfileConfig,
         home: &HomePaths,
-        proxy_port: Option<u16>,
-    ) -> sandbox_fc::FirecrackerConfig {
-        Self::build_firecracker_config(
+    ) -> sandbox::FactoryConfig {
+        Self::build_factory_config(
             &self.firecracker,
             &self.base_dir,
             profile_name,
             profile,
             home,
-            proxy_port,
         )
     }
 
-    /// Build a `sandbox_fc::FirecrackerConfig` from components.
+    /// Build a [`sandbox::FactoryConfig`] from components.
     ///
-    /// Static variant of [`firecracker_config`](Self::firecracker_config) for
+    /// Static variant of [`factory_config`](Self::factory_config) for
     /// use after `RunnerConfig` has been destructured.
-    pub fn build_firecracker_config(
+    pub fn build_factory_config(
         firecracker: &FirecrackerConfig,
         base_dir: &Path,
         profile_name: &str,
         profile: &ProfileConfig,
         home: &HomePaths,
-        proxy_port: Option<u16>,
-    ) -> sandbox_fc::FirecrackerConfig {
+    ) -> sandbox::FactoryConfig {
         let rootfs_paths = RootfsPaths::new(home, &profile.rootfs_hash);
-        let snapshot = profile.snapshot_hash.as_ref().map(|hash| {
-            let snapshot_output =
-                sandbox_fc::SnapshotOutputPaths::new(home.snapshots_dir().join(hash));
-            snapshot_output.snapshot_config(hash)
-        });
-        sandbox_fc::FirecrackerConfig {
+        let snapshot = profile
+            .snapshot_hash
+            .as_ref()
+            .map(|hash| sandbox::SnapshotRef {
+                output_dir: home.snapshots_dir().join(hash),
+                hash: hash.clone(),
+            });
+        sandbox::FactoryConfig {
+            profile: profile_name.to_string(),
             binary_path: firecracker.binary.clone(),
             kernel_path: firecracker.kernel.clone(),
             rootfs_path: rootfs_paths.rootfs(),
             base_dir: base_dir.to_path_buf(),
-            profile: profile_name.to_string(),
-            proxy_port,
             snapshot,
         }
     }
@@ -626,7 +624,7 @@ profiles:
     }
 
     #[test]
-    fn firecracker_config_resolves_paths() {
+    fn factory_config_resolves_paths() {
         let dir = tempfile::tempdir().unwrap();
         let home = HomePaths::with_root(dir.path().to_path_buf());
 
@@ -645,7 +643,7 @@ profiles:
         };
 
         let profile = &config.profiles["vm0/default"];
-        let fc = config.firecracker_config("vm0/default", profile, &home, Some(8080));
+        let fc = config.factory_config("vm0/default", profile, &home);
 
         assert_eq!(fc.binary_path, dir.path().join("firecracker"));
         assert_eq!(fc.kernel_path, dir.path().join("vmlinux"));
@@ -654,7 +652,8 @@ profiles:
             home.rootfs_dir().join("abc123").join("rootfs.ext4")
         );
         assert_eq!(fc.profile, "vm0/default");
-        assert_eq!(fc.proxy_port, Some(8080));
-        assert!(fc.snapshot.is_some());
+        let snap = fc.snapshot.unwrap();
+        assert_eq!(snap.hash, "def456");
+        assert_eq!(snap.output_dir, home.snapshots_dir().join("def456"));
     }
 }

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -9,6 +9,7 @@ mod network;
 mod paths;
 mod prerequisites;
 mod process;
+mod runtime;
 mod sandbox;
 mod snapshot;
 
@@ -19,5 +20,6 @@ pub use network::{NetnsPool, NetnsPoolConfig};
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,
 };
+pub use runtime::FirecrackerRuntime;
 pub use sandbox::FirecrackerSandbox;
 pub use snapshot::{SnapshotCreateConfig, SnapshotError, create_snapshot};

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -101,7 +101,10 @@ impl SandboxRuntime for FirecrackerRuntime {
         // Clean up base image cache — detach any remaining loop devices.
         self.base_cache
             .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .unwrap_or_else(|e| {
+                warn!("base_cache mutex poisoned, recovering for cleanup");
+                e.into_inner()
+            })
             .cleanup();
 
         info!("runtime shutdown complete");

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tracing::{info, warn};
+
+use sandbox::{FactoryConfig, SandboxError, SandboxFactory, SandboxRuntime, SnapshotRef};
+
+use crate::config::{FirecrackerConfig, SnapshotConfig};
+use crate::factory::FirecrackerFactory;
+use crate::network::{NetnsPool, NetnsPoolConfig};
+use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
+
+/// Firecracker-backed sandbox runtime.
+///
+/// Manages shared resources ([`NetnsPool`], [`BaseLoopCache`](block_cow::BaseLoopCache))
+/// and creates [`FirecrackerFactory`] instances that share them.
+pub struct FirecrackerRuntime {
+    netns_pool: Arc<tokio::sync::Mutex<NetnsPool>>,
+    base_cache: Arc<std::sync::Mutex<block_cow::BaseLoopCache>>,
+    proxy_port: Option<u16>,
+}
+
+impl FirecrackerRuntime {
+    /// Create a new runtime with shared resources.
+    ///
+    /// This allocates a network namespace pool and an empty base loop cache.
+    /// All factories created via [`SandboxRuntime::create_factory`] share these
+    /// resources.
+    pub async fn new(config: sandbox::RuntimeConfig) -> Result<Self, SandboxError> {
+        let t = std::time::Instant::now();
+        let netns_pool = NetnsPool::create(NetnsPoolConfig {
+            proxy_port: config.proxy_port,
+        })
+        .await
+        .map_err(|e| SandboxError::CreationFailed(format!("netns pool: {e}")))?;
+        info!(
+            elapsed_ms = t.elapsed().as_millis() as u64,
+            "runtime netns pool created"
+        );
+
+        Ok(Self {
+            netns_pool: Arc::new(tokio::sync::Mutex::new(netns_pool)),
+            base_cache: Arc::new(std::sync::Mutex::new(block_cow::BaseLoopCache::new())),
+            proxy_port: config.proxy_port,
+        })
+    }
+
+    fn to_firecracker_config(&self, config: FactoryConfig) -> FirecrackerConfig {
+        let snapshot = config.snapshot.map(|s| Self::resolve_snapshot(&s));
+        FirecrackerConfig {
+            binary_path: config.binary_path,
+            kernel_path: config.kernel_path,
+            rootfs_path: config.rootfs_path,
+            base_dir: config.base_dir,
+            profile: config.profile,
+            proxy_port: self.proxy_port,
+            snapshot,
+        }
+    }
+
+    fn resolve_snapshot(snapshot_ref: &SnapshotRef) -> SnapshotConfig {
+        let output = SnapshotOutputPaths::new(snapshot_ref.output_dir.clone());
+        let work = SandboxPaths::new(output.work_dir());
+        let runtime = RuntimePaths::new();
+        let sock = SockPaths::new(runtime.sock_dir(&snapshot_ref.hash));
+        SnapshotConfig {
+            snapshot_path: output.snapshot(),
+            memory_path: output.memory(),
+            cow_path: output.cow(),
+            drive_bind_path: work.cow_device_bind(),
+            vsock_bind_dir: sock.vsock_dir(),
+        }
+    }
+}
+
+#[async_trait]
+impl SandboxRuntime for FirecrackerRuntime {
+    async fn create_factory(
+        &self,
+        config: FactoryConfig,
+    ) -> sandbox::Result<Box<dyn SandboxFactory>> {
+        let fc_config = self.to_firecracker_config(config);
+        let mut factory = FirecrackerFactory::new(
+            fc_config,
+            Some(Arc::clone(&self.netns_pool)),
+            Arc::clone(&self.base_cache),
+        )
+        .await?;
+        factory.startup().await?;
+        Ok(Box::new(factory))
+    }
+
+    async fn shutdown(&mut self) {
+        // Clean up shared netns pool.
+        let mut pool = self.netns_pool.lock().await;
+        if let Err(e) = pool.cleanup().await {
+            warn!(error = %e, "failed to cleanup shared netns pool");
+        }
+        drop(pool);
+
+        // Clean up base image cache — detach any remaining loop devices.
+        self.base_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .cleanup();
+
+        info!("runtime shutdown complete");
+    }
+}

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 pub struct ResourceLimits {
     pub cpu_count: u32,
     pub memory_mb: u32,
@@ -6,4 +8,35 @@ pub struct ResourceLimits {
 pub struct SandboxConfig {
     pub id: uuid::Uuid,
     pub resources: ResourceLimits,
+}
+
+/// Reference to a pre-built snapshot for fast VM boot.
+/// The backend resolves individual artifact paths from the output directory.
+pub struct SnapshotRef {
+    /// Directory containing snapshot artifacts (snapshot.bin, memory.bin, cow.img).
+    pub output_dir: PathBuf,
+    /// Content hash of the snapshot, used as an identifier for path derivation.
+    pub hash: String,
+}
+
+/// Configuration for creating a sandbox factory for a specific profile.
+pub struct FactoryConfig {
+    /// Profile name (e.g., "vm0/default").
+    pub profile: String,
+    /// Path to the sandbox backend binary (e.g., firecracker).
+    pub binary_path: PathBuf,
+    /// Path to the guest kernel image.
+    pub kernel_path: PathBuf,
+    /// Path to the root filesystem image.
+    pub rootfs_path: PathBuf,
+    /// Base directory for runtime data (workspaces, COW devices, etc.).
+    pub base_dir: PathBuf,
+    /// Snapshot to restore from. When set, VMs boot via snapshot restore.
+    pub snapshot: Option<SnapshotRef>,
+}
+
+/// Configuration for the sandbox runtime (shared resources).
+pub struct RuntimeConfig {
+    /// Proxy port for network traffic interception. Shared across all factories.
+    pub proxy_port: Option<u16>,
 }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -1,11 +1,13 @@
 mod config;
 mod error;
 mod factory;
+mod runtime;
 mod sandbox;
 mod types;
 
-pub use config::{ResourceLimits, SandboxConfig};
+pub use config::{FactoryConfig, ResourceLimits, RuntimeConfig, SandboxConfig, SnapshotRef};
 pub use error::{Result, SandboxError};
 pub use factory::SandboxFactory;
+pub use runtime::SandboxRuntime;
 pub use sandbox::Sandbox;
 pub use types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};

--- a/crates/sandbox/src/runtime.rs
+++ b/crates/sandbox/src/runtime.rs
@@ -1,0 +1,22 @@
+use async_trait::async_trait;
+
+use crate::config::FactoryConfig;
+use crate::error::Result;
+use crate::factory::SandboxFactory;
+
+/// Manages shared resources (e.g., loop device cache, network pools) and
+/// creates sandbox factories that share those resources.
+///
+/// All factories created by this runtime **must** be shut down before calling
+/// [`SandboxRuntime::shutdown`].
+#[async_trait]
+pub trait SandboxRuntime: Send + Sync {
+    /// Create a new sandbox factory for the given profile configuration.
+    ///
+    /// The returned factory is fully initialized (`startup()` has been called)
+    /// and ready to create sandboxes.
+    async fn create_factory(&self, config: FactoryConfig) -> Result<Box<dyn SandboxFactory>>;
+
+    /// Release shared resources (network pools, device caches).
+    async fn shutdown(&mut self);
+}


### PR DESCRIPTION
## Summary

- Introduce `SandboxRuntime` trait in `sandbox` crate with `FactoryConfig`, `SnapshotRef`, and `RuntimeConfig` types
- Implement `FirecrackerRuntime` in `sandbox-fc` that owns `BaseLoopCache` and `NetnsPool` internally
- Runner no longer depends on `block-cow` crate and no longer constructs `FirecrackerConfig`
- Factory stored as `Arc<Box<dyn SandboxFactory>>` (`SharedFactory` type alias) to support `Arc::try_unwrap` on trait objects

Closes #7120
Parent: #7119

## Test plan

- [x] All 357 existing tests pass (runner: 266, sandbox-fc: 91)
- [x] Clippy clean across sandbox, sandbox-fc, runner
- [ ] CI integration tests verify factory lifecycle on metal hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)