### PR TITLE
refactor: replace fixed e2e test users with ephemeral per-run accounts

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -908,14 +908,32 @@ jobs:
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
           deployment-env: ${{ steps.deployment.outputs.env }}
 
-      # Step 6: Generate test tokens for E2E tests (one per test user)
-      - name: Generate E2E test tokens
+      # Step 6: Cleanup stale test users and generate fresh tokens
+      - name: Cleanup stale test users
         run: |
-          for variant in serial runner; do
-            e2e/scripts/generate-test-token.sh "$variant"
-            cp ~/.vm0/config.json "/tmp/e2e-token-${variant}.json"
+          echo "Cleaning up stale test users for ${JOB_REF}..."
+          USERS=$(curl -sS "https://api.clerk.com/v1/users?query=${JOB_REF}%2Bclerk_test&limit=100" \
+            -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+            -H "Content-Type: application/json")
+          for uid in $(echo "$USERS" | jq -r '.[] | select(.email_addresses[0].email_address | startswith("'"${JOB_REF}+clerk_test@"'")) | .id' 2>/dev/null); do
+            echo "Deleting user $uid"
+            curl -sS -X DELETE "https://api.clerk.com/v1/users/${uid}" \
+              -H "Authorization: Bearer ${CLERK_SECRET_KEY}" > /dev/null
           done
         env:
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+
+      - name: Generate E2E test tokens
+        run: |
+          SERIAL_EMAIL="${JOB_REF}+clerk_test@serial.dev"
+          RUNNER_EMAIL="${JOB_REF}+clerk_test@runner.dev"
+          e2e/scripts/generate-test-token.sh "$SERIAL_EMAIL"
+          cp ~/.vm0/config.json "/tmp/e2e-token-serial.json"
+          e2e/scripts/generate-test-token.sh "$RUNNER_EMAIL"
+          cp ~/.vm0/config.json "/tmp/e2e-token-runner.json"
+        env:
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           VM0_API_URL: ${{ steps.alias.outputs.url || steps.deploy.outputs.url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
@@ -1073,7 +1091,7 @@ jobs:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test@vm0-e2e.ai
+          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test@browser.dev
       - name: Cleanup test accounts
         if: always()
         env:
@@ -1087,8 +1105,8 @@ jobs:
             -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
             -H "Content-Type: application/json")
 
-          # Extract user IDs, skipping the persistent e2e test account
-          ids=$(echo "$users" | jq -r '.[] | select((.email_addresses[]?.email_address != "e2e+clerk_test@vm0.ai") and (.email_addresses[]?.email_address != "e2e_02+clerk_test@vm0.ai")) | .id' 2>/dev/null || true)
+          # Extract user IDs
+          ids=$(echo "$users" | jq -r '.[].id' 2>/dev/null || true)
 
           if [ -z "$ids" ]; then
             echo "No test accounts to clean up"
@@ -1664,7 +1682,6 @@ jobs:
         run: mkdir -p ~/.vm0 && cp /tmp/e2e-token-runner.json ~/.vm0/config.json
       - name: Bootstrap test account
         run: |
-          zero org set "e2e-runner" --force
           zero org model-provider setup --type "claude-code-oauth-token" --secret "mock-oauth-token-for-e2e"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
@@ -1919,6 +1936,7 @@ jobs:
           WEB_URL: ${{ needs.deploy-web.outputs.preview-url }}
           APP_URL: ${{ needs.prepare.outputs.app-preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          E2E_SERIAL_EMAIL: ${{ needs.prepare.outputs.job-ref }}+clerk_test@serial.dev
       - name: Locate LHCI output (app)
         id: lhci-dir-app
         if: always()

--- a/e2e/lighthouse/puppeteer-auth.js
+++ b/e2e/lighthouse/puppeteer-auth.js
@@ -13,7 +13,10 @@
  *   VERCEL_AUTOMATION_BYPASS_SECRET  – Vercel protection bypass token
  */
 
-const TEST_EMAIL = process.env.E2E_SERIAL_EMAIL || "dev+clerk_test@serial.dev";
+if (!process.env.E2E_SERIAL_EMAIL) {
+  throw new Error("E2E_SERIAL_EMAIL environment variable is required");
+}
+const TEST_EMAIL = process.env.E2E_SERIAL_EMAIL;
 const TEST_OTP = "424242";
 
 /** Wait for a selector to appear and return the element handle. */

--- a/e2e/lighthouse/puppeteer-auth.js
+++ b/e2e/lighthouse/puppeteer-auth.js
@@ -13,7 +13,7 @@
  *   VERCEL_AUTOMATION_BYPASS_SECRET  – Vercel protection bypass token
  */
 
-const TEST_EMAIL = "e2e+clerk_test@vm0.ai";
+const TEST_EMAIL = process.env.E2E_SERIAL_EMAIL || "dev+clerk_test@serial.dev";
 const TEST_OTP = "424242";
 
 /** Wait for a selector to appear and return the element handle. */

--- a/e2e/scripts/generate-test-token.sh
+++ b/e2e/scripts/generate-test-token.sh
@@ -10,19 +10,19 @@
 #   - VERCEL_AUTOMATION_BYPASS_SECRET for Vercel bypass
 #   - USE_MOCK_CLAUDE must be "true" on the server
 #
-# Usage: ./generate-test-token.sh [variant]
-#   variant: "serial" (default) or "runner" — selects which test user
+# Usage: ./generate-test-token.sh <email>
+#   email: the test user's email address (e.g., "pr-123+clerk_test@serial.dev")
 
 set -euo pipefail
 
-# Test user variant (serial or runner)
-VARIANT="${1:-serial}"
+# Test user email
+EMAIL="${1:?Usage: generate-test-token.sh <email>}"
 
 # Retry configuration
 MAX_RETRIES=5
 INITIAL_DELAY=2
 
-echo "=== Generating Test CLI Token (variant: ${VARIANT}) ==="
+echo "=== Generating Test CLI Token (email: ${EMAIL}) ==="
 
 # Validate environment
 if [[ -z "${VM0_API_URL:-}" ]]; then
@@ -74,7 +74,7 @@ call_test_token_endpoint() {
     response=$(curl -s -w "\n%{http_code}" \
       "${CURL_HEADERS[@]}" \
       -X POST \
-      "${VM0_API_URL}/api/cli/auth/test-token?variant=${VARIANT}" 2>&1) || true
+      "${VM0_API_URL}/api/cli/auth/test-token?email=$(printf '%s' "$EMAIL" | jq -sRr @uri)" 2>&1) || true
 
     http_code=$(echo "$response" | tail -n1)
     body=$(echo "$response" | head -n-1)

--- a/turbo/apps/docs/package.json
+++ b/turbo/apps/docs/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev --turbo --port 3001",
     "start": "next start",
     "lint": "oxlint && eslint . --max-warnings 0",
-    "check-types": "next typegen && tsc --noEmit",
+    "check-types": "fumadocs-mdx && next typegen && tsc --noEmit",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/turbo/apps/web/app/api/cli/auth/test-approve/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-approve/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { POST as createDeviceRoute } from "../../device/route";
 import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../../src/env";
+import { DEFAULT_TEST_EMAIL } from "../../../../../../src/lib/auth/test-user";
 
 // Mock Clerk Server API
 const mockGetUserList = vi.fn();
@@ -272,10 +273,13 @@ describe("/api/cli/auth/test-approve", () => {
         },
       );
 
-      await POST(request);
+      const response = await POST(request);
+      const data = await response.json();
 
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
       expect(mockGetUserList).toHaveBeenCalledWith({
-        emailAddress: ["dev+clerk_test@serial.dev"],
+        emailAddress: [DEFAULT_TEST_EMAIL],
       });
     });
   });

