### PR TITLE
refactor: extract zero-runs writes from infra layer to zero platform layer

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/route.ts
@@ -3,7 +3,7 @@ import { runsQueueContract, orgTierSchema } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { getRunQueueStatus } from "../../../../../src/lib/run/run-queue-service";
+import { getRunQueueStatus } from "../../../../../src/lib/zero/zero-queue-service";
 
 const router = tsr.router(runsQueueContract, {
   getQueue: async ({ headers }, { request }) => {

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -231,7 +231,6 @@ const router = tsr.router(runsMainContract, {
         artifactVersion: body.artifactVersion,
         memoryName: body.memoryName,
         volumeVersions: body.volumeVersions,
-        triggerSource: body.triggerSource ?? "cli",
         debugNoMockClaude: body.debugNoMockClaude,
         modelProvider: body.modelProvider,
         checkEnv: body.checkEnv,

--- a/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
+++ b/turbo/apps/web/app/api/telegram/webhook/__tests__/commands.test.ts
@@ -18,7 +18,7 @@ import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../src/mocks/server";
 import { http } from "../../../../../src/__tests__/msw";
 import { POST } from "../[installationId]/route";
-import * as runModule from "../../../../../src/lib/run";
+import * as zeroRunModule from "../../../../../src/lib/zero/zero-run-service";
 
 // Mock Next.js after() to execute synchronously
 const afterPromises: Promise<unknown>[] = [];
@@ -544,7 +544,7 @@ describe("Telegram bot commands", () => {
       const editMsg = telegramEditMessageText();
       server.use(sendMsg.handler, editMsg.handler);
 
-      vi.spyOn(runModule, "startRun").mockResolvedValue({
+      vi.spyOn(zeroRunModule, "createZeroRun").mockResolvedValue({
         runId: "mock-run-id",
         status: "queued",
         createdAt: new Date(),
@@ -579,7 +579,7 @@ describe("Telegram bot commands", () => {
       const editMsg = telegramEditMessageText();
       server.use(sendMsg.handler, editMsg.handler);
 
-      vi.spyOn(runModule, "startRun").mockResolvedValue({
+      vi.spyOn(zeroRunModule, "createZeroRun").mockResolvedValue({
         runId: "mock-run-id",
         status: "queued",
         createdAt: new Date(),

--- a/turbo/apps/web/app/api/zero/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/route.ts
@@ -10,7 +10,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { getRunQueueStatus } from "../../../../../src/lib/run/run-queue-service";
+import { getRunQueueStatus } from "../../../../../src/lib/zero/zero-queue-service";
 
 const router = tsr.router(zeroRunsQueueContract, {
   getQueue: async ({ headers }, { request }) => {

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -15,7 +15,6 @@ import {
   createTestOrgModelProvider,
   insertStalePendingRun,
   findTestRunRecord,
-  findTestZeroRun,
   findTestRunCallbacks,
   findTestStorage,
   findTestRunnerJobEntry,
@@ -150,14 +149,6 @@ describe("createRun()", () => {
       const run = await findTestRunRecord(result.runId);
 
       expect(run!.secretNames).toEqual(["API_KEY", "DB_PASS"]);
-    });
-
-    it("should set null scheduleId when not provided", async () => {
-      const result = await createRun(baseParams());
-
-      const zeroRun = await findTestZeroRun(result.runId);
-
-      expect(zeroRun!.scheduleId).toBeNull();
     });
   });
 

--- a/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
@@ -7,7 +7,6 @@ import {
 import {
   createTestCompose,
   findTestRunRecord,
-  findTestZeroRun,
   findTestQueueEntry,
   markRunningRunsAsCompleted,
   expireQueueEntry,
@@ -70,22 +69,6 @@ describe("run-queue-service", () => {
       expect(queueEntry!.orgId).toBe(user.orgId);
       expect(queueEntry!.encryptedParams).toBeTruthy();
       expect(queueEntry!.expiresAt).toBeInstanceOf(Date);
-    });
-
-    it("should persist triggerSource on the zero_runs record", async () => {
-      const result = await enqueueRun(
-        baseParams({ prompt: "Web run", triggerSource: "web" }),
-      );
-
-      const zeroRun = await findTestZeroRun(result.runId);
-      expect(zeroRun!.triggerSource).toBe("web");
-    });
-
-    it("should default triggerSource to cli when not provided", async () => {
-      const result = await enqueueRun(baseParams({ prompt: "No source" }));
-
-      const zeroRun = await findTestZeroRun(result.runId);
-      expect(zeroRun!.triggerSource).toBe("cli");
     });
 
     it("should store encrypted params that can be decrypted", async () => {

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -1,45 +1,20 @@
-import {
-  eq,
-  lt,
-  and,
-  or,
-  count,
-  gt,
-  sql,
-  inArray,
-  asc,
-  desc,
-  isNotNull,
-  avg,
-} from "drizzle-orm";
+import { eq, lt, and, or, count, gt, sql, inArray } from "drizzle-orm";
 import { agentRuns } from "../../db/schema/agent-run";
-import { zeroRuns } from "../../db/schema/zero-run";
 import { transitionRunStatus } from "./run-status";
 import { agentRunQueue } from "../../db/schema/agent-run-queue";
 import { orgMetadata } from "../../db/schema/org-metadata";
-import {
-  agentComposeVersions,
-  agentComposes,
-} from "../../db/schema/agent-compose";
-import { zeroAgents } from "../../db/schema/zero-agent";
+import { modelProviders } from "../../db/schema/model-provider";
 import { env } from "../../env";
 import { logger } from "../logger";
 import { isConcurrentRunLimit, insufficientCredits } from "../errors";
-import { modelProviders } from "../../db/schema/model-provider";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import {
   encryptSecretsMap,
   decryptSecretsMap,
 } from "../crypto/secrets-encryption";
-import {
-  PENDING_RUN_TTL_MS,
-  checkRunConcurrencyLimit,
-  getEffectiveConcurrencyLimit,
-} from "./run-service";
-
-import { getCachedUser } from "../auth/user-cache-service";
+import { PENDING_RUN_TTL_MS, checkRunConcurrencyLimit } from "./run-service";
 import type { CreateRunParams, CreateRunResult } from "./run-service";
-import type { OrgTier, QueueResponse, TriggerSource } from "@vm0/core";
+import type { OrgTier } from "@vm0/core";
 
 const log = logger("service:run-queue");
 
@@ -104,12 +79,6 @@ export async function enqueueRun(
     if (!inserted) {
       throw new Error("Failed to create queued run record");
     }
-
-    await tx.insert(zeroRuns).values({
-      id: inserted.id,
-      triggerSource: params.triggerSource ?? "cli",
-      scheduleId: params.scheduleId ?? null,
-    });
 
     await tx.insert(agentRunQueue).values({
       runId: inserted.id,
@@ -446,184 +415,4 @@ async function markQueuedRunFailed(
     },
     ["queued", "pending"],
   );
-}
-
-const RECENT_RUNS_FOR_ETA = 20;
-const PROMPT_TRUNCATE_LENGTH = 200;
-
-/**
- * Get run queue status for an org, including concurrency info,
- * queued/running entries, and estimated time per run.
- *
- * Privacy filtering: non-owners see nullified personal fields.
- */
-export async function getRunQueueStatus(
-  userId: string,
-  orgId: string,
-  orgTier: OrgTier,
-): Promise<QueueResponse> {
-  const db = globalThis.services.db;
-  const limit = getEffectiveConcurrencyLimit(orgTier);
-
-  // Count active runs (same logic as checkRunConcurrencyLimit)
-  const staleThreshold = new Date(Date.now() - PENDING_RUN_TTL_MS);
-  const [activeResult] = await db
-    .select({ count: count() })
-    .from(agentRuns)
-    .where(
-      and(
-        eq(agentRuns.orgId, orgId),
-        or(
-          eq(agentRuns.status, "running"),
-          and(
-            eq(agentRuns.status, "pending"),
-            gt(agentRuns.createdAt, staleThreshold),
-          ),
-        ),
-      ),
-    );
-  const active = Number(activeResult?.count ?? 0);
-
-  // Fetch queued runs in FIFO order (with extra fields for owner details)
-  const queuedRuns = await db
-    .select({
-      id: agentRuns.id,
-      runUserId: agentRuns.userId,
-      createdAt: agentRuns.createdAt,
-      agentName: agentComposes.name,
-      agentDisplayName: zeroAgents.displayName,
-      prompt: agentRuns.prompt,
-      triggerSource: zeroRuns.triggerSource,
-      continuedFromSessionId: agentRuns.continuedFromSessionId,
-    })
-    .from(agentRuns)
-    .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
-    .leftJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .leftJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
-    )
-    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
-    .where(and(eq(agentRuns.orgId, orgId), eq(agentRuns.status, "queued")))
-    .orderBy(asc(agentRuns.createdAt));
-
-  // Fetch running tasks
-  const runningRuns = await db
-    .select({
-      id: agentRuns.id,
-      runUserId: agentRuns.userId,
-      startedAt: agentRuns.startedAt,
-      agentName: agentComposes.name,
-      agentDisplayName: zeroAgents.displayName,
-    })
-    .from(agentRuns)
-    .leftJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .leftJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
-    )
-    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
-    .where(and(eq(agentRuns.orgId, orgId), eq(agentRuns.status, "running")))
-    .orderBy(asc(agentRuns.startedAt));
-
-  // Calculate estimated time per run from recent completed runs
-  const recentRuns = db
-    .select({
-      durationMs:
-        sql<number>`EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000`.as(
-          "duration_ms",
-        ),
-    })
-    .from(agentRuns)
-    .where(
-      and(
-        eq(agentRuns.orgId, orgId),
-        eq(agentRuns.status, "completed"),
-        isNotNull(agentRuns.completedAt),
-        isNotNull(agentRuns.startedAt),
-      ),
-    )
-    .orderBy(desc(agentRuns.completedAt))
-    .limit(RECENT_RUNS_FOR_ETA)
-    .as("recent_runs");
-  const [etaResult] = await db
-    .select({
-      avgMs: avg(recentRuns.durationMs),
-    })
-    .from(recentRuns);
-  const estimatedTimePerRun = etaResult?.avgMs
-    ? Math.round(Number(etaResult.avgMs))
-    : null;
-
-  // Resolve user emails in parallel (for both queued and running)
-  const allUserIds = [
-    ...new Set([
-      ...queuedRuns.map((r) => r.runUserId),
-      ...runningRuns.map((r) => r.runUserId),
-    ]),
-  ];
-  const userMap = new Map<string, string>();
-  await Promise.all(
-    allUserIds.map(async (uid) => {
-      const user = await getCachedUser(uid);
-      userMap.set(uid, user.email);
-    }),
-  );
-
-  // Build queue response with privacy filtering
-  const queue = queuedRuns.map((run, index) => {
-    const isOwner = run.runUserId === userId;
-    return {
-      position: index + 1,
-      agentName: isOwner ? (run.agentName ?? "unknown") : null,
-      agentDisplayName: isOwner ? (run.agentDisplayName ?? null) : null,
-      userEmail: isOwner ? (userMap.get(run.runUserId) ?? "unknown") : null,
-      createdAt: run.createdAt.toISOString(),
-      isOwner,
-      runId: isOwner ? run.id : null,
-      prompt: isOwner
-        ? run.prompt.length > PROMPT_TRUNCATE_LENGTH
-          ? run.prompt.slice(0, PROMPT_TRUNCATE_LENGTH) + "..."
-          : run.prompt
-        : null,
-      triggerSource: isOwner
-        ? ((run.triggerSource ?? "cli") as TriggerSource)
-        : null,
-      sessionLink:
-        isOwner && run.continuedFromSessionId
-          ? `/chat/${run.continuedFromSessionId}`
-          : null,
-    };
-  });
-
-  // Build running tasks response with privacy filtering
-  const runningTasks = runningRuns.map((run) => {
-    const isOwner = run.runUserId === userId;
-    return {
-      runId: isOwner ? run.id : null,
-      agentName: run.agentName ?? "unknown",
-      agentDisplayName: run.agentDisplayName ?? null,
-      userEmail: userMap.get(run.runUserId) ?? "unknown",
-      startedAt: run.startedAt?.toISOString() ?? null,
-      isOwner,
-    };
-  });
-
-  return {
-    concurrency: {
-      tier: orgTier,
-      limit,
-      active,
-      available: limit === 0 ? -1 : Math.max(0, limit - active),
-    },
-    queue,
-    runningTasks,
-    estimatedTimePerRun,
-  };
 }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -2,7 +2,6 @@ import { eq, and, count, gt, or, sql } from "drizzle-orm";
 import { env } from "../../env";
 import { checkpoints } from "../../db/schema/checkpoint";
 import { agentRuns } from "../../db/schema/agent-run";
-import { zeroRuns } from "../../db/schema/zero-run";
 import { transitionRunStatus, dispatchTerminalSideEffects } from "./run-status";
 import {
   agentComposeVersions,
@@ -46,7 +45,6 @@ import { encryptSecretValue } from "../crypto/secrets-encryption";
 import {
   type OrgTier,
   type RunStatus,
-  type TriggerSource,
   type GetRunResponse,
   type FirewallPolicies,
   orgTierSchema,
@@ -460,12 +458,10 @@ export interface CreateRunParams {
   artifactVersion?: string;
   memoryName?: string;
   volumeVersions?: Record<string, string>;
-  scheduleId?: string;
   callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
   resumedFromCheckpointId?: string;
   agentName?: string;
   modelProvider?: string;
-  triggerSource?: TriggerSource;
   debugNoMockClaude?: boolean;
   checkEnv?: boolean;
   // Caller-resolved org context for variable/storage resolution.
@@ -517,10 +513,8 @@ export interface StartRunParams {
   artifactVersion?: string;
   memoryName?: string;
   volumeVersions?: Record<string, string>;
-  scheduleId?: string;
   callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
   modelProvider?: string;
-  triggerSource?: TriggerSource;
   debugNoMockClaude?: boolean;
   checkEnv?: boolean;
   firewallPolicies?: FirewallPolicies;
@@ -1087,12 +1081,10 @@ export async function startRun(
     artifactVersion: params.artifactVersion,
     memoryName: params.memoryName,
     volumeVersions: params.volumeVersions,
-    scheduleId: params.scheduleId,
     callbacks: params.callbacks,
     resumedFromCheckpointId: params.checkpointId,
     agentName: resolved.agentName,
     modelProvider: params.modelProvider,
-    triggerSource: params.triggerSource,
     debugNoMockClaude: params.debugNoMockClaude,
     checkEnv: params.checkEnv,
     firewallPolicies: params.firewallPolicies,
@@ -1207,12 +1199,6 @@ export async function createRun(
       if (!newRun) {
         throw new Error("Failed to create run record");
       }
-
-      await tx.insert(zeroRuns).values({
-        id: newRun.id,
-        triggerSource: params.triggerSource ?? "cli",
-        scheduleId: params.scheduleId ?? null,
-      });
 
       return newRun;
     });

--- a/turbo/apps/web/src/lib/zero/zero-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-queue-service.ts
@@ -1,0 +1,208 @@
+import {
+  eq,
+  and,
+  count,
+  gt,
+  or,
+  sql,
+  asc,
+  desc,
+  isNotNull,
+  avg,
+} from "drizzle-orm";
+import { agentRuns } from "../../db/schema/agent-run";
+import { zeroRuns } from "../../db/schema/zero-run";
+import {
+  agentComposeVersions,
+  agentComposes,
+} from "../../db/schema/agent-compose";
+import { zeroAgents } from "../../db/schema/zero-agent";
+import { getCachedUser } from "../auth/user-cache-service";
+import {
+  PENDING_RUN_TTL_MS,
+  getEffectiveConcurrencyLimit,
+} from "../run/run-service";
+import type { OrgTier, QueueResponse, TriggerSource } from "@vm0/core";
+
+const RECENT_RUNS_FOR_ETA = 20;
+const PROMPT_TRUNCATE_LENGTH = 200;
+
+/**
+ * Get run queue status for an org, including concurrency info,
+ * queued/running entries, and estimated time per run.
+ *
+ * Privacy filtering: non-owners see nullified personal fields.
+ *
+ * This is a Zero-layer concern because it joins zero_runs and zero_agents
+ * to enrich queue entries with triggerSource and agent display names.
+ */
+export async function getRunQueueStatus(
+  userId: string,
+  orgId: string,
+  orgTier: OrgTier,
+): Promise<QueueResponse> {
+  const db = globalThis.services.db;
+  const limit = getEffectiveConcurrencyLimit(orgTier);
+
+  // Count active runs (same logic as checkRunConcurrencyLimit)
+  const staleThreshold = new Date(Date.now() - PENDING_RUN_TTL_MS);
+  const [activeResult] = await db
+    .select({ count: count() })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.orgId, orgId),
+        or(
+          eq(agentRuns.status, "running"),
+          and(
+            eq(agentRuns.status, "pending"),
+            gt(agentRuns.createdAt, staleThreshold),
+          ),
+        ),
+      ),
+    );
+  const active = Number(activeResult?.count ?? 0);
+
+  // Fetch queued runs in FIFO order (with extra fields for owner details)
+  const queuedRuns = await db
+    .select({
+      id: agentRuns.id,
+      runUserId: agentRuns.userId,
+      createdAt: agentRuns.createdAt,
+      agentName: agentComposes.name,
+      agentDisplayName: zeroAgents.displayName,
+      prompt: agentRuns.prompt,
+      triggerSource: zeroRuns.triggerSource,
+      continuedFromSessionId: agentRuns.continuedFromSessionId,
+    })
+    .from(agentRuns)
+    .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .leftJoin(
+      agentComposes,
+      eq(agentComposeVersions.composeId, agentComposes.id),
+    )
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .where(and(eq(agentRuns.orgId, orgId), eq(agentRuns.status, "queued")))
+    .orderBy(asc(agentRuns.createdAt));
+
+  // Fetch running tasks
+  const runningRuns = await db
+    .select({
+      id: agentRuns.id,
+      runUserId: agentRuns.userId,
+      startedAt: agentRuns.startedAt,
+      agentName: agentComposes.name,
+      agentDisplayName: zeroAgents.displayName,
+    })
+    .from(agentRuns)
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .leftJoin(
+      agentComposes,
+      eq(agentComposeVersions.composeId, agentComposes.id),
+    )
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .where(and(eq(agentRuns.orgId, orgId), eq(agentRuns.status, "running")))
+    .orderBy(asc(agentRuns.startedAt));
+
+  // Calculate estimated time per run from recent completed runs
+  const recentRuns = db
+    .select({
+      durationMs:
+        sql<number>`EXTRACT(EPOCH FROM (${agentRuns.completedAt} - ${agentRuns.startedAt})) * 1000`.as(
+          "duration_ms",
+        ),
+    })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.orgId, orgId),
+        eq(agentRuns.status, "completed"),
+        isNotNull(agentRuns.completedAt),
+        isNotNull(agentRuns.startedAt),
+      ),
+    )
+    .orderBy(desc(agentRuns.completedAt))
+    .limit(RECENT_RUNS_FOR_ETA)
+    .as("recent_runs");
+  const [etaResult] = await db
+    .select({
+      avgMs: avg(recentRuns.durationMs),
+    })
+    .from(recentRuns);
+  const estimatedTimePerRun = etaResult?.avgMs
+    ? Math.round(Number(etaResult.avgMs))
+    : null;
+
+  // Resolve user emails in parallel (for both queued and running)
+  const allUserIds = [
+    ...new Set([
+      ...queuedRuns.map((r) => r.runUserId),
+      ...runningRuns.map((r) => r.runUserId),
+    ]),
+  ];
+  const userMap = new Map<string, string>();
+  await Promise.all(
+    allUserIds.map(async (uid) => {
+      const user = await getCachedUser(uid);
+      userMap.set(uid, user.email);
+    }),
+  );
+
+  // Build queue response with privacy filtering
+  const queue = queuedRuns.map((run, index) => {
+    const isOwner = run.runUserId === userId;
+    return {
+      position: index + 1,
+      agentName: isOwner ? (run.agentName ?? "unknown") : null,
+      agentDisplayName: isOwner ? (run.agentDisplayName ?? null) : null,
+      userEmail: isOwner ? (userMap.get(run.runUserId) ?? "unknown") : null,
+      createdAt: run.createdAt.toISOString(),
+      isOwner,
+      runId: isOwner ? run.id : null,
+      prompt: isOwner
+        ? run.prompt.length > PROMPT_TRUNCATE_LENGTH
+          ? run.prompt.slice(0, PROMPT_TRUNCATE_LENGTH) + "..."
+          : run.prompt
+        : null,
+      triggerSource: isOwner
+        ? ((run.triggerSource ?? "cli") as TriggerSource)
+        : null,
+      sessionLink:
+        isOwner && run.continuedFromSessionId
+          ? `/chat/${run.continuedFromSessionId}`
+          : null,
+    };
+  });
+
+  // Build running tasks response with privacy filtering
+  const runningTasks = runningRuns.map((run) => {
+    const isOwner = run.runUserId === userId;
+    return {
+      runId: isOwner ? run.id : null,
+      agentName: run.agentName ?? "unknown",
+      agentDisplayName: run.agentDisplayName ?? null,
+      userEmail: userMap.get(run.runUserId) ?? "unknown",
+      startedAt: run.startedAt?.toISOString() ?? null,
+      isOwner,
+    };
+  });
+
+  return {
+    concurrency: {
+      tier: orgTier,
+      limit,
+      active,
+      available: limit === 0 ? -1 : Math.max(0, limit - active),
+    },
+    queue,
+    runningTasks,
+    estimatedTimePerRun,
+  };
+}

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -8,6 +8,7 @@ import {
 import { formatAgentIdentityPrompt } from "../agent-identity";
 import type { CallbackPayload } from "../callback/callback-payloads";
 import { zeroAgents } from "../../db/schema/zero-agent";
+import { zeroRuns } from "../../db/schema/zero-run";
 
 /**
  * Parameters accepted by createZeroRun().
@@ -74,16 +75,14 @@ export async function createZeroRun(
     ? `${agentPrompt}\n\n${appendSystemPrompt}`
     : agentPrompt;
 
-  return startRun({
+  const result = await startRun({
     userId: params.userId,
     prompt: params.prompt,
     composeId: params.agentId,
-    triggerSource: params.triggerSource,
     sessionId: params.sessionId,
     appendSystemPrompt,
     modelProvider: params.modelProvider,
     callbacks: params.callbacks,
-    scheduleId: params.scheduleId,
     memoryName: "memory",
     artifactName: "artifact",
     disallowedTools: [...DISALLOWED_TOOLS],
@@ -91,4 +90,13 @@ export async function createZeroRun(
     firewallPolicies: agent.firewallPolicies ?? undefined,
     injectZeroToken: true,
   });
+
+  // Persist zero-layer metadata (triggerSource + schedule association)
+  await globalThis.services.db.insert(zeroRuns).values({
+    id: result.runId,
+    triggerSource: params.triggerSource,
+    scheduleId: params.scheduleId ?? null,
+  });
+
+  return result;
 }


### PR DESCRIPTION
## Summary

- Move `zeroRuns` table writes (`triggerSource`, `scheduleId`) from generic infra layer (`run-service.ts`, `run-queue-service.ts`) to Zero platform layer (`zero-run-service.ts`)
- Move `getRunQueueStatus()` to new `zero-queue-service.ts` since it joins `zeroRuns` and `zeroAgents` (Zero-layer concerns)
- Remove `triggerSource` and `scheduleId` from `CreateRunParams` and `StartRunParams` interfaces

## Test plan

- [x] All 23 `zero-run-service.test.ts` tests pass (triggerSource persistence verified at Zero layer)
- [x] All 15 `run-queue-service.test.ts` tests pass (removed infra-level zeroRuns assertions)
- [x] All 52 `create-run.test.ts` tests pass (removed infra-level scheduleId assertion)
- [x] All 17 `telegram/commands.test.ts` tests pass (mock updated to `createZeroRun`)
- [x] All 16 `credit-check.test.ts` tests pass
- [x] Full test suite: 2548/2548 passing (1 pre-existing Clerk module failure)
- [x] Lint, format, knip all clean
- [x] Type check passes (only pre-existing Clerk module error)

Closes #7154

🤖 Generated with [Claude Code](https://claude.com/claude-code)