### PR TITLE
fix(platform): use dynamic poll interval for session list refresh

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/polling.ts
+++ b/turbo/apps/platform/src/signals/zero-page/polling.ts
@@ -17,7 +17,7 @@ export const setPollIntervalForTest$ = command(({ set }, interval: number) => {
   set(internalPollInterval$, interval);
 });
 
-const poolInterval$ = computed((get) => get(internalPollInterval$));
+export const poolInterval$ = computed((get) => get(internalPollInterval$));
 
 function isTerminalStatus(status: string | null): boolean {
   return (

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -5,7 +5,11 @@ import { fetch$ } from "../fetch.ts";
 import { throwIfAbort, resetSignal, createDeferredPromise } from "../utils.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { logger } from "../log.ts";
-import { createRunLoop, type PagedRunEvents } from "./polling.ts";
+import {
+  createRunLoop,
+  poolInterval$,
+  type PagedRunEvents,
+} from "./polling.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
 import {
   navigateToChat$,
@@ -966,7 +970,7 @@ const finalizeCompletedRun$ = command(
 
     // Refresh session list (messages are persisted server-side via webhook)
     set(reloadChatThreadList$, (n) => n + 1);
-    await delay(1000, { signal });
+    await delay(get(poolInterval$), { signal });
     set(reloadChatThreadList$, (n) => n + 1);
   },
 );


### PR DESCRIPTION
## Summary
- Export `poolInterval$` from `polling.ts` so it can be consumed by other modules
- Replace hardcoded `delay(1000)` with `delay(get(poolInterval$))` in `finalizeCompletedRun$` to use the configurable polling interval for session list refresh timing

## Test plan
- [ ] Verify session list refreshes correctly after a run completes
- [ ] Verify `setPollIntervalForTest$` still controls the interval used in session refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)