### PR TITLE
fix(sandbox-fc): do not delete workspace after deferred cow removal

### DIFF
--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -438,11 +438,14 @@ impl SandboxFactory for FirecrackerFactory {
                     } else {
                         // Last resort: schedule deferred removal. The kernel
                         // removes the target when Firecracker releases the fd.
+                        // Note: cow_destroyed stays false — deferred means the
+                        // dm target and loop device are NOT yet gone, so we must
+                        // keep the workspace (and its cow.img) intact.  Deleting
+                        // the backing file while the loop device still references
+                        // it creates an orphaned loop pointing at "(deleted)".
                         warn!(id = %sandbox_id, error = %e, "destroy failed after retries, trying deferred removal");
                         match sandbox.cow_device.destroy_deferred() {
-                            Ok(()) => {
-                                cow_destroyed = true;
-                            }
+                            Ok(()) => {}
                             Err(e) => {
                                 warn!(id = %sandbox_id, error = %e, "deferred removal also failed — relying on GC");
                                 sandbox.cow_device.abandon();


### PR DESCRIPTION
## Summary
- Fix orphaned loop devices pointing at `cow.img (deleted)` on metal hosts
- `destroy_deferred()` only schedules dm removal — the device and loop are still active until Firecracker releases its fd
- Previously set `cow_destroyed = true`, causing the workspace to be deleted while the loop device still referenced `cow.img`
- Now keeps `cow_destroyed = false` so the workspace is preserved for GC

## Root Cause
When `dmsetup remove` fails with EBUSY (Firecracker still holds the device fd), the code falls back to `destroy_deferred()` which uses `DM_DEFERRED_REMOVE`. This succeeds immediately but the actual removal is deferred. Setting `cow_destroyed = true` after deferred removal caused the workspace directory (containing `cow.img`) to be deleted, creating an orphaned loop device pointing at a deleted file.

## Test plan
- [ ] `runner doctor` on metal hosts should no longer report `orphan loop device ... cow.img (deleted)` for new runs
- [ ] Existing orphans from before this fix can be cleaned with `losetup -d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)