### PR TITLE
fix(mitm): add network logging to error() hook for connection failures

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -809,10 +809,66 @@ def response(flow: http.HTTPFlow) -> None:
 
 def error(flow: http.HTTPFlow) -> None:
     """
-    Clean up _request_start_times on flow error (timeout, connection reset, etc.)
-    to prevent unbounded dict growth over the runner's lifetime.
+    Log connection-level errors (timeout, RST, TLS failure) to the
+    per-run JSONL network log and clean up request tracking state.
     """
-    _request_start_times.pop(flow.id, None)
+    start_time = _request_start_times.pop(flow.id, None)
+
+    run_id = flow.metadata.get("vm_run_id", "")
+    network_log_path = flow.metadata.get("vm_network_log_path", "")
+
+    if not run_id or not network_log_path:
+        return
+
+    latency_ms = int((time.time() - start_time) * 1000) if start_time else 0
+    original_url = flow.metadata.get("original_url", flow.request.pretty_url)
+    firewall_action = flow.metadata.get("firewall_action", "ALLOW")
+
+    try:
+        parsed_url = urllib.parse.urlparse(original_url)
+        host = parsed_url.hostname or flow.request.pretty_host
+        port = parsed_url.port or (443 if parsed_url.scheme == "https" else 80)
+    except Exception:
+        host = flow.request.pretty_host
+        port = flow.request.port
+
+    request_size = len(flow.request.content) if flow.request.content else 0
+    error_msg = flow.error.msg if flow.error else "unknown error"
+
+    # [NETWORK_LOG_FIELDS] — keep in sync with response() and runs.ts schema
+    log_entry: dict = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()),
+        "type": "http",
+        "action": firewall_action,
+        "host": host,
+        "port": port,
+        "method": flow.request.method,
+        "url": original_url,
+        "status": 0,
+        "latency_ms": latency_ms,
+        "request_size": request_size,
+        "response_size": 0,
+        "error": error_msg,
+    }
+
+    # Add firewall context if available
+    firewall_base = flow.metadata.get("firewall_base")
+    if firewall_base:
+        log_entry["firewall_base"] = firewall_base
+        log_entry["firewall_name"] = flow.metadata.get("firewall_name", "")
+        log_entry["firewall_ref"] = flow.metadata.get("firewall_ref", "")
+        log_entry["firewall_permission"] = flow.metadata.get("firewall_permission", "")
+        log_entry["firewall_rule_match"] = flow.metadata.get("firewall_rule_match", "")
+        params = flow.metadata.get("firewall_params")
+        if params:
+            log_entry["firewall_params"] = params
+        fw_error = flow.metadata.get("firewall_error")
+        if fw_error:
+            log_entry["firewall_error"] = fw_error
+
+    log_network_entry(network_log_path, log_entry)
+
+    ctx.log.warn(f"[{run_id}] Error: {error_msg}: {original_url}")
 
 
 # ============================================================================

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -755,7 +755,7 @@ def response(flow: http.HTTPFlow) -> None:
         parsed_url = urllib.parse.urlparse(original_url)
         host = parsed_url.hostname or flow.request.pretty_host
         port = parsed_url.port or (443 if parsed_url.scheme == "https" else 80)
-    except Exception:
+    except ValueError:
         host = flow.request.pretty_host
         port = flow.request.port
 
@@ -828,7 +828,7 @@ def error(flow: http.HTTPFlow) -> None:
         parsed_url = urllib.parse.urlparse(original_url)
         host = parsed_url.hostname or flow.request.pretty_host
         port = parsed_url.port or (443 if parsed_url.scheme == "https" else 80)
-    except Exception:
+    except ValueError:
         host = flow.request.pretty_host
         port = flow.request.port
 

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -463,20 +463,99 @@ class TestErrorHandler:
     def setup_method(self):
         _reset()
 
-    def test_cleans_up_start_time(self):
-        flow = MagicMock()
+    def test_cleans_up_start_time(self, tmp_path):
+        flow = _make_http_flow()
         flow.id = "flow-err-1"
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = str(tmp_path / "net.jsonl")
+        flow.error = MagicMock()
+        flow.error.msg = "connection reset"
         mitm_addon._request_start_times["flow-err-1"] = 12345.0
 
-        mitm_addon.error(flow)
+        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+            mitm_addon.error(flow)
 
         assert "flow-err-1" not in mitm_addon._request_start_times
 
