### PR TITLE
ci: restrict cli e2e jobs to merge queue only

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1048,7 +1048,7 @@ jobs:
     needs: [prepare, deploy-web, deploy-app]
     if: |
       always() &&
-      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+      github.event_name == 'merge_group' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
@@ -1189,7 +1189,7 @@ jobs:
         test-other,
       ]
     if: |
-      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+      github.event_name == 'merge_group' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
@@ -1686,7 +1686,7 @@ jobs:
         e2e-runner-bootstrap,
       ]
     if: |
-      github.event_name != 'push' &&
+      github.event_name == 'merge_group' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||


### PR DESCRIPTION
## Summary
- Skip `cli-e2e-01-serial`, `cli-e2e-02-browser`, and `cli-e2e-03-runner` on PR and push events
- These jobs now only run in the merge queue (`merge_group` event), reducing CI time for regular PRs
- CI gate already treats these as `allow_skip`, so no gate changes needed

## Test plan
- [ ] Open PR → verify the 3 e2e jobs are skipped
- [ ] Enter merge queue → verify the 3 e2e jobs run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)