### PR TITLE
refactor: make pr-check atomic and extract pr-check-loop

### DIFF
--- a/.claude/skills/issue-action/SKILL.md
+++ b/.claude/skills/issue-action/SKILL.md
@@ -92,16 +92,18 @@ Review new comments for:
 
 2. Run `/pr-review-loop` skill to perform a full code review and fix cycle
    - The pr-review-loop skill will review the PR, post comments, fix issues, and re-review until LGTM
-   - After the review loop completes, it automatically invokes `/pr-check` to monitor and fix CI pipeline
 
-3. **If pr-review-loop completes successfully (including CI check)**: Post comment to issue:
+3. Run `/pr-check-loop` skill to monitor and fix CI pipeline
+   - The pr-check-loop skill will poll CI status, auto-fix lint/format issues, and loop until all checks pass
+
+4. **If both complete successfully**: Post comment to issue:
    ```bash
    gh issue comment {issue-id} --body "Work completed. PR created: {pr-url}
 
    Code review passed and all CI checks passing."
    ```
 
-4. **If pr-review-loop exits with manual intervention required**: Add "pending" label and exit
+5. **If pr-review-loop or pr-check-loop exits with manual intervention required**: Add "pending" label and exit
 
 5. Keep issue open (user will close it after merging PR)
 

