### PR TITLE
feat(firewalls): support path and host parameter matching in base urls

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -128,6 +128,155 @@ def get_original_url(flow: http.HTTPFlow) -> str:
 # ============================================================================
 
 
+def match_host(host: str, pattern: str) -> dict | None:
+    """Match a hostname against a pattern. Returns extracted params or None.
+
+    Segments are `.`-delimited. Since subdomains grow leftward, greedy params
+    ({name+}, {name*}) must appear in the first (leftmost) position.
+
+    - Literal segments must match exactly (case-insensitive).
+    - {name} matches a single host segment.
+    - {name+} matches one or more leading host segments. Must be first.
+    - {name*} matches zero or more leading host segments. Must be first.
+    """
+    host_segs = host.lower().split(".")
+    pattern_segs = pattern.lower().split(".")
+
+    params: dict[str, str] = {}
+
+    # Match right-to-left: reverse both, then match like a path.
+    host_segs.reverse()
+    pattern_segs.reverse()
+
+    hi = 0
+    for seg in pattern_segs:
+        if seg.startswith("{") and seg.endswith("}"):
+            name = seg[1:-1]
+            if name.endswith("+"):
+                # Greedy: consume rest (one or more)
+                if hi >= len(host_segs):
+                    return None
+                remaining = list(reversed(host_segs[hi:]))
+                params[name[:-1]] = ".".join(remaining)
+                return params
+            if name.endswith("*"):
+                # Greedy: consume rest (zero or more)
+                remaining = list(reversed(host_segs[hi:]))
+                params[name[:-1]] = ".".join(remaining)
+                return params
+            # Single segment
+            if hi >= len(host_segs):
+                return None
+            params[name] = host_segs[hi]
+            hi += 1
+        else:
+            if hi >= len(host_segs) or host_segs[hi] != seg:
+                return None
+            hi += 1
+
+    if hi != len(host_segs):
+        return None
+    return params
+
+
+def match_path_prefix(path_segs: list[str], pattern_segs: list[str]) -> tuple[dict, int] | None:
+    """Match pattern segments against the beginning of path segments.
+
+    Unlike match_path(), does NOT require full path consumption.
+    Does NOT support greedy params (not allowed in base URL paths).
+
+    Returns (params, consumed_count) on match, None on no match.
+    """
+    params: dict[str, str] = {}
+    pi = 0
+
+    for seg in pattern_segs:
+        if seg.startswith("{") and seg.endswith("}"):
+            name = seg[1:-1]
+            if pi >= len(path_segs):
+                return None
+            params[name] = path_segs[pi]
+            pi += 1
+        else:
+            if pi >= len(path_segs) or path_segs[pi] != seg:
+                return None
+            pi += 1
+
+    return params, pi
+
+
+def match_base_url(url: str, base: str) -> tuple[str, dict] | None:
+    """Match a request URL against a (possibly parameterized) base URL.
+
+    Returns (rel_path, params) on match, None on no match.
+    - rel_path: the path after the base (for permission rule matching)
+    - params: extracted parameters from the base URL
+    """
+    # Fast path: no parameters — use simple prefix matching
+    if "{" not in base:
+        base_stripped = base.rstrip("/")
+        if not url.startswith(base_stripped):
+            return None
+        rest = url[len(base_stripped) :]
+        if rest and rest[0] not in ("/", "?", "#"):
+            return None
+        rel_path = rest.split("?")[0].split("#")[0] or "/"
+        return rel_path, {}
+
+    # Parameterized base URL: parse into scheme, host pattern, path pattern
+    scheme_end = base.find("://")
+    if scheme_end == -1:
+        return None
+    scheme = base[: scheme_end + 3]  # e.g., "https://"
+
+    # Request must start with same scheme
+    if not url.lower().startswith(scheme.lower()):
+        return None
+
+    base_rest = base[scheme_end + 3 :]  # after "://"
+    url_rest = url[scheme_end + 3 :]
+
+    # Split host from path
+    base_slash = base_rest.find("/")
+    base_host = base_rest if base_slash == -1 else base_rest[:base_slash]
+    base_path = "" if base_slash == -1 else base_rest[base_slash:]
+
+    url_slash = url_rest.find("/")
+    url_host_with_port = url_rest if url_slash == -1 else url_rest[:url_slash]
+    url_path = "" if url_slash == -1 else url_rest[url_slash:]
+
+    # Strip port from URL host for matching
+    if ":" in url_host_with_port:
+        url_host = url_host_with_port.rsplit(":", 1)[0]
+    else:
+        url_host = url_host_with_port
+
+    # Match host
+    host_params = match_host(url_host, base_host)
+    if host_params is None:
+        return None
+
+    # Strip query/fragment from URL path
+    clean_url_path = url_path.split("?")[0].split("#")[0]
+
+    # Match base path prefix
+    if base_path and base_path != "/":
+        base_path_segs = [s for s in base_path.split("/") if s]
+        url_path_segs = [s for s in clean_url_path.split("/") if s]
+        path_result = match_path_prefix(url_path_segs, base_path_segs)
+        if path_result is None:
+            return None
+        path_params, consumed = path_result
+        remaining_segs = url_path_segs[consumed:]
+        rel_path = "/" + "/".join(remaining_segs) if remaining_segs else "/"
+        all_params = {**host_params, **path_params}
+    else:
+        rel_path = clean_url_path or "/"
+        all_params = host_params
+
+    return rel_path, all_params
+
+
 def match_path(path: str, pattern: str) -> dict | None:
     """Match a URL path against a rule pattern. Returns extracted params or None.
 
@@ -212,30 +361,34 @@ def match_firewall_request(
 
     upper_method = method.upper()
 
+    # Track the relative path of the first blocked base for error messages
+    blocked_rel_path = "/"
+
     for fw_entry in vm_firewalls:
         fw_name = fw_entry.get("name", "")
         fw_ref = fw_entry.get("ref", "")
         for api_entry in fw_entry.get("apis", []):
             base = api_entry.get("base", "").rstrip("/")
-            if not base or not url.startswith(base):
+            if not base:
                 continue
-            rest = url[len(base) :]
-            if rest and rest[0] not in ("/", "?", "#"):
+
+            base_result = match_base_url(url, base)
+            if base_result is None:
                 continue
+
+            rel_path, base_params = base_result
 
             # Base URL matched
             if blocked_base is None:
                 blocked_base = base
                 blocked_ref = fw_ref
                 blocked_name = fw_name
+                blocked_rel_path = rel_path
 
             permissions = api_entry.get("permissions")
             if not permissions:
                 # No permissions defined or empty → block (fail-closed)
                 continue
-
-            # Extract relative path, strip query/fragment
-            rel_path = rest.split("?")[0].split("#")[0] or "/"
 
             for perm in permissions:
                 perm_name = perm.get("name", "")
@@ -248,22 +401,23 @@ def match_firewall_request(
                         continue
                     params = match_path(rel_path, rule_pattern)
                     if params is not None:
+                        # Merge base params with rule params
+                        all_params = {**base_params, **params}
                         return FirewallAllow(
                             api_entry,
                             {
                                 "name": fw_name,
                                 "ref": fw_ref,
                                 "permission": perm_name,
-                                "params": params,
+                                "params": all_params,
                                 "rule": rule_str,
                             },
                         )
 
     if blocked_base is not None:
-        # Extract relative path for the error message
-        rest = url[len(blocked_base) :]
-        rel_path = rest.split("?")[0].split("#")[0] or "/"
-        return FirewallBlock(blocked_base, blocked_ref, blocked_name, upper_method, rel_path)
+        return FirewallBlock(
+            blocked_base, blocked_ref, blocked_name, upper_method, blocked_rel_path
+        )
     return None
 
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -247,14 +247,12 @@ def match_base_url(url: str, base: str) -> tuple[str, dict] | None:
     url_host_with_port = url_rest if url_slash == -1 else url_rest[:url_slash]
     url_path = "" if url_slash == -1 else url_rest[url_slash:]
 
-    # Strip port from URL host for matching
-    if ":" in url_host_with_port:
-        url_host = url_host_with_port.rsplit(":", 1)[0]
-    else:
-        url_host = url_host_with_port
-
-    # Match host
-    host_params = match_host(url_host, base_host)
+    # Match host directly — do NOT strip port. Non-standard ports (e.g., :8443)
+    # are included in URLs by get_original_url() and must NOT match base patterns
+    # without an explicit port, otherwise auth headers could leak to rogue servers.
+    # Standard ports (443 for https, 80 for http) are omitted from URLs by
+    # get_original_url(), so they match naturally.
+    host_params = match_host(url_host_with_port, base_host)
     if host_params is None:
         return None
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -140,18 +140,20 @@ def match_host(host: str, pattern: str) -> dict | None:
     - {name*} matches zero or more leading host segments. Must be first.
     """
     host_segs = host.lower().split(".")
