### PR TITLE
feat(nbd-cow): add minimal nbd server prototype with cow write buffer

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -69,6 +69,7 @@ jobs:
       guest-agent-changed: ${{ steps.detect.outputs.guest-agent-changed }}
       guest-mock-claude-changed: ${{ steps.detect.outputs.guest-mock-claude-changed }}
       block-cow-changed: ${{ steps.detect.outputs.block-cow-changed }}
+      nbd-cow-changed: ${{ steps.detect.outputs.nbd-cow-changed }}
       metal-host: ${{ steps.host.outputs.host }}
       metal-job-ref: ${{ steps.host.outputs.job-ref }}
     steps:
@@ -114,6 +115,7 @@ jobs:
           check_crate guest-agent
           check_crate guest-mock-claude
           check_crate block-cow
+          check_crate nbd-cow
 
           # Aggregate: true if any crate or CI config changed
           if grep -q "=true" "$GITHUB_OUTPUT"; then
@@ -289,6 +291,63 @@ jobs:
           scp "$TEST_BIN" "${REMOTE}:${REMOTE_BIN}"
           # shellcheck disable=SC2029
           ssh "$REMOTE" "trap 'rm -f ${REMOTE_BIN}' EXIT && sudo ${REMOTE_BIN} --ignored --test-threads=1"
+
+  nbd-cow-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vm0-ai/vm0-toolchain-rust:20260320
+    needs: [detect]
+    if: |
+      needs.detect.outputs.ci-changed == 'true' ||
+      needs.detect.outputs.nbd-cow-changed == 'true'
+    timeout-minutes: 5
+    env:
+      CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=-fuse-ld=mold"
+      TARGET_TRIPLE: aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mold linker
+        env:
+          MOLD_VERSION: "2.40.4"
+        run: |
+          curl -fsSL "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz" \
+            | tar xz --strip-components=2 -C /usr/local/bin "mold-${MOLD_VERSION}-x86_64-linux/bin/mold"
+          ln -sf /usr/local/bin/mold /usr/local/bin/ld.mold
+          ln -sf /usr/local/bin/mold /usr/local/bin/aarch64-linux-gnu-ld.mold
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates -> target
+          shared-key: aarch64-musl-ci
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Cross-compile nbd-cow tests for ARM64
+        run: |
+          cd crates
+          cargo test --no-run --release --target "$TARGET_TRIPLE" -p nbd-cow
+          TEST_BIN=$(find "target/$TARGET_TRIPLE/release/deps" -name "integration-*" -executable -type f | head -1)
+          cp "$TEST_BIN" "target/nbd-cow-integration-test"
+          echo "TEST_BIN=crates/target/nbd-cow-integration-test" >> "$GITHUB_ENV"
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Run nbd-cow integration tests on metal
+        env:
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          HOST: ${{ needs.detect.outputs.metal-host }}
+          JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
+        run: |
+          REMOTE="${METAL_USER}@${HOST}"
+          REMOTE_BIN="/tmp/nbd-cow-test-${JOB_REF}"
+          scp "$TEST_BIN" "${REMOTE}:${REMOTE_BIN}"
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "trap 'rm -f ${REMOTE_BIN}' EXIT && sudo modprobe nbd nbds_max=256 && sudo ${REMOTE_BIN} --ignored --test-threads=1"
 
   runner-build:
     runs-on: ubuntu-latest

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1346,7 +1346,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "uuid",
 ]
 
 [[package]]

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -1340,6 +1340,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec",
  "libc",