--- a/.claude/skills/pr-check-loop/SKILL.md
+++ b/.claude/skills/pr-check-loop/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: pr-check-loop
+description: Monitor PR CI pipeline, auto-fix issues, and loop until all checks pass
+context: fork
+---
+
+You are a CI pipeline monitor for the vm0 project. Your role is to continuously monitor PR CI checks, automatically fix what can be fixed, and loop until all checks pass or manual intervention is needed.
+
+## Architecture
+
+Loop control is handled by a **bash driver script**, not by your memory. You MUST follow the ACTION output from the driver script at every step. The driver script is deterministic — it enforces the check-fix cycle.
+
+```
+┌──────────┐     ACTION: REVIEW_PR     ┌─────────┐
+│  Driver   │ ──────────────────────→   │   LLM   │  ← check if PR has been reviewed
+│  Script   │ ←──────────────────────   │ (you)   │
+│           │   review-done             │         │
+│           │                           │         │
+│           │     ACTION: WAIT          │         │  ← sleep 60s for CI to settle
+│           │ ──────────────────────→   │         │
+│           │ ←──────────────────────   │         │
+│           │       wait-done           │         │
+│           │                           │         │
+│           │     ACTION: CHECK         │         │  ← poll CI status
+│           │ ──────────────────────→   │         │
+│           │ ←──────────────────────   │         │
+│           │   check-done <status>     │         │
+│           │                           │         │
+│           │     ACTION: FIX           │         │  ← auto-fix lint/format
+│           │ ──────────────────────→   │         │
+│           │ ←──────────────────────   │         │
+│           │       fix-done            │         │
+│           │                           │         │
+│           │     ACTION: PASS          │         │  ← all checks passed, done
+│           │ ──────────────────────→   │         │
+│           │                           │         │
+│           │     ACTION: MANUAL        │         │  ← type/test errors, exit
+│           │ ──────────────────────→   │         │
+│           │                           │         │
+│           │     ACTION: TIMEOUT       │         │  ← max iterations, exit
+│           │ ──────────────────────→   │         │
+└──────────┘                            └─────────┘
+```
+
+---
+
+## Phase 1: Setup
+
+### 1a: Identify PR
+
+**CRITICAL — do this FIRST before anything else.**
+
+Your args are: `$ARGUMENTS`
+
+Extract the PR number from the args above using these rules:
+1. **Args is a URL** containing `/pull/<number>` or `/issues/<number>` → extract `<number>` (e.g., `https://github.com/vm0-ai/vm0/pull/4128` → `4128`)
+2. **Args is a plain number** → use it directly (e.g., `4128`)
+3. **Args is empty** → detect from current branch using `gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'`
+
+Once you have the PR number, **hardcode it as a literal** in all subsequent bash commands. Never use shell variables for the PR number derived from args — always substitute the actual number directly.
+
+### 1b: Create Driver Script
+
+Write this script to `/tmp/pr-check-loop-driver.sh` and make it executable:
+
+```bash
+cat > /tmp/pr-check-loop-driver.sh << 'DRIVER'
+#!/bin/bash
+set -euo pipefail
+
+PR="$1"
+CMD="$2"
+STATE="/tmp/pr-check-loop-${PR}.state"
+FIXES="/tmp/pr-check-loop-${PR}.fixes"
+
+case "$CMD" in
+  init)
+    echo "0" > "$STATE"
+    echo "0" > "$FIXES"
+    echo "ACTION: REVIEW_PR"
+    ;;
+  review-done)
+    echo "ACTION: WAIT"
+    ;;
+  wait-done)
+    echo "ACTION: CHECK"
+    ;;
+  check-done)
+    STATUS="${3:-pending}"
+    ITER=$(cat "$STATE")
+    ITER=$((ITER + 1))
+    echo "$ITER" > "$STATE"
+    case "$STATUS" in
+      pass)
+        echo "ACTION: PASS"
+        ;;
+      fail-fixable)
+        if [ "$ITER" -ge 30 ]; then
+          echo "ACTION: TIMEOUT"
+        else
+          echo "ACTION: FIX"
+        fi
+        ;;
+      fail-manual)
+        echo "ACTION: MANUAL"
+        ;;
+      pending)
+        if [ "$ITER" -ge 30 ]; then
+          echo "ACTION: TIMEOUT"
+        else
+          echo "ACTION: WAIT"
+        fi
+        ;;
+    esac
+    ;;
+  fix-done)
+    FIXES_COUNT=$(cat "$FIXES")
+    FIXES_COUNT=$((FIXES_COUNT + 1))
+    echo "$FIXES_COUNT" > "$FIXES"
+    echo "ACTION: WAIT"
+    ;;
+esac
+DRIVER
+chmod +x /tmp/pr-check-loop-driver.sh
+```
+
+### 1c: Initialize
+
+```bash
+ACTION=$(/tmp/pr-check-loop-driver.sh "$PR_NUMBER" init)
+# Output: ACTION: REVIEW_PR
+```
+
+Display PR metadata, then proceed to Phase 2 following the ACTION.
+
+---
+
+## Phase 2: Action Loop
+
+Read the ACTION output from the driver script and execute the corresponding action. **Always call the driver script after completing an action to get the next ACTION.**
+
+### On `ACTION: REVIEW_PR`
+
+Check if the PR already has a code review comment:
+
+```bash
+comments=$(gh pr view "$pr_id" --json comments --jq '.comments[].body')
+```
+
+Look for review comments containing patterns like:
+- "## Code Review"
+- "LGTM"
+- "Changes Requested"
+
+**If no review found**: Execute `/pr-review` to analyze the PR and post findings.
+
+**If review exists**: Skip to next action.
+
+Report to driver:
+
+```bash
+ACTION=$(/tmp/pr-check-loop-driver.sh "$PR_NUMBER" review-done)
+# Output: ACTION: WAIT
+```
+
+Follow the returned ACTION.
+
+---
+
+### On `ACTION: WAIT`
+
+Wait 60 seconds for CI pipeline to settle:
+
+```bash
+sleep 60
+```
+
+Report to driver:
+
+```bash
+ACTION=$(/tmp/pr-check-loop-driver.sh "$PR_NUMBER" wait-done)
+# Output: ACTION: CHECK
+```
+
+Follow the returned ACTION.
+
+---
+
+### On `ACTION: CHECK`
+
+Poll CI status:
+
+```bash
+gh pr checks "$pr_id"
+```
+
+Classify the result:
+
+1. **All checks `pass` or `skipping`** → status is `pass`
+2. **Any check `fail`** → analyze failure type:
+   - Lint/format failures only → status is `fail-fixable`
+   - Type/test failures (with or without lint/format) → status is `fail-manual`
+3. **No failures, some `pending`** → status is `pending`
+
+**Fail-fast**: If ANY check has `fail` status, classify immediately without waiting for pending checks.
+
+When failures are detected, get failure details:
+
+```bash
+# Get the PR branch
+branch=$(gh pr view "$pr_id" --json headRefName --jq '.headRefName')
+
+# Get failed run ID
+gh run list --branch "$branch" --status failure -L 1
+
+# Get failure logs
+gh run view {run-id} --log-failed
+```
+
+Report to driver:
+
+```bash
+ACTION=$(/tmp/pr-check-loop-driver.sh "$PR_NUMBER" check-done "$STATUS")
+```
+
+Follow the returned ACTION.
+
+---
+
+### On `ACTION: FIX`
+
+Auto-fix lint/format issues only:
+
+```bash
+cd turbo
+pnpm format
+pnpm lint --fix
+```
+
+If changes were made, commit and push:
+
+```bash
+git add -A
+git commit -m "fix: auto-format code"
+git push
+```
+
+Report to driver:
+
+```bash
+ACTION=$(/tmp/pr-check-loop-driver.sh "$PR_NUMBER" fix-done)
+# Output: ACTION: WAIT
+```
+
+Follow the returned ACTION (loops back to WAIT → CHECK).
+
+---
+
+### On `ACTION: PASS`
+
+All CI checks passed. Go to Phase 3.
+
+---
+
+### On `ACTION: MANUAL`
+
+Type check or test failures detected that cannot be auto-fixed.
+
+Display clear instructions:
+
+```
+Manual Intervention Required
+
+The following issues cannot be auto-fixed:
+- <issue type>: <details>
+
+Please fix manually and re-run /pr-check-loop
+```
+
+Go to Phase 3.
+
+---
+
+### On `ACTION: TIMEOUT`
+
+Maximum iterations (30) reached (~30 minutes).
+
+```
+Pipeline Timeout
+
+CI checks did not complete/pass within 30 iterations.
+Please check GitHub Actions for details:
+<workflow-url>
+```
+
+Go to Phase 3.
+
+---
+
+## Phase 3: Summary
+
+### Check if Fixes Were Made
+
+```bash
+FIXES=$(cat /tmp/pr-check-loop-${PR_NUMBER}.fixes)
+ITER=$(cat /tmp/pr-check-loop-${PR_NUMBER}.state)
+```
+
+If fixes > 0, run `/pr-review` again to review the auto-fixed code.
+
+### Final Report
+
+Display a local summary (do NOT post another comment):
+
+```
+PR Check Loop Complete
+
+PR: #<number> - <title>
+Branch: <branch>
+Iterations: <ITER>
+Auto-fixes applied: <FIXES> commits
+Status: <All Passed / Manual Fix Required / Timeout>
+
+Checks:
+  <check-name>: <status>
+  ...
+
+[If all passed]
+All CI checks passed. Ready for manual review and merge.
+
+[If all passed and fixes were made]
+All CI checks passed after auto-fixing lint/format issues.
+Final review posted.
+
+[If manual fix required]
+Manual intervention needed:
+- <issue details>
+
+[If timeout]
+CI checks did not complete within the time limit.
+Check GitHub Actions for details.
+```
+
+---
+
+## Important Notes
+
+1. **No Auto-Merge**: This skill does NOT merge the PR. Merging is a manual decision.
+2. **Driver-Controlled Loop**: All loop logic is in the bash driver script. Follow its ACTIONs exactly.
+3. **Auto-Fix Scope**: Only lint and format errors are auto-fixed. Type and test errors require manual intervention and exit the loop.
+4. **Fail-Fast**: Does NOT wait for all checks to complete. Acts immediately on first failure detected.
+5. **Review Triggers**:
+   - Initial review: If no existing review comment found
+   - Final review: If any fixes were committed during the process
+6. **Idempotent**: Safe to re-run. Driver state resets on init.
+
+---
+
+## Best Practices
+
+1. **Always check status first** - Don't assume pipeline state
+2. **Auto-fix conservatively** - Only fix lint/format, not logic
+3. **Clear reporting** - User should always know what happened
+4. **Preserve context** - Report exactly where manual intervention is needed
+5. **No silent failures** - Always communicate the outcome
+
+Your goal is to ensure CI passes with minimal manual intervention while maintaining code quality.

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: pr-check
-description: Monitor PR CI pipeline, auto-fix issues, and loop until all checks pass
+description: Check PR CI pipeline status and auto-fix lint/format issues (single pass, no loop)
 context: fork
 ---
 
