### PR TITLE
fix(mitm): add per-key lock to coalesce concurrent firewall header fetches

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -57,8 +57,8 @@ _registry_cache_key = (0, 0)
 # Track request start times for latency calculation
 _request_start_times = {}
 
-# Cache for firewall auth headers: (run_id, api_id) -> {"headers": dict}
-_firewall_header_cache = {}
+# Cache for firewall auth headers: (run_id, api_id) -> {"headers": dict, "expiresAt": float | None}
+_firewall_header_cache: dict[tuple[str, str], dict] = {}
 
 # Per-key locks to coalesce concurrent fetches for the same (run_id, api_id)
 _cache_locks: dict[tuple[str, str], asyncio.Lock] = {}

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -61,7 +61,7 @@ _request_start_times = {}
 _firewall_header_cache = {}
 
 # Per-key locks to coalesce concurrent fetches for the same (run_id, api_id)
-_cache_locks: dict[tuple, asyncio.Lock] = {}
+_cache_locks: dict[tuple[str, str], asyncio.Lock] = {}
 
 
 def load_registry() -> dict:

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -60,6 +60,9 @@ _request_start_times = {}
 # Cache for firewall auth headers: (run_id, api_id) -> {"headers": dict}
 _firewall_header_cache = {}
 
+# Per-key locks to coalesce concurrent fetches for the same (run_id, api_id)
+_cache_locks: dict[tuple, asyncio.Lock] = {}
+
 
 def load_registry() -> dict:
     """Load the proxy registry from file, with stat-based cache invalidation."""
@@ -79,6 +82,7 @@ def load_registry() -> dict:
         stale = [k for k in _firewall_header_cache if k[0] not in active_run_ids]
         for k in stale:
             _firewall_header_cache.pop(k, None)
+            _cache_locks.pop(k, None)
 
         _registry_cache = new_registry
         _registry_cache_key = key
@@ -481,25 +485,42 @@ async def get_firewall_headers(
 ) -> dict:
     """Get firewall auth headers with TTL-based caching.
 
+    Uses per-key locking so that concurrent requests for the same
+    (run_id, api_id) coalesce into a single HTTP fetch.
+
     Cache is evicted when:
     - The run is removed from the registry (see load_registry)
     - A 401 response is received (see response handler)
     - The expiresAt timestamp from the auth endpoint has passed
     """
     cache_key = (run_id, api_id)
+
+    # Fast path: cache hit (no lock needed — single-threaded event loop)
     cached = _firewall_header_cache.get(cache_key)
     if cached:
         expires_at = cached.get("expiresAt")
         if expires_at is None or time.time() < expires_at:
             return cached["headers"]
-        # Token expired — evict and re-fetch
 