--- a/turbo/apps/web/app/api/cli/auth/test-approve/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-approve/__tests__/route.test.ts
@@ -7,10 +7,12 @@ import { reloadEnv } from "../../../../../../src/env";
 
 // Mock Clerk Server API
 const mockGetUserList = vi.fn();
+const mockCreateUser = vi.fn();
 vi.mock("@clerk/nextjs/server", () => ({
   clerkClient: vi.fn(async () => ({
     users: {
       getUserList: mockGetUserList,
+      createUser: mockCreateUser,
     },
   })),
   auth: vi.fn(),
@@ -38,6 +40,7 @@ describe("/api/cli/auth/test-approve", () => {
     vi.stubEnv("CLERK_SECRET_KEY", "test-secret-key");
     reloadEnv();
     mockGetUserList.mockReset();
+    mockCreateUser.mockReset();
   });
 
   describe("environment gate", () => {
@@ -230,10 +233,9 @@ describe("/api/cli/auth/test-approve", () => {
   });
 
   describe("Clerk integration", () => {
-    it("should return 500 when test user is not found", async () => {
-      mockGetUserList.mockResolvedValue({
-        data: [],
-      });
+    it("should auto-create user when not found in Clerk", async () => {
+      mockGetUserList.mockResolvedValue({ data: [] });
+      mockCreateUser.mockResolvedValue({ id: "user_auto_created" });
 
       const code = await createTestDeviceCode();
 
@@ -249,11 +251,12 @@ describe("/api/cli/auth/test-approve", () => {
       const response = await POST(request);
       const data = await response.json();
 
-      expect(response.status).toBe(500);
-      expect(data.error).toBe("Test user not found");
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.userId).toBe("user_auto_created");
     });
 
-    it("should call Clerk with correct email address", async () => {
+    it("should call Clerk with default email address", async () => {
       mockGetUserList.mockResolvedValue({
         data: [{ id: "user_test789" }],
       });
@@ -272,7 +275,7 @@ describe("/api/cli/auth/test-approve", () => {
       await POST(request);
 
       expect(mockGetUserList).toHaveBeenCalledWith({
-        emailAddress: ["e2e+clerk_test@vm0.ai"],
+        emailAddress: ["dev+clerk_test@serial.dev"],
       });
     });
   });

--- a/turbo/apps/web/app/api/cli/auth/test-approve/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-approve/route.ts
@@ -2,7 +2,10 @@ import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { deviceCodes } from "../../../../../src/db/schema/device-codes";
-import { resolveTestUserId } from "../../../../../src/lib/auth/test-user";
+import {
+  resolveTestUserId,
+  DEFAULT_TEST_EMAIL,
+} from "../../../../../src/lib/auth/test-user";
 import { env } from "../../../../../src/env";
 
 /**
@@ -57,7 +60,7 @@ export async function POST(req: Request) {
   }
 
   const url = new URL(req.url);
-  const email = url.searchParams.get("email") ?? undefined;
+  const email = url.searchParams.get("email") ?? DEFAULT_TEST_EMAIL;
   const testUserId = await resolveTestUserId(email);
 
   await globalThis.services.db

--- a/turbo/apps/web/app/api/cli/auth/test-approve/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-approve/route.ts
@@ -56,10 +56,9 @@ export async function POST(req: Request) {
     );
   }
 
-  const testUserId = await resolveTestUserId();
-  if (!testUserId) {
-    return NextResponse.json({ error: "Test user not found" }, { status: 500 });
-  }
+  const url = new URL(req.url);
+  const email = url.searchParams.get("email") ?? undefined;
+  const testUserId = await resolveTestUserId(email);
 
   await globalThis.services.db
     .update(deviceCodes)

--- a/turbo/apps/web/app/api/cli/auth/test-connector/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/__tests__/route.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  insertOrgCacheEntry,
+  ensureOrgRow,
+  insertOrgMembersCacheEntry,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import { testContext } from "../../../../../../src/__tests__/test-helpers";
+import { reloadEnv } from "../../../../../../src/env";
+import { DEFAULT_TEST_EMAIL } from "../../../../../../src/lib/auth/test-user";
+
+// Mock Clerk Server API
+const mockGetUserList = vi.fn();
+const mockCreateUser = vi.fn();
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkClient: vi.fn(async () => ({
+    users: {
+      getUserList: mockGetUserList,
+      createUser: mockCreateUser,
+    },
+  })),
+  auth: vi.fn(async () => ({ userId: null, orgId: null, orgRole: null })),
+}));
+
+const context = testContext();
+
+const TEST_ORG_ID = "org_connector_test";
+const TEST_ORG_SLUG = "connector-test-org";
+const TEST_USER_ID = "user_connector_test123";
+
+describe("/api/cli/auth/test-connector", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    vi.stubEnv("CLERK_SECRET_KEY", "test-secret-key");
+    vi.stubEnv("VERCEL_ENV", "");
+    vi.stubEnv("NODE_ENV", "development");
+    reloadEnv();
+    mockGetUserList.mockReset();
+    mockCreateUser.mockReset();
+    mockGetUserList.mockResolvedValue({
+      data: [{ id: TEST_USER_ID }],
+    });
+
+    // Pre-populate org cache and membership so test-connector can resolve the org
+    await insertOrgCacheEntry({ orgId: TEST_ORG_ID, slug: TEST_ORG_SLUG });
+    await ensureOrgRow(TEST_ORG_ID);
+    await insertOrgMembersCacheEntry({
+      orgId: TEST_ORG_ID,
+      userId: TEST_USER_ID,
+      role: "admin",
+    });
+  });
+
+  describe("environment gate", () => {
+    it("returns 404 in production", async () => {
+      vi.stubEnv("VERCEL_ENV", "production");
+      vi.stubEnv("NODE_ENV", "production");
+      reloadEnv();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            connectorName: "github",
+            accessToken: "gho_test",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(404);
+    });
+
+    it("returns 404 in preview without bypass header", async () => {
+      vi.stubEnv("VERCEL_ENV", "preview");
+      vi.stubEnv("NODE_ENV", "production");
+      vi.stubEnv("VERCEL_AUTOMATION_BYPASS_SECRET", "test-secret");
+      reloadEnv();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            connectorName: "github",
+            accessToken: "gho_test",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("input validation", () => {
+    it("returns 400 for invalid JSON body", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "not-json",
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Invalid JSON body");
+    });
+
+    it("returns 400 when connectorName is missing", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ accessToken: "gho_test" }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("connectorName and accessToken are required");
+    });
+
+    it("returns 400 when accessToken is missing", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ connectorName: "github" }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("connectorName and accessToken are required");
+    });
+
+    it("returns 400 for unknown connector type", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            connectorName: "not-a-real-connector",
+            accessToken: "some-token",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toContain("not-a-real-connector");
+    });
+  });
+
+  describe("org resolution", () => {
+    it("returns 400 when user has no org in org_members_cache", async () => {
+      // Use a user ID not in org_members_cache
+      mockGetUserList.mockResolvedValue({
+        data: [{ id: "user_no_org" }],
+      });
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            connectorName: "github",
+            accessToken: "gho_test",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe("Test user has no org — run test-token first");
+    });
+  });
+
+  describe("successful connector setup", () => {
+    it("creates connector and returns ok with connectorType and orgId", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            connectorName: "github",
+            accessToken: "gho_test_token",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ok).toBe(true);
+      expect(data.connectorType).toBe("github");
+      expect(data.orgId).toBe(TEST_ORG_ID);
+    });
+
+    it("uses default email when email param is absent", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-connector",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            connectorName: "github",
+            accessToken: "gho_test_token",
+          }),
+        },
+      );
+
+      await POST(request);
+
+      expect(mockGetUserList).toHaveBeenCalledWith({
+        emailAddress: [DEFAULT_TEST_EMAIL],
+      });
+    });
+
+    it("uses provided email param", async () => {
+      const email = "pr-99+clerk_test@runner.dev";
+      const userIdForEmail = "user_email_test";
+      mockGetUserList.mockResolvedValue({ data: [{ id: userIdForEmail }] });
+
+      // Pre-populate org membership for this user
+      await insertOrgMembersCacheEntry({
+        orgId: TEST_ORG_ID,
+        userId: userIdForEmail,
+        role: "admin",
+      });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/cli/auth/test-connector?email=${encodeURIComponent(email)}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            connectorName: "github",
+            accessToken: "gho_test_token",
+          }),
+        },
+      );
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.ok).toBe(true);
+      expect(mockGetUserList).toHaveBeenCalledWith({
+        emailAddress: [email],
+      });
+    });
+  });
+});

--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -4,10 +4,7 @@ import { eq, desc } from "drizzle-orm";
 import { connectorTypeSchema } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { upsertOAuthConnector } from "../../../../../src/lib/connector/connector-service";
-import {
-  resolveTestUserId,
-  isTestVariant,
-} from "../../../../../src/lib/auth/test-user";
+import { resolveTestUserId } from "../../../../../src/lib/auth/test-user";
 import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
 import { getOrgDataOrNull } from "../../../../../src/lib/org/resolve-org";
 import { env } from "../../../../../src/env";
@@ -80,18 +77,8 @@ export async function POST(request: Request) {
   const connectorType = connectorParsed.data;
 
   const url = new URL(request.url);
-  const variant = url.searchParams.get("variant") ?? "serial";
-  if (!isTestVariant(variant)) {
-    return NextResponse.json(
-      { error: `Unknown test variant: ${variant}` },
-      { status: 400 },
-    );
-  }
-
-  const userId = await resolveTestUserId(variant);
-  if (!userId) {
-    return NextResponse.json({ error: "Test user not found" }, { status: 500 });
-  }
+  const email = url.searchParams.get("email") ?? undefined;
+  const userId = await resolveTestUserId(email);
 
   // Look up test user's org from org_members_cache (populated by test-token endpoint)
   const [cached] = await globalThis.services.db

--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -4,7 +4,10 @@ import { eq, desc } from "drizzle-orm";
 import { connectorTypeSchema } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { upsertOAuthConnector } from "../../../../../src/lib/connector/connector-service";
-import { resolveTestUserId } from "../../../../../src/lib/auth/test-user";
+import {
+  resolveTestUserId,
+  DEFAULT_TEST_EMAIL,
+} from "../../../../../src/lib/auth/test-user";
 import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
 import { getOrgDataOrNull } from "../../../../../src/lib/org/resolve-org";
 import { env } from "../../../../../src/env";
@@ -77,7 +80,7 @@ export async function POST(request: Request) {
   const connectorType = connectorParsed.data;
 
   const url = new URL(request.url);
-  const email = url.searchParams.get("email") ?? undefined;
+  const email = url.searchParams.get("email") ?? DEFAULT_TEST_EMAIL;
   const userId = await resolveTestUserId(email);
 
   // Look up test user's org from org_members_cache (populated by test-token endpoint)

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -226,6 +226,10 @@ describe("/api/cli/auth/test-token", () => {
       const response = await POST(request);
       expect(response.status).toBe(200);
 
+      const data = await response.json();
+      expect(data.access_token).toMatch(/^vm0_pat_/);
+      expect(data.token_type).toBe("Bearer");
+
       expect(mockCreateUser).toHaveBeenCalledWith({
         emailAddress: [email],
       });

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -255,6 +255,10 @@ describe("/api/cli/auth/test-token", () => {
       const response = await POST(request);
       expect(response.status).toBe(200);
 
+      const data = await response.json();
+      expect(data.access_token).toMatch(/^vm0_pat_/);
+      expect(data.token_type).toBe("Bearer");
+
       expect(mockGetUserList).toHaveBeenCalledWith({
         emailAddress: [email],
       });

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -212,10 +212,11 @@ describe("/api/cli/auth/test-token", () => {
       expect(data.org_slug).toBe("test-token-org");
     });
 
-    it("creates user when not found in Clerk", async () => {
+    it("creates user and org when not found in Clerk", async () => {
       mockGetUserList.mockResolvedValue({ data: [] });
       mockCreateUser.mockResolvedValue({ id: "user_created" });
       mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
+      mockCreateOrganization.mockResolvedValue({ id: "org_newly_created" });
 
       const email = "pr-1+clerk_test@serial.dev";
       const request = createTestRequest(
@@ -233,6 +234,11 @@ describe("/api/cli/auth/test-token", () => {
       expect(mockCreateUser).toHaveBeenCalledWith({
         emailAddress: [email],
         skipPasswordRequirement: true,
+      });
+      expect(mockCreateOrganization).toHaveBeenCalledWith({
+        name: "test-pr-1-serial",
+        slug: "test-pr-1-serial",
+        createdBy: "user_created",
       });
     });
 

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { POST } from "../route";
 import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../../src/env";
+import { DEFAULT_TEST_EMAIL } from "../../../../../../src/lib/auth/test-user";
 
 // Mock Clerk Server API
 const mockGetUserList = vi.fn();
@@ -236,10 +237,11 @@ describe("/api/cli/auth/test-token", () => {
         { method: "POST" },
       );
 
-      await POST(request);
+      const response = await POST(request);
+      expect(response.status).toBe(200);
 
       expect(mockGetUserList).toHaveBeenCalledWith({
-        emailAddress: ["dev+clerk_test@serial.dev"],
+        emailAddress: [DEFAULT_TEST_EMAIL],
       });
     });
 
@@ -250,7 +252,8 @@ describe("/api/cli/auth/test-token", () => {
         { method: "POST" },
       );
 
-      await POST(request);
+      const response = await POST(request);
+      expect(response.status).toBe(200);
 
       expect(mockGetUserList).toHaveBeenCalledWith({
         emailAddress: [email],

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -9,11 +9,13 @@ const mockGetUserList = vi.fn();
 const mockGetOrganizationMembershipList = vi.fn();
 const mockCreateOrganization = vi.fn();
 const mockGetOrganization = vi.fn();
+const mockCreateUser = vi.fn();
 vi.mock("@clerk/nextjs/server", () => ({
   clerkClient: vi.fn(async () => ({
     users: {
       getUserList: mockGetUserList,
       getOrganizationMembershipList: mockGetOrganizationMembershipList,
+      createUser: mockCreateUser,
     },
     organizations: {
       createOrganization: mockCreateOrganization,
@@ -34,6 +36,7 @@ describe("/api/cli/auth/test-token", () => {
     mockGetOrganizationMembershipList.mockReset();
     mockCreateOrganization.mockReset();
     mockGetOrganization.mockReset();
+    mockCreateUser.mockReset();
     mockGetUserList.mockResolvedValue({
       data: [{ id: "user_test123" }],
     });
@@ -208,22 +211,26 @@ describe("/api/cli/auth/test-token", () => {
       expect(data.org_slug).toBe("test-token-org");
     });
 
-    it("returns 500 when test user is not found", async () => {
+    it("creates user when not found in Clerk", async () => {
       mockGetUserList.mockResolvedValue({ data: [] });
+      mockCreateUser.mockResolvedValue({ id: "user_created" });
+      mockGetOrganizationMembershipList.mockResolvedValue({ data: [] });
 
+      const email = "pr-1+clerk_test@serial.dev";
       const request = createTestRequest(
-        "http://localhost:3000/api/cli/auth/test-token",
+        `http://localhost:3000/api/cli/auth/test-token?email=${encodeURIComponent(email)}`,
         { method: "POST" },
       );
 
       const response = await POST(request);
-      const data = await response.json();
+      expect(response.status).toBe(200);
 
-      expect(response.status).toBe(500);
-      expect(data.error).toBe("Test user not found");
+      expect(mockCreateUser).toHaveBeenCalledWith({
+        emailAddress: [email],
+      });
     });
 
-    it("calls Clerk with correct email address", async () => {
+    it("uses default email when email param is absent", async () => {
       const request = createTestRequest(
         "http://localhost:3000/api/cli/auth/test-token",
         { method: "POST" },
@@ -232,7 +239,21 @@ describe("/api/cli/auth/test-token", () => {
       await POST(request);
 
       expect(mockGetUserList).toHaveBeenCalledWith({
-        emailAddress: ["e2e+clerk_test@vm0.ai"],
+        emailAddress: ["dev+clerk_test@serial.dev"],
+      });
+    });
+
+    it("uses provided email param", async () => {
+      const email = "pr-42+clerk_test@runner.dev";
+      const request = createTestRequest(
+        `http://localhost:3000/api/cli/auth/test-token?email=${encodeURIComponent(email)}`,
+        { method: "POST" },
+      );
+
+      await POST(request);
+
+      expect(mockGetUserList).toHaveBeenCalledWith({
+        emailAddress: [email],
       });
     });
   });

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -232,6 +232,7 @@ describe("/api/cli/auth/test-token", () => {
 
       expect(mockCreateUser).toHaveBeenCalledWith({
         emailAddress: [email],
+        skipPasswordRequirement: true,
       });
     });
 

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -12,10 +12,7 @@ import {
   getOrgBySlug,
 } from "../../../../../src/lib/org/org-cache-service";
 import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
-import {
-  resolveTestUserId,
-  isTestVariant,
-} from "../../../../../src/lib/auth/test-user";
+import { resolveTestUserId } from "../../../../../src/lib/auth/test-user";
 import { env } from "../../../../../src/env";
 
 /**
@@ -133,17 +130,8 @@ export async function POST(request: Request) {
   initServices();
 
   const url = new URL(request.url);
-  const variant = url.searchParams.get("variant") ?? "serial";
-  if (!isTestVariant(variant)) {
-    return NextResponse.json(
-      { error: `Unknown test variant: ${variant}` },
-      { status: 400 },
-    );
-  }
-  const userId = await resolveTestUserId(variant);
-  if (!userId) {
-    return NextResponse.json({ error: "Test user not found" }, { status: 500 });
-  }
+  const email = url.searchParams.get("email") ?? undefined;
+  const userId = await resolveTestUserId(email);
 
   // Auto-create org if user doesn't have one (creates real Clerk org or sentinel)
   const { slug: orgSlug } = await ensureTestOrg(userId);

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -12,7 +12,10 @@ import {
   getOrgBySlug,
 } from "../../../../../src/lib/org/org-cache-service";
 import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
-import { resolveTestUserId } from "../../../../../src/lib/auth/test-user";
+import {
+  resolveTestUserId,
+  DEFAULT_TEST_EMAIL,
+} from "../../../../../src/lib/auth/test-user";
 import { env } from "../../../../../src/env";
 
 /**
@@ -130,7 +133,7 @@ export async function POST(request: Request) {
   initServices();
 
   const url = new URL(request.url);
-  const email = url.searchParams.get("email") ?? undefined;
+  const email = url.searchParams.get("email") ?? DEFAULT_TEST_EMAIL;
   const userId = await resolveTestUserId(email);
 
   // Auto-create org if user doesn't have one (creates real Clerk org or sentinel)

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -15,6 +15,7 @@ import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
 import {
   resolveTestUserId,
   DEFAULT_TEST_EMAIL,
+  orgSlugFromEmail,
 } from "../../../../../src/lib/auth/test-user";
 import { env } from "../../../../../src/env";
 
@@ -45,22 +46,24 @@ function isTestTokenAllowed(request: Request): boolean {
 }
 
 /**
- * Ensure the test user has an org_cache entry for org resolution.
- * Queries Clerk API directly to find the user's org membership,
- * then pre-populates org_members_cache for fast verification.
+ * Ensure the test user has a real Clerk org and corresponding org_cache entry.
+ * Queries Clerk API to find the user's org membership. If found in org_cache,
+ * refreshes the cache TTL. If not in Clerk, creates a real Clerk org.
  *
- * If the user has no Clerk org yet, creates org_cache and org_members_cache
- * entries with a sentinel orgId.
+ * Always creates a real Clerk org (never a sentinel) so all Clerk-aware
+ * operations (e.g. zero org set, model-provider setup) work correctly.
  */
-async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
+async function ensureTestOrg(
+  userId: string,
+  email: string,
+): Promise<{ slug: string }> {
   // Query Clerk API directly for user's org memberships
   const client = await clerkClient();
   const memberships = await client.users.getOrganizationMembershipList({
     userId,
   });
 
-  // Use a far-future cachedAt so org_cache TTL checks never expire these
-  // entries and trigger a Clerk API refresh (sentinel orgs don't exist in Clerk).
+  // Use a far-future cachedAt so org_cache TTL checks never expire during tests
   const farFuture = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
 
   // Find first org with a matching org_cache entry
@@ -91,25 +94,32 @@ async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
     }
   }
 
-  // User has no Clerk org — use sentinel orgId with org_cache + membership cache
-  const sentinelOrgId = `org_test_${userId}`;
-  const slug = "test-org";
+  // User has no Clerk org — create a real one so Clerk-aware operations work
+  const slug = orgSlugFromEmail(email);
+  const org = await client.organizations.createOrganization({
+    name: slug,
+    slug,
+    createdBy: userId,
+  });
+  const orgId = org.id;
+
+  // Populate caches for the newly created org
   await globalThis.services.db
     .insert(orgCache)
     .values({
-      orgId: sentinelOrgId,
+      orgId,
       slug,
       cachedAt: farFuture,
     })
     .onConflictDoNothing();
   await globalThis.services.db
     .insert(orgMetadata)
-    .values({ orgId: sentinelOrgId })
+    .values({ orgId })
     .onConflictDoNothing();
   await globalThis.services.db
     .insert(orgMembersCache)
     .values({
-      orgId: sentinelOrgId,
+      orgId,
       userId,
       role: "admin",
       cachedAt: farFuture,
@@ -136,8 +146,8 @@ export async function POST(request: Request) {
   const email = url.searchParams.get("email") ?? DEFAULT_TEST_EMAIL;
   const userId = await resolveTestUserId(email);
 
-  // Auto-create org if user doesn't have one (creates real Clerk org or sentinel)
-  const { slug: orgSlug } = await ensureTestOrg(userId);
+  // Auto-create org if user doesn't have one
+  const { slug: orgSlug } = await ensureTestOrg(userId, email);
 
   // Resolve orgId from slug (ensureTestOrg creates org_cache entry, so this is a cache hit)
   const orgData = await getOrgBySlug(orgSlug);

--- a/turbo/apps/web/src/lib/auth/test-user.ts
+++ b/turbo/apps/web/src/lib/auth/test-user.ts
@@ -1,18 +1,16 @@
 import { clerkClient } from "@clerk/nextjs/server";
 
-const DEFAULT_TEST_EMAIL = "dev+clerk_test@serial.dev";
+export const DEFAULT_TEST_EMAIL = "dev+clerk_test@serial.dev";
 
 /**
  * Resolve a test user ID by email. If the user doesn't exist in Clerk,
  * creates one automatically. Used by test-token, test-approve, and
  * test-connector endpoints.
  *
- * @param email - the test user's email address (defaults to dev fallback)
+ * @param email - the test user's email address
  * @returns the Clerk user ID
  */
-export async function resolveTestUserId(
-  email: string = DEFAULT_TEST_EMAIL,
-): Promise<string> {
+export async function resolveTestUserId(email: string): Promise<string> {
   const clerk = await clerkClient();
   const { data: users } = await clerk.users.getUserList({
     emailAddress: [email],

--- a/turbo/apps/web/src/lib/auth/test-user.ts
+++ b/turbo/apps/web/src/lib/auth/test-user.ts
@@ -23,6 +23,7 @@ export async function resolveTestUserId(email: string): Promise<string> {
   // User doesn't exist — create on the fly
   const newUser = await clerk.users.createUser({
     emailAddress: [email],
+    skipPasswordRequirement: true,
   });
   return newUser.id;
 }

--- a/turbo/apps/web/src/lib/auth/test-user.ts
+++ b/turbo/apps/web/src/lib/auth/test-user.ts
@@ -3,6 +3,33 @@ import { clerkClient } from "@clerk/nextjs/server";
 export const DEFAULT_TEST_EMAIL = "dev+clerk_test@serial.dev";
 
 /**
+ * Derive a unique, valid org slug from a test user email.
+ * Handles emails like "pr-123+clerk_test@runner.dev" → "test-pr-123-runner".
+ *
+ * Org slug rules: lowercase letters, numbers, and hyphens; 3–64 chars;
+ * must start and end with alphanumeric.
+ *
+ * @param email - the test user's email address
+ * @returns a valid org slug derived from the email
+ */
+export function orgSlugFromEmail(email: string): string {
+  // Extract the local part before the first "@"
+  const local = email.split("@")[0] ?? email;
+  // Use the part before "+" (job ref) and the domain label (e.g. "runner")
+  const [jobRef] = local.split("+");
+  const domain = email.split("@")[1]?.split(".")[0] ?? "test";
+  const raw = `test-${jobRef ?? local}-${domain}`;
+  // Sanitize: keep only lowercase alphanumeric and hyphens, collapse runs
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return slug.length >= 3 ? slug : `test-${slug}`;
+}
+
+/**
  * Resolve a test user ID by email. If the user doesn't exist in Clerk,
  * creates one automatically. Used by test-token, test-approve, and
  * test-connector endpoints.

--- a/turbo/apps/web/src/lib/auth/test-user.ts
+++ b/turbo/apps/web/src/lib/auth/test-user.ts
@@ -1,28 +1,30 @@
 import { clerkClient } from "@clerk/nextjs/server";
 
-const TEST_USER_EMAILS = {
-  serial: "e2e+clerk_test@vm0.ai",
-  runner: "e2e_02+clerk_test@vm0.ai",
-} as const;
-
-type TestVariant = keyof typeof TEST_USER_EMAILS;
-
-export function isTestVariant(value: string): value is TestVariant {
-  return value in TEST_USER_EMAILS;
-}
+const DEFAULT_TEST_EMAIL = "dev+clerk_test@serial.dev";
 
 /**
- * Resolve the test user ID by querying Clerk Backend API for the e2e test user.
+ * Resolve a test user ID by email. If the user doesn't exist in Clerk,
+ * creates one automatically. Used by test-token, test-approve, and
+ * test-connector endpoints.
  *
- * @param variant - which test user to resolve ("serial" or "runner")
+ * @param email - the test user's email address (defaults to dev fallback)
+ * @returns the Clerk user ID
  */
 export async function resolveTestUserId(
-  variant: TestVariant = "serial",
-): Promise<string | null> {
-  const email = TEST_USER_EMAILS[variant];
+  email: string = DEFAULT_TEST_EMAIL,
+): Promise<string> {
   const clerk = await clerkClient();
   const { data: users } = await clerk.users.getUserList({
     emailAddress: [email],
   });
-  return users[0]?.id ?? null;
+
+  if (users[0]) {
+    return users[0].id;
+  }
+
+  // User doesn't exist — create on the fly
+  const newUser = await clerk.users.createUser({
+    emailAddress: [email],
+  });
+  return newUser.id;
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded `serial`/`runner` test user variants with dynamic email-based user creation in test endpoints (`test-token`, `test-approve`, `test-connector`)
- Auto-create Clerk users on the fly when they don't exist, eliminating the need for pre-provisioned persistent test accounts
- Add a CI cleanup step that purges stale test users before each run, preventing cross-run state leakage
- Update `generate-test-token.sh` to accept an email parameter instead of a variant name

## Test plan

- [ ] CI `cli-e2e` serial and runner tests pass with ephemeral users
- [ ] Lighthouse puppeteer auth uses the correct email from env
- [ ] Stale user cleanup step works correctly in CI
- [ ] Existing integration tests pass (`test-approve`, `test-token`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)