### PR TITLE
feat: emit warn-level log for local storage config overrides

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap/loggers.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/loggers.ts
@@ -18,13 +18,13 @@ export const setupLoggers$ = command(({ get }) => {
       // silence JSON parse errors because this data only for debugging
     }
     if (loggerNames.length > 0) {
-      L.infoGroup("Enable DEBUG for loggers:");
+      L.warnGroup("Enable DEBUG for loggers:");
       for (const name of loggerNames) {
-        L.info(name);
+        L.warn(name);
         const l = logger(name);
         l.level = Level.Debug;
       }
-      L.infoGroupEnd();
+      L.warnGroupEnd();
     }
   }
 });

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -31,14 +31,13 @@ export const featureSwitch$ = computed(async (get) => {
   try {
     const parsed = JSON.parse(override);
     if (parsed) {
-      L.debugGroup("Loaded feature switches from localStorage:");
       for (const key of Object.values(FeatureSwitchKey)) {
         const value = parsed[key];
         if (value !== undefined) {
           result[key] = Boolean(value);
+          L.warn(`Override feature switch: ${key} = ${Boolean(value)}`);
         }
       }
-      L.debugGroupEnd();
     }
   } catch (error) {
     throwIfAbort(error);
@@ -63,6 +62,5 @@ export const overrideFeatureSwitch$ = command(
     set(internalReload$, (v) => v + 1);
   },
 );
-L.debugGroup("Overriding feature switches:");
 
 export const setFeatureSwitchLocalStorage$ = set$;


### PR DESCRIPTION
## Summary

- Change `featureSwitch$` logging from debug-level group to flat `L.warn()` per overridden key, so developers can see which feature switches are being overridden via localStorage
- Swap `setupLoggers$` logging from info level (`infoGroup`/`info`/`infoGroupEnd`) to warn level (`warnGroup`/`warn`/`warnGroupEnd`)
- Remove orphaned `L.debugGroup("Overriding feature switches:");` at module scope in feature-switch.ts (bug: unconditional side effect that opens a console group never closed)

Closes #7144

## Test plan

- [x] Existing `feature-switch.test.ts` tests pass (3/3) -- tests check return values, not log output
- [x] Lint, type check, and knip all clean
- [ ] Manual: set `localStorage.setItem("featureSwitch", '{"dummy":false}')` in browser devtools and confirm yellow warn output appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)