-    pattern_segs = pattern.lower().split(".")
+    # Keep original pattern segments for param name extraction;
+    # only lowercase for literal comparison.
+    pattern_segs_orig = pattern.split(".")
 
     params: dict[str, str] = {}
 
     # Match right-to-left: reverse both, then match like a path.
     host_segs.reverse()
-    pattern_segs.reverse()
+    pattern_segs_orig.reverse()
 
     hi = 0
-    for seg in pattern_segs:
-        if seg.startswith("{") and seg.endswith("}"):
-            name = seg[1:-1]
+    for seg_orig in pattern_segs_orig:
+        if seg_orig.startswith("{") and seg_orig.endswith("}"):
+            name = seg_orig[1:-1]
             if name.endswith("+"):
                 # Greedy: consume rest (one or more)
                 if hi >= len(host_segs):
@@ -170,7 +172,7 @@ def match_host(host: str, pattern: str) -> dict | None:
             params[name] = host_segs[hi]
             hi += 1
         else:
-            if hi >= len(host_segs) or host_segs[hi] != seg:
+            if hi >= len(host_segs) or host_segs[hi] != seg_orig.lower():
                 return None
             hi += 1
 

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -669,6 +669,40 @@ class TestMatchFirewallRequest:
         assert zd.match_info["name"] == "zendesk"
         assert zd.match_info["params"]["sub"] == "acme"
 