+ "nix",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -195,6 +195,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +601,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -1244,7 +1262,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1258,6 +1276,15 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1305,6 +1332,20 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nbd-cow"
+version = "0.1.0"
+dependencies = [
+ "bitvec",
+ "libc",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1376,6 +1417,29 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "path-tree"
@@ -1475,6 +1539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,6 +1571,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1833,6 +1912,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,6 +2220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,6 +2348,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3082,6 +3174,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xattr"

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "guest-download",
     "guest-init",
     "guest-mock-claude",
+    "nbd-cow",
     "runner",
     "sandbox",
     "sandbox-fc",
@@ -31,6 +32,7 @@ guest-common = { path = "guest-common" }
 guest-download = { path = "guest-download" }
 guest-init = { path = "guest-init" }
 guest-mock-claude = { path = "guest-mock-claude" }
+nbd-cow = { path = "nbd-cow" }
 reqeast = { path = "reqeast" }
 sandbox = { path = "sandbox" }
 sandbox-fc = { path = "sandbox-fc" }
@@ -42,6 +44,7 @@ vsock-proto = { path = "vsock-proto" }
 # External dependencies
 async-trait = "0.1"
 base64 = "0.22"
+bitvec = "1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false }
 clap = "4"

--- a/crates/nbd-cow/Cargo.toml
+++ b/crates/nbd-cow/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "nbd-cow"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+bitvec = { workspace = true }
+libc = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/nbd-cow/Cargo.toml
+++ b/crates/nbd-cow/Cargo.toml
@@ -10,7 +10,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 nix = { workspace = true, features = ["user"] }

--- a/crates/nbd-cow/Cargo.toml
+++ b/crates/nbd-cow/Cargo.toml
@@ -13,6 +13,7 @@ tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
+nix = { workspace = true, features = ["user"] }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/nbd-cow/src/bin/bench.rs
+++ b/crates/nbd-cow/src/bin/bench.rs
@@ -1,19 +1,26 @@
 //! Benchmark: NBD COW vs dm-snapshot.
 //!
 //! Runs fio workloads on both a dm-snapshot device and an NBD COW device,
-//! then compares IOPS, latency, and host disk IOPS.
+//! then compares VM-visible IOPS, latency, AND actual host disk IOPS.
 //!
 //! Requires: root, nbd kernel module, fio, losetup, dmsetup.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-fn main() {
+use nbd_cow::NbdCowDevice;
+
+#[tokio::main]
+async fn main() {
     let args: Vec<String> = std::env::args().collect();
     let base_size_mb: u64 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(1024);
 
     eprintln!("=== NBD COW vs dm-snapshot Benchmark ===");
     eprintln!("Base image size: {base_size_mb} MB");
+
+    // Detect host disk
+    let host_disk = detect_host_disk();
+    eprintln!("Host disk: {host_disk}");
     eprintln!();
 
     // Check prerequisites
@@ -40,8 +47,16 @@ fn main() {
 
     let workloads = vec![
         FioWorkload {
+            name: "rand4k-read",
+            args: "--rw=randread --bs=4k --size=256m --numjobs=4 --direct=1",
+        },
+        FioWorkload {
             name: "rand4k-write",
             args: "--rw=randwrite --bs=4k --size=256m --numjobs=4 --direct=1",
+        },
+        FioWorkload {
+            name: "seq128k-read",
+            args: "--rw=read --bs=128k --size=512m --direct=1",
         },
         FioWorkload {
             name: "seq128k-write",
@@ -55,45 +70,59 @@ fn main() {
 
     // --- dm-snapshot benchmark ---
     eprintln!("[2/5] Setting up dm-snapshot...");
-    let dm_results = match run_dm_snapshot_bench(&work_dir, &base_path, base_size, &workloads) {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("dm-snapshot bench failed: {e}");
-            vec![]
-        }
-    };
+    let dm_results =
+        match run_dm_snapshot_bench(&work_dir, &base_path, base_size, &workloads, &host_disk) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("dm-snapshot bench failed: {e}");
+                vec![]
+            }
+        };
 
     // --- NBD COW benchmark ---
     eprintln!("[3/5] Setting up NBD COW...");
-    let nbd_results = match run_nbd_cow_bench(&work_dir, &base_path, base_size, &workloads) {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("NBD COW bench failed: {e}");
-            vec![]
-        }
-    };
+    // Clean up any stale NBD devices from previous runs
+    cleanup_stale_nbd_devices();
+    let nbd_results =
+        match run_nbd_cow_bench(&work_dir, &base_path, base_size, &workloads, &host_disk).await {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("NBD COW bench failed: {e}");
+                vec![]
+            }
+        };
 
     // --- Print results ---
     eprintln!("[5/5] Results:");
     eprintln!();
     println!(
-        "{:<20} {:<12} {:<12} {:<12} {:<12} {:<12} {:<12}",
-        "Workload", "DM IOPS", "DM p50(us)", "DM p99(us)", "NBD IOPS", "NBD p50(us)", "NBD p99(us)"
+        "{:<16} {:>10} {:>10} {:>10} {:>12} {:>10} {:>10} {:>10} {:>12}",
+        "Workload",
+        "DM IOPS",
+        "DM p50",
+        "DM p99",
+        "DM disk-IO",
+        "NBD IOPS",
+        "NBD p50",
+        "NBD p99",
+        "NBD disk-IO"
     );
-    println!("{}", "-".repeat(92));
+    println!("{}", "-".repeat(118));
 
     for (i, wl) in workloads.iter().enumerate() {
         let dm = dm_results.get(i);
         let nbd = nbd_results.get(i);
         println!(
-            "{:<20} {:<12} {:<12} {:<12} {:<12} {:<12} {:<12}",
+            "{:<16} {:>10} {:>8}us {:>8}us {:>10}/s {:>10} {:>8}us {:>8}us {:>10}/s",
             wl.name,
-            dm.map_or("-".to_string(), |r| r.iops.to_string()),
-            dm.map_or("-".to_string(), |r| r.lat_p50_us.to_string()),
-            dm.map_or("-".to_string(), |r| r.lat_p99_us.to_string()),
-            nbd.map_or("-".to_string(), |r| r.iops.to_string()),
-            nbd.map_or("-".to_string(), |r| r.lat_p50_us.to_string()),
-            nbd.map_or("-".to_string(), |r| r.lat_p99_us.to_string()),
+            dm.map_or("-".into(), |r| r.vm_iops.to_string()),
+            dm.map_or("-".into(), |r| r.lat_p50_us.to_string()),
+            dm.map_or("-".into(), |r| r.lat_p99_us.to_string()),
+            dm.map_or("-".into(), |r| r.host_disk_iops.to_string()),
+            nbd.map_or("-".into(), |r| r.vm_iops.to_string()),
+            nbd.map_or("-".into(), |r| r.lat_p50_us.to_string()),
+            nbd.map_or("-".into(), |r| r.lat_p99_us.to_string()),
+            nbd.map_or("-".into(), |r| r.host_disk_iops.to_string()),
         );
     }
 
@@ -111,9 +140,25 @@ struct FioWorkload {
 
 #[derive(Debug, Default)]
 struct FioResult {
-    iops: u64,
+    /// IOPS as seen by the VM / fio
+    vm_iops: u64,
     lat_p50_us: u64,
     lat_p99_us: u64,
+    /// Actual IOPS on the host disk during the test
+    host_disk_iops: u64,
+}
+
+/// Snapshot of /proc/diskstats for a specific device.
+#[derive(Debug, Clone)]
+struct DiskStats {
+    reads_completed: u64,
+    writes_completed: u64,
+}
+
+impl DiskStats {
+    fn total_ios(&self) -> u64 {
+        self.reads_completed + self.writes_completed
+    }
 }
 
 fn run_dm_snapshot_bench(
@@ -121,20 +166,18 @@ fn run_dm_snapshot_bench(
     base_path: &Path,
     base_size: u64,
     workloads: &[FioWorkload],
+    host_disk: &str,
 ) -> Result<Vec<FioResult>, String> {
     let cow_path = work_dir.join("dm-cow.img");
     let sectors = base_size / 512;
     let mut results = Vec::new();
 
-    // Setup base loop device
     let base_loop = attach_loop(base_path, true)?;
 
     for wl in workloads {
-        // Create fresh COW file for each workload
         create_sparse_file(&cow_path, base_size);
         let cow_loop = attach_loop(&cow_path, false)?;
 
-        // Create dm-snapshot
         let dm_name = "bench-cow";
         let table = format!("0 {sectors} snapshot {base_loop} {cow_loop} P 8");
         run_cmd("dmsetup", &["create", dm_name, "--table", &table])?;
@@ -142,10 +185,9 @@ fn run_dm_snapshot_bench(
         let device = format!("/dev/mapper/{dm_name}");
         eprintln!("  Running fio ({}) on {device}...", wl.name);
 
-        let result = run_fio(&device, wl)?;
+        let result = run_fio_with_iostat(&device, wl, host_disk)?;
         results.push(result);
 
-        // Cleanup
         let _ = run_cmd("dmsetup", &["remove", dm_name]);
         detach_loop(&cow_loop)?;
         let _ = std::fs::remove_file(&cow_path);
@@ -155,52 +197,155 @@ fn run_dm_snapshot_bench(
     Ok(results)
 }
 
-fn run_nbd_cow_bench(
+async fn run_nbd_cow_bench(
     work_dir: &Path,
-    _base_path: &Path,
+    base_path: &Path,
     base_size: u64,
     workloads: &[FioWorkload],
+    host_disk: &str,
 ) -> Result<Vec<FioResult>, String> {
-    // For the benchmark, we use the NBD COW crate via a simple inline approach:
-    // Since we need root + nbd module, we create socketpairs and set up the device.
-    // However, in this benchmark binary we test the "simulated" path by just
-    // running fio against a file-backed approach to measure the COW layer overhead.
-    //
-    // Full NBD device benchmarking requires the nbd kernel module loaded.
-    // If nbd module is not available, we fall back to file-based benchmarking.
-
     let mut results = Vec::new();
 
     if !nbd_module_loaded() {
-        eprintln!("  WARNING: nbd kernel module not loaded, skipping NBD device benchmark.");
+        eprintln!("  WARNING: nbd kernel module not loaded.");
         eprintln!("  Load with: modprobe nbd nbds_max=256");
-        eprintln!("  Falling back to file-based COW benchmark...");
+        return Ok(results);
+    }
 
-        for wl in workloads {
-            let cow_path = work_dir.join("nbd-cow-data.img");
-            create_sparse_file(&cow_path, base_size);
+    eprintln!("  NBD module loaded, setting up NBD COW device...");
 
-            // Use the COW file directly with fio to measure raw file I/O baseline
-            eprintln!("  Running fio ({}) on file-backed COW...", wl.name);
-            let result = run_fio(
-                cow_path
-                    .to_str()
-                    .unwrap_or("/tmp/nbd-cow-bench/nbd-cow-data.img"),
-                wl,
-            )?;
-            results.push(result);
+    for wl in workloads {
+        let cow_path = work_dir.join("nbd-cow.img");
 
-            let _ = std::fs::remove_file(&cow_path);
-        }
-    } else {
-        eprintln!("  NBD module loaded, setting up NBD COW device...");
-        // TODO: Use nbd_cow::NbdCowDevice::create() here once running on metal
-        // For now, this path requires the full runtime which needs tokio
-        eprintln!("  Full NBD device benchmark not yet implemented in this binary.");
-        eprintln!("  Use the integration test suite on a metal host instead.");
+        let mut device = NbdCowDevice::create(base_path, &cow_path, base_size)
+            .await
+            .map_err(|e| format!("failed to create NBD COW device: {e}"))?;
+
+        let dev_path = device.device_path().to_string_lossy().to_string();
+        eprintln!("  Running fio ({}) on {dev_path}...", wl.name);
+
+        let result = run_fio_with_iostat(&dev_path, wl, host_disk)?;
+        results.push(result);
+
+        device
+            .destroy()
+            .await
+            .map_err(|e| format!("failed to destroy NBD device: {e}"))?;
+        let _ = std::fs::remove_file(&cow_path);
     }
 
     Ok(results)
+}
+
+/// Run fio while sampling /proc/diskstats before and after to measure actual host disk IOPS.
+fn run_fio_with_iostat(
+    device: &str,
+    workload: &FioWorkload,
+    host_disk: &str,
+) -> Result<FioResult, String> {
+    // Snapshot disk stats before
+    let before = read_diskstats(host_disk)?;
+
+    let start = std::time::Instant::now();
+
+    let output = Command::new("fio")
+        .arg(format!("--name={}", workload.name))
+        .arg(format!("--filename={device}"))
+        .args(workload.args.split_whitespace())
+        .arg("--runtime=10")
+        .arg("--time_based")
+        .arg("--output-format=json")
+        .output()
+        .map_err(|e| format!("fio failed to start: {e}"))?;
+
+    let elapsed_secs = start.elapsed().as_secs_f64();
+
+    // Snapshot disk stats after
+    let after = read_diskstats(host_disk)?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("fio failed: {stderr}"));
+    }
+
+    let mut result = parse_fio_json(&output.stdout)?;
+
+    // Calculate actual host disk IOPS
+    let delta_ios = after.total_ios().saturating_sub(before.total_ios());
+    if elapsed_secs > 0.0 {
+        result.host_disk_iops = (delta_ios as f64 / elapsed_secs) as u64;
+    }
+
+    eprintln!(
+        "    VM IOPS: {}, Host disk IOPS: {}, Duration: {:.1}s",
+        result.vm_iops, result.host_disk_iops, elapsed_secs
+    );
+
+    Ok(result)
+}
+
+/// Read /proc/diskstats for a given device name.
+///
+/// Format: major minor name rd_ios rd_merges rd_sectors rd_ticks
+///         wr_ios wr_merges wr_sectors wr_ticks ...
+fn read_diskstats(device_name: &str) -> Result<DiskStats, String> {
+    let content =
+        std::fs::read_to_string("/proc/diskstats").map_err(|e| format!("read diskstats: {e}"))?;
+
+    for line in content.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 7 && parts.get(2).is_some_and(|name| *name == device_name) {
+            let reads = parts
+                .get(3)
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(0);
+            let writes = parts
+                .get(7)
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(0);
+            return Ok(DiskStats {
+                reads_completed: reads,
+                writes_completed: writes,
+            });
+        }
+    }
+
+    Err(format!("device {device_name} not found in /proc/diskstats"))
+}
+
+/// Auto-detect the host disk by finding the block device backing /tmp.
+fn detect_host_disk() -> String {
+    // Try to find the device for /tmp via df
+    if let Ok(output) = Command::new("df").arg("/tmp").output() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if let Some(line) = stdout.lines().nth(1)
+            && let Some(dev) = line.split_whitespace().next()
+        {
+            // /dev/root -> find actual device
+            if dev == "/dev/root" {
+                // Check /proc/diskstats for nvme or xvd devices
+                if let Ok(stats) = std::fs::read_to_string("/proc/diskstats") {
+                    for candidate in &["nvme0n1", "xvda", "sda", "vda"] {
+                        if stats.contains(candidate) {
+                            return (*candidate).to_string();
+                        }
+                    }
+                }
+            } else {
+                // Strip /dev/ prefix and partition suffix
+                let name = dev.trim_start_matches("/dev/");
+                // Remove partition number (nvme0n1p1 -> nvme0n1, sda1 -> sda)
+                if let Some(base) = name.strip_suffix(|c: char| c.is_ascii_digit()) {
+                    if base.ends_with('p') && base.contains("nvme") {
+                        return base.trim_end_matches('p').to_string();
+                    }
+                    return base.to_string();
+                }
+                return name.to_string();
+            }
+        }
+    }
+    "nvme0n1".to_string()
 }
 
 fn create_sparse_file(path: &Path, size: u64) {
@@ -214,55 +359,32 @@ fn create_sparse_file(path: &Path, size: u64) {
     });
 }
 
-fn run_fio(device: &str, workload: &FioWorkload) -> Result<FioResult, String> {
-    let output = Command::new("fio")
-        .arg(format!("--name={}", workload.name))
-        .arg(format!("--filename={device}"))
-        .args(workload.args.split_whitespace())
-        .arg("--runtime=10")
-        .arg("--time_based")
-        .arg("--output-format=json")
-        .output()
-        .map_err(|e| format!("fio failed to start: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("fio failed: {stderr}"));
-    }
-
-    parse_fio_json(&output.stdout)
-}
-
 fn parse_fio_json(stdout: &[u8]) -> Result<FioResult, String> {
     let text = String::from_utf8_lossy(stdout);
-    // Simple JSON parsing: extract iops and latency from fio JSON output
-    // Look for "iops" and "clat_ns" percentiles
     let mut result = FioResult::default();
 
-    // Find write or read IOPS (take the larger one)
     for pattern in &["\"iops\""] {
         for line in text.lines() {
             if line.contains(pattern)
                 && let Some(val) = extract_number(line)
-                && val > result.iops
+                && val > result.vm_iops
             {
-                result.iops = val;
+                result.vm_iops = val;
             }
         }
     }
 
-    // Find p50 and p99 latencies
     for line in text.lines() {
         let trimmed = line.trim();
         if trimmed.contains("\"50.000000\"")
             && let Some(val) = extract_number(trimmed)
         {
-            result.lat_p50_us = val / 1000; // ns to us
+            result.lat_p50_us = val / 1000;
         }
         if trimmed.contains("\"99.000000\"")
             && let Some(val) = extract_number(trimmed)
         {
-            result.lat_p99_us = val / 1000; // ns to us
+            result.lat_p99_us = val / 1000;
         }
     }
 
@@ -270,7 +392,6 @@ fn parse_fio_json(stdout: &[u8]) -> Result<FioResult, String> {
 }
 
 fn extract_number(s: &str) -> Option<u64> {
-    // Find the last numeric value in the string (after colon)
     let after_colon = s.rsplit(':').next()?;
     let cleaned: String = after_colon
         .chars()
@@ -328,6 +449,21 @@ fn tool_exists(name: &str) -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
+}
+
+/// Try to disconnect any NBD devices that still have a non-zero size (stale from previous runs).
+fn cleanup_stale_nbd_devices() {
+    for i in 0..16u32 {
+        let size_path = format!("/sys/block/nbd{i}/size");
+        if let Ok(content) = std::fs::read_to_string(&size_path) {
+            let size: u64 = content.trim().parse().unwrap_or(0);
+            if size > 0 {
+                eprintln!("  Cleaning up stale /dev/nbd{i} (size={size})...");
+                let _ = nbd_cow::netlink::disconnect(i);
+                std::thread::sleep(std::time::Duration::from_millis(200));
+            }
+        }
+    }
 }
 
 fn nbd_module_loaded() -> bool {

--- a/crates/nbd-cow/src/bin/bench.rs
+++ b/crates/nbd-cow/src/bin/bench.rs
@@ -1,0 +1,337 @@
+//! Benchmark: NBD COW vs dm-snapshot.
+//!
+//! Runs fio workloads on both a dm-snapshot device and an NBD COW device,
+//! then compares IOPS, latency, and host disk IOPS.
+//!
+//! Requires: root, nbd kernel module, fio, losetup, dmsetup.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let base_size_mb: u64 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(1024);
+
+    eprintln!("=== NBD COW vs dm-snapshot Benchmark ===");
+    eprintln!("Base image size: {base_size_mb} MB");
+    eprintln!();
+
+    // Check prerequisites
+    if !is_root() {
+        eprintln!("ERROR: must run as root");
+        std::process::exit(1);
+    }
+    for tool in &["fio", "losetup", "dmsetup"] {
+        if !tool_exists(tool) {
+            eprintln!("ERROR: {tool} not found in PATH");
+            std::process::exit(1);
+        }
+    }
+
+    let work_dir = PathBuf::from("/tmp/nbd-cow-bench");
+    let _ = std::fs::create_dir_all(&work_dir);
+
+    let base_path = work_dir.join("base.img");
+    let base_size = base_size_mb * 1024 * 1024;
+
+    // Create base image
+    eprintln!("[1/5] Creating {base_size_mb}MB base image...");
+    create_sparse_file(&base_path, base_size);
+
+    let workloads = vec![
+        FioWorkload {
+            name: "rand4k-write",
+            args: "--rw=randwrite --bs=4k --size=256m --numjobs=4 --direct=1",
+        },
+        FioWorkload {
+            name: "seq128k-write",
+            args: "--rw=write --bs=128k --size=512m --direct=1",
+        },
+        FioWorkload {
+            name: "mixed-70r30w",
+            args: "--rw=randrw --rwmixread=70 --bs=4k --size=256m --direct=1",
+        },
+    ];
+
+    // --- dm-snapshot benchmark ---
+    eprintln!("[2/5] Setting up dm-snapshot...");
+    let dm_results = match run_dm_snapshot_bench(&work_dir, &base_path, base_size, &workloads) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("dm-snapshot bench failed: {e}");
+            vec![]
+        }
+    };
+
+    // --- NBD COW benchmark ---
+    eprintln!("[3/5] Setting up NBD COW...");
+    let nbd_results = match run_nbd_cow_bench(&work_dir, &base_path, base_size, &workloads) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("NBD COW bench failed: {e}");
+            vec![]
+        }
+    };
+
+    // --- Print results ---
+    eprintln!("[5/5] Results:");
+    eprintln!();
+    println!(
+        "{:<20} {:<12} {:<12} {:<12} {:<12} {:<12} {:<12}",
+        "Workload", "DM IOPS", "DM p50(us)", "DM p99(us)", "NBD IOPS", "NBD p50(us)", "NBD p99(us)"
+    );
+    println!("{}", "-".repeat(92));
+
+    for (i, wl) in workloads.iter().enumerate() {
+        let dm = dm_results.get(i);
+        let nbd = nbd_results.get(i);
+        println!(
+            "{:<20} {:<12} {:<12} {:<12} {:<12} {:<12} {:<12}",
+            wl.name,
+            dm.map_or("-".to_string(), |r| r.iops.to_string()),
+            dm.map_or("-".to_string(), |r| r.lat_p50_us.to_string()),
+            dm.map_or("-".to_string(), |r| r.lat_p99_us.to_string()),
+            nbd.map_or("-".to_string(), |r| r.iops.to_string()),
+            nbd.map_or("-".to_string(), |r| r.lat_p50_us.to_string()),
+            nbd.map_or("-".to_string(), |r| r.lat_p99_us.to_string()),
+        );
+    }
+
+    // Cleanup
+    eprintln!();
+    eprintln!("Cleaning up...");
+    let _ = std::fs::remove_dir_all(&work_dir);
+    eprintln!("Done.");
+}
+
+struct FioWorkload {
+    name: &'static str,
+    args: &'static str,
+}
+
+#[derive(Debug, Default)]
+struct FioResult {
+    iops: u64,
+    lat_p50_us: u64,
+    lat_p99_us: u64,
+}
+
+fn run_dm_snapshot_bench(
+    work_dir: &Path,
+    base_path: &Path,
+    base_size: u64,
+    workloads: &[FioWorkload],
+) -> Result<Vec<FioResult>, String> {
+    let cow_path = work_dir.join("dm-cow.img");
+    let sectors = base_size / 512;
+    let mut results = Vec::new();
+
+    // Setup base loop device
+    let base_loop = attach_loop(base_path, true)?;
+
+    for wl in workloads {
+        // Create fresh COW file for each workload
+        create_sparse_file(&cow_path, base_size);
+        let cow_loop = attach_loop(&cow_path, false)?;
+
+        // Create dm-snapshot
+        let dm_name = "bench-cow";
+        let table = format!("0 {sectors} snapshot {base_loop} {cow_loop} P 8");
+        run_cmd("dmsetup", &["create", dm_name, "--table", &table])?;
+
+        let device = format!("/dev/mapper/{dm_name}");
+        eprintln!("  Running fio ({}) on {device}...", wl.name);
+
+        let result = run_fio(&device, wl)?;
+        results.push(result);
+
+        // Cleanup
+        let _ = run_cmd("dmsetup", &["remove", dm_name]);
+        detach_loop(&cow_loop)?;
+        let _ = std::fs::remove_file(&cow_path);
+    }
+
+    detach_loop(&base_loop)?;
+    Ok(results)
+}
+
+fn run_nbd_cow_bench(
+    work_dir: &Path,
+    _base_path: &Path,
+    base_size: u64,
+    workloads: &[FioWorkload],
+) -> Result<Vec<FioResult>, String> {
+    // For the benchmark, we use the NBD COW crate via a simple inline approach:
+    // Since we need root + nbd module, we create socketpairs and set up the device.
+    // However, in this benchmark binary we test the "simulated" path by just
+    // running fio against a file-backed approach to measure the COW layer overhead.
+    //
+    // Full NBD device benchmarking requires the nbd kernel module loaded.
+    // If nbd module is not available, we fall back to file-based benchmarking.
+
+    let mut results = Vec::new();
+
+    if !nbd_module_loaded() {
+        eprintln!("  WARNING: nbd kernel module not loaded, skipping NBD device benchmark.");
+        eprintln!("  Load with: modprobe nbd nbds_max=256");
+        eprintln!("  Falling back to file-based COW benchmark...");
+
+        for wl in workloads {
+            let cow_path = work_dir.join("nbd-cow-data.img");
+            create_sparse_file(&cow_path, base_size);
+
+            // Use the COW file directly with fio to measure raw file I/O baseline
+            eprintln!("  Running fio ({}) on file-backed COW...", wl.name);
+            let result = run_fio(
+                cow_path
+                    .to_str()
+                    .unwrap_or("/tmp/nbd-cow-bench/nbd-cow-data.img"),
+                wl,
+            )?;
+            results.push(result);
+
+            let _ = std::fs::remove_file(&cow_path);
+        }
+    } else {
+        eprintln!("  NBD module loaded, setting up NBD COW device...");
+        // TODO: Use nbd_cow::NbdCowDevice::create() here once running on metal
+        // For now, this path requires the full runtime which needs tokio
+        eprintln!("  Full NBD device benchmark not yet implemented in this binary.");
+        eprintln!("  Use the integration test suite on a metal host instead.");
+    }
+
+    Ok(results)
+}
+
+fn create_sparse_file(path: &Path, size: u64) {
+    let f = std::fs::File::create(path).unwrap_or_else(|e| {
+        eprintln!("Failed to create {}: {e}", path.display());
+        std::process::exit(1);
+    });
+    f.set_len(size).unwrap_or_else(|e| {
+        eprintln!("Failed to set file size: {e}");
+        std::process::exit(1);
+    });
+}
+
+fn run_fio(device: &str, workload: &FioWorkload) -> Result<FioResult, String> {
+    let output = Command::new("fio")
+        .arg(format!("--name={}", workload.name))
+        .arg(format!("--filename={device}"))
+        .args(workload.args.split_whitespace())
+        .arg("--runtime=10")
+        .arg("--time_based")
+        .arg("--output-format=json")
+        .output()
+        .map_err(|e| format!("fio failed to start: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("fio failed: {stderr}"));
+    }
+
+    parse_fio_json(&output.stdout)
+}
+
+fn parse_fio_json(stdout: &[u8]) -> Result<FioResult, String> {
+    let text = String::from_utf8_lossy(stdout);
+    // Simple JSON parsing: extract iops and latency from fio JSON output
+    // Look for "iops" and "clat_ns" percentiles
+    let mut result = FioResult::default();
+
+    // Find write or read IOPS (take the larger one)
+    for pattern in &["\"iops\""] {
+        for line in text.lines() {
+            if line.contains(pattern)
+                && let Some(val) = extract_number(line)
+                && val > result.iops
+            {
+                result.iops = val;
+            }
+        }
+    }
+
+    // Find p50 and p99 latencies
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.contains("\"50.000000\"")
+            && let Some(val) = extract_number(trimmed)
+        {
+            result.lat_p50_us = val / 1000; // ns to us
+        }
+        if trimmed.contains("\"99.000000\"")
+            && let Some(val) = extract_number(trimmed)
+        {
+            result.lat_p99_us = val / 1000; // ns to us
+        }
+    }
+
+    Ok(result)
+}
+
+fn extract_number(s: &str) -> Option<u64> {
+    // Find the last numeric value in the string (after colon)
+    let after_colon = s.rsplit(':').next()?;
+    let cleaned: String = after_colon
+        .chars()
+        .filter(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    cleaned.split('.').next()?.parse().ok()
+}
+
+fn attach_loop(path: &Path, read_only: bool) -> Result<String, String> {
+    let mut args = vec!["--find", "--show"];
+    if read_only {
+        args.push("--read-only");
+    }
+    args.push("--direct-io=on");
+    let path_str = path.to_str().ok_or("invalid path")?;
+    args.push(path_str);
+
+    let output = Command::new("losetup")
+        .args(&args)
+        .output()
+        .map_err(|e| format!("losetup failed: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("losetup failed: {stderr}"));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn detach_loop(device: &str) -> Result<(), String> {
+    run_cmd("losetup", &["-d", device])
+}
+
+fn run_cmd(cmd: &str, args: &[&str]) -> Result<(), String> {
+    let output = Command::new(cmd)
+        .args(args)
+        .output()
+        .map_err(|e| format!("{cmd} failed to start: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("{cmd} failed: {stderr}"));
+    }
+    Ok(())
+}
+
+fn is_root() -> bool {
+    unsafe { libc::geteuid() == 0 }
+}
+
+fn tool_exists(name: &str) -> bool {
+    Command::new("which")
+        .arg(name)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn nbd_module_loaded() -> bool {
+    std::fs::read_to_string("/proc/modules")
+        .map(|s| s.lines().any(|l| l.starts_with("nbd ")))
+        .unwrap_or(false)
+}

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -95,8 +95,9 @@ impl CowLayer {
                 if let Some(ref cow_fd) = self.cow_fd {
                     cow_fd.read_at(dest, current_offset)?;
                 } else {
-                    // Dirty bit set but no COW file -- should not happen, fall back to base
-                    self.base_fd.read_at(dest, current_offset)?;
+                    return Err(NbdCowError::Io(std::io::Error::other(
+                        "dirty bit set but COW file not open",
+                    )));
                 }
             } else {
                 // Read from base image

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::os::unix::fs::FileExt;
 use std::path::Path;
@@ -22,7 +22,7 @@ pub struct CowLayer {
     /// 1 bit per block: set if the block has been written (and flushed to COW file).
     dirty: BitVec,
     /// Pending writes: block index -> block data.
-    write_buffer: HashMap<u64, Vec<u8>>,
+    write_buffer: BTreeMap<u64, Vec<u8>>,
     /// Current buffer usage in bytes.
     buffer_bytes: usize,
     /// Flush when buffer_bytes exceeds this threshold.
@@ -56,7 +56,7 @@ impl CowLayer {
             cow_path: cow_path.to_path_buf(),
             cow_fd: None,
             dirty: bitvec![0; num_blocks],
-            write_buffer: HashMap::new(),
+            write_buffer: BTreeMap::new(),
             buffer_bytes: 0,
             flush_threshold,
             block_size,
@@ -151,7 +151,7 @@ impl CowLayer {
 
     /// Flush the write buffer to the COW file.
     ///
-    /// Sorts dirty blocks by offset and writes them sequentially via pwrite.
+    /// BTreeMap iterates in key order, giving sequential I/O for free.
     pub fn flush(&mut self) -> Result<()> {
         if self.write_buffer.is_empty() {
             return Ok(());
@@ -159,9 +159,8 @@ impl CowLayer {
 
         self.ensure_cow_fd()?;
 
-        // Sort blocks by index for sequential I/O
-        let mut blocks: Vec<(u64, Vec<u8>)> = self.write_buffer.drain().collect();
-        blocks.sort_by_key(|(idx, _)| *idx);
+        // BTreeMap iterates in sorted order — no explicit sort needed
+        let blocks = std::mem::take(&mut self.write_buffer);
 
         let block_size = self.block_size;
         for (block_idx, data) in &blocks {

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -152,6 +152,7 @@ impl CowLayer {
     /// Flush the write buffer to the COW file.
     ///
     /// BTreeMap iterates in key order, giving sequential I/O for free.
+    /// On I/O failure, unwritten blocks are restored to the buffer so no data is lost.
     pub fn flush(&mut self) -> Result<()> {
         if self.write_buffer.is_empty() {
             return Ok(());
@@ -159,16 +160,24 @@ impl CowLayer {
 
         self.ensure_cow_fd()?;
 
-        // BTreeMap iterates in sorted order — no explicit sort needed
-        let blocks = std::mem::take(&mut self.write_buffer);
+        // Take ownership; on failure we put unwritten blocks back.
+        let blocks: Vec<(u64, Vec<u8>)> =
+            std::mem::take(&mut self.write_buffer).into_iter().collect();
 
         let block_size = self.block_size;
-        for (block_idx, data) in &blocks {
-            let offset = block_idx * block_size as u64;
-            if let Some(ref cow_fd) = self.cow_fd {
-                cow_fd.write_at(data, offset)?;
+        for (i, entry) in blocks.iter().enumerate() {
+            let offset = entry.0 * block_size as u64;
+            if let Some(ref cow_fd) = self.cow_fd
+                && let Err(e) = cow_fd.write_at(&entry.1, offset)
+            {
+                // Restore unwritten blocks back to the buffer
+                for (idx, buf) in blocks.into_iter().skip(i) {
+                    self.write_buffer.insert(idx, buf);
+                }
+                self.buffer_bytes = self.write_buffer.len() * self.block_size;
+                return Err(e.into());
             }
-            self.set_dirty(*block_idx);
+            self.set_dirty(entry.0);
         }
 
         self.buffer_bytes = 0;

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -1,0 +1,398 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::os::unix::fs::FileExt;
+use std::path::Path;
+
+use bitvec::prelude::*;
+
+use crate::error::{NbdCowError, Result};
+
+/// COW (Copy-on-Write) layer with write buffering.
+///
+/// Reads check: write buffer -> dirty COW file -> base image.
+/// Writes accumulate in an in-memory buffer that is flushed to the COW file
+/// when the buffer exceeds the flush threshold.
+pub struct CowLayer {
+    /// Read-only base image file.
+    base_fd: File,
+    /// Sparse COW file for persisting dirty blocks (created on first flush).
+    cow_path: Option<std::path::PathBuf>,
+    cow_fd: Option<File>,
+    /// 1 bit per block: set if the block has been written (and flushed to COW file).
+    dirty: BitVec,
+    /// Pending writes: block index -> block data.
+    write_buffer: HashMap<u64, Vec<u8>>,
+    /// Current buffer usage in bytes.
+    buffer_bytes: usize,
+    /// Flush when buffer_bytes exceeds this threshold.
+    flush_threshold: usize,
+    /// Block size in bytes.
+    block_size: usize,
+    /// Total device size in bytes.
+    size: u64,
+}
+
+impl CowLayer {
+    /// Create a new COW layer.
+    ///
+    /// `base_path`: read-only base image file
+    /// `size`: total device size in bytes
+    /// `block_size`: block size (typically 4096)
+    /// `flush_threshold`: flush write buffer when it exceeds this size in bytes
+    pub fn new(
+        base_path: &Path,
+        size: u64,
+        block_size: usize,
+        flush_threshold: usize,
+    ) -> Result<Self> {
+        let base_fd = File::open(base_path)?;
+        let num_blocks = (size as usize).div_ceil(block_size);
+
+        Ok(Self {
+            base_fd,
+            cow_path: None,
+            cow_fd: None,
+            dirty: bitvec![0; num_blocks],
+            write_buffer: HashMap::new(),
+            buffer_bytes: 0,
+            flush_threshold,
+            block_size,
+            size,
+        })
+    }
+
+    /// Set the COW file path. The file is created on first flush.
+    pub fn set_cow_path(&mut self, path: &Path) {
+        self.cow_path = Some(path.to_path_buf());
+    }
+
+    /// Read `buf.len()` bytes starting at `offset`.
+    ///
+    /// Read path: write buffer -> COW file (if dirty) -> base image.
+    pub fn read(&self, offset: u64, buf: &mut [u8]) -> Result<()> {
+        self.check_bounds(offset, buf.len() as u32)?;
+
+        let mut pos = 0usize;
+        while pos < buf.len() {
+            let current_offset = offset + pos as u64;
+            let block_idx = current_offset / self.block_size as u64;
+            let block_offset = (current_offset % self.block_size as u64) as usize;
+            let remaining_in_block = self.block_size - block_offset;
+            let to_read = remaining_in_block.min(buf.len() - pos);
+
+            let dest = buf.get_mut(pos..pos + to_read).ok_or_else(|| {
+                NbdCowError::Io(std::io::Error::other("slice out of bounds in read"))
+            })?;
+
+            // Check write buffer first
+            if let Some(block_data) = self.write_buffer.get(&block_idx) {
+                let src = block_data
+                    .get(block_offset..block_offset + to_read)
+                    .ok_or_else(|| {
+                        NbdCowError::Io(std::io::Error::other("block_data slice out of bounds"))
+                    })?;
+                dest.copy_from_slice(src);
+            } else if self.is_dirty(block_idx) {
+                // Read from COW file
+                if let Some(ref cow_fd) = self.cow_fd {
+                    cow_fd.read_at(dest, current_offset)?;
+                } else {
+                    // Dirty bit set but no COW file -- should not happen, fall back to base
+                    self.base_fd.read_at(dest, current_offset)?;
+                }
+            } else {
+                // Read from base image
+                self.base_fd.read_at(dest, current_offset)?;
+            }
+
+            pos += to_read;
+        }
+
+        Ok(())
+    }
+
+    /// Write `data` at `offset`. Returns `true` if the buffer needs flushing.
+    pub fn write(&mut self, offset: u64, data: &[u8]) -> Result<bool> {
+        self.check_bounds(offset, data.len() as u32)?;
+
+        let mut pos = 0usize;
+        while pos < data.len() {
+            let current_offset = offset + pos as u64;
+            let block_idx = current_offset / self.block_size as u64;
+            let block_offset = (current_offset % self.block_size as u64) as usize;
+            let remaining_in_block = self.block_size - block_offset;
+            let to_write = remaining_in_block.min(data.len() - pos);
+
+            if !self.write_buffer.contains_key(&block_idx) {
+                let full_block = self.read_full_block(block_idx);
+                self.write_buffer.insert(block_idx, full_block);
+            }
+            let block_data = self
+                .write_buffer
+                .get_mut(&block_idx)
+                .ok_or_else(|| NbdCowError::Io(std::io::Error::other("missing buffer entry")))?;
+
+            let dest_slice = block_data
+                .get_mut(block_offset..block_offset + to_write)
+                .ok_or_else(|| {
+                    NbdCowError::Io(std::io::Error::other("block_data dest slice out of bounds"))
+                })?;
+            let src_slice = data.get(pos..pos + to_write).ok_or_else(|| {
+                NbdCowError::Io(std::io::Error::other("data src slice out of bounds"))
+            })?;
+            dest_slice.copy_from_slice(src_slice);
+
+            // Only count newly added blocks toward buffer size
+            if block_data.len() == self.block_size
+                && block_offset == 0
+                && to_write == self.block_size
+            {
+                // Full block overwrite -- already counted if existing, count if new
+            }
+
+            pos += to_write;
+        }
+
+        // Recalculate buffer bytes
+        self.buffer_bytes = self.write_buffer.len() * self.block_size;
+
+        Ok(self.buffer_bytes >= self.flush_threshold)
+    }
+
+    /// Flush the write buffer to the COW file.
+    ///
+    /// Sorts dirty blocks by offset and writes them sequentially via pwrite.
+    pub fn flush(&mut self) -> Result<()> {
+        if self.write_buffer.is_empty() {
+            return Ok(());
+        }
+
+        self.ensure_cow_fd()?;
+
+        // Sort blocks by index for sequential I/O
+        let mut blocks: Vec<(u64, Vec<u8>)> = self.write_buffer.drain().collect();
+        blocks.sort_by_key(|(idx, _)| *idx);
+
+        let block_size = self.block_size;
+        for (block_idx, data) in &blocks {
+            let offset = block_idx * block_size as u64;
+            if let Some(ref cow_fd) = self.cow_fd {
+                cow_fd.write_at(data, offset)?;
+            }
+            self.set_dirty(*block_idx);
+        }
+
+        self.buffer_bytes = 0;
+        Ok(())
+    }
+
+    /// Flush and fsync the COW file.
+    pub fn sync(&mut self) -> Result<()> {
+        self.flush()?;
+        if let Some(ref cow_fd) = self.cow_fd {
+            cow_fd.sync_all()?;
+        }
+        Ok(())
+    }
+
+    /// Number of dirty blocks (flushed to COW file).
+    pub fn dirty_block_count(&self) -> usize {
+        self.dirty.count_ones()
+    }
+
+    /// Number of blocks in the write buffer (not yet flushed).
+    pub fn buffered_block_count(&self) -> usize {
+        self.write_buffer.len()
+    }
+
+    /// Current write buffer size in bytes.
+    pub fn buffer_bytes(&self) -> usize {
+        self.buffer_bytes
+    }
+
+    fn check_bounds(&self, offset: u64, length: u32) -> Result<()> {
+        if offset + u64::from(length) > self.size {
+            return Err(NbdCowError::OutOfBounds {
+                offset,
+                length,
+                device_size: self.size,
+            });
+        }
+        Ok(())
+    }
+
+    fn is_dirty(&self, block_idx: u64) -> bool {
+        self.dirty
+            .get(block_idx as usize)
+            .as_deref()
+            .copied()
+            .unwrap_or(false)
+    }
+
+    fn set_dirty(&mut self, block_idx: u64) {
+        if let Some(mut bit) = self.dirty.get_mut(block_idx as usize) {
+            *bit = true;
+        }
+    }
+
+    /// Read a full block, preferring COW file if dirty, otherwise base image.
+    fn read_full_block(&self, block_idx: u64) -> Vec<u8> {
+        let mut buf = vec![0u8; self.block_size];
+        let offset = block_idx * self.block_size as u64;
+
+        if self.is_dirty(block_idx)
+            && let Some(ref cow_fd) = self.cow_fd
+        {
+            let _ = cow_fd.read_at(&mut buf, offset);
+            return buf;
+        }
+
+        let _ = self.base_fd.read_at(&mut buf, offset);
+        buf
+    }
+
+    fn ensure_cow_fd(&mut self) -> Result<()> {
+        if self.cow_fd.is_none() {
+            let path = self.cow_path.as_ref().ok_or_else(|| {
+                NbdCowError::Io(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "no COW file path configured",
+                ))
+            })?;
+            let fd = File::options()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(path)?;
+            self.cow_fd = Some(fd);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as IoWrite;
+    use tempfile::NamedTempFile;
+
+    fn create_base_image(data: &[u8]) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(data).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn read_from_base_when_no_writes() {
+        let base_data = vec![0xAA; 8192]; // 2 blocks
+        let base = create_base_image(&base_data);
+        let cow = CowLayer::new(base.path(), 8192, 4096, 1024 * 1024).unwrap();
+
+        let mut buf = vec![0u8; 4096];
+        cow.read(0, &mut buf).unwrap();
+        assert!(buf.iter().all(|&b| b == 0xAA));
+
+        cow.read(4096, &mut buf).unwrap();
+        assert!(buf.iter().all(|&b| b == 0xAA));
+    }
+
+    #[test]
+    fn write_then_read_returns_written_data() {
+        let base_data = vec![0x00; 8192];
+        let base = create_base_image(&base_data);
+        let mut cow = CowLayer::new(base.path(), 8192, 4096, 1024 * 1024).unwrap();
+
+        let write_data = vec![0xBB; 4096];
+        cow.write(0, &write_data).unwrap();
+
+        let mut buf = vec![0u8; 4096];
+        cow.read(0, &mut buf).unwrap();
+        assert!(buf.iter().all(|&b| b == 0xBB));
+
+        // Second block still reads from base
+        cow.read(4096, &mut buf).unwrap();
+        assert!(buf.iter().all(|&b| b == 0x00));
+    }
+
+    #[test]
+    fn partial_block_write() {
+        let base_data = vec![0xAA; 4096];
+        let base = create_base_image(&base_data);
+        let mut cow = CowLayer::new(base.path(), 4096, 4096, 1024 * 1024).unwrap();
+
+        // Write 10 bytes at offset 100
+        let write_data = vec![0xFF; 10];
+        cow.write(100, &write_data).unwrap();
+
+        // Read full block -- should have base data with our write in the middle
+        let mut buf = vec![0u8; 4096];
+        cow.read(0, &mut buf).unwrap();
+        assert!(buf[..100].iter().all(|&b| b == 0xAA));
+        assert!(buf[100..110].iter().all(|&b| b == 0xFF));
+        assert!(buf[110..].iter().all(|&b| b == 0xAA));
+    }
+
+    #[test]
+    fn flush_writes_to_cow_file() {
+        let base_data = vec![0x00; 8192];
+        let base = create_base_image(&base_data);
+        let cow_file = NamedTempFile::new().unwrap();
+
+        let mut cow = CowLayer::new(base.path(), 8192, 4096, 1024 * 1024).unwrap();
+        cow.set_cow_path(cow_file.path());
+
+        let write_data = vec![0xCC; 4096];
+        cow.write(0, &write_data).unwrap();
+        assert_eq!(cow.buffered_block_count(), 1);
+
+        cow.flush().unwrap();
+        assert_eq!(cow.buffered_block_count(), 0);
+        assert_eq!(cow.dirty_block_count(), 1);
+
+        // Data should still be readable (now from COW file)
+        let mut buf = vec![0u8; 4096];
+        cow.read(0, &mut buf).unwrap();
+        assert!(buf.iter().all(|&b| b == 0xCC));
+    }
+
+    #[test]
+    fn buffer_threshold_triggers_flush_signal() {
+        let base_data = vec![0x00; 8192];
+        let base = create_base_image(&base_data);
+        // Threshold: 1 block (4096 bytes)
+        let mut cow = CowLayer::new(base.path(), 8192, 4096, 4096).unwrap();
+
+        let write_data = vec![0xDD; 4096];
+        let needs_flush = cow.write(0, &write_data).unwrap();
+        assert!(needs_flush, "should signal flush when threshold reached");
+    }
+
+    #[test]
+    fn out_of_bounds_error() {
+        let base_data = vec![0x00; 4096];
+        let base = create_base_image(&base_data);
+        let cow = CowLayer::new(base.path(), 4096, 4096, 1024 * 1024).unwrap();
+
+        let mut buf = vec![0u8; 4096];
+        let err = cow.read(4096, &mut buf);
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn cross_block_read_write() {
+        let base_data = vec![0xAA; 8192]; // 2 blocks
+        let base = create_base_image(&base_data);
+        let mut cow = CowLayer::new(base.path(), 8192, 4096, 1024 * 1024).unwrap();
+
+        // Write across block boundary
+        let write_data = vec![0xEE; 100];
+        cow.write(4090, &write_data).unwrap();
+
+        let mut buf = vec![0u8; 100];
+        cow.read(4090, &mut buf).unwrap();
+        assert!(buf.iter().all(|&b| b == 0xEE));
+        assert_eq!(cow.buffered_block_count(), 2); // spans 2 blocks
+    }
+}

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -365,6 +365,60 @@ mod tests {
     }
 
     #[test]
+    fn write_after_flush_overwrites_dirty_block() {
+        let base = create_base_image(&vec![0x00; 4096]);
+        let cow_file = NamedTempFile::new().unwrap();
+        let mut cow = make_cow(&base, &cow_file, 4096, 1024 * 1024);
+
+        // Write and flush
+        cow.write(0, &vec![0xAA; 4096]).unwrap();
+        cow.flush().unwrap();
+        assert_eq!(cow.dirty_block_count(), 1);
+
+        // Overwrite the same block (now in COW file, not buffer)
+        cow.write(0, &vec![0xBB; 4096]).unwrap();
+        assert_eq!(cow.buffered_block_count(), 1);
+
+        // Read should return the latest write (from buffer)
+        let mut buf = vec![0u8; 4096];
+        cow.read(0, &mut buf).unwrap();
+        assert!(buf.iter().all(|&b| b == 0xBB));
+
+        // Flush again and read — should still be 0xBB
+        cow.flush().unwrap();
+        cow.read(0, &mut buf).unwrap();
+        assert!(buf.iter().all(|&b| b == 0xBB));
+    }
+
+    #[test]
+    fn zero_length_read_write() {
+        let base = create_base_image(&vec![0xAA; 4096]);
+        let cow_file = NamedTempFile::new().unwrap();
+        let mut cow = make_cow(&base, &cow_file, 4096, 1024 * 1024);
+
+        // Zero-length read and write should succeed as no-ops
+        cow.read(0, &mut []).unwrap();
+        cow.write(0, &[]).unwrap();
+        assert_eq!(cow.buffered_block_count(), 0);
+
+        // Also at end of device
+        cow.read(4096, &mut []).unwrap();
+        cow.write(4096, &[]).unwrap();
+    }
+
+    #[test]
+    fn sync_without_writes() {
+        let base = create_base_image(&vec![0x00; 4096]);
+        let cow_file = NamedTempFile::new().unwrap();
+        let mut cow = make_cow(&base, &cow_file, 4096, 1024 * 1024);
+
+        // Sync with no writes should be a no-op (no COW file created)
+        cow.sync().unwrap();
+        assert_eq!(cow.dirty_block_count(), 0);
+        assert_eq!(cow.buffered_block_count(), 0);
+    }
+
+    #[test]
     fn cross_block_read_write() {
         let base = create_base_image(&vec![0xAA; 8192]);
         let cow_file = NamedTempFile::new().unwrap();

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -36,11 +36,13 @@ impl CowLayer {
     /// Create a new COW layer.
     ///
     /// `base_path`: read-only base image file
+    /// `cow_path`: path for the sparse COW file (created on first flush)
     /// `size`: total device size in bytes
     /// `block_size`: block size (typically 4096)
     /// `flush_threshold`: flush write buffer when it exceeds this size in bytes
     pub fn new(
         base_path: &Path,
+        cow_path: &Path,
         size: u64,
         block_size: usize,
         flush_threshold: usize,
@@ -50,7 +52,7 @@ impl CowLayer {
 
         Ok(Self {
             base_fd,
-            cow_path: None,
+            cow_path: Some(cow_path.to_path_buf()),
             cow_fd: None,
             dirty: bitvec![0; num_blocks],
             write_buffer: HashMap::new(),
@@ -61,16 +63,11 @@ impl CowLayer {
         })
     }
 
-    /// Set the COW file path. The file is created on first flush.
-    pub fn set_cow_path(&mut self, path: &Path) {
-        self.cow_path = Some(path.to_path_buf());
-    }
-
     /// Read `buf.len()` bytes starting at `offset`.
     ///
     /// Read path: write buffer -> COW file (if dirty) -> base image.
     pub fn read(&self, offset: u64, buf: &mut [u8]) -> Result<()> {
-        self.check_bounds(offset, buf.len() as u32)?;
+        self.check_bounds(offset, buf.len() as u64)?;
 
         let mut pos = 0usize;
         while pos < buf.len() {
@@ -113,7 +110,7 @@ impl CowLayer {
 
     /// Write `data` at `offset`. Returns `true` if the buffer needs flushing.
     pub fn write(&mut self, offset: u64, data: &[u8]) -> Result<bool> {
-        self.check_bounds(offset, data.len() as u32)?;
+        self.check_bounds(offset, data.len() as u64)?;
 
         let mut pos = 0usize;
         while pos < data.len() {
@@ -141,14 +138,6 @@ impl CowLayer {
                 NbdCowError::Io(std::io::Error::other("data src slice out of bounds"))
             })?;
             dest_slice.copy_from_slice(src_slice);
-
-            // Only count newly added blocks toward buffer size
-            if block_data.len() == self.block_size
-                && block_offset == 0
-                && to_write == self.block_size
-            {
-                // Full block overwrite -- already counted if existing, count if new
-            }
 
             pos += to_write;
         }
@@ -210,8 +199,8 @@ impl CowLayer {
         self.buffer_bytes
     }
 
-    fn check_bounds(&self, offset: u64, length: u32) -> Result<()> {
-        if offset + u64::from(length) > self.size {
+    fn check_bounds(&self, offset: u64, length: u64) -> Result<()> {
+        if offset.saturating_add(length) > self.size {
             return Err(NbdCowError::OutOfBounds {
                 offset,
                 length,
@@ -284,11 +273,20 @@ mod tests {
         f
     }
 
+    fn make_cow(
+        base: &NamedTempFile,
+        cow_file: &NamedTempFile,
+        size: u64,
+        flush_threshold: usize,
+    ) -> CowLayer {
+        CowLayer::new(base.path(), cow_file.path(), size, 4096, flush_threshold).unwrap()
+    }
+
     #[test]
     fn read_from_base_when_no_writes() {
-        let base_data = vec![0xAA; 8192]; // 2 blocks
-        let base = create_base_image(&base_data);
-        let cow = CowLayer::new(base.path(), 8192, 4096, 1024 * 1024).unwrap();
+        let base = create_base_image(&vec![0xAA; 8192]);
+        let cow_file = NamedTempFile::new().unwrap();
+        let cow = make_cow(&base, &cow_file, 8192, 1024 * 1024);
 
         let mut buf = vec![0u8; 4096];
         cow.read(0, &mut buf).unwrap();
@@ -300,12 +298,11 @@ mod tests {
 
     #[test]
     fn write_then_read_returns_written_data() {
-        let base_data = vec![0x00; 8192];
-        let base = create_base_image(&base_data);
-        let mut cow = CowLayer::new(base.path(), 8192, 4096, 1024 * 1024).unwrap();
+        let base = create_base_image(&vec![0x00; 8192]);
+        let cow_file = NamedTempFile::new().unwrap();
+        let mut cow = make_cow(&base, &cow_file, 8192, 1024 * 1024);
 
-        let write_data = vec![0xBB; 4096];
-        cow.write(0, &write_data).unwrap();
+        cow.write(0, &vec![0xBB; 4096]).unwrap();
 
         let mut buf = vec![0u8; 4096];
         cow.read(0, &mut buf).unwrap();
@@ -318,15 +315,12 @@ mod tests {
 
     #[test]
     fn partial_block_write() {
-        let base_data = vec![0xAA; 4096];
-        let base = create_base_image(&base_data);
-        let mut cow = CowLayer::new(base.path(), 4096, 4096, 1024 * 1024).unwrap();
+        let base = create_base_image(&vec![0xAA; 4096]);
+        let cow_file = NamedTempFile::new().unwrap();
+        let mut cow = make_cow(&base, &cow_file, 4096, 1024 * 1024);
 
-        // Write 10 bytes at offset 100
-        let write_data = vec![0xFF; 10];
-        cow.write(100, &write_data).unwrap();
+        cow.write(100, &[0xFF; 10]).unwrap();
 
-        // Read full block -- should have base data with our write in the middle
         let mut buf = vec![0u8; 4096];
         cow.read(0, &mut buf).unwrap();
         assert!(buf[..100].iter().all(|&b| b == 0xAA));
@@ -336,15 +330,11 @@ mod tests {
 
     #[test]
     fn flush_writes_to_cow_file() {
-        let base_data = vec![0x00; 8192];
-        let base = create_base_image(&base_data);
+        let base = create_base_image(&vec![0x00; 8192]);
         let cow_file = NamedTempFile::new().unwrap();
+        let mut cow = make_cow(&base, &cow_file, 8192, 1024 * 1024);
 
-        let mut cow = CowLayer::new(base.path(), 8192, 4096, 1024 * 1024).unwrap();
-        cow.set_cow_path(cow_file.path());
-
-        let write_data = vec![0xCC; 4096];
-        cow.write(0, &write_data).unwrap();
+        cow.write(0, &vec![0xCC; 4096]).unwrap();
         assert_eq!(cow.buffered_block_count(), 1);
 
         cow.flush().unwrap();
@@ -359,21 +349,20 @@ mod tests {
 
     #[test]
     fn buffer_threshold_triggers_flush_signal() {
-        let base_data = vec![0x00; 8192];
-        let base = create_base_image(&base_data);
+        let base = create_base_image(&vec![0x00; 8192]);
+        let cow_file = NamedTempFile::new().unwrap();
         // Threshold: 1 block (4096 bytes)
-        let mut cow = CowLayer::new(base.path(), 8192, 4096, 4096).unwrap();
+        let mut cow = make_cow(&base, &cow_file, 8192, 4096);
 
-        let write_data = vec![0xDD; 4096];
-        let needs_flush = cow.write(0, &write_data).unwrap();
+        let needs_flush = cow.write(0, &vec![0xDD; 4096]).unwrap();
         assert!(needs_flush, "should signal flush when threshold reached");
     }
 
     #[test]
     fn out_of_bounds_error() {
-        let base_data = vec![0x00; 4096];
-        let base = create_base_image(&base_data);
-        let cow = CowLayer::new(base.path(), 4096, 4096, 1024 * 1024).unwrap();
+        let base = create_base_image(&vec![0x00; 4096]);
+        let cow_file = NamedTempFile::new().unwrap();
+        let cow = make_cow(&base, &cow_file, 4096, 1024 * 1024);
 
         let mut buf = vec![0u8; 4096];
         let err = cow.read(4096, &mut buf);
@@ -382,17 +371,15 @@ mod tests {
 
     #[test]
     fn cross_block_read_write() {
-        let base_data = vec![0xAA; 8192]; // 2 blocks
-        let base = create_base_image(&base_data);
-        let mut cow = CowLayer::new(base.path(), 8192, 4096, 1024 * 1024).unwrap();
+        let base = create_base_image(&vec![0xAA; 8192]);
+        let cow_file = NamedTempFile::new().unwrap();
+        let mut cow = make_cow(&base, &cow_file, 8192, 1024 * 1024);
 
-        // Write across block boundary
-        let write_data = vec![0xEE; 100];
-        cow.write(4090, &write_data).unwrap();
+        cow.write(4090, &[0xEE; 100]).unwrap();
 
         let mut buf = vec![0u8; 100];
         cow.read(4090, &mut buf).unwrap();
         assert!(buf.iter().all(|&b| b == 0xEE));
-        assert_eq!(cow.buffered_block_count(), 2); // spans 2 blocks
+        assert_eq!(cow.buffered_block_count(), 2);
     }
 }

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -15,8 +15,9 @@ use crate::error::{NbdCowError, Result};
 pub struct CowLayer {
     /// Read-only base image file.
     base_fd: File,
-    /// Sparse COW file for persisting dirty blocks (created on first flush).
-    cow_path: Option<std::path::PathBuf>,
+    /// Path for the sparse COW file (created on first flush).
+    cow_path: std::path::PathBuf,
+    /// Open file handle for the COW file (lazily opened on first flush).
     cow_fd: Option<File>,
     /// 1 bit per block: set if the block has been written (and flushed to COW file).
     dirty: BitVec,
@@ -52,7 +53,7 @@ impl CowLayer {
 
         Ok(Self {
             base_fd,
-            cow_path: Some(cow_path.to_path_buf()),
+            cow_path: cow_path.to_path_buf(),
             cow_fd: None,
             dirty: bitvec![0; num_blocks],
             write_buffer: HashMap::new(),
@@ -121,7 +122,7 @@ impl CowLayer {
             let to_write = remaining_in_block.min(data.len() - pos);
 
             if !self.write_buffer.contains_key(&block_idx) {
-                let full_block = self.read_full_block(block_idx);
+                let full_block = self.read_full_block(block_idx)?;
                 self.write_buffer.insert(block_idx, full_block);
             }
             let block_data = self
@@ -225,35 +226,29 @@ impl CowLayer {
     }
 
     /// Read a full block, preferring COW file if dirty, otherwise base image.
-    fn read_full_block(&self, block_idx: u64) -> Vec<u8> {
+    fn read_full_block(&self, block_idx: u64) -> Result<Vec<u8>> {
         let mut buf = vec![0u8; self.block_size];
         let offset = block_idx * self.block_size as u64;
 
         if self.is_dirty(block_idx)
             && let Some(ref cow_fd) = self.cow_fd
         {
-            let _ = cow_fd.read_at(&mut buf, offset);
-            return buf;
+            cow_fd.read_at(&mut buf, offset)?;
+            return Ok(buf);
         }
 
-        let _ = self.base_fd.read_at(&mut buf, offset);
-        buf
+        self.base_fd.read_at(&mut buf, offset)?;
+        Ok(buf)
     }
 
     fn ensure_cow_fd(&mut self) -> Result<()> {
         if self.cow_fd.is_none() {
-            let path = self.cow_path.as_ref().ok_or_else(|| {
-                NbdCowError::Io(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "no COW file path configured",
-                ))
-            })?;
             let fd = File::options()
                 .read(true)
                 .write(true)
                 .create(true)
                 .truncate(false)
-                .open(path)?;
+                .open(&self.cow_path)?;
             self.cow_fd = Some(fd);
         }
         Ok(())

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -239,11 +239,14 @@ impl CowLayer {
         let mut buf = vec![0u8; self.block_size];
         let offset = block_idx * self.block_size as u64;
 
-        if self.is_dirty(block_idx)
-            && let Some(ref cow_fd) = self.cow_fd
-        {
-            cow_fd.read_at(&mut buf, offset)?;
-            return Ok(buf);
+        if self.is_dirty(block_idx) {
+            if let Some(ref cow_fd) = self.cow_fd {
+                cow_fd.read_at(&mut buf, offset)?;
+                return Ok(buf);
+            }
+            return Err(NbdCowError::Io(std::io::Error::other(
+                "dirty bit set but COW file not open",
+            )));
         }
 
         self.base_fd.read_at(&mut buf, offset)?;

--- a/crates/nbd-cow/src/error.rs
+++ b/crates/nbd-cow/src/error.rs
@@ -18,6 +18,9 @@ pub enum NbdCowError {
     #[error("netlink error: {0}")]
     Netlink(String),
 
+    #[error("netlink errno {errno}: {message}")]
+    NetlinkErrno { errno: i32, message: String },
+
     #[error("no free NBD device found")]
     NoFreeDevice,
 }

--- a/crates/nbd-cow/src/error.rs
+++ b/crates/nbd-cow/src/error.rs
@@ -11,7 +11,7 @@ pub enum NbdCowError {
     #[error("offset {offset} + length {length} exceeds device size {device_size}")]
     OutOfBounds {
         offset: u64,
-        length: u32,
+        length: u64,
         device_size: u64,
     },
 

--- a/crates/nbd-cow/src/error.rs
+++ b/crates/nbd-cow/src/error.rs
@@ -1,0 +1,25 @@
+use crate::protocol::ProtocolError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum NbdCowError {
+    #[error("protocol error: {0}")]
+    Protocol(#[from] ProtocolError),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("offset {offset} + length {length} exceeds device size {device_size}")]
+    OutOfBounds {
+        offset: u64,
+        length: u32,
+        device_size: u64,
+    },
+
+    #[error("netlink error: {0}")]
+    Netlink(String),
+
+    #[error("no free NBD device found")]
+    NoFreeDevice,
+}
+
+pub type Result<T> = std::result::Result<T, NbdCowError>;

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -25,8 +25,6 @@ pub const DEFAULT_FLUSH_THRESHOLD: usize = 4 * 1024 * 1024;
 /// Writes go to an in-memory buffer that is periodically flushed to a sparse COW file.
 /// Reads check the buffer, then COW file, then base image.
 pub struct NbdCowDevice {
-    /// Unique identifier for this device.
-    pub id: String,
     /// NBD device index (N in /dev/nbdN).
     device_index: u32,
     /// Path to the block device (e.g., /dev/nbd0).
@@ -47,7 +45,6 @@ impl NbdCowDevice {
     /// 3. Spawns dispatch tasks for each connection
     /// 4. Connects via netlink
     pub async fn create(base_image: &Path, cow_file: &Path, size: u64) -> Result<Self> {
-        let id = uuid::Uuid::new_v4().to_string();
         let device_index = netlink::find_free_device()?;
         let device_path = PathBuf::from(format!("/dev/nbd{device_index}"));
         let shutdown = CancellationToken::new();
@@ -84,7 +81,6 @@ impl NbdCowDevice {
         netlink::connect(device_index, &client_fds, size, BLOCK_SIZE as u64)?;
 
         Ok(Self {
-            id,
             device_index,
             device_path,
             cow_file: cow_file.to_path_buf(),
@@ -134,8 +130,20 @@ impl NbdCowDevice {
             tracing::warn!("NBD disconnect failed for nbd{}: {e}", self.device_index);
         }
 
-        // Wait for kernel to release the device
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // Wait for kernel to release the device (poll pid file)
+        let pid_path = format!("/sys/block/nbd{}/pid", self.device_index);
+        for _ in 0..10 {
+            match std::fs::read_to_string(&pid_path) {
+                Ok(content) => {
+                    let pid = content.trim();
+                    if pid == "-1" || pid == "0" || pid.is_empty() {
+                        break;
+                    }
+                }
+                Err(_) => break, // pid file gone means device released
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
 
         Ok(())
     }

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -53,10 +53,14 @@ impl NbdCowDevice {
         let shutdown = CancellationToken::new();
 
         // Create COW layer
-        let mut cow_layer =
-            cow::CowLayer::new(base_image, size, BLOCK_SIZE, DEFAULT_FLUSH_THRESHOLD)?;
-        cow_layer.set_cow_path(cow_file);
-        let cow_layer = std::sync::Arc::new(tokio::sync::Mutex::new(cow_layer));
+        let cow_layer = cow::CowLayer::new(
+            base_image,
+            cow_file,
+            size,
+            BLOCK_SIZE,
+            DEFAULT_FLUSH_THRESHOLD,
+        )?;
+        let cow_layer = std::sync::Arc::new(tokio::sync::RwLock::new(cow_layer));
 
         // Create socketpairs and spawn server tasks
         let mut client_fds = Vec::with_capacity(NUM_CONNECTIONS);

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -1,0 +1,131 @@
+pub mod cow;
+pub mod error;
+pub mod netlink;
+pub mod protocol;
+pub mod server;
+
+use std::path::{Path, PathBuf};
+
+use error::{NbdCowError, Result};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// Default block size: 4KB (matching dm-snapshot chunk size).
+pub const BLOCK_SIZE: usize = 4096;
+
+/// Default number of connections per NBD device.
+pub const NUM_CONNECTIONS: usize = 4;
+
+/// Default write buffer flush threshold: 4MB.
+pub const DEFAULT_FLUSH_THRESHOLD: usize = 4 * 1024 * 1024;
+
+/// An NBD COW block device backed by a base image and sparse COW file.
+///
+/// The device appears as `/dev/nbdN` and can be used as a Firecracker rootfs.
+/// Writes go to an in-memory buffer that is periodically flushed to a sparse COW file.
+/// Reads check the buffer, then COW file, then base image.
+pub struct NbdCowDevice {
+    /// Unique identifier for this device.
+    pub id: String,
+    /// NBD device index (N in /dev/nbdN).
+    device_index: u32,
+    /// Path to the block device (e.g., /dev/nbd0).
+    device_path: PathBuf,
+    /// Path to the sparse COW file.
+    cow_file: PathBuf,
+    /// Background server task handles (one per connection).
+    server_handles: Vec<JoinHandle<()>>,
+    /// Shutdown signal for all server tasks.
+    shutdown: CancellationToken,
+}
+
+impl NbdCowDevice {
+    /// Create a new NBD COW device.
+    ///
+    /// 1. Finds a free NBD device index
+    /// 2. Creates socketpairs (NUM_CONNECTIONS connections)
+    /// 3. Spawns dispatch tasks for each connection
+    /// 4. Connects via netlink
+    pub async fn create(base_image: &Path, cow_file: &Path, size: u64) -> Result<Self> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let device_index = netlink::find_free_device()?;
+        let device_path = PathBuf::from(format!("/dev/nbd{device_index}"));
+        let shutdown = CancellationToken::new();
+
+        // Create COW layer
+        let cow_layer = cow::CowLayer::new(base_image, size, BLOCK_SIZE, DEFAULT_FLUSH_THRESHOLD)?;
+        let cow_layer = std::sync::Arc::new(tokio::sync::Mutex::new(cow_layer));
+
+        // Create socketpairs and spawn server tasks
+        let mut client_fds = Vec::with_capacity(NUM_CONNECTIONS);
+        let mut server_handles = Vec::with_capacity(NUM_CONNECTIONS);
+
+        for _ in 0..NUM_CONNECTIONS {
+            let (client_fd, server_fd) = netlink::create_socketpair()?;
+            client_fds.push(client_fd);
+
+            let cow = cow_layer.clone();
+            let token = shutdown.clone();
+            let handle = tokio::spawn(async move {
+                if let Err(e) = server::dispatch(server_fd, cow, token).await {
+                    tracing::error!("NBD dispatch error: {e}");
+                }
+            });
+            server_handles.push(handle);
+        }
+
+        // Connect via netlink
+        netlink::connect(device_index, &client_fds, size, BLOCK_SIZE as u32)?;
+
+        Ok(Self {
+            id,
+            device_index,
+            device_path,
+            cow_file: cow_file.to_path_buf(),
+            server_handles,
+            shutdown,
+        })
+    }
+
+    /// Path to the block device (e.g., `/dev/nbd0`).
+    pub fn device_path(&self) -> &Path {
+        &self.device_path
+    }
+
+    /// Path to the sparse COW file.
+    pub fn cow_file(&self) -> &Path {
+        &self.cow_file
+    }
+
+    /// Destroy the device, removing the COW file.
+    pub async fn destroy(&mut self) -> Result<()> {
+        self.shutdown_inner().await?;
+
+        // Remove COW file
+        if self.cow_file.exists() {
+            std::fs::remove_file(&self.cow_file).map_err(NbdCowError::Io)?;
+        }
+
+        Ok(())
+    }
+
+    /// Destroy the device but keep the COW file for snapshot persistence.
+    pub async fn destroy_keep_cow(&mut self) -> Result<()> {
+        self.shutdown_inner().await
+    }
+
+    async fn shutdown_inner(&mut self) -> Result<()> {
+        // Signal all dispatch tasks to stop
+        self.shutdown.cancel();
+
+        // Disconnect via netlink
+        netlink::disconnect(self.device_index)?;
+
+        // Wait for all tasks to complete
+        for handle in self.server_handles.drain(..) {
+            let _ = handle.await;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -45,8 +45,6 @@ impl NbdCowDevice {
     /// 3. Spawns dispatch tasks for each connection
     /// 4. Connects via netlink
     pub async fn create(base_image: &Path, cow_file: &Path, size: u64) -> Result<Self> {
-        let device_index = netlink::find_free_device()?;
-        let device_path = PathBuf::from(format!("/dev/nbd{device_index}"));
         let shutdown = CancellationToken::new();
 
         // Create COW layer
@@ -77,15 +75,19 @@ impl NbdCowDevice {
             server_handles.push(handle);
         }
 
-        // Connect via netlink — on failure, abort spawned tasks so they don't
-        // leak as detached (they would exit on EOF anyway, but this is cleaner).
-        if let Err(e) = netlink::connect(device_index, &client_fds, size, BLOCK_SIZE as u64) {
-            shutdown.cancel();
-            for handle in server_handles {
-                handle.abort();
+        // Atomically find a free device and connect — retries on EBUSY so
+        // concurrent runners don't race for the same device index.
+        let device_index = match netlink::find_and_connect(&client_fds, size, BLOCK_SIZE as u64) {
+            Ok(idx) => idx,
+            Err(e) => {
+                shutdown.cancel();
+                for handle in server_handles {
+                    handle.abort();
+                }
+                return Err(e);
             }
-            return Err(e);
-        }
+        };
+        let device_path = PathBuf::from(format!("/dev/nbd{device_index}"));
 
         Ok(Self {
             device_index,

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -53,7 +53,9 @@ impl NbdCowDevice {
         let shutdown = CancellationToken::new();
 
         // Create COW layer
-        let cow_layer = cow::CowLayer::new(base_image, size, BLOCK_SIZE, DEFAULT_FLUSH_THRESHOLD)?;
+        let mut cow_layer =
+            cow::CowLayer::new(base_image, size, BLOCK_SIZE, DEFAULT_FLUSH_THRESHOLD)?;
+        cow_layer.set_cow_path(cow_file);
         let cow_layer = std::sync::Arc::new(tokio::sync::Mutex::new(cow_layer));
 
         // Create socketpairs and spawn server tasks
@@ -75,7 +77,7 @@ impl NbdCowDevice {
         }
 
         // Connect via netlink
-        netlink::connect(device_index, &client_fds, size, BLOCK_SIZE as u32)?;
+        netlink::connect(device_index, &client_fds, size, BLOCK_SIZE as u64)?;
 
         Ok(Self {
             id,
@@ -118,13 +120,16 @@ impl NbdCowDevice {
         // Signal all dispatch tasks to stop
         self.shutdown.cancel();
 
-        // Disconnect via netlink
-        netlink::disconnect(self.device_index)?;
-
-        // Wait for all tasks to complete
+        // Wait for all tasks to complete (they will flush on shutdown)
         for handle in self.server_handles.drain(..) {
             let _ = handle.await;
         }
+
+        // Disconnect via netlink (after tasks are done)
+        netlink::disconnect(self.device_index)?;
+
+        // Wait for kernel to release the device
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         Ok(())
     }

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -35,6 +35,8 @@ pub struct NbdCowDevice {
     server_handles: Vec<JoinHandle<()>>,
     /// Shutdown signal for all server tasks.
     shutdown: CancellationToken,
+    /// Set to true after shutdown_inner completes, so Drop doesn't double-disconnect.
+    disconnected: bool,
 }
 
 impl NbdCowDevice {
@@ -95,6 +97,7 @@ impl NbdCowDevice {
             cow_file: cow_file.to_path_buf(),
             server_handles,
             shutdown,
+            disconnected: false,
         })
     }
 
@@ -138,6 +141,7 @@ impl NbdCowDevice {
         if let Err(e) = netlink::disconnect(self.device_index) {
             tracing::warn!("NBD disconnect failed for nbd{}: {e}", self.device_index);
         }
+        self.disconnected = true;
 
         // Wait for kernel to release the device (poll pid file)
         let pid_path = format!("/sys/block/nbd{}/pid", self.device_index);
@@ -168,7 +172,10 @@ impl Drop for NbdCowDevice {
         for handle in self.server_handles.drain(..) {
             handle.abort();
         }
-        // Synchronous netlink disconnect — best effort
-        let _ = netlink::disconnect(self.device_index);
+        // Only disconnect if shutdown_inner hasn't already done it,
+        // to avoid disconnecting a device that was recycled by another runner.
+        if !self.disconnected {
+            let _ = netlink::disconnect(self.device_index);
+        }
     }
 }

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -77,8 +77,15 @@ impl NbdCowDevice {
             server_handles.push(handle);
         }
 
-        // Connect via netlink
-        netlink::connect(device_index, &client_fds, size, BLOCK_SIZE as u64)?;
+        // Connect via netlink — on failure, abort spawned tasks so they don't
+        // leak as detached (they would exit on EOF anyway, but this is cleaner).
+        if let Err(e) = netlink::connect(device_index, &client_fds, size, BLOCK_SIZE as u64) {
+            shutdown.cancel();
+            for handle in server_handles {
+                handle.abort();
+            }
+            return Err(e);
+        }
 
         Ok(Self {
             device_index,

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -126,11 +126,28 @@ impl NbdCowDevice {
         }
 
         // Disconnect via netlink (after tasks are done)
-        netlink::disconnect(self.device_index)?;
+        if let Err(e) = netlink::disconnect(self.device_index) {
+            tracing::warn!("NBD disconnect failed for nbd{}: {e}", self.device_index);
+        }
 
         // Wait for kernel to release the device
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         Ok(())
+    }
+}
+
+/// Best-effort cleanup on drop: cancel tasks and disconnect the NBD device.
+/// This ensures leaked devices are cleaned up even if `destroy()` is not called
+/// (e.g., test panics).
+impl Drop for NbdCowDevice {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+        // Abort all server tasks (they may be blocked on socket I/O)
+        for handle in self.server_handles.drain(..) {
+            handle.abort();
+        }
+        // Synchronous netlink disconnect — best effort
+        let _ = netlink::disconnect(self.device_index);
     }
 }

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -58,82 +58,78 @@ pub fn create_socketpair() -> Result<(OwnedFd, OwnedFd)> {
     Ok(unsafe { (OwnedFd::from_raw_fd(fd0), OwnedFd::from_raw_fd(fd1)) })
 }
 
-/// Find a free NBD device by scanning `/sys/block/nbdN/pid`.
-///
-/// A device is free if its pid file contains "0" or "-1" or does not exist.
-pub fn find_free_device() -> Result<u32> {
-    for i in 0..256u32 {
-        let pid_path = format!("/sys/block/nbd{i}/pid");
-        let path = Path::new(&pid_path);
+/// Read the kernel's nbds_max parameter to know how many devices are available.
+fn nbds_max() -> u32 {
+    std::fs::read_to_string("/sys/module/nbd/parameters/nbds_max")
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(256)
+}
 
-        if !path.exists() {
-            // Device exists in kernel but no pid file -> free
-            // But first check if the device node exists
-            let dev_path = format!("/dev/nbd{i}");
-            if Path::new(&dev_path).exists() {
-                return Ok(i);
-            }
+/// Check if a device index appears free by inspecting its pid file.
+fn device_appears_free(index: u32) -> bool {
+    let pid_path = format!("/sys/block/nbd{index}/pid");
+    let path = Path::new(&pid_path);
+
+    if !path.exists() {
+        // No pid file — free if the device node exists
+        return Path::new(&format!("/dev/nbd{index}")).exists();
+    }
+
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let pid = contents.trim();
+            pid == "-1" || pid == "0" || pid.is_empty()
+        }
+        Err(_) => true, // Can't read pid file → assume free
+    }
+}
+
+/// Atomically find a free NBD device and connect it.
+///
+/// Iterates candidate devices, attempts `connect` on each one that appears free.
+/// If the kernel returns EBUSY (another process grabbed it first), tries the next
+/// device. This eliminates the TOCTOU race between find and connect.
+///
+/// Returns the device index on success.
+pub fn find_and_connect(client_fds: &[OwnedFd], size: u64, block_size: u64) -> Result<u32> {
+    let max = nbds_max();
+
+    let sock = open_genl_socket()?;
+    let family_id = resolve_nbd_family(&sock)?;
+
+    // Build socket attributes once (reused across attempts)
+    let sockets_nla = build_sockets_nla(client_fds);
+    let flags = NBD_FLAG_HAS_FLAGS | NBD_FLAG_CAN_MULTI_CONN;
+
+    for i in 0..max {
+        if !device_appears_free(i) {
             continue;
         }
 
-        match std::fs::read_to_string(path) {
-            Ok(contents) => {
-                let pid = contents.trim();
-                if pid == "-1" || pid == "0" || pid.is_empty() {
-                    return Ok(i);
-                }
+        // Build per-device attributes
+        let mut attrs = Vec::new();
+        attrs.extend_from_slice(&build_nla(NBD_ATTR_INDEX, &i.to_ne_bytes()));
+        attrs.extend_from_slice(&build_nla(NBD_ATTR_SIZE_BYTES, &size.to_ne_bytes()));
+        attrs.extend_from_slice(&build_nla(
+            NBD_ATTR_BLOCK_SIZE_BYTES,
+            &block_size.to_ne_bytes(),
+        ));
+        attrs.extend_from_slice(&build_nla(NBD_ATTR_SERVER_FLAGS, &flags.to_ne_bytes()));
+        attrs.extend_from_slice(&sockets_nla);
+
+        send_genl_msg(&sock, family_id, NBD_CMD_CONNECT, &attrs)?;
+        match recv_genl_ack(&sock) {
+            Ok(()) => return Ok(i),
+            Err(NbdCowError::NetlinkErrno { errno, .. }) if errno == libc::EBUSY => {
+                // Device was grabbed by another process — try next
+                continue;
             }
-            Err(_) => {
-                // Can't read pid file -> assume free
-                return Ok(i);
-            }
+            Err(e) => return Err(e),
         }
     }
 
     Err(NbdCowError::NoFreeDevice)
-}
-
-/// Connect an NBD device via generic netlink.
-///
-/// This passes the client-side socket fds to the kernel, which takes ownership
-/// of them for the NBD device's I/O.
-pub fn connect(
-    device_index: u32,
-    client_fds: &[OwnedFd],
-    size: u64,
-    block_size: u64,
-) -> Result<()> {
-    let sock = open_genl_socket()?;
-    let family_id = resolve_nbd_family(&sock)?;
-    let flags = NBD_FLAG_HAS_FLAGS | NBD_FLAG_CAN_MULTI_CONN;
-
-    // Build nested SOCKETS attribute:
-    // NBD_ATTR_SOCKETS (nested)
-    //   NBD_SOCK_ITEM (nested, per socket)
-    //     NBD_SOCK_FD (u32)
-    let mut sockets_payload = Vec::new();
-    for fd in client_fds.iter() {
-        let raw_fd = std::os::unix::io::AsRawFd::as_raw_fd(fd) as u32;
-        let fd_nla = build_nla(NBD_SOCK_FD, &raw_fd.to_ne_bytes());
-        let item_nla = build_nested_nla(NBD_SOCK_ITEM, &fd_nla);
-        sockets_payload.extend_from_slice(&item_nla);
-    }
-
-    // Build the full message
-    let mut attrs = Vec::new();
-    attrs.extend_from_slice(&build_nla(NBD_ATTR_INDEX, &device_index.to_ne_bytes()));
-    attrs.extend_from_slice(&build_nla(NBD_ATTR_SIZE_BYTES, &size.to_ne_bytes()));
-    attrs.extend_from_slice(&build_nla(
-        NBD_ATTR_BLOCK_SIZE_BYTES,
-        &block_size.to_ne_bytes(),
-    ));
-    attrs.extend_from_slice(&build_nla(NBD_ATTR_SERVER_FLAGS, &flags.to_ne_bytes()));
-    attrs.extend_from_slice(&build_nested_nla(NBD_ATTR_SOCKETS, &sockets_payload));
-
-    send_genl_msg(&sock, family_id, NBD_CMD_CONNECT, &attrs)?;
-    recv_genl_ack(&sock)?;
-
-    Ok(())
 }
 
 /// Disconnect an NBD device via generic netlink.
@@ -335,13 +331,26 @@ fn recv_genl_ack(sock: &GenlSocket) -> Result<()> {
         if error == 0 {
             return Ok(()); // ACK (error=0 means success)
         }
-        return Err(NbdCowError::Netlink(format!(
-            "netlink error: {}",
-            std::io::Error::from_raw_os_error(-error)
-        )));
+        let errno = -error;
+        return Err(NbdCowError::NetlinkErrno {
+            errno,
+            message: std::io::Error::from_raw_os_error(errno).to_string(),
+        });
     }
 
     Ok(())
+}
+
+/// Build the nested NBD_ATTR_SOCKETS NLA from a list of client fds.
+fn build_sockets_nla(client_fds: &[OwnedFd]) -> Vec<u8> {
+    let mut sockets_payload = Vec::new();
+    for fd in client_fds.iter() {
+        let raw_fd = std::os::unix::io::AsRawFd::as_raw_fd(fd) as u32;
+        let fd_nla = build_nla(NBD_SOCK_FD, &raw_fd.to_ne_bytes());
+        let item_nla = build_nested_nla(NBD_SOCK_ITEM, &fd_nla);
+        sockets_payload.extend_from_slice(&item_nla);
+    }
+    build_nested_nla(NBD_ATTR_SOCKETS, &sockets_payload)
 }
 
 /// Build a netlink attribute (NLA).

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -199,27 +199,26 @@ fn resolve_nbd_family(sock: &GenlSocket) -> Result<u16> {
     // Parse attributes to find CTRL_ATTR_FAMILY_ID
     let mut offset = 20;
     while offset + 4 <= msg.len() {
-        let nla_len = u16::from_ne_bytes([
-            *msg.get(offset)
-                .ok_or_else(|| NbdCowError::Netlink("truncated nla".into()))?,
-            *msg.get(offset + 1)
-                .ok_or_else(|| NbdCowError::Netlink("truncated nla".into()))?,
-        ]) as usize;
-        let nla_type = u16::from_ne_bytes([
-            *msg.get(offset + 2)
-                .ok_or_else(|| NbdCowError::Netlink("truncated nla".into()))?,
-            *msg.get(offset + 3)
-                .ok_or_else(|| NbdCowError::Netlink("truncated nla".into()))?,
-        ]);
+        let nla_len_bytes: [u8; 2] = msg
+            .get(offset..offset + 2)
+            .ok_or_else(|| NbdCowError::Netlink("truncated nla".into()))?
+            .try_into()
+            .map_err(|_| NbdCowError::Netlink("nla len conversion".into()))?;
+        let nla_type_bytes: [u8; 2] = msg
+            .get(offset + 2..offset + 4)
+            .ok_or_else(|| NbdCowError::Netlink("truncated nla".into()))?
+            .try_into()
+            .map_err(|_| NbdCowError::Netlink("nla type conversion".into()))?;
+        let nla_len = u16::from_ne_bytes(nla_len_bytes) as usize;
+        let nla_type = u16::from_ne_bytes(nla_type_bytes);
 
         if nla_type == CTRL_ATTR_FAMILY_ID && nla_len >= 6 {
-            let id = u16::from_ne_bytes([
-                *msg.get(offset + 4)
-                    .ok_or_else(|| NbdCowError::Netlink("truncated id".into()))?,
-                *msg.get(offset + 5)
-                    .ok_or_else(|| NbdCowError::Netlink("truncated id".into()))?,
-            ]);
-            return Ok(id);
+            let id_bytes: [u8; 2] = msg
+                .get(offset + 4..offset + 6)
+                .ok_or_else(|| NbdCowError::Netlink("truncated family id".into()))?
+                .try_into()
+                .map_err(|_| NbdCowError::Netlink("id conversion".into()))?;
+            return Ok(u16::from_ne_bytes(id_bytes));
         }
 
         // Advance to next attribute (4-byte aligned)
@@ -253,39 +252,30 @@ fn send_genl_msg_raw(
     let total_len = 16 + 4 + attrs.len();
     let mut msg = vec![0u8; total_len];
 
-    // nlmsghdr
-    let len_bytes = (total_len as u32).to_ne_bytes();
-    // Safe: msg is at least 20 bytes (16 + 4)
-    let header = msg
-        .get_mut(..20)
-        .ok_or_else(|| NbdCowError::Netlink("msg buffer too small for header".into()))?;
-    header
-        .get_mut(..4)
-        .ok_or_else(|| NbdCowError::Netlink("msg buffer too small".into()))?
-        .copy_from_slice(&len_bytes);
-    header
-        .get_mut(4..6)
-        .ok_or_else(|| NbdCowError::Netlink("msg buffer too small".into()))?
-        .copy_from_slice(&msg_type.to_ne_bytes());
-    header
-        .get_mut(6..8)
-        .ok_or_else(|| NbdCowError::Netlink("msg buffer too small".into()))?
-        .copy_from_slice(&(NLM_F_REQUEST | NLM_F_ACK).to_ne_bytes());
+    // nlmsghdr: length(4) + type(2) + flags(2) + seq(4) + pid(4)
+    if let Some(s) = msg.get_mut(..4) {
+        s.copy_from_slice(&(total_len as u32).to_ne_bytes());
+    }
+    if let Some(s) = msg.get_mut(4..6) {
+        s.copy_from_slice(&msg_type.to_ne_bytes());
+    }
+    if let Some(s) = msg.get_mut(6..8) {
+        s.copy_from_slice(&(NLM_F_REQUEST | NLM_F_ACK).to_ne_bytes());
+    }
     // seq and pid left as 0
 
-    // genlmsghdr
-    if let Some(b) = header.get_mut(16) {
+    // genlmsghdr: cmd(1) + version(1) + reserved(2)
+    if let Some(b) = msg.get_mut(16) {
         *b = cmd;
     }
-    if let Some(b) = header.get_mut(17) {
+    if let Some(b) = msg.get_mut(17) {
         *b = version;
     }
-    // reserved (2 bytes) = 0
 
     // attributes
-    msg.get_mut(20..)
-        .ok_or_else(|| NbdCowError::Netlink("msg buffer too small for attrs".into()))?
-        .copy_from_slice(attrs);
+    if let Some(dest) = msg.get_mut(20..) {
+        dest.copy_from_slice(attrs);
+    }
 
     let ret = unsafe {
         libc::send(
@@ -325,27 +315,23 @@ fn recv_genl_ack(sock: &GenlSocket) -> Result<()> {
         return Err(NbdCowError::Netlink("ack response too short".into()));
     }
 
-    let msg_type = u16::from_ne_bytes([
-        *buf.get(4)
-            .ok_or_else(|| NbdCowError::Netlink("ack too short for msg_type".into()))?,
-        *buf.get(5)
-            .ok_or_else(|| NbdCowError::Netlink("ack too short for msg_type".into()))?,
-    ]);
+    let type_bytes: [u8; 2] = buf
+        .get(4..6)
+        .ok_or_else(|| NbdCowError::Netlink("ack too short for msg_type".into()))?
+        .try_into()
+        .map_err(|_| NbdCowError::Netlink("msg_type conversion".into()))?;
+    let msg_type = u16::from_ne_bytes(type_bytes);
     if msg_type == NLMSG_ERROR {
         // Error message: nlmsghdr (16) + error code (4 bytes as i32)
         if n < 20 {
             return Err(NbdCowError::Netlink("error response too short".into()));
         }
-        let error = i32::from_ne_bytes([
-            *buf.get(16)
-                .ok_or_else(|| NbdCowError::Netlink("error response truncated".into()))?,
-            *buf.get(17)
-                .ok_or_else(|| NbdCowError::Netlink("error response truncated".into()))?,
-            *buf.get(18)
-                .ok_or_else(|| NbdCowError::Netlink("error response truncated".into()))?,
-            *buf.get(19)
-                .ok_or_else(|| NbdCowError::Netlink("error response truncated".into()))?,
-        ]);
+        let err_bytes: [u8; 4] = buf
+            .get(16..20)
+            .ok_or_else(|| NbdCowError::Netlink("error response truncated".into()))?
+            .try_into()
+            .map_err(|_| NbdCowError::Netlink("error code conversion".into()))?;
+        let error = i32::from_ne_bytes(err_bytes);
         if error == 0 {
             return Ok(()); // ACK (error=0 means success)
         }

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -1,0 +1,393 @@
+//! NBD device setup via generic netlink.
+//!
+//! This module handles creating and destroying `/dev/nbdN` devices using the
+//! kernel's NBD generic netlink interface. This is the modern approach (vs ioctl)
+//! and supports multi-connection.
+
+use std::os::unix::io::{FromRawFd, OwnedFd};
+use std::path::Path;
+
+use crate::error::{NbdCowError, Result};
+
+// NBD generic netlink command constants
+const NBD_CMD_CONNECT: u8 = 0;
+const NBD_CMD_DISCONNECT: u8 = 1;
+
+// NBD generic netlink attribute types
+const NBD_ATTR_INDEX: u16 = 1;
+const NBD_ATTR_SIZE_BYTES: u16 = 2;
+const NBD_ATTR_BLOCK_SIZE_BYTES: u16 = 3;
+const NBD_ATTR_SERVER_FLAGS: u16 = 5;
+const NBD_ATTR_SOCKETS: u16 = 7;
+const NBD_SOCK_FD: u16 = 0;
+
+// NBD server flags
+const NBD_FLAG_HAS_FLAGS: u64 = 1 << 0;
+const NBD_FLAG_CAN_MULTI_CONN: u64 = 1 << 8;
+
+// Netlink constants
+const NETLINK_GENERIC: i32 = 16;
+const GENL_ID_CTRL: u16 = 0x10;
+const CTRL_CMD_GETFAMILY: u8 = 3;
+const CTRL_ATTR_FAMILY_NAME: u16 = 2;
+const CTRL_ATTR_FAMILY_ID: u16 = 1;
+
+const NLM_F_REQUEST: u16 = 1;
+const NLM_F_ACK: u16 = 4;
+
+const NLMSG_ERROR: u16 = 2;
+
+/// Create a Unix socketpair for NBD communication.
+pub fn create_socketpair() -> Result<(OwnedFd, OwnedFd)> {
+    let mut fds = [0i32; 2];
+    let ret = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+    if ret < 0 {
+        return Err(NbdCowError::Io(std::io::Error::last_os_error()));
+    }
+    let fd0 = fds
+        .first()
+        .copied()
+        .ok_or_else(|| NbdCowError::Io(std::io::Error::other("failed to get fd[0]")))?;
+    let fd1 = fds
+        .get(1)
+        .copied()
+        .ok_or_else(|| NbdCowError::Io(std::io::Error::other("failed to get fd[1]")))?;
+    Ok(unsafe { (OwnedFd::from_raw_fd(fd0), OwnedFd::from_raw_fd(fd1)) })
+}
+
+/// Find a free NBD device by scanning `/sys/block/nbdN/pid`.
+///
+/// A device is free if its pid file contains "0" or "-1" or does not exist.
+pub fn find_free_device() -> Result<u32> {
+    for i in 0..256u32 {
+        let pid_path = format!("/sys/block/nbd{i}/pid");
+        let path = Path::new(&pid_path);
+
+        if !path.exists() {
+            // Device exists in kernel but no pid file -> free
+            // But first check if the device node exists
+            let dev_path = format!("/dev/nbd{i}");
+            if Path::new(&dev_path).exists() {
+                return Ok(i);
+            }
+            continue;
+        }
+
+        match std::fs::read_to_string(path) {
+            Ok(contents) => {
+                let pid = contents.trim();
+                if pid == "-1" || pid == "0" || pid.is_empty() {
+                    return Ok(i);
+                }
+            }
+            Err(_) => {
+                // Can't read pid file -> assume free
+                return Ok(i);
+            }
+        }
+    }
+
+    Err(NbdCowError::NoFreeDevice)
+}
+
+/// Connect an NBD device via generic netlink.
+///
+/// This passes the client-side socket fds to the kernel, which takes ownership
+/// of them for the NBD device's I/O.
+pub fn connect(
+    device_index: u32,
+    client_fds: &[OwnedFd],
+    size: u64,
+    block_size: u32,
+) -> Result<()> {
+    let sock = open_genl_socket()?;
+    let family_id = resolve_nbd_family(&sock)?;
+    let flags = NBD_FLAG_HAS_FLAGS | NBD_FLAG_CAN_MULTI_CONN;
+
+    // Build nested SOCKETS attribute
+    let mut sockets_payload = Vec::new();
+    for (i, fd) in client_fds.iter().enumerate() {
+        let raw_fd = std::os::unix::io::AsRawFd::as_raw_fd(fd) as u32;
+        // Each socket is a nested attribute containing NBD_SOCK_FD
+        let fd_nla = build_nla(NBD_SOCK_FD, &raw_fd.to_ne_bytes());
+        let sock_nla = build_nested_nla((i as u16) + 1, &fd_nla);
+        sockets_payload.extend_from_slice(&sock_nla);
+    }
+
+    // Build the full message
+    let mut attrs = Vec::new();
+    attrs.extend_from_slice(&build_nla(NBD_ATTR_INDEX, &device_index.to_ne_bytes()));
+    attrs.extend_from_slice(&build_nla(NBD_ATTR_SIZE_BYTES, &size.to_ne_bytes()));
+    attrs.extend_from_slice(&build_nla(
+        NBD_ATTR_BLOCK_SIZE_BYTES,
+        &block_size.to_ne_bytes(),
+    ));
+    attrs.extend_from_slice(&build_nla(NBD_ATTR_SERVER_FLAGS, &flags.to_ne_bytes()));
+    attrs.extend_from_slice(&build_nested_nla(NBD_ATTR_SOCKETS, &sockets_payload));
+
+    send_genl_msg(&sock, family_id, NBD_CMD_CONNECT, &attrs)?;
+    recv_genl_ack(&sock)?;
+
+    Ok(())
+}
+
+/// Disconnect an NBD device via generic netlink.
+pub fn disconnect(device_index: u32) -> Result<()> {
+    let sock = open_genl_socket()?;
+    let family_id = resolve_nbd_family(&sock)?;
+
+    let attrs = build_nla(NBD_ATTR_INDEX, &device_index.to_ne_bytes());
+    send_genl_msg(&sock, family_id, NBD_CMD_DISCONNECT, &attrs)?;
+    recv_genl_ack(&sock)?;
+
+    Ok(())
+}
+
+// --- Internal netlink helpers ---
+
+struct GenlSocket {
+    fd: OwnedFd,
+}
+
+fn open_genl_socket() -> Result<GenlSocket> {
+    let fd = unsafe { libc::socket(libc::AF_NETLINK, libc::SOCK_DGRAM, NETLINK_GENERIC) };
+    if fd < 0 {
+        return Err(NbdCowError::Io(std::io::Error::last_os_error()));
+    }
+    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+
+    // Bind to kernel
+    let mut addr: libc::sockaddr_nl = unsafe { std::mem::zeroed() };
+    addr.nl_family = libc::AF_NETLINK as u16;
+    let ret = unsafe {
+        libc::bind(
+            std::os::unix::io::AsRawFd::as_raw_fd(&fd),
+            std::ptr::from_ref(&addr).cast(),
+            std::mem::size_of::<libc::sockaddr_nl>() as u32,
+        )
+    };
+    if ret < 0 {
+        return Err(NbdCowError::Io(std::io::Error::last_os_error()));
+    }
+
+    Ok(GenlSocket { fd })
+}
+
+fn resolve_nbd_family(sock: &GenlSocket) -> Result<u16> {
+    // Build CTRL_CMD_GETFAMILY request for "nbd"
+    let name = b"nbd\0";
+    let attrs = build_nla(CTRL_ATTR_FAMILY_NAME, name);
+    send_genl_msg_raw(sock, GENL_ID_CTRL, CTRL_CMD_GETFAMILY, 1, &attrs)?;
+
+    // Parse response to get family ID
+    let mut buf = vec![0u8; 4096];
+    let n = recv_nl(sock, &mut buf)?;
+    let msg = buf
+        .get(..n)
+        .ok_or_else(|| NbdCowError::Netlink("recv length exceeds buffer".into()))?;
+
+    // Skip nlmsghdr (16 bytes) + genlmsghdr (4 bytes)
+    if msg.len() < 20 {
+        return Err(NbdCowError::Netlink("response too short".into()));
+    }
+
+    // Parse attributes to find CTRL_ATTR_FAMILY_ID
+    let mut offset = 20;
+    while offset + 4 <= msg.len() {
+        let nla_len = u16::from_ne_bytes([
+            *msg.get(offset)
+                .ok_or_else(|| NbdCowError::Netlink("truncated nla".into()))?,
+            *msg.get(offset + 1)
+                .ok_or_else(|| NbdCowError::Netlink("truncated nla".into()))?,
+        ]) as usize;
+        let nla_type = u16::from_ne_bytes([
+            *msg.get(offset + 2)
+                .ok_or_else(|| NbdCowError::Netlink("truncated nla".into()))?,
+            *msg.get(offset + 3)
+                .ok_or_else(|| NbdCowError::Netlink("truncated nla".into()))?,
+        ]);
+
+        if nla_type == CTRL_ATTR_FAMILY_ID && nla_len >= 6 {
+            let id = u16::from_ne_bytes([
+                *msg.get(offset + 4)
+                    .ok_or_else(|| NbdCowError::Netlink("truncated id".into()))?,
+                *msg.get(offset + 5)
+                    .ok_or_else(|| NbdCowError::Netlink("truncated id".into()))?,
+            ]);
+            return Ok(id);
+        }
+
+        // Advance to next attribute (4-byte aligned)
+        let aligned = (nla_len + 3) & !3;
+        if aligned == 0 {
+            break;
+        }
+        offset += aligned;
+    }
+
+    Err(NbdCowError::Netlink(
+        "NBD family ID not found in response".into(),
+    ))
+}
+
+fn send_genl_msg(sock: &GenlSocket, family_id: u16, cmd: u8, attrs: &[u8]) -> Result<()> {
+    send_genl_msg_raw(sock, family_id, cmd, 0, attrs)
+}
+
+fn send_genl_msg_raw(
+    sock: &GenlSocket,
+    msg_type: u16,
+    cmd: u8,
+    version: u8,
+    attrs: &[u8],
+) -> Result<()> {
+    // nlmsghdr (16) + genlmsghdr (4) + attrs
+    let total_len = 16 + 4 + attrs.len();
+    let mut msg = vec![0u8; total_len];
+
+    // nlmsghdr
+    let len_bytes = (total_len as u32).to_ne_bytes();
+    // Safe: msg is at least 20 bytes (16 + 4)
+    let header = msg
+        .get_mut(..20)
+        .ok_or_else(|| NbdCowError::Netlink("msg buffer too small for header".into()))?;
+    header
+        .get_mut(..4)
+        .ok_or_else(|| NbdCowError::Netlink("msg buffer too small".into()))?
+        .copy_from_slice(&len_bytes);
+    header
+        .get_mut(4..6)
+        .ok_or_else(|| NbdCowError::Netlink("msg buffer too small".into()))?
+        .copy_from_slice(&msg_type.to_ne_bytes());
+    header
+        .get_mut(6..8)
+        .ok_or_else(|| NbdCowError::Netlink("msg buffer too small".into()))?
+        .copy_from_slice(&(NLM_F_REQUEST | NLM_F_ACK).to_ne_bytes());
+    // seq and pid left as 0
+
+    // genlmsghdr
+    if let Some(b) = header.get_mut(16) {
+        *b = cmd;
+    }
+    if let Some(b) = header.get_mut(17) {
+        *b = version;
+    }
+    // reserved (2 bytes) = 0
+
+    // attributes
+    msg.get_mut(20..)
+        .ok_or_else(|| NbdCowError::Netlink("msg buffer too small for attrs".into()))?
+        .copy_from_slice(attrs);
+
+    let ret = unsafe {
+        libc::send(
+            std::os::unix::io::AsRawFd::as_raw_fd(&sock.fd),
+            msg.as_ptr().cast(),
+            msg.len(),
+            0,
+        )
+    };
+    if ret < 0 {
+        return Err(NbdCowError::Io(std::io::Error::last_os_error()));
+    }
+
+    Ok(())
+}
+
+fn recv_nl(sock: &GenlSocket, buf: &mut [u8]) -> Result<usize> {
+    let n = unsafe {
+        libc::recv(
+            std::os::unix::io::AsRawFd::as_raw_fd(&sock.fd),
+            buf.as_mut_ptr().cast(),
+            buf.len(),
+            0,
+        )
+    };
+    if n < 0 {
+        return Err(NbdCowError::Io(std::io::Error::last_os_error()));
+    }
+    Ok(n as usize)
+}
+
+fn recv_genl_ack(sock: &GenlSocket) -> Result<()> {
+    let mut buf = vec![0u8; 4096];
+    let n = recv_nl(sock, &mut buf)?;
+
+    if n < 16 {
+        return Err(NbdCowError::Netlink("ack response too short".into()));
+    }
+
+    let msg_type = u16::from_ne_bytes([
+        *buf.get(4)
+            .ok_or_else(|| NbdCowError::Netlink("ack too short for msg_type".into()))?,
+        *buf.get(5)
+            .ok_or_else(|| NbdCowError::Netlink("ack too short for msg_type".into()))?,
+    ]);
+    if msg_type == NLMSG_ERROR {
+        // Error message: nlmsghdr (16) + error code (4 bytes as i32)
+        if n < 20 {
+            return Err(NbdCowError::Netlink("error response too short".into()));
+        }
+        let error = i32::from_ne_bytes([
+            *buf.get(16)
+                .ok_or_else(|| NbdCowError::Netlink("error response truncated".into()))?,
+            *buf.get(17)
+                .ok_or_else(|| NbdCowError::Netlink("error response truncated".into()))?,
+            *buf.get(18)
+                .ok_or_else(|| NbdCowError::Netlink("error response truncated".into()))?,
+            *buf.get(19)
+                .ok_or_else(|| NbdCowError::Netlink("error response truncated".into()))?,
+        ]);
+        if error == 0 {
+            return Ok(()); // ACK (error=0 means success)
+        }
+        return Err(NbdCowError::Netlink(format!(
+            "netlink error: {}",
+            std::io::Error::from_raw_os_error(-error)
+        )));
+    }
+
+    Ok(())
+}
+
+/// Build a netlink attribute (NLA).
+fn build_nla(nla_type: u16, payload: &[u8]) -> Vec<u8> {
+    let nla_len = 4 + payload.len();
+    let aligned_len = (nla_len + 3) & !3;
+    let mut buf = vec![0u8; aligned_len];
+    if let Some(header) = buf.get_mut(..4) {
+        let len_bytes = (nla_len as u16).to_ne_bytes();
+        if let Some(s) = header.get_mut(..2) {
+            s.copy_from_slice(&len_bytes);
+        }
+        if let Some(s) = header.get_mut(2..4) {
+            s.copy_from_slice(&nla_type.to_ne_bytes());
+        }
+    }
+    if let Some(dest) = buf.get_mut(4..4 + payload.len()) {
+        dest.copy_from_slice(payload);
+    }
+    buf
+}
+
+/// Build a nested netlink attribute.
+fn build_nested_nla(nla_type: u16, payload: &[u8]) -> Vec<u8> {
+    let nla_len = 4 + payload.len();
+    let aligned_len = (nla_len + 3) & !3;
+    let mut buf = vec![0u8; aligned_len];
+    // Set NLA_F_NESTED flag (1 << 15)
+    let nested_type = nla_type | (1 << 15);
+    if let Some(header) = buf.get_mut(..4) {
+        let len_bytes = (nla_len as u16).to_ne_bytes();
+        if let Some(s) = header.get_mut(..2) {
+            s.copy_from_slice(&len_bytes);
+        }
+        if let Some(s) = header.get_mut(2..4) {
+            s.copy_from_slice(&nested_type.to_ne_bytes());
+        }
+    }
+    if let Some(dest) = buf.get_mut(4..4 + payload.len()) {
+        dest.copy_from_slice(payload);
+    }
+    buf
+}

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -235,8 +235,11 @@ fn resolve_nbd_family(sock: &GenlSocket) -> Result<u16> {
     ))
 }
 
+// NBD genl family version (from kernel: NBD_GENL_VERSION = 0x1)
+const NBD_GENL_VERSION: u8 = 1;
+
 fn send_genl_msg(sock: &GenlSocket, family_id: u16, cmd: u8, attrs: &[u8]) -> Result<()> {
-    send_genl_msg_raw(sock, family_id, cmd, 0, attrs)
+    send_genl_msg_raw(sock, family_id, cmd, NBD_GENL_VERSION, attrs)
 }
 
 fn send_genl_msg_raw(

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -9,9 +9,9 @@ use std::path::Path;
 
 use crate::error::{NbdCowError, Result};
 
-// NBD generic netlink command constants
-const NBD_CMD_CONNECT: u8 = 0;
-const NBD_CMD_DISCONNECT: u8 = 1;
+// NBD generic netlink command constants (from include/uapi/linux/nbd-netlink.h)
+const NBD_CMD_CONNECT: u8 = 1;
+const NBD_CMD_DISCONNECT: u8 = 2;
 
 // NBD generic netlink attribute types
 const NBD_ATTR_INDEX: u16 = 1;
@@ -19,7 +19,10 @@ const NBD_ATTR_SIZE_BYTES: u16 = 2;
 const NBD_ATTR_BLOCK_SIZE_BYTES: u16 = 3;
 const NBD_ATTR_SERVER_FLAGS: u16 = 5;
 const NBD_ATTR_SOCKETS: u16 = 7;
-const NBD_SOCK_FD: u16 = 0;
+
+// NBD socket item attribute types (nested inside NBD_ATTR_SOCKETS)
+const NBD_SOCK_ITEM: u16 = 1;
+const NBD_SOCK_FD: u16 = 1;
 
 // NBD server flags
 const NBD_FLAG_HAS_FLAGS: u64 = 1 << 0;
@@ -98,20 +101,22 @@ pub fn connect(
     device_index: u32,
     client_fds: &[OwnedFd],
     size: u64,
-    block_size: u32,
+    block_size: u64,
 ) -> Result<()> {
     let sock = open_genl_socket()?;
     let family_id = resolve_nbd_family(&sock)?;
     let flags = NBD_FLAG_HAS_FLAGS | NBD_FLAG_CAN_MULTI_CONN;
 
-    // Build nested SOCKETS attribute
+    // Build nested SOCKETS attribute:
+    // NBD_ATTR_SOCKETS (nested)
+    //   NBD_SOCK_ITEM (nested, per socket)
+    //     NBD_SOCK_FD (u32)
     let mut sockets_payload = Vec::new();
-    for (i, fd) in client_fds.iter().enumerate() {
+    for fd in client_fds.iter() {
         let raw_fd = std::os::unix::io::AsRawFd::as_raw_fd(fd) as u32;
-        // Each socket is a nested attribute containing NBD_SOCK_FD
         let fd_nla = build_nla(NBD_SOCK_FD, &raw_fd.to_ne_bytes());
-        let sock_nla = build_nested_nla((i as u16) + 1, &fd_nla);
-        sockets_payload.extend_from_slice(&sock_nla);
+        let item_nla = build_nested_nla(NBD_SOCK_ITEM, &fd_nla);
+        sockets_payload.extend_from_slice(&item_nla);
     }
 
     // Build the full message

--- a/crates/nbd-cow/src/protocol.rs
+++ b/crates/nbd-cow/src/protocol.rs
@@ -1,0 +1,281 @@
+//! NBD transmission protocol constants and types.
+//!
+//! When using netlink + socketpair, no handshake is needed.
+//! The kernel NBD client communicates directly using the transmission protocol.
+
+use std::io::{Cursor, Read, Write};
+
+/// Magic number in every NBD request (client -> server).
+pub const REQUEST_MAGIC: u32 = 0x2560_9513;
+
+/// Magic number in every NBD reply (server -> client).
+pub const REPLY_MAGIC: u32 = 0x6744_6698;
+
+/// Size of the request header in bytes (excluding payload).
+pub const REQUEST_HEADER_SIZE: usize = 28;
+
+/// Size of the reply header in bytes (excluding payload).
+pub const REPLY_HEADER_SIZE: usize = 16;
+
+/// NBD command types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub enum Command {
+    Read = 0,
+    Write = 1,
+    Disconnect = 2,
+    Flush = 3,
+    Trim = 4,
+}
+
+impl Command {
+    pub fn from_u16(val: u16) -> Result<Self, ProtocolError> {
+        match val {
+            0 => Ok(Self::Read),
+            1 => Ok(Self::Write),
+            2 => Ok(Self::Disconnect),
+            3 => Ok(Self::Flush),
+            4 => Ok(Self::Trim),
+            other => Err(ProtocolError::UnknownCommand(other)),
+        }
+    }
+}
+
+/// NBD request header (28 bytes, client -> server).
+#[derive(Debug, Clone)]
+pub struct NbdRequest {
+    pub flags: u16,
+    pub command: Command,
+    pub handle: u64,
+    pub offset: u64,
+    pub length: u32,
+}
+
+/// NBD reply header (16 bytes, server -> client).
+#[derive(Debug, Clone)]
+pub struct NbdReply {
+    pub error: u32,
+    pub handle: u64,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProtocolError {
+    #[error("invalid request magic: expected {REQUEST_MAGIC:#x}, got {0:#x}")]
+    InvalidRequestMagic(u32),
+
+    #[error("unknown NBD command: {0}")]
+    UnknownCommand(u16),
+
+    #[error("buffer too short: need {expected} bytes, got {actual}")]
+    BufferTooShort { expected: usize, actual: usize },
+}
+
+/// Parse a 28-byte NBD request header.
+pub fn parse_request(buf: &[u8]) -> Result<NbdRequest, ProtocolError> {
+    if buf.len() < REQUEST_HEADER_SIZE {
+        return Err(ProtocolError::BufferTooShort {
+            expected: REQUEST_HEADER_SIZE,
+            actual: buf.len(),
+        });
+    }
+
+    let mut cursor = Cursor::new(buf);
+    let mut b4 = [0u8; 4];
+    let mut b2 = [0u8; 2];
+    let mut b8 = [0u8; 8];
+
+    // We already checked buf.len() >= 28, so all reads will succeed.
+    let _: () = cursor
+        .read_exact(&mut b4)
+        .map_err(|_| ProtocolError::BufferTooShort {
+            expected: REQUEST_HEADER_SIZE,
+            actual: buf.len(),
+        })?;
+    let magic = u32::from_be_bytes(b4);
+    if magic != REQUEST_MAGIC {
+        return Err(ProtocolError::InvalidRequestMagic(magic));
+    }
+
+    let _: () = cursor
+        .read_exact(&mut b2)
+        .map_err(|_| ProtocolError::BufferTooShort {
+            expected: REQUEST_HEADER_SIZE,
+            actual: buf.len(),
+        })?;
+    let flags = u16::from_be_bytes(b2);
+
+    let _: () = cursor
+        .read_exact(&mut b2)
+        .map_err(|_| ProtocolError::BufferTooShort {
+            expected: REQUEST_HEADER_SIZE,
+            actual: buf.len(),
+        })?;
+    let cmd_type = u16::from_be_bytes(b2);
+    let command = Command::from_u16(cmd_type)?;
+
+    let _: () = cursor
+        .read_exact(&mut b8)
+        .map_err(|_| ProtocolError::BufferTooShort {
+            expected: REQUEST_HEADER_SIZE,
+            actual: buf.len(),
+        })?;
+    let handle = u64::from_be_bytes(b8);
+
+    let _: () = cursor
+        .read_exact(&mut b8)
+        .map_err(|_| ProtocolError::BufferTooShort {
+            expected: REQUEST_HEADER_SIZE,
+            actual: buf.len(),
+        })?;
+    let offset = u64::from_be_bytes(b8);
+
+    let _: () = cursor
+        .read_exact(&mut b4)
+        .map_err(|_| ProtocolError::BufferTooShort {
+            expected: REQUEST_HEADER_SIZE,
+            actual: buf.len(),
+        })?;
+    let length = u32::from_be_bytes(b4);
+
+    Ok(NbdRequest {
+        flags,
+        command,
+        handle,
+        offset,
+        length,
+    })
+}
+
+/// Serialize a 16-byte NBD reply header.
+pub fn serialize_reply(reply: &NbdReply) -> [u8; REPLY_HEADER_SIZE] {
+    let mut buf = [0u8; REPLY_HEADER_SIZE];
+    let mut cursor = Cursor::new(buf.as_mut_slice());
+    // All writes fit within the 16-byte buffer, so write_all cannot fail.
+    let _ = cursor.write_all(&REPLY_MAGIC.to_be_bytes());
+    let _ = cursor.write_all(&reply.error.to_be_bytes());
+    let _ = cursor.write_all(&reply.handle.to_be_bytes());
+    buf
+}
+
+/// Serialize a 28-byte NBD request header (for testing).
+pub fn serialize_request(req: &NbdRequest) -> [u8; REQUEST_HEADER_SIZE] {
+    let mut buf = [0u8; REQUEST_HEADER_SIZE];
+    let mut cursor = Cursor::new(buf.as_mut_slice());
+    // All writes fit within the 28-byte buffer, so write_all cannot fail.
+    let _ = cursor.write_all(&REQUEST_MAGIC.to_be_bytes());
+    let _ = cursor.write_all(&req.flags.to_be_bytes());
+    let _ = cursor.write_all(&(req.command as u16).to_be_bytes());
+    let _ = cursor.write_all(&req.handle.to_be_bytes());
+    let _ = cursor.write_all(&req.offset.to_be_bytes());
+    let _ = cursor.write_all(&req.length.to_be_bytes());
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_request() {
+        let req = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 0xDEAD_BEEF_CAFE_BABE,
+            offset: 4096,
+            length: 512,
+        };
+
+        let buf = serialize_request(&req);
+        let parsed = parse_request(&buf).unwrap();
+
+        assert_eq!(parsed.flags, req.flags);
+        assert_eq!(parsed.command, req.command);
+        assert_eq!(parsed.handle, req.handle);
+        assert_eq!(parsed.offset, req.offset);
+        assert_eq!(parsed.length, req.length);
+    }
+
+    #[test]
+    fn round_trip_reply() {
+        let reply = NbdReply {
+            error: 0,
+            handle: 0x1234_5678_9ABC_DEF0,
+        };
+
+        let buf = serialize_reply(&reply);
+
+        assert_eq!(
+            u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]),
+            REPLY_MAGIC
+        );
+        assert_eq!(u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]), 0);
+        assert_eq!(
+            u64::from_be_bytes([
+                buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15]
+            ]),
+            0x1234_5678_9ABC_DEF0
+        );
+    }
+
+    #[test]
+    fn parse_all_commands() {
+        for (cmd, val) in [
+            (Command::Read, 0u16),
+            (Command::Write, 1),
+            (Command::Disconnect, 2),
+            (Command::Flush, 3),
+            (Command::Trim, 4),
+        ] {
+            let req = NbdRequest {
+                flags: 0,
+                command: cmd,
+                handle: 1,
+                offset: 0,
+                length: 0,
+            };
+            let buf = serialize_request(&req);
+            let parsed = parse_request(&buf).unwrap();
+            assert_eq!(parsed.command, cmd);
+            assert_eq!(parsed.command as u16, val);
+        }
+    }
+
+    #[test]
+    fn invalid_magic() {
+        let mut buf = [0u8; REQUEST_HEADER_SIZE];
+        buf[0..4].copy_from_slice(&0xBAD_0000u32.to_be_bytes());
+
+        let err = parse_request(&buf).unwrap_err();
+        assert!(matches!(err, ProtocolError::InvalidRequestMagic(_)));
+    }
+
+    #[test]
+    fn unknown_command() {
+        let req = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 0,
+            offset: 0,
+            length: 0,
+        };
+        let mut buf = serialize_request(&req);
+        // Overwrite command with invalid value
+        buf[6..8].copy_from_slice(&99u16.to_be_bytes());
+
+        let err = parse_request(&buf).unwrap_err();
+        assert!(matches!(err, ProtocolError::UnknownCommand(99)));
+    }
+
+    #[test]
+    fn buffer_too_short() {
+        let buf = [0u8; 10];
+        let err = parse_request(&buf).unwrap_err();
+        assert!(matches!(
+            err,
+            ProtocolError::BufferTooShort {
+                expected: 28,
+                actual: 10
+            }
+        ));
+    }
+}

--- a/crates/nbd-cow/src/protocol.rs
+++ b/crates/nbd-cow/src/protocol.rs
@@ -158,7 +158,8 @@ pub fn serialize_reply(reply: &NbdReply) -> [u8; REPLY_HEADER_SIZE] {
 }
 
 /// Serialize a 28-byte NBD request header (for testing).
-pub fn serialize_request(req: &NbdRequest) -> [u8; REQUEST_HEADER_SIZE] {
+#[cfg(test)]
+pub(crate) fn serialize_request(req: &NbdRequest) -> [u8; REQUEST_HEADER_SIZE] {
     let mut buf = [0u8; REQUEST_HEADER_SIZE];
     let mut cursor = Cursor::new(buf.as_mut_slice());
     // All writes fit within the 28-byte buffer, so write_all cannot fail.

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -1,0 +1,296 @@
+use std::os::unix::io::{FromRawFd, OwnedFd};
+use std::sync::Arc;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::cow::CowLayer;
+use crate::error::Result;
+use crate::protocol::{self, Command, NbdReply, NbdRequest, REQUEST_HEADER_SIZE};
+
+/// Run the NBD dispatch loop on a Unix stream.
+///
+/// Reads NBD requests from the socket, dispatches to the COW layer,
+/// and sends replies back. Handles graceful shutdown via the cancellation token.
+pub async fn dispatch(
+    socket_fd: OwnedFd,
+    cow: Arc<Mutex<CowLayer>>,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let raw_fd = std::os::unix::io::AsRawFd::as_raw_fd(&socket_fd);
+    let std_stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(raw_fd) };
+    std_stream.set_nonblocking(true)?;
+    let stream = UnixStream::from_std(std_stream)?;
+    // Prevent double-close: the UnixStream now owns the fd
+    std::mem::forget(socket_fd);
+
+    let (mut reader, mut writer) = stream.into_split();
+
+    let mut header_buf = [0u8; REQUEST_HEADER_SIZE];
+
+    loop {
+        // Wait for either a request or shutdown signal
+        tokio::select! {
+            biased;
+            () = shutdown.cancelled() => {
+                // Graceful shutdown: flush remaining data
+                let mut cow = cow.lock().await;
+                cow.sync()?;
+                return Ok(());
+            }
+            result = reader.read_exact(&mut header_buf) => {
+                match result {
+                    Ok(_) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                        // Connection closed
+                        return Ok(());
+                    }
+                    Err(e) => return Err(e.into()),
+                }
+            }
+        }
+
+        let request = protocol::parse_request(&header_buf)?;
+
+        match request.command {
+            Command::Read => {
+                handle_read(&request, &cow, &mut writer).await?;
+            }
+            Command::Write => {
+                handle_write(&request, &mut reader, &cow, &mut writer).await?;
+            }
+            Command::Flush => {
+                handle_flush(&request, &cow, &mut writer).await?;
+            }
+            Command::Trim => {
+                // Trim is a no-op for now (COW file is sparse, unused blocks are holes)
+                send_reply(
+                    &mut writer,
+                    &NbdReply {
+                        error: 0,
+                        handle: request.handle,
+                    },
+                )
+                .await?;
+            }
+            Command::Disconnect => {
+                let mut cow = cow.lock().await;
+                cow.sync()?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+async fn handle_read(
+    request: &NbdRequest,
+    cow: &Arc<Mutex<CowLayer>>,
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+) -> Result<()> {
+    let mut data = vec![0u8; request.length as usize];
+    {
+        let cow = cow.lock().await;
+        cow.read(request.offset, &mut data)?;
+    }
+
+    let reply = NbdReply {
+        error: 0,
+        handle: request.handle,
+    };
+    let reply_buf = protocol::serialize_reply(&reply);
+    writer.write_all(&reply_buf).await?;
+    writer.write_all(&data).await?;
+    Ok(())
+}
+
+async fn handle_write(
+    request: &NbdRequest,
+    reader: &mut tokio::net::unix::OwnedReadHalf,
+    cow: &Arc<Mutex<CowLayer>>,
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+) -> Result<()> {
+    // Read the write payload from the socket
+    let mut data = vec![0u8; request.length as usize];
+    reader.read_exact(&mut data).await?;
+
+    let needs_flush = {
+        let mut cow = cow.lock().await;
+        cow.write(request.offset, &data)?
+    };
+
+    if needs_flush {
+        let mut cow = cow.lock().await;
+        cow.flush()?;
+    }
+
+    let reply = NbdReply {
+        error: 0,
+        handle: request.handle,
+    };
+    send_reply(writer, &reply).await
+}
+
+async fn handle_flush(
+    request: &NbdRequest,
+    cow: &Arc<Mutex<CowLayer>>,
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+) -> Result<()> {
+    {
+        let mut cow = cow.lock().await;
+        cow.sync()?;
+    }
+
+    let reply = NbdReply {
+        error: 0,
+        handle: request.handle,
+    };
+    send_reply(writer, &reply).await
+}
+
+async fn send_reply(writer: &mut tokio::net::unix::OwnedWriteHalf, reply: &NbdReply) -> Result<()> {
+    let buf = protocol::serialize_reply(reply);
+    writer.write_all(&buf).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cow::CowLayer;
+    use crate::protocol::{Command, NbdRequest, serialize_request};
+    use std::io::Write as _;
+    use tempfile::NamedTempFile;
+
+    fn create_test_cow(base_data: &[u8]) -> (NamedTempFile, NamedTempFile, CowLayer) {
+        let mut base = NamedTempFile::new().unwrap();
+        base.write_all(base_data).unwrap();
+        base.flush().unwrap();
+        let cow_file = NamedTempFile::new().unwrap();
+        let mut cow =
+            CowLayer::new(base.path(), base_data.len() as u64, 4096, 4 * 1024 * 1024).unwrap();
+        cow.set_cow_path(cow_file.path());
+        (base, cow_file, cow)
+    }
+
+    #[tokio::test]
+    async fn dispatch_read_write_disconnect() {
+        let base_data = vec![0xAA; 8192];
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(Mutex::new(cow));
+        let shutdown = CancellationToken::new();
+
+        // Create a socketpair
+        let (client_fd, server_fd) = {
+            let mut fds = [0i32; 2];
+            let ret =
+                unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+            assert_eq!(ret, 0);
+            unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+        };
+
+        // Spawn the dispatch task
+        let cow_clone = cow.clone();
+        let shutdown_clone = shutdown.clone();
+        let server_task =
+            tokio::spawn(async move { dispatch(server_fd, cow_clone, shutdown_clone).await });
+
+        // Use the client side
+        let client_std = unsafe {
+            std::os::unix::net::UnixStream::from_raw_fd(std::os::unix::io::AsRawFd::as_raw_fd(
+                &client_fd,
+            ))
+        };
+        client_std.set_nonblocking(true).unwrap();
+        let client_stream = UnixStream::from_std(client_std).unwrap();
+        std::mem::forget(client_fd);
+
+        let (mut client_reader, mut client_writer) = client_stream.into_split();
+
+        // 1. Send a READ request for first block
+        let read_req = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 1,
+            offset: 0,
+            length: 4096,
+        };
+        client_writer
+            .write_all(&serialize_request(&read_req))
+            .await
+            .unwrap();
+
+        // Read reply header + data
+        let mut reply_buf = [0u8; 16];
+        client_reader.read_exact(&mut reply_buf).await.unwrap();
+        assert_eq!(
+            u32::from_be_bytes([reply_buf[0], reply_buf[1], reply_buf[2], reply_buf[3]]),
+            protocol::REPLY_MAGIC
+        );
+        assert_eq!(
+            u32::from_be_bytes([reply_buf[4], reply_buf[5], reply_buf[6], reply_buf[7]]),
+            0 // no error
+        );
+
+        let mut data = vec![0u8; 4096];
+        client_reader.read_exact(&mut data).await.unwrap();
+        assert!(data.iter().all(|&b| b == 0xAA));
+
+        // 2. Send a WRITE request
+        let write_req = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 2,
+            offset: 0,
+            length: 4096,
+        };
+        let write_data = vec![0xBB; 4096];
+        client_writer
+            .write_all(&serialize_request(&write_req))
+            .await
+            .unwrap();
+        client_writer.write_all(&write_data).await.unwrap();
+
+        // Read write reply
+        client_reader.read_exact(&mut reply_buf).await.unwrap();
+        assert_eq!(
+            u32::from_be_bytes([reply_buf[4], reply_buf[5], reply_buf[6], reply_buf[7]]),
+            0 // no error
+        );
+
+        // 3. Read back the written data
+        let read_req2 = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 3,
+            offset: 0,
+            length: 4096,
+        };
+        client_writer
+            .write_all(&serialize_request(&read_req2))
+            .await
+            .unwrap();
+
+        client_reader.read_exact(&mut reply_buf).await.unwrap();
+        let mut data2 = vec![0u8; 4096];
+        client_reader.read_exact(&mut data2).await.unwrap();
+        assert!(data2.iter().all(|&b| b == 0xBB));
+
+        // 4. Send DISCONNECT
+        let disc_req = NbdRequest {
+            flags: 0,
+            command: Command::Disconnect,
+            handle: 4,
+            offset: 0,
+            length: 0,
+        };
+        client_writer
+            .write_all(&serialize_request(&disc_req))
+            .await
+            .unwrap();
+
+        // Server should exit cleanly
+        server_task.await.unwrap().unwrap();
+    }
+}

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -494,6 +494,121 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dispatch_oversized_read_returns_error() {
+        let base_data = vec![0xAA; 8192];
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(RwLock::new(cow));
+
+        let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow).await;
+
+        // Send a read request exceeding MAX_REQUEST_LENGTH (32 MB)
+        let big_read = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 1,
+            offset: 0,
+            length: 33 * 1024 * 1024, // 33 MB > 32 MB limit
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &big_read).await;
+        assert_ne!(error, 0, "oversized read should return error");
+
+        // A normal read should still work afterwards
+        let normal_read = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 2,
+            offset: 0,
+            length: 4096,
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &normal_read).await;
+        assert_eq!(error, 0, "normal read after oversized should succeed");
+        // Consume the data payload
+        let mut data = vec![0u8; 4096];
+        reader.read_exact(&mut data).await.unwrap();
+        assert!(data.iter().all(|&b| b == 0xAA));
+
+        // Disconnect
+        let disc = NbdRequest {
+            flags: 0,
+            command: Command::Disconnect,
+            handle: 3,
+            offset: 0,
+            length: 0,
+        };
+        writer.write_all(&serialize_request(&disc)).await.unwrap();
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn dispatch_oversized_write_discards_and_returns_error() {
+        let base_data = vec![0xAA; 8192];
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(RwLock::new(cow));
+
+        let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow).await;
+
+        // Send a write request header claiming 33 MB, but only send a small payload
+        // to test that discard_bytes works correctly.
+        // We use a small oversized value to keep the test fast.
+        let big_write = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 1,
+            offset: 0,
+            length: 33 * 1024 * 1024, // claimed 33 MB
+        };
+        writer
+            .write_all(&serialize_request(&big_write))
+            .await
+            .unwrap();
+        // Send 33 MB of data (the server must discard all of it)
+        // To keep the test fast, we send in chunks
+        let chunk = vec![0xFFu8; 64 * 1024];
+        let total = 33 * 1024 * 1024;
+        let mut sent = 0usize;
+        while sent < total {
+            let to_send = chunk.len().min(total - sent);
+            writer
+                .write_all(chunk.get(..to_send).unwrap())
+                .await
+                .unwrap();
+            sent += to_send;
+        }
+
+        // Should get an error reply
+        let mut reply_buf = [0u8; 16];
+        reader.read_exact(&mut reply_buf).await.unwrap();
+        let error = u32::from_be_bytes([reply_buf[4], reply_buf[5], reply_buf[6], reply_buf[7]]);
+        assert_ne!(error, 0, "oversized write should return error");
+
+        // Protocol should still be in sync — a normal read should work
+        let normal_read = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 2,
+            offset: 0,
+            length: 4096,
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &normal_read).await;
+        assert_eq!(error, 0, "normal read after oversized write should succeed");
+        let mut data = vec![0u8; 4096];
+        reader.read_exact(&mut data).await.unwrap();
+        // Data should still be original base data (oversized write was rejected)
+        assert!(data.iter().all(|&b| b == 0xAA));
+
+        // Disconnect
+        let disc = NbdRequest {
+            flags: 0,
+            command: Command::Disconnect,
+            handle: 3,
+            offset: 0,
+            length: 0,
+        };
+        writer.write_all(&serialize_request(&disc)).await.unwrap();
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
     async fn dispatch_shutdown_flushes_data() {
         let base_data = vec![0x00; 8192];
         let (_base, _cow_file, cow) = create_test_cow(&base_data);

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -3,20 +3,29 @@ use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
 use crate::cow::CowLayer;
-use crate::error::Result;
+use crate::error::{NbdCowError, Result};
 use crate::protocol::{self, Command, NbdReply, NbdRequest, REQUEST_HEADER_SIZE};
+
+/// Maximum allowed request length (32 MB). Requests exceeding this are rejected
+/// with an I/O error to prevent OOM from malformed requests.
+const MAX_REQUEST_LENGTH: u32 = 32 * 1024 * 1024;
 
 /// Run the NBD dispatch loop on a Unix stream.
 ///
 /// Reads NBD requests from the socket, dispatches to the COW layer,
 /// and sends replies back. Handles graceful shutdown via the cancellation token.
+///
+/// NOTE: CowLayer uses synchronous file I/O (pread/pwrite) while holding the
+/// mutex lock. This briefly blocks the tokio worker thread. For our workload
+/// (4KB blocks, fast NVMe/EBS storage) this is acceptable. If latency becomes
+/// an issue, consider `spawn_blocking` or async file I/O.
 pub async fn dispatch(
     socket_fd: OwnedFd,
-    cow: Arc<Mutex<CowLayer>>,
+    cow: Arc<RwLock<CowLayer>>,
     shutdown: CancellationToken,
 ) -> Result<()> {
     let raw_fd = std::os::unix::io::AsRawFd::as_raw_fd(&socket_fd);
@@ -36,7 +45,7 @@ pub async fn dispatch(
             biased;
             () = shutdown.cancelled() => {
                 // Graceful shutdown: flush remaining data
-                let mut cow = cow.lock().await;
+                let mut cow = cow.write().await;
                 cow.sync()?;
                 return Ok(());
             }
@@ -76,7 +85,7 @@ pub async fn dispatch(
                 .await?;
             }
             Command::Disconnect => {
-                let mut cow = cow.lock().await;
+                let mut cow = cow.write().await;
                 cow.sync()?;
                 return Ok(());
             }
@@ -86,12 +95,18 @@ pub async fn dispatch(
 
 async fn handle_read(
     request: &NbdRequest,
-    cow: &Arc<Mutex<CowLayer>>,
+    cow: &Arc<RwLock<CowLayer>>,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
 ) -> Result<()> {
+    if request.length > MAX_REQUEST_LENGTH {
+        return Err(NbdCowError::Io(std::io::Error::other(format!(
+            "read request too large: {} bytes (max {})",
+            request.length, MAX_REQUEST_LENGTH
+        ))));
+    }
     let mut data = vec![0u8; request.length as usize];
     {
-        let cow = cow.lock().await;
+        let cow = cow.read().await;
         cow.read(request.offset, &mut data)?;
     }
 
@@ -108,21 +123,25 @@ async fn handle_read(
 async fn handle_write(
     request: &NbdRequest,
     reader: &mut tokio::net::unix::OwnedReadHalf,
-    cow: &Arc<Mutex<CowLayer>>,
+    cow: &Arc<RwLock<CowLayer>>,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
 ) -> Result<()> {
+    if request.length > MAX_REQUEST_LENGTH {
+        return Err(NbdCowError::Io(std::io::Error::other(format!(
+            "write request too large: {} bytes (max {})",
+            request.length, MAX_REQUEST_LENGTH
+        ))));
+    }
     // Read the write payload from the socket
     let mut data = vec![0u8; request.length as usize];
     reader.read_exact(&mut data).await?;
 
-    let needs_flush = {
-        let mut cow = cow.lock().await;
-        cow.write(request.offset, &data)?
-    };
-
-    if needs_flush {
-        let mut cow = cow.lock().await;
-        cow.flush()?;
+    {
+        let mut cow = cow.write().await;
+        let needs_flush = cow.write(request.offset, &data)?;
+        if needs_flush {
+            cow.flush()?;
+        }
     }
 
     let reply = NbdReply {
@@ -134,11 +153,11 @@ async fn handle_write(
 
 async fn handle_flush(
     request: &NbdRequest,
-    cow: &Arc<Mutex<CowLayer>>,
+    cow: &Arc<RwLock<CowLayer>>,
     writer: &mut tokio::net::unix::OwnedWriteHalf,
 ) -> Result<()> {
     {
-        let mut cow = cow.lock().await;
+        let mut cow = cow.write().await;
         cow.sync()?;
     }
 
@@ -169,9 +188,14 @@ mod tests {
         base.write_all(base_data).unwrap();
         base.flush().unwrap();
         let cow_file = NamedTempFile::new().unwrap();
-        let mut cow =
-            CowLayer::new(base.path(), base_data.len() as u64, 4096, 4 * 1024 * 1024).unwrap();
-        cow.set_cow_path(cow_file.path());
+        let cow = CowLayer::new(
+            base.path(),
+            cow_file.path(),
+            base_data.len() as u64,
+            4096,
+            4 * 1024 * 1024,
+        )
+        .unwrap();
         (base, cow_file, cow)
     }
 
@@ -179,7 +203,7 @@ mod tests {
     async fn dispatch_read_write_disconnect() {
         let base_data = vec![0xAA; 8192];
         let (_base, _cow_file, cow) = create_test_cow(&base_data);
-        let cow = Arc::new(Mutex::new(cow));
+        let cow = Arc::new(RwLock::new(cow));
         let shutdown = CancellationToken::new();
 
         // Create a socketpair
@@ -297,7 +321,7 @@ mod tests {
 
     /// Helper: create socketpair, spawn dispatch, return client stream halves.
     async fn setup_dispatch(
-        cow: Arc<Mutex<CowLayer>>,
+        cow: Arc<RwLock<CowLayer>>,
     ) -> (
         tokio::net::unix::OwnedReadHalf,
         tokio::net::unix::OwnedWriteHalf,
@@ -351,7 +375,7 @@ mod tests {
     async fn dispatch_flush_persists_to_cow_file() {
         let base_data = vec![0x00; 8192];
         let (_base, cow_file, cow) = create_test_cow(&base_data);
-        let cow = Arc::new(Mutex::new(cow));
+        let cow = Arc::new(RwLock::new(cow));
 
         let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow.clone()).await;
 
@@ -384,7 +408,7 @@ mod tests {
 
         // Verify data was flushed to COW file
         {
-            let cow = cow.lock().await;
+            let cow = cow.read().await;
             assert_eq!(
                 cow.buffered_block_count(),
                 0,
@@ -419,7 +443,7 @@ mod tests {
     async fn dispatch_trim_succeeds() {
         let base_data = vec![0xAA; 8192];
         let (_base, _cow_file, cow) = create_test_cow(&base_data);
-        let cow = Arc::new(Mutex::new(cow));
+        let cow = Arc::new(RwLock::new(cow));
 
         let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow).await;
 
@@ -450,7 +474,7 @@ mod tests {
     async fn dispatch_shutdown_flushes_data() {
         let base_data = vec![0x00; 8192];
         let (_base, _cow_file, cow) = create_test_cow(&base_data);
-        let cow = Arc::new(Mutex::new(cow));
+        let cow = Arc::new(RwLock::new(cow));
 
         let (mut reader, mut writer, task, shutdown) = setup_dispatch(cow.clone()).await;
 
@@ -472,7 +496,7 @@ mod tests {
 
         // Verify data is in buffer
         {
-            let cow = cow.lock().await;
+            let cow = cow.read().await;
             assert_eq!(cow.buffered_block_count(), 1);
         }
 
@@ -482,7 +506,7 @@ mod tests {
 
         // After shutdown, buffer should be flushed
         {
-            let cow = cow.lock().await;
+            let cow = cow.read().await;
             assert_eq!(
                 cow.buffered_block_count(),
                 0,

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -20,7 +20,7 @@ const MAX_REQUEST_LENGTH: u32 = 32 * 1024 * 1024;
 /// and sends replies back. Handles graceful shutdown via the cancellation token.
 ///
 /// NOTE: CowLayer uses synchronous file I/O (pread/pwrite) while holding the
-/// mutex lock. This briefly blocks the tokio worker thread. For our workload
+/// RwLock. This briefly blocks the tokio worker thread. For our workload
 /// (4KB blocks, fast NVMe/EBS storage) this is acceptable. If latency becomes
 /// an issue, consider `spawn_blocking` or async file I/O.
 pub async fn dispatch(

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -1,4 +1,4 @@
-use std::os::unix::io::{FromRawFd, OwnedFd};
+use std::os::unix::io::{FromRawFd, IntoRawFd, OwnedFd};
 use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -28,12 +28,10 @@ pub async fn dispatch(
     cow: Arc<RwLock<CowLayer>>,
     shutdown: CancellationToken,
 ) -> Result<()> {
-    let raw_fd = std::os::unix::io::AsRawFd::as_raw_fd(&socket_fd);
+    let raw_fd = socket_fd.into_raw_fd();
     let std_stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(raw_fd) };
     std_stream.set_nonblocking(true)?;
     let stream = UnixStream::from_std(std_stream)?;
-    // Prevent double-close: the UnixStream now owns the fd
-    std::mem::forget(socket_fd);
 
     let (mut reader, mut writer) = stream.into_split();
 
@@ -227,34 +225,9 @@ mod tests {
         let base_data = vec![0xAA; 8192];
         let (_base, _cow_file, cow) = create_test_cow(&base_data);
         let cow = Arc::new(RwLock::new(cow));
-        let shutdown = CancellationToken::new();
 
-        // Create a socketpair
-        let (client_fd, server_fd) = {
-            let mut fds = [0i32; 2];
-            let ret =
-                unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
-            assert_eq!(ret, 0);
-            unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
-        };
-
-        // Spawn the dispatch task
-        let cow_clone = cow.clone();
-        let shutdown_clone = shutdown.clone();
-        let server_task =
-            tokio::spawn(async move { dispatch(server_fd, cow_clone, shutdown_clone).await });
-
-        // Use the client side
-        let client_std = unsafe {
-            std::os::unix::net::UnixStream::from_raw_fd(std::os::unix::io::AsRawFd::as_raw_fd(
-                &client_fd,
-            ))
-        };
-        client_std.set_nonblocking(true).unwrap();
-        let client_stream = UnixStream::from_std(client_std).unwrap();
-        std::mem::forget(client_fd);
-
-        let (mut client_reader, mut client_writer) = client_stream.into_split();
+        let (mut client_reader, mut client_writer, server_task, _shutdown) =
+            setup_dispatch(cow).await;
 
         // 1. Send a READ request for first block
         let read_req = NbdRequest {
@@ -365,14 +338,10 @@ mod tests {
         let task =
             tokio::spawn(async move { dispatch(server_fd, cow_clone, shutdown_clone).await });
 
-        let client_std = unsafe {
-            std::os::unix::net::UnixStream::from_raw_fd(std::os::unix::io::AsRawFd::as_raw_fd(
-                &client_fd,
-            ))
-        };
+        let client_std =
+            unsafe { std::os::unix::net::UnixStream::from_raw_fd(client_fd.into_raw_fd()) };
         client_std.set_nonblocking(true).unwrap();
         let client_stream = UnixStream::from_std(client_std).unwrap();
-        std::mem::forget(client_fd);
 
         let (reader, writer) = client_stream.into_split();
         (reader, writer, task, shutdown)

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -99,10 +99,8 @@ async fn handle_read(
     writer: &mut tokio::net::unix::OwnedWriteHalf,
 ) -> Result<()> {
     if request.length > MAX_REQUEST_LENGTH {
-        return Err(NbdCowError::Io(std::io::Error::other(format!(
-            "read request too large: {} bytes (max {})",
-            request.length, MAX_REQUEST_LENGTH
-        ))));
+        send_error_reply(writer, request.handle, libc::EIO as u32).await?;
+        return Ok(());
     }
     let mut data = vec![0u8; request.length as usize];
     {
@@ -127,10 +125,10 @@ async fn handle_write(
     writer: &mut tokio::net::unix::OwnedWriteHalf,
 ) -> Result<()> {
     if request.length > MAX_REQUEST_LENGTH {
-        return Err(NbdCowError::Io(std::io::Error::other(format!(
-            "write request too large: {} bytes (max {})",
-            request.length, MAX_REQUEST_LENGTH
-        ))));
+        // Must consume the payload to keep the protocol stream in sync
+        discard_bytes(reader, request.length as u64).await?;
+        send_error_reply(writer, request.handle, libc::EIO as u32).await?;
+        return Ok(());
     }
     // Read the write payload from the socket
     let mut data = vec![0u8; request.length as usize];
@@ -171,6 +169,31 @@ async fn handle_flush(
 async fn send_reply(writer: &mut tokio::net::unix::OwnedWriteHalf, reply: &NbdReply) -> Result<()> {
     let buf = protocol::serialize_reply(reply);
     writer.write_all(&buf).await?;
+    Ok(())
+}
+
+async fn send_error_reply(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    handle: u64,
+    error: u32,
+) -> Result<()> {
+    send_reply(writer, &NbdReply { error, handle }).await
+}
+
+/// Discard `n` bytes from the reader to keep the protocol stream in sync.
+async fn discard_bytes(
+    reader: &mut tokio::net::unix::OwnedReadHalf,
+    mut remaining: u64,
+) -> Result<()> {
+    let mut buf = [0u8; 4096];
+    while remaining > 0 {
+        let to_read = (remaining as usize).min(buf.len());
+        let dest = buf
+            .get_mut(..to_read)
+            .ok_or_else(|| NbdCowError::Io(std::io::Error::other("discard slice error")))?;
+        reader.read_exact(dest).await?;
+        remaining -= to_read as u64;
+    }
     Ok(())
 }
 

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -161,6 +161,7 @@ mod tests {
     use crate::cow::CowLayer;
     use crate::protocol::{Command, NbdRequest, serialize_request};
     use std::io::Write as _;
+    use std::os::unix::fs::MetadataExt;
     use tempfile::NamedTempFile;
 
     fn create_test_cow(base_data: &[u8]) -> (NamedTempFile, NamedTempFile, CowLayer) {
@@ -292,5 +293,201 @@ mod tests {
 
         // Server should exit cleanly
         server_task.await.unwrap().unwrap();
+    }
+
+    /// Helper: create socketpair, spawn dispatch, return client stream halves.
+    async fn setup_dispatch(
+        cow: Arc<Mutex<CowLayer>>,
+    ) -> (
+        tokio::net::unix::OwnedReadHalf,
+        tokio::net::unix::OwnedWriteHalf,
+        tokio::task::JoinHandle<crate::error::Result<()>>,
+        CancellationToken,
+    ) {
+        let shutdown = CancellationToken::new();
+        let (client_fd, server_fd) = {
+            let mut fds = [0i32; 2];
+            let ret =
+                unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+            assert_eq!(ret, 0);
+            unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+        };
+
+        let cow_clone = cow.clone();
+        let shutdown_clone = shutdown.clone();
+        let task =
+            tokio::spawn(async move { dispatch(server_fd, cow_clone, shutdown_clone).await });
+
+        let client_std = unsafe {
+            std::os::unix::net::UnixStream::from_raw_fd(std::os::unix::io::AsRawFd::as_raw_fd(
+                &client_fd,
+            ))
+        };
+        client_std.set_nonblocking(true).unwrap();
+        let client_stream = UnixStream::from_std(client_std).unwrap();
+        std::mem::forget(client_fd);
+
+        let (reader, writer) = client_stream.into_split();
+        (reader, writer, task, shutdown)
+    }
+
+    /// Helper: send a request and read the reply header, return the error field.
+    async fn send_and_recv_reply(
+        reader: &mut tokio::net::unix::OwnedReadHalf,
+        writer: &mut tokio::net::unix::OwnedWriteHalf,
+        req: &NbdRequest,
+    ) -> u32 {
+        writer.write_all(&serialize_request(req)).await.unwrap();
+        let mut reply_buf = [0u8; 16];
+        reader.read_exact(&mut reply_buf).await.unwrap();
+        assert_eq!(
+            u32::from_be_bytes([reply_buf[0], reply_buf[1], reply_buf[2], reply_buf[3]]),
+            protocol::REPLY_MAGIC
+        );
+        u32::from_be_bytes([reply_buf[4], reply_buf[5], reply_buf[6], reply_buf[7]])
+    }
+
+    #[tokio::test]
+    async fn dispatch_flush_persists_to_cow_file() {
+        let base_data = vec![0x00; 8192];
+        let (_base, cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(Mutex::new(cow));
+
+        let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow.clone()).await;
+
+        // Write data
+        let write_req = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 1,
+            offset: 0,
+            length: 4096,
+        };
+        writer
+            .write_all(&serialize_request(&write_req))
+            .await
+            .unwrap();
+        writer.write_all(&vec![0xCC; 4096]).await.unwrap();
+        let mut reply_buf = [0u8; 16];
+        reader.read_exact(&mut reply_buf).await.unwrap();
+
+        // Send FLUSH
+        let flush_req = NbdRequest {
+            flags: 0,
+            command: Command::Flush,
+            handle: 2,
+            offset: 0,
+            length: 0,
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &flush_req).await;
+        assert_eq!(error, 0, "flush should succeed");
+
+        // Verify data was flushed to COW file
+        {
+            let cow = cow.lock().await;
+            assert_eq!(
+                cow.buffered_block_count(),
+                0,
+                "buffer should be empty after flush"
+            );
+            assert!(
+                cow.dirty_block_count() > 0,
+                "should have dirty blocks in COW file"
+            );
+        }
+
+        // Verify COW file has data
+        let cow_meta = std::fs::metadata(cow_file.path()).unwrap();
+        assert!(
+            cow_meta.blocks() > 0,
+            "COW file should have allocated blocks after flush"
+        );
+
+        // Disconnect
+        let disc = NbdRequest {
+            flags: 0,
+            command: Command::Disconnect,
+            handle: 3,
+            offset: 0,
+            length: 0,
+        };
+        writer.write_all(&serialize_request(&disc)).await.unwrap();
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn dispatch_trim_succeeds() {
+        let base_data = vec![0xAA; 8192];
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(Mutex::new(cow));
+
+        let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow).await;
+
+        // Send TRIM
+        let trim_req = NbdRequest {
+            flags: 0,
+            command: Command::Trim,
+            handle: 1,
+            offset: 0,
+            length: 4096,
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &trim_req).await;
+        assert_eq!(error, 0, "trim should succeed (no-op)");
+
+        // Disconnect
+        let disc = NbdRequest {
+            flags: 0,
+            command: Command::Disconnect,
+            handle: 2,
+            offset: 0,
+            length: 0,
+        };
+        writer.write_all(&serialize_request(&disc)).await.unwrap();
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn dispatch_shutdown_flushes_data() {
+        let base_data = vec![0x00; 8192];
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(Mutex::new(cow));
+
+        let (mut reader, mut writer, task, shutdown) = setup_dispatch(cow.clone()).await;
+
+        // Write data (stays in buffer)
+        let write_req = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 1,
+            offset: 0,
+            length: 4096,
+        };
+        writer
+            .write_all(&serialize_request(&write_req))
+            .await
+            .unwrap();
+        writer.write_all(&vec![0xDD; 4096]).await.unwrap();
+        let mut reply_buf = [0u8; 16];
+        reader.read_exact(&mut reply_buf).await.unwrap();
+
+        // Verify data is in buffer
+        {
+            let cow = cow.lock().await;
+            assert_eq!(cow.buffered_block_count(), 1);
+        }
+
+        // Signal shutdown (should flush)
+        shutdown.cancel();
+        task.await.unwrap().unwrap();
+
+        // After shutdown, buffer should be flushed
+        {
+            let cow = cow.lock().await;
+            assert_eq!(
+                cow.buffered_block_count(),
+                0,
+                "shutdown should flush buffer"
+            );
+        }
     }
 }

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -48,7 +48,7 @@ fn create_test_base_image(path: &Path) {
 // Full device lifecycle tests (require root + nbd module)
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn create_and_destroy() {
     require_root!();
@@ -76,7 +76,7 @@ async fn create_and_destroy() {
     assert!(!cow.exists(), "COW file should be removed after destroy");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn destroy_keep_cow_preserves_file() {
     require_root!();
@@ -96,7 +96,7 @@ async fn destroy_keep_cow_preserves_file() {
     assert!(cow.exists(), "COW file should be preserved");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn write_and_read_back_via_block_device() {
     require_root!();
@@ -160,7 +160,7 @@ async fn write_and_read_back_via_block_device() {
     device.destroy().await.expect("destroy");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn cow_file_is_sparse() {
     require_root!();
@@ -208,7 +208,7 @@ async fn cow_file_is_sparse() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn device_path_format() {
     require_root!();
@@ -233,7 +233,7 @@ async fn device_path_format() {
     device.destroy().await.expect("destroy");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn multiple_devices_from_same_base() {
     require_root!();

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -92,6 +92,25 @@ async fn destroy_keep_cow_preserves_file() {
         .await
         .expect("create");
 
+    // Write a small amount so the COW file is actually created on disk
+    let dev_path = device.device_path().to_owned();
+    let status = Command::new("dd")
+        .args([
+            "if=/dev/urandom",
+            &format!("of={}", dev_path.to_string_lossy()),
+            "bs=4096",
+            "count=1",
+            "conv=notrunc",
+        ])
+        .status()
+        .expect("dd write");
+    assert!(status.success(), "dd write should succeed");
+
+    // Sync to flush the write buffer to the COW file
+    let status = Command::new("sync").status().expect("sync");
+    assert!(status.success());
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
     device.destroy_keep_cow().await.expect("destroy_keep_cow");
     assert!(cow.exists(), "COW file should be preserved");
 }

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -1,0 +1,263 @@
+#![cfg(test)]
+
+//! Integration tests for the nbd-cow crate.
+//!
+//! Tests marked `#[ignore]` require root privileges and the `nbd` kernel module.
+//! Run with:
+//!
+//! ```sh
+//! sudo modprobe nbd nbds_max=256
+//! cargo test -p nbd-cow -- --ignored
+//! ```
+//!
+//! Non-ignored tests run unprivileged and exercise the protocol, COW layer,
+//! and server dispatch over socketpairs (no real block device needed).
+
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+use std::process::Command;
+
+/// Skip the test early if not running as root.
+macro_rules! require_root {
+    () => {
+        if !nix::unistd::getuid().is_root() {
+            eprintln!("skipping: requires root");
+            return;
+        }
+    };
+}
+
+/// Skip if the nbd kernel module is not loaded.
+macro_rules! require_nbd {
+    () => {
+        let modules = std::fs::read_to_string("/proc/modules").unwrap_or_default();
+        if !modules.lines().any(|l| l.starts_with("nbd ")) {
+            eprintln!("skipping: nbd kernel module not loaded");
+            return;
+        }
+    };
+}
+
+fn create_test_base_image(path: &Path) {
+    let f = fs::File::create(path).expect("create base image");
+    f.set_len(64 * 1024 * 1024).expect("truncate base image");
+}
+
+// ---------------------------------------------------------------------------
+// Full device lifecycle tests (require root + nbd module)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn create_and_destroy() {
+    require_root!();
+    require_nbd!();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let cow = tmp.path().join("cow.img");
+    let size = 64 * 1024 * 1024;
+
+    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+        .await
+        .expect("create");
+
+    let dev_path = device.device_path().to_owned();
+    assert!(dev_path.exists(), "device should exist: {dev_path:?}");
+    assert!(
+        dev_path.to_string_lossy().contains("/dev/nbd"),
+        "path should be /dev/nbdN"
+    );
+
+    device.destroy().await.expect("destroy");
+    // After destroy, the COW file should be removed
+    assert!(!cow.exists(), "COW file should be removed after destroy");
+}
+
+#[tokio::test]
+#[ignore]
+async fn destroy_keep_cow_preserves_file() {
+    require_root!();
+    require_nbd!();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let cow = tmp.path().join("cow.img");
+    let size = 64 * 1024 * 1024;
+
+    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+        .await
+        .expect("create");
+
+    device.destroy_keep_cow().await.expect("destroy_keep_cow");
+    assert!(cow.exists(), "COW file should be preserved");
+}
+
+#[tokio::test]
+#[ignore]
+async fn write_and_read_back_via_block_device() {
+    require_root!();
+    require_nbd!();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let cow = tmp.path().join("cow.img");
+    let size = 64 * 1024 * 1024;
+
+    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+        .await
+        .expect("create");
+    let dev_path = device.device_path().to_owned();
+
+    // Write a marker via dd
+    let marker = "NBD_COW_TEST_MARKER_12345678";
+    let status = Command::new("dd")
+        .args([
+            "if=/dev/zero",
+            &format!("of={}", dev_path.to_string_lossy()),
+            "bs=4096",
+            "count=1",
+            "conv=notrunc",
+        ])
+        .status()
+        .expect("dd zero");
+    assert!(status.success());
+
+    let status = Command::new("bash")
+        .args([
+            "-c",
+            &format!(
+                "echo -n '{}' | dd of={} bs=1 count={} conv=notrunc",
+                marker,
+                dev_path.to_string_lossy(),
+                marker.len()
+            ),
+        ])
+        .status()
+        .expect("dd marker");
+    assert!(status.success());
+
+    // Read back
+    let output = Command::new("dd")
+        .args([
+            &format!("if={}", dev_path.to_string_lossy()),
+            "bs=1",
+            &format!("count={}", marker.len()),
+        ])
+        .output()
+        .expect("dd read");
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        marker,
+        "marker should survive write/read"
+    );
+
+    device.destroy().await.expect("destroy");
+}
+
+#[tokio::test]
+#[ignore]
+async fn cow_file_is_sparse() {
+    require_root!();
+    require_nbd!();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let cow = tmp.path().join("cow.img");
+    let size = 64 * 1024 * 1024;
+
+    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+        .await
+        .expect("create");
+
+    // Write a small amount (16KB)
+    let dev_path = device.device_path().to_owned();
+    let status = Command::new("dd")
+        .args([
+            "if=/dev/urandom",
+            &format!("of={}", dev_path.to_string_lossy()),
+            "bs=4096",
+            "count=4",
+            "conv=notrunc",
+        ])
+        .status()
+        .expect("dd");
+    assert!(status.success());
+
+    // Flush to disk
+    let status = Command::new("sync").status().expect("sync");
+    assert!(status.success());
+
+    // Give the flush a moment
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    device.destroy_keep_cow().await.expect("destroy");
+
+    // Check COW file is sparse — actual disk usage should be much less than 64MB
+    let meta = fs::metadata(&cow).expect("metadata");
+    let actual_bytes = meta.blocks() * 512;
+    assert!(
+        actual_bytes < 1024 * 1024,
+        "COW file disk usage ({actual_bytes} bytes) should be < 1 MiB for 16KB write"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn device_path_format() {
+    require_root!();
+    require_nbd!();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let cow = tmp.path().join("cow.img");
+    let size = 64 * 1024 * 1024;
+
+    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+        .await
+        .expect("create");
+
+    let path_str = device.device_path().to_string_lossy();
+    assert!(
+        path_str.starts_with("/dev/nbd"),
+        "device path should start with /dev/nbd, got: {path_str}"
+    );
+
+    device.destroy().await.expect("destroy");
+}
+
+#[tokio::test]
+#[ignore]
+async fn multiple_devices_from_same_base() {
+    require_root!();
+    require_nbd!();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let size = 64 * 1024 * 1024;
+
+    let cow1 = tmp.path().join("cow1.img");
+    let cow2 = tmp.path().join("cow2.img");
+
+    let mut dev1 = nbd_cow::NbdCowDevice::create(&base, &cow1, size)
+        .await
+        .expect("create 1");
+    let mut dev2 = nbd_cow::NbdCowDevice::create(&base, &cow2, size)
+        .await
+        .expect("create 2");
+
+    assert_ne!(dev1.device_path(), dev2.device_path());
+    assert!(dev1.device_path().exists());
+    assert!(dev2.device_path().exists());
+
+    dev1.destroy().await.expect("destroy 1");
+    dev2.destroy().await.expect("destroy 2");
+}


### PR DESCRIPTION
## Summary

- Add new `crates/nbd-cow/` crate implementing a minimal NBD COW server with write buffering
- NBD transmission protocol parser (28-byte request / 16-byte reply, 5 commands)
- COW layer with dirty bitmap tracking and configurable write buffer (flushes at 4MB threshold)
- Async dispatch loop over Unix socketpairs using tokio
- Netlink-based `/dev/nbdN` device setup (modern, supports multi-connection)
- Public `NbdCowDevice` API matching existing `CowDevice` interface contract
- Benchmark binary for comparing dm-snapshot vs NBD COW via fio
- 14 unit/integration tests covering protocol parsing, COW read/write/flush, and server dispatch

Closes #7247

## Test plan

- [x] Protocol parse/serialize round-trip tests
- [x] COW layer: read from base, write-then-read, partial block, cross-block, flush, threshold
- [x] Server dispatch: full read → write → read-back → disconnect cycle over socketpair
- [ ] Full NBD device integration test (requires root + nbd kernel module on metal host)
- [ ] Benchmark on metal host with EBS storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)