### PR TITLE
perf(axiom): merge duplicate queries and consolidate logger client

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -438,8 +438,10 @@ describe("POST /api/webhooks/agent/complete", () => {
       };
 
       // Mock Axiom to return a result event for this run
+      // persistChatMessages uses a single combined query for both result and assistant events
       context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
         {
+          eventType: "result",
           eventData: { result: "Here is the agent response." },
         },
       ]);
@@ -575,14 +577,10 @@ describe("POST /api/webhooks/agent/complete", () => {
         agentSessionId: string;
       };
 
-      // First Axiom call: extractRunOutput — returns the result text
-      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
-        { eventData: { result: "Done. Created 3 files." } },
-      ]);
-      // Second Axiom call: extractSummariesFromAxiom — returns message events
-      // with tool_use blocks and a final text block (which should be skipped)
+      // Combined Axiom query returns both result and assistant events
       context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
         {
+          eventType: "assistant",
           eventData: {
             message: {
               content: [{ type: "tool_use", name: "Bash" }],
@@ -590,6 +588,7 @@ describe("POST /api/webhooks/agent/complete", () => {
           },
         },
         {
+          eventType: "assistant",
           eventData: {
             message: {
               content: [{ type: "tool_use", name: "Read" }],
@@ -597,11 +596,16 @@ describe("POST /api/webhooks/agent/complete", () => {
           },
         },
         {
+          eventType: "assistant",
           eventData: {
             message: {
               content: [{ type: "text", text: "Done. Created 3 files." }],
             },
           },
+        },
+        {
+          eventType: "result",
+          eventData: { result: "Done. Created 3 files." },
         },
       ]);
 
@@ -679,14 +683,10 @@ describe("POST /api/webhooks/agent/complete", () => {
         agentSessionId: string;
       };
 
-      // First Axiom call: extractRunOutput
-      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
-        { eventData: { result: "Analysis complete." } },
-      ]);
-      // Second Axiom call: extractSummariesFromAxiom — text-only events
-      // Last text event should be skipped, earlier ones included
+      // Combined Axiom query returns both result and assistant events
       context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
         {
+          eventType: "assistant",
           eventData: {
             message: {
               content: [{ type: "text", text: "Let me check the logs first" }],
@@ -694,11 +694,16 @@ describe("POST /api/webhooks/agent/complete", () => {
           },
         },
         {
+          eventType: "assistant",
           eventData: {
             message: {
               content: [{ type: "text", text: "Analysis complete." }],
             },
           },
+        },
+        {
+          eventType: "result",
+          eventData: { result: "Analysis complete." },
         },
       ]);
 
@@ -771,13 +776,10 @@ describe("POST /api/webhooks/agent/complete", () => {
 
       const longText = "x".repeat(100);
 
-      // First Axiom call: extractRunOutput
-      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
-        { eventData: { result: "Done." } },
-      ]);
-      // Second Axiom call: extractSummariesFromAxiom — one long text, then final text
+      // Combined Axiom query returns both result and assistant events
       context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
         {
+          eventType: "assistant",
           eventData: {
             message: {
               content: [{ type: "text", text: longText }],
@@ -785,11 +787,16 @@ describe("POST /api/webhooks/agent/complete", () => {
           },
         },
         {
+          eventType: "assistant",
           eventData: {
             message: {
               content: [{ type: "text", text: "Done." }],
             },
           },
+        },
+        {
+          eventType: "result",
+          eventData: { result: "Done." },
         },
       ]);
 
@@ -864,12 +871,13 @@ describe("POST /api/webhooks/agent/complete", () => {
         agentSessionId: string;
       };
 
-      // First Axiom call: extractRunOutput — returns result
+      // Combined Axiom query returns result event only (no assistant events)
       context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
-        { eventData: { result: "All good." } },
+        {
+          eventType: "result",
+          eventData: { result: "All good." },
+        },
       ]);
-      // Second Axiom call: extractSummariesFromAxiom — no events
-      context.mocks.axiom.queryAxiom.mockResolvedValueOnce([]);
 
       const request = createTestRequest(
         "http://localhost:3000/api/webhooks/agent/complete",
@@ -1024,9 +1032,12 @@ describe("POST /api/webhooks/agent/complete", () => {
       );
       expect(checkpointRes.status).toBe(200);
 
-      // Mock Axiom to return an assistant result
+      // Mock Axiom to return a result event
       context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
-        { eventData: { result: "Use --inspect flag for debugging." } },
+        {
+          eventType: "result",
+          eventData: { result: "Use --inspect flag for debugging." },
+        },
       ]);
 
       // Mock OpenRouter to return a generated title
@@ -1092,7 +1103,10 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(cpRes.status).toBe(200);
 
       context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
-        { eventData: { result: "Use flexbox for centering" } },
+        {
+          eventType: "result",
+          eventData: { result: "Use flexbox for centering" },
+        },
       ]);
 
       vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
@@ -1220,7 +1234,7 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(cpRes.status).toBe(200);
 
       context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
-        { eventData: { result: "Some result" } },
+        { eventType: "result", eventData: { result: "Some result" } },
       ]);
 
       // Do NOT set OPENROUTER_API_KEY — feature should be a no-op