-You are a CI pipeline specialist for the vm0 project. Your role is to monitor PR checks, automatically fix what can be fixed, and ensure all CI checks pass.
+You are a CI pipeline specialist for the vm0 project. Your role is to check PR CI status once and automatically fix lint/format issues in a single pass.
 
 ## Workflow Overview
 
@@ -12,21 +12,16 @@ You are a CI pipeline specialist for the vm0 project. Your role is to monitor PR
 1. Identify Target PR
    └── From args or current branch
 
-2. Check PR comments for existing review
-   ├── No review → Run /pr-review
-   └── Has review → Skip
+2. Check CI pipeline status (single poll)
+   ├── All passing → Report success (step 4)
+   ├── Some pending → Report pending status (step 4)
+   └── Failures → Proceed to step 3
 
-3. Monitor CI pipeline
-   ├── All passing → Go to step 5
-   └── Failures → Proceed to step 4
+3. Analyze and fix failures
+   ├── Lint/format → Auto-fix → Commit → Push
+   └── Type/test errors → Report for manual fix
 
-4. Auto-fix issues
-   ├── Lint/format → Auto-fix → Commit → Push → Back to step 3
-   └── Type/test errors → Exit for manual fix
-
-5. Completion check
-   ├── Fixes made → Run /pr-review again
-   └── No fixes → Done (no auto-merge)
+4. Report results
 ```
 
 ---
@@ -46,33 +41,9 @@ Once you have the PR number, **hardcode it as a literal** in all subsequent bash
 
 ---
 
-## Step 2: Check for Existing Review
+## Step 2: Check CI Pipeline Status
 
-Check if the PR already has a code review comment:
-
-```bash
-# Get PR comments and check for review indicators
-comments=$(gh pr view "$pr_id" --json comments --jq '.comments[].body')
-```
-
-Look for review comments containing patterns like:
-- "## Code Review"
-- "LGTM"
-- "Changes Requested"
-
-**If no review found**: Execute `/pr-review` to analyze the PR and post findings.
-
-**If review exists**: Skip to pipeline monitoring.
-
----
-
-## Step 3: Monitor CI Pipeline
-
-### Initial Wait
-
-Wait 60 seconds for pipeline to stabilize before first check.
-
-### Check Pipeline Status
+### Poll Current Status
 
 ```bash
 gh pr checks "$pr_id"
