### PR TITLE
refactor: make assistant message content reactive via result$ computed

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -234,7 +234,10 @@ describe("zero-chat signals", () => {
       expect(context.store.get(chatThreadId$)).toBe("url-thread");
       const messages = await context.store.get(zeroChatMessages$);
       expect(messages).toHaveLength(1);
-      expect(messages[0]?.content).toBe("From URL");
+      expect(messages[0]?.role).toBe("user");
+      if (messages[0]?.role === "user") {
+        expect(messages[0].content).toBe("From URL");
+      }
     });
 
     it("should return null for URL without session ID", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -83,15 +83,14 @@ export interface UserChatMessage {
 export interface AssistantChatMessage {
   id: string;
   role: "assistant";
-  content: string;
+  /** Reactive result content — always present. For static (historical) messages this resolves immediately. */
+  result$: Computed<Promise<string>>;
   legacyRunId?: string;
   status?: LogStatus;
   error?: string;
   cancelled?: boolean;
   summaries?: string[];
   runLoop?: ReturnType<typeof createRunLoop>;
-  /** Reactive result content derived from runLoop events. */
-  result$?: Computed<Promise<string>>;
   /** Reactive summaries derived from runLoop events. */
   summaries$?: Computed<Promise<string[]>>;
   /** Command to start the polling loop for this run. */
@@ -403,7 +402,6 @@ function createActiveRunMessage(
     assistantMessage: {
       id: crypto.randomUUID(),
       role: "assistant",
-      content: "",
       legacyRunId: runId,
       runLoop,
       result$,
@@ -436,7 +434,7 @@ function unsavedRunsToMessages(unsavedRuns: ChatThreadData["unsavedRuns"]): {
       messages.push({
         id: crypto.randomUUID(),
         role: "assistant",
-        content: "",
+        result$: computed(() => Promise.resolve("")),
         legacyRunId: run.runId,
         status: "failed",
         error: isCancelled
@@ -535,12 +533,24 @@ const currentChatMessages$ = computed(
             })
           : undefined;
 
-      return {
+      const base = {
         id: crypto.randomUUID(),
-        role: m.role,
-        content: m.content,
-        legacyRunId: m.runId,
         ...(summaries && summaries.length > 0 ? { summaries } : {}),
+      };
+
+      if (m.role === "user") {
+        return {
+          ...base,
+          role: "user" as const,
+          content: m.content,
+        };
+      }
+
+      return {
+        ...base,
+        role: "assistant" as const,
+        result$: computed(() => Promise.resolve(m.content)),
+        legacyRunId: m.runId,
         ...(m.error ? { status: "failed" as const, error: m.error } : {}),
       };
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
+import { mockChatLifecycle } from "./chat-test-helpers.ts";
 
 const context = testContext();
 
@@ -185,5 +186,92 @@ describe("agent avatar link", () => {
       "href",
       "/team/c0000000-0000-4000-a000-000000000001",
     );
+  });
+});
+
+describe("chat message activity line", () => {
+  it("should keep activity line visible when result arrives but run is still running", async () => {
+    const lifecycle = mockChatLifecycle({
+      threadId: "thread-activity-running",
+      unsavedRuns: [
+        {
+          runId: "run-activity-1",
+          status: "running",
+          prompt: "Do something",
+          error: null,
+        },
+      ],
+    });
+
+    // Provide a result event while keeping the run status as "running"
+    lifecycle.setEvents([
+      {
+        sequenceNumber: 1,
+        eventType: "result",
+        eventData: { result: "Here is the partial result" },
+        createdAt: "2026-03-10T00:00:10Z",
+      },
+    ]);
+
+    await setupPage({ context, path: "/chat/thread-activity-running" });
+
+    // The result content should be rendered
+    await waitFor(() => {
+      expect(
+        screen.getByText("Here is the partial result"),
+      ).toBeInTheDocument();
+    });
+
+    // The activity line (spinner) should still be visible since the run is not terminal
+    await waitFor(() => {
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
+    });
+  });
+
+  it("should hide activity line after run reaches terminal status", async () => {
+    const lifecycle = mockChatLifecycle({
+      threadId: "thread-activity-done",
+      unsavedRuns: [
+        {
+          runId: "run-activity-2",
+          status: "running",
+          prompt: "Do something else",
+          error: null,
+        },
+      ],
+    });
+
+    // Start with a result event while still running
+    lifecycle.setEvents([
+      {
+        sequenceNumber: 1,
+        eventType: "result",
+        eventData: { result: "Final answer" },
+        createdAt: "2026-03-10T00:00:10Z",
+      },
+    ]);
+
+    await setupPage({ context, path: "/chat/thread-activity-done" });
+
+    // Wait for content to appear
+    await waitFor(() => {
+      expect(screen.getByText("Final answer")).toBeInTheDocument();
+    });
+
+    // Activity line should be visible while running
+    await waitFor(() => {
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
+    });
+
+    // Now complete the run
+    lifecycle.completeRun("Final answer");
+
+    // Activity line should disappear after reaching terminal status
+    await waitFor(() => {
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).not.toBeInTheDocument();
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-session-chat-page.tsx
@@ -3,6 +3,7 @@ import {
   useSet,
   useLoadable,
   useLastLoadable,
+  useLastResolved,
   useResolved,
 } from "ccstate-react";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -648,7 +649,7 @@ interface AssistantMessageProps {
 
 function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
   // Delegate to reactive variant when the message carries its own runLoop signals
-  if (message.result$) {
+  if (message.runLoop) {
     return (
       <ReactiveAssistantMessage
         message={message}
@@ -661,13 +662,27 @@ function AssistantMessage({ message, zeroAvatarSrc }: AssistantMessageProps) {
   );
 }
 
+function failedRunErrorMessage(
+  status: string | undefined,
+  error: string | null | undefined,
+): string {
+  if (error) {
+    return error;
+  }
+  if (status === "timeout") {
+    return "Run timed out";
+  }
+  if (status === "cancelled") {
+    return "Run cancelled.";
+  }
+  return "Run failed";
+}
+
 /** Assistant message with reactive result$/summaries$/detail$ from runLoop. */
 function ReactiveAssistantMessage({
   message,
   zeroAvatarSrc,
 }: AssistantMessageProps) {
-  const resultLoadable = useLastLoadable(message.result$!);
-  const content = resultLoadable.state === "hasData" ? resultLoadable.data : "";
   const summariesLoadable = useLastLoadable(message.summaries$!);
   const summaries =
     summariesLoadable.state === "hasData" ? summariesLoadable.data : [];
@@ -678,20 +693,15 @@ function ReactiveAssistantMessage({
     detail?.status === "failed" ||
     detail?.status === "timeout" ||
     detail?.status === "cancelled";
+  const isTerminal = isFailed || detail?.status === "completed";
 
   // Build an enriched message with reactive content for the static renderer
   const enrichedMessage: AssistantChatMessage = {
     ...message,
-    content,
     summaries: summaries.length > 0 ? summaries : message.summaries,
     status: detail?.status ?? undefined,
     error: isFailed
-      ? (detail?.error ??
-        (detail?.status === "timeout"
-          ? "Run timed out"
-          : detail?.status === "cancelled"
-            ? "Run cancelled."
-            : "Run failed"))
+      ? failedRunErrorMessage(detail?.status, detail?.error)
       : undefined,
   };
   return (
@@ -699,7 +709,7 @@ function ReactiveAssistantMessage({
       message={enrichedMessage}
       zeroAvatarSrc={zeroAvatarSrc}
       renderActivityLine={
-        !isFailed ? <MessageRunActivityLine message={message} /> : undefined
+        !isTerminal ? <MessageRunActivityLine message={message} /> : undefined
       }
     />
   );
@@ -713,6 +723,7 @@ function StaticAssistantMessage({
   const setOrgManageOpen = useSet(setOrgManageDialogOpen$);
   const setTab = useSet(setActiveTab$);
   const pageSignal = useGet(pageSignal$);
+  const content = useLastResolved(message.result$) ?? "";
   const avatar = (
     <div className="h-9 w-9 shrink-0 mt-0.5 overflow-hidden rounded-xl">
       <img
@@ -731,10 +742,10 @@ function StaticAssistantMessage({
   const copyMessage = useSet(copyMessageContent$);
 
   const handleCopy = () => {
-    if (!message.content) {
+    if (!content) {
       return;
     }
-    detach(copyMessage(message.id, message.content), Reason.DomCallback);
+    detach(copyMessage(message.id, content), Reason.DomCallback);
   };
 
   const logButton = message.legacyRunId ? (
@@ -756,7 +767,7 @@ function StaticAssistantMessage({
             <TooltipContent side="bottom">View activity logs</TooltipContent>
           </Tooltip>
         </TooltipProvider>
-        {message.content && (
+        {content && (
           <TooltipProvider delayDuration={300}>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -861,7 +872,7 @@ function StaticAssistantMessage({
     );
   }
 
-  if (message.content) {
+  if (content) {
     return (
       <div className="group flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300">
         <div className="grid grid-cols-[28px_1fr] sm:grid-cols-[36px_1fr] gap-2.5 -ml-[38px] sm:-ml-[46px] items-start">
@@ -873,12 +884,15 @@ function StaticAssistantMessage({
                 messageId={message.id}
               />
             )}
-            <Markdown source={message.content} />
+            <Markdown source={content} />
             {message.cancelled && (
               <div className="mt-3 pt-3 border-t flex items-center gap-1.5 text-xs text-muted-foreground">
                 <IconPlayerStop size={12} />
                 <span>Cancelled</span>
               </div>
+            )}
+            {renderActivityLine && (
+              <div className="mt-3 pt-3 border-t">{renderActivityLine}</div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace the static `content` string field on `AssistantChatMessage` with a reactive `result$` (`Computed<Promise<string>>`), unifying how content is resolved for both active (runLoop) and historical messages
- Fix the activity line (shimmer) remaining visible after a run reaches terminal status (completed/failed/cancelled) by checking `isTerminal` instead of only `isFailed`
- Extract `failedRunErrorMessage` helper for cleaner error message construction

## Test plan
- [x] Existing `zero-chat.test.ts` updated to use type-narrowed assertions matching the new interface
- [ ] New `zero-session-chat-page.test.tsx` tests verify activity line visibility during running state and hiding after terminal status
- [ ] CI passes lint, type-check, and test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)