### PR TITLE
refactor: replace manual boolean loading state with async computed

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -872,14 +872,14 @@ export const startNewZeroSession$ = command(({ set }) => {
 // Commands: create new chat session (from sidebar "New chat" button)
 // ---------------------------------------------------------------------------
 
-const creatingNewSession$ = state(false);
-export const zeroCreatingNewSession$ = computed((get) =>
-  get(creatingNewSession$),
-);
+const internalCreatingPromise$ = state<Promise<void> | undefined>(undefined);
 
-export const createNewChatSession$ = command(
+export const creatingNewSession$ = computed(async (get) => {
+  await get(internalCreatingPromise$);
+});
+
+const internalCreateNewChatSession$ = command(
   async ({ get, set }, agentComposeId: string | null, _signal: AbortSignal) => {
-    set(creatingNewSession$, true);
     try {
       set(startNewZeroSession$);
 
@@ -899,9 +899,15 @@ export const createNewChatSession$ = command(
       throwIfAbort(error);
       L.error("Failed to create new chat session:", error);
       toast.error("Failed to create new chat session");
-    } finally {
-      set(creatingNewSession$, false);
     }
+  },
+);
+
+export const createNewChatSession$ = command(
+  ({ set }, agentComposeId: string | null, signal: AbortSignal) => {
+    const promise = set(internalCreateNewChatSession$, agentComposeId, signal);
+    set(internalCreatingPromise$, promise);
+    return promise;
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -63,7 +63,7 @@ import { reloadAgents$ } from "../../signals/zero-page/agents-list.ts";
 import {
   zeroSessionList$,
   createNewChatSession$,
-  zeroCreatingNewSession$,
+  creatingNewSession$,
 } from "../../signals/zero-page/zero-chat.ts";
 import {
   pinnedAgentIds$,
@@ -989,7 +989,8 @@ export function ZeroSidebar() {
         : "Failed to load chats"
       : null;
   const createNewChat = useSet(createNewChatSession$);
-  const creatingNewSession = useGet(zeroCreatingNewSession$);
+  const creatingNewSessionLoadable = useLoadable(creatingNewSession$);
+  const creatingNewSession = creatingNewSessionLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
   const onNewChat = (agentId: string | null) => {
     detach(createNewChat(agentId, pageSignal), Reason.DomCallback);


### PR DESCRIPTION
## Summary

- Replace manual boolean `state(false)` + `try/finally` toggle pattern in `creatingNewSession$` with the canonical ccstate promise-derived async computed pattern
- Store promise in `internalCreatingPromise$` state, derive loading via `async computed`, consume with `useLoadable` in the view
- Remove `zeroCreatingNewSession$` export, rename to `creatingNewSession$`

## Changes

**`zero-chat.ts`**: Replace 3 atoms (boolean state + passthrough computed + async command with manual toggle) with 4 atoms:
- `internalCreatingPromise$` — holds the pending promise
- `creatingNewSession$` — async computed that awaits the promise
- `internalCreateNewChatSession$` — async command with actual logic (no boolean toggling)
- `createNewChatSession$` — sync wrapper that stores promise and returns it

**`zero-sidebar.tsx`**: Switch from `useGet(zeroCreatingNewSession$)` to `useLoadable(creatingNewSession$)` with `state === "loading"` derivation.

## Test plan

- [ ] Verify "New chat" button disables during session creation
- [ ] Verify button re-enables after session creation completes
- [ ] Verify button re-enables on error (toast shown)
- [ ] Verify no loading flash on initial page load
- [ ] All CI checks pass (lint, types, knip, format)

Closes #7157

🤖 Generated with [Claude Code](https://claude.com/claude-code)