-    def test_noop_if_no_start_time(self):
+    def test_skips_log_when_no_metadata(self, tmp_path):
         flow = MagicMock()
         flow.id = "flow-err-2"
+        flow.metadata = {}
 
-        mitm_addon.error(flow)  # Should not raise
+        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+            mitm_addon.error(flow)  # Should not raise
+
+    def test_logs_error_to_jsonl(self, tmp_path):
+        flow = _make_http_flow(host="slack.com", path="/api/chat.postMessage")
+        flow.request.method = "POST"
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["original_url"] = "https://slack.com/api/chat.postMessage"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.error = MagicMock()
+        flow.error.msg = "connection reset by peer"
+        mitm_addon._request_start_times[flow.id] = time.time() - 1.5
+
+        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+            mitm_addon.error(flow)
+
+        lines = Path(log_path).read_text().splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["type"] == "http"
+        assert entry["action"] == "ALLOW"
+        assert entry["host"] == "slack.com"
+        assert entry["method"] == "POST"
+        assert entry["status"] == 0
+        assert entry["response_size"] == 0
+        assert entry["error"] == "connection reset by peer"
+        assert entry["latency_ms"] > 0
+
+    def test_error_includes_firewall_context(self, tmp_path):
+        flow = _make_http_flow(host="slack.com")
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["original_url"] = "https://slack.com/api/chat.postMessage"
+        flow.metadata["firewall_action"] = "ALLOW"
+        flow.metadata["firewall_base"] = "https://slack.com/api"
+        flow.metadata["firewall_ref"] = "slack"
+        flow.metadata["firewall_name"] = "Slack API"
+        flow.metadata["firewall_permission"] = "chat:write"
+        flow.metadata["firewall_rule_match"] = "POST /chat.postMessage"
+        flow.error = MagicMock()
+        flow.error.msg = "timed out"
+
+        with patch.object(mitm_addon.ctx, "log", MagicMock(), create=True):
+            mitm_addon.error(flow)
+
+        entry = json.loads(Path(log_path).read_text().strip())
+        assert entry["firewall_base"] == "https://slack.com/api"
+        assert entry["firewall_ref"] == "slack"
+        assert entry["firewall_name"] == "Slack API"
+        assert entry["firewall_permission"] == "chat:write"
+        assert entry["firewall_rule_match"] == "POST /chat.postMessage"
+        assert entry["error"] == "timed out"
+
+    def test_error_logs_warning_to_console(self, tmp_path):
+        flow = _make_http_flow(host="slack.com")
+        log_path = str(tmp_path / "network.jsonl")
+        flow.metadata["vm_run_id"] = "run-abc-123"
+        flow.metadata["vm_network_log_path"] = log_path
+        flow.metadata["original_url"] = "https://slack.com/api/test"
+        flow.error = MagicMock()
+        flow.error.msg = "connection reset by peer"
+
+        mock_log = MagicMock()
+        with patch.object(mitm_addon.ctx, "log", mock_log, create=True):
+            mitm_addon.error(flow)
+
+        mock_log.warn.assert_called_once()
+        warn_msg = mock_log.warn.call_args[0][0]
+        assert "run-abc-123" in warn_msg
+        assert "connection reset by peer" in warn_msg
+        assert "slack.com" in warn_msg
 
 
 class TestTlsClienthello:


### PR DESCRIPTION
## Summary

- Add JSONL network logging to the `error()` hook so connection-level failures (curl 56, timeouts, TLS errors) are captured in per-run network logs
- Log entries include error message, request metadata, firewall context, and latency — matching `response()` structure with `status=0` and an `error` field
- Add `ctx.log.warn` for visibility in runner system logs (`--quiet` mode)
- Python-only change — no TypeScript schema or Rust changes needed (`error` field already exists in Zod schema)

Closes #7293

## Test plan

- [x] `test_logs_error_to_jsonl` — verifies JSONL entry structure and field values
- [x] `test_error_includes_firewall_context` — verifies firewall metadata is included
- [x] `test_skips_log_when_no_metadata` — verifies graceful handling of untracked flows
- [x] `test_error_logs_warning_to_console` — verifies `ctx.log.warn` is called
- [x] `test_cleans_up_start_time` — existing test updated for new signature
- [x] All 144 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)