### PR TITLE
feat(cli): add zero skill command group for custom skill management

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -19,6 +19,7 @@ describe("zero CLI program", () => {
       "run",
       "schedule",
       "secret",
+      "skill",
       "slack",
       "variable",
       "whoami",
@@ -47,7 +48,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 12 commands", () => {
-    expect(commandNames).toHaveLength(12);
+  it("should have exactly 13 commands", () => {
+    expect(commandNames).toHaveLength(13);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -32,6 +32,9 @@ Examples:
         const connectors = await getZeroAgentUserConnectors(agentId);
         if (connectors.length > 0)
           console.log(`Connectors:   ${connectors.join(", ")}`);
+        if (agent.customSkills?.length > 0) {
+          console.log(`Skills:       ${agent.customSkills.join(", ")}`);
+        }
         if (agent.description)
           console.log(`Description:  ${agent.description}`);
         if (agent.sound) console.log(`Sound:        ${agent.sound}`);

--- a/turbo/apps/cli/src/commands/zero/skill/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/__tests__/create.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for zero skill create command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { server } from "../../../../mocks/server";
+import { createCommand } from "../create";
+import chalk from "chalk";
+
+const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+const mockSkill = {
+  name: "my-skill",
+  displayName: "My Skill",
+  description: "A test skill",
+};
+
+describe("zero skill create command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  let skillDir: string;
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    skillDir = join(tmpdir(), `test-skill-${Date.now()}`);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# Test Skill\nDo things.");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    rmSync(skillDir, { recursive: true, force: true });
+  });
+
+  describe("successful create", () => {
+    it("should create skill with --agent flag", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(mockSkill, { status: 201 });
+          },
+        ),
+      );
+
+      await createCommand.parseAsync([
+        "node",
+        "cli",
+        "my-skill",
+        "--dir",
+        skillDir,
+        "--agent",
+        AGENT_ID,
+        "--display-name",
+        "My Skill",
+        "--description",
+        "A test skill",
+      ]);
+
+      expect(capturedBody?.name).toBe("my-skill");
+      expect(capturedBody?.content).toBe("# Test Skill\nDo things.");
+      expect(capturedBody?.displayName).toBe("My Skill");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-skill");
+      expect(logCalls).toContain("created");
+    });
+
+    it("should use $ZERO_AGENT_ID when --agent not provided", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", AGENT_ID);
+
+      server.use(
+        http.post(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills`,
+          () => {
+            return HttpResponse.json(mockSkill, { status: 201 });
+          },
+        ),
+      );
+
+      await createCommand.parseAsync([
+        "node",
+        "cli",
+        "my-skill",
+        "--dir",
+        skillDir,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("created");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should fail when SKILL.md not found in directory", async () => {
+      const emptyDir = join(tmpdir(), `empty-skill-${Date.now()}`);
+      mkdirSync(emptyDir, { recursive: true });
+
+      await expect(async () => {
+        await createCommand.parseAsync([
+          "node",
+          "cli",
+          "my-skill",
+          "--dir",
+          emptyDir,
+          "--agent",
+          AGENT_ID,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("SKILL.md not found"),
+      );
+
+      rmSync(emptyDir, { recursive: true, force: true });
+    });
+
+    it("should fail when no agent ID available", async () => {
+      vi.stubEnv("ZERO_AGENT_ID", "");
+
+      await expect(async () => {
+        await createCommand.parseAsync([
+          "node",
+          "cli",
+          "my-skill",
+          "--dir",
+          skillDir,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Agent ID required"),
+      );
+    });
+
+    it("should handle authentication error", async () => {
+      server.use(
+        http.post(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills`,
+          () => {
+            return HttpResponse.json(
+              { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+              { status: 401 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await createCommand.parseAsync([
+          "node",
+          "cli",
+          "my-skill",
+          "--dir",
+          skillDir,
+          "--agent",
+          AGENT_ID,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/skill/__tests__/delete.test.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/__tests__/delete.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for zero skill delete command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { deleteCommand } from "../delete";
+import chalk from "chalk";
+
+const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("zero skill delete command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful delete", () => {
+    it("should delete with --yes flag without prompting", async () => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills/my-skill`,
+          () => {
+            return HttpResponse.json({
+              name: "my-skill",
+              displayName: "My Skill",
+              description: null,
+              content: "# Skill",
+            });
+          },
+        ),
+        http.delete(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills/my-skill`,
+          () => {
+            return new HttpResponse(null, { status: 204 });
+          },
+        ),
+      );
+
+      await deleteCommand.parseAsync([
+        "node",
+        "cli",
+        "my-skill",
+        "--agent",
+        AGENT_ID,
+        "--yes",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-skill");
+      expect(logCalls).toContain("deleted");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle not found error", async () => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills/missing`,
+          () => {
+            return HttpResponse.json(
+              { error: { message: "Skill not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync([
+          "node",
+          "cli",
+          "missing",
+          "--agent",
+          AGENT_ID,
+          "--yes",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --yes in non-interactive mode", async () => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills/my-skill`,
+          () => {
+            return HttpResponse.json({
+              name: "my-skill",
+              displayName: null,
+              description: null,
+              content: "# Skill",
+            });
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await deleteCommand.parseAsync([
+          "node",
+          "cli",
+          "my-skill",
+          "--agent",
+          AGENT_ID,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--yes flag is required"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/skill/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/__tests__/edit.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for zero skill edit command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { server } from "../../../../mocks/server";
+import { editCommand } from "../edit";
+import chalk from "chalk";
+
+const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("zero skill edit command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  let skillDir: string;
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    skillDir = join(tmpdir(), `test-skill-edit-${Date.now()}`);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "# Updated Skill\nNew content.");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    rmSync(skillDir, { recursive: true, force: true });
+  });
+
+  describe("successful edit", () => {
+    it("should update skill content from directory", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.put(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills/my-skill`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              name: "my-skill",
+              displayName: "My Skill",
+              description: null,
+              content: "# Updated Skill\nNew content.",
+            });
+          },
+        ),
+      );
+
+      await editCommand.parseAsync([
+        "node",
+        "cli",
+        "my-skill",
+        "--dir",
+        skillDir,
+        "--agent",
+        AGENT_ID,
+      ]);
+
+      expect(capturedBody?.content).toBe("# Updated Skill\nNew content.");
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-skill");
+      expect(logCalls).toContain("updated");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should fail when SKILL.md not found", async () => {
+      const emptyDir = join(tmpdir(), `empty-skill-edit-${Date.now()}`);
+      mkdirSync(emptyDir, { recursive: true });
+
+      await expect(async () => {
+        await editCommand.parseAsync([
+          "node",
+          "cli",
+          "my-skill",
+          "--dir",
+          emptyDir,
+          "--agent",
+          AGENT_ID,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("SKILL.md not found"),
+      );
+
+      rmSync(emptyDir, { recursive: true, force: true });
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/skill/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/__tests__/list.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for zero skill list command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { listCommand } from "../list";
+import chalk from "chalk";
+
+const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("zero skill list command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful list", () => {
+    it("should display skills in table format", async () => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills`,
+          () => {
+            return HttpResponse.json([
+              {
+                name: "code-review",
+                displayName: "Code Review",
+                description: "Reviews code",
+              },
+              {
+                name: "deploy",
+                displayName: null,
+                description: null,
+              },
+            ]);
+          },
+        ),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--agent", AGENT_ID]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("code-review");
+      expect(logCalls).toContain("Code Review");
+      expect(logCalls).toContain("deploy");
+    });
+
+    it("should show empty state when no skills", async () => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills`,
+          () => {
+            return HttpResponse.json([]);
+          },
+        ),
+      );
+
+      await listCommand.parseAsync(["node", "cli", "--agent", AGENT_ID]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("No custom skills found");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle authentication error", async () => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills`,
+          () => {
+            return HttpResponse.json(
+              { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+              { status: 401 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await listCommand.parseAsync(["node", "cli", "--agent", AGENT_ID]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/skill/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/__tests__/view.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for zero skill view command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { viewCommand } from "../view";
+import chalk from "chalk";
+
+const AGENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+describe("zero skill view command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("successful view", () => {
+    it("should display skill with content", async () => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills/my-skill`,
+          () => {
+            return HttpResponse.json({
+              name: "my-skill",
+              displayName: "My Skill",
+              description: "A helpful skill",
+              content: "# My Skill\nDoes helpful things.",
+            });
+          },
+        ),
+      );
+
+      await viewCommand.parseAsync([
+        "node",
+        "cli",
+        "my-skill",
+        "--agent",
+        AGENT_ID,
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-skill");
+      expect(logCalls).toContain("My Skill");
+      expect(logCalls).toContain("A helpful skill");
+      expect(logCalls).toContain("# My Skill");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle skill not found", async () => {
+      server.use(
+        http.get(
+          `http://localhost:3000/api/zero/agents/${AGENT_ID}/skills/missing`,
+          () => {
+            return HttpResponse.json(
+              { error: { message: "Skill not found", code: "NOT_FOUND" } },
+              { status: 404 },
+            );
+          },
+        ),
+      );
+
+      await expect(async () => {
+        await viewCommand.parseAsync([
+          "node",
+          "cli",
+          "missing",
+          "--agent",
+          AGENT_ID,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/skill/create.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/create.ts
@@ -1,0 +1,71 @@
+import { Command } from "commander";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import chalk from "chalk";
+import { createAgentSkill } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const createCommand = new Command()
+  .name("create")
+  .description("Create a custom skill for a zero agent")
+  .argument("<name>", "Skill name (lowercase alphanumeric with hyphens)")
+  .requiredOption("--dir <path>", "Path to directory containing SKILL.md")
+  .option("--agent <id>", "Agent ID (defaults to $ZERO_AGENT_ID)")
+  .option("--display-name <name>", "Skill display name")
+  .option("--description <text>", "Skill description")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero skill create my-skill --dir ./skills/my-skill/
+  zero skill create my-skill --dir ./skills/my-skill/ --agent <id>
+  zero skill create my-skill --dir ./skills/my-skill/ --display-name "My Skill" --description "Does things"
+
+Notes:
+  - The directory must contain a SKILL.md file
+  - Agent ID defaults to $ZERO_AGENT_ID if --agent is not provided`,
+  )
+  .action(
+    withErrorHandler(
+      async (
+        name: string,
+        options: {
+          dir: string;
+          agent?: string;
+          displayName?: string;
+          description?: string;
+        },
+      ) => {
+        const agentId = options.agent ?? process.env.ZERO_AGENT_ID;
+        if (!agentId) {
+          throw new Error(
+            "Agent ID required: use --agent <id> or set $ZERO_AGENT_ID",
+          );
+        }
+
+        const skillMdPath = join(options.dir, "SKILL.md");
+        if (!existsSync(skillMdPath)) {
+          throw new Error(`SKILL.md not found in ${options.dir}`);
+        }
+
+        const content = readFileSync(skillMdPath, "utf-8");
+
+        const skill = await createAgentSkill(agentId, {
+          name,
+          content,
+          displayName: options.displayName,
+          description: options.description,
+        });
+
+        console.log(chalk.green(`✓ Skill "${skill.name}" created`));
+        console.log(`  Name:         ${skill.name}`);
+        console.log(`  Agent:        ${agentId}`);
+        if (skill.displayName) {
+          console.log(`  Display Name: ${skill.displayName}`);
+        }
+        if (skill.description) {
+          console.log(`  Description:  ${skill.description}`);
+        }
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/skill/delete.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/delete.ts
@@ -1,0 +1,55 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getAgentSkill, deleteAgentSkill } from "../../../lib/api";
+import { isInteractive, promptConfirm } from "../../../lib/utils/prompt-utils";
+import { withErrorHandler } from "../../../lib/command";
+
+export const deleteCommand = new Command()
+  .name("delete")
+  .alias("rm")
+  .description("Delete a custom skill")
+  .argument("<name>", "Skill name")
+  .option("--agent <id>", "Agent ID (defaults to $ZERO_AGENT_ID)")
+  .option("-y, --yes", "Skip confirmation prompt")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero skill delete my-skill
+  zero skill delete my-skill -y
+  zero skill delete my-skill --agent <id>
+
+Notes:
+  - Use -y to skip confirmation in non-interactive mode`,
+  )
+  .action(
+    withErrorHandler(
+      async (name: string, options: { agent?: string; yes?: boolean }) => {
+        const agentId = options.agent ?? process.env.ZERO_AGENT_ID;
+        if (!agentId) {
+          throw new Error(
+            "Agent ID required: use --agent <id> or set $ZERO_AGENT_ID",
+          );
+        }
+
+        await getAgentSkill(agentId, name);
+
+        if (!options.yes) {
+          if (!isInteractive()) {
+            throw new Error("--yes flag is required in non-interactive mode");
+          }
+          const confirmed = await promptConfirm(
+            `Delete skill '${name}'?`,
+            false,
+          );
+          if (!confirmed) {
+            console.log(chalk.dim("Cancelled"));
+            return;
+          }
+        }
+
+        await deleteAgentSkill(agentId, name);
+        console.log(chalk.green(`✓ Skill "${name}" deleted`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/skill/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/edit.ts
@@ -1,0 +1,45 @@
+import { Command } from "commander";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import chalk from "chalk";
+import { updateAgentSkill } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const editCommand = new Command()
+  .name("edit")
+  .description("Update a custom skill's content")
+  .argument("<name>", "Skill name")
+  .requiredOption(
+    "--dir <path>",
+    "Path to directory containing updated SKILL.md",
+  )
+  .option("--agent <id>", "Agent ID (defaults to $ZERO_AGENT_ID)")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero skill edit my-skill --dir ./skills/my-skill/
+  zero skill edit my-skill --dir ./skills/my-skill/ --agent <id>`,
+  )
+  .action(
+    withErrorHandler(
+      async (name: string, options: { dir: string; agent?: string }) => {
+        const agentId = options.agent ?? process.env.ZERO_AGENT_ID;
+        if (!agentId) {
+          throw new Error(
+            "Agent ID required: use --agent <id> or set $ZERO_AGENT_ID",
+          );
+        }
+
+        const skillMdPath = join(options.dir, "SKILL.md");
+        if (!existsSync(skillMdPath)) {
+          throw new Error(`SKILL.md not found in ${options.dir}`);
+        }
+
+        const content = readFileSync(skillMdPath, "utf-8");
+        await updateAgentSkill(agentId, name, { content });
+
+        console.log(chalk.green(`✓ Skill "${name}" updated`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/skill/index.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/index.ts
@@ -1,0 +1,27 @@
+import { Command } from "commander";
+import { createCommand } from "./create";
+import { editCommand } from "./edit";
+import { viewCommand } from "./view";
+import { listCommand } from "./list";
+import { deleteCommand } from "./delete";
+
+export const zeroSkillCommand = new Command("skill")
+  .description("Manage custom skills for zero agents")
+  .addCommand(createCommand)
+  .addCommand(editCommand)
+  .addCommand(viewCommand)
+  .addCommand(listCommand)
+  .addCommand(deleteCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Create from directory:   zero skill create my-skill --dir ./skills/my-skill/
+  List agent's skills:     zero skill list --agent <id>
+  View skill content:      zero skill view my-skill
+  Update skill content:    zero skill edit my-skill --dir ./skills/my-skill/
+  Delete a skill:          zero skill delete my-skill -y
+
+Notes:
+  Agent ID comes from --agent flag or $ZERO_AGENT_ID environment variable`,
+  );

--- a/turbo/apps/cli/src/commands/zero/skill/list.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/list.ts
@@ -1,0 +1,59 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { listAgentSkills } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const listCommand = new Command()
+  .name("list")
+  .alias("ls")
+  .description("List custom skills for a zero agent")
+  .option("--agent <id>", "Agent ID (defaults to $ZERO_AGENT_ID)")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero skill list
+  zero skill list --agent <id>`,
+  )
+  .action(
+    withErrorHandler(async (options: { agent?: string }) => {
+      const agentId = options.agent ?? process.env.ZERO_AGENT_ID;
+      if (!agentId) {
+        throw new Error(
+          "Agent ID required: use --agent <id> or set $ZERO_AGENT_ID",
+        );
+      }
+
+      const skills = await listAgentSkills(agentId);
+
+      if (skills.length === 0) {
+        console.log(chalk.dim("No custom skills found"));
+        console.log(
+          chalk.dim("  Create one with: zero skill create <name> --dir <path>"),
+        );
+        return;
+      }
+
+      const nameWidth = Math.max(4, ...skills.map((s) => s.name.length));
+      const displayWidth = Math.max(
+        12,
+        ...skills.map((s) => (s.displayName ?? "").length),
+      );
+
+      const header = [
+        "NAME".padEnd(nameWidth),
+        "DISPLAY NAME".padEnd(displayWidth),
+        "DESCRIPTION",
+      ].join("  ");
+      console.log(chalk.dim(header));
+
+      for (const skill of skills) {
+        const row = [
+          skill.name.padEnd(nameWidth),
+          (skill.displayName ?? "-").padEnd(displayWidth),
+          skill.description ?? "-",
+        ].join("  ");
+        console.log(row);
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/skill/view.ts
+++ b/turbo/apps/cli/src/commands/zero/skill/view.ts
@@ -1,0 +1,44 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { getAgentSkill } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const viewCommand = new Command()
+  .name("view")
+  .description("View a custom skill")
+  .argument("<name>", "Skill name")
+  .option("--agent <id>", "Agent ID (defaults to $ZERO_AGENT_ID)")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero skill view my-skill
+  zero skill view my-skill --agent <id>`,
+  )
+  .action(
+    withErrorHandler(async (name: string, options: { agent?: string }) => {
+      const agentId = options.agent ?? process.env.ZERO_AGENT_ID;
+      if (!agentId) {
+        throw new Error(
+          "Agent ID required: use --agent <id> or set $ZERO_AGENT_ID",
+        );
+      }
+
+      const skill = await getAgentSkill(agentId, name);
+
+      console.log(chalk.bold(skill.name));
+      if (skill.displayName) console.log(chalk.dim(skill.displayName));
+      console.log();
+      console.log(`Name:         ${skill.name}`);
+      if (skill.displayName) console.log(`Display Name: ${skill.displayName}`);
+      if (skill.description) console.log(`Description:  ${skill.description}`);
+
+      console.log();
+      if (skill.content) {
+        console.log(chalk.dim("── SKILL.md ──"));
+        console.log(skill.content);
+      } else {
+        console.log(chalk.dim("No content"));
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-agent-skills.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-agent-skills.ts
@@ -1,0 +1,67 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroAgentSkillsContract,
+  type ZeroAgentCustomSkill,
+  type ZeroAgentSkillContentResponse,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function listAgentSkills(
+  agentId: string,
+): Promise<ZeroAgentCustomSkill[]> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentSkillsContract, config);
+  const result = await client.list({ params: { id: agentId } });
+  if (result.status === 200) return result.body;
+  handleError(result, `Failed to list skills for agent "${agentId}"`);
+}
+
+export async function createAgentSkill(
+  agentId: string,
+  body: {
+    name: string;
+    content: string;
+    displayName?: string;
+    description?: string;
+  },
+): Promise<ZeroAgentCustomSkill> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentSkillsContract, config);
+  const result = await client.create({ params: { id: agentId }, body });
+  if (result.status === 201) return result.body;
+  handleError(result, `Failed to create skill "${body.name}"`);
+}
+
+export async function getAgentSkill(
+  agentId: string,
+  name: string,
+): Promise<ZeroAgentSkillContentResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentSkillsContract, config);
+  const result = await client.get({ params: { id: agentId, name } });
+  if (result.status === 200) return result.body;
+  handleError(result, `Skill "${name}" not found`);
+}
+
+export async function updateAgentSkill(
+  agentId: string,
+  name: string,
+  body: { content: string },
+): Promise<ZeroAgentSkillContentResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentSkillsContract, config);
+  const result = await client.update({ params: { id: agentId, name }, body });
+  if (result.status === 200) return result.body;
+  handleError(result, `Failed to update skill "${name}"`);
+}
+
+export async function deleteAgentSkill(
+  agentId: string,
+  name: string,
+): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroAgentSkillsContract, config);
+  const result = await client.delete({ params: { id: agentId, name } });
+  if (result.status === 204) return;
+  handleError(result, `Skill "${name}" not found`);
+}

--- a/turbo/apps/cli/src/lib/api/domains/zero-agent-skills.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-agent-skills.ts
@@ -1,6 +1,7 @@
 import { initClient } from "@ts-rest/core";
 import {
-  zeroAgentSkillsContract,
+  zeroAgentSkillsCollectionContract,
+  zeroAgentSkillsDetailContract,
   type ZeroAgentCustomSkill,
   type ZeroAgentSkillContentResponse,
 } from "@vm0/core";
@@ -10,7 +11,7 @@ export async function listAgentSkills(
   agentId: string,
 ): Promise<ZeroAgentCustomSkill[]> {
   const config = await getClientConfig();
-  const client = initClient(zeroAgentSkillsContract, config);
+  const client = initClient(zeroAgentSkillsCollectionContract, config);
   const result = await client.list({ params: { id: agentId } });
   if (result.status === 200) return result.body;
   handleError(result, `Failed to list skills for agent "${agentId}"`);
@@ -26,7 +27,7 @@ export async function createAgentSkill(
   },
 ): Promise<ZeroAgentCustomSkill> {
   const config = await getClientConfig();
-  const client = initClient(zeroAgentSkillsContract, config);
+  const client = initClient(zeroAgentSkillsCollectionContract, config);
   const result = await client.create({ params: { id: agentId }, body });
   if (result.status === 201) return result.body;
   handleError(result, `Failed to create skill "${body.name}"`);
@@ -37,7 +38,7 @@ export async function getAgentSkill(
   name: string,
 ): Promise<ZeroAgentSkillContentResponse> {
   const config = await getClientConfig();
-  const client = initClient(zeroAgentSkillsContract, config);
+  const client = initClient(zeroAgentSkillsDetailContract, config);
   const result = await client.get({ params: { id: agentId, name } });
   if (result.status === 200) return result.body;
   handleError(result, `Skill "${name}" not found`);
@@ -49,7 +50,7 @@ export async function updateAgentSkill(
   body: { content: string },
 ): Promise<ZeroAgentSkillContentResponse> {
   const config = await getClientConfig();
-  const client = initClient(zeroAgentSkillsContract, config);
+  const client = initClient(zeroAgentSkillsDetailContract, config);
   const result = await client.update({ params: { id: agentId, name }, body });
   if (result.status === 200) return result.body;
   handleError(result, `Failed to update skill "${name}"`);
@@ -60,7 +61,7 @@ export async function deleteAgentSkill(
   name: string,
 ): Promise<void> {
   const config = await getClientConfig();
-  const client = initClient(zeroAgentSkillsContract, config);
+  const client = initClient(zeroAgentSkillsDetailContract, config);
   const result = await client.delete({ params: { id: agentId, name } });
   if (result.status === 204) return;
   handleError(result, `Skill "${name}" not found`);

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -107,6 +107,15 @@ export {
   setZeroAgentUserConnectors,
 } from "./domains/zero-agents";
 
+// Domain modules - Zero Agent Skills
+export {
+  listAgentSkills,
+  createAgentSkill,
+  getAgentSkill,
+  updateAgentSkill,
+  deleteAgentSkill,
+} from "./domains/zero-agent-skills";
+
 // Domain modules - Zero Connectors
 export {
   listZeroConnectors,

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -15,6 +15,7 @@ import { zeroSlackCommand } from "./commands/zero/slack";
 import { zeroVariableCommand } from "./commands/zero/variable";
 import { zeroWhoamiCommand } from "./commands/zero/whoami";
 import { zeroAskUserCommand } from "./commands/zero/ask-user";
+import { zeroSkillCommand } from "./commands/zero/skill";
 import {
   decodeZeroTokenPayload,
   type ZeroTokenPayload,
@@ -27,6 +28,7 @@ import {
  */
 const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   agent: "agent:read",
+  skill: "agent:read",
   run: "agent-run:write",
   schedule: "schedule:read",
   doctor: null,
@@ -48,6 +50,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroVariableCommand,
   zeroWhoamiCommand,
   zeroAskUserCommand,
+  zeroSkillCommand,
 ];
 
 function shouldHideCommand(


### PR DESCRIPTION
## Summary

- Add `zero skill` CLI command group with full CRUD operations: `create`, `list`, `view`, `edit`, `delete`
- Add skill API client layer using `zeroAgentSkillsContract` from `@vm0/core`
- Show `customSkills` in `zero agent view` output
- Support `$ZERO_AGENT_ID` env var as fallback for `--agent` flag (sandbox self-management)

## Changes

### New files
- `turbo/apps/cli/src/commands/zero/skill/` — 5 subcommands + index
- `turbo/apps/cli/src/lib/api/domains/zero-agent-skills.ts` — API client (5 functions)
- `turbo/apps/cli/src/commands/zero/skill/__tests__/` — 5 test files (15 test cases)

### Modified files
- `turbo/apps/cli/src/zero.ts` — register `zeroSkillCommand` + `skill: "agent:read"` capability
- `turbo/apps/cli/src/lib/api/index.ts` — export skill API functions
- `turbo/apps/cli/src/commands/zero/agent/view.ts` — display custom skills

## Dependencies

- Requires #7191 (core schemas) — already merged
- API routes (#7192) should be merged before this PR for end-to-end functionality

## Test plan

- [x] All 15 new skill command tests pass
- [x] All 17 existing agent command tests pass (no regression)
- [x] `pnpm check-types` passes for CLI workspace
- [x] `pnpm turbo run lint --filter=cli` passes (0 warnings, 0 errors)
- [x] `pnpm knip` passes (no unused exports)
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

Closes #7193

🤖 Generated with [Claude Code](https://claude.com/claude-code)