### PR TITLE
docs(cli): add slack notification note to schedule setup help

### DIFF
--- a/turbo/apps/cli/src/commands/zero/schedule/setup.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/setup.ts
@@ -717,7 +717,8 @@ Examples:
 Notes:
   - Re-running setup with the same agent updates the existing "default" schedule
   - Use -n to manage multiple named schedules for the same agent
-  - All flags are required in non-interactive mode; interactive mode prompts for missing values`,
+  - All flags are required in non-interactive mode; interactive mode prompts for missing values
+  - When --notify-slack is enabled, run results are automatically posted to the Slack channel specified by --notify-slack-channel-id (or as a DM if not set). No need to include Slack delivery instructions in your prompt.`,
   )
   .action(
     withErrorHandler(async (agentIdentifier: string, options: SetupOptions) => {


### PR DESCRIPTION
## Summary
- Add a note to `zero schedule setup --help` clarifying that `--notify-slack` automatically posts run results to the specified channel (or DM), so users don't need to include Slack delivery instructions in their prompt.

## Test plan
- [x] `zero schedule setup --help` displays the new note

🤖 Generated with [Claude Code](https://claude.com/claude-code)