### PR TITLE
test(axiom): add regression tests and address review feedback for #7228

### DIFF
--- a/turbo/apps/web/src/__tests__/test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/test-helpers.ts
@@ -125,8 +125,10 @@ interface AxiomMocks {
   flush: Mock;
   /** Spy for queryAxiom function - use mockResolvedValue to set return value */
   queryAxiom: MockInstance<typeof axiomClient.queryAxiom>;
-  /** Spy for ingestToAxiom function - use mockResolvedValue to set return value */
+  /** Spy for ingestToAxiom function - use mockReturnValue to set return value */
   ingestToAxiom: MockInstance<typeof axiomClient.ingestToAxiom>;
+  /** Spy for flushAxiom function */
+  flushAxiom: MockInstance<typeof axiomClient.flushAxiom>;
 }
 
 /**
@@ -291,7 +293,10 @@ export function testContext(): TestContext {
       queryAxiom: vi.spyOn(axiomClient, "queryAxiom").mockResolvedValue([]),
       ingestToAxiom: vi
         .spyOn(axiomClient, "ingestToAxiom")
-        .mockResolvedValue(true),
+        .mockReturnValue(true),
+      flushAxiom: vi
+        .spyOn(axiomClient, "flushAxiom")
+        .mockResolvedValue(undefined),
     };
     // Use try/catch since Axiom may not be mocked in all test files
     try {

--- a/turbo/apps/web/src/lib/axiom/__tests__/client.test.ts
+++ b/turbo/apps/web/src/lib/axiom/__tests__/client.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock @axiomhq/js at the package boundary.
+const mockQuery = vi.fn();
+const mockIngest = vi.fn();
+const mockFlush = vi.fn();
+vi.mock("@axiomhq/js", () => ({
+  Axiom: vi.fn().mockImplementation(function () {
+    return { query: mockQuery, ingest: mockIngest, flush: mockFlush };
+  }),
+}));
+vi.mock("@axiomhq/logging", () => ({
+  Logger: vi.fn().mockImplementation(function () {
+    return {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      flush: vi.fn().mockResolvedValue(undefined),
+    };
+  }),
+  AxiomJSTransport: vi.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
+import { reloadEnv } from "../../../env";
+import { queryAxiom, ingestToAxiom, flushAxiom } from "../client";
+
+beforeEach(() => {
+  vi.stubEnv("AXIOM_TOKEN_TELEMETRY", "test-telemetry-token");
+  vi.stubEnv("AXIOM_TOKEN_SESSIONS", "test-sessions-token");
+  reloadEnv();
+  mockQuery.mockReset();
+  mockIngest.mockReset();
+  mockFlush.mockReset();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function axiomResponse(events: Array<Record<string, unknown>>) {
+  return {
+    matches: events.map((data) => ({
+      _time: "2026-01-01T00:00:00.000Z",
+      data,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// ingestToAxiom
+// ---------------------------------------------------------------------------
+
+describe("ingestToAxiom", () => {
+  it("buffers events without flushing", () => {
+    const result = ingestToAxiom("vm0-test-dataset-dev", [{ key: "value" }]);
+
+    expect(result).toBe(true);
+    expect(mockIngest).toHaveBeenCalledWith("vm0-test-dataset-dev", [
+      { key: "value" },
+    ]);
+    expect(mockFlush).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// flushAxiom
+// ---------------------------------------------------------------------------
+
+describe("flushAxiom", () => {
+  it("flushes all clients", async () => {
+    mockFlush.mockResolvedValue(undefined);
+
+    // Trigger client initialization by ingesting something
+    ingestToAxiom("vm0-sandbox-telemetry-system-dev", [{ a: 1 }]);
+    await flushAxiom();
+
+    expect(mockFlush).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queryAxiom — retry behavior
+// ---------------------------------------------------------------------------
+
+describe("queryAxiom", () => {
+  const apl = "['vm0-agent-run-events-dev'] | where runId == \"run-1\"";
+
+  it("returns results on successful query", async () => {
+    mockQuery.mockResolvedValue(
+      axiomResponse([{ eventType: "result", eventData: { result: "hello" } }]),
+    );
+
+    const results = await queryAxiom(apl);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ eventType: "result" });
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on rate limit error and succeeds", async () => {
+    mockQuery
+      .mockRejectedValueOnce(new Error("429 rate limit"))
+      .mockResolvedValueOnce(axiomResponse([{ eventType: "result" }]));
+
+    const promise = queryAxiom(apl);
+    await vi.advanceTimersByTimeAsync(2000);
+    const results = await promise;
+
+    expect(results).toHaveLength(1);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after exhausting retries on persistent rate limit", async () => {
+    mockQuery.mockRejectedValue(new Error("429 rate limit"));
+
+    // Attach catch immediately to prevent unhandled rejection
+    const promise = queryAxiom(apl).catch((e: unknown) => e);
+    // Advance through all 3 retry backoffs: 2s + 4s + 8s = 14s
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    const error = await promise;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("429 rate limit");
+    // 1 initial + 3 retries = 4 total attempts
+    expect(mockQuery).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not retry on non-rate-limit errors", async () => {
+    mockQuery.mockRejectedValue(new Error("network timeout"));
+
+    await expect(queryAxiom(apl)).rejects.toThrow("network timeout");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/turbo/apps/web/src/lib/axiom/client.ts
+++ b/turbo/apps/web/src/lib/axiom/client.ts
@@ -104,6 +104,9 @@ export function ingestToAxiom(
  *
  * Call at request/response boundaries to ensure buffered events are sent
  * before the serverless function terminates.
+ *
+ * Errors are logged but not propagated — telemetry data is non-critical
+ * and a flush failure must not break the request/response cycle.
  */
 export async function flushAxiom(): Promise<void> {
   const results = await Promise.allSettled([
@@ -185,8 +188,9 @@ export async function queryAxiom<T = Record<string, unknown>>(
     }
   }
 
-  // Unreachable — the final attempt either returns or throws above
-  return [];
+  throw new Error(
+    "queryAxiom: unreachable — retry loop exited without return or throw",
+  );
 }
 
 interface RequestLogEntry {

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -160,8 +160,7 @@ export function createHandler<T extends AppRouter>(
         }
 
         // Flush all pending logs and ingested events to Axiom
-        await flushLogs();
-        await flushAxiom();
+        await Promise.all([flushLogs(), flushAxiom()]);
       },
     ],
   });


### PR DESCRIPTION
## Summary

Follow-up to #7228. Addresses code review feedback:

- **P0**: Add regression tests for `queryAxiom()` retry/backoff logic (6 tests covering success, retry-on-429, max-retry-exhaustion, non-rate-limit-error passthrough)
- **P1**: Add JSDoc explaining why `flushAxiom()` silently swallows errors (telemetry is non-critical)
- **P2**: Replace unreachable `return []` with explicit `throw new Error("unreachable")`
- **P2**: Parallelize `flushLogs()` and `flushAxiom()` with `Promise.all()`
- Fix `test-helpers.ts` mock: `ingestToAxiom` now uses `mockReturnValue` (sync), add `flushAxiom` spy

## Test plan

- [x] 4518 tests pass (including 6 new axiom client tests)
- [x] Type check clean
- [x] Lint clean
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)