-    result = await fetch_firewall_headers(
-        encrypted_secrets, auth_headers, sandbox_token, secret_connector_map
-    )
-    headers = result["headers"]
-    _firewall_header_cache[cache_key] = {"headers": headers, "expiresAt": result.get("expiresAt")}
-    return headers
+    # Slow path: acquire per-key lock so only one coroutine fetches
+    lock = _cache_locks.setdefault(cache_key, asyncio.Lock())
+    async with lock:
+        # Double-check: another coroutine may have populated cache while we waited
+        cached = _firewall_header_cache.get(cache_key)
+        if cached:
+            expires_at = cached.get("expiresAt")
+            if expires_at is None or time.time() < expires_at:
+                return cached["headers"]
+
+        result = await fetch_firewall_headers(
+            encrypted_secrets, auth_headers, sandbox_token, secret_connector_map
+        )
+        headers = result["headers"]
+        _firewall_header_cache[cache_key] = {
+            "headers": headers,
+            "expiresAt": result.get("expiresAt"),
+        }
+        return headers
 
 
 async def handle_firewall_request(

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -891,6 +891,7 @@ class TestMatchBaseUrl:
 class TestGetFirewallHeaders:
     def setup_method(self):
         mitm_addon._firewall_header_cache.clear()
+        mitm_addon._cache_locks.clear()
 
     async def test_cache_miss_fetches_and_caches(self):
         mock_headers = {"Authorization": "Bearer fresh-token"}
@@ -995,6 +996,7 @@ class TestGetFirewallHeaders:
 class TestHandleFirewallRequest:
     def setup_method(self):
         mitm_addon._firewall_header_cache.clear()
+        mitm_addon._cache_locks.clear()
 
     async def test_success_injects_headers_and_audit_metadata(self):
         flow = _make_http_flow()

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -1,5 +1,6 @@
 """Tests for HTTP/TLS/TCP handlers."""
 
+import asyncio
 import json
 import time
 from pathlib import Path
@@ -39,6 +40,8 @@ def _reset():
     mitm_addon._request_start_times.clear()
     mitm_addon._registry_cache = {}
     mitm_addon._registry_cache_key = (0, 0)
+    mitm_addon._firewall_header_cache.clear()
+    mitm_addon._cache_locks.clear()
 
 
 class TestRequestHandler:
@@ -656,3 +659,105 @@ class TestTcpLog:
 
         entry = json.loads(Path(log_path).read_text().strip())
         assert entry["latency_ms"] == 0
+
+
+class TestFirewallHeaderCache:
+    """Tests for get_firewall_headers caching and concurrency protection."""
+
+    def setup_method(self):
+        _reset()
+
+    async def test_concurrent_fetches_coalesce(self):
+        """Multiple concurrent get_firewall_headers calls should make only one HTTP request."""
+        fetch_count = 0
+
+        def counting_fetch(*args, **kwargs):
+            nonlocal fetch_count
+            fetch_count += 1
+            return {
+                "headers": {"Authorization": "Bearer token"},
+                "expiresAt": time.time() + 3600,
+            }
+
+        with patch.object(mitm_addon, "_fetch_firewall_headers_sync", side_effect=counting_fetch):
+            results = await asyncio.gather(
+                mitm_addon.get_firewall_headers("run-1", "api-1", "enc", {}, "tok"),
+                mitm_addon.get_firewall_headers("run-1", "api-1", "enc", {}, "tok"),
+                mitm_addon.get_firewall_headers("run-1", "api-1", "enc", {}, "tok"),
+            )
+
+        assert fetch_count == 1
+        assert all(r == {"Authorization": "Bearer token"} for r in results)
+
+    async def test_different_keys_fetch_independently(self):
+        """Different (run_id, api_id) pairs should fetch independently."""
+        fetch_count = 0
+
+        def counting_fetch(*args, **kwargs):
+            nonlocal fetch_count
+            fetch_count += 1
+            return {
+                "headers": {"Authorization": f"Bearer token-{fetch_count}"},
+                "expiresAt": time.time() + 3600,
+            }
+
+        with patch.object(mitm_addon, "_fetch_firewall_headers_sync", side_effect=counting_fetch):
+            await asyncio.gather(
+                mitm_addon.get_firewall_headers("run-1", "api-1", "enc", {}, "tok"),
+                mitm_addon.get_firewall_headers("run-1", "api-2", "enc", {}, "tok"),
+            )
+
+        assert fetch_count == 2
+
+    async def test_cache_hit_skips_fetch(self):
+        """Cached entry should be returned without fetching."""
+        mitm_addon._firewall_header_cache[("run-1", "api-1")] = {
+            "headers": {"Authorization": "Bearer cached"},
+            "expiresAt": time.time() + 3600,
+        }
+
+        with patch.object(mitm_addon, "_fetch_firewall_headers_sync") as mock_fetch:
+            result = await mitm_addon.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
+
+        mock_fetch.assert_not_called()
+        assert result == {"Authorization": "Bearer cached"}
+
+    async def test_expired_cache_triggers_fetch(self):
+        """Expired cache entry should trigger a new fetch."""
+        mitm_addon._firewall_header_cache[("run-1", "api-1")] = {
+            "headers": {"Authorization": "Bearer old"},
+            "expiresAt": time.time() - 10,
+        }
+
+        def fresh_fetch(*args, **kwargs):
+            return {
+                "headers": {"Authorization": "Bearer fresh"},
+                "expiresAt": time.time() + 3600,
+            }
+
+        with patch.object(mitm_addon, "_fetch_firewall_headers_sync", side_effect=fresh_fetch):
+            result = await mitm_addon.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
+
+        assert result == {"Authorization": "Bearer fresh"}
+
+    def test_registry_eviction_cleans_locks(self, tmp_path):
+        """When a run is evicted from registry, its locks should be cleaned up too."""
+        mitm_addon._firewall_header_cache[("run-old", "api-1")] = {
+            "headers": {},
+            "expiresAt": None,
+        }
+        mitm_addon._cache_locks[("run-old", "api-1")] = asyncio.Lock()
+
+        registry = {"vms": {"10.200.0.1": {"runId": "run-new"}}}
+        reg_path = tmp_path / "registry.json"
+        reg_path.write_text(json.dumps(registry))
+
+        with (
+            patch.object(mitm_addon, "get_registry_path", return_value=str(reg_path)),
+            patch.object(mitm_addon.ctx, "log", MagicMock(), create=True),
+        ):
+            mitm_addon._registry_cache_key = (0, 0)
+            mitm_addon.load_registry()
+
+        assert ("run-old", "api-1") not in mitm_addon._firewall_header_cache
+        assert ("run-old", "api-1") not in mitm_addon._cache_locks

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -6,6 +6,8 @@ import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 import mitm_addon
 
 
@@ -739,6 +741,18 @@ class TestFirewallHeaderCache:
             result = await mitm_addon.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
 
         assert result == {"Authorization": "Bearer fresh"}
+
+    async def test_fetch_failure_does_not_cache(self):
+        """Failed fetch should not populate cache; next caller retries independently."""
+
+        def failing_fetch(*args, **kwargs):
+            raise ConnectionError("server unreachable")
+
+        with patch.object(mitm_addon, "_fetch_firewall_headers_sync", side_effect=failing_fetch):
+            with pytest.raises(ConnectionError):
+                await mitm_addon.get_firewall_headers("run-1", "api-1", "enc", {}, "tok")
+
+        assert ("run-1", "api-1") not in mitm_addon._firewall_header_cache
 
     def test_registry_eviction_cleans_locks(self, tmp_path):
         """When a run is evicted from registry, its locks should be cleaned up too."""

--- a/crates/runner/mitm-addon/tests/test_registry.py
+++ b/crates/runner/mitm-addon/tests/test_registry.py
@@ -1,5 +1,6 @@
 """Tests for registry loading, caching, and network logging."""
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -11,6 +12,8 @@ def _reset_cache():
     """Reset the module-level registry cache between tests."""
     mitm_addon._registry_cache = {}
     mitm_addon._registry_cache_key = (0, 0)
+    mitm_addon._firewall_header_cache.clear()
+    mitm_addon._cache_locks.clear()
 
 
 class TestLoadRegistry:
@@ -59,14 +62,16 @@ class TestLoadRegistry:
         with patch.object(mitm_addon, "get_registry_path", return_value=str(registry_file)):
             mitm_addon.load_registry()  # initial load (has run-abc-123)
 
-            # Simulate cached headers for run-abc-123
+            # Simulate cached headers and locks for run-abc-123
             mitm_addon._firewall_header_cache[("run-abc-123", "api-0")] = {
                 "headers": {"Authorization": "Bearer tok"},
             }
+            mitm_addon._cache_locks[("run-abc-123", "api-0")] = asyncio.Lock()
             # Also cache for run-other (will appear in new registry)
             mitm_addon._firewall_header_cache[("run-other", "api-0")] = {
                 "headers": {"Authorization": "Bearer other"},
             }
+            mitm_addon._cache_locks[("run-other", "api-0")] = asyncio.Lock()
 
             # Update registry: remove run-abc-123, add run-other
             new_data = {"vms": {"10.200.0.99": {"runId": "run-other"}}, "updatedAt": 0}
@@ -74,10 +79,12 @@ class TestLoadRegistry:
 
             mitm_addon.load_registry()  # reload triggers eviction
 
-        # run-abc-123 cache should be evicted (no longer in registry)
+        # run-abc-123 cache and lock should be evicted (no longer in registry)
         assert ("run-abc-123", "api-0") not in mitm_addon._firewall_header_cache
-        # run-other cache should remain (still in registry)
+        assert ("run-abc-123", "api-0") not in mitm_addon._cache_locks
+        # run-other cache and lock should remain (still in registry)
         assert ("run-other", "api-0") in mitm_addon._firewall_header_cache
+        assert ("run-other", "api-0") in mitm_addon._cache_locks
 
 
 class TestGetVmInfo:


### PR DESCRIPTION
## Summary

- Add `asyncio.Lock` per `(run_id, api_id)` cache key in `get_firewall_headers()` with double-checked locking pattern
- When cache expires, concurrent requests now coalesce into a single HTTP fetch instead of N independent fetches
- Clean up lock entries alongside cache entries on registry eviction

Closes #7261

## Test plan

- [x] Concurrent fetches coalesce into single HTTP request (`test_concurrent_fetches_coalesce`)
- [x] Different cache keys fetch independently (`test_different_keys_fetch_independently`)
- [x] Cache hit skips fetch entirely (`test_cache_hit_skips_fetch`)
- [x] Expired cache triggers fresh fetch (`test_expired_cache_triggers_fetch`)
- [x] Lock cleanup on registry eviction (`test_registry_eviction_cleans_locks`)
- [x] All 100 existing tests pass
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)