### PR TITLE
feat(cli): add --firewall-policies flag to run commands

### DIFF
--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -4,6 +4,7 @@ import {
   collectKeyValue,
   isUUID,
   loadValues,
+  parseFirewallPolicies,
   pollEvents,
   showNextSteps,
   renderRunCreated,
@@ -53,6 +54,10 @@ export const continueCommand = new Command()
     "--settings <json>",
     "Settings JSON to pass to Claude CLI (e.g., hooks, permissions)",
   )
+  .option(
+    "--firewall-policies <json>",
+    'Firewall policies JSON (e.g., \'{"github": {"actions:read": "allow"}}\')',
+  )
   .option("--verbose", "Show full tool inputs and outputs")
   .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -70,6 +75,7 @@ export const continueCommand = new Command()
           disallowedTools?: string[];
           tools?: string[];
           settings?: string;
+          firewallPolicies?: string;
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -87,6 +93,7 @@ export const continueCommand = new Command()
           disallowedTools?: string[];
           tools?: string[];
           settings?: string;
+          firewallPolicies?: string;
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -126,6 +133,9 @@ export const continueCommand = new Command()
           disallowedTools: options.disallowedTools || allOpts.disallowedTools,
           tools: options.tools || allOpts.tools,
           settings: options.settings || allOpts.settings,
+          firewallPolicies: parseFirewallPolicies(
+            options.firewallPolicies || allOpts.firewallPolicies,
+          ),
           checkEnv: options.checkEnv || allOpts.checkEnv || undefined,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -5,6 +5,7 @@ import {
   collectVolumeVersions,
   isUUID,
   loadValues,
+  parseFirewallPolicies,
   pollEvents,
   showNextSteps,
   renderRunCreated,
@@ -58,6 +59,10 @@ export const resumeCommand = new Command()
     "--settings <json>",
     "Settings JSON to pass to Claude CLI (e.g., hooks, permissions)",
   )
+  .option(
+    "--firewall-policies <json>",
+    'Firewall policies JSON (e.g., \'{"github": {"actions:read": "allow"}}\')',
+  )
   .option("--verbose", "Show full tool inputs and outputs")
   .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -75,6 +80,7 @@ export const resumeCommand = new Command()
           disallowedTools?: string[];
           tools?: string[];
           settings?: string;
+          firewallPolicies?: string;
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -93,6 +99,7 @@ export const resumeCommand = new Command()
           disallowedTools?: string[];
           tools?: string[];
           settings?: string;
+          firewallPolicies?: string;
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -136,6 +143,9 @@ export const resumeCommand = new Command()
           disallowedTools: options.disallowedTools || allOpts.disallowedTools,
           tools: options.tools || allOpts.tools,
           settings: options.settings || allOpts.settings,
+          firewallPolicies: parseFirewallPolicies(
+            options.firewallPolicies || allOpts.firewallPolicies,
+          ),
           checkEnv: options.checkEnv || allOpts.checkEnv || undefined,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -12,6 +12,7 @@ import {
   extractVarNames,
   extractSecretNames,
   loadValues,
+  parseFirewallPolicies,
   parseIdentifier,
   pollEvents,
   showNextSteps,
@@ -85,6 +86,10 @@ export const mainRunCommand = new Command()
     "--settings <json>",
     "Settings JSON to pass to Claude CLI (e.g., hooks, permissions)",
   )
+  .option(
+    "--firewall-policies <json>",
+    'Firewall policies JSON (e.g., \'{"github": {"actions:read": "allow"}}\')',
+  )
   .option("--verbose", "Show full tool inputs and outputs")
   .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
@@ -108,6 +113,7 @@ export const mainRunCommand = new Command()
           disallowedTools?: string[];
           tools?: string[];
           settings?: string;
+          firewallPolicies?: string;
           verbose?: boolean;
           checkEnv?: boolean;
           debugNoMockClaude?: boolean;
@@ -195,6 +201,7 @@ export const mainRunCommand = new Command()
           disallowedTools: options.disallowedTools,
           tools: options.tools,
           settings: options.settings,
+          firewallPolicies: parseFirewallPolicies(options.firewallPolicies),
           checkEnv: options.checkEnv || undefined,
           debugNoMockClaude: options.debugNoMockClaude || undefined,
         });

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -4,7 +4,11 @@ import { config as dotenvConfig } from "dotenv";
 import { getEvents } from "../../lib/api";
 import { parseEvent } from "../../lib/events/event-parser-factory";
 import { EventRenderer } from "../../lib/events/event-renderer";
