### PR TITLE
fix(ci): skip runner deployment when pr is already closed

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -195,8 +195,21 @@ jobs:
 
       - name: Set job-ref
         id: set-job-ref
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Skip runner deployment if the PR was already merged or closed.
+            # A late pull_request:synchronize run can reach here after
+            # cleanup.yml has already stopped the runner — deploying again
+            # would resurrect a stale service that no cleanup will ever reach.
+            STATE=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" \
+              | jq -r .state)
+            if [ "$STATE" != "open" ]; then
+              echo "::warning::PR #${{ github.event.pull_request.number }} is ${STATE}, skipping job-ref to prevent stale runner deployment"
+              exit 0
+            fi
             echo "job-ref=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "Job ref set to: pr-${{ github.event.pull_request.number }}"
           elif [ "${{ github.event_name }}" = "merge_group" ]; then


### PR DESCRIPTION
## Summary
- Add PR state check at the start of `deploy-runner-prepare` to skip deployment if the PR is already merged or closed
- Prevents stale runner services from being resurrected after `cleanup.yml` has already stopped them

## Root Cause
When a user pushes to a PR branch while the merge queue is processing, the `pull_request:synchronize` event triggers a new turbo run. This run's `deploy-runner-prepare` → `deploy-runner-start` can execute **after** `cleanup.yml` has already stopped the runner (triggered by PR close/merge). The newly deployed runner service will never be cleaned up because `cleanup.yml` only runs once on PR close.

Timeline from PR #7190:
```
12:51  User pushes merge commit to PR branch
12:54  PR merged via merge queue
12:55  cleanup.yml stops runner ✓
12:56  Late pull_request turbo run starts deploy-runner-prepare
13:00  deploy-runner-start resurrects the runner ✗
```

## Test plan
- [ ] PR with push during merge queue processing should not deploy runner after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)