### PR TITLE
fix(web): fix agent header truncation in schedule skeleton

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -283,8 +283,8 @@ const SKELETON_ROW_KEYS = ["r-0", "r-1", "r-2", "r-3"] as const;
 
 function ScheduleListSkeleton() {
   return (
-    <div className="w-full overflow-x-auto -mx-1">
-      <table className="w-full text-sm border-collapse">
+    <div className="w-full overflow-x-auto">
+      <table className="w-full text-sm border-collapse [&_tr>:first-child]:pl-5 [&_tr>:last-child]:pr-5">
         <thead>
           <tr className="border-b border-border/40 bg-card text-left text-sm text-muted-foreground">
             <th


### PR DESCRIPTION
## Summary
- Remove `-mx-1` from `ScheduleListSkeleton` container div
- Add `[&_tr>:first-child]:pl-5 [&_tr>:last-child]:pr-5` to skeleton `<table>` to match `ScheduleListView`

## Root Cause
The skeleton's `-mx-1` (negative margin) pushed the table 4px past the parent's `overflow-hidden` boundary, clipping the "Agent" `<th>` text which had no left padding to clear the edge. The real table uses `[&_tr>:first-child]:pl-5` for left padding but the skeleton was missing both fixes.

## Test plan
- [ ] Load `/schedule` page and observe skeleton loading state — "Agent" header should be fully visible
- [ ] Verify skeleton column alignment matches the loaded table
- [ ] Lint passes ✅

Closes #7213

🤖 Generated with [Claude Code](https://claude.com/claude-code)