### PR TITLE
ci: add --no-parallelize-within-files to runner e2e bats

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1744,7 +1744,7 @@ jobs:
           echo "=== Running Runner E2E Tests (Chunk ${{ matrix.index }}, ${PARALLEL} parallel, total capacity ${RUNNER_TOTAL_CAPACITY}) ==="
           echo "Files: ${{ matrix.files }}"
           mkdir -p e2e/results
-          BATS_TEST_TIMEOUT=60 ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --report-formatter junit --output e2e/results ${{ matrix.files }}
+          BATS_TEST_TIMEOUT=60 ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files --report-formatter junit --output e2e/results ${{ matrix.files }}
           echo "✅ Chunk ${{ matrix.index }} tests passed"
         env:
           RUNNER_TOTAL_CAPACITY: ${{ needs.deploy-runner-start.outputs.total-capacity }}


### PR DESCRIPTION
## Summary
- Add `--no-parallelize-within-files` flag to runner E2E bats command in CI
- This matches the local `e2e/run.sh` configuration, preventing tests within the same `.bats` file from running concurrently while keeping file-level parallelism (`-j`)

## Test plan
- [ ] Runner E2E tests pass in CI with the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)