### PR TITLE
fix(block-cow): sync writes before dm teardown in restore test

### DIFF
--- a/crates/block-cow/tests/integration.rs
+++ b/crates/block-cow/tests/integration.rs
@@ -179,8 +179,18 @@ fn restore_from_existing_cow() {
     let dev_path = device.device_path().to_owned();
 
     // Write a marker to the raw block device to dirty the COW.
+    // Use explicit open + sync + drop so the kernel flushes page cache
+    // before we tear down the dm device (avoids EBUSY from dmsetup remove).
     let marker = b"BLOCK_COW_TEST_MARKER";
-    fs::write(&dev_path, marker).expect("write marker to device");
+    {
+        use std::io::Write;
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .open(&dev_path)
+            .expect("open device for writing");
+        f.write_all(marker).expect("write marker");
+        f.sync_all().expect("sync marker");
+    }
 
     device.destroy_keep_cow().expect("destroy_keep_cow");
     assert!(cow_file.exists(), "COW file should be preserved");


### PR DESCRIPTION
## Summary
- Fix intermittent `Device or resource busy` failure in `restore_from_existing_cow` test
- Replace `fs::write()` (no fsync) with explicit `open + write_all + sync_all + drop` to flush kernel page cache before `dmsetup remove`

## Root Cause
`fs::write()` does not call `fsync`. When the test immediately calls `destroy_keep_cow()` → `dmsetup remove`, the kernel may still have pending page cache I/O on the device, causing EBUSY.

Failure: https://github.com/vm0-ai/vm0/actions/runs/23737326888/job/69145317755

## Test plan
- [ ] `block-cow-test` CI job passes (requires metal host with root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)