### PR TITLE
refactor: remove dead orgSlug from run execution pipeline

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -789,7 +789,6 @@ describe("createRun()", () => {
           artifactName: "artifact",
           memoryName: "memory",
           orgId: orgClerkOrgId,
-          orgSlug: uniqueId("org"), // slug used for S3 prefix (mocked in tests)
         }),
       );
 

--- a/turbo/apps/web/src/lib/run/build-context.ts
+++ b/turbo/apps/web/src/lib/run/build-context.ts
@@ -26,7 +26,6 @@ import {
 } from "@vm0/core";
 import { agentComposeVersions } from "../../db/schema/agent-compose";
 import { badRequest, notFound, providerIncompatible } from "../errors";
-import { getOrgData } from "../org/org-cache-service";
 import { logger } from "../logger";
 import type { ExecutionContext, ResumeSession, RuntimeOrg } from "./types";
 import type { ArtifactSnapshot } from "../checkpoint/types";
@@ -650,7 +649,6 @@ interface BuildContextParams {
   // Per-permission firewall policies from zero agent configuration.
   firewallPolicies?: FirewallPolicies;
   // Caller-resolved org context for secret/variable/storage resolution.
-  orgSlug?: string;
   orgId: string;
 }
 
@@ -888,27 +886,13 @@ function applyResolutionDefaults(
  *
  * When params.orgId is not provided, the user's default org is used.
  */
-async function resolveOrgs(params: BuildContextParams): Promise<{
+function resolveOrgs(params: BuildContextParams): {
   runtimeClerkOrgId: string;
-  pendingRuntimeScope: Promise<RuntimeOrg> | RuntimeOrg;
-}> {
-  if (params.orgSlug) {
-    return {
-      runtimeClerkOrgId: params.orgId,
-      pendingRuntimeScope: {
-        slug: params.orgSlug,
-        orgId: params.orgId,
-      },
-    };
-  }
-  // Have orgId but no slug — resolve slug from org cache
-  const orgData = await getOrgData(params.orgId);
+  pendingRuntimeScope: RuntimeOrg;
+} {
   return {
     runtimeClerkOrgId: params.orgId,
-    pendingRuntimeScope: {
-      slug: orgData.slug,
-      orgId: params.orgId,
-    },
+    pendingRuntimeScope: { orgId: params.orgId },
   };
 }
 

--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -15,7 +15,6 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
-import { getOrgData } from "../../org/org-cache-service";
 import { extractCliAgentType } from "../utils";
 
 const log = logger("context:preparer");
@@ -113,11 +112,7 @@ export async function prepareForExecution(
     throw badRequest("Agent compose not found");
   }
 
-  const agentOrgData = await getOrgData(agentComposeInfo.orgId);
-  const agentOrgInfo = {
-    orgId: agentComposeInfo.orgId,
-    orgSlug: agentOrgData.slug,
-  };
+  const agentOrgId = agentComposeInfo.orgId;
 
   // Auto-create artifact and memory storages if they don't exist yet
   const ensureStart = Date.now();
@@ -148,7 +143,7 @@ export async function prepareForExecution(
   const storageManifest = await prepareStorageManifest(
     context.agentCompose as AgentComposeYaml,
     context.vars || {},
-    agentOrgInfo.orgId,
+    agentOrgId,
     runtimeOrg.orgId,
     userId,
     context.artifactName,
@@ -161,7 +156,7 @@ export async function prepareForExecution(
   const storageEnd = Date.now();
 
   log.debug(
-    `Storage manifest prepared with dual orgs: agentClerkOrgId=${agentOrgInfo.orgId}, runtimeClerkOrgId=${runtimeOrg.orgId}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
+    `Storage manifest prepared with dual orgs: agentClerkOrgId=${agentOrgId}, runtimeClerkOrgId=${runtimeOrg.orgId}, ${storageManifest.storages.length} storages, ${storageManifest.artifact ? "1 artifact" : "no artifact"}`,
   );
 
   // Build PreparedContext

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -465,7 +465,6 @@ export interface CreateRunParams {
   debugNoMockClaude?: boolean;
   checkEnv?: boolean;
   // Caller-resolved org context for variable/storage resolution.
-  orgSlug?: string;
   orgId: string;
   // Caller-resolved org tier for concurrency limit derivation.
   orgTier?: OrgTier;
@@ -729,7 +728,6 @@ export async function buildAndDispatchRun(opts: {
   params: CreateRunParams;
   composeContent: AgentComposeYaml;
   apiStartTime: number;
-  orgSlug: string | undefined;
   orgId: string;
   authorizeTime: number;
   transactionTime: number;
@@ -740,7 +738,6 @@ export async function buildAndDispatchRun(opts: {
     params,
     composeContent,
     apiStartTime,
-    orgSlug,
     orgId,
     authorizeTime,
     transactionTime,
@@ -808,7 +805,6 @@ export async function buildAndDispatchRun(opts: {
       checkEnv: params.checkEnv,
       firewallPolicies: params.firewallPolicies,
       apiStartTime,
-      orgSlug,
       orgId,
     });
     const buildContextTime = Date.now();
@@ -1089,7 +1085,6 @@ export async function startRun(
     checkEnv: params.checkEnv,
     firewallPolicies: params.firewallPolicies,
     injectZeroToken: params.injectZeroToken,
-    orgSlug: orgData.slug,
     orgId: authOrgId,
     orgTier,
   });
@@ -1102,7 +1097,6 @@ export async function startRun(
 export interface CreateRunRecordResult {
   run: { id: string; createdAt: Date };
   composeContent: AgentComposeYaml;
-  orgSlug: string | undefined;
   orgId: string;
   apiStartTime: number;
   authorizeTime: number;
@@ -1161,7 +1155,6 @@ export async function createRunRecord(
   }
 
   // Org context for the run record and storage (required from caller)
-  const orgSlug = params.orgSlug;
   const orgId = params.orgId;
 
   // Step 5: Concurrency check + INSERT in a transaction with advisory lock
@@ -1217,7 +1210,6 @@ export async function createRunRecord(
   return {
     run: { id: run.id, createdAt: run.createdAt },
     composeContent,
-    orgSlug,
     orgId,
     apiStartTime,
     authorizeTime,
@@ -1256,7 +1248,6 @@ export async function createRun(
     params,
     composeContent: record.composeContent,
     apiStartTime: record.apiStartTime,
-    orgSlug: record.orgSlug,
     orgId: record.orgId,
     authorizeTime: record.authorizeTime,
     transactionTime: record.transactionTime,
@@ -1316,7 +1307,6 @@ export async function dispatchQueuedRun(
     params,
     composeContent,
     apiStartTime,
-    orgSlug: params.orgSlug,
     orgId: params.orgId,
     authorizeTime,
     transactionTime,

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -114,6 +114,5 @@ export interface ExecutionContext {
  * Resolved once in buildExecutionContext to avoid redundant DB lookups.
  */
 export interface RuntimeOrg {
-  slug: string;
   orgId: string;
 }


### PR DESCRIPTION
## Summary

- Remove unused `orgSlug`/`slug` passthrough from the run execution pipeline (`run-service` → `build-context` → `execution-preparer`)
- Eliminate unnecessary `getOrgData()` DB calls that existed solely to populate the unused slug field
- Simplify `resolveOrgs()` from async with DB lookup to a synchronous function
- Remove dead `agentOrgInfo.orgSlug` and its associated `getOrgData()` call in execution-preparer

Closes #7286

## Test plan

- [x] TypeScript type checking passes (`tsc --noEmit` — 0 errors)
- [x] Lint passes (`oxlint` + `eslint` — 0 warnings, 0 errors)
- [x] Knip passes (no unused exports/dependencies)
- [x] Prettier formatting unchanged
- [ ] CI pipeline passes (existing test suite validates no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)