### PR TITLE
fix(firewalls): read current token from db for skipped connectors in auth endpoint

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -334,7 +334,10 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     it("should skip refresh for valid token and return its expiresAt", async () => {
       // Token valid for another 30 minutes — well outside the 60s buffer
       const validExpiry = new Date(Date.now() + 30 * 60 * 1000);
-      await setupNotionConnector({ tokenExpiresAt: validExpiry });
+      await setupNotionConnector({
+        tokenExpiresAt: validExpiry,
+        accessToken: "valid-notion-token",
+      });
 
       const encrypted = encryptTestSecrets({
         NOTION_ACCESS_TOKEN: "valid-notion-token",
@@ -365,7 +368,10 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
 
     it("should return null expiresAt for non-expiring token", async () => {
       // tokenExpiresAt = null means non-expiring
-      await setupNotionConnector({ tokenExpiresAt: null });
+      await setupNotionConnector({
+        tokenExpiresAt: null,
+        accessToken: "permanent-notion-token",
+      });
 
       const encrypted = encryptTestSecrets({
         NOTION_ACCESS_TOKEN: "permanent-notion-token",
@@ -613,6 +619,115 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       const data = await response.json();
       expect(data.error.code).toBe("TOKEN_REFRESH_FAILED");
       expect(data.error.connectors).toEqual(["close"]);
+    });
+
+    it("should use current DB token when another request already refreshed", async () => {
+      // Simulate race condition: token was recently refreshed by another request.
+      // DB has fresh expiry (30 min) and fresh token in secrets table,
+      // but encryptedSecrets still has the stale build-time token.
+      const validExpiry = new Date(Date.now() + 30 * 60 * 1000);
+      await setupNotionConnector({
+        tokenExpiresAt: validExpiry,
+        accessToken: "fresh-db-token",
+      });
+
+      // encryptedSecrets has the STALE build-time token
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "stale-build-time-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      // Must use the fresh DB token, NOT the stale encryptedSecrets token
+      expect(data.headers.Authorization).toBe("Bearer fresh-db-token");
+      expect(data.expiresAt).toBeTypeOf("number");
+    });
+
+    it("should sync skipped connector tokens when only some need refresh", async () => {
+      const expiredAt = new Date(Date.now() - 60 * 1000);
+
+      // Notion: expired, will be refreshed via provider
+      await setupNotionConnector({ tokenExpiresAt: expiredAt });
+
+      // GitHub: valid (recently refreshed by another request), DB has fresh token
+      vi.stubEnv("GITHUB_OAUTH_CLIENT_ID", "test-github-client-id");
+      vi.stubEnv("GITHUB_OAUTH_CLIENT_SECRET", "test-github-client-secret");
+      const { reloadEnv } = await import("../../../../../../../src/env");
+      reloadEnv();
+
+      await context.createConnector(user.orgId, {
+        userId: user.userId,
+        type: "github",
+        authMethod: "oauth",
+        tokenExpiresAt: new Date(Date.now() + 30 * 60 * 1000),
+      });
+      await insertTestConnectorSecret(
+        user.orgId,
+        user.userId,
+        "GITHUB_ACCESS_TOKEN",
+        "fresh-github-token",
+      );
+      await insertTestConnectorSecret(
+        user.orgId,
+        user.userId,
+        "GITHUB_REFRESH_TOKEN",
+        "github-refresh-token",
+      );
+
+      // MSW for Notion refresh
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, () =>
+          HttpResponse.json({
+            access_token: "fresh-notion-token",
+            expires_in: 3600,
+          }),
+        ),
+      );
+
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "stale-notion-token",
+        NOTION_REFRESH_TOKEN: "notion-refresh-token",
+        GITHUB_ACCESS_TOKEN: "stale-github-token",
+        GITHUB_REFRESH_TOKEN: "github-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              "X-Notion": "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
+              "X-Github": "token ${{ secrets.GITHUB_ACCESS_TOKEN }}",
+            },
+            secretConnectorMap: {
+              NOTION_ACCESS_TOKEN: "notion",
+              GITHUB_ACCESS_TOKEN: "github",
+            },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      // Notion: refreshed via provider
+      expect(data.headers["X-Notion"]).toBe("Bearer fresh-notion-token");
+      // GitHub: synced from DB (not refreshed, but DB has fresh token)
+      expect(data.headers["X-Github"]).toBe("token fresh-github-token");
     });
   });
 });

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -114,7 +114,8 @@ async function refreshExpiredTokens(
   // read the current token from the secrets store. This fixes a race condition
   // where another concurrent request just refreshed the token — the DB expiry
   // looks fresh but encryptedSecrets still has the stale build-time value.
-  const skippedTypes = connectorTypes.filter((ct) => !toRefresh.includes(ct));
+  const toRefreshSet = new Set(toRefresh);
+  const skippedTypes = connectorTypes.filter((ct) => !toRefreshSet.has(ct));
   if (skippedTypes.length > 0) {
     const currentTokens = await Promise.all(
       skippedTypes.map(async (ct) => ({
@@ -123,7 +124,12 @@ async function refreshExpiredTokens(
       })),
     );
     for (const { connectorType, token } of currentTokens) {
-      if (!token) continue;
+      if (!token) {
+        log.warn(
+          `[${auth.runId}] No DB token for skipped connector ${connectorType}, using encryptedSecrets value`,
+        );
+        continue;
+      }
       for (const envVar of envVarsByConnector.get(connectorType) ?? []) {
         secrets[envVar] = token;
       }

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -10,6 +10,7 @@ import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import {
   refreshConnectorAccessToken,
   getConnectorExpiry,
+  getConnectorAccessToken,
 } from "../../../../../../src/lib/connector/connector-service";
 
 const bodySchema = z.object({
@@ -109,6 +110,26 @@ async function refreshExpiredTokens(
       return { connectorType, ok: true as const };
     }),
   );
+  // For connector types we did NOT refresh (DB says token is still valid),
+  // read the current token from the secrets store. This fixes a race condition
+  // where another concurrent request just refreshed the token — the DB expiry
+  // looks fresh but encryptedSecrets still has the stale build-time value.
+  const skippedTypes = connectorTypes.filter((ct) => !toRefresh.includes(ct));
+  if (skippedTypes.length > 0) {
+    const currentTokens = await Promise.all(
+      skippedTypes.map(async (ct) => ({
+        connectorType: ct,
+        token: await getConnectorAccessToken(ct, run.orgId, auth.userId),
+      })),
+    );
+    for (const { connectorType, token } of currentTokens) {
+      if (!token) continue;
+      for (const envVar of envVarsByConnector.get(connectorType) ?? []) {
+        secrets[envVar] = token;
+      }
+    }
+  }
+
   const refreshed = refreshResults.some((r) => r.ok);
   const failedConnectors = refreshResults
     .filter((r) => !r.ok)

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -644,6 +644,21 @@ export async function getConnectorExpiry(
 }
 
 /**
+ * Read the current access token for a connector type from the secrets store.
+ * Does NOT trigger a refresh — returns the latest persisted value.
+ */
+export async function getConnectorAccessToken(
+  connectorType: string,
+  orgId: string,
+  userId: string,
+): Promise<string | null> {
+  const handler =
+    PROVIDER_HANDLERS[connectorType as keyof typeof PROVIDER_HANDLERS];
+  if (!handler) return null;
+  return getSecretValue(orgId, userId, handler.getSecretName(), "connector");
+}
+
+/**
  * Create or update a connector secret (e.g., refresh token)
  */
 async function upsertConnectorSecret(


### PR DESCRIPTION
## Summary

- Fix P0 race condition where concurrent firewall auth requests return stale access tokens
- When Request A refreshes an expired token and updates DB, Request B sees fresh `tokenExpiresAt` but still uses the old token from `encryptedSecrets` (frozen at compose time)
- For connector types not refreshed (DB says valid), now read the current token from the `secrets` table to ensure `resolveTemplates` always uses the latest value

## Changes

- **`connector-service.ts`**: Add `getConnectorAccessToken()` — reads current access token from DB via handler's `getSecretName()` without triggering refresh
- **`route.ts`**: After refresh block, sync skipped connector types from DB into `secrets` map
- **`route.test.ts`**: Add 2 regression tests (full-skip race condition + partial-skip mixed scenario), fix 2 existing tests for DB/encryptedSecrets consistency

## Test plan

- [x] New test: "should use current DB token when another request already refreshed" — reproduces the exact race condition
- [x] New test: "should sync skipped connector tokens when only some need refresh" — covers mixed refresh/skip
- [x] All 20 existing tests pass (2 updated for consistent DB/encryptedSecrets values)
- [x] Lint, type-check, format pass

Closes #7260

🤖 Generated with [Claude Code](https://claude.com/claude-code)