### PR TITLE
fix(axiom): batch ingestion and add query retry to avoid org rate limit

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/events/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/route.ts
@@ -73,9 +73,9 @@ const router = tsr.router(webhookEventsContract, {
       }),
     );
 
-    // Ingest events to Axiom
+    // Buffer events for Axiom (flushed at response boundary)
     const axiomDataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
-    await ingestToAxiom(axiomDataset, axiomEvents);
+    ingestToAxiom(axiomDataset, axiomEvents);
 
     // Get first and last sequence numbers from the events
     // Note: events array is validated as non-empty by the contract

--- a/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/telemetry/route.ts
@@ -66,7 +66,7 @@ const router = tsr.router(webhookTelemetryContract, {
     // Telemetry data is already masked client-side in the sandbox before sending
     // No server-side masking needed - secrets values are never stored
 
-    // Ingest system log to Axiom (fire-and-forget - don't fail webhook if Axiom fails)
+    // Buffer telemetry for Axiom (all flushed at response boundary)
     if (body.systemLog) {
       const axiomDataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_SYSTEM);
       const axiomEvent = {
@@ -75,12 +75,9 @@ const router = tsr.router(webhookTelemetryContract, {
         userId: auth.userId,
         log: body.systemLog, // Already masked by client
       };
-      await ingestToAxiom(axiomDataset, [axiomEvent]).catch((err) => {
-        log.error("Axiom system log ingest failed:", err);
-      });
+      ingestToAxiom(axiomDataset, [axiomEvent]);
     }
 
-    // Ingest metrics to Axiom (fire-and-forget)
     if (body.metrics && body.metrics.length > 0) {
       const axiomDataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_METRICS);
       const axiomEvents = body.metrics.map(
@@ -102,12 +99,9 @@ const router = tsr.router(webhookTelemetryContract, {
           disk_total: metric.disk_total,
         }),
       );
-      ingestToAxiom(axiomDataset, axiomEvents).catch((err) => {
-        log.error("Axiom metrics ingest failed:", err);
-      });
+      ingestToAxiom(axiomDataset, axiomEvents);
     }
 
-    // Ingest network logs to Axiom (fire-and-forget)
     if (body.networkLogs && body.networkLogs.length > 0) {
       const axiomDataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_NETWORK);
       const axiomEvents = body.networkLogs.map(
@@ -118,9 +112,7 @@ const router = tsr.router(webhookTelemetryContract, {
           userId: auth.userId,
         }),
       );
-      ingestToAxiom(axiomDataset, axiomEvents).catch((err) => {
-        log.error("Axiom network logs ingest failed:", err);
-      });
+      ingestToAxiom(axiomDataset, axiomEvents);
     }
 
     // Record sandbox internal operations as OpenTelemetry metrics (to sandbox-metric-{env} dataset)

--- a/turbo/apps/web/src/lib/axiom/client.ts
+++ b/turbo/apps/web/src/lib/axiom/client.ts
@@ -78,34 +78,77 @@ function extractDatasetFromApl(apl: string): string | null {
 }
 
 /**
- * Ingest events to Axiom dataset.
- * Non-blocking - logs errors but doesn't throw.
+ * Buffer events for Axiom ingestion.
+ *
+ * Events are queued in the Axiom SDK's internal batch and flushed at the
+ * response boundary via {@link flushAxiom} (called from ts-rest-handler).
+ * This avoids per-call HTTP requests and keeps API usage within org limits.
  */
-export async function ingestToAxiom(
+export function ingestToAxiom(
   dataset: string,
   events: Record<string, unknown>[],
-): Promise<boolean> {
+): boolean {
   const client = getClientForDataset(dataset);
   if (!client) {
     log.debug("Axiom not configured, skipping ingest");
     return false;
   }
 
-  try {
-    client.ingest(dataset, events);
-    await client.flush();
-    log.debug(`Ingested ${events.length} events to ${dataset}`);
-    return true;
-  } catch (error) {
-    log.error(`Axiom ingest failed for ${dataset}:`, error);
-    return false;
+  client.ingest(dataset, events);
+  log.debug(`Buffered ${events.length} events for ${dataset}`);
+  return true;
+}
+
+/**
+ * Flush all pending Axiom ingestion batches.
+ *
+ * Call at request/response boundaries to ensure buffered events are sent
+ * before the serverless function terminates.
+ */
+export async function flushAxiom(): Promise<void> {
+  const results = await Promise.allSettled([
+    sessionsClient?.flush(),
+    telemetryClient?.flush(),
+  ]);
+  for (const r of results) {
+    if (r.status === "rejected") {
+      log.error("Axiom flush failed:", r.reason);
+    }
   }
+}
+
+// ── Query retry ─────────────────────────────────────────────────────────
+
+const MAX_QUERY_RETRIES = 3;
+const QUERY_BACKOFF_BASE_MS = 2000;
+
+function isRateLimitError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const msg = error.message.toLowerCase();
+    return msg.includes("rate limit") || msg.includes("429");
+  }
+  return false;
+}
+
+function extractRetryAfterMs(error: unknown): number | null {
+  if (error instanceof Error) {
+    // Axiom error format: "try again in 0m19s"
+    const match = error.message.match(/try again in (\d+)m(\d+)s/);
+    if (match?.[1] && match[2]) {
+      return (parseInt(match[1], 10) * 60 + parseInt(match[2], 10)) * 1000;
+    }
+  }
+  return null;
 }
 
 /**
  * Query events from Axiom dataset using APL.
  * Automatically routes to the correct client based on the dataset in the APL query.
  * Returns empty array if Axiom is not configured.
+ *
+ * Retries up to {@link MAX_QUERY_RETRIES} times on rate-limit (429) errors
+ * with exponential backoff, respecting the server's `retry_after` hint when
+ * available.
  */
 export async function queryAxiom<T = Record<string, unknown>>(
   apl: string,
@@ -118,12 +161,32 @@ export async function queryAxiom<T = Record<string, unknown>>(
     return [];
   }
 
-  const result = await client.query(apl);
-  // Axiom stores _time separately from data, merge them for the response
-  return (
-    result.matches?.map((m: Entry) => ({ _time: m._time, ...m.data }) as T) ??
-    []
-  );
+  for (let attempt = 0; attempt <= MAX_QUERY_RETRIES; attempt++) {
+    try {
+      const result = await client.query(apl);
+      // Axiom stores _time separately from data, merge them for the response
+      return (
+        result.matches?.map(
+          (m: Entry) => ({ _time: m._time, ...m.data }) as T,
+        ) ?? []
+      );
+    } catch (error) {
+      if (attempt < MAX_QUERY_RETRIES && isRateLimitError(error)) {
+        const waitMs =
+          extractRetryAfterMs(error) ??
+          QUERY_BACKOFF_BASE_MS * Math.pow(2, attempt);
+        log.warn(
+          `Axiom query rate limited, retrying in ${waitMs}ms (attempt ${attempt + 1}/${MAX_QUERY_RETRIES})`,
+        );
+        await new Promise((r) => setTimeout(r, waitMs));
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  // Unreachable — the final attempt either returns or throws above
+  return [];
 }
 
 interface RequestLogEntry {

--- a/turbo/apps/web/src/lib/axiom/index.ts
+++ b/turbo/apps/web/src/lib/axiom/index.ts
@@ -1,5 +1,6 @@
 export {
   ingestToAxiom,
+  flushAxiom,
   queryAxiom,
   ingestRequestLog,
   ingestSandboxOpLog,

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -17,7 +17,7 @@ import { TsRestResponse } from "@ts-rest/serverless";
 import type { TsRestRequest } from "@ts-rest/serverless";
 import type { AppRouter } from "@ts-rest/core";
 import { flushLogs, logger } from "./logger";
-import { ingestRequestLog } from "./axiom";
+import { ingestRequestLog, flushAxiom } from "./axiom";
 
 // Re-export tsr and TsRestResponse for convenience
 export { tsr, TsRestResponse };
@@ -159,8 +159,9 @@ export function createHandler<T extends AppRouter>(
           requestStartTimes.delete(request);
         }
 
-        // Flush all pending logs to Axiom after each request
+        // Flush all pending logs and ingested events to Axiom
         await flushLogs();
+        await flushAxiom();
       },
     ],
   });


### PR DESCRIPTION
## Summary

- **Batch Axiom ingestion**: `ingestToAxiom()` now buffers events without flushing. A new `flushAxiom()` function is called once at the response boundary in `ts-rest-handler`, reducing telemetry webhook calls from 3 HTTP requests to 1.
- **Query retry with backoff**: `queryAxiom()` retries up to 3 times on 429 rate-limit errors with exponential backoff (2s/4s/8s), respecting server `retry_after` hints. Prevents silent data loss in `persistChatMessages()`.

Closes #7219

## Test plan

- [x] All 4512 existing tests pass
- [x] Type check clean (7/7 workspaces)
- [x] Lint clean (0 warnings)
- [x] Knip clean (no unused exports)
- [ ] Verify in staging: telemetry webhook Axiom API call count reduced
- [ ] Verify in staging: `persistChatMessages` survives transient 429 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)