### PR TITLE
refactor(sandbox): introduce snapshot provider trait and decouple snapshot operations

### DIFF
--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -1,9 +1,7 @@
 use clap::Args;
+use sandbox::SnapshotProvider;
 use sha2::{Digest, Sha256};
 
-use sandbox_fc::SnapshotOutputPaths;
-
-use crate::config::SnapshotConfig;
 use crate::deps::{FIRECRACKER_VERSION, KERNEL_VERSION};
 use crate::error::{RunnerError, RunnerResult};
 use crate::lock;
@@ -28,37 +26,35 @@ pub struct SnapshotArgs {
     pub dry_run: bool,
 }
 
-/// Create a snapshot and return the complete snapshot path information.
-pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<(String, Option<SnapshotConfig>)> {
-    let snapshot_hash = compute_snapshot_hash(&args);
+/// Create a snapshot and return the snapshot hash.
+pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<String> {
+    let provider = sandbox_fc::FirecrackerSnapshotProvider;
+    let snapshot_hash = compute_snapshot_hash(&args, &provider);
     tracing::info!("snapshot hash: {snapshot_hash}");
     // Machine-readable output — do not change format without updating consumers
     println!("snapshot_hash={snapshot_hash}");
 
     if args.dry_run {
-        return Ok((snapshot_hash, None));
+        return Ok(snapshot_hash);
     }
 
     let paths = HomePaths::new()?;
     let output_dir = paths.snapshots_dir().join(&snapshot_hash);
-    let output = SnapshotOutputPaths::new(output_dir.clone());
 
-    if is_snapshot_complete(&output).await? {
+    if provider.is_complete(&output_dir).await? {
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
         touch_mtime(&output_dir);
-        let config = output.snapshot_config(&snapshot_hash).into();
-        return Ok((snapshot_hash, Some(config)));
+        return Ok(snapshot_hash);
     }
 
     // Acquire exclusive lock to prevent concurrent builds with the same hash.
     let _lock = lock::acquire(paths.snapshot_lock(&snapshot_hash)).await?;
 
     // Re-check after acquiring lock — another process may have completed the build.
-    if is_snapshot_complete(&output).await? {
+    if provider.is_complete(&output_dir).await? {
         tracing::info!("[OK] snapshot already exists: {}", output_dir.display());
         touch_mtime(&output_dir);
-        let config = output.snapshot_config(&snapshot_hash).into();
-        return Ok((snapshot_hash, Some(config)));
+        return Ok(snapshot_hash);
     }
 
     let rootfs_path = RootfsPaths::new(&paths, &args.rootfs_hash).rootfs();
@@ -72,7 +68,7 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<(String, Option<Sn
         )));
     }
 
-    let create_config = sandbox_fc::SnapshotCreateConfig {
+    let create_config = sandbox::SnapshotCreateConfig {
         id: snapshot_hash.clone(),
         binary_path: paths.firecracker_bin(FIRECRACKER_VERSION),
         kernel_path: paths.kernel_bin(FIRECRACKER_VERSION, KERNEL_VERSION),
@@ -82,53 +78,43 @@ pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<(String, Option<Sn
         memory_mb: args.memory_mb,
     };
 
-    let sc = sandbox_fc::create_snapshot(create_config).await?;
+    let output = provider.create_snapshot(create_config).await?;
 
     let (snapshot_sz, memory_sz, cow_sz) = tokio::join!(
-        file_sizes(&sc.snapshot_path),
-        file_sizes(&sc.memory_path),
-        file_sizes(&sc.cow_path),
+        file_sizes(&output.snapshot_path),
+        file_sizes(&output.memory_path),
+        file_sizes(&output.cow_path),
     );
     tracing::info!(
-        snapshot = %sc.snapshot_path.display(),
+        snapshot = %output.snapshot_path.display(),
         snapshot_logical = %snapshot_sz.0,
         snapshot_disk = %snapshot_sz.1,
-        memory = %sc.memory_path.display(),
+        memory = %output.memory_path.display(),
         memory_logical = %memory_sz.0,
         memory_disk = %memory_sz.1,
-        cow = %sc.cow_path.display(),
+        cow = %output.cow_path.display(),
         cow_logical = %cow_sz.0,
         cow_disk = %cow_sz.1,
         "snapshot creation complete"
     );
 
-    Ok((snapshot_hash, Some(sc.into())))
-}
-
-/// Check whether all expected snapshot outputs exist in the directory.
-async fn is_snapshot_complete(output: &SnapshotOutputPaths) -> RunnerResult<bool> {
-    for path in [output.snapshot(), output.memory(), output.cow()] {
-        let exists = tokio::fs::try_exists(&path)
-            .await
-            .map_err(|e| RunnerError::Internal(format!("check {}: {e}", path.display())))?;
-        if !exists {
-            return Ok(false);
-        }
-    }
-    Ok(true)
+    Ok(snapshot_hash)
 }
 
 /// Compute a composite cache key from all inputs that affect the snapshot.
 ///
 /// Inputs:
-///   - `sandbox_fc::config_hash()` — boot args, guest network config
+///   - `provider.config_hash()` — boot args, guest network config
 ///   - `rootfs_hash` — rootfs content (from `rootfs`)
 ///   - `FIRECRACKER_VERSION` / `KERNEL_VERSION` — binary versions
 ///   - `vcpu` / `memory_mb` — VM resource settings
 ///
 /// **Changing this function invalidates all cached snapshots.**
-pub(crate) fn compute_snapshot_hash(args: &SnapshotArgs) -> String {
-    let fc_config = sandbox_fc::config_hash();
+pub(crate) fn compute_snapshot_hash(
+    args: &SnapshotArgs,
+    provider: &dyn SnapshotProvider,
+) -> String {
+    let fc_config = provider.config_hash();
     let mut hasher = Sha256::new();
     // Cache version seed — bump SNAPSHOT_CACHE_VERSION to force invalidation.
     hasher.update(b"version:");
@@ -188,13 +174,14 @@ mod tests {
 
     #[test]
     fn snapshot_hash_is_stable() {
+        let provider = sandbox_fc::FirecrackerSnapshotProvider;
         let args = SnapshotArgs {
             rootfs_hash: "abc123".into(),
             vcpu: 2,
             memory_mb: 2048,
             dry_run: false,
         };
-        let hash = compute_snapshot_hash(&args);
+        let hash = compute_snapshot_hash(&args, &provider);
 
         // Changing this assertion means ALL existing cached snapshots are
         // invalidated.  Only update deliberately.
@@ -206,6 +193,7 @@ mod tests {
 
     #[test]
     fn different_inputs_produce_different_hashes() {
+        let provider = sandbox_fc::FirecrackerSnapshotProvider;
         let base = SnapshotArgs {
             rootfs_hash: "abc123".into(),
             vcpu: 2,
@@ -229,11 +217,20 @@ mod tests {
             ..base.clone()
         };
 
-        let base_hash = compute_snapshot_hash(&base);
-        assert_ne!(base_hash, compute_snapshot_hash(&different_rootfs));
-        assert_ne!(base_hash, compute_snapshot_hash(&different_vcpu));
-        assert_ne!(base_hash, compute_snapshot_hash(&different_memory));
+        let base_hash = compute_snapshot_hash(&base, &provider);
+        assert_ne!(
+            base_hash,
+            compute_snapshot_hash(&different_rootfs, &provider)
+        );
+        assert_ne!(base_hash, compute_snapshot_hash(&different_vcpu, &provider));
+        assert_ne!(
+            base_hash,
+            compute_snapshot_hash(&different_memory, &provider)
+        );
         // dry_run is not a build input — it must not change the hash.
-        assert_eq!(base_hash, compute_snapshot_hash(&different_dry_run));
+        assert_eq!(
+            base_hash,
+            compute_snapshot_hash(&different_dry_run, &provider)
+        );
     }
 }

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -40,27 +40,6 @@ pub struct ProfileConfig {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct SnapshotConfig {
-    pub snapshot_path: PathBuf,
-    pub memory_path: PathBuf,
-    pub cow_path: PathBuf,
-    pub drive_bind_path: PathBuf,
-    pub vsock_bind_dir: PathBuf,
-}
-
-impl From<sandbox_fc::SnapshotConfig> for SnapshotConfig {
-    fn from(sc: sandbox_fc::SnapshotConfig) -> Self {
-        Self {
-            snapshot_path: sc.snapshot_path,
-            memory_path: sc.memory_path,
-            cow_path: sc.cow_path,
-            drive_bind_path: sc.drive_bind_path,
-            vsock_bind_dir: sc.vsock_bind_dir,
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SandboxConfig {
     pub max_concurrent: usize,

--- a/crates/runner/src/error.rs
+++ b/crates/runner/src/error.rs
@@ -16,7 +16,7 @@ pub enum RunnerError {
     Internal(String),
 
     #[error("snapshot error: {0}")]
-    Snapshot(#[from] sandbox_fc::SnapshotError),
+    Snapshot(#[from] sandbox::SnapshotError),
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -23,5 +23,5 @@ pub use paths::{
 };
 pub use runtime::FirecrackerRuntime;
 pub use sandbox::FirecrackerSandbox;
-pub use snapshot::{SnapshotCreateConfig, SnapshotError, create_snapshot};
+pub use snapshot::{SnapshotError, create_snapshot};
 pub use snapshot_provider::FirecrackerSnapshotProvider;

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -12,6 +12,7 @@ mod process;
 mod runtime;
 mod sandbox;
 mod snapshot;
+mod snapshot_provider;
 
 pub use api::{ApiClient, ApiError, BalloonStatistics};
 pub use config::{FirecrackerConfig, SnapshotConfig};
@@ -23,3 +24,4 @@ pub use paths::{
 pub use runtime::FirecrackerRuntime;
 pub use sandbox::FirecrackerSandbox;
 pub use snapshot::{SnapshotCreateConfig, SnapshotError, create_snapshot};
+pub use snapshot_provider::FirecrackerSnapshotProvider;

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -1,10 +1,10 @@
-use std::path::PathBuf;
 use std::time::Duration;
 
 use tokio::io::AsyncBufReadExt;
 use tracing::info;
 
 use block_cow::{BaseLoopCache, CowDevice, CowDeviceConfig};
+use sandbox::SnapshotCreateConfig;
 
 use crate::api::{ApiClient, ApiError};
 use crate::command;
@@ -23,25 +23,6 @@ const API_READY_TIMEOUT: Duration = Duration::from_secs(5);
 const VSOCK_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 use crate::factory::{DESTROY_RETRIES, DESTROY_RETRY_DELAY};
-
-/// Configuration for creating a snapshot.
-#[derive(Debug, Clone)]
-pub struct SnapshotCreateConfig {
-    /// Unique identifier for this snapshot (used for runtime socket directory).
-    pub id: String,
-    /// Path to the Firecracker binary.
-    pub binary_path: PathBuf,
-    /// Path to the guest kernel image.
-    pub kernel_path: PathBuf,
-    /// Path to the root filesystem image.
-    pub rootfs_path: PathBuf,
-    /// Directory where snapshot artifacts will be written.
-    pub output_dir: PathBuf,
-    /// Number of vCPUs for the VM.
-    pub vcpu_count: u32,
-    /// Memory size in MiB for the VM.
-    pub memory_mb: u32,
-}
 
 /// Errors that can occur during snapshot creation.
 #[derive(Debug, thiserror::Error)]

--- a/crates/sandbox-fc/src/snapshot_provider.rs
+++ b/crates/sandbox-fc/src/snapshot_provider.rs
@@ -19,16 +19,7 @@ impl SnapshotProvider for FirecrackerSnapshotProvider {
         &self,
         config: SnapshotCreateConfig,
     ) -> Result<SnapshotOutput, SnapshotError> {
-        let fc_config = snapshot::SnapshotCreateConfig {
-            id: config.id,
-            binary_path: config.binary_path,
-            kernel_path: config.kernel_path,
-            rootfs_path: config.rootfs_path,
-            output_dir: config.output_dir,
-            vcpu_count: config.vcpu_count,
-            memory_mb: config.memory_mb,
-        };
-        let sc = snapshot::create_snapshot(fc_config)
+        let sc = snapshot::create_snapshot(config)
             .await
             .map_err(|e| match e {
                 snapshot::SnapshotError::Setup(msg) => SnapshotError::Setup(msg),

--- a/crates/sandbox-fc/src/snapshot_provider.rs
+++ b/crates/sandbox-fc/src/snapshot_provider.rs
@@ -1,0 +1,61 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+
+use sandbox::{SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider};
+
+use crate::factory::config_hash;
+use crate::paths::SnapshotOutputPaths;
+use crate::snapshot;
+
+/// Firecracker-backed snapshot provider.
+///
+/// Stateless — can be created with zero cost and used immediately.
+pub struct FirecrackerSnapshotProvider;
+
+#[async_trait]
+impl SnapshotProvider for FirecrackerSnapshotProvider {
+    async fn create_snapshot(
+        &self,
+        config: SnapshotCreateConfig,
+    ) -> Result<SnapshotOutput, SnapshotError> {
+        let fc_config = snapshot::SnapshotCreateConfig {
+            id: config.id,
+            binary_path: config.binary_path,
+            kernel_path: config.kernel_path,
+            rootfs_path: config.rootfs_path,
+            output_dir: config.output_dir,
+            vcpu_count: config.vcpu_count,
+            memory_mb: config.memory_mb,
+        };
+        let sc = snapshot::create_snapshot(fc_config)
+            .await
+            .map_err(|e| match e {
+                snapshot::SnapshotError::Setup(msg) => SnapshotError::Setup(msg),
+                snapshot::SnapshotError::Process(msg) => SnapshotError::Process(msg),
+                snapshot::SnapshotError::Api(api_err) => SnapshotError::Api(api_err.to_string()),
+                snapshot::SnapshotError::Vsock(msg) => SnapshotError::Vsock(msg),
+                snapshot::SnapshotError::Io(io_err) => SnapshotError::Io(io_err),
+            })?;
+        Ok(SnapshotOutput {
+            snapshot_path: sc.snapshot_path,
+            memory_path: sc.memory_path,
+            cow_path: sc.cow_path,
+        })
+    }
+
+    fn config_hash(&self) -> String {
+        config_hash()
+    }
+
+    async fn is_complete(&self, output_dir: &Path) -> Result<bool, SnapshotError> {
+        let output = SnapshotOutputPaths::new(output_dir.to_path_buf());
+        for path in [output.snapshot(), output.memory(), output.cow()] {
+            let exists = tokio::fs::try_exists(&path).await?;
+            if !exists {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+}

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -3,6 +3,7 @@ mod error;
 mod factory;
 mod runtime;
 mod sandbox;
+mod snapshot;
 mod types;
 
 pub use config::{FactoryConfig, ResourceLimits, RuntimeConfig, SandboxConfig, SnapshotRef};
@@ -10,4 +11,5 @@ pub use error::{Result, SandboxError};
 pub use factory::SandboxFactory;
 pub use runtime::SandboxRuntime;
 pub use sandbox::Sandbox;
+pub use snapshot::{SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider};
 pub use types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 
 /// Configuration for creating a snapshot.
+#[derive(Debug)]
 pub struct SnapshotCreateConfig {
     /// Unique identifier for this snapshot (used for runtime socket directory).
     pub id: String,
@@ -21,6 +22,7 @@ pub struct SnapshotCreateConfig {
 }
 
 /// Output paths from a successful snapshot creation.
+#[derive(Debug)]
 pub struct SnapshotOutput {
     /// Path to the snapshot state file.
     pub snapshot_path: PathBuf,

--- a/crates/sandbox/src/snapshot.rs
+++ b/crates/sandbox/src/snapshot.rs
@@ -1,0 +1,68 @@
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+/// Configuration for creating a snapshot.
+pub struct SnapshotCreateConfig {
+    /// Unique identifier for this snapshot (used for runtime socket directory).
+    pub id: String,
+    /// Path to the sandbox backend binary (e.g., firecracker).
+    pub binary_path: PathBuf,
+    /// Path to the guest kernel image.
+    pub kernel_path: PathBuf,
+    /// Path to the root filesystem image.
+    pub rootfs_path: PathBuf,
+    /// Directory where snapshot artifacts will be written.
+    pub output_dir: PathBuf,
+    /// Number of vCPUs for the VM.
+    pub vcpu_count: u32,
+    /// Memory size in MiB for the VM.
+    pub memory_mb: u32,
+}
+
+/// Output paths from a successful snapshot creation.
+pub struct SnapshotOutput {
+    /// Path to the snapshot state file.
+    pub snapshot_path: PathBuf,
+    /// Path to the memory dump file.
+    pub memory_path: PathBuf,
+    /// Path to the COW (copy-on-write) file.
+    pub cow_path: PathBuf,
+}
+
+/// Errors that can occur during snapshot operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    #[error("setup failed: {0}")]
+    Setup(String),
+    #[error("process failed: {0}")]
+    Process(String),
+    #[error("backend api error: {0}")]
+    Api(String),
+    #[error("vsock connection failed: {0}")]
+    Vsock(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Creates snapshots for fast sandbox boot.
+///
+/// This is a lightweight, stateless trait — it does not require a
+/// [`SandboxRuntime`](crate::SandboxRuntime) instance.
+#[async_trait]
+pub trait SnapshotProvider: Send + Sync {
+    /// Create a snapshot by booting a temporary VM, configuring it, and
+    /// capturing its state to the output directory.
+    async fn create_snapshot(
+        &self,
+        config: SnapshotCreateConfig,
+    ) -> Result<SnapshotOutput, SnapshotError>;
+
+    /// Content hash of all internal configuration that affects snapshot output.
+    ///
+    /// Used by the runner to build a composite cache key for snapshots.
+    fn config_hash(&self) -> String;
+
+    /// Check whether all expected snapshot artifacts exist in the output directory.
+    async fn is_complete(&self, output_dir: &Path) -> Result<bool, SnapshotError>;
+}


### PR DESCRIPTION
## Summary

- Introduce `SnapshotProvider` trait in `sandbox` crate with `SnapshotCreateConfig`, `SnapshotOutput`, and `SnapshotError` types
- Implement `FirecrackerSnapshotProvider` in `sandbox-fc` (stateless, wraps existing `create_snapshot()`)
- Runner `snapshot.rs` uses `&dyn SnapshotProvider` instead of direct `sandbox_fc::` calls
- Runner `error.rs` uses `sandbox::SnapshotError` instead of `sandbox_fc::SnapshotError`
- Remove dead `config::SnapshotConfig` type (return value was never consumed by any caller)
- `is_complete()` moved into the trait — provider knows what artifacts a complete snapshot contains

Closes #7121
Parent: #7119

## Test plan

- [x] All 357 existing tests pass (runner: 266, sandbox-fc: 91)
- [x] Snapshot hash stability test unchanged (same hash value)
- [x] Clippy clean across sandbox, sandbox-fc, runner
- [ ] CI integration tests verify snapshot creation on metal hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)