@@ -1277,7 +1291,7 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(cpRes.status).toBe(200);
 
       context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
-        { eventData: { result: "Some result" } },
+        { eventType: "result", eventData: { result: "Some result" } },
       ]);
 
       vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -24,7 +24,6 @@ import { drainOrgQueue } from "../../../../../src/lib/run/run-queue-service";
 import { dispatchQueuedRun } from "../../../../../src/lib/run/run-service";
 import { processOrgCredits } from "../../../../../src/lib/credit/credit-service";
 import { appendChatMessages } from "../../../../../src/lib/agent-session/agent-session-service";
-import { extractRunOutput } from "../../../../../src/lib/run/extract-run-output";
 import { chatThreadRuns } from "../../../../../src/db/schema/chat-thread";
 import { updateChatThreadTitle } from "../../../../../src/lib/chat-thread";
 import { generateChatTitle } from "../../../../../src/lib/ai/lightweight-model";
@@ -99,21 +98,45 @@ function extractSummariesFromEvents(
   return summaries;
 }
 
-async function extractSummariesFromAxiom(
-  runId: string,
-): Promise<SummaryEntry[]> {
+interface CombinedRunEvent {
+  eventType: string;
+  eventData: {
+    result?: string;
+    message?: { content?: AxiomEventContent[] };
+  };
+}
+
+/**
+ * Single Axiom query to fetch both "result" and "assistant" events for a run.
+ * Replaces two separate queries (extractRunOutput + extractSummariesFromAxiom)
+ * to halve the API call count per completion.
+ */
+async function queryRunEventsForChat(runId: string): Promise<{
+  resultText: string | null;
+  summaries: SummaryEntry[];
+}> {
   const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
   const apl = `['${dataset}']
 | where runId == "${runId}"
-| where eventType == "assistant"
+| where eventType in ("result", "assistant")
 | order by sequenceNumber asc
-| limit 200`;
+| limit 201`;
 
-  const events = await queryAxiom<{
-    eventData: { message?: { content?: AxiomEventContent[] } };
-  }>(apl);
+  const events = await queryAxiom<CombinedRunEvent>(apl);
 
-  return extractSummariesFromEvents(events);
+  // Extract last result event
+  const resultEvents = events.filter((e) => e.eventType === "result");
+  const lastResult = resultEvents[resultEvents.length - 1];
+  const resultText =
+    typeof lastResult?.eventData?.result === "string"
+      ? lastResult.eventData.result
+      : null;
+
+  // Extract summaries from assistant events
+  const assistantEvents = events.filter((e) => e.eventType === "assistant");
+  const summaries = extractSummariesFromEvents(assistantEvents);
+
+  return { resultText, summaries };
 }
 
 /**
@@ -128,10 +151,7 @@ async function persistChatMessages(
   userId: string,
   prompt: string,
 ): Promise<string | null> {
-  const [output, summaries] = await Promise.all([
-    extractRunOutput(runId),
-    extractSummariesFromAxiom(runId),
-  ]);
+  const { resultText, summaries } = await queryRunEventsForChat(runId);
 
   const messages: Array<{
     role: "user" | "assistant";
@@ -140,10 +160,10 @@ async function persistChatMessages(
     summaries?: SummaryEntry[];
   }> = [{ role: "user", content: prompt }];
 
-  if (output.result) {
+  if (resultText) {
     messages.push({
       role: "assistant",
-      content: output.result,
+      content: resultText,
       runId,
       ...(summaries.length > 0 ? { summaries } : {}),
     });
@@ -151,7 +171,7 @@ async function persistChatMessages(
 
   await appendChatMessages(sessionId, userId, messages);
   log.debug(`Persisted ${messages.length} chat messages for run ${runId}`);
-  return output.result;
+  return resultText;
 }
 
 /**

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -120,7 +120,7 @@ async function queryRunEventsForChat(runId: string): Promise<{
 | where runId == "${runId}"
 | where eventType in ("result", "assistant")
 | order by sequenceNumber asc
-| limit 201`;
+| limit 201`; // 200 assistant events + 1 result event
 
   const events = await queryAxiom<CombinedRunEvent>(apl);
 

--- a/turbo/apps/web/src/lib/axiom/client.ts
+++ b/turbo/apps/web/src/lib/axiom/client.ts
@@ -1,70 +1,27 @@
 import "server-only";
-import { Axiom, Entry } from "@axiomhq/js";
+import type { Axiom } from "@axiomhq/js";
+import { Entry } from "@axiomhq/js";
 import { env } from "../../env";
 import { logger } from "../logger";
 import { getDatasetName, DATASETS, isSessionsDataset } from "./datasets";
+import {
+  getSessionsInstance,
+  getTelemetryInstance,
+  getSessionsClient,
+  getTelemetryClient,
+} from "./instances";
 
 const log = logger("axiom");
 
-let sessionsClient: Axiom | null = null;
-let telemetryClient: Axiom | null = null;
-let sessionsInitialized = false;
-let telemetryInitialized = false;
-
-/**
- * Resolve the token for the sessions scope (agent-run-events).
- */
-function getSessionsToken(): string | undefined {
-  return env().AXIOM_TOKEN_SESSIONS;
-}
-
-/**
- * Resolve the token for the telemetry scope (all other datasets).
- */
-function getTelemetryToken(): string | undefined {
-  return env().AXIOM_TOKEN_TELEMETRY;
-}
-
-/**
- * Get the Axiom client for the sessions scope (agent-run-events).
- * Returns null if no token is configured.
- */
-function getSessionsClient(): Axiom | null {
-  if (sessionsInitialized) return sessionsClient;
-  sessionsInitialized = true;
-
-  const token = getSessionsToken();
-  if (!token) return null;
-
-  sessionsClient = new Axiom({ token });
-  log.debug("Axiom sessions client initialized");
-  return sessionsClient;
-}
-
-/**
- * Get the Axiom client for the telemetry scope (all other datasets).
- * Returns null if no token is configured.
- */
-function getTelemetryClient(): Axiom | null {
-  if (telemetryInitialized) return telemetryClient;
-  telemetryInitialized = true;
-
-  const token = getTelemetryToken();
-  if (!token) return null;
-
-  telemetryClient = new Axiom({ token });
-  log.debug("Axiom telemetry client initialized");
-  return telemetryClient;
-}
-
 /**
  * Get the appropriate Axiom client for a dataset name.
- * Routes to sessions client for agent-run-events, telemetry client for everything else.
+ * Initializes the client on first access, routes to sessions client
+ * for agent-run-events and telemetry client for everything else.
  */
 function getClientForDataset(dataset: string): Axiom | null {
   return isSessionsDataset(dataset)
-    ? getSessionsClient()
-    : getTelemetryClient();
+    ? getSessionsInstance(env().AXIOM_TOKEN_SESSIONS)
+    : getTelemetryInstance(env().AXIOM_TOKEN_TELEMETRY);
 }
 
 /**
@@ -107,8 +64,8 @@ export function ingestToAxiom(
  */
 export async function flushAxiom(): Promise<void> {
   const results = await Promise.allSettled([
-    sessionsClient?.flush(),
-    telemetryClient?.flush(),
+    getSessionsClient()?.flush(),
+    getTelemetryClient()?.flush(),
   ]);
   for (const r of results) {
     if (r.status === "rejected") {
@@ -155,7 +112,9 @@ export async function queryAxiom<T = Record<string, unknown>>(
 ): Promise<T[]> {
   const dataset = extractDatasetFromApl(apl);
   // If we can't determine the dataset, default to telemetry client (broader scope)
-  const client = dataset ? getClientForDataset(dataset) : getTelemetryClient();
+  const client = dataset
+    ? getClientForDataset(dataset)
+    : getTelemetryInstance(env().AXIOM_TOKEN_TELEMETRY);
   if (!client) {
     log.debug("Axiom not configured, skipping query");
     return [];
@@ -205,7 +164,7 @@ interface RequestLogEntry {
  * Fire-and-forget - doesn't block the response.
  */
 export function ingestRequestLog(entry: RequestLogEntry): void {
-  const client = getTelemetryClient();
+  const client = getTelemetryInstance(env().AXIOM_TOKEN_TELEMETRY);
   if (!client) {
     return;
   }
@@ -232,7 +191,7 @@ interface SandboxOpLogEntry {
  * Fire-and-forget - doesn't block the response.
  */
 export function ingestSandboxOpLog(entry: SandboxOpLogEntry): void {
-  const client = getTelemetryClient();
+  const client = getTelemetryInstance(env().AXIOM_TOKEN_TELEMETRY);
   if (!client) {
     return;
   }

--- a/turbo/apps/web/src/lib/axiom/instances.ts
+++ b/turbo/apps/web/src/lib/axiom/instances.ts
@@ -19,7 +19,13 @@ let telemetryInitialized = false;
  * Get or create the sessions-scoped Axiom client (agent-run-events).
  */
 export function getSessionsInstance(token: string | undefined): Axiom | null {
-  if (sessionsInitialized) return sessionsClient;
+  if (sessionsInitialized) {
+    // Late initialization: first caller had no token, but one is now available.
+    if (token && !sessionsClient) {
+      sessionsClient = new Axiom({ token });
+    }
+    return sessionsClient;
+  }
   sessionsInitialized = true;
   if (!token) return null;
   sessionsClient = new Axiom({ token });
@@ -30,7 +36,12 @@ export function getSessionsInstance(token: string | undefined): Axiom | null {
  * Get or create the telemetry-scoped Axiom client (all other datasets).
  */
 export function getTelemetryInstance(token: string | undefined): Axiom | null {
-  if (telemetryInitialized) return telemetryClient;
+  if (telemetryInitialized) {
+    if (token && !telemetryClient) {
+      telemetryClient = new Axiom({ token });
+    }
+    return telemetryClient;
+  }
   telemetryInitialized = true;
   if (!token) return null;
   telemetryClient = new Axiom({ token });

--- a/turbo/apps/web/src/lib/axiom/instances.ts
+++ b/turbo/apps/web/src/lib/axiom/instances.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared Axiom client instances.
+ *
+ * This is a leaf module with no dependency on logger.ts, breaking the
+ * circular dependency chain: axiom/client → logger → axiom/client.
+ *
+ * Both axiom/client.ts and logger.ts import from here to share the same
+ * Axiom SDK instances, ensuring a single flush covers all datasets.
+ */
+import "server-only";
+import { Axiom } from "@axiomhq/js";
+
+let sessionsClient: Axiom | null = null;
+let telemetryClient: Axiom | null = null;
+let sessionsInitialized = false;
+let telemetryInitialized = false;
+
+/**
+ * Get or create the sessions-scoped Axiom client (agent-run-events).
+ */
+export function getSessionsInstance(token: string | undefined): Axiom | null {
+  if (sessionsInitialized) return sessionsClient;
+  sessionsInitialized = true;
+  if (!token) return null;
+  sessionsClient = new Axiom({ token });
+  return sessionsClient;
+}
+
+/**
+ * Get or create the telemetry-scoped Axiom client (all other datasets).
+ */
+export function getTelemetryInstance(token: string | undefined): Axiom | null {
+  if (telemetryInitialized) return telemetryClient;
+  telemetryInitialized = true;
+  if (!token) return null;
+  telemetryClient = new Axiom({ token });
+  return telemetryClient;
+}
+
+/** Access the sessions client after initialization. */
+export function getSessionsClient(): Axiom | null {
+  return sessionsClient;
+}
+
+/** Access the telemetry client after initialization. */
+export function getTelemetryClient(): Axiom | null {
+  return telemetryClient;
+}

--- a/turbo/apps/web/src/lib/logger.ts
+++ b/turbo/apps/web/src/lib/logger.ts
@@ -27,8 +27,8 @@
  */
 import "server-only";
 import { Logger as AxiomLogger, AxiomJSTransport } from "@axiomhq/logging";
-import { Axiom } from "@axiomhq/js";
 import { getDatasetName, DATASETS } from "./axiom/datasets";
+import { getTelemetryInstance } from "./axiom/instances";
 
 type LogMethod = (...args: unknown[]) => void;
 
@@ -47,8 +47,8 @@ let axiomInitialized = false;
 
 /**
  * Get or create the Axiom logger for web logs.
- * Uses a separate Axiom client instance to avoid circular dependency with axiom/client.ts.
- * Uses AXIOM_TOKEN_TELEMETRY for the telemetry scope.
+ * Uses the shared telemetry Axiom instance from axiom/instances.ts so that
+ * a single flushAxiom() call covers web-logs alongside all other datasets.
  * Returns null if no token is configured.
  */
 function getAxiomLogger(): AxiomLogger | null {
@@ -56,11 +56,11 @@ function getAxiomLogger(): AxiomLogger | null {
   axiomInitialized = true;
 
   const token = process.env.AXIOM_TOKEN_TELEMETRY;
-  if (!token) {
+  const axiom = getTelemetryInstance(token);
+  if (!axiom) {
     return null;
   }
 
-  const axiom = new Axiom({ token });
   axiomLogger = new AxiomLogger({
     transports: [
       new AxiomJSTransport({


### PR DESCRIPTION
## Summary

- **Merge duplicate queries**: `persistChatMessages()` in the complete webhook previously made 2 separate Axiom queries (result events + assistant events) against the same dataset. Now uses a single combined APL query with `eventType in ("result", "assistant")`, split in code. Saves 1 HTTP request per run completion.
- **Consolidate logger client**: Extracted Axiom client instances to `axiom/instances.ts` (a leaf module with no logger dependency). Both `axiom/client.ts` and `logger.ts` now share the same telemetry client instance. This eliminates the 3rd independent Axiom client, reducing flush HTTP requests by 1 per API request.

Closes #7231

## Test plan

- [x] All 32 complete webhook tests pass (mocks updated for combined query)
- [x] Type check clean (7/7 workspaces)
- [x] Lint clean
- [x] Knip clean
- [ ] Verify in staging: `persistChatMessages` makes 1 Axiom query instead of 2
- [ ] Verify in staging: `flushAxiom()` covers web-logs dataset (no separate logger flush needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)