### PR TITLE
fix(platform): dismiss loading toast when schedule run is aborted

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -543,6 +543,7 @@ export const deleteOrgSchedule$ = command(
 export const runScheduleNow$ = command(
   async ({ get }, scheduleId: string, signal: AbortSignal): Promise<string> => {
     const toastId = toast.loading("Starting run…");
+    signal.addEventListener("abort", () => toast.dismiss(toastId));
     const client = get(zeroClient$)(zeroScheduleRunContract);
     const result = await client.run({ body: { scheduleId } });
     signal.throwIfAborted();


### PR DESCRIPTION
## Summary
- Dismiss the "Starting run…" loading toast when the `runScheduleNow$` command is aborted via its abort signal, preventing stale toasts from lingering in the UI.

## Test plan
- [ ] Trigger a schedule run and abort it before completion — verify the loading toast is dismissed
- [ ] Trigger a schedule run and let it complete normally — verify toast behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)