+    def test_parameterized_host_with_query_string(self):
+        """Parameterized base URL + query string in request."""
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://{sub}.zendesk.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "tickets", "rules": ["GET /api/v2/tickets"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://acme.zendesk.com/api/v2/tickets?page=2", "GET", fw_configs
+        )
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["params"]["sub"] == "acme"
+
+    def test_parameterized_host_with_port_in_url(self):
+        """URL with explicit port still matches parameterized base."""
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://{sub}.zendesk.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["GET /api"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://acme.zendesk.com:443/api", "GET", fw_configs
+        )
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["params"]["sub"] == "acme"
+
 
 # =========================================================================
 # match_host
@@ -716,6 +750,12 @@ class TestMatchHost:
 
     def test_host_too_few_segments(self):
         assert match_host("github.com", "api.github.com") is None
+
+    def test_param_name_preserves_case(self):
+        """Param names should preserve original case from the pattern."""
+        result = match_host("acme.zendesk.com", "{Subdomain}.zendesk.com")
+        assert "Subdomain" in result
+        assert result["Subdomain"] == "acme"
 
 
 # =========================================================================

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -686,22 +686,21 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["params"]["sub"] == "acme"
 
-    def test_parameterized_host_with_port_in_url(self):
-        """URL with explicit port still matches parameterized base."""
+    def test_parameterized_host_rejects_nonstandard_port(self):
+        """Non-standard port must NOT match — prevents auth header leaking to rogue server."""
         fw_configs = _wrap_firewalls(
             [
                 {
                     "base": "https://{sub}.zendesk.com",
                     "auth": {"headers": {}},
-                    "permissions": [{"name": "p", "rules": ["GET /api"]}],
+                    "permissions": [{"name": "p", "rules": ["ANY /{path+}"]}],
                 }
             ]
         )
         result = mitm_addon.match_firewall_request(
-            "https://acme.zendesk.com:443/api", "GET", fw_configs
+            "https://acme.zendesk.com:8443/api", "GET", fw_configs
         )
-        assert isinstance(result, FirewallAllow)
-        assert result.match_info["params"]["sub"] == "acme"
+        assert result is None
 
 
 # =========================================================================
@@ -863,6 +862,25 @@ class TestMatchBaseUrl:
         rel_path, params = result
         assert rel_path == "/"
         assert params == {"sub": "acme"}
+
+    def test_nonstandard_port_rejected(self):
+        """Non-standard port in URL must not match base without port."""
+        result = match_base_url(
+            "https://acme.zendesk.com:8443/api",
+            "https://{sub}.zendesk.com",
+        )
+        assert result is None
+
+    def test_base_with_port_matches_url_with_same_port(self):
+        """Base with explicit port matches URL with same port."""
+        result = match_base_url(
+            "https://internal.example.com:8443/api",
+            "https://{sub}.example.com:8443",
+        )
+        assert result is not None
+        rel_path, params = result
+        assert rel_path == "/api"
+        assert params == {"sub": "internal"}
 
 
 # =========================================================================

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -5,7 +5,7 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import mitm_addon
-from mitm_addon import FirewallAllow, FirewallBlock
+from mitm_addon import FirewallAllow, FirewallBlock, match_base_url, match_host, match_path_prefix
 
 
 def _make_http_flow(client_ip="10.200.0.1", host="api.github.com", port=443, path="/repos"):
@@ -509,6 +509,320 @@ class TestMatchFirewallRequest:
         assert isinstance(result, FirewallAllow)
         assert result.api_entry["auth"]["headers"]["Authorization"] == "Bearer user"
         assert result.match_info["permission"] == "send"