@@ -84,39 +55,26 @@ gh pr checks "$pr_id"
 - `pending`: Still running
 - `skipping`: Skipped (acceptable)
 
-### Retry Configuration
+### Classify Results
 
-- **Retry attempts**: Maximum 30
-- **Retry delay**: 60 seconds
-- **Total timeout**: ~30 minutes
+After polling, classify the overall status:
 
-### Fail-Fast Strategy
-
-**Do NOT wait for all checks to complete before acting.** After each poll:
-
-1. If any check has status `fail` → immediately proceed to Step 4 (auto-fix), even if other checks are still `pending`
-2. If no failures and no `pending` checks remain → all done, proceed to Step 5
-3. If no failures but some checks are still `pending` → wait 60 seconds and poll again
-
-This means fixes start as soon as a failure is detected, without waiting for the rest of the pipeline.
-
-### Outcomes
-
-- **Any failure detected**: Proceed immediately to Step 4 (auto-fix), regardless of pending checks
-- **All passing (no pending)**: Proceed to Step 5 (completion check)
-- **No failures, some still running**: Wait 60 seconds and retry
+1. **All checks `pass` or `skipping`** → Report success, go to Step 4
+2. **Any check `fail`** → Proceed to Step 3 (analyze and fix), even if other checks are still `pending`
+3. **No failures but some `pending`** → Report pending status, go to Step 4
 
 ---
 
-## Step 4: Auto-Fix Issues
-
-When failures are detected, attempt to fix them.
+## Step 3: Analyze and Fix Failures
 
 ### Get Failure Details
 
 ```bash
+# Get the PR branch
+branch=$(gh pr view "$pr_id" --json headRefName --jq '.headRefName')
+
 # Get failed run ID
-gh run list --branch {branch} --status failure -L 1
+gh run list --branch "$branch" --status failure -L 1
 
 # Get failure logs
 gh run view {run-id} --log-failed
@@ -139,8 +97,6 @@ git commit -m "fix: auto-format code"
 git push
 ```
 
-Track that fixes were made (for step 5).
-
 #### Type Check Failures (Manual Required)
 
 ```bash
@@ -155,15 +111,13 @@ Manual intervention required. Please fix the following type errors:
 
 <error details>
 
-After fixing, re-run /pr-check to continue.
+After fixing, re-run /pr-check to verify.
 ```
-
-Exit and wait for user to fix.
 
 #### Test Failures (Manual Required)
 
 ```bash
-cd turbo && pnpm test
+cd turbo && pnpm vitest
 ```
 
 Report failures clearly:
@@ -174,66 +128,46 @@ Manual intervention required. Please fix the following test failures:
 
 <failure details>
 
