### PR TITLE
fix(web): clarify agent traffic scope in pricing page copy

### DIFF
--- a/turbo/apps/web/app/[locale]/pricing/page.tsx
+++ b/turbo/apps/web/app/[locale]/pricing/page.tsx
@@ -468,7 +468,7 @@ export default function PricingPage() {
                   />
                   <TableRow
                     feature="Full audit trail"
-                    description="HTTP/HTTPS logs with SHA-256 integrity per run"
+                    description="Agent HTTP/HTTPS traffic logged with SHA-256 integrity per run"
                     free={true}
                     pro={true}
                     team={true}
@@ -573,7 +573,7 @@ export default function PricingPage() {
               />
               <FAQItem
                 question="How secure is VM0?"
-                answer="Every agent run executes in an isolated Firecracker microVM with hardware-level KVM isolation. Credentials are injected at the network layer and never exposed to agent code. All HTTP/HTTPS traffic is logged with SHA-256 integrity."
+                answer="Every agent run executes in an isolated Firecracker microVM with hardware-level KVM isolation. Credentials are injected at the network layer and never exposed to agent code. All agent HTTP/HTTPS traffic is logged with SHA-256 integrity per run."
               />
               <FAQItem
                 question="Do you offer annual billing or discounts?"


### PR DESCRIPTION
## Summary
- Add `agent` qualifier to two HTTP/HTTPS log references on the pricing page
- Feature comparison table: `"HTTP/HTTPS logs with SHA-256 integrity per run"` → `"Agent HTTP/HTTPS traffic logged with SHA-256 integrity per run"`
- Security FAQ answer: `"All HTTP/HTTPS traffic is logged with SHA-256 integrity."` → `"All agent HTTP/HTTPS traffic is logged with SHA-256 integrity per run."`

## Problem
Without the `agent` qualifier, users visiting `/en/pricing` may misread the audit trail description as monitoring of their own browser traffic, reducing trust and conversion.

## Test plan
- [ ] Visit `/en/pricing` and verify the feature comparison table row reads "Agent HTTP/HTTPS traffic logged with SHA-256 integrity per run"
- [ ] Expand "How secure is VM0?" FAQ and verify updated wording
- [ ] Confirm lint and type checks pass (pre-existing `.next/dev/types` TS errors are unrelated to this change)

Closes #6886

🤖 Generated with [Claude Code](https://claude.com/claude-code)