### PR TITLE
refactor: remove user-defined runner groups and enforce vm0/ prefix

### DIFF
--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/__tests__/route.test.ts
@@ -6,7 +6,6 @@ import {
   createTestCliToken,
   createTestCompose,
   createTestRunnerJob,
-  findTestComposeWithOrg,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -236,14 +235,11 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
   describe("Claim flow - Agent metadata", () => {
     it("should return appendSystemPrompt in claim response", async () => {
-      const { composeId, versionId } = await createTestCompose("test-asp");
-      const composeInfo = await findTestComposeWithOrg(composeId);
-      const orgSlug = composeInfo!.orgSlug;
-
+      const { versionId } = await createTestCompose("test-asp");
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
-        `${orgSlug}/default`,
+        "vm0/default",
         undefined,
         { appendSystemPrompt: "Your name is Aria." },
       );
@@ -269,14 +265,11 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should return null appendSystemPrompt when not set", async () => {
-      const { composeId, versionId } = await createTestCompose("test-asp-null");
-      const composeInfo = await findTestComposeWithOrg(composeId);
-      const orgSlug = composeInfo!.orgSlug;
-
+      const { versionId } = await createTestCompose("test-asp-null");
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
-        `${orgSlug}/default`,
+        "vm0/default",
       );
 
       const token = await createTestCliToken(user.userId);
@@ -302,14 +295,11 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
   describe("Claim flow - sandbox token generation", () => {
     it("should generate sandbox token without capabilities", async () => {
-      const { composeId, versionId } = await createTestCompose("test-no-caps");
-      const composeInfo = await findTestComposeWithOrg(composeId);
-      const orgSlug = composeInfo!.orgSlug;
-
+      const { versionId } = await createTestCompose("test-no-caps");
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
-        `${orgSlug}/default`,
+        "vm0/default",
       );
 
       const token = await createTestCliToken(user.userId);
@@ -337,10 +327,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
   describe("Claim flow - secretValues filtering", () => {
     it("should only include secret values present in environment", async () => {
-      const { composeId, versionId } =
-        await createTestCompose("test-secret-filter");
-      const composeInfo = await findTestComposeWithOrg(composeId);
-      const orgSlug = composeInfo!.orgSlug;
+      const { versionId } = await createTestCompose("test-secret-filter");
 
       const encryptedSecrets = encryptSecretsMap(
         {
@@ -354,7 +341,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
-        `${orgSlug}/default`,
+        "vm0/default",
         {
           encryptedSecrets,
           environment: {
@@ -390,9 +377,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should return empty array when no secrets match environment", async () => {
-      const { composeId, versionId } = await createTestCompose("test-no-match");
-      const composeInfo = await findTestComposeWithOrg(composeId);
-      const orgSlug = composeInfo!.orgSlug;
+      const { versionId } = await createTestCompose("test-no-match");
 
       const encryptedSecrets = encryptSecretsMap(
         { SECRET: "not-in-env" },
@@ -402,7 +387,7 @@ describe("POST /api/runners/jobs/:id/claim", () => {
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
-        `${orgSlug}/default`,
+        "vm0/default",
         {
           encryptedSecrets,
           environment: { SOME_VAR: "other-value" },
@@ -430,15 +415,11 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should return null when no encrypted secrets exist", async () => {
-      const { composeId, versionId } =
-        await createTestCompose("test-no-secrets");
-      const composeInfo = await findTestComposeWithOrg(composeId);
-      const orgSlug = composeInfo!.orgSlug;
-
+      const { versionId } = await createTestCompose("test-no-secrets");
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
-        `${orgSlug}/default`,
+        "vm0/default",
       );
 
       const token = await createTestCliToken(user.userId);
@@ -464,14 +445,11 @@ describe("POST /api/runners/jobs/:id/claim", () => {
 
   describe("Claim flow - execution context fields", () => {
     it("should return settings when present in stored context", async () => {
-      const { composeId, versionId } = await createTestCompose("test-settings");
-      const composeInfo = await findTestComposeWithOrg(composeId);
-      const orgSlug = composeInfo!.orgSlug;
-
+      const { versionId } = await createTestCompose("test-settings");
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
-        `${orgSlug}/default`,
+        "vm0/default",
         { settings: '{"hooks":{}}' },
       );
 
@@ -496,14 +474,11 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should return tools when present in stored context", async () => {
-      const { composeId, versionId } = await createTestCompose("test-tools");
-      const composeInfo = await findTestComposeWithOrg(composeId);
-      const orgSlug = composeInfo!.orgSlug;
-
+      const { versionId } = await createTestCompose("test-tools");
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
-        `${orgSlug}/default`,
+        "vm0/default",
         { tools: ["Bash", "Edit"] },
       );
 
@@ -528,15 +503,11 @@ describe("POST /api/runners/jobs/:id/claim", () => {
     });
 
     it("should omit fields when not in stored context", async () => {
-      const { composeId, versionId } =
-        await createTestCompose("test-no-extras");
-      const composeInfo = await findTestComposeWithOrg(composeId);
-      const orgSlug = composeInfo!.orgSlug;
-
+      const { versionId } = await createTestCompose("test-no-extras");
       const { runId } = await createTestRunnerJob(
         user.userId,
         versionId,
-        `${orgSlug}/default`,
+        "vm0/default",
       );
 
       const token = await createTestCliToken(user.userId);

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -16,10 +16,7 @@ import { getRunnerAuth } from "../../../../../../src/lib/auth/runner-auth";
 import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
 import { logger } from "../../../../../../src/lib/logger";
 import { decryptSecretsMap } from "../../../../../../src/lib/crypto/secrets-encryption";
-import {
-  validateRunnerGroupOrg,
-  isOfficialRunnerGroup,
-} from "../../../../../../src/lib/org/org-service";
+import { isOfficialRunnerGroup } from "../../../../../../src/lib/org/org-service";
 import { recordSandboxOperation } from "../../../../../../src/lib/metrics";
 
 const log = logger("api:runners:jobs:claim");
@@ -83,10 +80,11 @@ const router = tsr.router(runnersJobClaimContract, {
         return createErrorResponse("FORBIDDEN", "Job does not belong to user");
       }
 
-      try {
-        await validateRunnerGroupOrg(auth.userId, jobWithRun.job.runnerGroup);
-      } catch {
-        return createErrorResponse("FORBIDDEN", "Access denied");
+      if (!isOfficialRunnerGroup(jobWithRun.job.runnerGroup)) {
+        return createErrorResponse(
+          "FORBIDDEN",
+          "Only vm0/* runner groups are supported",
+        );
       }
     }
 

--- a/turbo/apps/web/app/api/runners/poll/route.ts
+++ b/turbo/apps/web/app/api/runners/poll/route.ts
@@ -10,10 +10,7 @@ import { runnerJobQueue } from "../../../../src/db/schema/runner-job-queue";
 import { eq, and, isNull, inArray, type SQL } from "drizzle-orm";
 import { getRunnerAuth } from "../../../../src/lib/auth/runner-auth";
 import { logger } from "../../../../src/lib/logger";
-import {
-  validateRunnerGroupOrg,
-  isOfficialRunnerGroup,
-} from "../../../../src/lib/org/org-service";
+import { isOfficialRunnerGroup } from "../../../../src/lib/org/org-service";
 
 const log = logger("api:runners:poll");
 
@@ -46,11 +43,12 @@ const router = tsr.router(runnersPollContract, {
       ];
       log.debug(`Official runner polling group: ${group}`);
     } else {
-      // User runners: validate org and filter by userId
-      try {
-        await validateRunnerGroupOrg(auth.userId, group);
-      } catch {
-        return createErrorResponse("FORBIDDEN", "Access denied");
+      // User runners: enforce vm0/* groups and filter by userId
+      if (!isOfficialRunnerGroup(group)) {
+        return createErrorResponse(
+          "FORBIDDEN",
+          "Only vm0/* runner groups are supported",
+        );
       }
       whereConditions = [
         eq(runnerJobQueue.runnerGroup, group),

--- a/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/__tests__/route.test.ts
@@ -158,17 +158,13 @@ describe("POST /api/runners/realtime/token", () => {
       expect(data.mac).toBe("test-mac");
     });
 
-    it("should return Ably TokenRequest for user runner with matching org group", async () => {
+    it("should return Ably TokenRequest for user runner with vm0 group", async () => {
       vi.stubEnv("ABLY_API_KEY", "test-api-key");
       reloadEnv();
       const token = await createTestCliToken(user.userId);
 
-      // Derive org slug from user context - setupUser creates org-{suffix}
-      const suffix = user.userId.replace("test-user-", "");
-      const orgSlug = `org-${suffix}`;
-
       const response = await POST(
-        makeRequest({ group: `${orgSlug}/default` }, `Bearer ${token}`),
+        makeRequest({ group: "vm0/production" }, `Bearer ${token}`),
       );
       const data = await response.json();
 

--- a/turbo/apps/web/app/api/runners/realtime/token/route.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/route.ts
@@ -3,10 +3,7 @@ import { runnerRealtimeTokenContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getRunnerAuth } from "../../../../../src/lib/auth/runner-auth";
 import { generateRunnerGroupToken } from "../../../../../src/lib/realtime/client";
-import {
-  validateRunnerGroupOrg,
-  isOfficialRunnerGroup,
-} from "../../../../../src/lib/org/org-service";
+import { isOfficialRunnerGroup } from "../../../../../src/lib/org/org-service";
 import { logger } from "../../../../../src/lib/logger";
 
 const log = logger("api:runners:realtime:token");
@@ -33,11 +30,12 @@ const router = tsr.router(runnerRealtimeTokenContract, {
       }
       log.debug(`Official runner requesting token for ${group}`);
     } else {
-      // User runners: validate org
-      try {
-        await validateRunnerGroupOrg(auth.userId, group);
-      } catch {
-        return createErrorResponse("FORBIDDEN", "Access denied");
+      // User runners: enforce vm0/* groups
+      if (!isOfficialRunnerGroup(group)) {
+        return createErrorResponse(
+          "FORBIDDEN",
+          "Only vm0/* runner groups are supported",
+        );
       }
       log.debug(`User runner ${auth.userId} requesting token for ${group}`);
     }

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -44,7 +44,7 @@ const resetEnv = vi.hoisted(() => {
     vi.stubEnv("NGROK_API_KEY", "test-ngrok-api-key");
     vi.stubEnv("NGROK_COMPUTER_CONNECTOR_DOMAIN", "computer.test.vm0.io");
     // Runner executor default group (runs dispatch to runner)
-    // Uses "vm0" org which is hardcoded as public in validateRunnerGroupOrg
+    // Uses "vm0" org which is hardcoded as public in isOfficialRunnerGroup
     vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/default");
     // API URL for compose job webhooks
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");

--- a/turbo/apps/web/src/lib/org/org-service.ts
+++ b/turbo/apps/web/src/lib/org/org-service.ts
@@ -6,9 +6,8 @@ import {
   getOrgBySlug,
   invalidateOrgCache,
 } from "./org-cache-service";
-import { badRequest, forbidden } from "../errors";
+import { badRequest } from "../errors";
 import { logger } from "../logger";
-import { verifyMembershipCached } from "./org-membership-cache";
 import type { ResolvedOrg } from "./resolve-org";
 
 const log = logger("service:org");
@@ -115,43 +114,6 @@ export function isOfficialRunnerGroup(group: string): boolean {
   const orgSlug = group.split("/")[0];
   // TODO: Runner group public access for vm0 is hardcoded. This should be configurable.
   return orgSlug === "vm0";
-}
-
-/**
- * Validate that a runner group's org matches the user's org.
- * Runner groups are in format "org/name" (e.g., "e2e-stable/pr-851").
- *
- * For official runner groups (vm0/*), any authenticated user is allowed.
- * For user runner groups, verifies membership via org_members_cache.
- *
- * @throws ForbiddenError if org doesn't match (for non-official groups)
- */
-export async function validateRunnerGroupOrg(
-  userId: string,
-  group: string,
-): Promise<void> {
-  const orgSlug = group.split("/")[0];
-  if (!orgSlug) {
-    throw forbidden("Invalid runner group format");
-  }
-
-  // TODO: Runner group public access for vm0 is hardcoded. This should be configurable.
-  if (orgSlug === "vm0") {
-    return;
-  }
-
-  // Look up the org by slug, then verify membership via cache
-  const orgData = await getOrgBySlug(orgSlug);
-  if (!orgData) {
-    throw forbidden(
-      `Runner group org "${orgSlug}" requires you to have an org configured`,
-    );
-  }
-
-  const membership = await verifyMembershipCached(orgData.orgId, userId);
-  if (!membership) {
-    throw forbidden(`Runner group org "${orgSlug}" does not match your org`);
-  }
 }
 
 /**

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -651,7 +651,7 @@ describe("createRun()", () => {
       expect(result.status).toBe("pending");
     });
 
-    it("should mark run as failed when runner group org validation fails", async () => {
+    it("should mark run as failed when runner group is not vm0/*", async () => {
       vi.stubEnv("RUNNER_DEFAULT_GROUP", "nonexistent-org/default");
       reloadEnv();
 
@@ -675,7 +675,7 @@ describe("createRun()", () => {
       const run = await findTestRunRecord(runId);
       expect(run).toBeDefined();
       expect(run!.status).toBe("failed");
-      expect(run!.error).toMatch(/nonexistent-org/);
+      expect(run!.error).toMatch(/vm0/);
     });
   });
 

--- a/turbo/apps/web/src/lib/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/run/executors/runner-executor.ts
@@ -3,7 +3,8 @@ import { eq } from "drizzle-orm";
 import { agentRuns } from "../../../db/schema/agent-run";
 import { runnerJobQueue } from "../../../db/schema/runner-job-queue";
 import { encryptSecretsMap } from "../../crypto/secrets-encryption";
-import { validateRunnerGroupOrg } from "../../org/org-service";
+import { isOfficialRunnerGroup } from "../../org/org-service";
+import { forbidden } from "../../errors";
 import { publishJobNotification } from "../../realtime/client";
 import { logger } from "../../logger";
 import { recordSandboxOperation } from "../../metrics";
@@ -41,8 +42,10 @@ export async function executeRunnerJob(
 
   log.debug(`Queueing run ${context.runId} for runner group: ${runnerGroup}`);
 
-  // Validate runner group org matches user's org
-  await validateRunnerGroupOrg(context.userId, runnerGroup);
+  // Enforce vm0/* runner groups only
+  if (!isOfficialRunnerGroup(runnerGroup)) {
+    throw forbidden("Only vm0/* runner groups are supported");
+  }
 
   // Encrypt secrets map (key-value pairs) before storing
   const encryptedSecrets = encryptSecretsMap(


### PR DESCRIPTION
## Summary

- Remove `validateRunnerGroupOrg()` function and replace with `isOfficialRunnerGroup()` checks in all runner API endpoints and executor
- Clean up unused imports (`verifyMembershipCached`, `forbidden`) from `org-service.ts`
- Update tests to use `vm0/default` runner groups instead of user-org groups

## Motivation

No real users use non-`vm0/*` runner groups. This eliminates the async org-slug-based validation code path (`getOrgBySlug` → membership check) that adds unnecessary complexity.

Closes #7202

## Test plan

- [x] All 28 runner API tests pass (`poll`, `claim`, `realtime/token`)
- [x] All 52 `create-run` tests pass
- [x] Lint passes clean
- [x] Knip reports no unused exports
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)