-import { extractAndGroupVariables } from "@vm0/core";
+import {
+  extractAndGroupVariables,
+  firewallPoliciesSchema,
+  type FirewallPolicies,
+} from "@vm0/core";
 /**
  * Collector for --secrets and --vars flags
  * Format: KEY=value
@@ -41,6 +45,31 @@ export function collectVolumeVersions(
   }
 
   return { ...previous, [volumeName]: version };
+}
+
+/**
+ * Parse and validate --firewall-policies JSON string.
+ * Returns undefined when no value is provided.
+ */
+export function parseFirewallPolicies(
+  json: string | undefined,
+): FirewallPolicies | undefined {
+  if (!json) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error(
+      `Invalid --firewall-policies JSON: ${json}\nExpected format: '{"ref": {"permission": "allow|deny|ask"}}'`,
+    );
+  }
+  const result = firewallPoliciesSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `Invalid --firewall-policies: ${result.error.issues.map((i) => i.message).join(", ")}`,
+    );
+  }
+  return result.data;
 }
 
 export function isUUID(str: string): boolean {

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -7,6 +7,7 @@ import {
   type RunsListResponse,
   type CancelRunResponse,
   type QueueResponse,
+  type FirewallPolicies,
 } from "@vm0/core";
 import { getClientConfig, handleError } from "../core/client-factory";
 import type { CreateRunResponse, GetEventsResponse } from "../core/types";
@@ -44,6 +45,8 @@ export async function createRun(body: {
   tools?: string[];
   // Settings JSON to pass to Claude CLI (passed as --settings)
   settings?: string;
+  // Per-permission firewall policies
+  firewallPolicies?: FirewallPolicies;
   // Required
   prompt: string;
 }): Promise<CreateRunResponse> {

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -22,6 +22,7 @@ import {
   getOrgCacheEntry,
   createTestZeroAgent,
   updateOrgTier,
+  findTestRunnerJobEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
 import {
@@ -101,6 +102,32 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const run = await getTestRun(data.runId);
 
       expect(run.appendSystemPrompt).toBe("Custom instructions");
+    });
+
+    it("should forward firewallPolicies to execution context", async () => {
+      await createTestConnector({ type: "github" });
+
+      const data = await createTestRun(testComposeId, "Test with policies", {
+        firewallPolicies: {
+          github: {
+            "actions:read": "allow",
+            "actions:write": "deny",
+            "issues:read": "allow",
+          },
+        },
+      });
+
+      expect(data.runId).toBeDefined();
+      const job = await findTestRunnerJobEntry(data.runId);
+      expect(job).toBeDefined();
+      const firewalls = job!.executionContext.experimentalFirewalls;
+      expect(firewalls).toBeDefined();
+      const ghFirewall = firewalls!.find((fw) => fw.ref === "github");
+      expect(ghFirewall).toBeDefined();
+      const permNames = ghFirewall!.apis[0]!.permissions!.map((p) => p.name);
+      expect(permNames).toContain("actions:read");
+      expect(permNames).toContain("issues:read");
+      expect(permNames).not.toContain("actions:write");
     });
   });
 

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -234,6 +234,7 @@ const router = tsr.router(runsMainContract, {
         debugNoMockClaude: body.debugNoMockClaude,
         modelProvider: body.modelProvider,
         checkEnv: body.checkEnv,
+        firewallPolicies: body.firewallPolicies,
         callerOrgId: org.orgId,
       });
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -857,6 +857,7 @@ export async function createTestRun(
     checkEnv?: boolean;
     memoryName?: string;
     appendSystemPrompt?: string;
+    firewallPolicies?: Record<string, Record<string, string>>;
   },
 ): Promise<{ runId: string; status: string }> {
   const request = createTestRequest("http://localhost:3000/api/agent/runs", {

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
+import { firewallPoliciesSchema } from "./firewalls";
 import { triggerSourceSchema } from "./logs";
 import { orgTierSchema } from "./orgs";
 
@@ -69,6 +70,9 @@ const unifiedRunRequestSchema = z.object({
 
   // How the run was triggered (defaults to "cli" on the server if not provided)
   triggerSource: triggerSourceSchema.optional(),
+
+  // Per-permission firewall policies (e.g., { "github": { "actions:read": "allow" } })
+  firewallPolicies: firewallPoliciesSchema.optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Add `--firewall-policies <json>` option to `vm0 run`, `vm0 run resume`, and `vm0 run continue`
- Forward `firewallPolicies` through API contract and route handler to `startRun()`
- Client-side Zod validation for immediate error feedback

## Details

The downstream infrastructure (`startRun` → `buildContext` → `applyConnectorPolicies`) already supports `firewallPolicies`. This PR connects the CLI layer to the existing plumbing.

Usage:
```bash
vm0 run my-agent "prompt" --firewall-policies '{"github": {"actions:read": "allow", "actions:write": "deny"}}'
```

Closes #7208

## Test plan

- [ ] Existing `zero-run-service.test.ts` firewall policy tests pass (covers downstream flow)
- [ ] Type-check, lint, knip all pass
- [ ] Manual: `vm0 run --help` shows `--firewall-policies` option
- [ ] Manual: invalid JSON gives clear client-side error
- [ ] Manual: invalid policy values (e.g., `"block"`) rejected by Zod validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)