### PR TITLE
refactor(sandbox): introduce runtime provider trait and consolidate sandbox-fc construction

### DIFF
--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -3,7 +3,7 @@ use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
 use clap::Args;
-use sandbox::{ExecRequest, ExecResult, SandboxConfig, SandboxFactory, SandboxRuntime};
+use sandbox::{ExecRequest, ExecResult, RuntimeProvider, SandboxConfig, SandboxFactory};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -42,7 +42,10 @@ pub struct BenchmarkArgs {
     profile: String,
 }
 
-pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
+pub async fn run_benchmark(
+    args: BenchmarkArgs,
+    runtime_provider: &dyn RuntimeProvider,
+) -> RunnerResult<ExitCode> {
     let total = Instant::now();
 
     // 1. Load config, force concurrency=1
@@ -88,10 +91,11 @@ pub async fn run_benchmark(args: BenchmarkArgs) -> RunnerResult<ExitCode> {
     let factory_config = runner_config.factory_config(&args.profile, &default_profile, &home);
 
     let t = Instant::now();
-    let mut runtime = sandbox_fc::FirecrackerRuntime::new(sandbox::RuntimeConfig {
-        proxy_port: Some(mitm.port()),
-    })
-    .await?;
+    let mut runtime = runtime_provider
+        .create_runtime(sandbox::RuntimeConfig {
+            proxy_port: Some(mitm.port()),
+        })
+        .await?;
     let mut factory = runtime.create_factory(factory_config).await?;
     let factory_ms = t.elapsed().as_millis();
     info!(factory_ms, "factory ready");

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use sandbox::SnapshotProvider;
 
 use super::rootfs::RootfsArgs;
 use super::snapshot::SnapshotArgs;
@@ -11,16 +12,19 @@ pub struct BuildArgs {
     rootfs: RootfsArgs,
 }
 
-pub async fn run_build(args: BuildArgs) -> RunnerResult<()> {
+pub async fn run_build(args: BuildArgs, provider: &dyn SnapshotProvider) -> RunnerResult<()> {
     let def = profile::get(&args.rootfs.profile)?;
     let dry_run = args.rootfs.dry_run;
     let rootfs_hash = super::rootfs::run_rootfs(args.rootfs).await?;
-    super::snapshot::run_snapshot(SnapshotArgs {
-        rootfs_hash,
-        vcpu: def.vcpu,
-        memory_mb: def.memory_mb,
-        dry_run,
-    })
+    super::snapshot::run_snapshot(
+        SnapshotArgs {
+            rootfs_hash,
+            vcpu: def.vcpu,
+            memory_mb: def.memory_mb,
+            dry_run,
+        },
+        provider,
+    )
     .await?;
 
     Ok(())

--- a/crates/runner/src/cmd/snapshot.rs
+++ b/crates/runner/src/cmd/snapshot.rs
@@ -27,9 +27,11 @@ pub struct SnapshotArgs {
 }
 
 /// Create a snapshot and return the snapshot hash.
-pub async fn run_snapshot(args: SnapshotArgs) -> RunnerResult<String> {
-    let provider = sandbox_fc::FirecrackerSnapshotProvider;
-    let snapshot_hash = compute_snapshot_hash(&args, &provider);
+pub async fn run_snapshot(
+    args: SnapshotArgs,
+    provider: &dyn SnapshotProvider,
+) -> RunnerResult<String> {
+    let snapshot_hash = compute_snapshot_hash(&args, provider);
     tracing::info!("snapshot hash: {snapshot_hash}");
     // Machine-readable output — do not change format without updating consumers
     println!("snapshot_hash={snapshot_hash}");

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Args;
-use sandbox::{SandboxFactory, SandboxRuntime};
+use sandbox::{RuntimeProvider, SandboxFactory, SandboxRuntime};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -51,7 +51,10 @@ pub struct StartArgs {
 }
 
 /// Load config and run the main poll loop.
-pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
+pub async fn run_start(
+    args: StartArgs,
+    runtime_provider: &dyn RuntimeProvider,
+) -> RunnerResult<()> {
     let mut runner_config = config::load(&args.config).await?;
 
     // CLI / env overrides — take server out so we can mutate independently
@@ -210,11 +213,12 @@ pub async fn run_start(args: StartArgs) -> RunnerResult<()> {
     };
 
     // Build sandbox runtime with shared resources (netns pool, base loop cache).
-    let runtime = sandbox_fc::FirecrackerRuntime::new(sandbox::RuntimeConfig {
-        proxy_port: Some(mitm.port()),
-    })
-    .await
-    .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;
+    let runtime = runtime_provider
+        .create_runtime(sandbox::RuntimeConfig {
+            proxy_port: Some(mitm.port()),
+        })
+        .await
+        .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;
 
     let mut status = StatusTracker::new(paths.status(), estimated_capacity);
     status.set_proxy_port(mitm.port()).await;
@@ -286,7 +290,7 @@ struct RunConfig {
     name: String,
     group: String,
     profiles: std::collections::BTreeMap<String, ProfileConfig>,
-    runtime: sandbox_fc::FirecrackerRuntime,
+    runtime: Box<dyn SandboxRuntime>,
     home: HomePaths,
     budget: Arc<ResourceBudget>,
     status: Arc<StatusTracker>,
@@ -344,7 +348,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         let factory = match factory_result {
             Ok(f) => f,
             Err(e) => {
-                shutdown_factories(&mut factories, &mut runtime).await;
+                shutdown_factories(&mut factories, runtime.as_mut()).await;
                 return Err(e.into());
             }
         };
@@ -542,7 +546,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     }
 
     info!("shutting down factories");
-    shutdown_factories(&mut factories, &mut runtime).await;
+    shutdown_factories(&mut factories, runtime.as_mut()).await;
 
     // Stop proxy after all jobs have drained and factory is shut down.
     if let Err(e) = mitm.stop().await {
@@ -578,7 +582,7 @@ struct JobProfile {
 /// Shut down all factories, then release shared runtime resources.
 async fn shutdown_factories(
     factories: &mut BTreeMap<String, (SharedFactory, bool)>,
-    runtime: &mut sandbox_fc::FirecrackerRuntime,
+    runtime: &mut dyn SandboxRuntime,
 ) {
     for (name, (factory, _)) in std::mem::take(factories) {
         match Arc::try_unwrap(factory) {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -210,14 +210,24 @@ async fn main() -> ExitCode {
 
     let result = match cli.command {
         Command::Setup => cmd::run_setup().await.map(|()| ExitCode::SUCCESS),
-        Command::Build(args) => cmd::run_build(args).await.map(|()| ExitCode::SUCCESS),
+        Command::Build(args) => cmd::run_build(args, &sandbox_fc::FirecrackerSnapshotProvider)
+            .await
+            .map(|()| ExitCode::SUCCESS),
         Command::Rootfs(args) => cmd::run_rootfs(args).await.map(|_| ExitCode::SUCCESS),
-        Command::Snapshot(args) => cmd::run_snapshot(args).await.map(|_| ExitCode::SUCCESS),
+        Command::Snapshot(args) => {
+            cmd::run_snapshot(args, &sandbox_fc::FirecrackerSnapshotProvider)
+                .await
+                .map(|_| ExitCode::SUCCESS)
+        }
         Command::Config(args) => cmd::run_config(args).await.map(|()| ExitCode::SUCCESS),
-        Command::Benchmark(args) => cmd::run_benchmark(args).await,
+        Command::Benchmark(args) => {
+            cmd::run_benchmark(args, &sandbox_fc::FirecrackerRuntimeProvider).await
+        }
         Command::Exec(args) => cmd::run_exec(args, &sandbox_fc::FirecrackerControl).await,
         Command::Kill(args) => cmd::run_kill(args, &sandbox_fc::FirecrackerControl).await,
-        Command::Start(args) => cmd::run_start(*args).await.map(|()| ExitCode::SUCCESS),
+        Command::Start(args) => cmd::run_start(*args, &sandbox_fc::FirecrackerRuntimeProvider)
+            .await
+            .map(|()| ExitCode::SUCCESS),
         Command::Service(args) => cmd::run_service(args).await.map(|()| ExitCode::SUCCESS),
         Command::Gc(args) => cmd::run_gc(args).await.map(|()| ExitCode::SUCCESS),
         Command::Doctor(args) => cmd::run_doctor(args).await,

--- a/crates/sandbox-fc/src/lib.rs
+++ b/crates/sandbox-fc/src/lib.rs
@@ -22,7 +22,7 @@ pub use network::{NetnsPool, NetnsPoolConfig};
 pub use paths::{
     FactoryPaths, LockPaths, RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths,
 };
-pub use runtime::FirecrackerRuntime;
+pub use runtime::{FirecrackerRuntime, FirecrackerRuntimeProvider};
 pub use sandbox::FirecrackerSandbox;
 pub use sandbox_control::FirecrackerControl;
 pub use snapshot::{SnapshotError, create_snapshot};

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tracing::{info, warn};
 
-use sandbox::{FactoryConfig, SandboxError, SandboxFactory, SandboxRuntime, SnapshotRef};
+use sandbox::{
+    FactoryConfig, RuntimeProvider, SandboxError, SandboxFactory, SandboxRuntime, SnapshotRef,
+};
 
 use crate::config::{FirecrackerConfig, SnapshotConfig};
 use crate::factory::FirecrackerFactory;
@@ -108,5 +110,18 @@ impl SandboxRuntime for FirecrackerRuntime {
             .cleanup();
 
         info!("runtime shutdown complete");
+    }
+}
+
+/// Factory for creating [`FirecrackerRuntime`] instances.
+pub struct FirecrackerRuntimeProvider;
+
+#[async_trait]
+impl RuntimeProvider for FirecrackerRuntimeProvider {
+    async fn create_runtime(
+        &self,
+        config: sandbox::RuntimeConfig,
+    ) -> sandbox::Result<Box<dyn SandboxRuntime>> {
+        Ok(Box::new(FirecrackerRuntime::new(config).await?))
     }
 }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -11,7 +11,7 @@ pub use config::{FactoryConfig, ResourceLimits, RuntimeConfig, SandboxConfig, Sn
 pub use control::{RemoteExecResult, SandboxControl, SandboxControlError};
 pub use error::{Result, SandboxError};
 pub use factory::SandboxFactory;
-pub use runtime::SandboxRuntime;
+pub use runtime::{RuntimeProvider, SandboxRuntime};
 pub use sandbox::Sandbox;
 pub use snapshot::{SnapshotCreateConfig, SnapshotError, SnapshotOutput, SnapshotProvider};
 pub use types::{ExecRequest, ExecResult, ProcessExit, SpawnHandle};

--- a/crates/sandbox/src/runtime.rs
+++ b/crates/sandbox/src/runtime.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::config::FactoryConfig;
+use crate::config::{FactoryConfig, RuntimeConfig};
 use crate::error::Result;
 use crate::factory::SandboxFactory;
 
@@ -19,4 +19,15 @@ pub trait SandboxRuntime: Send + Sync {
 
     /// Release shared resources (network pools, device caches).
     async fn shutdown(&mut self);
+}
+
+/// Constructs a [`SandboxRuntime`] from configuration.
+///
+/// This trait decouples the runner from the concrete runtime implementation.
+/// The runner calls [`RuntimeProvider::create_runtime`] when shared resources
+/// are needed (e.g., after proxy setup provides the port), without knowing
+/// which backend is in use.
+#[async_trait]
+pub trait RuntimeProvider: Send + Sync {
+    async fn create_runtime(&self, config: RuntimeConfig) -> Result<Box<dyn SandboxRuntime>>;
 }


### PR DESCRIPTION
## Summary
- Add `RuntimeProvider` trait to the sandbox crate for deferred runtime construction, completing the trait abstraction layer alongside `SandboxRuntime`, `SnapshotProvider`, and `SandboxControl`
- Move all `sandbox_fc` concrete type references out of business logic files (`start.rs`, `benchmark.rs`, `build.rs`, `snapshot.rs`) into `main.rs` as the single construction point
- All runner commands now use a consistent `&dyn Trait` injection pattern

## Motivation

This is the final step of #7119. After P1–P3 merged, runner business logic was decoupled via traits, but `start.rs` and `benchmark.rs` still stored `sandbox_fc::FirecrackerRuntime` as a concrete type. Runtime construction must be deferred (it depends on proxy port from proxy setup), so a `RuntimeProvider` trait enables passing a factory without exposing the concrete type.

**Before:**
```
runner/src/cmd/start.rs      → sandbox_fc::FirecrackerRuntime (struct field + shutdown param)
runner/src/cmd/benchmark.rs  → sandbox_fc::FirecrackerRuntime::new()
runner/src/cmd/snapshot.rs   → sandbox_fc::FirecrackerSnapshotProvider
runner/src/cmd/build.rs      → (via snapshot.rs)
```

**After:**
```
runner/src/main.rs            → sandbox_fc::* (sole construction point)
runner/src/cmd/start.rs       → &dyn RuntimeProvider
runner/src/cmd/benchmark.rs   → &dyn RuntimeProvider
runner/src/cmd/snapshot.rs    → &dyn SnapshotProvider
runner/src/cmd/build.rs       → &dyn SnapshotProvider
runner/src/cmd/exec.rs        → &dyn SandboxControl (unchanged)
runner/src/cmd/kill.rs        → &dyn SandboxControl (unchanged)
```

Closes #7119

## Test plan
- [x] `cargo check -p runner` passes
- [x] `cargo clippy -p runner -p sandbox -p sandbox-fc` clean
- [x] `cargo test -p runner -p sandbox -p sandbox-fc` — 265 + 93 tests pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)