### PR TITLE
fix(platform): prevent avatar flicker on page load

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-sending-state.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-sending-state.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor, act } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import { delay } from "signal-timers";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import {
@@ -126,9 +127,12 @@ describe("chat sending state", () => {
     );
 
     // Type a new message and press Enter while still sending
-    act(() => {
-      sendMessageInUI(activeTextarea, "Second message");
-    });
+    sendMessageInUI(activeTextarea, "Second message");
+
+    // Give any potential second request time to fire.
+    // NOTE: intentionally not wrapped in act() — background polling loops with
+    // 0ms interval cause act() to hang indefinitely waiting for them to settle.
+    await delay(100);
 
     // The sending state is still active (Stop button visible), so the run
     // creation endpoint should have been called only once — no artificial

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -34,7 +34,6 @@ import { getRandomPrompts } from "./zero-ideation-page.tsx";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { Link } from "../router/link.tsx";
-import zeroAvatarImg from "./assets/avatar_0.png";
 
 function getTagline(
   agentName: string,
@@ -143,7 +142,7 @@ interface ZeroChatPageProps {
     message: string,
     options?: { modelProvider?: string },
   ) => void;
-  zeroAvatarSrc?: string;
+  zeroAvatarSrc?: string | null;
   /** Override agent name when chatting with a sub-agent. */
   chatAgentName?: string;
   /** Agent ID used to build the avatar link to the team detail page. */
@@ -153,7 +152,7 @@ interface ZeroChatPageProps {
 export function ZeroChatPage({
   onNavigateToMeet,
   onSendMessage,
-  zeroAvatarSrc = zeroAvatarImg,
+  zeroAvatarSrc,
   chatAgentName,
   avatarAgentId,
 }: ZeroChatPageProps) {
@@ -244,12 +243,19 @@ export function ZeroChatPage({
                         aria-label="View agent profile"
                         className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent cursor-pointer"
                       >
-                        <img
-                          src={zeroAvatarSrc}
-                          alt=""
-                          role="presentation"
-                          className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
-                        />
+                        {zeroAvatarSrc ? (
+                          <img
+                            src={zeroAvatarSrc}
+                            alt=""
+                            role="presentation"
+                            className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
+                          />
+                        ) : (
+                          <div
+                            className="h-14 w-14 rounded-full bg-muted sm:h-16 sm:w-16"
+                            aria-hidden
+                          />
+                        )}
                       </Link>
                     </TooltipTrigger>
                     <TooltipContent side="bottom">
@@ -259,12 +265,19 @@ export function ZeroChatPage({
                 </TooltipProvider>
               ) : (
                 <div className="h-14 w-14 shrink-0 sm:h-16 sm:w-16 flex items-center justify-center overflow-hidden rounded-xl">
-                  <img
-                    src={zeroAvatarSrc}
-                    alt=""
-                    role="presentation"
-                    className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
-                  />
+                  {zeroAvatarSrc ? (
+                    <img
+                      src={zeroAvatarSrc}
+                      alt=""
+                      role="presentation"
+                      className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
+                    />
+                  ) : (
+                    <div
+                      className="h-14 w-14 rounded-full bg-muted sm:h-16 sm:w-16"
+                      aria-hidden
+                    />
+                  )}
                 </div>
               )}
               {showPinPill && (

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -450,11 +450,18 @@ export function ZeroJobDetailPage({ agentId }: ZeroJobDetailPageProps) {
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-6 pb-3">
         <div className="mx-auto max-w-[900px]">
           <div className="flex items-center gap-4">
-            <img
-              src={currentAvatar}
-              alt={displayName}
-              className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
-            />
+            {currentAvatar ? (
+              <img
+                src={currentAvatar}
+                alt={displayName}
+                className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
+              />
+            ) : (
+              <div
+                className="h-14 w-14 shrink-0 rounded-full bg-muted sm:h-16 sm:w-16"
+                aria-hidden
+              />
+            )}
             <div className="min-w-0">
               <h1 className="text-xl font-semibold tracking-tight text-foreground">
                 {displayName}

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -114,11 +114,18 @@ export function ZeroJobsPage() {
             >
               <Card className="zero-card cursor-pointer hover:bg-muted/30 transition-colors">
                 <CardContent className="p-5 flex items-center gap-4">
-                  <img
-                    src={zeroAvatarSrc}
-                    alt={displayName}
-                    className="h-12 w-12 shrink-0 rounded-full object-cover object-top"
-                  />
+                  {zeroAvatarSrc ? (
+                    <img
+                      src={zeroAvatarSrc}
+                      alt={displayName}
+                      className="h-12 w-12 shrink-0 rounded-full object-cover object-top"
+                    />
+                  ) : (
+                    <div
+                      className="h-12 w-12 shrink-0 rounded-full bg-muted"
+                      aria-hidden
+                    />
+                  )}
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
                       <h2 className="text-base font-semibold tracking-tight text-foreground truncate">
@@ -144,11 +151,18 @@ export function ZeroJobsPage() {
           ) : (
             <Card className="zero-card">
               <CardContent className="p-5 flex items-center gap-4">
-                <img
-                  src={zeroAvatarSrc}
-                  alt={displayName}
-                  className="h-12 w-12 shrink-0 rounded-full object-cover object-top"
-                />
+                {zeroAvatarSrc ? (
+                  <img
+                    src={zeroAvatarSrc}
+                    alt={displayName}
+                    className="h-12 w-12 shrink-0 rounded-full object-cover object-top"
+                  />
+                ) : (
+                  <div
+                    className="h-12 w-12 shrink-0 rounded-full bg-muted"
+                    aria-hidden
+                  />
+                )}
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <h2 className="text-base font-semibold tracking-tight text-foreground truncate">
@@ -459,11 +473,18 @@ function AgentCard({
           Workspace
         </span>
         <div className="flex items-center gap-2.5">
-          <img
-            src={avatarSrc}
-            alt={displayName}
-            className="h-10 w-10 shrink-0 rounded-full object-cover object-top"
-          />
+          {avatarSrc ? (
+            <img
+              src={avatarSrc}
+              alt={displayName}
+              className="h-10 w-10 shrink-0 rounded-full object-cover object-top"
+            />
+          ) : (
+            <div
+              className="h-10 w-10 shrink-0 rounded-full bg-muted"
+              aria-hidden
+            />
+          )}
           <h2 className="text-base font-semibold tracking-tight text-foreground truncate">
             {displayName}
           </h2>

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -313,7 +313,7 @@ function WhereToWorkContent({
   error,
 }: {
   name: string;
-  zeroAvatarSrc: string;
+  zeroAvatarSrc: string | null;
   onAddToSlack: () => void;
   onContinueWeb: () => void;
   saving: boolean;
@@ -361,12 +361,16 @@ function WhereToWorkContent({
           className="flex items-center gap-4 rounded-xl bg-card px-6 py-6 text-left transition-colors hover:bg-muted/30 disabled:opacity-50 zero-border"
         >
           <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg overflow-hidden">
-            <img
-              src={zeroAvatarSrc}
-              alt=""
-              role="presentation"
-              className="h-10 w-10 rounded-lg object-cover object-top"
-            />
+            {zeroAvatarSrc ? (
+              <img
+                src={zeroAvatarSrc}
+                alt=""
+                role="presentation"
+                className="h-10 w-10 rounded-lg object-cover object-top"
+              />
+            ) : (
+              <div className="h-10 w-10 rounded-lg bg-muted" aria-hidden />
+            )}
           </span>
           <div className="min-w-0 flex-1">
             <span className="block text-sm font-semibold text-foreground">
@@ -634,7 +638,7 @@ function OnboardingPage({
   showBack: boolean;
   showNext: boolean;
   nextDisabled?: boolean;
-  zeroAvatarSrc?: string;
+  zeroAvatarSrc?: string | null;
   selectedConnectors?: string[];
   children: React.ReactNode;
 }) {
@@ -802,7 +806,7 @@ function WorkspaceStep({
   zeroAvatarSrc,
   onNext,
 }: {
-  zeroAvatarSrc: string;
+  zeroAvatarSrc: string | null;
   onNext: () => void;
 }) {
   const workspaceName = useGet(zeroWorkspaceName$);
@@ -994,7 +998,7 @@ export function ZeroOnboarding({
   isAdmin,
   displayName = "Zero",
 }: {
-  zeroAvatarSrc?: string;
+  zeroAvatarSrc?: string | null;
   isAdmin: boolean;
   displayName?: string;
 }) {

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -64,14 +64,27 @@ import {
   copiedMessageIdValue$,
   copyMessageContent$,
 } from "../../signals/zero-page/zero-session-chat-ui.ts";
-import zeroAvatarImg from "./assets/avatar_0.png";
+function AvatarOrPlaceholder({
+  src,
+  className,
+  placeholderClassName,
+}: {
+  src: string | null | undefined;
+  className: string;
+  placeholderClassName?: string;
+}) {
+  if (src) {
+    return <img src={src} alt="" role="presentation" className={className} />;
+  }
+  return <div className={placeholderClassName ?? className} aria-hidden />;
+}
 
 // ---------------------------------------------------------------------------
 // ZeroSessionChatPage — real conversation backed by agent runs
 // ---------------------------------------------------------------------------
 
 interface ZeroSessionChatPageProps {
-  zeroAvatarSrc?: string;
+  zeroAvatarSrc?: string | null;
   onNavigateToSchedule?: () => void;
   /** Agent ID used to build the avatar link to the team detail page. */
   avatarAgentId?: string;
@@ -79,7 +92,7 @@ interface ZeroSessionChatPageProps {
 }
 
 export function ZeroSessionChatPage({
-  zeroAvatarSrc = zeroAvatarImg,
+  zeroAvatarSrc,
   onNavigateToSchedule,
   avatarAgentId,
   chatAgentName,
@@ -153,11 +166,10 @@ export function ZeroSessionChatPage({
                       className="h-8 w-8 shrink-0 overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       aria-label="View agent profile"
                     >
-                      <img
+                      <AvatarOrPlaceholder
                         src={zeroAvatarSrc}
-                        alt=""
-                        role="presentation"
                         className="h-8 w-8 rounded-full object-cover object-top"
+                        placeholderClassName="h-8 w-8 rounded-full bg-muted"
                       />
                     </Link>
                   </TooltipTrigger>
@@ -168,11 +180,10 @@ export function ZeroSessionChatPage({
               </TooltipProvider>
             ) : (
               <div className="h-8 w-8 shrink-0 overflow-hidden rounded-xl">
-                <img
+                <AvatarOrPlaceholder
                   src={zeroAvatarSrc}
-                  alt=""
-                  role="presentation"
                   className="h-8 w-8 rounded-full object-cover object-top"
+                  placeholderClassName="h-8 w-8 rounded-full bg-muted"
                 />
               </div>
             )}
@@ -332,7 +343,7 @@ function ChatSkeleton() {
 
 interface ChatMessageRowProps {
   message: ZeroChatMessage;
-  zeroAvatarSrc: string;
+  zeroAvatarSrc: string | null | undefined;
 }
 
 function ChatMessageRow({ message, zeroAvatarSrc }: ChatMessageRowProps) {
@@ -644,7 +655,7 @@ function CollapsibleTimeline({
 
 interface AssistantMessageProps {
   message: AssistantChatMessage;
-  zeroAvatarSrc: string;
+  zeroAvatarSrc: string | null | undefined;
 }
 
 function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
@@ -726,11 +737,10 @@ function StaticAssistantMessage({
   const content = useLastResolved(message.result$) ?? "";
   const avatar = (
     <div className="h-9 w-9 shrink-0 mt-0.5 overflow-hidden rounded-xl">
-      <img
+      <AvatarOrPlaceholder
         src={zeroAvatarSrc}
-        alt=""
-        role="presentation"
         className="h-7 w-7 sm:h-9 sm:w-9 rounded-full object-cover object-top"
+        placeholderClassName="h-7 w-7 sm:h-9 sm:w-9 rounded-full bg-muted"
       />
     </div>
   );

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -126,7 +126,7 @@ export function ManagePinnedAgentsDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   saving?: boolean;
-  zeroAvatarSrc: string;
+  zeroAvatarSrc: string | null;
   displayName: string;
   subagents: SubagentInfo[];
   onPinnedIdsChange: (ids: string[]) => void;
@@ -198,11 +198,18 @@ export function ManagePinnedAgentsDialog({
 
         <div className="px-5 pb-1">
           <div className="flex items-center gap-2 px-1 py-2.5 rounded-lg">
-            <img
-              src={zeroAvatarSrc}
-              alt={displayName}
-              className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
-            />
+            {zeroAvatarSrc ? (
+              <img
+                src={zeroAvatarSrc}
+                alt={displayName}
+                className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+              />
+            ) : (
+              <div
+                className="h-8 w-8 shrink-0 rounded-lg bg-muted"
+                aria-hidden
+              />
+            )}
             <span className="text-sm font-medium text-foreground flex-1 truncate">
               {displayName}
             </span>
@@ -325,7 +332,7 @@ export function ChatListDialog({
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  zeroAvatarSrc: string;
+  zeroAvatarSrc: string | null;
   displayName: string;
   subagents: SubagentInfo[];
   pinnedIds: string[];
@@ -445,11 +452,18 @@ export function ChatListDialog({
                 onClick={() => handleChat(null)}
                 className="flex w-full items-center gap-2 px-1 py-2 rounded-lg hover:bg-accent transition-colors"
               >
-                <img
-                  src={zeroAvatarSrc}
-                  alt={displayName}
-                  className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
-                />
+                {zeroAvatarSrc ? (
+                  <img
+                    src={zeroAvatarSrc}
+                    alt={displayName}
+                    className="h-8 w-8 shrink-0 rounded-lg object-cover object-top"
+                  />
+                ) : (
+                  <div
+                    className="h-8 w-8 shrink-0 rounded-lg bg-muted"
+                    aria-hidden
+                  />
+                )}
                 <div className="flex-1 min-w-0 text-left">
                   <span className="text-sm font-medium text-foreground truncate block">
                     {displayName}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-shared.tsx
@@ -10,11 +10,11 @@ import avatar1Img from "./assets/avatar_1.png";
  * Falls back to the first preset avatar when nothing is persisted.
  */
 export function useAgentAvatar(id: string): string | null {
-  const agents = useLastResolved(agents$) ?? [];
-  if (!id) {
+  const resolved = useLastResolved(agents$);
+  if (!id || resolved === undefined) {
     return null;
   }
-  const agent = agents.find((a) => a.id === id);
+  const agent = resolved.find((a) => a.id === id);
   const dbAvatar = resolveAvatarUrl(agent?.avatarUrl);
   return dbAvatar ?? avatar1Img;
 }
@@ -31,7 +31,7 @@ export function AgentAvatarImg({
 }) {
   const src = useAgentAvatar(name);
   if (!src) {
-    return <div className={className} aria-hidden />;
+    return <div className={`${className} bg-muted`} aria-hidden />;
   }
   return <img src={src} alt={alt} className={className} />;
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-shared.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-shared.tsx
@@ -5,10 +5,15 @@ import avatar1Img from "./assets/avatar_1.png";
 
 /**
  * Reactive hook that returns the agent avatar from the DB.
+ * Returns `null` while the agent id is unknown (still loading) to avoid
+ * flashing an incorrect fallback avatar before the real one resolves.
  * Falls back to the first preset avatar when nothing is persisted.
  */
-export function useAgentAvatar(id: string): string {
+export function useAgentAvatar(id: string): string | null {
   const agents = useLastResolved(agents$) ?? [];
+  if (!id) {
+    return null;
+  }
   const agent = agents.find((a) => a.id === id);
   const dbAvatar = resolveAvatarUrl(agent?.avatarUrl);
   return dbAvatar ?? avatar1Img;
@@ -25,6 +30,9 @@ export function AgentAvatarImg({
   className: string;
 }) {
   const src = useAgentAvatar(name);
+  if (!src) {
+    return <div className={className} aria-hidden />;
+  }
   return <img src={src} alt={alt} className={className} />;
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -659,7 +659,7 @@ function TalkToSection({
   selectedAgentIdFromChat: string | null | undefined;
   displayName: string;
   defaultAgentRawName?: string | null;
-  zeroAvatarSrc: string;
+  zeroAvatarSrc: string | null;
   pinnedAgents: SubagentInfo[];
   pinnedIds: string[];
   subagents: SubagentInfo[];
@@ -735,11 +735,18 @@ function TalkToSection({
                       : "text-sidebar-foreground hover:bg-sidebar-accent"
                 }`}
               >
-                <img
-                  src={zeroAvatarSrc}
-                  alt={displayName}
-                  className="h-5 w-5 shrink-0 rounded-md object-cover object-top"
-                />
+                {zeroAvatarSrc ? (
+                  <img
+                    src={zeroAvatarSrc}
+                    alt={displayName}
+                    className="h-5 w-5 shrink-0 rounded-md object-cover object-top"
+                  />
+                ) : (
+                  <div
+                    className="h-5 w-5 shrink-0 rounded-md bg-muted"
+                    aria-hidden
+                  />
+                )}
                 <span className="truncate">{displayName}</span>
               </Link>
             );


### PR DESCRIPTION
## Summary

- **Root cause**: `useAgentAvatar("")` returned `avatar_1.png` (blue fur) as a fallback while the agent ID was still loading, then switched to the correct avatar once data resolved — causing a visible blue→yellow flicker.
- **Fix**: `useAgentAvatar` now returns `null` when the agent ID is empty (still loading). All avatar `<img>` elements across the platform show a neutral `bg-muted` placeholder until the correct avatar resolves.
- Extracted `AvatarOrPlaceholder` helper in the chat page to keep function complexity within lint limits.

Closes #7212

## Test plan

- [ ] Open the Zero chat page and verify the avatar appears without a blue→yellow color flash
- [ ] Verify avatars render correctly once loaded across: chat page, sidebar, team page, job detail page, onboarding
- [ ] Verify custom uploaded avatars still display correctly
- [ ] Verify the loading skeleton displays briefly (neutral gray circle) before the correct avatar appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)