### PR TITLE
chore: update runner group examples from acme/ to vm0/ prefix

### DIFF
--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -27,7 +27,7 @@ pub struct ConfigArgs {
     /// Runner logical name
     #[arg(long)]
     name: String,
-    /// Runner group in org/name format (e.g. "vm0/production")
+    /// Runner group in vm0/<name> format (e.g. "vm0/production")
     #[arg(long)]
     group: String,
     /// Runner directory name (under ~/.vm0-runner/runners/)

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -27,7 +27,7 @@ pub struct ConfigArgs {
     /// Runner logical name
     #[arg(long)]
     name: String,
-    /// Runner group in org/name format (e.g. "acme/production")
+    /// Runner group in org/name format (e.g. "vm0/production")
     #[arg(long)]
     group: String,
     /// Runner directory name (under ~/.vm0-runner/runners/)

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -281,7 +281,7 @@ mod tests {
         let yaml = format!(
             r#"
 name: test-runner
-group: acme/prod
+group: vm0/prod
 base_dir: {base_dir}
 ca_dir: {ca_dir}
 firecracker:
@@ -541,7 +541,7 @@ sandbox:
         let runner_dir = dir.path().join("my-runner");
         let config = RunnerConfig {
             name: "test-runner".into(),
-            group: "acme/prod".into(),
+            group: "vm0/prod".into(),
             base_dir: runner_dir.clone(),
             ca_dir: dir.path().to_path_buf(),
             firecracker: FirecrackerConfig { binary: fc, kernel },

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -867,7 +867,7 @@ agents:
     description: "Test agent with valid runner group"
     framework: claude-code
     experimental_runner:
-      group: acme/production`,
+      group: vm0/production`,
       );
 
       server.use(

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -858,7 +858,7 @@ agents:
   });
 
   describe("runner group validation", () => {
-    it("should accept valid runner group format (org/name)", async () => {
+    it("should accept valid runner group format (vm0/<name>)", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         `version: "1.0"
@@ -911,7 +911,7 @@ agents:
         (call) => call[0] as string,
       );
       const hasFormatError = allErrors.some(
-        (err) => err.includes("org/name") || err.includes("format"),
+        (err) => err.includes("vm0/") || err.includes("format"),
       );
       expect(hasFormatError).toBe(true);
       expect(mockExit).toHaveBeenCalledWith(1);

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -71,7 +71,7 @@ Each agent key must be a valid agent name: 3-64 characters, starting and ending 
 | `skills`                 | array  | No       | `[]`           | List of skill references. Supports bare names (e.g., `"slack"`) which resolve to `https://github.com/vm0-ai/vm0-skills/tree/main/slack`, or full GitHub URLs. See [Skills](/docs/core-concept/skills) |
 | `volumes`                | array  | No       | `[]`           | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
 | `environment`            | object | No       | `{}`           | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
-| `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `org/name` format (e.g., `vm0/production`) |
+| `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `vm0/<name>` format (e.g., `vm0/production`) |
 
 ## Volume Fields
 

--- a/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
+++ b/turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx
@@ -71,7 +71,7 @@ Each agent key must be a valid agent name: 3-64 characters, starting and ending 
 | `skills`                 | array  | No       | `[]`           | List of skill references. Supports bare names (e.g., `"slack"`) which resolve to `https://github.com/vm0-ai/vm0-skills/tree/main/slack`, or full GitHub URLs. See [Skills](/docs/core-concept/skills) |
 | `volumes`                | array  | No       | `[]`           | Volume mounts in format `name:path`. See [Volume](/docs/core-concept/volume)                      |
 | `environment`            | object | No       | `{}`           | Environment variables. See [Environment Variables](/docs/core-concept/environment-variable)       |
-| `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `org/name` format (e.g., `acme/production`) |
+| `experimental_runner`    | object | No       | -              | Self-hosted runner configuration. Object with `group` field in `org/name` format (e.g., `vm0/production`) |
 
 ## Volume Fields
 

--- a/turbo/apps/web/src/lib/org/org-service.ts
+++ b/turbo/apps/web/src/lib/org/org-service.ts
@@ -107,7 +107,7 @@ export async function updateOrg(
  * Check if a runner group belongs to the official vm0 org.
  * Official runner groups (vm0/production, vm0/development) can be used by any user.
  *
- * @param group - Runner group in format "org/name"
+ * @param group - Runner group in format "vm0/<name>"
  * @returns true if the group is an official runner group (vm0/*)
  */
 export function isOfficialRunnerGroup(group: string): boolean {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -125,7 +125,7 @@ const agentDefinitionSchema = z.object({
         .string()
         .regex(
           /^[a-z0-9-]+\/[a-z0-9-]+$/,
-          "Runner group must be in org/name format (e.g., vm0/production)",
+          "Runner group must be in vm0/<name> format (e.g., vm0/production)",
         ),
     })
     .optional(),

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -125,7 +125,7 @@ const agentDefinitionSchema = z.object({
         .string()
         .regex(
           /^[a-z0-9-]+\/[a-z0-9-]+$/,
-          "Runner group must be in org/name format (e.g., acme/production)",
+          "Runner group must be in org/name format (e.g., vm0/production)",
         ),
     })
     .optional(),

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -12,13 +12,13 @@ const c = initContract();
 export const DEFAULT_PROFILE = "vm0/default";
 
 /**
- * Runner group format: org/name (e.g., "acme/production")
+ * Runner group format: org/name (e.g., "vm0/production")
  */
 export const runnerGroupSchema = z
   .string()
   .regex(
     /^[a-z0-9-]+\/[a-z0-9-]+$/,
-    "Runner group must be in org/name format (e.g., acme/production)",
+    "Runner group must be in org/name format (e.g., vm0/production)",
   );
 
 /**

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -12,13 +12,13 @@ const c = initContract();
 export const DEFAULT_PROFILE = "vm0/default";
 
 /**
- * Runner group format: org/name (e.g., "vm0/production")
+ * Runner group format: vm0/<name> (e.g., "vm0/production")
  */
 export const runnerGroupSchema = z
   .string()
   .regex(
     /^[a-z0-9-]+\/[a-z0-9-]+$/,
-    "Runner group must be in org/name format (e.g., vm0/production)",
+    "Runner group must be in vm0/<name> format (e.g., vm0/production)",
   );
 
 /**


### PR DESCRIPTION
## Summary
- Update all runner group examples from `acme/production` and `acme/prod` to `vm0/production` and `vm0/prod`
- Follows up on PR #7207 which removed user-defined runner groups and enforced the `vm0/` prefix
- Text-only changes across docs, contracts, CLI args, and test data — no logic changes

## Files Changed
- `turbo/apps/docs/content/docs/reference/configuration/vm0-yaml.mdx` — docs table
- `turbo/packages/core/src/contracts/runners.ts` — comment and error message
- `turbo/packages/core/src/contracts/composes.ts` — error message
- `crates/runner/src/cmd/config.rs` — CLI arg doc
- `crates/runner/src/config.rs` — test data (2 occurrences)
- `turbo/apps/cli/src/commands/compose/__tests__/index.test.ts` — test data

## Test plan
- [x] All lint checks pass
- [x] All formatting checks pass
- [x] Knip finds no issues
- [x] Cargo clippy passes
- [x] No remaining `acme/prod` or `acme/production` references in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)