### PR TITLE
fix(connector): notify parent window on oauth completion via broadcast channel

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -12,7 +12,7 @@ function makeGithubConnectorResponse(): ConnectorListResponse {
   return {
     connectors: [
       {
-        id: "conn-12345",
+        id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
         type: "github",
         authMethod: "oauth",
         externalId: "12345",

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server.ts";
 import { testContext } from "../../../__tests__/test-helpers.ts";
@@ -8,26 +8,32 @@ import type { ConnectorListResponse } from "@vm0/core";
 
 const context = testContext();
 
-const GITHUB_CONNECTOR_RESPONSE: ConnectorListResponse = {
-  connectors: [
-    {
-      type: "github",
-      authMethod: "oauth",
-      externalId: "12345",
-      externalUsername: "testuser",
-      externalEmail: "test@example.com",
-      oauthScopes: ["repo", "read:user"],
-      tokenExpiresAt: null,
-      needsReconnect: false,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    },
-  ],
-  configuredTypes: ["github"],
-  connectorProvidedSecretNames: [],
-};
+function makeGithubConnectorResponse(): ConnectorListResponse {
+  return {
+    connectors: [
+      {
+        id: "conn-12345",
+        type: "github",
+        authMethod: "oauth",
+        externalId: "12345",
+        externalUsername: "testuser",
+        externalEmail: "test@example.com",
+        oauthScopes: ["repo", "read:user"],
+        needsReconnect: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ],
+    configuredTypes: ["github"],
+    connectorProvidedSecretNames: [],
+  };
+}
 
 describe("connectConnector$", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("exits polling when BroadcastChannel message arrives", async () => {
     await setupPage({ context, path: "/", withoutRender: true });
 
@@ -37,7 +43,7 @@ describe("connectConnector$", () => {
     // After BroadcastChannel notification, API returns the connected connector
     server.use(
       http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json(GITHUB_CONNECTOR_RESPONSE);
+        return HttpResponse.json(makeGithubConnectorResponse());
       }),
     );
 
@@ -54,8 +60,8 @@ describe("connectConnector$", () => {
 
     const result = await connectPromise;
 
-    expect(result).toBe(true);
-    expect(mockWindow.close).toHaveBeenCalled();
+    expect(result).toBeTruthy();
+    expect(mockWindow.close).toHaveBeenCalledWith();
 
     // Polling state should be cleared
     const polling = context.store.get(pollingConnectorType$);
@@ -70,31 +76,41 @@ describe("connectConnector$", () => {
 
     server.use(
       http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json(GITHUB_CONNECTOR_RESPONSE);
+        return HttpResponse.json(makeGithubConnectorResponse());
       }),
     );
 
     // Hide BroadcastChannel to test fallback
     const OriginalBC = globalThis.BroadcastChannel;
-    // @ts-expect-error -- intentionally removing for test
-    delete globalThis.BroadcastChannel;
+    Object.defineProperty(globalThis, "BroadcastChannel", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
 
     try {
+      vi.useFakeTimers();
+
       const connectPromise = context.store.set(
         connectConnector$,
         "github",
         context.signal,
       );
 
-      // Simulate popup closing after a tick
-      setTimeout(() => {
-        mockWindow.closed = true;
-      }, 100);
+      // Advance past the first polling interval, then simulate popup closing
+      await vi.advanceTimersByTimeAsync(500);
+      mockWindow.closed = true;
+      await vi.advanceTimersByTimeAsync(500);
 
       const result = await connectPromise;
-      expect(result).toBe(true);
+      expect(result).toBeTruthy();
     } finally {
-      globalThis.BroadcastChannel = OriginalBC;
+      vi.useRealTimers();
+      Object.defineProperty(globalThis, "BroadcastChannel", {
+        value: OriginalBC,
+        writable: true,
+        configurable: true,
+      });
     }
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -8,6 +8,14 @@ import type { ConnectorListResponse } from "@vm0/core";
 
 const context = testContext();
 
+function makeEmptyConnectorResponse(): ConnectorListResponse {
+  return {
+    connectors: [],
+    configuredTypes: [],
+    connectorProvidedSecretNames: [],
+  };
+}
+
 function makeGithubConnectorResponse(): ConnectorListResponse {
   return {
     connectors: [
@@ -34,18 +42,25 @@ describe("connectConnector$", () => {
     vi.useRealTimers();
   });
 
-  it("exits polling when BroadcastChannel message arrives", async () => {
+  it("detects connector via API polling while popup is open", async () => {
     await setupPage({ context, path: "/", withoutRender: true });
 
     const mockWindow = { closed: false, close: vi.fn() };
     vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
 
-    // After BroadcastChannel notification, API returns the connected connector
+    let pollCount = 0;
     server.use(
       http.get("*/api/zero/connectors", () => {
+        pollCount++;
+        // First poll returns empty, second returns connected
+        if (pollCount <= 1) {
+          return HttpResponse.json(makeEmptyConnectorResponse());
+        }
         return HttpResponse.json(makeGithubConnectorResponse());
       }),
     );
+
+    vi.useFakeTimers();
 
     const connectPromise = context.store.set(
       connectConnector$,
@@ -53,22 +68,21 @@ describe("connectConnector$", () => {
       context.signal,
     );
 
-    // Simulate OAuth success via BroadcastChannel
-    const channel = new BroadcastChannel("vm0:connector-oauth");
-    channel.postMessage({ connectorType: "github", status: "success" });
-    channel.close();
+    // Advance past first polling interval (2s) — connector not yet connected
+    await vi.advanceTimersByTimeAsync(2000);
+    // Advance past second polling interval — connector now connected
+    await vi.advanceTimersByTimeAsync(2000);
 
     const result = await connectPromise;
 
     expect(result).toBeTruthy();
-    expect(mockWindow.close).toHaveBeenCalledWith();
+    expect(pollCount).toBeGreaterThanOrEqual(2);
 
-    // Polling state should be cleared
     const polling = context.store.get(pollingConnectorType$);
     expect(polling).toBeNull();
   });
 
-  it("falls back to authWindow.closed when BroadcastChannel is unavailable", async () => {
+  it("exits when popup is closed even if connector not found", async () => {
     await setupPage({ context, path: "/", withoutRender: true });
 
     const mockWindow = { closed: false, close: vi.fn() };
@@ -76,41 +90,27 @@ describe("connectConnector$", () => {
 
     server.use(
       http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json(makeGithubConnectorResponse());
+        return HttpResponse.json(makeEmptyConnectorResponse());
       }),
     );
 
-    // Hide BroadcastChannel to test fallback
-    const OriginalBC = globalThis.BroadcastChannel;
-    Object.defineProperty(globalThis, "BroadcastChannel", {
-      value: undefined,
-      writable: true,
-      configurable: true,
-    });
+    vi.useFakeTimers();
 
-    try {
-      vi.useFakeTimers();
+    const connectPromise = context.store.set(
+      connectConnector$,
+      "github",
+      context.signal,
+    );
 
-      const connectPromise = context.store.set(
-        connectConnector$,
-        "github",
-        context.signal,
-      );
+    // Advance one poll interval, then close popup
+    await vi.advanceTimersByTimeAsync(2000);
+    mockWindow.closed = true;
+    await vi.advanceTimersByTimeAsync(2000);
 
-      // Advance past the first polling interval, then simulate popup closing
-      await vi.advanceTimersByTimeAsync(500);
-      mockWindow.closed = true;
-      await vi.advanceTimersByTimeAsync(500);
+    const result = await connectPromise;
+    expect(result).toBeFalsy();
 
-      const result = await connectPromise;
-      expect(result).toBeTruthy();
-    } finally {
-      vi.useRealTimers();
-      Object.defineProperty(globalThis, "BroadcastChannel", {
-        value: OriginalBC,
-        writable: true,
-        configurable: true,
-      });
-    }
+    const polling = context.store.get(pollingConnectorType$);
+    expect(polling).toBeNull();
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/connect-connector.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server.ts";
+import { testContext } from "../../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../../__tests__/page-helper.ts";
+import { connectConnector$, pollingConnectorType$ } from "../connectors.ts";
+import type { ConnectorListResponse } from "@vm0/core";
+
+const context = testContext();
+
+const GITHUB_CONNECTOR_RESPONSE: ConnectorListResponse = {
+  connectors: [
+    {
+      type: "github",
+      authMethod: "oauth",
+      externalId: "12345",
+      externalUsername: "testuser",
+      externalEmail: "test@example.com",
+      oauthScopes: ["repo", "read:user"],
+      tokenExpiresAt: null,
+      needsReconnect: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  ],
+  configuredTypes: ["github"],
+  connectorProvidedSecretNames: [],
+};
+
+describe("connectConnector$", () => {
+  it("exits polling when BroadcastChannel message arrives", async () => {
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const mockWindow = { closed: false, close: vi.fn() };
+    vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
+
+    // After BroadcastChannel notification, API returns the connected connector
+    server.use(
+      http.get("*/api/zero/connectors", () => {
+        return HttpResponse.json(GITHUB_CONNECTOR_RESPONSE);
+      }),
+    );
+
+    const connectPromise = context.store.set(
+      connectConnector$,
+      "github",
+      context.signal,
+    );
+
+    // Simulate OAuth success via BroadcastChannel
+    const channel = new BroadcastChannel("vm0:connector-oauth");
+    channel.postMessage({ connectorType: "github", status: "success" });
+    channel.close();
+
+    const result = await connectPromise;
+
+    expect(result).toBe(true);
+    expect(mockWindow.close).toHaveBeenCalled();
+
+    // Polling state should be cleared
+    const polling = context.store.get(pollingConnectorType$);
+    expect(polling).toBeNull();
+  });
+
+  it("falls back to authWindow.closed when BroadcastChannel is unavailable", async () => {
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const mockWindow = { closed: false, close: vi.fn() };
+    vi.spyOn(window, "open").mockReturnValue(mockWindow as unknown as Window);
+
+    server.use(
+      http.get("*/api/zero/connectors", () => {
+        return HttpResponse.json(GITHUB_CONNECTOR_RESPONSE);
+      }),
+    );
+
+    // Hide BroadcastChannel to test fallback
+    const OriginalBC = globalThis.BroadcastChannel;
+    // @ts-expect-error -- intentionally removing for test
+    delete globalThis.BroadcastChannel;
+
+    try {
+      const connectPromise = context.store.set(
+        connectConnector$,
+        "github",
+        context.signal,
+      );
+
+      // Simulate popup closing after a tick
+      setTimeout(() => {
+        mockWindow.closed = true;
+      }, 100);
+
+      const result = await connectPromise;
+      expect(result).toBe(true);
+    } finally {
+      globalThis.BroadcastChannel = OriginalBC;
+    }
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -300,25 +300,6 @@ export const connectConnector$ = command(
 
     set(internalPollingType$, type);
 
-    // Listen for OAuth completion via BroadcastChannel so the UI updates
-    // immediately — without waiting for the user to close the popup.
-    const channel =
-      typeof BroadcastChannel !== "undefined"
-        ? new BroadcastChannel("vm0:connector-oauth")
-        : null;
-    let channelNotified = false;
-
-    if (channel) {
-      channel.addEventListener("message", (event: MessageEvent) => {
-        if (
-          event.data?.connectorType === type &&
-          event.data?.status === "success"
-        ) {
-          channelNotified = true;
-        }
-      });
-    }
-
     const authWindow = window.open(
       `${baseUrl}/api/zero/connectors/${type}/authorize`,
       "_blank",
@@ -326,32 +307,30 @@ export const connectConnector$ = command(
     );
 
     if (!authWindow) {
-      channel?.close();
       throw new Error("Failed to open authorization window");
     }
 
-    try {
-      while (true) {
-        await delay(500, { signal });
+    // Poll the API until the connector appears or the popup is closed.
+    // The platform and OAuth callback page live on different origins
+    // (app.* vs www.*), so BroadcastChannel cannot be used.
+    let freshConnectors: ConnectorResponse[] = [];
+    while (true) {
+      await delay(2000, { signal });
 
-        if (!channelNotified && !authWindow.closed) {
-          continue;
-        }
+      set(reloadConnectors$);
+      const { connectors: polled } = await get(connectors$);
+      signal.throwIfAborted();
 
+      if (polled.some((c) => c.type === type)) {
+        freshConnectors = polled;
         break;
       }
-    } finally {
-      channel?.close();
-    }
 
-    // Auto-close popup if it's still open (notified via BroadcastChannel)
-    if (!authWindow.closed) {
-      authWindow.close();
+      if (authWindow.closed) {
+        freshConnectors = polled;
+        break;
+      }
     }
-
-    set(reloadConnectors$);
-    const { connectors: freshConnectors } = await get(connectors$);
-    signal.throwIfAborted();
 
     // Mark as optimistically connected before clearing polling so the UI
     // transitions directly from "Connecting…" to "Connected" without flash.

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -310,7 +310,10 @@ export const connectConnector$ = command(
 
     if (channel) {
       channel.addEventListener("message", (event: MessageEvent) => {
-        if (event.data?.connectorType === type) {
+        if (
+          event.data?.connectorType === type &&
+          event.data?.status === "success"
+        ) {
           channelNotified = true;
         }
       });

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -300,6 +300,22 @@ export const connectConnector$ = command(
 
     set(internalPollingType$, type);
 
+    // Listen for OAuth completion via BroadcastChannel so the UI updates
+    // immediately — without waiting for the user to close the popup.
+    const channel =
+      typeof BroadcastChannel !== "undefined"
+        ? new BroadcastChannel("vm0:connector-oauth")
+        : null;
+    let channelNotified = false;
+
+    if (channel) {
+      channel.addEventListener("message", (event: MessageEvent) => {
+        if (event.data?.connectorType === type) {
+          channelNotified = true;
+        }
+      });
+    }
+
     const authWindow = window.open(
       `${baseUrl}/api/zero/connectors/${type}/authorize`,
       "_blank",
@@ -307,36 +323,48 @@ export const connectConnector$ = command(
     );
 
     if (!authWindow) {
+      channel?.close();
       throw new Error("Failed to open authorization window");
     }
 
-    while (true) {
-      await delay(500, { signal });
+    try {
+      while (true) {
+        await delay(500, { signal });
 
-      if (!authWindow.closed) {
-        continue;
-      }
+        if (!channelNotified && !authWindow.closed) {
+          continue;
+        }
 
-      set(reloadConnectors$);
-      const { connectors: freshConnectors } = await get(connectors$);
-      signal.throwIfAborted();
-
-      // Mark as optimistically connected before clearing polling so the UI
-      // transitions directly from "Connecting…" to "Connected" without flash.
-      const isConnected = freshConnectors.some((c) => c.type === type);
-      if (isConnected) {
-        set(internalJustConnectedTypes$, (prev) => new Set([...prev, type]));
+        break;
       }
-      set(internalPollingType$, null);
-      // Show in connections list again when user connects
-      const hidden = new Set(get(hiddenConnectorTypes$));
-      hidden.delete(type);
-      set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
-      // Close connect modal on OAuth success
-      if (isConnected) {
-        set(internalSelectedConnectorType$, null);
-      }
-      return isConnected;
+    } finally {
+      channel?.close();
     }
+
+    // Auto-close popup if it's still open (notified via BroadcastChannel)
+    if (!authWindow.closed) {
+      authWindow.close();
+    }
+
+    set(reloadConnectors$);
+    const { connectors: freshConnectors } = await get(connectors$);
+    signal.throwIfAborted();
+
+    // Mark as optimistically connected before clearing polling so the UI
+    // transitions directly from "Connecting…" to "Connected" without flash.
+    const isConnected = freshConnectors.some((c) => c.type === type);
+    if (isConnected) {
+      set(internalJustConnectedTypes$, (prev) => new Set([...prev, type]));
+    }
+    set(internalPollingType$, null);
+    // Show in connections list again when user connects
+    const hidden = new Set(get(hiddenConnectorTypes$));
+    hidden.delete(type);
+    set(setHiddenConnectorTypes$, JSON.stringify([...hidden]));
+    // Close connect modal on OAuth success
+    if (isConnected) {
+      set(internalSelectedConnectorType$, null);
+    }
+    return isConnected;
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -119,4 +119,84 @@ describe("connectors page", () => {
       expect(screen.getByText(/No connectors matching/)).toBeInTheDocument();
     });
   });
+
+  it("shows loading toast then success toast on disconnect", async () => {
+    mockConnectors([{ type: "github", externalUsername: "testuser" }]);
+
+    let deleteResolve: () => void;
+    const deletePromise = new Promise<void>((r) => {
+      deleteResolve = r;
+    });
+
+    server.use(
+      http.delete("*/api/zero/connectors/:type", async () => {
+        await deletePromise;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await setupPage({ context, path: "/connectors" });
+
+    // Wait for the connected GitHub card to appear
+    await waitFor(() => {
+      expect(screen.getByText(/Connected \(/)).toBeInTheDocument();
+    });
+
+    // Radix DropdownMenu opens on pointerDown
+    const moreButton = screen.getByRole("button", { name: "More options" });
+    fireEvent.pointerDown(moreButton, { button: 0, ctrlKey: false });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("menuitem", { name: "Disconnect" }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disconnect" }));
+
+    // Loading toast should appear while API is in-flight
+    await waitFor(() => {
+      expect(screen.getByText("Disconnecting GitHub...")).toBeInTheDocument();
+    });
+
+    // Resolve the API call
+    deleteResolve!();
+
+    // Success toast should replace the loading toast
+    await waitFor(() => {
+      expect(screen.getByText("GitHub disconnected")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error toast when disconnect fails", async () => {
+    mockConnectors([{ type: "github", externalUsername: "testuser" }]);
+
+    server.use(
+      http.delete("*/api/zero/connectors/:type", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    await setupPage({ context, path: "/connectors" });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Connected \(/)).toBeInTheDocument();
+    });
+
+    // Radix DropdownMenu opens on pointerDown
+    const moreButton = screen.getByRole("button", { name: "More options" });
+    fireEvent.pointerDown(moreButton, { button: 0, ctrlKey: false });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("menuitem", { name: "Disconnect" }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Disconnect" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to disconnect GitHub"),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connectors-page.test.tsx
@@ -124,8 +124,8 @@ describe("connectors page", () => {
     mockConnectors([{ type: "github", externalUsername: "testuser" }]);
 
     let deleteResolve: () => void;
-    const deletePromise = new Promise<void>((r) => {
-      deleteResolve = r;
+    const deletePromise = new Promise<void>((resolve) => {
+      deleteResolve = resolve;
     });
 
     server.use(

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -25,7 +25,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { ScopeReviewModal } from "./components/settings/scope-review-modal.tsx";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { detach, Reason } from "../../signals/utils.ts";
+import { detach, Reason, throwIfAbort } from "../../signals/utils.ts";
 import {
   Button,
   DropdownMenu,
@@ -268,9 +268,18 @@ export function ZeroConnectorsPage() {
   };
 
   const disconnectHandler = (type: ConnectorType) => {
-    detach(disconnect(type, signal), Reason.DomCallback);
     const label = allConnectors.find((c) => c.type === type)?.label ?? type;
-    toast.success(`${label} disconnected`);
+    const toastId = toast.loading(`Disconnecting ${label}...`);
+    detach(
+      disconnect(type, signal).then(
+        () => toast.success(`${label} disconnected`, { id: toastId }),
+        (error: unknown) => {
+          throwIfAbort(error);
+          toast.error(`Failed to disconnect ${label}`, { id: toastId });
+        },
+      ),
+      Reason.DomCallback,
+    );
   };
 
   const getEffective = (c: ConnectorTypeWithStatus) =>

--- a/turbo/apps/web/app/connector/[status]/page.tsx
+++ b/turbo/apps/web/app/connector/[status]/page.tsx
@@ -33,10 +33,10 @@ export default function ConnectorStatusPage({
       status: isSuccess ? "success" : "error",
     });
     channel.close();
-    // Small delay to ensure the parent window receives the BroadcastChannel
-    // message before the popup closes. Message delivery is asynchronous and
-    // calling window.close() immediately could prevent delivery.
-    const timer = setTimeout(() => window.close(), 300);
+    // Yield to the event loop so the parent window's BroadcastChannel listener
+    // processes the message before the popup closes. postMessage dispatches
+    // asynchronously, so a single macrotask yield is sufficient.
+    const timer = setTimeout(() => window.close(), 0);
     return () => clearTimeout(timer);
   }, [connectorType, isSuccess]);
   const connectorLabel =

--- a/turbo/apps/web/app/connector/[status]/page.tsx
+++ b/turbo/apps/web/app/connector/[status]/page.tsx
@@ -4,7 +4,7 @@ import { useTheme } from "../../components/ThemeProvider";
 import Image from "next/image";
 import { IconCheck, IconX } from "@tabler/icons-react";
 import { useSearchParams } from "next/navigation";
-import { use } from "react";
+import { use, useEffect } from "react";
 
 interface PageProps {
   params: Promise<{ status: string }>;
@@ -22,6 +22,19 @@ export default function ConnectorStatusPage({
   const errorMessage = searchParams.get("message");
 
   const isSuccess = status === "success";
+
+  useEffect(() => {
+    if (typeof BroadcastChannel === "undefined") {
+      return;
+    }
+    const channel = new BroadcastChannel("vm0:connector-oauth");
+    channel.postMessage({
+      connectorType,
+      status: isSuccess ? "success" : "error",
+    });
+    channel.close();
+    window.close();
+  }, [connectorType, isSuccess]);
   const connectorLabel =
     connectorType === "github" ? "GitHub" : connectorType.toUpperCase();
 

--- a/turbo/apps/web/app/connector/[status]/page.tsx
+++ b/turbo/apps/web/app/connector/[status]/page.tsx
@@ -33,7 +33,11 @@ export default function ConnectorStatusPage({
       status: isSuccess ? "success" : "error",
     });
     channel.close();
-    window.close();
+    // Small delay to ensure the parent window receives the BroadcastChannel
+    // message before the popup closes. Message delivery is asynchronous and
+    // calling window.close() immediately could prevent delivery.
+    const timer = setTimeout(() => window.close(), 300);
+    return () => clearTimeout(timer);
   }, [connectorType, isSuccess]);
   const connectorLabel =
     connectorType === "github" ? "GitHub" : connectorType.toUpperCase();

--- a/turbo/apps/web/app/connector/[status]/page.tsx
+++ b/turbo/apps/web/app/connector/[status]/page.tsx
@@ -4,7 +4,7 @@ import { useTheme } from "../../components/ThemeProvider";
 import Image from "next/image";
 import { IconCheck, IconX } from "@tabler/icons-react";
 import { useSearchParams } from "next/navigation";
-import { use, useEffect } from "react";
+import { use } from "react";
 
 interface PageProps {
   params: Promise<{ status: string }>;
@@ -22,23 +22,6 @@ export default function ConnectorStatusPage({
   const errorMessage = searchParams.get("message");
 
   const isSuccess = status === "success";
-
-  useEffect(() => {
-    if (typeof BroadcastChannel === "undefined") {
-      return;
-    }
-    const channel = new BroadcastChannel("vm0:connector-oauth");
-    channel.postMessage({
-      connectorType,
-      status: isSuccess ? "success" : "error",
-    });
-    channel.close();
-    // Yield to the event loop so the parent window's BroadcastChannel listener
-    // processes the message before the popup closes. postMessage dispatches
-    // asynchronously, so a single macrotask yield is sufficient.
-    const timer = setTimeout(() => window.close(), 0);
-    return () => clearTimeout(timer);
-  }, [connectorType, isSuccess]);
   const connectorLabel =
     connectorType === "github" ? "GitHub" : connectorType.toUpperCase();
 


### PR DESCRIPTION
## Summary

- **Replace BroadcastChannel with API polling**: platform (`app.*`) and OAuth callback page (`www.*`) are on different origins, so BroadcastChannel cannot work cross-origin. Now polls the connectors API every 2s while the popup is open to detect completion.
- **Disconnect loading toast**: show a loading toast immediately on disconnect click, then replace with success/error toast after the API responds (instead of showing success before the API call completes).
- Existing `authWindow.closed` fallback preserved — if the user closes the popup manually, polling exits and checks one final time.

## Test plan

- [x] Integration test: API polling detects connector and exits loop
- [x] Integration test: exits when popup is closed even if connector not found
- [x] Integration test: disconnect shows loading then success toast
- [x] Integration test: disconnect shows error toast on failure
- [x] All platform tests pass
- [ ] Manual: connect a connector via OAuth, verify UI updates while popup is still open
- [ ] Manual: disconnect a connector, verify loading → success toast transition

Closes #7220

🤖 Generated with [Claude Code](https://claude.com/claude-code)