### PR TITLE
refactor(e2e): replace fixed test accounts with ephemeral per-job-ref accounts

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1137,7 +1137,7 @@ jobs:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test@${{ steps.browser-email.outputs.hex }}.dev
+          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test@${{ steps.browser-email.outputs.hex }}.test
       - name: Cleanup test accounts
         if: always()
         env:

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -940,8 +940,8 @@ jobs:
               -H "Authorization: Bearer ${CLERK_SECRET_KEY}" > /dev/null
           done
 
-          # Create 3 test users + orgs
-          for variant in browser serial runner; do
+          # Create test users + orgs (browser is created via UI sign-up flow)
+          for variant in serial runner; do
             email="${JOB_REF}+clerk_test+${variant}@vm0-e2e.ai"
             user=$(curl -sS -X POST "https://api.clerk.com/v1/users" \
               -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
@@ -1127,9 +1127,6 @@ jobs:
           node-version: 22
       - name: Install E2E dependencies
         run: npm install -g agent-browser@0.22.0
-      - name: Generate random email for browser sign-up test
-        id: browser-email
-        run: echo "hex=$(openssl rand -hex 4)" >> "$GITHUB_OUTPUT"
       - name: Run browser E2E tests
         run: |
           BATS_TEST_TIMEOUT=180 ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/02-browser/*.bats
@@ -1137,7 +1134,7 @@ jobs:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test@${{ steps.browser-email.outputs.hex }}.test
+          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test+browser@vm0-e2e.ai
       - name: Cleanup test accounts
         if: always()
         env:
@@ -1818,6 +1815,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.CI_ANTHROPIC_API_KEY }}
           OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
           CI_GITHUB_TOKEN: ${{ github.token }}
+          E2E_RUNNER_EMAIL: ${{ needs.prepare.outputs.job-ref }}+clerk_test+runner@vm0-e2e.ai
 
       - name: Print E2E trace log
         if: always()

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -941,29 +941,39 @@ jobs:
           done
 
           # Create 3 test users + orgs
-          for domain in browser.test serial.test runner.test; do
-            email="${JOB_REF}+clerk_test@${domain}"
+          for variant in browser serial runner; do
+            email="${JOB_REF}+clerk_test+${variant}@vm0-e2e.ai"
             user=$(curl -sS -X POST "https://api.clerk.com/v1/users" \
               -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
               -H "Content-Type: application/json" \
               -d "{\"email_address\":[\"${email}\"],\"skip_password_requirement\":true}")
             user_id=$(echo "$user" | jq -r '.id')
+            if [[ "$user_id" == "null" || -z "$user_id" ]]; then
+              echo "Error: Failed to create user ${email}"
+              echo "Clerk response: ${user}"
+              exit 1
+            fi
             echo "Created user ${email} -> ${user_id}"
 
             org=$(curl -sS -X POST "https://api.clerk.com/v1/organizations" \
               -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
               -H "Content-Type: application/json" \
-              -d "{\"name\":\"e2e-${domain%%.*}-${JOB_REF}\",\"created_by\":\"${user_id}\"}")
+              -d "{\"name\":\"e2e-${variant}-${JOB_REF}\",\"created_by\":\"${user_id}\"}")
             org_id=$(echo "$org" | jq -r '.id')
+            if [[ "$org_id" == "null" || -z "$org_id" ]]; then
+              echo "Error: Failed to create org for user ${email}"
+              echo "Clerk response: ${org}"
+              exit 1
+            fi
             echo "Created org -> ${org_id}"
           done
 
       # Step 7: Generate test tokens for E2E tests (one per test user)
       - name: Generate E2E test tokens
         run: |
-          e2e/scripts/generate-test-token.sh "${JOB_REF}+clerk_test@serial.test"
+          e2e/scripts/generate-test-token.sh "${JOB_REF}+clerk_test+serial@vm0-e2e.ai"
           cp ~/.vm0/config.json "/tmp/e2e-token-serial.json"
-          e2e/scripts/generate-test-token.sh "${JOB_REF}+clerk_test@runner.test"
+          e2e/scripts/generate-test-token.sh "${JOB_REF}+clerk_test+runner@vm0-e2e.ai"
           cp ~/.vm0/config.json "/tmp/e2e-token-runner.json"
         env:
           VM0_API_URL: ${{ steps.alias.outputs.url || steps.deploy.outputs.url }}
@@ -1972,7 +1982,7 @@ jobs:
           WEB_URL: ${{ needs.deploy-web.outputs.preview-url }}
           APP_URL: ${{ needs.prepare.outputs.app-preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-          E2E_SERIAL_EMAIL: ${{ needs.prepare.outputs.job-ref }}+clerk_test@serial.test
+          E2E_SERIAL_EMAIL: ${{ needs.prepare.outputs.job-ref }}+clerk_test+serial@vm0-e2e.ai
       - name: Locate LHCI output (app)
         id: lhci-dir-app
         if: always()

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -924,16 +924,51 @@ jobs:
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
           deployment-env: ${{ steps.deployment.outputs.env }}
 
-      # Step 6: Generate test tokens for E2E tests (one per test user)
+      # Step 6: Provision ephemeral E2E test accounts in Clerk
+      - name: Provision E2E test accounts
+        env:
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+        run: |
+          # Delete existing users matching JOB_REF+clerk_test
+          users=$(curl -sS -X GET \
+            "https://api.clerk.com/v1/users?query=${JOB_REF}%2Bclerk_test&limit=100" \
+            -H "Authorization: Bearer ${CLERK_SECRET_KEY}")
+          ids=$(echo "$users" | jq -r '.[].id' 2>/dev/null || true)
+          for uid in $ids; do
+            curl -sS -X DELETE "https://api.clerk.com/v1/users/${uid}" \
+              -H "Authorization: Bearer ${CLERK_SECRET_KEY}" > /dev/null
+          done
+
+          # Create 3 test users + orgs
+          for domain in browser.test serial.test runner.test; do
+            email="${JOB_REF}+clerk_test@${domain}"
+            user=$(curl -sS -X POST "https://api.clerk.com/v1/users" \
+              -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+              -H "Content-Type: application/json" \
+              -d "{\"email_address\":[\"${email}\"],\"skip_password_requirement\":true}")
+            user_id=$(echo "$user" | jq -r '.id')
+            echo "Created user ${email} -> ${user_id}"
+
+            org=$(curl -sS -X POST "https://api.clerk.com/v1/organizations" \
+              -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
+              -H "Content-Type: application/json" \
+              -d "{\"name\":\"e2e-${domain%%.*}-${JOB_REF}\",\"created_by\":\"${user_id}\"}")
+            org_id=$(echo "$org" | jq -r '.id')
+            echo "Created org -> ${org_id}"
+          done
+
+      # Step 7: Generate test tokens for E2E tests (one per test user)
       - name: Generate E2E test tokens
         run: |
-          for variant in serial runner; do
-            e2e/scripts/generate-test-token.sh "$variant"
-            cp ~/.vm0/config.json "/tmp/e2e-token-${variant}.json"
-          done
+          e2e/scripts/generate-test-token.sh "${JOB_REF}+clerk_test@serial.test"
+          cp ~/.vm0/config.json "/tmp/e2e-token-serial.json"
+          e2e/scripts/generate-test-token.sh "${JOB_REF}+clerk_test@runner.test"
+          cp ~/.vm0/config.json "/tmp/e2e-token-runner.json"
         env:
           VM0_API_URL: ${{ steps.alias.outputs.url || steps.deploy.outputs.url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
 
       - name: Upload E2E test tokens
         uses: actions/upload-artifact@v7
@@ -1082,6 +1117,9 @@ jobs:
           node-version: 22
       - name: Install E2E dependencies
         run: npm install -g agent-browser@0.22.0
+      - name: Generate random email for browser sign-up test
+        id: browser-email
+        run: echo "hex=$(openssl rand -hex 4)" >> "$GITHUB_OUTPUT"
       - name: Run browser E2E tests
         run: |
           BATS_TEST_TIMEOUT=180 ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/02-browser/*.bats
@@ -1089,7 +1127,7 @@ jobs:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test@vm0-e2e.ai
+          E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test@${{ steps.browser-email.outputs.hex }}.dev
       - name: Cleanup test accounts
         if: always()
         env:
@@ -1097,14 +1135,14 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
         run: |
           echo "Cleaning up Clerk test accounts..."
-          # List users whose email contains the JOB_REF prefix (created by brw-t01-auth sign-up)
+          # List users whose email contains the JOB_REF prefix
           users=$(curl -sS -X GET \
             "https://api.clerk.com/v1/users?query=${JOB_REF}%2Bclerk_test&limit=100" \
             -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
             -H "Content-Type: application/json")
 
-          # Extract user IDs, skipping the persistent e2e test account
-          ids=$(echo "$users" | jq -r '.[] | select((.email_addresses[]?.email_address != "e2e+clerk_test@vm0.ai") and (.email_addresses[]?.email_address != "e2e_02+clerk_test@vm0.ai")) | .id' 2>/dev/null || true)
+          # Delete all matching users (no exclusions — all accounts are ephemeral)
+          ids=$(echo "$users" | jq -r '.[].id' 2>/dev/null || true)
 
           if [ -z "$ids" ]; then
             echo "No test accounts to clean up"
@@ -1680,7 +1718,6 @@ jobs:
         run: mkdir -p ~/.vm0 && cp /tmp/e2e-token-runner.json ~/.vm0/config.json
       - name: Bootstrap test account
         run: |
-          zero org set "e2e-runner" --force
           zero org model-provider setup --type "claude-code-oauth-token" --secret "mock-oauth-token-for-e2e"
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
@@ -1935,6 +1972,7 @@ jobs:
           WEB_URL: ${{ needs.deploy-web.outputs.preview-url }}
           APP_URL: ${{ needs.prepare.outputs.app-preview-url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          E2E_SERIAL_EMAIL: ${{ needs.prepare.outputs.job-ref }}+clerk_test@serial.test
       - name: Locate LHCI output (app)
         id: lhci-dir-app
         if: always()

--- a/e2e/lighthouse/puppeteer-auth.js
+++ b/e2e/lighthouse/puppeteer-auth.js
@@ -10,10 +10,13 @@
  * Environment variables:
  *   WEB_URL                          – Web app origin (for sign-in flow)
  *   APP_URL                          – App origin (audit target)
+ *   E2E_SERIAL_EMAIL                 – Test user email (provisioned by CI)
  *   VERCEL_AUTOMATION_BYPASS_SECRET  – Vercel protection bypass token
  */
 
-const TEST_EMAIL = "e2e+clerk_test@vm0.ai";
+const TEST_EMAIL = process.env.E2E_SERIAL_EMAIL;
+if (!TEST_EMAIL)
+  throw new Error("E2E_SERIAL_EMAIL environment variable is required");
 const TEST_OTP = "424242";
 
 /** Wait for a selector to appear and return the element handle. */

--- a/e2e/lighthouse/puppeteer-auth.js
+++ b/e2e/lighthouse/puppeteer-auth.js
@@ -79,33 +79,47 @@ module.exports = async (browser, context) => {
   const continueBtn = await waitFor(page, ".cl-formButtonPrimary");
   await continueBtn.click();
 
-  // Wait for factor-one page with "Use another method" link
-  await page.waitForFunction(
-    () =>
-      [...document.querySelectorAll("a, button")].some((el) =>
-        el.textContent?.includes("Use another method"),
-      ),
+  // After clicking continue, Clerk shows one of two flows depending on the
+  // account configuration:
+  //   A) OTP input appears directly (passwordless accounts)
+  //   B) "Use another method" link appears first (accounts with password set)
+  // Race both conditions and follow whichever path wins.
+  const flowResult = await page.waitForFunction(
+    () => {
+      const hasOtp = !!document.querySelector('input[data-input-otp="true"]');
+      const hasAltMethod = [...document.querySelectorAll("a, button")].some(
+        (el) => el.textContent?.includes("Use another method"),
+      );
+      if (hasOtp) return "otp";
+      if (hasAltMethod) return "alt";
+      return false;
+    },
     { timeout: 15000 },
   );
 
-  // Switch to email code method
-  await clickByText(page, "a, button", "Use another method");
+  const flow = await flowResult.jsonValue();
 
-  // Wait for method selection and choose email code
-  await page.waitForFunction(
-    () =>
-      [...document.querySelectorAll("button")].some((b) =>
-        b.textContent?.includes("Email code"),
-      ),
-    { timeout: 10000 },
-  );
-  await clickByText(page, "button", "Email code");
+  if (flow === "alt") {
+    // Switch to email code method
+    await clickByText(page, "a, button", "Use another method");
 
-  // Wait for OTP input and enter code
-  await page.waitForSelector('input[data-input-otp="true"]', {
-    visible: true,
-    timeout: 15000,
-  });
+    // Wait for method selection and choose email code
+    await page.waitForFunction(
+      () =>
+        [...document.querySelectorAll("button")].some((b) =>
+          b.textContent?.includes("Email code"),
+        ),
+      { timeout: 10000 },
+    );
+    await clickByText(page, "button", "Email code");
+
+    // Wait for OTP input after selecting email code
+    await page.waitForSelector('input[data-input-otp="true"]', {
+      visible: true,
+      timeout: 15000,
+    });
+  }
+  // If flow === "otp", the OTP input is already visible
 
   // Enter OTP with retry
   for (let attempt = 0; attempt < 3; attempt++) {

--- a/e2e/scripts/generate-test-token.sh
+++ b/e2e/scripts/generate-test-token.sh
@@ -11,12 +11,12 @@
 #   - USE_MOCK_CLAUDE must be "true" on the server
 #
 # Usage: ./generate-test-token.sh <email>
-#   email: test user email (default: dev+clerk_test@serial.test)
+#   email: test user email (default: dev+clerk_test+serial@vm0-e2e.ai)
 
 set -euo pipefail
 
 # Test user email
-EMAIL="${1:-dev+clerk_test@serial.test}"
+EMAIL="${1:-dev+clerk_test+serial@vm0-e2e.ai}"
 
 # URL-encode the email (handle + and @)
 ENCODED_EMAIL=$(printf '%s' "$EMAIL" | sed 's/+/%2B/g; s/@/%40/g')

--- a/e2e/scripts/generate-test-token.sh
+++ b/e2e/scripts/generate-test-token.sh
@@ -10,19 +10,22 @@
 #   - VERCEL_AUTOMATION_BYPASS_SECRET for Vercel bypass
 #   - USE_MOCK_CLAUDE must be "true" on the server
 #
-# Usage: ./generate-test-token.sh [variant]
-#   variant: "serial" (default) or "runner" — selects which test user
+# Usage: ./generate-test-token.sh <email>
+#   email: test user email (default: dev+clerk_test@serial.test)
 
 set -euo pipefail
 
-# Test user variant (serial or runner)
-VARIANT="${1:-serial}"
+# Test user email
+EMAIL="${1:-dev+clerk_test@serial.test}"
+
+# URL-encode the email (handle + and @)
+ENCODED_EMAIL=$(printf '%s' "$EMAIL" | sed 's/+/%2B/g; s/@/%40/g')
 
 # Retry configuration
 MAX_RETRIES=5
 INITIAL_DELAY=2
 
-echo "=== Generating Test CLI Token (variant: ${VARIANT}) ==="
+echo "=== Generating Test CLI Token (email: ${EMAIL}) ==="
 
 # Validate environment
 if [[ -z "${VM0_API_URL:-}" ]]; then
@@ -74,7 +77,7 @@ call_test_token_endpoint() {
     response=$(curl -s -w "\n%{http_code}" \
       "${CURL_HEADERS[@]}" \
       -X POST \
-      "${VM0_API_URL}/api/cli/auth/test-token?variant=${VARIANT}" 2>&1) || true
+      "${VM0_API_URL}/api/cli/auth/test-token?email=${ENCODED_EMAIL}" 2>&1) || true
 
     http_code=$(echo "$response" | tail -n1)
     body=$(echo "$response" | head -n-1)

--- a/e2e/tests/03-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-runner/t42-firewall-placeholder.bats
@@ -56,7 +56,15 @@ create_artifact() {
 setup_test_connector() {
     local connector_name="$1"
     local access_token="$2"
-    local variant="${3:-runner}"
+
+    if [[ -z "${E2E_RUNNER_EMAIL:-}" ]]; then
+        echo "E2E_RUNNER_EMAIL not set" >&2
+        return 1
+    fi
+
+    # URL-encode the email (handle + and @)
+    local encoded_email
+    encoded_email=$(printf '%s' "$E2E_RUNNER_EMAIL" | sed 's/+/%2B/g; s/@/%40/g')
 
     local curl_args=(-s -w "\n%{http_code}" -X POST)
     curl_args+=(-H "Content-Type: application/json")
@@ -67,7 +75,7 @@ setup_test_connector() {
 
     local response
     response=$(curl "${curl_args[@]}" \
-        "${VM0_API_URL}/api/cli/auth/test-connector?variant=${variant}")
+        "${VM0_API_URL}/api/cli/auth/test-connector?email=${encoded_email}")
 
     local http_code
     http_code=$(echo "$response" | tail -n1)

--- a/turbo/apps/docs/package.json
+++ b/turbo/apps/docs/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev --turbo --port 3001",
     "start": "next start",
     "lint": "oxlint && eslint . --max-warnings 0",
-    "check-types": "next typegen && tsc --noEmit",
+    "check-types": "fumadocs-mdx && next typegen && tsc --noEmit",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/turbo/apps/web/app/api/cli/auth/test-approve/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-approve/__tests__/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../route";
 import { POST as createDeviceRoute } from "../../device/route";
+import { DEFAULT_TEST_EMAIL } from "../../../../../../src/lib/auth/test-user";
 import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../../src/env";
@@ -230,7 +231,7 @@ describe("/api/cli/auth/test-approve", () => {
   });
 
   describe("Clerk integration", () => {
-    it("should return 500 when test user is not found", async () => {
+    it("should throw when test user is not found", async () => {
       mockGetUserList.mockResolvedValue({
         data: [],
       });
@@ -246,14 +247,12 @@ describe("/api/cli/auth/test-approve", () => {
         },
       );
 
-      const response = await POST(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(500);
-      expect(data.error).toBe("Test user not found");
+      await expect(POST(request)).rejects.toThrow(
+        "Test user not found for email:",
+      );
     });
 
-    it("should call Clerk with correct email address", async () => {
+    it("should call Clerk with default email address", async () => {
       mockGetUserList.mockResolvedValue({
         data: [{ id: "user_test789" }],
       });
@@ -272,7 +271,30 @@ describe("/api/cli/auth/test-approve", () => {
       await POST(request);
 
       expect(mockGetUserList).toHaveBeenCalledWith({
-        emailAddress: ["e2e+clerk_test@vm0.ai"],
+        emailAddress: [DEFAULT_TEST_EMAIL],
+      });
+    });
+
+    it("should call Clerk with custom email via query param", async () => {
+      mockGetUserList.mockResolvedValue({
+        data: [{ id: "user_test789" }],
+      });
+
+      const code = await createTestDeviceCode();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-approve?email=custom%40test.com",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ device_code: code }),
+        },
+      );
+
+      await POST(request);
+
+      expect(mockGetUserList).toHaveBeenCalledWith({
+        emailAddress: ["custom@test.com"],
       });
     });
   });

--- a/turbo/apps/web/app/api/cli/auth/test-approve/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-approve/route.ts
@@ -2,7 +2,10 @@ import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../../src/lib/init-services";
 import { deviceCodes } from "../../../../../src/db/schema/device-codes";
-import { resolveTestUserId } from "../../../../../src/lib/auth/test-user";
+import {
+  resolveTestUserId,
+  DEFAULT_TEST_EMAIL,
+} from "../../../../../src/lib/auth/test-user";
 import { env } from "../../../../../src/env";
 
 /**
@@ -56,10 +59,9 @@ export async function POST(req: Request) {
     );
   }
 
-  const testUserId = await resolveTestUserId();
-  if (!testUserId) {
-    return NextResponse.json({ error: "Test user not found" }, { status: 500 });
-  }
+  const url = new URL(req.url);
+  const email = url.searchParams.get("email") ?? DEFAULT_TEST_EMAIL;
+  const testUserId = await resolveTestUserId(email);
 
   await globalThis.services.db
     .update(deviceCodes)

--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -45,7 +45,7 @@ function isAllowed(request: Request): boolean {
  * Used by E2E tests to verify proxy-side token replacement.
  *
  * Body: { connectorName: string, accessToken: string }
- * Query: ?email=<email> (default: dev+clerk_test@serial.test)
+ * Query: ?email=<email> (default: dev+clerk_test+serial@vm0-e2e.ai)
  */
 export async function POST(request: Request) {
   if (!isAllowed(request)) {

--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -6,7 +6,7 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { upsertOAuthConnector } from "../../../../../src/lib/connector/connector-service";
 import {
   resolveTestUserId,
-  isTestVariant,
+  DEFAULT_TEST_EMAIL,
 } from "../../../../../src/lib/auth/test-user";
 import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
 import { getOrgDataOrNull } from "../../../../../src/lib/org/resolve-org";
@@ -45,7 +45,7 @@ function isAllowed(request: Request): boolean {
  * Used by E2E tests to verify proxy-side token replacement.
  *
  * Body: { connectorName: string, accessToken: string }
- * Query: ?variant=serial|runner (default: serial)
+ * Query: ?email=<email> (default: dev+clerk_test@serial.test)
  */
 export async function POST(request: Request) {
   if (!isAllowed(request)) {
@@ -80,18 +80,8 @@ export async function POST(request: Request) {
   const connectorType = connectorParsed.data;
 
   const url = new URL(request.url);
-  const variant = url.searchParams.get("variant") ?? "serial";
-  if (!isTestVariant(variant)) {
-    return NextResponse.json(
-      { error: `Unknown test variant: ${variant}` },
-      { status: 400 },
-    );
-  }
-
-  const userId = await resolveTestUserId(variant);
-  if (!userId) {
-    return NextResponse.json({ error: "Test user not found" }, { status: 500 });
-  }
+  const email = url.searchParams.get("email") ?? DEFAULT_TEST_EMAIL;
+  const userId = await resolveTestUserId(email);
 
   // Look up test user's org from org_members_cache (populated by test-token endpoint)
   const [cached] = await globalThis.services.db

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_TEST_EMAIL } from "../../../../../../src/lib/auth/test-user";
 import {
   createTestRequest,
   insertOrgCacheEntry,
+  deleteOrgCacheEntry,
   ensureOrgRow,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
@@ -12,11 +13,15 @@ import { reloadEnv } from "../../../../../../src/env";
 // Mock Clerk Server API
 const mockGetUserList = vi.fn();
 const mockGetOrganizationMembershipList = vi.fn();
+const mockGetOrganization = vi.fn();
 vi.mock("@clerk/nextjs/server", () => ({
   clerkClient: vi.fn(async () => ({
     users: {
       getUserList: mockGetUserList,
       getOrganizationMembershipList: mockGetOrganizationMembershipList,
+    },
+    organizations: {
+      getOrganization: mockGetOrganization,
     },
   })),
   auth: vi.fn(async () => ({ userId: null, orgId: null, orgRole: null })),
@@ -31,6 +36,7 @@ describe("/api/cli/auth/test-token", () => {
     reloadEnv();
     mockGetUserList.mockReset();
     mockGetOrganizationMembershipList.mockReset();
+    mockGetOrganization.mockReset();
     mockGetUserList.mockResolvedValue({
       data: [{ id: "user_test123" }],
     });
@@ -47,6 +53,12 @@ describe("/api/cli/auth/test-token", () => {
           publicUserData: { userId: "user_test123" },
         },
       ],
+    });
+    // Mock getOrganization for cache-miss fallback path (getOrgData)
+    mockGetOrganization.mockResolvedValue({
+      id: "org_test_token",
+      slug: "test-token-org",
+      name: "test-token-org",
     });
     // Pre-populate org_cache so ensureTestOrg() finds a matching entry
     await insertOrgCacheEntry({
@@ -219,6 +231,27 @@ describe("/api/cli/auth/test-token", () => {
 
       expect(mockGetUserList).toHaveBeenCalledWith({
         emailAddress: [DEFAULT_TEST_EMAIL],
+      });
+    });
+
+    it("populates org_cache from Clerk when entry is missing", async () => {
+      // Clear org_cache — simulate CI scenario where org was just
+      // created in Clerk but no cache entry exists yet
+      await deleteOrgCacheEntry("org_test_token");
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token",
+        { method: "POST" },
+      );
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.org_slug).toBe("test-token-org");
+      // Verify getOrganization was called to populate the cache
+      expect(mockGetOrganization).toHaveBeenCalledWith({
+        organizationId: "org_test_token",
       });
     });
 

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -48,7 +48,7 @@ describe("/api/cli/auth/test-token", () => {
         },
       ],
     });
-    // Pre-populate org_cache so getOrgData() resolves without hitting Clerk API
+    // Pre-populate org_cache so ensureTestOrg() finds a matching entry
     await insertOrgCacheEntry({
       orgId: "org_test_token",
       slug: "test-token-org",

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../route";
+import { DEFAULT_TEST_EMAIL } from "../../../../../../src/lib/auth/test-user";
 import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../../src/env";
@@ -7,17 +8,11 @@ import { reloadEnv } from "../../../../../../src/env";
 // Mock Clerk Server API
 const mockGetUserList = vi.fn();
 const mockGetOrganizationMembershipList = vi.fn();
-const mockCreateOrganization = vi.fn();
-const mockGetOrganization = vi.fn();
 vi.mock("@clerk/nextjs/server", () => ({
   clerkClient: vi.fn(async () => ({
     users: {
       getUserList: mockGetUserList,
       getOrganizationMembershipList: mockGetOrganizationMembershipList,
-    },
-    organizations: {
-      createOrganization: mockCreateOrganization,
-      getOrganization: mockGetOrganization,
     },
   })),
   auth: vi.fn(async () => ({ userId: null, orgId: null, orgRole: null })),
@@ -32,12 +27,10 @@ describe("/api/cli/auth/test-token", () => {
     reloadEnv();
     mockGetUserList.mockReset();
     mockGetOrganizationMembershipList.mockReset();
-    mockCreateOrganization.mockReset();
-    mockGetOrganization.mockReset();
     mockGetUserList.mockResolvedValue({
       data: [{ id: "user_test123" }],
     });
-    // Return a Clerk org membership so ensureDefaultOrg can discover/create a local org
+    // Return a Clerk org membership so ensureTestOrg can discover a local org
     mockGetOrganizationMembershipList.mockResolvedValue({
       data: [
         {
@@ -51,21 +44,6 @@ describe("/api/cli/auth/test-token", () => {
         },
       ],
     });
-    mockCreateOrganization.mockResolvedValue({ id: "org_mock_test" });
-    mockGetOrganization.mockImplementation(
-      (params: { organizationId?: string; slug?: string }) => {
-        const orgId = params.organizationId;
-        if (orgId === "org_test_token") {
-          return Promise.resolve({
-            id: "org_test_token",
-            slug: "test-token-org",
-            name: "test-token-org",
-            publicMetadata: {},
-          });
-        }
-        return Promise.reject(new Error(`Organization ${orgId} not found`));
-      },
-    );
   });
 
   describe("environment-based access control", () => {
@@ -208,7 +186,7 @@ describe("/api/cli/auth/test-token", () => {
       expect(data.org_slug).toBe("test-token-org");
     });
 
-    it("returns 500 when test user is not found", async () => {
+    it("throws when test user is not found", async () => {
       mockGetUserList.mockResolvedValue({ data: [] });
 
       const request = createTestRequest(
@@ -216,14 +194,12 @@ describe("/api/cli/auth/test-token", () => {
         { method: "POST" },
       );
 
-      const response = await POST(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(500);
-      expect(data.error).toBe("Test user not found");
+      await expect(POST(request)).rejects.toThrow(
+        "Test user not found for email:",
+      );
     });
 
-    it("calls Clerk with correct email address", async () => {
+    it("calls Clerk with default email address", async () => {
       const request = createTestRequest(
         "http://localhost:3000/api/cli/auth/test-token",
         { method: "POST" },
@@ -232,7 +208,20 @@ describe("/api/cli/auth/test-token", () => {
       await POST(request);
 
       expect(mockGetUserList).toHaveBeenCalledWith({
-        emailAddress: ["e2e+clerk_test@vm0.ai"],
+        emailAddress: [DEFAULT_TEST_EMAIL],
+      });
+    });
+
+    it("calls Clerk with custom email via query param", async () => {
+      const request = createTestRequest(
+        "http://localhost:3000/api/cli/auth/test-token?email=custom%40test.com",
+        { method: "POST" },
+      );
+
+      await POST(request);
+
+      expect(mockGetUserList).toHaveBeenCalledWith({
+        emailAddress: ["custom@test.com"],
       });
     });
   });

--- a/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/__tests__/route.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../route";
 import { DEFAULT_TEST_EMAIL } from "../../../../../../src/lib/auth/test-user";
-import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestRequest,
+  insertOrgCacheEntry,
+  ensureOrgRow,
+} from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { reloadEnv } from "../../../../../../src/env";
 
@@ -21,7 +25,7 @@ vi.mock("@clerk/nextjs/server", () => ({
 const context = testContext();
 
 describe("/api/cli/auth/test-token", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     context.setupMocks();
     vi.stubEnv("CLERK_SECRET_KEY", "test-secret-key");
     reloadEnv();
@@ -44,6 +48,12 @@ describe("/api/cli/auth/test-token", () => {
         },
       ],
     });
+    // Pre-populate org_cache so getOrgData() resolves without hitting Clerk API
+    await insertOrgCacheEntry({
+      orgId: "org_test_token",
+      slug: "test-token-org",
+    });
+    await ensureOrgRow("org_test_token");
   });
 
   describe("environment-based access control", () => {

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -5,7 +5,6 @@ import { clerkClient } from "@clerk/nextjs/server";
 import { initServices } from "../../../../../src/lib/init-services";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 import { orgCache } from "../../../../../src/db/schema/org-cache";
-import { orgMetadata } from "../../../../../src/db/schema/org-metadata";
 import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
 import {
   getOrgData,
@@ -14,7 +13,7 @@ import {
 import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
 import {
   resolveTestUserId,
-  isTestVariant,
+  DEFAULT_TEST_EMAIL,
 } from "../../../../../src/lib/auth/test-user";
 import { env } from "../../../../../src/env";
 
@@ -49,8 +48,7 @@ function isTestTokenAllowed(request: Request): boolean {
  * Queries Clerk API directly to find the user's org membership,
  * then pre-populates org_members_cache for fast verification.
  *
- * If the user has no Clerk org yet, creates org_cache and org_members_cache
- * entries with a sentinel orgId.
+ * Throws if the user has no Clerk org with a matching org_cache entry.
  */
 async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
   // Query Clerk API directly for user's org memberships
@@ -60,7 +58,7 @@ async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
   });
 
   // Use a far-future cachedAt so org_cache TTL checks never expire these
-  // entries and trigger a Clerk API refresh (sentinel orgs don't exist in Clerk).
+  // entries during E2E test runs (avoids Clerk API calls + 429 rate limits).
   const farFuture = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
 
   // Find first org with a matching org_cache entry
@@ -91,31 +89,7 @@ async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
     }
   }
 
-  // User has no Clerk org — use sentinel orgId with org_cache + membership cache
-  const sentinelOrgId = `org_test_${userId}`;
-  const slug = "test-org";
-  await globalThis.services.db
-    .insert(orgCache)
-    .values({
-      orgId: sentinelOrgId,
-      slug,
-      cachedAt: farFuture,
-    })
-    .onConflictDoNothing();
-  await globalThis.services.db
-    .insert(orgMetadata)
-    .values({ orgId: sentinelOrgId })
-    .onConflictDoNothing();
-  await globalThis.services.db
-    .insert(orgMembersCache)
-    .values({
-      orgId: sentinelOrgId,
-      userId,
-      role: "admin",
-      cachedAt: farFuture,
-    })
-    .onConflictDoNothing();
-  return { slug };
+  throw new Error(`Test user ${userId} has no organization in org_cache`);
 }
 
 /**
@@ -133,19 +107,10 @@ export async function POST(request: Request) {
   initServices();
 
   const url = new URL(request.url);
-  const variant = url.searchParams.get("variant") ?? "serial";
-  if (!isTestVariant(variant)) {
-    return NextResponse.json(
-      { error: `Unknown test variant: ${variant}` },
-      { status: 400 },
-    );
-  }
-  const userId = await resolveTestUserId(variant);
-  if (!userId) {
-    return NextResponse.json({ error: "Test user not found" }, { status: 500 });
-  }
+  const email = url.searchParams.get("email") ?? DEFAULT_TEST_EMAIL;
+  const userId = await resolveTestUserId(email);
 
-  // Auto-create org if user doesn't have one (creates real Clerk org or sentinel)
+  // Ensure user has an org in org_cache (provisioned by CI)
   const { slug: orgSlug } = await ensureTestOrg(userId);
 
   // Resolve orgId from slug (ensureTestOrg creates org_cache entry, so this is a cache hit)

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -6,7 +6,10 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 import { orgCache } from "../../../../../src/db/schema/org-cache";
 import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
-import { getOrgBySlug } from "../../../../../src/lib/org/org-cache-service";
+import {
+  getOrgBySlug,
+  getOrgData,
+} from "../../../../../src/lib/org/org-cache-service";
 import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
 import {
   resolveTestUserId,
@@ -61,19 +64,23 @@ async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
   // entries during E2E test runs (avoids Clerk API calls + 429 rate limits).
   const farFuture = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
 
-  // Find first org with a matching org_cache entry (query DB directly to avoid
-  // catching unrelated errors from getOrgData's Clerk API fallback path)
+  // Find first org: check org_cache first, populate from Clerk if missing
   for (const membership of memberships.data) {
     const orgId = membership.organization.id;
-    const [cached] = await globalThis.services.db
+    let [cached] = await globalThis.services.db
       .select({ slug: orgCache.slug })
       .from(orgCache)
       .where(eq(orgCache.orgId, orgId))
       .limit(1);
 
     if (!cached) {
-      log.warn(`skipping org ${orgId} for user ${userId}: not in org_cache`);
-      continue;
+      // Org was just created in Clerk by CI but not yet in org_cache.
+      // Populate the cache from Clerk so subsequent lookups are fast.
+      log.info(
+        `org ${orgId} not in org_cache, populating from Clerk for user ${userId}`,
+      );
+      const orgData = await getOrgData(orgId);
+      cached = { slug: orgData.slug };
     }
 
     const role = membership.role === "org:admin" ? "admin" : "member";

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -6,10 +6,7 @@ import { initServices } from "../../../../../src/lib/init-services";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 import { orgCache } from "../../../../../src/db/schema/org-cache";
 import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
-import {
-  getOrgData,
-  getOrgBySlug,
-} from "../../../../../src/lib/org/org-cache-service";
+import { getOrgBySlug } from "../../../../../src/lib/org/org-cache-service";
 import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
 import {
   resolveTestUserId,
@@ -64,33 +61,38 @@ async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
   // entries during E2E test runs (avoids Clerk API calls + 429 rate limits).
   const farFuture = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
 
-  // Find first org with a matching org_cache entry
+  // Find first org with a matching org_cache entry (query DB directly to avoid
+  // catching unrelated errors from getOrgData's Clerk API fallback path)
   for (const membership of memberships.data) {
     const orgId = membership.organization.id;
-    try {
-      const orgData = await getOrgData(orgId);
-      const role = membership.role === "org:admin" ? "admin" : "member";
-      // Pre-populate caches with far-future timestamps to prevent TTL expiry
-      // during E2E test runs (avoids Clerk API calls + 429 rate limits)
-      await globalThis.services.db
-        .insert(orgMembersCache)
-        .values({
-          orgId,
-          userId,
-          role,
-          cachedAt: farFuture,
-        })
-        .onConflictDoNothing();
-      await globalThis.services.db
-        .update(orgCache)
-        .set({ cachedAt: farFuture })
-        .where(eq(orgCache.orgId, orgId));
-      return { slug: orgData.slug };
-    } catch (error) {
-      // Org not in org_cache — try next membership
-      log.warn(`skipping org ${orgId} for user ${userId}`, error);
+    const [cached] = await globalThis.services.db
+      .select({ slug: orgCache.slug })
+      .from(orgCache)
+      .where(eq(orgCache.orgId, orgId))
+      .limit(1);
+
+    if (!cached) {
+      log.warn(`skipping org ${orgId} for user ${userId}: not in org_cache`);
       continue;
     }
+
+    const role = membership.role === "org:admin" ? "admin" : "member";
+    // Pre-populate caches with far-future timestamps to prevent TTL expiry
+    // during E2E test runs (avoids Clerk API calls + 429 rate limits)
+    await globalThis.services.db
+      .insert(orgMembersCache)
+      .values({
+        orgId,
+        userId,
+        role,
+        cachedAt: farFuture,
+      })
+      .onConflictDoNothing();
+    await globalThis.services.db
+      .update(orgCache)
+      .set({ cachedAt: farFuture })
+      .where(eq(orgCache.orgId, orgId));
+    return { slug: cached.slug };
   }
 
   throw new Error(`Test user ${userId} has no organization in org_cache`);

--- a/turbo/apps/web/app/api/cli/auth/test-token/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-token/route.ts
@@ -16,6 +16,9 @@ import {
   DEFAULT_TEST_EMAIL,
 } from "../../../../../src/lib/auth/test-user";
 import { env } from "../../../../../src/env";
+import { logger } from "../../../../../src/lib/logger";
+
+const log = logger("api:test-token");
 
 /**
  * Check if test-token endpoint is allowed based on environment.
@@ -83,8 +86,9 @@ async function ensureTestOrg(userId: string): Promise<{ slug: string }> {
         .set({ cachedAt: farFuture })
         .where(eq(orgCache.orgId, orgId));
       return { slug: orgData.slug };
-    } catch {
+    } catch (error) {
       // Org not in org_cache — try next membership
+      log.warn(`skipping org ${orgId} for user ${userId}`, error);
       continue;
     }
   }

--- a/turbo/apps/web/src/lib/auth/test-user.ts
+++ b/turbo/apps/web/src/lib/auth/test-user.ts
@@ -1,6 +1,6 @@
 import { clerkClient } from "@clerk/nextjs/server";
 
-export const DEFAULT_TEST_EMAIL = "dev+clerk_test@serial.test";
+export const DEFAULT_TEST_EMAIL = "dev+clerk_test+serial@vm0-e2e.ai";
 
 /**
  * Resolve the test user ID by querying Clerk Backend API for the e2e test user.

--- a/turbo/apps/web/src/lib/auth/test-user.ts
+++ b/turbo/apps/web/src/lib/auth/test-user.ts
@@ -1,28 +1,23 @@
 import { clerkClient } from "@clerk/nextjs/server";
 
-const TEST_USER_EMAILS = {
-  serial: "e2e+clerk_test@vm0.ai",
-  runner: "e2e_02+clerk_test@vm0.ai",
-} as const;
-
-type TestVariant = keyof typeof TEST_USER_EMAILS;
-
-export function isTestVariant(value: string): value is TestVariant {
-  return value in TEST_USER_EMAILS;
-}
+export const DEFAULT_TEST_EMAIL = "dev+clerk_test@serial.test";
 
 /**
  * Resolve the test user ID by querying Clerk Backend API for the e2e test user.
+ * Throws if the user is not found (accounts must be pre-provisioned by CI).
  *
- * @param variant - which test user to resolve ("serial" or "runner")
+ * @param email - the email address of the test user to look up
  */
 export async function resolveTestUserId(
-  variant: TestVariant = "serial",
-): Promise<string | null> {
-  const email = TEST_USER_EMAILS[variant];
+  email: string = DEFAULT_TEST_EMAIL,
+): Promise<string> {
   const clerk = await clerkClient();
   const { data: users } = await clerk.users.getUserList({
     emailAddress: [email],
   });
-  return users[0]?.id ?? null;
+  const userId = users[0]?.id;
+  if (!userId) {
+    throw new Error(`Test user not found for email: ${email}`);
+  }
+  return userId;
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded E2E test emails (`e2e+clerk_test@vm0.ai`, `e2e_02+clerk_test@vm0.ai`) with ephemeral accounts derived from `jobRef`
- Backend endpoints (`test-token`, `test-approve`, `test-connector`) now accept `?email=` query param instead of `?variant=`
- CI provisions 3 ephemeral Clerk accounts + orgs before token generation, and cleans them up after browser tests
- Remove `TestVariant`, `isTestVariant`, `TEST_USER_EMAILS` and sentinel org auto-creation

## Test plan

- [x] Integration tests updated and passing for test-token, test-approve routes
- [x] Type checking passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Knip passes (no unused exports)
- [ ] CI E2E tests pass with ephemeral accounts

Closes #7244

🤖 Generated with [Claude Code](https://claude.com/claude-code)