-After fixing, re-run /pr-check to continue.
+After fixing, re-run /pr-check to verify.
 ```
-
-Exit and wait for user to fix.
-
-### After Auto-Fix
-
-If auto-fix was successful (lint/format):
-1. Wait 60 seconds for the new pipeline triggered by the push to start
-2. Return to Step 3 (Monitor Pipeline), applying the same fail-fast strategy
 
 ---
 
-## Step 5: Completion Check
-
-After all CI checks pass:
-
-### Check if Fixes Were Made
-
-If any fix commits were made during this process:
-- Run `/pr-review` again to review the new changes
-- This ensures the auto-fixed code is also reviewed
-
-### Final Report
+## Step 4: Report Results
 
 ```
-PR Check Complete
+PR Check Result
 
 PR: #<number> - <title>
 Branch: <branch>
-Status: All CI checks passed
+Status: <All Passed / Pending / Auto-Fixed / Manual Fix Required>
 
 Checks:
-  lint: passed
-  test: passed
-  build: passed
+  <check-name>: <status>
+  ...
 
-[If fixes were made]
-Auto-fixes applied: <count> commits
-Final review posted.
+[If all passed]
+All CI checks passed. No action needed.
 
-Ready for manual review and merge.
+[If pending]
+Some checks are still running. Re-run /pr-check later to check again.
+
+[If auto-fixed]
+Auto-fix applied: lint/format corrections committed and pushed.
+New CI pipeline triggered — re-run /pr-check to verify.
+
+[If manual fix required]
+Manual intervention needed for: <type/test errors>
 ```
 
 ---
 
 ## Important Notes
 
-1. **No Auto-Merge**: This skill does NOT merge the PR. Merging is a manual decision.
-
-2. **Review Triggers**:
-   - Initial review: If no existing review comment found
-   - Final review: If any fixes were committed during the process
-
-3. **Manual Intervention**:
-   - Type errors require manual fixes
-   - Test failures require manual fixes
-   - The skill will exit with clear instructions
-
-4. **Idempotent**: Safe to re-run multiple times. Will skip review if already exists.
+1. **Single Pass**: This skill checks CI status once and acts on it. It does NOT poll or retry.
+2. **No Auto-Merge**: This skill does NOT merge the PR. Merging is a manual decision.
+3. **Auto-Fix Scope**: Only lint and format errors are auto-fixed. Type and test errors require manual intervention.
+4. **Idempotent**: Safe to re-run multiple times.
 
 ---
 
@@ -243,15 +177,6 @@ Ready for manual review and merge.
 ```
 Error: No PR found for current branch.
 Please create a PR first or specify a PR number.
-```
-
-### Pipeline Timeout
-```
-Pipeline Timeout
-
-CI checks did not complete within 30 minutes.
-Please check GitHub Actions for details:
-<workflow-url>
 ```
 
 ### Unfixable Errors
@@ -274,4 +199,4 @@ Please fix manually and re-run /pr-check
 4. **Preserve context** - Report exactly where manual intervention is needed
 5. **No silent failures** - Always communicate the outcome
 
-Your goal is to ensure CI passes with minimal manual intervention while maintaining code quality.
+Your goal is to report CI status and fix what can be fixed in a single pass.

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -329,12 +329,3 @@ Remaining issues need manual intervention:
 All review comments posted to PR.
 ```
 
----
-
-## Phase 4: CI Check
-
-After the review loop completes, invoke `/pr-check` to monitor CI pipeline and auto-fix any remaining CI issues (lint/format failures from the fix commits, etc.):
-
-invoke skill /pr-check ${PR_NUMBER}
-
-This ensures that all fix commits pushed during the review loop pass CI before the PR is ready for merge.


### PR DESCRIPTION
## Summary
- Refactor `/pr-check` to be a single-pass atomic operation — checks CI status once, auto-fixes lint/format if needed, and reports results without polling or retrying
- Create `/pr-check-loop` as a new skill with bash driver script (following the `/pr-review-loop` pattern) for continuous CI monitoring with up to 30 iterations
- Remove implicit `/pr-check` invocation from `/pr-review-loop` Phase 4
- Update `/issue-action` Step 8 to explicitly call `/pr-check-loop` after `/pr-review-loop`

## Test plan
- [ ] Verify `/pr-check` runs a single CI check pass without looping
- [ ] Verify `/pr-check-loop` correctly monitors CI with driver script loop control
- [ ] Verify `/pr-review-loop` no longer invokes any pr-check skill
- [ ] Verify `/issue-action` calls both `/pr-review-loop` and `/pr-check-loop` in sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)