### PR TITLE
fix(platform): replace native scrollbar with overlay indicator in sidebar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -817,6 +817,69 @@ function TalkToSection({
   );
 }
 
+/** Overlay scroll area: hides native scrollbar, renders a custom thin indicator. */
+function OverlayScrollArea({
+  className,
+  children,
+  onScroll,
+  style,
+}: {
+  className?: string;
+  children: ReactNode;
+  onScroll?: (e: React.UIEvent<HTMLDivElement>) => void;
+  style?: React.CSSProperties;
+}) {
+  const [thumbStyle, setThumbStyle] = useState<{
+    top: number;
+    height: number;
+    visible: boolean;
+  }>({ top: 0, height: 0, visible: false });
+  const [hovering, setHovering] = useState(false);
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    onScroll?.(e);
+    const el = e.currentTarget;
+    const { scrollTop, scrollHeight, clientHeight } = el;
+    if (scrollHeight <= clientHeight) {
+      setThumbStyle((prev) => ({ ...prev, visible: false }));
+      return;
+    }
+    const ratio = clientHeight / scrollHeight;
+    const thumbH = Math.max(ratio * clientHeight, 24);
+    const maxTop = clientHeight - thumbH;
+    const top = (scrollTop / (scrollHeight - clientHeight)) * maxTop;
+    setThumbStyle({ top, height: thumbH, visible: true });
+  };
+
+  const showThumb = thumbStyle.visible && hovering;
+
+  return (
+    <div
+      className={`relative ${className ?? ""}`}
+      onMouseEnter={() => setHovering(true)}
+      onMouseLeave={() => setHovering(false)}
+    >
+      <div
+        className="h-full overflow-y-auto overflow-x-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        style={style}
+        onScroll={handleScroll}
+      >
+        {children}
+      </div>
+      <div
+        className="absolute -right-2 top-0 bottom-0 w-[6px] pointer-events-none"
+        aria-hidden="true"
+        style={{ opacity: showThumb ? 1 : 0, transition: "opacity 150ms" }}
+      >
+        <div
+          className="absolute right-0 w-[5px] rounded-full bg-foreground/15"
+          style={{ top: thumbStyle.top, height: thumbStyle.height }}
+        />
+      </div>
+    </div>
+  );
+}
+
 function nextTierInfo(tier: string): { label: string; img: string } | null {
   if (tier === "free") {
     return { label: "Pro", img: planProImg };
@@ -1127,9 +1190,9 @@ export function ZeroSidebar() {
           </div>
 
           {/* Scrollable: Pinned + Recent chats */}
-          <div
+          <OverlayScrollArea
+            className="flex-1 min-h-0 -mx-2 px-2 mt-2 pt-2"
             onScroll={(e) => setIsScrolled(e.currentTarget.scrollTop > 0)}
-            className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden -mx-2 px-2 mt-2 pt-2"
             style={{
               boxShadow: isScrolled
                 ? "0 -1px 0 0 hsl(var(--border) / 0.4)"
@@ -1165,7 +1228,7 @@ export function ZeroSidebar() {
               onNewChat={onNewChat}
               newChatDisabled={creatingNewSession}
             />
-          </div>
+          </OverlayScrollArea>
         </nav>
 
         {/* Upgrade card */}


### PR DESCRIPTION
## Summary
- Hide native scrollbar in sidebar chat list (no layout space consumed)
- Render a custom 5px overlay scrollbar indicator that floats over content
- Scrollbar appears on hover, fades out when mouse leaves
- Zero layout shift — icons and text stay perfectly aligned when scrolling

## Test plan
- [ ] Sidebar with many chats: scrollbar appears on hover, no content shift
- [ ] Scrollbar thumb position and size match scroll position
- [ ] Scrollbar fades in/out smoothly
- [ ] Works in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)