+
+    def test_parameterized_host_allows(self):
+        """Base URL with {subdomain} in host matches dynamically."""
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://{subdomain}.zendesk.com",
+                    "auth": {"headers": {"Authorization": "Basic ${{ secrets.AUTH }}"}},
+                    "permissions": [{"name": "tickets", "rules": ["GET /api/v2/tickets"]}],
+                }
+            ],
+            name="zendesk",
+            ref="zendesk",
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://acme.zendesk.com/api/v2/tickets", "GET", fw_configs
+        )
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["name"] == "zendesk"
+        assert result.match_info["permission"] == "tickets"
+        assert result.match_info["params"] == {"subdomain": "acme"}
+
+    def test_parameterized_host_blocks_no_permission(self):
+        """Base URL with host param matches but no rule → block."""
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://{subdomain}.zendesk.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "tickets", "rules": ["GET /api/v2/tickets"]}],
+                }
+            ],
+            name="zendesk",
+            ref="zendesk",
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://acme.zendesk.com/api/v2/users", "GET", fw_configs
+        )
+        assert isinstance(result, FirewallBlock)
+        assert result.name == "zendesk"
+
+    def test_parameterized_host_no_match_returns_none(self):
+        """Different domain entirely → None (pass-through)."""
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://{subdomain}.zendesk.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["ANY /{path+}"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.github.com/repos", "GET", fw_configs
+        )
+        assert result is None
+
+    def test_parameterized_path_allows(self):
+        """Base URL with {param} in path matches dynamically."""
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.example.com/v1/{org}",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "projects", "rules": ["GET /projects/{id}"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://api.example.com/v1/acme/projects/123", "GET", fw_configs
+        )
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["params"] == {"org": "acme", "id": "123"}
+
+    def test_parameterized_host_and_path(self):
+        """Both host and path params extracted."""
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://{tenant}.api.example.com/v1/{org}",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "data", "rules": ["GET /data"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://us.api.example.com/v1/acme/data", "GET", fw_configs
+        )
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["params"] == {"tenant": "us", "org": "acme"}
+
+    def test_greedy_host_param_matches_multi_level(self):
+        """Greedy {sub+} in host matches multiple subdomain levels."""
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://{sub+}.example.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["GET /api"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request(
+            "https://a.b.c.example.com/api", "GET", fw_configs
+        )
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["params"]["sub"] == "a.b.c"
+
+    def test_greedy_star_host_param_matches_zero(self):
+        """Greedy {sub*} in host matches zero subdomains."""
+        fw_configs = _wrap_firewalls(
+            [
+                {
+                    "base": "https://{sub*}.example.com",
+                    "auth": {"headers": {}},
+                    "permissions": [{"name": "p", "rules": ["GET /api"]}],
+                }
+            ]
+        )
+        result = mitm_addon.match_firewall_request("https://example.com/api", "GET", fw_configs)
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["params"]["sub"] == ""
+
+    def test_mixed_static_and_parameterized_bases(self):
+        """Static and parameterized bases in same config both work."""
+        fw_configs = [
+            {
+                "name": "github",
+                "ref": "github",
+                "apis": [
+                    {
+                        "base": "https://api.github.com",
+                        "auth": {"headers": {}},
+                        "permissions": [{"name": "p", "rules": ["ANY /{path+}"]}],
+                    }
+                ],
+            },
+            {
+                "name": "zendesk",
+                "ref": "zendesk",
+                "apis": [
+                    {
+                        "base": "https://{sub}.zendesk.com",
+                        "auth": {"headers": {}},
+                        "permissions": [{"name": "p", "rules": ["ANY /{path+}"]}],
+                    }
+                ],
+            },
+        ]
+        gh = mitm_addon.match_firewall_request("https://api.github.com/repos", "GET", fw_configs)
+        assert isinstance(gh, FirewallAllow)
+        assert gh.match_info["name"] == "github"
+
+        zd = mitm_addon.match_firewall_request(
+            "https://acme.zendesk.com/api/v2/tickets", "GET", fw_configs
+        )
+        assert isinstance(zd, FirewallAllow)
+        assert zd.match_info["name"] == "zendesk"
+        assert zd.match_info["params"]["sub"] == "acme"
+
+
+# =========================================================================
+# match_host
+# =========================================================================
+
+
+class TestMatchHost:
+    def test_exact_host(self):
+        assert match_host("api.github.com", "api.github.com") == {}
+
+    def test_single_param(self):
+        result = match_host("acme.zendesk.com", "{subdomain}.zendesk.com")
+        assert result == {"subdomain": "acme"}
+
+    def test_single_param_no_match_multi_level(self):
+        """Single {param} must not match multiple host segments."""
+        result = match_host("a.b.zendesk.com", "{subdomain}.zendesk.com")
+        assert result is None
+
+    def test_greedy_plus_matches_multi(self):
+        result = match_host("a.b.c.example.com", "{sub+}.example.com")
+        assert result == {"sub": "a.b.c"}
+
+    def test_greedy_plus_matches_single(self):
+        result = match_host("x.example.com", "{sub+}.example.com")
+        assert result == {"sub": "x"}
+
+    def test_greedy_plus_rejects_zero(self):
+        result = match_host("example.com", "{sub+}.example.com")
+        assert result is None
+
+    def test_greedy_star_matches_multi(self):
+        result = match_host("a.b.example.com", "{sub*}.example.com")
+        assert result == {"sub": "a.b"}
+
+    def test_greedy_star_matches_zero(self):
+        result = match_host("example.com", "{sub*}.example.com")
+        assert result == {"sub": ""}
+
+    def test_literal_mismatch(self):
+        assert match_host("api.gitlab.com", "api.github.com") is None
+
+    def test_case_insensitive(self):
+        assert match_host("API.GitHub.COM", "api.github.com") == {}
+
+    def test_host_too_few_segments(self):
+        assert match_host("github.com", "api.github.com") is None
+
+
+# =========================================================================
+# match_path_prefix
+# =========================================================================
+
+
+class TestMatchPathPrefix:
+    def test_exact_match(self):
+        result = match_path_prefix(["v1", "projects"], ["v1", "projects"])
+        assert result == ({}, 2)
+
+    def test_single_param(self):
+        result = match_path_prefix(["v1", "acme", "projects"], ["v1", "{org}"])
+        assert result == ({"org": "acme"}, 2)
+
+    def test_remaining_segments(self):
+        result = match_path_prefix(["v1", "acme", "projects", "123"], ["v1", "{org}"])
+        assert result == ({"org": "acme"}, 2)
+
+    def test_mismatch(self):
+        result = match_path_prefix(["v2", "acme"], ["v1", "{org}"])
+        assert result is None
+
+    def test_empty_pattern(self):
+        result = match_path_prefix(["v1", "acme"], [])
+        assert result == ({}, 0)
+
+    def test_path_too_short(self):
+        result = match_path_prefix(["v1"], ["v1", "{org}"])
+        assert result is None
+
+
+# =========================================================================
+# match_base_url
+# =========================================================================
+
+
+class TestMatchBaseUrl:
+    def test_static_base(self):
+        result = match_base_url("https://api.github.com/repos", "https://api.github.com")
+        assert result == ("/repos", {})
+
+    def test_static_base_exact(self):
+        result = match_base_url("https://api.github.com", "https://api.github.com")
+        assert result == ("/", {})
+
+    def test_static_base_evil_domain(self):
+        result = match_base_url("https://api.github.com.evil.com/steal", "https://api.github.com")
+        assert result is None
+
+    def test_parameterized_host(self):
+        result = match_base_url(
+            "https://acme.zendesk.com/api/v2/tickets",
+            "https://{subdomain}.zendesk.com",
+        )
+        assert result is not None
+        rel_path, params = result
+        assert rel_path == "/api/v2/tickets"
+        assert params == {"subdomain": "acme"}
+
+    def test_parameterized_path(self):
+        result = match_base_url(
+            "https://api.example.com/v1/acme/projects/123",
+            "https://api.example.com/v1/{org}",
+        )
+        assert result is not None
+        rel_path, params = result
+        assert rel_path == "/projects/123"
+        assert params == {"org": "acme"}
+
+    def test_parameterized_host_and_path(self):
+        result = match_base_url(
+            "https://us.api.example.com/v1/acme/data",
+            "https://{region}.api.example.com/v1/{org}",
+        )
+        assert result is not None
+        rel_path, params = result
+        assert rel_path == "/data"
+        assert params == {"region": "us", "org": "acme"}
+
+    def test_host_mismatch_returns_none(self):
+        result = match_base_url("https://api.github.com/repos", "https://{sub}.zendesk.com")
+        assert result is None
+
+    def test_scheme_mismatch_returns_none(self):
+        result = match_base_url("http://acme.zendesk.com/api", "https://{sub}.zendesk.com")
+        assert result is None
+
+    def test_query_stripped(self):
+        result = match_base_url(
+            "https://acme.zendesk.com/api?key=val",
+            "https://{sub}.zendesk.com",
+        )
+        assert result is not None
+        rel_path, _ = result
+        assert rel_path == "/api"
+
+    def test_no_path_after_parameterized_base(self):
+        result = match_base_url(
+            "https://acme.zendesk.com",
+            "https://{sub}.zendesk.com",
+        )
+        assert result is not None
+        rel_path, params = result
+        assert rel_path == "/"
+        assert params == {"sub": "acme"}
 
 
 # =========================================================================

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   validateBaseUrl,
+  hasBaseUrlParams,
   hasBaseUrlVars,
   resolveFirewallBaseUrlVars,
 } from "../firewalls";
