### PR TITLE
fix(ci): add cancel runner cleanup to crates ci playbook

### DIFF
--- a/ansible/playbooks/cleanup-crates-runner.yml
+++ b/ansible/playbooks/cleanup-crates-runner.yml
@@ -67,6 +67,11 @@
       ignore_errors: true
       become: true
 
+    - name: Stop transient service cancel
+      command: systemctl stop vm0-runner-{{ job_ref }}-cancel.service
+      ignore_errors: true
+      become: true
+
     - name: Reload systemd daemon
       command: systemctl daemon-reload
       ignore_errors: true
@@ -79,10 +84,12 @@
       loop:
         - "{{ bin_dir }}"
         - "{{ base_dir }}/runners/{{ job_ref }}-bench"
+        - "{{ base_dir }}/runners/{{ job_ref }}-cancel"
         - "{{ base_dir }}/runners/{{ job_ref }}-exec"
         - "{{ base_dir }}/runners/{{ job_ref }}-balloon"
         - "{{ base_dir }}/runners/{{ job_ref }}-upgrade-a"
         - "{{ base_dir }}/runners/{{ job_ref }}-upgrade-b"
+        - "{{ base_dir }}/groups/vm0/cancel-{{ job_ref }}"
         - "{{ base_dir }}/groups/vm0/exec-{{ job_ref }}"
         - "{{ base_dir }}/groups/vm0/balloon-{{ job_ref }}"
         - "{{ base_dir }}/groups/vm0/upgrade-{{ job_ref }}"


### PR DESCRIPTION
## Summary

- Add `systemctl stop` for the `-cancel` transient service in the cleanup playbook
- Add `runners/{{ job_ref }}-cancel` directory removal
- Add `groups/vm0/cancel-{{ job_ref }}` directory removal

The `runner-cancel` CI test was the only test whose resources were not covered by the cleanup playbook, causing `pr-XXXX-test-cancel` directories to accumulate on metal hosts (30+ stale dirs found on dev-1/dev-2).

## Test plan

- [x] Verified stale `-test-cancel` dirs exist on dev-1 and dev-2 (manually cleaned)
- [x] Cross-checked all CI test suffixes against playbook cleanup list

🤖 Generated with [Claude Code](https://claude.com/claude-code)