@@ -395,6 +396,120 @@ describe("validateBaseUrl", () => {
         "zendesk",
       ),
     ).not.toThrow();
+  });
+
+  it("should accept base URL with single host param", () => {
+    expect(() =>
+      validateBaseUrl("https://{subdomain}.zendesk.com", "zendesk"),
+    ).not.toThrow();
+  });
+
+  it("should accept base URL with greedy host param in first position", () => {
+    expect(() =>
+      validateBaseUrl("https://{sub+}.example.com", "fw"),
+    ).not.toThrow();
+    expect(() =>
+      validateBaseUrl("https://{sub*}.example.com", "fw"),
+    ).not.toThrow();
+  });
+
+  it("should accept base URL with single path param", () => {
+    expect(() =>
+      validateBaseUrl("https://api.example.com/v1/{org}", "fw"),
+    ).not.toThrow();
+    expect(() =>
+      validateBaseUrl("https://api.example.com/v1/{org}/projects", "fw"),
+    ).not.toThrow();
+  });
+
+  it("should accept base URL with host and path params", () => {
+    expect(() =>
+      validateBaseUrl("https://{sub}.example.com/v1/{org}", "fw"),
+    ).not.toThrow();
+  });
+
+  it("should reject greedy host param not in first position", () => {
+    expect(() =>
+      validateBaseUrl("https://api.{sub+}.example.com", "fw"),
+    ).toThrow("{sub+} must be the first host segment");
+    expect(() =>
+      validateBaseUrl("https://api.{sub*}.example.com", "fw"),
+    ).toThrow("{sub*} must be the first host segment");
+  });
+
+  it("should reject greedy path param in base URL", () => {
+    expect(() =>
+      validateBaseUrl("https://api.example.com/{path+}", "fw"),
+    ).toThrow("greedy parameter {path+} is not allowed in base URL path");
+    expect(() =>
+      validateBaseUrl("https://api.example.com/{path*}", "fw"),
+    ).toThrow("greedy parameter {path*} is not allowed in base URL path");
+  });
+
+  it("should reject host with no static segments", () => {
+    expect(() => validateBaseUrl("https://{a}.{b}", "fw")).toThrow(
+      "must have at least one static segment",
+    );
+  });
+
+  it("should reject empty param name in host", () => {
+    expect(() => validateBaseUrl("https://{}.example.com", "fw")).toThrow(
+      "empty parameter name in host",
+    );
+  });
+
+  it("should reject empty param name in path", () => {
+    expect(() => validateBaseUrl("https://api.example.com/{}", "fw")).toThrow(
+      "empty parameter name in path",
+    );
+  });
+
+  it("should reject duplicate param names in host", () => {
+    expect(() =>
+      validateBaseUrl("https://{sub}.{sub}.example.com", "fw"),
+    ).toThrow('duplicate parameter name "{sub}" in host');
+  });
+
+  it("should reject duplicate param names across host and path", () => {
+    expect(() =>
+      validateBaseUrl("https://{org}.example.com/{org}", "fw"),
+    ).toThrow('duplicate parameter name "{org}"');
+  });
+
+  it("should reject query string in parameterized base URL", () => {
+    expect(() =>
+      validateBaseUrl("https://{sub}.example.com?key=val", "fw"),
+    ).toThrow("must not contain query string");
+  });
+
+  it("should reject fragment in parameterized base URL", () => {
+    expect(() =>
+      validateBaseUrl("https://{sub}.example.com#section", "fw"),
+    ).toThrow("must not contain fragment");
+  });
+
+  it("should reject param in scheme", () => {
+    expect(() => validateBaseUrl("{proto}://api.example.com", "fw")).toThrow(
+      "scheme must not contain parameters",
+    );
+  });
+});
+
+describe("hasBaseUrlParams", () => {
+  it("returns true for host params", () => {
+    expect(hasBaseUrlParams("https://{sub}.zendesk.com")).toBe(true);
+  });
+
+  it("returns true for path params", () => {
+    expect(hasBaseUrlParams("https://api.example.com/v1/{org}")).toBe(true);
+  });
+
+  it("returns false for static URLs", () => {
+    expect(hasBaseUrlParams("https://api.github.com")).toBe(false);
+  });
+
+  it("returns false for template vars", () => {
+    expect(hasBaseUrlParams("https://${{ vars.X }}.example.com")).toBe(false);
   });
 });
 

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -511,6 +511,17 @@ describe("hasBaseUrlParams", () => {
   it("returns false for template vars", () => {
     expect(hasBaseUrlParams("https://${{ vars.X }}.example.com")).toBe(false);
   });
+
+  it("returns true when both template vars and params present", () => {
+    expect(hasBaseUrlParams("https://${{ vars.X }}.{region}.example.com")).toBe(
+      true,
+    );
+  });
+
+  it("handles adversarial input with many ${{ without closing }}", () => {
+    const adversarial = "https://" + "${{".repeat(1000) + ".example.com";
+    expect(hasBaseUrlParams(adversarial)).toBe(false);
+  });
 });
 
 describe("hasBaseUrlVars", () => {

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -493,6 +493,18 @@ describe("validateBaseUrl", () => {
       "scheme must not contain parameters",
     );
   });
+
+  it("should reject partial param in host segment", () => {
+    expect(() =>
+      validateBaseUrl("https://api-{version}.example.com", "fw"),
+    ).toThrow('host segment "api-{version}" contains "{"');
+  });
+
+  it("should reject partial param in path segment", () => {
+    expect(() =>
+      validateBaseUrl("https://api.example.com/v1-{version}", "fw"),
+    ).toThrow('path segment "v1-{version}" contains "{"');
+  });
 });
 
 describe("hasBaseUrlParams", () => {

--- a/turbo/packages/core/src/contracts/firewalls.ts
+++ b/turbo/packages/core/src/contracts/firewalls.ts
@@ -163,8 +163,16 @@ const PARAM_SEGMENT_PATTERN = /^\{([^}]*)\}$/;
  * (as opposed to `${{ vars.X }}` template references).
  */
 export function hasBaseUrlParams(base: string): boolean {
-  // Strip ${{ ... }} template references first, then check for remaining { }
-  const stripped = base.replace(/\$\{\{[^}]*\}\}/g, "");
+  // Strip ${{ ... }} template references, then check for remaining { }.
+  // Uses string iteration instead of regex to avoid ReDoS risk.
+  let stripped = base;
+  let start = stripped.indexOf("${{");
+  while (start !== -1) {
+    const end = stripped.indexOf("}}", start + 3);
+    if (end === -1) break;
+    stripped = stripped.slice(0, start) + stripped.slice(end + 2);
+    start = stripped.indexOf("${{");
+  }
   return stripped.includes("{") && stripped.includes("}");
 }
 

--- a/turbo/packages/core/src/contracts/firewalls.ts
+++ b/turbo/packages/core/src/contracts/firewalls.ts
@@ -153,9 +153,160 @@ export function resolveFirewallBaseUrlVars(
   }));
 }
 
+/**
+ * Pattern matching `{name}`, `{name+}`, or `{name*}` parameter segments.
+ */
+const PARAM_SEGMENT_PATTERN = /^\{([^}]*)\}$/;
+
+/**
+ * Check if a base URL contains `{name}` style parameter placeholders
+ * (as opposed to `${{ vars.X }}` template references).
+ */
+export function hasBaseUrlParams(base: string): boolean {
+  // Strip ${{ ... }} template references first, then check for remaining { }
+  const stripped = base.replace(/\$\{\{[^}]*\}\}/g, "");
+  return stripped.includes("{") && stripped.includes("}");
+}
+
+function errMsg(base: string, svc: string, detail: string): string {
+  return `Invalid base URL "${base}" in firewall "${svc}": ${detail}`;
+}
+
+/**
+ * Validate host segments (`.`-delimited) for parameterized base URLs.
+ * Greedy params (`+`/`*`) must be the first (leftmost) host segment.
+ * At least one static segment is required for security.
+ */
+function validateHostParams(
+  segments: string[],
+  paramNames: Set<string>,
+  base: string,
+  svc: string,
+): void {
+  if (segments.length < 2) {
+    throw new Error(errMsg(base, svc, "host must have at least two segments"));
+  }
+  let hasStatic = false;
+  for (let i = 0; i < segments.length; i++) {
+    const match = PARAM_SEGMENT_PATTERN.exec(segments[i]!);
+    if (!match) {
+      hasStatic = true;
+      continue;
+    }
+    const name = match[1]!;
+    const isGreedy = name.endsWith("+") || name.endsWith("*");
+    const baseName = isGreedy ? name.slice(0, -1) : name;
+    if (!baseName) {
+      throw new Error(errMsg(base, svc, "empty parameter name in host"));
+    }
+    if (paramNames.has(baseName)) {
+      throw new Error(
+        errMsg(base, svc, `duplicate parameter name "{${baseName}}" in host`),
+      );
+    }
+    paramNames.add(baseName);
+    if (isGreedy && i !== 0) {
+      throw new Error(
+        errMsg(base, svc, `{${name}} must be the first host segment`),
+      );
+    }
+  }
+  if (!hasStatic) {
+    throw new Error(
+      errMsg(base, svc, "host must have at least one static segment"),
+    );
+  }
+}
+
+/**
+ * Validate path segments (`/`-delimited) for parameterized base URLs.
+ * Only `{param}` is allowed — greedy params are rejected.
+ */
+function validatePathParams(
+  segments: string[],
+  paramNames: Set<string>,
+  base: string,
+  svc: string,
+): void {
+  for (const seg of segments) {
+    const match = PARAM_SEGMENT_PATTERN.exec(seg);
+    if (!match) continue;
+    const name = match[1]!;
+    if (!name) {
+      throw new Error(errMsg(base, svc, "empty parameter name in path"));
+    }
+    if (name.endsWith("+") || name.endsWith("*")) {
+      throw new Error(
+        errMsg(
+          base,
+          svc,
+          `greedy parameter {${name}} is not allowed in base URL path`,
+        ),
+      );
+    }
+    if (paramNames.has(name)) {
+      throw new Error(
+        errMsg(base, svc, `duplicate parameter name "{${name}}"`),
+      );
+    }
+    paramNames.add(name);
+  }
+}
+
+/**
+ * Validate parameter segments in a firewall base URL.
+ *
+ * Host portion: `{param}`, `{param+}`, `{param*}` allowed.
+ *   - Greedy (`+`/`*`) must be in the leftmost (first) host segment.
+ *   - At least one static host segment is required for security.
+ *
+ * Path portion: only `{param}` (single-segment) allowed.
+ *   - Greedy (`+`/`*`) is rejected — it would consume the entire remaining
+ *     path, leaving nothing for permission rules to match against.
+ */
+function validateBaseUrlParams(base: string, serviceName: string): void {
+  const schemeEnd = base.indexOf("://");
+  if (schemeEnd === -1) {
+    throw new Error(errMsg(base, serviceName, "missing scheme"));
+  }
+  if (base.slice(0, schemeEnd).includes("{")) {
+    throw new Error(
+      errMsg(base, serviceName, "scheme must not contain parameters"),
+    );
+  }
+  if (base.includes("?")) {
+    throw new Error(errMsg(base, serviceName, "must not contain query string"));
+  }
+  if (base.includes("#")) {
+    throw new Error(errMsg(base, serviceName, "must not contain fragment"));
+  }
+
+  const rest = base.slice(schemeEnd + 3);
+  const slashIdx = rest.indexOf("/");
+  const host = slashIdx === -1 ? rest : rest.slice(0, slashIdx);
+  const path = slashIdx === -1 ? "" : rest.slice(slashIdx);
+
+  const paramNames = new Set<string>();
+  validateHostParams(host.split("."), paramNames, base, serviceName);
+  if (path) {
+    validatePathParams(
+      path.split("/").filter(Boolean),
+      paramNames,
+      base,
+      serviceName,
+    );
+  }
+}
+
 export function validateBaseUrl(base: string, serviceName: string): void {
   // Template base URLs are validated after variable resolution at compose time.
   if (hasBaseUrlVars(base)) return;
+
+  // Parameterized base URLs have their own validation path.
+  if (hasBaseUrlParams(base)) {
+    validateBaseUrlParams(base, serviceName);
+    return;
+  }
 
   let url: URL;
   try {

--- a/turbo/packages/core/src/contracts/firewalls.ts
+++ b/turbo/packages/core/src/contracts/firewalls.ts
@@ -196,8 +196,18 @@ function validateHostParams(
   }
   let hasStatic = false;
   for (let i = 0; i < segments.length; i++) {
-    const match = PARAM_SEGMENT_PATTERN.exec(segments[i]!);
+    const seg = segments[i]!;
+    const match = PARAM_SEGMENT_PATTERN.exec(seg);
     if (!match) {
+      if (seg.includes("{") || seg.includes("}")) {
+        throw new Error(
+          errMsg(
+            base,
+            svc,
+            `host segment "${seg}" contains "{" or "}" but is not a valid parameter (use "{name}" for the full segment)`,
+          ),
+        );
+      }
       hasStatic = true;
       continue;
     }
@@ -238,7 +248,18 @@ function validatePathParams(
 ): void {
   for (const seg of segments) {
     const match = PARAM_SEGMENT_PATTERN.exec(seg);
-    if (!match) continue;
+    if (!match) {
+      if (seg.includes("{") || seg.includes("}")) {
+        throw new Error(
+          errMsg(
+            base,
+            svc,
+            `path segment "${seg}" contains "{" or "}" but is not a valid parameter (use "{name}" for the full segment)`,
+          ),
+        );
+      }
+      continue;
+    }
     const name = match[1]!;
     if (!name) {
       throw new Error(errMsg(base, svc, "empty parameter name in path"));

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -406,6 +406,7 @@ export {
   type ExperimentalFirewalls,
   type FirewallPolicyValue,
   type FirewallPolicies,
+  hasBaseUrlParams,
   hasBaseUrlVars,
   resolveFirewallBaseUrlVars,
   validateBaseUrl,


### PR DESCRIPTION
## Summary

- Add `{param}`, `{param+}`, `{param*}` support in firewall base URL **host** portion (dot-delimited matching, greedy must be leftmost)
- Add `{param}` support in firewall base URL **path** portion (single-segment only, greedy rejected)
- Extend Python proxy `match_firewall_request()` with `match_host()`, `match_path_prefix()`, `match_base_url()` helpers
- Extend TypeScript `validateBaseUrl()` with parameterized URL validation
- Zero performance impact on existing static base URLs (fast-path `startswith` check)

Closes #7252

## Test plan

- [x] 62 TypeScript tests pass (20 new for param validation + `hasBaseUrlParams`)
- [x] 130 Python tests pass (38 new for `match_host`, `match_path_prefix`, `match_base_url`, parameterized `match_firewall_request`)
- [x] All existing tests unchanged and passing (backwards compatibility)
- [x] Lint, type-check, knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)