### PR TITLE
refactor: remove redundant ?org=slug query param from all routes

### DIFF
--- a/e2e/tests/03-runner/t22-vm0-compose-org.bats
+++ b/e2e/tests/03-runner/t22-vm0-compose-org.bats
@@ -1,13 +1,11 @@
 #!/usr/bin/env bats
 
-# Test VM0 compose with org support (E2E happy path only)
-# Tests the org/name:version naming convention for agent composes
+# Test VM0 compose (E2E happy path only)
+# Tests the name:version naming convention for agent composes
 #
-# This test covers issue #757: Add org support to agent compose
-#
-# Note: Identifier format parsing and error handling (org/name, org/name:version, name:version,
-# backward compat, org errors) are tested via CLI Command Integration Tests
-# (see run/__tests__/index.test.ts, "org error handling" section).
+# Note: Identifier format parsing and error handling (name:version,
+# backward compat) are tested via CLI Command Integration Tests
+# (see run/__tests__/index.test.ts).
 
 load '../../helpers/setup'
 
@@ -28,7 +26,7 @@ teardown() {
 # vm0 compose displays org/name format
 # ============================================
 
-@test "t22-1: vm0 compose shows org/name:version in run instructions" {
+@test "t22-1: vm0 compose shows name:version in run instructions" {
     echo "# Creating config file..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
@@ -44,35 +42,31 @@ EOF
     run $VM0_CLI compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    echo "# Verifying output contains org/name format..."
-    # Output should show something like "Compose created: user-abc12345/e2e-org-compose-xxxx"
-    assert_output --regexp "Compose (created|version exists): [a-z0-9-]+/$AGENT_NAME"
+    echo "# Verifying output contains agent name..."
+    # Output should show something like "Compose created: e2e-org-compose-xxxx"
+    assert_output --regexp "Compose (created|version exists): $AGENT_NAME"
 
     echo "# Verifying output contains version..."
     assert_output --partial "Version:"
     assert_output --regexp "Version:[ ]+[0-9a-f]{8}"
 
-    echo "# Verifying run instructions include org/name:version format..."
-    # Output should show: vm0 run org/name:version
-    assert_output --regexp "vm0 run [a-z0-9-]+/$AGENT_NAME:[0-9a-f]{8}"
+    echo "# Verifying run instructions include name:version format..."
+    # Output should show: vm0 run name:version
+    assert_output --regexp "vm0 run $AGENT_NAME:[0-9a-f]{8}"
 }
 
 # ============================================
 # vm0 run with org/name format (E2E happy path)
 # ============================================
 
-@test "t22-2: vm0 run with org/name format resolves agent correctly" {
-    # This test verifies the end-to-end happy path for org/name format.
-    # Other identifier formats (org/name:version, name:version, backward compat)
-    # are tested via CLI Command Integration Tests in run/__tests__/index.test.ts.
-
+@test "t22-2: vm0 run with name format resolves agent correctly" {
     echo "# Step 1: Creating agent config..."
     cat > "$TEST_DIR/vm0.yaml" <<EOF
 version: "1.0"
 
 agents:
   $AGENT_NAME:
-    description: "Test agent for org/name run"
+    description: "Test agent for name run"
     framework: claude-code
     working_dir: /home/user/workspace
 EOF
@@ -81,17 +75,6 @@ EOF
     run $VM0_CLI compose "$TEST_DIR/vm0.yaml"
     assert_success
 
-    # Extract org from compose output (format: "Compose created: org/agent-name")
-    # This ensures we use the same org that compose actually used, avoiding race conditions
-    USER_ORG=$(echo "$output" | grep -oP '(created|exists): \K[a-z0-9-]+(?=/)' | head -1)
-    echo "# Org from compose output: $USER_ORG"
-
-    [ -n "$USER_ORG" ] || {
-        echo "# Failed to extract org from compose output"
-        echo "# Output was: $output"
-        return 1
-    }
-
     echo "# Step 3: Setting up artifact..."
     mkdir -p "$TEST_DIR/$ARTIFACT_NAME"
     cd "$TEST_DIR/$ARTIFACT_NAME"
@@ -99,13 +82,13 @@ EOF
     run $VM0_CLI artifact push
     assert_success
 
-    echo "# Step 4: Running with org/name format..."
-    run $VM0_CLI run "$USER_ORG/$AGENT_NAME" \
+    echo "# Step 4: Running with name format..."
+    run $VM0_CLI run "$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME" \
-        "echo hello from org test"
+        "echo hello from name test"
     assert_success
     assert_output --partial "● Bash("
-    assert_output --partial "hello from org test"
+    assert_output --partial "hello from name test"
 }
 
 # ============================================
@@ -135,6 +118,6 @@ EOF
     assert_success
 
     echo "# Verifying compose succeeded with default vm0.yaml..."
-    assert_output --regexp "Compose (created|version exists): [a-z0-9-]+/$AGENT_NAME"
+    assert_output --regexp "Compose (created|version exists): $AGENT_NAME"
     assert_output --partial "Version:"
 }

--- a/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/compose/__tests__/index.test.ts
@@ -528,11 +528,6 @@ describe("compose command", () => {
         path.join(tempDir, "config.yaml"),
         `version: "1.0"\nagents:\n  test:\n    framework: claude-code`,
       );
-      server.use(
-        http.get("http://localhost:3000/api/zero/org", () => {
-          return HttpResponse.json(orgResponse);
-        }),
-      );
     });
 
     it("should display loading message", async () => {
@@ -571,7 +566,7 @@ describe("compose command", () => {
       await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("Compose created: user-abc12345/test-agent"),
+        expect.stringContaining("Compose created: test-agent"),
       );
       expect(mockConsoleLog).toHaveBeenCalledWith(
         expect.stringContaining("Version: a1b2c3d4"),
@@ -594,9 +589,7 @@ describe("compose command", () => {
       await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Compose version exists: user-abc12345/test-agent",
-        ),
+        expect.stringContaining("Compose version exists: test-agent"),
       );
     });
 
@@ -616,7 +609,7 @@ describe("compose command", () => {
       await composeCommand.parseAsync(["node", "cli", "config.yaml"]);
 
       expect(mockConsoleLog).toHaveBeenCalledWith(
-        expect.stringContaining("vm0 run user-abc12345/test"),
+        expect.stringContaining("vm0 run test"),
       );
     });
   });
@@ -1372,13 +1365,12 @@ agents:
       expect(allLogs.some((log) => log.includes("Approve"))).toBe(false);
     });
 
-    it("should not call getZeroOrg or checkMissingItems in --json mode", async () => {
+    it("should not call checkMissingItems in --json mode", async () => {
       await fs.writeFile(
         path.join(tempDir, "vm0.yaml"),
         `version: "1.0"\nagents:\n  test-agent:\n    framework: claude-code`,
       );
 
-      let orgCalled = false;
       let secretsCalled = false;
       let variablesCalled = false;
       let connectorsCalled = false;
@@ -1392,10 +1384,6 @@ agents:
               "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6a1b2c3d4e5f6",
             action: "created",
           });
-        }),
-        http.get("http://localhost:3000/api/zero/org", () => {
-          orgCalled = true;
-          return HttpResponse.json(orgResponse);
         }),
         http.get("http://localhost:3000/api/zero/secrets", () => {
           secretsCalled = true;
@@ -1417,7 +1405,6 @@ agents:
 
       await composeCommand.parseAsync(["node", "cli", "--json"]);
 
-      expect(orgCalled).toBe(false);
       expect(secretsCalled).toBe(false);
       expect(variablesCalled).toBe(false);
       expect(connectorsCalled).toBe(false);
@@ -1667,9 +1654,6 @@ agents:
           action: "created",
         });
       }),
-      http.get("http://localhost:3000/api/zero/org", () => {
-        return HttpResponse.json(orgResponse);
-      }),
     );
 
     await composeCommand.parseAsync([
@@ -1682,7 +1666,7 @@ agents:
       expect.stringContaining("Downloading from GitHub"),
     );
     expect(mockConsoleLog).toHaveBeenCalledWith(
-      expect.stringContaining("Compose created: user-abc12345/intro"),
+      expect.stringContaining("Compose created: intro"),
     );
   });
 

--- a/turbo/apps/cli/src/commands/compose/index.ts
+++ b/turbo/apps/cli/src/commands/compose/index.ts
@@ -8,7 +8,6 @@ import { extractAndGroupVariables, resolveSkillRef } from "@vm0/core";
 import {
   getComposeByName,
   createOrUpdateCompose,
-  getZeroOrg,
   listZeroSecrets,
   listZeroVariables,
   listZeroConnectors,
@@ -302,10 +301,7 @@ async function finalizeCompose(
   const response = await createOrUpdateCompose({ content: config });
 
   const shortVersionId = response.versionId.slice(0, 8);
-  // In --json mode, skip getOrg() — the org prefix in displayName is for human display only
-  const displayName = options.json
-    ? response.name
-    : `${(await getZeroOrg()).slug}/${response.name}`;
+  const displayName = response.name;
 
   // Build result
   const result: ComposeResult = {

--- a/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/index.test.ts
@@ -420,21 +420,18 @@ describe("run command", () => {
       expect(mockExit).toHaveBeenCalledWith(1);
     });
 
-    it("should parse org/name format", async () => {
-      let capturedQueryParams:
-        | { name: string | null; org: string | null }
-        | undefined;
+    it("should treat slash in identifier as part of name", async () => {
+      let capturedQueryParams: { name: string | null } | undefined;
       let capturedBody: unknown;
       server.use(
         http.get("http://localhost:3000/api/agent/composes", ({ request }) => {
           const url = new URL(request.url);
           capturedQueryParams = {
             name: url.searchParams.get("name"),
-            org: url.searchParams.get("org"),
           };
           return HttpResponse.json({
             id: "550e8400-e29b-41d4-a716-446655440000",
-            name: "my-agent",
+            name: "user-abc123/my-agent",
             headVersionId:
               "abc12345def67890abc12345def67890abc12345def67890abc12345def67890",
             content: { version: "1", agents: { main: { provider: "claude" } } },
@@ -478,8 +475,7 @@ describe("run command", () => {
       ]);
 
       expect(capturedQueryParams).toEqual({
-        name: "my-agent",
-        org: "user-abc123",
+        name: "user-abc123/my-agent",
       });
       expect(capturedBody).toEqual(
         expect.objectContaining({

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -31,7 +31,7 @@ export const mainRunCommand = new Command()
   .description("Run an agent")
   .argument(
     "<agent-name>",
-    "Agent reference: [org/]name[:version] (e.g., 'my-agent', 'lancy/my-agent:abc123', 'my-agent:latest')",
+    "Agent reference: name[:version] (e.g., 'my-agent', 'my-agent:abc123', 'my-agent:latest')",
   )
   .argument("<prompt>", "Prompt for the agent")
   .option(
@@ -125,8 +125,8 @@ export const mainRunCommand = new Command()
           await startSilentUpgrade(__CLI_VERSION__);
         }
 
-        // 1. Parse identifier for optional org and version specifier
-        const { org, name, version } = parseIdentifier(identifier);
+        // 1. Parse identifier for optional version specifier
+        const { name, version } = parseIdentifier(identifier);
 
         // 2. Resolve name to composeId and get compose content
         let composeId: string;
@@ -139,7 +139,7 @@ export const mainRunCommand = new Command()
           composeContent = compose.content;
         } else {
           // It's an agent name - resolve to compose ID
-          const compose = await getComposeByName(name, org);
+          const compose = await getComposeByName(name);
           if (!compose) {
             throw new Error(`Agent not found: ${identifier}`, {
               cause: new Error(

--- a/turbo/apps/cli/src/commands/run/shared.ts
+++ b/turbo/apps/cli/src/commands/run/shared.ts
@@ -157,16 +157,13 @@ export function loadValues(
 
 /**
  * Parse identifier with optional org and version specifier
- * Format: [org/]name[:version]
+ * Format: name[:version]
  * Examples:
  *   "demo:d084948d"      → { name: "demo", version: "d084948d" }
  *   "demo:latest"        → { name: "demo", version: "latest" }
  *   "demo"               → { name: "demo" }
- *   "lancy/demo"         → { org: "lancy", name: "demo" }
- *   "lancy/demo:abc123"  → { org: "lancy", name: "demo", version: "abc123" }
  */
 export function parseIdentifier(identifier: string): {
-  org?: string;
   name: string;
   version?: string;
 } {
@@ -175,27 +172,16 @@ export function parseIdentifier(identifier: string): {
     return { name: identifier };
   }
 
-  let org: string | undefined;
-  let rest = identifier;
-
-  // Check for org (contains "/")
-  const slashIndex = identifier.indexOf("/");
-  if (slashIndex > 0) {
-    org = identifier.slice(0, slashIndex);
-    rest = identifier.slice(slashIndex + 1);
-  }
-
   // Parse name:version format using indexOf (version comes after name)
-  const colonIndex = rest.indexOf(":");
-  if (colonIndex > 0 && colonIndex < rest.length - 1) {
+  const colonIndex = identifier.indexOf(":");
+  if (colonIndex > 0 && colonIndex < identifier.length - 1) {
     return {
-      org,
-      name: rest.slice(0, colonIndex),
-      version: rest.slice(colonIndex + 1),
+      name: identifier.slice(0, colonIndex),
+      version: identifier.slice(colonIndex + 1),
     };
   }
 
-  return { org, name: rest };
+  return { name: identifier };
 }
 
 /**

--- a/turbo/apps/cli/src/lib/api/domains/composes.ts
+++ b/turbo/apps/cli/src/lib/api/domains/composes.ts
@@ -19,13 +19,12 @@ import type {
 
 export async function getComposeByName(
   name: string,
-  org?: string,
 ): Promise<GetComposeResponse | null> {
   const config = await getClientConfig();
   const client = initClient(composesMainContract, config);
 
   const result = await client.getByName({
-    query: { name, org },
+    query: { name },
   });
 
   if (result.status === 200) {
@@ -49,7 +48,6 @@ const UUID_PATTERN =
  */
 export async function resolveCompose(
   identifier: string,
-  org?: string,
 ): Promise<GetComposeResponse | null> {
   if (UUID_PATTERN.test(identifier)) {
     try {
@@ -61,7 +59,7 @@ export async function resolveCompose(
       throw error;
     }
   }
-  return getComposeByName(identifier, org);
+  return getComposeByName(identifier);
 }
 
 export async function getComposeById(id: string): Promise<GetComposeResponse> {

--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -42,7 +42,7 @@ const orgAgents$ = computed((get) => get(internalOrgAgents$));
 
 const fetchOrgAgents$ = command(async ({ get, set }, _signal: AbortSignal) => {
   const client = get(zeroClient$)(zeroComposesListContract);
-  const result = await client.list();
+  const result = await client.list({ query: {} });
   if (result.status !== 200) {
     throw new Error(`Failed to fetch org agents (${result.status})`);
   }

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -225,6 +225,7 @@ export const completeZeroOnboarding$ = command(
       // Set as default agent
       const defaultAgentClient = createClient(orgDefaultAgentContract);
       const result = await defaultAgentClient.setDefaultAgent({
+        query: {},
         body: { agentId: agent.agentId },
       });
       signal.throwIfAborted();

--- a/turbo/apps/web/app/api/agent/checkpoints/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/checkpoints/[id]/route.ts
@@ -27,7 +27,7 @@ interface VolumeVersionsSnapshot {
 }
 
 const router = tsr.router(checkpointsByIdContract, {
-  getById: async ({ params, headers }, { request }) => {
+  getById: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -41,8 +41,7 @@ const router = tsr.router(checkpointsByIdContract, {
     }
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const [checkpoint] = await globalThis.services.db
       .select()

--- a/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/get-by-name.test.ts
@@ -3,7 +3,6 @@ import { GET } from "../route";
 import {
   createTestRequest,
   createTestCompose,
-  getOrgCacheEntry,
   insertOrgMembersCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
@@ -142,14 +141,11 @@ describe("GET /api/agent/composes?name=<name>", () => {
     expect(getData.error.message).toContain("Not authenticated");
   });
 
-  it("should return org member agent via cross-org lookup with ?org=", async () => {
+  it("should return org member agent via cross-org lookup", async () => {
     const agentName = `test-org-member-agent-${Date.now()}`;
 
     // Create compose as owner
     const { composeId } = await createTestCompose(agentName);
-
-    // Get the owner's org slug
-    const ownerOrg = (await getOrgCacheEntry(user.orgId))!;
 
     // Switch to recipient user who is a member of the owner's org
     const recipient = await context.setupUser({ prefix: "recipient" });
@@ -158,11 +154,12 @@ describe("GET /api/agent/composes?name=<name>", () => {
       userId: recipient.userId,
       cachedAt: new Date(),
     });
-    mockClerk({ userId: recipient.userId });
+    // Recipient accesses the owner's org as their active org
+    mockClerk({ userId: recipient.userId, orgId: user.orgId });
 
-    // Access the agent via cross-org lookup
+    // Access the agent via the owner's org (set as active org in session)
     const getRequest = createTestRequest(
-      `http://localhost:3000/api/agent/composes?name=${agentName}&org=${ownerOrg.slug}`,
+      `http://localhost:3000/api/agent/composes?name=${agentName}`,
       { method: "GET" },
     );
 
@@ -180,15 +177,12 @@ describe("GET /api/agent/composes?name=<name>", () => {
     // Create compose as owner (no permission granted)
     await createTestCompose(agentName);
 
-    // Get the owner's org slug
-    const ownerOrg = (await getOrgCacheEntry(user.orgId))!;
-
     // Switch to another user with no permission
     await context.setupUser({ prefix: "unauthorized" });
 
     // Try to access via cross-org lookup
     const getRequest = createTestRequest(
-      `http://localhost:3000/api/agent/composes?name=${agentName}&org=${ownerOrg.slug}`,
+      `http://localhost:3000/api/agent/composes?name=${agentName}`,
       { method: "GET" },
     );
 
@@ -219,15 +213,11 @@ describe("GET /api/agent/composes?name=<name>", () => {
     expect(getData.name).toBe(agentName);
   });
 
-  it("should return org member agent via cross-org lookup with ?org= using orgId", async () => {
+  it("should return org member agent via cross-org lookup using orgId in session", async () => {
     const agentName = `test-shared-org-${Date.now()}`;
 
     // Create compose as owner
     const { composeId } = await createTestCompose(agentName);
-
-    // Get the owner's org slug to derive orgId
-    const ownerOrg = (await getOrgCacheEntry(user.orgId))!;
-    const ownerOrgId = ownerOrg.orgId;
 
     // Switch to recipient user who is a member of the owner's org
     const recipient = await context.setupUser({ prefix: "recipient-org" });
@@ -236,11 +226,12 @@ describe("GET /api/agent/composes?name=<name>", () => {
       userId: recipient.userId,
       cachedAt: new Date(),
     });
-    mockClerk({ userId: recipient.userId });
+    // Recipient accesses the owner's org as their active org (orgId in session)
+    mockClerk({ userId: recipient.userId, orgId: user.orgId });
 
-    // Access the agent via cross-org lookup using ?org=
+    // Access the agent using owner's org as the active org in session
     const getRequest = createTestRequest(
-      `http://localhost:3000/api/agent/composes?name=${agentName}&org=${ownerOrgId}`,
+      `http://localhost:3000/api/agent/composes?name=${agentName}`,
       { method: "GET" },
     );
 
@@ -258,16 +249,12 @@ describe("GET /api/agent/composes?name=<name>", () => {
     // Create compose as owner (no permission granted)
     await createTestCompose(agentName);
 
-    // Get the owner's org slug to derive orgId
-    const ownerOrg = (await getOrgCacheEntry(user.orgId))!;
-    const ownerOrgId = ownerOrg.orgId;
-
     // Switch to another user with no permission
     await context.setupUser({ prefix: "unauthorized-org" });
 
-    // Try to access via cross-org lookup using ?org=
+    // Try to access via cross-org lookup
     const getRequest = createTestRequest(
-      `http://localhost:3000/api/agent/composes?name=${agentName}&org=${ownerOrgId}`,
+      `http://localhost:3000/api/agent/composes?name=${agentName}`,
       { method: "GET" },
     );
 
@@ -280,7 +267,7 @@ describe("GET /api/agent/composes?name=<name>", () => {
 
   it("should return 404 for invalid org slug in cross-org lookup", async () => {
     const getRequest = createTestRequest(
-      "http://localhost:3000/api/agent/composes?name=any-agent&org=nonexistent-org",
+      "http://localhost:3000/api/agent/composes?name=any-agent",
       { method: "GET" },
     );
 

--- a/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/__tests__/sandbox-capability.test.ts
@@ -14,7 +14,7 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
+import { generateZeroToken } from "../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -38,13 +38,13 @@ describe("Sandbox capability enforcement on compose routes", () => {
         role: "admin",
       });
 
-      // Switch to sandbox auth
-      const orgSlug = `org-${user.userId.slice(-8)}`;
-      mockClerk({ userId: null, orgId: user.orgId });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      // Switch to sandbox auth (no Clerk session)
+      mockClerk({ userId: null });
+      // Zero token carries orgId so resolveOrg can resolve the org
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
 
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/composes?name=${agentName}&org=${orgSlug}`,
+        `http://localhost:3000/api/agent/composes?name=${agentName}`,
         {
           headers: { Authorization: `Bearer ${token}` },
         },
@@ -67,12 +67,11 @@ describe("Sandbox capability enforcement on compose routes", () => {
         role: "admin",
       });
 
-      const orgSlug = `org-${user.userId.slice(-8)}`;
-      mockClerk({ userId: null, orgId: user.orgId });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      mockClerk({ userId: null });
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
 
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/composes?name=${agentName}&org=${orgSlug}`,
+        `http://localhost:3000/api/agent/composes?name=${agentName}`,
         {
           headers: { Authorization: `Bearer ${token}` },
         },
@@ -97,12 +96,11 @@ describe("Sandbox capability enforcement on compose routes", () => {
         role: "admin",
       });
 
-      const orgSlug = `org-${user.userId.slice(-8)}`;
-      mockClerk({ userId: null, orgId: user.orgId });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      mockClerk({ userId: null });
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
 
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/composes?org=${orgSlug}`,
+        "http://localhost:3000/api/agent/composes",
         {
           method: "POST",
           headers: {
@@ -136,12 +134,11 @@ describe("Sandbox capability enforcement on compose routes", () => {
         role: "admin",
       });
 
-      const orgSlug = `org-${user.userId.slice(-8)}`;
-      mockClerk({ userId: null, orgId: user.orgId });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      mockClerk({ userId: null });
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
 
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/composes?org=${orgSlug}`,
+        "http://localhost:3000/api/agent/composes",
         {
           method: "POST",
           headers: {
@@ -176,12 +173,11 @@ describe("Sandbox capability enforcement on compose routes", () => {
         role: "admin",
       });
 
-      const orgSlug = `org-${user.userId.slice(-8)}`;
-      mockClerk({ userId: null, orgId: user.orgId });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      mockClerk({ userId: null });
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
 
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/composes/list?org=${orgSlug}`,
+        "http://localhost:3000/api/agent/composes/list",
         {
           headers: { Authorization: `Bearer ${token}` },
         },
@@ -202,7 +198,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
       const { composeId } = await createTestCompose(agentName);
 
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/composes/${composeId}`,
@@ -225,7 +221,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
       const { composeId } = await createTestCompose(agentName);
 
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/composes/${composeId}`,
@@ -247,7 +243,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
       const { composeId } = await createTestCompose(agentName);
 
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/composes/${composeId}`,
@@ -268,7 +264,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
       const { composeId, versionId } = await createTestCompose(agentName);
 
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/composes/versions?composeId=${composeId}&version=latest`,
@@ -291,7 +287,7 @@ describe("Sandbox capability enforcement on compose routes", () => {
       const { composeId } = await createTestCompose(agentName);
 
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-123");
+      const token = await generateZeroToken(user.userId, "run-123", user.orgId);
 
       const request = createTestRequest(
         `http://localhost:3000/api/agent/composes/${composeId}/instructions`,

--- a/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/__tests__/route.test.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
-  uniqueId,
   type UserContext,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
@@ -37,12 +36,8 @@ describe("GET /api/agent/composes/list", () => {
   });
 
   it("should return no own composes when none exist in org", async () => {
-    // Use explicit org param to only get own agents (excludes shared)
-    const uniqueSuffix = user.userId.replace("test-user-", "");
-    const orgSlug = `org-${uniqueSuffix}`;
-
     const request = createTestRequest(
-      `http://localhost:3000/api/agent/composes/list?org=${orgSlug}`,
+      "http://localhost:3000/api/agent/composes/list",
     );
     const response = await GET(request);
     const data = await response.json();
@@ -59,12 +54,8 @@ describe("GET /api/agent/composes/list", () => {
     await createTestCompose(agentName1);
     await createTestCompose(agentName2);
 
-    // Use explicit org param to get only own agents
-    const uniqueSuffix = user.userId.replace("test-user-", "");
-    const orgSlug = `org-${uniqueSuffix}`;
-
     const request = createTestRequest(
-      `http://localhost:3000/api/agent/composes/list?org=${orgSlug}`,
+      "http://localhost:3000/api/agent/composes/list",
     );
     const response = await GET(request);
     const data = await response.json();
@@ -125,57 +116,14 @@ describe("GET /api/agent/composes/list", () => {
     expect(otherNames).not.toContain(userAgentName);
   });
 
-  it("should return 400 for non-existent org", async () => {
-    const request = createTestRequest(
-      "http://localhost:3000/api/agent/composes/list?org=nonexistent-org",
-    );
-    const response = await GET(request);
-    const data = await response.json();
-
-    expect(response.status).toBe(400);
-    expect(data.error.code).toBe("BAD_REQUEST");
-  });
-
-  it("should return 403 when user tries to access another user's org", async () => {
-    // Create another user with their own org
-    const otherUser = await context.setupUser({ prefix: "forbidden-user" });
-
-    // Create a compose for the other user
-    await createTestCompose(uniqueId("forbidden-compose"));
-
-    // Derive the other user's org slug from their userId
-    // userId format: {prefix}-{timestamp}-{uuid}
-    // org slug format: org-{timestamp}-{uuid}
-    const uniqueSuffix = otherUser.userId.replace("forbidden-user-", "");
-    const otherOrgSlug = `org-${uniqueSuffix}`;
-
-    // Switch back to original user and try to access the other user's org
-    mockClerk({ userId: user.userId });
-    const request = createTestRequest(
-      `http://localhost:3000/api/agent/composes/list?org=${otherOrgSlug}`,
-    );
-    const response = await GET(request);
-    const data = await response.json();
-
-    expect(response.status).toBe(403);
-    expect(data.error.code).toBe("FORBIDDEN");
-    expect(data.error.message).toContain("don't have access");
-  });
-
   it("should list composes by specified org slug", async () => {
     // Create a compose first
     const agentName = `test-org-agent-${Date.now()}`;
     await createTestCompose(agentName);
 
-    // Derive the user's org slug from their userId
-    // userId format: test-user-{timestamp}-{uuid}
-    // org slug format: org-{timestamp}-{uuid}
-    const uniqueSuffix = user.userId.replace("test-user-", "");
-    const orgSlug = `org-${uniqueSuffix}`;
-
     // List by org slug
     const request = createTestRequest(
-      `http://localhost:3000/api/agent/composes/list?org=${orgSlug}`,
+      "http://localhost:3000/api/agent/composes/list",
     );
     const response = await GET(request);
     const data = await response.json();

--- a/turbo/apps/web/app/api/agent/composes/list/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/list/route.ts
@@ -10,7 +10,7 @@ import { listComposes } from "../../../../../src/lib/agent-compose/compose-servi
 import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(composesListContract, {
-  list: async ({ query, headers }) => {
+  list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -20,7 +20,7 @@ const router = tsr.router(composesListContract, {
 
     let orgId: string;
     try {
-      const { org: resolvedOrg } = await resolveOrg(authCtx, query.org);
+      const { org: resolvedOrg } = await resolveOrg(authCtx);
       orgId = resolvedOrg.orgId;
     } catch (error) {
       if (isNotFound(error)) {

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -22,7 +22,6 @@ import { eq, and } from "drizzle-orm";
 import { computeComposeVersionId } from "../../../../src/lib/agent-compose/content-hash";
 import { getComposeByName } from "../../../../src/lib/agent-compose/compose-service";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
-import { getOrgBySlug } from "../../../../src/lib/org/org-cache-service";
 import {
   isNotFound,
   isForbidden,
@@ -38,23 +37,10 @@ const router = tsr.router(composesMainContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    // Resolve org and verify membership. For cross-org lookups (?org=),
-    // resolveOrg verifies the caller is a member of the target org,
-    // replacing the previous canAccessCompose authorization.
-    // ?org= supports both slug and orgId formats.
     let orgId: string;
     try {
-      if (query.org) {
-        // Try slug first, fall back to orgId (callers may pass either via ?org=)
-        const orgBySlug = await getOrgBySlug(query.org);
-        const { org } = orgBySlug
-          ? await resolveOrg(authCtx, query.org)
-          : await resolveOrg(authCtx, undefined, query.org);
-        orgId = org.orgId;
-      } else {
-        const { org } = await resolveOrg(authCtx);
-        orgId = org.orgId;
-      }
+      const { org } = await resolveOrg(authCtx);
+      orgId = org.orgId;
     } catch (error) {
       if (isNotFound(error) || isForbidden(error) || isBadRequest(error)) {
         return {
@@ -86,7 +72,7 @@ const router = tsr.router(composesMainContract, {
     return { status: 200 as const, body: compose };
   },
 
-  create: async ({ body, headers }, { request }) => {
+  create: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -199,8 +185,7 @@ const router = tsr.router(composesMainContract, {
     const versionId = computeComposeVersionId(resolvedContent);
 
     // Get user's org (required for compose creation)
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Check compose and version existence in parallel
     const [existingComposes, existingVersions] = await Promise.all([

--- a/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/__tests__/route.test.ts
@@ -11,7 +11,10 @@ import {
   insertOrgMembersCacheEntry,
   getOrgCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
-import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
+import {
+  generateSandboxToken,
+  generateZeroToken,
+} from "../../../../../../src/lib/auth/sandbox-token";
 import {
   testContext,
   uniqueId,
@@ -168,7 +171,7 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
       });
 
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/runs/${runId}?org=${orgEntry!.slug}`,
+        `http://localhost:3000/api/agent/runs/${runId}`,
       );
       const response = await GET(request);
       const data = await response.json();
@@ -196,11 +199,10 @@ describe("GET /api/agent/runs/:id - Get Run By ID", () => {
       });
 
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, run.runId);
+      const token = await generateZeroToken(user.userId, run.runId, user.orgId);
 
-      const orgEntry = await getOrgCacheEntry(user.orgId);
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/runs/${run.runId}?org=${orgEntry!.slug}`,
+        `http://localhost:3000/api/agent/runs/${run.runId}`,
         { headers: { authorization: `Bearer ${token}` } },
       );
       const response = await GET(request);

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/__tests__/route.test.ts
@@ -189,7 +189,7 @@ describe("POST /api/agent/runs/:id/cancel - Cancel Run", () => {
       });
 
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/runs/${runId}/cancel?org=${orgEntry!.slug}`,
+        `http://localhost:3000/api/agent/runs/${runId}/cancel`,
         { method: "POST" },
       );
       const response = await POST(request);

--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -22,7 +22,7 @@ import { after } from "next/server";
 const log = logger("api:runs:cancel");
 
 const router = tsr.router(runsCancelContract, {
-  cancel: async ({ params, headers }, { request }) => {
+  cancel: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -53,8 +53,7 @@ const router = tsr.router(runsCancelContract, {
       }
       orgId = (await getOrgData(sandboxRun.orgId)).orgId;
     } else {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       orgId = org.orgId;
     }
 

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/__tests__/route.test.ts
@@ -8,7 +8,6 @@ import {
   completeTestRun,
   createTestCliToken,
   deleteTestCliToken,
-  getOrgCacheEntry,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -807,9 +806,8 @@ describe("GET /api/agent/runs/:id/events", () => {
     });
 
     it("should accept request with valid CLI token", async () => {
-      const orgEntry = await getOrgCacheEntry(user.orgId);
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/runs/${testRunId}/events?org=${orgEntry!.slug}`,
+        `http://localhost:3000/api/agent/runs/${testRunId}/events`,
         {
           headers: {
             Authorization: `Bearer ${testCliToken}`,

--- a/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/events/route.ts
@@ -23,7 +23,7 @@ import type {
 import { filterConsecutiveEvents, type AxiomAgentEvent } from "./filter-events";
 
 const router = tsr.router(runEventsContract, {
-  getEvents: async ({ params, query, headers }, { request }) => {
+  getEvents: async ({ params, query, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization, {
@@ -41,8 +41,7 @@ const router = tsr.router(runEventsContract, {
 
     const { since, limit } = query;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Verify run exists and belongs to user+org, join with compose version to get framework
     const [runWithCompose] = await globalThis.services.db

--- a/turbo/apps/web/app/api/agent/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/route.ts
@@ -9,7 +9,7 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { getRunById } from "../../../../../src/lib/run/run-service";
 
 const router = tsr.router(runsByIdContract, {
-  getById: async ({ params, headers }, { request }) => {
+  getById: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -18,8 +18,7 @@ const router = tsr.router(runsByIdContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const run = await getRunById(params.id, userId, org.orgId);
     if (!run) {

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/agent/route.ts
@@ -11,7 +11,7 @@ import { getRunAgentEvents } from "../../../../../../../src/lib/run/run-telemetr
 import { isNotFound } from "../../../../../../../src/lib/errors";
 
 const router = tsr.router(runAgentEventsContract, {
-  getAgentEvents: async ({ params, query, headers }, { request }) => {
+  getAgentEvents: async ({ params, query, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization, {
@@ -27,8 +27,7 @@ const router = tsr.router(runAgentEventsContract, {
     }
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     try {
       const result = await getRunAgentEvents(

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/metrics/route.ts
@@ -26,7 +26,7 @@ interface AxiomMetricEvent {
 }
 
 const router = tsr.router(runMetricsContract, {
-  getMetrics: async ({ params, query, headers }, { request }) => {
+  getMetrics: async ({ params, query, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization, {
@@ -42,8 +42,7 @@ const router = tsr.router(runMetricsContract, {
     }
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Verify run exists and belongs to user+org
     const [run] = await globalThis.services.db

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -47,7 +47,7 @@ interface AxiomNetworkEvent {
 }
 
 const router = tsr.router(runNetworkLogsContract, {
-  getNetworkLogs: async ({ params, query, headers }, { request }) => {
+  getNetworkLogs: async ({ params, query, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization, {
@@ -63,8 +63,7 @@ const router = tsr.router(runNetworkLogsContract, {
     }
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Verify run exists and belongs to user+org
     const [run] = await globalThis.services.db

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/route.ts
@@ -27,7 +27,7 @@ interface TelemetryData {
 }
 
 const router = tsr.router(runTelemetryContract, {
-  getTelemetry: async ({ params, headers }, { request }) => {
+  getTelemetry: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization, {
@@ -43,8 +43,7 @@ const router = tsr.router(runTelemetryContract, {
     }
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Verify run exists and belongs to user+org
     const [run] = await globalThis.services.db

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/system-log/route.ts
@@ -22,7 +22,7 @@ interface AxiomSystemLogEvent {
 }
 
 const router = tsr.router(runSystemLogContract, {
-  getSystemLog: async ({ params, query, headers }, { request }) => {
+  getSystemLog: async ({ params, query, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization, {
@@ -38,8 +38,7 @@ const router = tsr.router(runSystemLogContract, {
     }
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Verify run exists and belongs to user+org
     const [run] = await globalThis.services.db

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -24,7 +24,10 @@ import {
   updateOrgTier,
   findTestRunnerJobEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
-import { generateSandboxToken } from "../../../../../src/lib/auth/sandbox-token";
+import {
+  generateSandboxToken,
+  generateZeroToken,
+} from "../../../../../src/lib/auth/sandbox-token";
 import {
   testContext,
   uniqueId,
@@ -568,9 +571,8 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
     });
 
     it("should authenticate with valid CLI token", async () => {
-      const orgSlug = `org-${user.userId.slice(-8)}`;
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/runs?org=${orgSlug}`,
+        "http://localhost:3000/api/agent/runs",
         {
           method: "POST",
           headers: {
@@ -1594,11 +1596,10 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       // Now switch to sandbox auth (no Clerk session)
       mockClerk({ userId: null });
 
-      const token = await generateSandboxToken(user.userId, runId);
+      const token = await generateZeroToken(user.userId, runId, user.orgId);
 
-      const orgEntry = await getOrgCacheEntry(user.orgId);
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/runs?limit=10&org=${orgEntry!.slug}`,
+        "http://localhost:3000/api/agent/runs?limit=10",
         { headers: { authorization: `Bearer ${token}` } },
       );
       const response = await GET(request);
@@ -1620,11 +1621,10 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       });
 
       mockClerk({ userId: null });
-      const token = await generateSandboxToken(user.userId, "run-1");
+      const token = await generateZeroToken(user.userId, "run-1", user.orgId);
 
-      const orgEntry = await getOrgCacheEntry(user.orgId);
       const request = createTestRequest(
-        `http://localhost:3000/api/agent/runs?limit=10&org=${orgEntry!.slug}`,
+        "http://localhost:3000/api/agent/runs?limit=10",
         { headers: { authorization: `Bearer ${token}` } },
       );
       const response = await GET(request);
@@ -1763,7 +1763,7 @@ describe("GET /api/agent/runs - List Runs", () => {
     });
 
     const request = createTestRequest(
-      `http://localhost:3000/api/agent/runs?status=running&limit=50&org=${orgEntry!.slug}`,
+      "http://localhost:3000/api/agent/runs?status=running&limit=50",
     );
     const response = await GET(request);
     const data = await response.json();

--- a/turbo/apps/web/app/api/agent/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/queue/route.ts
@@ -6,7 +6,7 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { getRunQueueStatus } from "../../../../../src/lib/zero/zero-queue-service";
 
 const router = tsr.router(runsQueueContract, {
-  getQueue: async ({ headers }, { request }) => {
+  getQueue: async ({ headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization, {
@@ -22,8 +22,7 @@ const router = tsr.router(runsQueueContract, {
     }
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     const orgTier = orgTierSchema.parse(org.tier);
 
     const result = await getRunQueueStatus(userId, org.orgId, orgTier);

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -76,7 +76,7 @@ function handleCreateRunError(error: unknown) {
 }
 
 const router = tsr.router(runsMainContract, {
-  list: async ({ query, headers }, { request }) => {
+  list: async ({ query, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -85,8 +85,7 @@ const router = tsr.router(runsMainContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Parse and validate status values
     const statusValues: string[] = query.status
@@ -194,7 +193,7 @@ const router = tsr.router(runsMainContract, {
       },
     };
   },
-  create: async ({ body, headers }, { request }) => {
+  create: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -204,8 +203,7 @@ const router = tsr.router(runsMainContract, {
     const { userId } = authCtx;
 
     // Resolve caller's org for authorization (ensures org membership)
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     log.debug(
       `Creating run - mode: ${body.checkpointId ? "checkpoint" : body.sessionId ? "session" : "new"}`,

--- a/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
@@ -6,12 +6,11 @@ import {
 import { sessionsByIdContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
-import { resolveCallerOrgId } from "../../../../../src/lib/org/resolve-org";
 import { getSessionResponse } from "../../../../../src/lib/agent-session/agent-session-service";
 import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(sessionsByIdContract, {
-  getById: async ({ params, headers }, { request }) => {
+  getById: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -25,7 +24,7 @@ const router = tsr.router(sessionsByIdContract, {
     }
     const { userId } = authCtx;
 
-    const callerOrgId = await resolveCallerOrgId(authCtx, request);
+    const callerOrgId = authCtx.orgId ?? null;
     if (!callerOrgId) {
       return {
         status: 404 as const,

--- a/turbo/apps/web/app/api/agent/sessions/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/route.ts
@@ -5,10 +5,9 @@ import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
 import { listAgentSessions } from "../../../../src/lib/agent-session";
 import { agentComposes } from "../../../../src/db/schema/agent-compose";
-import { resolveCallerOrgId } from "../../../../src/lib/org/resolve-org";
 
 const router = tsr.router(sessionsContract, {
-  list: async ({ query, headers }, { request }) => {
+  list: async ({ query, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -38,7 +37,7 @@ const router = tsr.router(sessionsContract, {
       };
     }
 
-    const callerOrgId = await resolveCallerOrgId(authCtx, request);
+    const callerOrgId = authCtx.orgId ?? null;
     if (callerOrgId !== compose.orgId) {
       return {
         status: 404 as const,

--- a/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/authorize/route.ts
@@ -104,8 +104,7 @@ export async function GET(
   // Auto-disconnect existing connector before re-authorizing.
   // This ensures old provider tokens are revoked during reconnect flows
   // (both "Connection expired" and "Permissions update" paths).
-  const orgSlug = url.searchParams.get("org");
-  const { org } = await resolveOrg(authCtx, orgSlug);
+  const { org } = await resolveOrg(authCtx);
 
   const [existing] = await globalThis.services.db
     .select({ id: connectors.id })

--- a/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
+++ b/turbo/apps/web/app/api/connectors/[type]/callback/route.ts
@@ -200,8 +200,7 @@ export async function GET(
     // when the code adds new scopes and prompt users to re-authorize.
     // Note: do not read "scope" from the callback URL — OAuth providers (e.g., Monday.com)
     // may append OAuth scopes as ?scope=... which would be mistaken for an app scope slug.
-    const orgSlug = url.searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     const { created } = await upsertOAuthConnector(
       org.orgId,
       userId,

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -125,8 +125,7 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's org for resource queries
-  const orgSlug = new URL(request.url).searchParams.get("org");
-  const { org } = await resolveOrg(authCtx, orgSlug);
+  const { org } = await resolveOrg(authCtx);
 
   // Get user's existing secrets, vars, connectors
   const [userSecrets, userVars, userConnectors] = await Promise.all([
@@ -349,8 +348,7 @@ export async function PATCH(request: Request) {
     }
     targetOrgId = targetOrg.orgId;
   } else {
-    const urlOrgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, urlOrgSlug);
+    const { org } = await resolveOrg(authCtx);
     targetOrgId = org.orgId;
   }
 

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -124,8 +124,7 @@ export async function GET(request: Request) {
   }
 
   // Resolve user's default org and get existing secrets, vars, connectors
-  const orgSlug = new URL(request.url).searchParams.get("org");
-  const { org } = await resolveOrg(authCtx, orgSlug);
+  const { org } = await resolveOrg(authCtx);
   const [userSecrets, userVars, userConnectors] = await Promise.all([
     listSecrets(org.orgId, userId),
     listVariables(org.orgId, userId),
@@ -272,8 +271,7 @@ export async function PATCH(request: Request) {
     targetOrg = resolved;
   } else {
     try {
-      const urlOrgSlug = new URL(request.url).searchParams.get("org");
-      ({ org: targetOrg } = await resolveOrg(authCtx, urlOrgSlug));
+      ({ org: targetOrg } = await resolveOrg(authCtx));
     } catch (error) {
       if (isNotFound(error)) {
         return NextResponse.json(

--- a/turbo/apps/web/app/api/logs/search/route.ts
+++ b/turbo/apps/web/app/api/logs/search/route.ts
@@ -175,7 +175,7 @@ function toRunEvent(event: AxiomAgentEvent): RunEvent {
 }
 
 const router = tsr.router(logsSearchContract, {
-  searchLogs: async ({ query, headers }, { request }) => {
+  searchLogs: async ({ query, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -189,8 +189,7 @@ const router = tsr.router(logsSearchContract, {
     }
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const { keyword, agent, runId, limit, before, after } = query;
     const since = query.since ?? Date.now() - SEVEN_DAYS_MS;

--- a/turbo/apps/web/app/api/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/storages/commit/route.ts
@@ -26,7 +26,7 @@ import { logger } from "../../../../src/lib/logger";
 const log = logger("api:storages:commit");
 
 const router = tsr.router(storagesCommitContract, {
-  commit: async ({ body, headers }, { request }) => {
+  commit: async ({ body, headers }) => {
     initServices();
 
     const { storageName, storageType, versionId, files, runId, message } = body;
@@ -62,8 +62,7 @@ const router = tsr.router(storagesCommitContract, {
       }
       runtimeOrg = await getOrgData(run.orgId);
     } else {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       runtimeOrg = org;
 
       // For CLI tokens, verify body.runId belongs to the user if provided

--- a/turbo/apps/web/app/api/storages/download/route.ts
+++ b/turbo/apps/web/app/api/storages/download/route.ts
@@ -23,7 +23,7 @@ import { logger } from "../../../../src/lib/logger";
 const log = logger("api:storages:download");
 
 const router = tsr.router(storagesDownloadContract, {
-  download: async ({ query, headers }, { request }) => {
+  download: async ({ query, headers }) => {
     initServices();
 
     const { name: storageName, type: storageType, version: versionId } = query;
@@ -54,8 +54,7 @@ const router = tsr.router(storagesDownloadContract, {
       }
       runtimeOrg = await getOrgData(run.orgId);
     } else {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       runtimeOrg = org;
     }
 

--- a/turbo/apps/web/app/api/storages/list/route.ts
+++ b/turbo/apps/web/app/api/storages/list/route.ts
@@ -20,7 +20,7 @@ import { logger } from "../../../../src/lib/logger";
 const log = logger("api:storages:list");
 
 const router = tsr.router(storagesListContract, {
-  list: async ({ query, headers }, { request }) => {
+  list: async ({ query, headers }) => {
     initServices();
 
     const { type: storageType } = query;
@@ -51,8 +51,7 @@ const router = tsr.router(storagesListContract, {
       }
       runtimeOrg = await getOrgData(run.orgId);
     } else {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       runtimeOrg = org;
     }
 

--- a/turbo/apps/web/app/api/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/storages/prepare/route.ts
@@ -92,7 +92,7 @@ async function mergeWithBaseVersion(
 }
 
 const router = tsr.router(storagesPrepareContract, {
-  prepare: async ({ body, headers }, { request }) => {
+  prepare: async ({ body, headers }) => {
     initServices();
 
     const {
@@ -153,8 +153,7 @@ const router = tsr.router(storagesPrepareContract, {
       }
       runtimeOrg = await getOrgData(run.orgId);
     } else {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       runtimeOrg = org;
 
       // For CLI tokens, verify body.runId belongs to the user if provided

--- a/turbo/apps/web/app/api/usage/route.ts
+++ b/turbo/apps/web/app/api/usage/route.ts
@@ -106,8 +106,7 @@ export async function GET(request: NextRequest) {
   const { userId } = authCtx;
 
   // Resolve org context
-  const orgSlug = request.nextUrl.searchParams.get("org");
-  const { org } = await resolveOrg(authCtx, orgSlug);
+  const { org } = await resolveOrg(authCtx);
 
   // Parse query parameters
   const searchParams = request.nextUrl.searchParams;

--- a/turbo/apps/web/app/api/user/export/route.ts
+++ b/turbo/apps/web/app/api/user/export/route.ts
@@ -29,8 +29,7 @@ export async function POST(request: Request) {
   const { userId } = ctx;
 
   // Resolve orgId via resolveOrg (works for both Clerk sessions and CLI tokens)
-  const orgSlug = new URL(request.url).searchParams.get("org");
-  const { org } = await resolveOrg(ctx, orgSlug);
+  const { org } = await resolveOrg(ctx);
   const resolvedOrgId = org.orgId;
 
   const db = globalThis.services.db;

--- a/turbo/apps/web/app/api/zero/__tests__/zero-agent.test.ts
+++ b/turbo/apps/web/app/api/zero/__tests__/zero-agent.test.ts
@@ -21,7 +21,6 @@ const context = testContext();
  * The only test helpers used are infrastructure (auth mock, skill seeding).
  */
 describe("Zero Agent E2E: create → run → zero token access", () => {
-  let orgSlug: string;
   let orgId: string;
   let userId: string;
   let agent: { agentId: string };
@@ -33,7 +32,6 @@ describe("Zero Agent E2E: create → run → zero token access", () => {
     await seedSeedSkills();
     await seedSeedSkillStorages();
     const result = await onboardNewOrgAndUser(context);
-    orgSlug = result.orgSlug;
     orgId = result.user.orgId;
     userId = result.user.userId;
     agent = result.agent;
@@ -86,10 +84,10 @@ describe("Zero Agent E2E: create → run → zero token access", () => {
     // zero-layer route auth, not the sandbox token (VM0_TOKEN).
     const zeroToken = await generateZeroToken(userId, run.runId, orgId);
 
-    // 6a. With ?org= → should succeed
+    // 6a. Should succeed
     const getRes = await getAgentRoute(
       new NextRequest(
-        `http://localhost:3000/api/zero/agents/${agent.agentId}?org=${orgSlug}`,
+        `http://localhost:3000/api/zero/agents/${agent.agentId}`,
         {
           method: "GET",
           headers: {

--- a/turbo/apps/web/app/api/zero/__tests__/zero-api-test-helper.ts
+++ b/turbo/apps/web/app/api/zero/__tests__/zero-api-test-helper.ts
@@ -19,17 +19,14 @@ export async function onboardNewOrgAndUser(context: TestContext): Promise<{
 
   // 2. Upsert model provider
   const providerRes = await upsertModelProviderRoute(
-    new NextRequest(
-      `http://localhost:3000/api/zero/model-providers?org=${orgSlug}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          type: "anthropic-api-key",
-          secret: "sk-ant-test-key",
-        }),
-      },
-    ),
+    new NextRequest(`http://localhost:3000/api/zero/model-providers`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "anthropic-api-key",
+        secret: "sk-ant-test-key",
+      }),
+    }),
   );
   if (!providerRes.ok) {
     throw new Error(
@@ -39,7 +36,7 @@ export async function onboardNewOrgAndUser(context: TestContext): Promise<{
 
   // 3. Create agent
   const agentRes = await createAgentRoute(
-    new NextRequest(`http://localhost:3000/api/zero/agents?org=${orgSlug}`, {
+    new NextRequest(`http://localhost:3000/api/zero/agents`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -59,7 +56,7 @@ export async function onboardNewOrgAndUser(context: TestContext): Promise<{
   // 4. Upload instructions
   const instructionsRes = await updateInstructionsRoute(
     new NextRequest(
-      `http://localhost:3000/api/zero/agents/${agent.agentId}/instructions?org=${orgSlug}`,
+      `http://localhost:3000/api/zero/agents/${agent.agentId}/instructions`,
       {
         method: "PUT",
         headers: { "Content-Type": "application/json" },

--- a/turbo/apps/web/app/api/zero/agents/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/instructions/route.ts
@@ -65,7 +65,7 @@ async function requireAdminForDefault(
 }
 
 const router = tsr.router(zeroAgentInstructionsContract, {
-  get: async ({ params, headers }, { request }) => {
+  get: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -73,8 +73,7 @@ const router = tsr.router(zeroAgentInstructionsContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Look up compose by ID
     const [compose] = await globalThis.services.db
@@ -205,7 +204,7 @@ const router = tsr.router(zeroAgentInstructionsContract, {
     };
   },
 
-  update: async ({ params, body, headers }, { request }) => {
+  update: async ({ params, body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -214,8 +213,7 @@ const router = tsr.router(zeroAgentInstructionsContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     // Look up existing compose by ID
     const [compose] = await globalThis.services.db
@@ -264,7 +262,6 @@ const router = tsr.router(zeroAgentInstructionsContract, {
     const result = await serverSideCompose({
       userId,
       orgId: org.orgId,
-      orgSlug: org.slug,
       content,
       instructions: body.content,
     });

--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -38,7 +38,7 @@ function agentResponseBody(
 }
 
 const router = tsr.router(zeroAgentsByIdContract, {
-  get: async ({ params, headers }, { request }) => {
+  get: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -46,8 +46,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Look up agent directly — params.id is the composeId which is also the PK
     const [agent] = await globalThis.services.db
@@ -74,7 +73,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     };
   },
 
-  update: async ({ params, body, headers }, { request }) => {
+  update: async ({ params, body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -83,8 +82,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     // Verify agent exists — need compose name for serverSideCompose
     // Join zeroAgents to get customSkills in the same query
@@ -138,7 +136,6 @@ const router = tsr.router(zeroAgentsByIdContract, {
     const result = await serverSideCompose({
       userId,
       orgId: org.orgId,
-      orgSlug: org.slug,
       content,
     });
 
@@ -204,7 +201,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     };
   },
 
-  updateMetadata: async ({ params, body, headers }, { request }) => {
+  updateMetadata: async ({ params, body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -212,8 +209,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     // Look up agent directly by id
     const [existing] = await globalThis.services.db
@@ -277,7 +273,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     };
   },
 
-  delete: async ({ params, headers }, { request }) => {
+  delete: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -285,8 +281,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     // Verify agent exists
     const [agent] = await globalThis.services.db

--- a/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/__tests__/route.test.ts
@@ -17,13 +17,11 @@ const context = testContext();
 
 let user: UserContext;
 let testCliToken: string;
-let testOrgSlug: string;
 
 /** Create an agent via the API, returning its agentId (= UUID). */
 async function createAgent(): Promise<string> {
-  const orgParam = `?org=${testOrgSlug}`;
   const res = await postAgentRoute(
-    createTestRequest(`http://localhost:3000/api/zero/agents${orgParam}`, {
+    createTestRequest(`http://localhost:3000/api/zero/agents`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -37,11 +35,10 @@ async function createAgent(): Promise<string> {
   return data.agentId as string;
 }
 
-function getUserConnectors(agentId: string, token: string, orgSlug?: string) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function getUserConnectors(agentId: string, token: string) {
   return GET(
     createTestRequest(
-      `http://localhost:3000/api/zero/agents/${agentId}/user-connectors${orgParam}`,
+      `http://localhost:3000/api/zero/agents/${agentId}/user-connectors`,
       {
         method: "GET",
         headers: { Authorization: `Bearer ${token}` },
@@ -54,12 +51,10 @@ function putUserConnectors(
   agentId: string,
   body: { enabledTypes: string[] },
   token: string,
-  orgSlug?: string,
 ) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
   return PUT(
     createTestRequest(
-      `http://localhost:3000/api/zero/agents/${agentId}/user-connectors${orgParam}`,
+      `http://localhost:3000/api/zero/agents/${agentId}/user-connectors`,
       {
         method: "PUT",
         headers: {
@@ -79,14 +74,13 @@ describe("User Connectors API", () => {
     await seedSeedSkills();
     user = await context.setupUser();
     testCliToken = await createTestCliToken(user.userId);
-    testOrgSlug = `org-${user.userId.slice(-8)}`;
   });
 
   describe("GET /api/zero/agents/:id/user-connectors", () => {
     it("should return empty enabledTypes for new agent", async () => {
       const agentId = await createAgent();
 
-      const res = await getUserConnectors(agentId, testCliToken, testOrgSlug);
+      const res = await getUserConnectors(agentId, testCliToken);
 
       expect(res.status).toBe(200);
       const data = await res.json();
@@ -96,7 +90,7 @@ describe("User Connectors API", () => {
     it("should return 404 for non-existent agent", async () => {
       const fakeId = "00000000-0000-0000-0000-000000000000";
 
-      const res = await getUserConnectors(fakeId, testCliToken, testOrgSlug);
+      const res = await getUserConnectors(fakeId, testCliToken);
 
       expect(res.status).toBe(404);
     });
@@ -105,7 +99,7 @@ describe("User Connectors API", () => {
       const agentId = await createAgent();
 
       mockClerk({ userId: null });
-      const res = await getUserConnectors(agentId, "no-token", testOrgSlug);
+      const res = await getUserConnectors(agentId, "no-token");
 
       expect(res.status).toBe(401);
     });
@@ -119,7 +113,6 @@ describe("User Connectors API", () => {
         agentId,
         { enabledTypes: ["github", "slack"] },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(res.status).toBe(200);
@@ -127,11 +120,7 @@ describe("User Connectors API", () => {
       expect(data.enabledTypes).toEqual(["github", "slack"]);
 
       // Verify via GET
-      const getRes = await getUserConnectors(
-        agentId,
-        testCliToken,
-        testOrgSlug,
-      );
+      const getRes = await getUserConnectors(agentId, testCliToken);
       const getData = await getRes.json();
       expect(getData.enabledTypes).toEqual(
         expect.arrayContaining(["github", "slack"]),
@@ -147,7 +136,6 @@ describe("User Connectors API", () => {
         agentId,
         { enabledTypes: ["github", "slack"] },
         testCliToken,
-        testOrgSlug,
       );
 
       // Replace with different set
@@ -155,7 +143,6 @@ describe("User Connectors API", () => {
         agentId,
         { enabledTypes: ["linear"] },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(res.status).toBe(200);
@@ -163,11 +150,7 @@ describe("User Connectors API", () => {
       expect(data.enabledTypes).toEqual(["linear"]);
 
       // Verify old ones are removed
-      const getRes = await getUserConnectors(
-        agentId,
-        testCliToken,
-        testOrgSlug,
-      );
+      const getRes = await getUserConnectors(agentId, testCliToken);
       const getData = await getRes.json();
       expect(getData.enabledTypes).toEqual(["linear"]);
     });
@@ -180,7 +163,6 @@ describe("User Connectors API", () => {
         agentId,
         { enabledTypes: ["github"] },
         testCliToken,
-        testOrgSlug,
       );
 
       // Clear all
@@ -188,7 +170,6 @@ describe("User Connectors API", () => {
         agentId,
         { enabledTypes: [] },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(res.status).toBe(200);
@@ -196,11 +177,7 @@ describe("User Connectors API", () => {
       expect(data.enabledTypes).toEqual([]);
 
       // Verify via GET that permissions are cleared
-      const getRes = await getUserConnectors(
-        agentId,
-        testCliToken,
-        testOrgSlug,
-      );
+      const getRes = await getUserConnectors(agentId, testCliToken);
       const getData = await getRes.json();
       expect(getData.enabledTypes).toEqual([]);
     });
@@ -212,7 +189,6 @@ describe("User Connectors API", () => {
         fakeId,
         { enabledTypes: ["github"] },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(res.status).toBe(404);
@@ -226,7 +202,6 @@ describe("User Connectors API", () => {
         agentId,
         { enabledTypes: ["github"] },
         "no-token",
-        testOrgSlug,
       );
 
       expect(res.status).toBe(401);
@@ -240,46 +215,31 @@ describe("User Connectors API", () => {
         agentId,
         { enabledTypes: ["github", "slack"] },
         testCliToken,
-        testOrgSlug,
       );
 
       // Create user 2 in the same org
       const user2 = await context.setupUser({ prefix: "test-user2" });
       const token2 = await createTestCliToken(user2.userId);
-      const orgSlug2 = `org-${user2.userId.slice(-8)}`;
 
       // User 2 sets different permissions on their own agent
       const agentId2 = await (async () => {
-        const orgParam = `?org=${orgSlug2}`;
         const res = await postAgentRoute(
-          createTestRequest(
-            `http://localhost:3000/api/zero/agents${orgParam}`,
-            {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token2}`,
-              },
-              body: JSON.stringify({}),
+          createTestRequest(`http://localhost:3000/api/zero/agents`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token2}`,
             },
-          ),
+            body: JSON.stringify({}),
+          }),
         );
         return ((await res.json()) as { agentId: string }).agentId;
       })();
 
-      await putUserConnectors(
-        agentId2,
-        { enabledTypes: ["linear"] },
-        token2,
-        orgSlug2,
-      );
+      await putUserConnectors(agentId2, { enabledTypes: ["linear"] }, token2);
 
       // Verify user 1's permissions unchanged
-      const getRes = await getUserConnectors(
-        agentId,
-        testCliToken,
-        testOrgSlug,
-      );
+      const getRes = await getUserConnectors(agentId, testCliToken);
       const getData = await getRes.json();
       expect(getData.enabledTypes).toEqual(
         expect.arrayContaining(["github", "slack"]),
@@ -287,7 +247,7 @@ describe("User Connectors API", () => {
       expect(getData.enabledTypes).toHaveLength(2);
 
       // Verify user 2's permissions are separate
-      const getRes2 = await getUserConnectors(agentId2, token2, orgSlug2);
+      const getRes2 = await getUserConnectors(agentId2, token2);
       const getData2 = await getRes2.json();
       expect(getData2.enabledTypes).toEqual(["linear"]);
     });

--- a/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/user-connectors/route.ts
@@ -15,7 +15,7 @@ import { userConnectors } from "../../../../../../src/db/schema/user-connector";
 import { eq, and } from "drizzle-orm";
 
 const router = tsr.router(zeroUserConnectorsContract, {
-  get: async ({ params, headers }, { request }) => {
+  get: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -24,8 +24,7 @@ const router = tsr.router(zeroUserConnectorsContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Verify agent exists in this org
     const [agent] = await globalThis.services.db
@@ -63,7 +62,7 @@ const router = tsr.router(zeroUserConnectorsContract, {
     };
   },
 
-  update: async ({ params, body, headers }, { request }) => {
+  update: async ({ params, body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -72,8 +71,7 @@ const router = tsr.router(zeroUserConnectorsContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Verify agent exists in this org
     const [agent] = await globalThis.services.db

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -66,11 +66,7 @@ function getAgent(name: string, token: string) {
   );
 }
 
-function putAgent(
-  name: string,
-  body: Record<string, unknown>,
-  token: string,
-) {
+function putAgent(name: string, body: Record<string, unknown>, token: string) {
   return PUT(
     createTestRequest(`http://localhost:3000/api/zero/agents/${name}`, {
       method: "PUT",
@@ -270,10 +266,7 @@ describe("Zero Agents API", () => {
       const created = await createResponse.json();
 
       // Get the agent
-      const response = await getAgent(
-        created.agentId,
-        testCliToken,
-      );
+      const response = await getAgent(created.agentId, testCliToken);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -335,11 +328,7 @@ describe("Zero Agents API", () => {
       const created = await createResponse.json();
 
       // Update with no metadata fields
-      const updateResponse = await putAgent(
-        created.agentId,
-        {},
-        testCliToken,
-      );
+      const updateResponse = await putAgent(created.agentId, {}, testCliToken);
       expect(updateResponse.status).toBe(200);
 
       // Verify metadata is preserved
@@ -352,9 +341,7 @@ describe("Zero Agents API", () => {
     });
 
     it("should rebuild compose with connector env var templates", async () => {
-      const created = await (
-        await postAgent({}, testCliToken)
-      ).json();
+      const created = await (await postAgent({}, testCliToken)).json();
 
       const response = await putAgent(
         created.agentId,
@@ -580,9 +567,7 @@ describe("Zero Agents API", () => {
     });
 
     it("should read back instructions content after PUT via GET", async () => {
-      const created = await (
-        await postAgent({}, testCliToken)
-      ).json();
+      const created = await (await postAgent({}, testCliToken)).json();
 
       const instructionsContent = "# My Instructions\nBe helpful.";
       await putAgentInstructions(
@@ -615,10 +600,7 @@ describe("Zero Agents API", () => {
         ),
       );
 
-      const getRes = await getAgentInstructions(
-        created.agentId,
-        testCliToken,
-      );
+      const getRes = await getAgentInstructions(created.agentId, testCliToken);
       expect(getRes.status).toBe(200);
       const fetched = await getRes.json();
 
@@ -650,10 +632,7 @@ describe("Zero Agents API", () => {
       const sandboxToken = await createTestSandboxToken(user.userId, runId);
 
       // Use the sandbox token to GET the agent — should be rejected
-      const response = await getAgent(
-        created.agentId,
-        sandboxToken,
-      );
+      const response = await getAgent(created.agentId, sandboxToken);
 
       // Then — sandbox tokens can no longer satisfy requiredCapability
       expect(response.status).toBe(403);
@@ -842,28 +821,18 @@ describe("Zero Agents API", () => {
 
   describe("DELETE /api/zero/agents/:name", () => {
     it("should delete an agent and return 204", async () => {
-      const created = await (
-        await postAgent({}, testCliToken)
-      ).json();
+      const created = await (await postAgent({}, testCliToken)).json();
 
-      const response = await deleteAgent(
-        created.agentId,
-        testCliToken,
-      );
+      const response = await deleteAgent(created.agentId, testCliToken);
       expect(response.status).toBe(204);
     });
 
     it("should return 404 on GET after delete", async () => {
-      const created = await (
-        await postAgent({}, testCliToken)
-      ).json();
+      const created = await (await postAgent({}, testCliToken)).json();
 
       await deleteAgent(created.agentId, testCliToken);
 
-      const getResponse = await getAgent(
-        created.agentId,
-        testCliToken,
-      );
+      const getResponse = await getAgent(created.agentId, testCliToken);
       expect(getResponse.status).toBe(404);
     });
 
@@ -879,9 +848,7 @@ describe("Zero Agents API", () => {
 
     it("should delete agent with linked Slack thread sessions and pending questions", async () => {
       // Create an agent
-      const created = await (
-        await postAgent({}, testCliToken)
-      ).json();
+      const created = await (await postAgent({}, testCliToken)).json();
 
       // Create an agent session linked to this compose
       const session = await createTestSessionWithConversation(
@@ -920,17 +887,11 @@ describe("Zero Agents API", () => {
       });
 
       // Delete the agent — this would fail with FK constraint before the fix
-      const response = await deleteAgent(
-        created.agentId,
-        testCliToken,
-      );
+      const response = await deleteAgent(created.agentId, testCliToken);
       expect(response.status).toBe(204);
 
       // Verify agent is gone
-      const getResponse = await getAgent(
-        created.agentId,
-        testCliToken,
-      );
+      const getResponse = await getAgent(created.agentId, testCliToken);
       expect(getResponse.status).toBe(404);
     });
 
@@ -973,9 +934,7 @@ describe("Zero Agents API", () => {
     });
 
     it("should return 409 when agent has running runs", async () => {
-      const created = await (
-        await postAgent({}, testCliToken)
-      ).json();
+      const created = await (await postAgent({}, testCliToken)).json();
 
       // Create a running run for this agent
       await createTestRunInDb(user.userId, created.agentId, {
@@ -983,10 +942,7 @@ describe("Zero Agents API", () => {
       });
 
       // Try to delete — should get 409
-      const response = await deleteAgent(
-        created.agentId,
-        testCliToken,
-      );
+      const response = await deleteAgent(created.agentId, testCliToken);
       expect(response.status).toBe(409);
       const data = await response.json();
       expect(data.error.code).toBe("CONFLICT");
@@ -1011,11 +967,7 @@ describe("Zero Agents API", () => {
     });
 
     it("PUT should return 400 for invalid UUID", async () => {
-      const response = await putAgent(
-        "not-a-uuid",
-        {},
-        testCliToken,
-      );
+      const response = await putAgent("not-a-uuid", {}, testCliToken);
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error.code).toBe("BAD_REQUEST");
@@ -1033,20 +985,14 @@ describe("Zero Agents API", () => {
     });
 
     it("DELETE should return 400 for invalid UUID", async () => {
-      const response = await deleteAgent(
-        "not-a-uuid",
-        testCliToken,
-      );
+      const response = await deleteAgent("not-a-uuid", testCliToken);
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error.code).toBe("BAD_REQUEST");
     });
 
     it("GET instructions should return 400 for invalid UUID", async () => {
-      const response = await getAgentInstructions(
-        "not-a-uuid",
-        testCliToken,
-      );
+      const response = await getAgentInstructions("not-a-uuid", testCliToken);
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error.code).toBe("BAD_REQUEST");
@@ -1255,10 +1201,7 @@ describe("Zero Agents API", () => {
       await clearOrgMembersCacheEntry(orgId, user.userId);
       const memberToken = await createTestCliToken(user.userId);
 
-      const response = await deleteAgent(
-        created.agentId,
-        memberToken,
-      );
+      const response = await deleteAgent(created.agentId, memberToken);
       expect(response.status).toBe(403);
       const data = await response.json();
       expect(data.error.code).toBe("FORBIDDEN");
@@ -1290,14 +1233,11 @@ describe("Zero Agents API", () => {
 
       // 3. Execute the schedule — should succeed
       const response = await runSchedule(
-        createTestRequest(
-          `http://localhost:3000/api/zero/schedules/run`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ scheduleId: schedule.id }),
-          },
-        ),
+        createTestRequest(`http://localhost:3000/api/zero/schedules/run`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ scheduleId: schedule.id }),
+        }),
       );
       const data = await response.json();
 

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -43,16 +43,10 @@ const context = testContext();
 
 let user: UserContext;
 let testCliToken: string;
-let testOrgSlug: string;
 
-function postAgent(
-  body: Record<string, unknown>,
-  token: string,
-  orgSlug?: string,
-) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function postAgent(body: Record<string, unknown>, token: string) {
   return POST(
-    createTestRequest(`http://localhost:3000/api/zero/agents${orgParam}`, {
+    createTestRequest(`http://localhost:3000/api/zero/agents`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -63,16 +57,12 @@ function postAgent(
   );
 }
 
-function getAgent(name: string, token: string, orgSlug?: string) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function getAgent(name: string, token: string) {
   return GET(
-    createTestRequest(
-      `http://localhost:3000/api/zero/agents/${name}${orgParam}`,
-      {
-        method: "GET",
-        headers: { Authorization: `Bearer ${token}` },
-      },
-    ),
+    createTestRequest(`http://localhost:3000/api/zero/agents/${name}`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    }),
   );
 }
 
@@ -80,21 +70,16 @@ function putAgent(
   name: string,
   body: Record<string, unknown>,
   token: string,
-  orgSlug?: string,
 ) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
   return PUT(
-    createTestRequest(
-      `http://localhost:3000/api/zero/agents/${name}${orgParam}`,
-      {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(body),
+    createTestRequest(`http://localhost:3000/api/zero/agents/${name}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
       },
-    ),
+      body: JSON.stringify(body),
+    }),
   );
 }
 
@@ -102,52 +87,41 @@ function patchAgent(
   name: string,
   body: Record<string, unknown>,
   token: string,
-  orgSlug?: string,
 ) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
   return PATCH(
-    createTestRequest(
-      `http://localhost:3000/api/zero/agents/${name}${orgParam}`,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(body),
+    createTestRequest(`http://localhost:3000/api/zero/agents/${name}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
       },
-    ),
+      body: JSON.stringify(body),
+    }),
   );
 }
 
-function listAgentsReq(token: string, orgSlug?: string) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function listAgentsReq(token: string) {
   return listAgents(
-    createTestRequest(`http://localhost:3000/api/zero/agents${orgParam}`, {
+    createTestRequest(`http://localhost:3000/api/zero/agents`, {
       method: "GET",
       headers: { Authorization: `Bearer ${token}` },
     }),
   );
 }
 
-function deleteAgent(name: string, token: string, orgSlug?: string) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function deleteAgent(name: string, token: string) {
   return DELETE(
-    createTestRequest(
-      `http://localhost:3000/api/zero/agents/${name}${orgParam}`,
-      {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
-      },
-    ),
+    createTestRequest(`http://localhost:3000/api/zero/agents/${name}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    }),
   );
 }
 
-function getAgentInstructions(name: string, token: string, orgSlug?: string) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function getAgentInstructions(name: string, token: string) {
   return getInstructions(
     createTestRequest(
-      `http://localhost:3000/api/zero/agents/${name}/instructions${orgParam}`,
+      `http://localhost:3000/api/zero/agents/${name}/instructions`,
       {
         method: "GET",
         headers: { Authorization: `Bearer ${token}` },
@@ -160,12 +134,10 @@ function putAgentInstructions(
   name: string,
   body: { content: string },
   token: string,
-  orgSlug?: string,
 ) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
   return putInstructions(
     createTestRequest(
-      `http://localhost:3000/api/zero/agents/${name}/instructions${orgParam}`,
+      `http://localhost:3000/api/zero/agents/${name}/instructions`,
       {
         method: "PUT",
         headers: {
@@ -185,12 +157,11 @@ describe("Zero Agents API", () => {
     await seedSeedSkills();
     user = await context.setupUser();
     testCliToken = await createTestCliToken(user.userId);
-    testOrgSlug = `org-${user.userId.slice(-8)}`;
   });
 
   describe("POST /api/zero/agents", () => {
     it("should create an agent", async () => {
-      const response = await postAgent({}, testCliToken, testOrgSlug);
+      const response = await postAgent({}, testCliToken);
 
       expect(response.status).toBe(201);
       const data = await response.json();
@@ -208,7 +179,6 @@ describe("Zero Agents API", () => {
           sound: "professional",
         },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(201);
@@ -219,7 +189,7 @@ describe("Zero Agents API", () => {
     });
 
     it("should create an agent with connector env var templates in compose", async () => {
-      const response = await postAgent({}, testCliToken, testOrgSlug);
+      const response = await postAgent({}, testCliToken);
 
       expect(response.status).toBe(201);
       const data = await response.json();
@@ -269,7 +239,7 @@ describe("Zero Agents API", () => {
     it("should return 422 when skills are not cached", async () => {
       await clearSkillsData();
 
-      const response = await postAgent({}, testCliToken, testOrgSlug);
+      const response = await postAgent({}, testCliToken);
 
       expect(response.status).toBe(422);
       const data = await response.json();
@@ -294,7 +264,6 @@ describe("Zero Agents API", () => {
           sound: "friendly",
         },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(createResponse.status).toBe(201);
@@ -304,7 +273,6 @@ describe("Zero Agents API", () => {
       const response = await getAgent(
         created.agentId,
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(200);
@@ -319,7 +287,6 @@ describe("Zero Agents API", () => {
       const response = await getAgent(
         "00000000-0000-0000-0000-000000000000",
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(404);
@@ -334,7 +301,6 @@ describe("Zero Agents API", () => {
       const createResponse = await postAgent(
         { displayName: "Original" },
         testCliToken,
-        testOrgSlug,
       );
       const created = await createResponse.json();
 
@@ -347,7 +313,6 @@ describe("Zero Agents API", () => {
           sound: "casual",
         },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(200);
@@ -366,7 +331,6 @@ describe("Zero Agents API", () => {
           sound: "professional",
         },
         testCliToken,
-        testOrgSlug,
       );
       const created = await createResponse.json();
 
@@ -375,12 +339,11 @@ describe("Zero Agents API", () => {
         created.agentId,
         {},
         testCliToken,
-        testOrgSlug,
       );
       expect(updateResponse.status).toBe(200);
 
       // Verify metadata is preserved
-      const getRes = await getAgent(created.agentId, testCliToken, testOrgSlug);
+      const getRes = await getAgent(created.agentId, testCliToken);
       expect(getRes.status).toBe(200);
       const fetched = await getRes.json();
       expect(fetched.displayName).toBe("My Agent");
@@ -390,14 +353,13 @@ describe("Zero Agents API", () => {
 
     it("should rebuild compose with connector env var templates", async () => {
       const created = await (
-        await postAgent({}, testCliToken, testOrgSlug)
+        await postAgent({}, testCliToken)
       ).json();
 
       const response = await putAgent(
         created.agentId,
         { displayName: "Refreshed" },
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(200);
 
@@ -473,7 +435,6 @@ describe("Zero Agents API", () => {
         "00000000-0000-0000-0000-000000000000",
         {},
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(404);
@@ -482,13 +443,12 @@ describe("Zero Agents API", () => {
 
   describe("GET /api/zero/agents/:name/instructions", () => {
     it("should return null content when no instructions uploaded", async () => {
-      const createResponse = await postAgent({}, testCliToken, testOrgSlug);
+      const createResponse = await postAgent({}, testCliToken);
       const created = await createResponse.json();
 
       const response = await getAgentInstructions(
         created.agentId,
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(200);
@@ -500,7 +460,6 @@ describe("Zero Agents API", () => {
       const response = await getAgentInstructions(
         "00000000-0000-0000-0000-000000000000",
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(404);
@@ -509,14 +468,13 @@ describe("Zero Agents API", () => {
 
   describe("PUT /api/zero/agents/:name/instructions", () => {
     it("should update instructions and return agent response", async () => {
-      const createResponse = await postAgent({}, testCliToken, testOrgSlug);
+      const createResponse = await postAgent({}, testCliToken);
       const created = await createResponse.json();
 
       const response = await putAgentInstructions(
         created.agentId,
         { content: "# Updated Instructions\nBe helpful." },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(200);
@@ -525,7 +483,7 @@ describe("Zero Agents API", () => {
     });
 
     it("should rebuild compose with connector env var templates", async () => {
-      const createResponse = await postAgent({}, testCliToken, testOrgSlug);
+      const createResponse = await postAgent({}, testCliToken);
       const created = await createResponse.json();
 
       // Update instructions
@@ -533,7 +491,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { content: "# New instructions" },
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(200);
 
@@ -558,7 +515,6 @@ describe("Zero Agents API", () => {
         "00000000-0000-0000-0000-000000000000",
         { content: "# Instructions" },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(404);
@@ -574,12 +530,11 @@ describe("Zero Agents API", () => {
           sound: "friendly",
         },
         testCliToken,
-        testOrgSlug,
       );
       expect(createRes.status).toBe(201);
       const created = await createRes.json();
 
-      const getRes = await getAgent(created.agentId, testCliToken, testOrgSlug);
+      const getRes = await getAgent(created.agentId, testCliToken);
       expect(getRes.status).toBe(200);
       const fetched = await getRes.json();
 
@@ -588,7 +543,7 @@ describe("Zero Agents API", () => {
 
     it("should read back updated agent data after PUT via GET", async () => {
       const created = await (
-        await postAgent({ displayName: "Original" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "Original" }, testCliToken)
       ).json();
 
       await putAgent(
@@ -599,10 +554,9 @@ describe("Zero Agents API", () => {
           sound: "casual",
         },
         testCliToken,
-        testOrgSlug,
       );
 
-      const getRes = await getAgent(created.agentId, testCliToken, testOrgSlug);
+      const getRes = await getAgent(created.agentId, testCliToken);
       expect(getRes.status).toBe(200);
       const fetched = await getRes.json();
 
@@ -613,12 +567,12 @@ describe("Zero Agents API", () => {
 
     it("should reflect deleted agent in list", async () => {
       const created = await (
-        await postAgent({ displayName: "To Delete" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "To Delete" }, testCliToken)
       ).json();
 
-      await deleteAgent(created.agentId, testCliToken, testOrgSlug);
+      await deleteAgent(created.agentId, testCliToken);
 
-      const listResponse = await listAgentsReq(testCliToken, testOrgSlug);
+      const listResponse = await listAgentsReq(testCliToken);
       const data = await listResponse.json();
       expect(
         data.find((a: { agentId: string }) => a.agentId === created.agentId),
@@ -627,7 +581,7 @@ describe("Zero Agents API", () => {
 
     it("should read back instructions content after PUT via GET", async () => {
       const created = await (
-        await postAgent({}, testCliToken, testOrgSlug)
+        await postAgent({}, testCliToken)
       ).json();
 
       const instructionsContent = "# My Instructions\nBe helpful.";
@@ -635,7 +589,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { content: instructionsContent },
         testCliToken,
-        testOrgSlug,
       );
 
       // Mock S3 downloads to return what was uploaded
@@ -665,7 +618,6 @@ describe("Zero Agents API", () => {
       const getRes = await getAgentInstructions(
         created.agentId,
         testCliToken,
-        testOrgSlug,
       );
       expect(getRes.status).toBe(200);
       const fetched = await getRes.json();
@@ -684,7 +636,6 @@ describe("Zero Agents API", () => {
           sound: "professional",
         },
         testCliToken,
-        testOrgSlug,
       );
       expect(createResponse.status).toBe(201);
       const created = await createResponse.json();
@@ -702,7 +653,6 @@ describe("Zero Agents API", () => {
       const response = await getAgent(
         created.agentId,
         sandboxToken,
-        testOrgSlug,
       );
 
       // Then — sandbox tokens can no longer satisfy requiredCapability
@@ -712,7 +662,7 @@ describe("Zero Agents API", () => {
 
   describe("GET /api/zero/agents", () => {
     it("should return empty array when no agents exist", async () => {
-      const response = await listAgentsReq(testCliToken, testOrgSlug);
+      const response = await listAgentsReq(testCliToken);
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data).toStrictEqual([]);
@@ -727,11 +677,10 @@ describe("Zero Agents API", () => {
             sound: "friendly",
           },
           testCliToken,
-          testOrgSlug,
         )
       ).json();
 
-      const response = await listAgentsReq(testCliToken, testOrgSlug);
+      const response = await listAgentsReq(testCliToken);
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data).toHaveLength(1);
@@ -754,7 +703,6 @@ describe("Zero Agents API", () => {
         await postAgent(
           { displayName: "Original", sound: "professional" },
           testCliToken,
-          testOrgSlug,
         )
       ).json();
 
@@ -762,7 +710,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { displayName: "Updated", description: "New desc", sound: "casual" },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(200);
@@ -782,7 +729,6 @@ describe("Zero Agents API", () => {
             sound: "professional",
           },
           testCliToken,
-          testOrgSlug,
         )
       ).json();
 
@@ -791,7 +737,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { displayName: "New Name" },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(200);
@@ -807,7 +752,6 @@ describe("Zero Agents API", () => {
         "00000000-0000-0000-0000-000000000000",
         { displayName: "X" },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(404);
@@ -829,21 +773,20 @@ describe("Zero Agents API", () => {
   describe("avatarUrl CRUD", () => {
     it("should set avatarUrl via PATCH and persist it", async () => {
       const created = await (
-        await postAgent({ displayName: "AvatarBot" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "AvatarBot" }, testCliToken)
       ).json();
 
       const patchRes = await patchAgent(
         created.agentId,
         { avatarUrl: "preset:2" },
         testCliToken,
-        testOrgSlug,
       );
       expect(patchRes.status).toBe(200);
       const patched = await patchRes.json();
       expect(patched.avatarUrl).toBe("preset:2");
 
       // Verify GET returns the same value
-      const getRes = await getAgent(created.agentId, testCliToken, testOrgSlug);
+      const getRes = await getAgent(created.agentId, testCliToken);
       expect(getRes.status).toBe(200);
       const fetched = await getRes.json();
       expect(fetched.avatarUrl).toBe("preset:2");
@@ -851,7 +794,7 @@ describe("Zero Agents API", () => {
 
     it("should clear avatarUrl by setting null", async () => {
       const created = await (
-        await postAgent({ displayName: "ClearBot" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "ClearBot" }, testCliToken)
       ).json();
 
       // Set avatar first
@@ -859,7 +802,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { avatarUrl: "https://example.com/avatar.png" },
         testCliToken,
-        testOrgSlug,
       );
 
       // Clear it
@@ -867,7 +809,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { avatarUrl: null },
         testCliToken,
-        testOrgSlug,
       );
       expect(clearRes.status).toBe(200);
       const cleared = await clearRes.json();
@@ -876,7 +817,7 @@ describe("Zero Agents API", () => {
 
     it("should preserve avatarUrl on unrelated partial update", async () => {
       const created = await (
-        await postAgent({ displayName: "KeepBot" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "KeepBot" }, testCliToken)
       ).json();
 
       // Set avatar
@@ -884,7 +825,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { avatarUrl: "preset:4" },
         testCliToken,
-        testOrgSlug,
       );
 
       // Update only displayName — avatarUrl should be preserved
@@ -892,7 +832,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { displayName: "Renamed" },
         testCliToken,
-        testOrgSlug,
       );
       expect(patchRes.status).toBe(200);
       const patched = await patchRes.json();
@@ -904,28 +843,26 @@ describe("Zero Agents API", () => {
   describe("DELETE /api/zero/agents/:name", () => {
     it("should delete an agent and return 204", async () => {
       const created = await (
-        await postAgent({}, testCliToken, testOrgSlug)
+        await postAgent({}, testCliToken)
       ).json();
 
       const response = await deleteAgent(
         created.agentId,
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(204);
     });
 
     it("should return 404 on GET after delete", async () => {
       const created = await (
-        await postAgent({}, testCliToken, testOrgSlug)
+        await postAgent({}, testCliToken)
       ).json();
 
-      await deleteAgent(created.agentId, testCliToken, testOrgSlug);
+      await deleteAgent(created.agentId, testCliToken);
 
       const getResponse = await getAgent(
         created.agentId,
         testCliToken,
-        testOrgSlug,
       );
       expect(getResponse.status).toBe(404);
     });
@@ -934,7 +871,6 @@ describe("Zero Agents API", () => {
       const response = await deleteAgent(
         "00000000-0000-0000-0000-000000000000",
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(404);
       const data = await response.json();
@@ -944,7 +880,7 @@ describe("Zero Agents API", () => {
     it("should delete agent with linked Slack thread sessions and pending questions", async () => {
       // Create an agent
       const created = await (
-        await postAgent({}, testCliToken, testOrgSlug)
+        await postAgent({}, testCliToken)
       ).json();
 
       // Create an agent session linked to this compose
@@ -987,7 +923,6 @@ describe("Zero Agents API", () => {
       const response = await deleteAgent(
         created.agentId,
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(204);
 
@@ -995,7 +930,6 @@ describe("Zero Agents API", () => {
       const getResponse = await getAgent(
         created.agentId,
         testCliToken,
-        testOrgSlug,
       );
       expect(getResponse.status).toBe(404);
     });
@@ -1024,7 +958,7 @@ describe("Zero Agents API", () => {
       ]);
 
       // Delete agent via zero agents API
-      const response = await deleteAgent(composeId, testCliToken, testOrgSlug);
+      const response = await deleteAgent(composeId, testCliToken);
       expect(response.status).toBe(204);
 
       // Verify instructions storage cleaned up
@@ -1040,7 +974,7 @@ describe("Zero Agents API", () => {
 
     it("should return 409 when agent has running runs", async () => {
       const created = await (
-        await postAgent({}, testCliToken, testOrgSlug)
+        await postAgent({}, testCliToken)
       ).json();
 
       // Create a running run for this agent
@@ -1052,7 +986,6 @@ describe("Zero Agents API", () => {
       const response = await deleteAgent(
         created.agentId,
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(409);
       const data = await response.json();
@@ -1071,7 +1004,7 @@ describe("Zero Agents API", () => {
 
   describe("invalid UUID handling", () => {
     it("GET should return 400 for invalid UUID", async () => {
-      const response = await getAgent("abc", testCliToken, testOrgSlug);
+      const response = await getAgent("abc", testCliToken);
       expect(response.status).toBe(400);
       const data = await response.json();
       expect(data.error.code).toBe("BAD_REQUEST");
@@ -1082,7 +1015,6 @@ describe("Zero Agents API", () => {
         "not-a-uuid",
         {},
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(400);
       const data = await response.json();
@@ -1094,7 +1026,6 @@ describe("Zero Agents API", () => {
         "not-a-uuid",
         { displayName: "X" },
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(400);
       const data = await response.json();
@@ -1105,7 +1036,6 @@ describe("Zero Agents API", () => {
       const response = await deleteAgent(
         "not-a-uuid",
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(400);
       const data = await response.json();
@@ -1116,7 +1046,6 @@ describe("Zero Agents API", () => {
       const response = await getAgentInstructions(
         "not-a-uuid",
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(400);
       const data = await response.json();
@@ -1128,7 +1057,6 @@ describe("Zero Agents API", () => {
         "not-a-uuid",
         { content: "# test" },
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(400);
       const data = await response.json();
@@ -1140,7 +1068,7 @@ describe("Zero Agents API", () => {
     it("should return 403 when member patches default agent metadata", async () => {
       // Create agent as admin
       const created = await (
-        await postAgent({ displayName: "Default" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "Default" }, testCliToken)
       ).json();
 
       const orgId = `org_mock_${user.userId}`;
@@ -1154,8 +1082,8 @@ describe("Zero Agents API", () => {
         clerkOrgs: [
           {
             id: orgId,
-            slug: testOrgSlug,
-            name: testOrgSlug,
+            slug: `org-${user.userId.slice(-8)}`,
+            name: `org-${user.userId.slice(-8)}`,
             role: "org:member",
           },
         ],
@@ -1167,7 +1095,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { displayName: "Hacked" },
         memberToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(403);
       const data = await response.json();
@@ -1176,7 +1103,7 @@ describe("Zero Agents API", () => {
 
     it("should return 403 when member updates default agent instructions", async () => {
       const created = await (
-        await postAgent({ displayName: "Default" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "Default" }, testCliToken)
       ).json();
 
       const orgId = `org_mock_${user.userId}`;
@@ -1190,8 +1117,8 @@ describe("Zero Agents API", () => {
         clerkOrgs: [
           {
             id: orgId,
-            slug: testOrgSlug,
-            name: testOrgSlug,
+            slug: `org-${user.userId.slice(-8)}`,
+            name: `org-${user.userId.slice(-8)}`,
             role: "org:member",
           },
         ],
@@ -1203,7 +1130,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { content: "# Hacked instructions" },
         memberToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(403);
       const data = await response.json();
@@ -1212,7 +1138,7 @@ describe("Zero Agents API", () => {
 
     it("should allow admin to patch default agent metadata", async () => {
       const created = await (
-        await postAgent({ displayName: "Default" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "Default" }, testCliToken)
       ).json();
 
       const orgId = `org_mock_${user.userId}`;
@@ -1223,7 +1149,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { displayName: "Updated by Admin" },
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -1233,10 +1158,10 @@ describe("Zero Agents API", () => {
     it("should allow member to patch non-default agent metadata", async () => {
       // Create two agents — mark only one as default
       const defaultAgent = await (
-        await postAgent({ displayName: "Default" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "Default" }, testCliToken)
       ).json();
       const otherAgent = await (
-        await postAgent({ displayName: "Other" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "Other" }, testCliToken)
       ).json();
 
       const orgId = `org_mock_${user.userId}`;
@@ -1250,8 +1175,8 @@ describe("Zero Agents API", () => {
         clerkOrgs: [
           {
             id: orgId,
-            slug: testOrgSlug,
-            name: testOrgSlug,
+            slug: `org-${user.userId.slice(-8)}`,
+            name: `org-${user.userId.slice(-8)}`,
             role: "org:member",
           },
         ],
@@ -1264,7 +1189,6 @@ describe("Zero Agents API", () => {
         otherAgent.agentId,
         { displayName: "Member Updated" },
         memberToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -1273,7 +1197,7 @@ describe("Zero Agents API", () => {
 
     it("should return 403 when member PUT-updates default agent", async () => {
       const created = await (
-        await postAgent({ displayName: "Default" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "Default" }, testCliToken)
       ).json();
 
       const orgId = `org_mock_${user.userId}`;
@@ -1287,8 +1211,8 @@ describe("Zero Agents API", () => {
         clerkOrgs: [
           {
             id: orgId,
-            slug: testOrgSlug,
-            name: testOrgSlug,
+            slug: `org-${user.userId.slice(-8)}`,
+            name: `org-${user.userId.slice(-8)}`,
             role: "org:member",
           },
         ],
@@ -1300,7 +1224,6 @@ describe("Zero Agents API", () => {
         created.agentId,
         { displayName: "Hacked via PUT" },
         memberToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(403);
       const data = await response.json();
@@ -1309,7 +1232,7 @@ describe("Zero Agents API", () => {
 
     it("should return 403 when member deletes default agent", async () => {
       const created = await (
-        await postAgent({ displayName: "Default" }, testCliToken, testOrgSlug)
+        await postAgent({ displayName: "Default" }, testCliToken)
       ).json();
 
       const orgId = `org_mock_${user.userId}`;
@@ -1323,8 +1246,8 @@ describe("Zero Agents API", () => {
         clerkOrgs: [
           {
             id: orgId,
-            slug: testOrgSlug,
-            name: testOrgSlug,
+            slug: `org-${user.userId.slice(-8)}`,
+            name: `org-${user.userId.slice(-8)}`,
             role: "org:member",
           },
         ],
@@ -1335,7 +1258,6 @@ describe("Zero Agents API", () => {
       const response = await deleteAgent(
         created.agentId,
         memberToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(403);
       const data = await response.json();
@@ -1355,7 +1277,6 @@ describe("Zero Agents API", () => {
       const createResponse = await postAgent(
         { displayName: "Schedule Bug Agent" },
         testCliToken,
-        testOrgSlug,
       );
       expect(createResponse.status).toBe(201);
       const agent = await createResponse.json();
@@ -1370,7 +1291,7 @@ describe("Zero Agents API", () => {
       // 3. Execute the schedule — should succeed
       const response = await runSchedule(
         createTestRequest(
-          `http://localhost:3000/api/zero/schedules/run?org=${testOrgSlug}`,
+          `http://localhost:3000/api/zero/schedules/run`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -210,7 +210,6 @@ describe("Zero Agents API", () => {
       const response = await postAgent(
         { customSkills: ["my-skill", "data-tool"] },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(201);
@@ -364,20 +363,17 @@ describe("Zero Agents API", () => {
     });
 
     it("should update custom skills and reflect in compose volumes", async () => {
-      const created = await (
-        await postAgent({}, testCliToken, testOrgSlug)
-      ).json();
+      const created = await (await postAgent({}, testCliToken)).json();
 
       const response = await putAgent(
         created.agentId,
         { customSkills: ["my-skill", "data-tool"] },
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(200);
 
       // Verify skills are persisted
-      const getRes = await getAgent(created.agentId, testCliToken, testOrgSlug);
+      const getRes = await getAgent(created.agentId, testCliToken);
       const fetched = await getRes.json();
       expect(fetched.customSkills).toEqual(["my-skill", "data-tool"]);
 
@@ -395,11 +391,7 @@ describe("Zero Agents API", () => {
     it("should preserve existing custom skills when not provided in update", async () => {
       // Create with custom skills
       const created = await (
-        await postAgent(
-          { customSkills: ["my-skill"] },
-          testCliToken,
-          testOrgSlug,
-        )
+        await postAgent({ customSkills: ["my-skill"] }, testCliToken)
       ).json();
 
       // Update without customSkills field
@@ -407,12 +399,11 @@ describe("Zero Agents API", () => {
         created.agentId,
         { displayName: "Updated" },
         testCliToken,
-        testOrgSlug,
       );
       expect(response.status).toBe(200);
 
       // Verify skills are preserved
-      const getRes = await getAgent(created.agentId, testCliToken, testOrgSlug);
+      const getRes = await getAgent(created.agentId, testCliToken);
       const fetched = await getRes.json();
       expect(fetched.customSkills).toEqual(["my-skill"]);
     });

--- a/turbo/apps/web/app/api/zero/agents/__tests__/sandbox-capability.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/sandbox-capability.test.ts
@@ -21,12 +21,10 @@ const context = testContext();
 
 describe("Sandbox capability enforcement on zero agent routes", () => {
   let user: UserContext;
-  let orgSlug: string;
 
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
-    orgSlug = `org-${user.userId.slice(-8)}`;
     await seedSeedSkills();
   });
 
@@ -42,7 +40,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
       const token = await generateSandboxToken(user.userId, "run-123");
 
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/agents?org=${orgSlug}`,
+        `http://localhost:3000/api/zero/agents`,
         {
           method: "POST",
           headers: {
@@ -64,7 +62,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
       const token = await generateSandboxToken(user.userId, "run-123");
 
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000?org=${orgSlug}`,
+        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000`,
         {
           headers: { Authorization: `Bearer ${token}` },
         },
@@ -81,7 +79,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
       const token = await generateSandboxToken(user.userId, "run-123");
 
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000?org=${orgSlug}`,
+        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000`,
         {
           method: "PUT",
           headers: {
@@ -103,7 +101,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
       const token = await generateSandboxToken(user.userId, "run-123");
 
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000/instructions?org=${orgSlug}`,
+        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000/instructions`,
         {
           headers: { Authorization: `Bearer ${token}` },
         },
@@ -120,7 +118,7 @@ describe("Sandbox capability enforcement on zero agent routes", () => {
       const token = await generateSandboxToken(user.userId, "run-123");
 
       const request = createTestRequest(
-        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000/instructions?org=${orgSlug}`,
+        `http://localhost:3000/api/zero/agents/00000000-0000-0000-0000-000000000000/instructions`,
         {
           method: "PUT",
           headers: {

--- a/turbo/apps/web/app/api/zero/agents/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/route.ts
@@ -19,7 +19,7 @@ import { logger } from "../../../../src/lib/logger";
 const log = logger("api:zero-agents");
 
 const router = tsr.router(zeroAgentsMainContract, {
-  create: async ({ body, headers }, { request }) => {
+  create: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -28,8 +28,7 @@ const router = tsr.router(zeroAgentsMainContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Generate UUID agent name
     const agentName = crypto.randomUUID();
@@ -48,7 +47,6 @@ const router = tsr.router(zeroAgentsMainContract, {
     const result = await serverSideCompose({
       userId,
       orgId: org.orgId,
-      orgSlug: org.slug,
       content,
       instructions: "",
     });
@@ -107,7 +105,7 @@ const router = tsr.router(zeroAgentsMainContract, {
     };
   },
 
-  list: async ({ headers }, { request }) => {
+  list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -115,8 +113,7 @@ const router = tsr.router(zeroAgentsMainContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const rows = await globalThis.services.db
       .select({

--- a/turbo/apps/web/app/api/zero/billing/auto-recharge/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/auto-recharge/route.ts
@@ -19,28 +19,26 @@ import {
 } from "../../../../../src/lib/billing/billing-service";
 
 const router = tsr.router(zeroBillingAutoRechargeContract, {
-  get: async ({ headers }, { request }) => {
+  get: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const config = await getAutoRechargeConfig(org.orgId);
 
     return { status: 200 as const, body: config };
   },
 
-  update: async ({ body, headers }, { request }) => {
+  update: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     if (member.role !== "admin") {
       return createErrorResponse(

--- a/turbo/apps/web/app/api/zero/billing/checkout/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/checkout/route.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../../../src/lib/billing/billing-service";
 
 const router = tsr.router(zeroBillingCheckoutContract, {
-  create: async ({ body, headers }, { request }) => {
+  create: async ({ body, headers }) => {
     initServices();
 
     const { STRIPE_SECRET_KEY } = env();
@@ -32,8 +32,7 @@ const router = tsr.router(zeroBillingCheckoutContract, {
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
     if (member.role !== "admin") {
       return createErrorResponse(
         "FORBIDDEN",

--- a/turbo/apps/web/app/api/zero/billing/downgrade/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/downgrade/route.ts
@@ -14,7 +14,7 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { downgradeSubscription } from "../../../../../src/lib/billing/billing-service";
 
 const router = tsr.router(zeroBillingDowngradeContract, {
-  create: async ({ body, headers }, { request }) => {
+  create: async ({ body, headers }) => {
     initServices();
 
     const { STRIPE_SECRET_KEY } = env();
@@ -29,8 +29,7 @@ const router = tsr.router(zeroBillingDowngradeContract, {
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
     if (member.role !== "admin") {
       return createErrorResponse(
         "FORBIDDEN",

--- a/turbo/apps/web/app/api/zero/billing/invoices/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/invoices/route.ts
@@ -13,14 +13,13 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { getOrgInvoices } from "../../../../../src/lib/billing/billing-service";
 
 const router = tsr.router(zeroBillingInvoicesContract, {
-  get: async ({ headers }, { request }) => {
+  get: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
     if (member.role !== "admin") {
       return createErrorResponse(
         "FORBIDDEN",

--- a/turbo/apps/web/app/api/zero/billing/portal/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/portal/route.ts
@@ -14,7 +14,7 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { createBillingPortalSession } from "../../../../../src/lib/billing/billing-service";
 
 const router = tsr.router(zeroBillingPortalContract, {
-  create: async ({ body, headers }, { request }) => {
+  create: async ({ body, headers }) => {
     initServices();
 
     const { STRIPE_SECRET_KEY } = env();
@@ -28,8 +28,7 @@ const router = tsr.router(zeroBillingPortalContract, {
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
     if (member.role !== "admin") {
       return createErrorResponse(
         "FORBIDDEN",

--- a/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/__tests__/route.test.ts
@@ -201,7 +201,7 @@ describe("GET /api/zero/billing/status", () => {
     });
 
     const request = createTestRequest(
-      `http://localhost:3000/api/zero/billing/status?org=${newSlug}`,
+      `http://localhost:3000/api/zero/billing/status`,
     );
     const response = await GET(request);
 

--- a/turbo/apps/web/app/api/zero/billing/status/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/route.ts
@@ -13,14 +13,13 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { getBillingStatus } from "../../../../../src/lib/billing/billing-service";
 
 const router = tsr.router(zeroBillingStatusContract, {
-  get: async ({ headers }, { request }) => {
+  get: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const status = await getBillingStatus(org.orgId);
 

--- a/turbo/apps/web/app/api/zero/chat-threads/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/route.ts
@@ -10,12 +10,11 @@ import {
   createChatThread,
   listChatThreads,
 } from "../../../../src/lib/chat-thread";
-import { resolveCallerOrgId } from "../../../../src/lib/org/resolve-org";
 import { agentComposes } from "../../../../src/db/schema/agent-compose";
 import { eq } from "drizzle-orm";
 
 const router = tsr.router(chatThreadsContract, {
-  create: async ({ body, headers }, { request }) => {
+  create: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -44,7 +43,7 @@ const router = tsr.router(chatThreadsContract, {
       };
     }
 
-    const callerOrgId = await resolveCallerOrgId(authCtx, request);
+    const callerOrgId = authCtx.orgId ?? null;
     if (callerOrgId !== compose.orgId) {
       return {
         status: 404 as const,
@@ -66,7 +65,7 @@ const router = tsr.router(chatThreadsContract, {
     };
   },
 
-  list: async ({ query, headers }, { request }) => {
+  list: async ({ query, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -95,7 +94,7 @@ const router = tsr.router(chatThreadsContract, {
       };
     }
 
-    const callerOrgId = await resolveCallerOrgId(authCtx, request);
+    const callerOrgId = authCtx.orgId ?? null;
     if (callerOrgId !== compose.orgId) {
       return {
         status: 404 as const,

--- a/turbo/apps/web/app/api/zero/composes/[id]/metadata/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/metadata/route.ts
@@ -30,8 +30,7 @@ export async function PATCH(
   }
   const { userId } = authCtx;
 
-  const orgSlug = new URL(request.url).searchParams.get("org") ?? undefined;
-  const { org } = await resolveOrg(authCtx, orgSlug);
+  const { org } = await resolveOrg(authCtx);
 
   const body = await request.json();
 

--- a/turbo/apps/web/app/api/zero/composes/list/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/composes/list/__tests__/route.test.ts
@@ -21,8 +21,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function listUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/composes/list?org=${slug}`;
+function listUrl(): string {
+  return `http://localhost:3000/api/zero/composes/list`;
 }
 
 describe("GET /api/zero/composes/list", () => {
@@ -32,9 +32,9 @@ describe("GET /api/zero/composes/list", () => {
 
   it("should return empty list", async () => {
     const userId = uniqueId("zlist-empty");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
-    const response = await GET(createTestRequest(listUrl(slug)));
+    const response = await GET(createTestRequest(listUrl()));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -43,10 +43,10 @@ describe("GET /api/zero/composes/list", () => {
 
   it("should return list with composes", async () => {
     const userId = uniqueId("zlist-has");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     await createTestCompose(`agent-${uniqueId("zlist")}`);
 
-    const response = await GET(createTestRequest(listUrl(slug)));
+    const response = await GET(createTestRequest(listUrl()));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -58,9 +58,7 @@ describe("GET /api/zero/composes/list", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest(
-        "http://localhost:3000/api/zero/composes/list?org=test",
-      ),
+      createTestRequest("http://localhost:3000/api/zero/composes/list"),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/apps/web/app/api/zero/composes/list/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/list/route.ts
@@ -14,7 +14,7 @@ import { listComposes } from "../../../../../src/lib/agent-compose/compose-servi
 import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroComposesListContract, {
-  list: async ({ query, headers }) => {
+  list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -22,7 +22,7 @@ const router = tsr.router(zeroComposesListContract, {
 
     let orgId: string;
     try {
-      const { org } = await resolveOrg(authCtx, query.org);
+      const { org } = await resolveOrg(authCtx);
       orgId = org.orgId;
     } catch (error) {
       if (isNotFound(error)) {

--- a/turbo/apps/web/app/api/zero/composes/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/route.ts
@@ -10,7 +10,6 @@ import {
   isAuthError,
 } from "../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
-import { getOrgBySlug } from "../../../../src/lib/org/org-cache-service";
 import { getComposeByName } from "../../../../src/lib/agent-compose/compose-service";
 import {
   isNotFound,
@@ -27,16 +26,8 @@ const router = tsr.router(zeroComposesMainContract, {
 
     let orgId: string;
     try {
-      if (query.org) {
-        const orgBySlug = await getOrgBySlug(query.org);
-        const { org } = orgBySlug
-          ? await resolveOrg(authCtx, query.org)
-          : await resolveOrg(authCtx, undefined, query.org);
-        orgId = org.orgId;
-      } else {
-        const { org } = await resolveOrg(authCtx);
-        orgId = org.orgId;
-      }
+      const { org } = await resolveOrg(authCtx);
+      orgId = org.orgId;
     } catch (error) {
       if (isNotFound(error) || isForbidden(error) || isBadRequest(error)) {
         return {

--- a/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
@@ -23,8 +23,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function connectorUrl(slug: string, type: string): string {
-  return `http://localhost:3000/api/zero/connectors/${type}?org=${slug}`;
+function connectorUrl(type: string): string {
+  return `http://localhost:3000/api/zero/connectors/${type}`;
 }
 
 describe("GET /api/zero/connectors/:type", () => {
@@ -34,10 +34,10 @@ describe("GET /api/zero/connectors/:type", () => {
 
   it("should return connector when present", async () => {
     const userId = uniqueId("zcget-ok");
-    const { slug, orgId } = await setupOrg(userId);
+    const { orgId } = await setupOrg(userId);
     await context.createConnector(orgId, { userId, type: "github" });
 
-    const response = await GET(createTestRequest(connectorUrl(slug, "github")));
+    const response = await GET(createTestRequest(connectorUrl("github")));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -46,9 +46,9 @@ describe("GET /api/zero/connectors/:type", () => {
 
   it("should return 404 when connector not found", async () => {
     const userId = uniqueId("zcget-nf");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
-    const response = await GET(createTestRequest(connectorUrl(slug, "github")));
+    const response = await GET(createTestRequest(connectorUrl("github")));
     expect(response.status).toBe(404);
   });
 
@@ -56,7 +56,7 @@ describe("GET /api/zero/connectors/:type", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest(connectorUrl("test", "github")),
+      createTestRequest(connectorUrl("github")),
     );
     expect(response.status).toBe(401);
   });
@@ -69,7 +69,6 @@ describe("GET /api/zero/connectors/:type", () => {
       type: "github",
     });
 
-    const orgSlug = `org-${user.userId.slice(-8)}`;
     const zeroToken = await generateZeroToken(
       user.userId,
       randomUUID(),
@@ -77,7 +76,7 @@ describe("GET /api/zero/connectors/:type", () => {
     );
 
     const response = await GET(
-      new NextRequest(connectorUrl(orgSlug, "github"), {
+      new NextRequest(connectorUrl("github"), {
         headers: { Authorization: `Bearer ${zeroToken}` },
       }),
     );
@@ -95,21 +94,21 @@ describe("DELETE /api/zero/connectors/:type", () => {
 
   it("should delete a connector and return 204", async () => {
     const userId = uniqueId("zcdel-ok");
-    const { slug, orgId } = await setupOrg(userId);
+    const { orgId } = await setupOrg(userId);
     await context.createConnector(orgId, { userId, type: "github" });
 
     const response = await DELETE(
-      createTestRequest(connectorUrl(slug, "github"), { method: "DELETE" }),
+      createTestRequest(connectorUrl("github"), { method: "DELETE" }),
     );
     expect(response.status).toBe(204);
   });
 
   it("should return 404 when connector not found", async () => {
     const userId = uniqueId("zcdel-nf");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await DELETE(
-      createTestRequest(connectorUrl(slug, "github"), { method: "DELETE" }),
+      createTestRequest(connectorUrl("github"), { method: "DELETE" }),
     );
     expect(response.status).toBe(404);
   });
@@ -118,7 +117,7 @@ describe("DELETE /api/zero/connectors/:type", () => {
     mockClerk({ userId: null });
 
     const response = await DELETE(
-      createTestRequest(connectorUrl("test", "github"), { method: "DELETE" }),
+      createTestRequest(connectorUrl("github"), { method: "DELETE" }),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
@@ -55,9 +55,7 @@ describe("GET /api/zero/connectors/:type", () => {
   it("should return 401 when not authenticated", async () => {
     mockClerk({ userId: null });
 
-    const response = await GET(
-      createTestRequest(connectorUrl("github")),
-    );
+    const response = await GET(createTestRequest(connectorUrl("github")));
     expect(response.status).toBe(401);
   });
 

--- a/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
@@ -17,7 +17,7 @@ import {
 import { isNotFound } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroConnectorsByTypeContract, {
-  get: async ({ params, headers }, { request }) => {
+  get: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -26,8 +26,7 @@ const router = tsr.router(zeroConnectorsByTypeContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     const connector = await getConnector(org.orgId, userId, params.type);
 
     if (!connector) {
@@ -39,7 +38,7 @@ const router = tsr.router(zeroConnectorsByTypeContract, {
       body: connector,
     };
   },
-  delete: async ({ params, headers }, { request }) => {
+  delete: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -47,8 +46,7 @@ const router = tsr.router(zeroConnectorsByTypeContract, {
     const { userId } = authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       await deleteConnector(org.orgId, userId, params.type);
 
       return {

--- a/turbo/apps/web/app/api/zero/connectors/[type]/scope-diff/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/scope-diff/route.ts
@@ -14,7 +14,7 @@ import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 import { getConnector } from "../../../../../../src/lib/connector/connector-service";
 
 const router = tsr.router(zeroConnectorScopeDiffContract, {
-  getScopeDiff: async ({ params, headers }, { request }) => {
+  getScopeDiff: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -23,8 +23,7 @@ const router = tsr.router(zeroConnectorScopeDiffContract, {
     }
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     const connector = await getConnector(org.orgId, userId, params.type);
 
     if (!connector) {

--- a/turbo/apps/web/app/api/zero/connectors/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/__tests__/route.test.ts
@@ -20,8 +20,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function connectorsUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/connectors?org=${slug}`;
+function connectorsUrl(): string {
+  return `http://localhost:3000/api/zero/connectors`;
 }
 
 describe("GET /api/zero/connectors", () => {
@@ -31,9 +31,9 @@ describe("GET /api/zero/connectors", () => {
 
   it("should return empty connectors list", async () => {
     const userId = uniqueId("zcon-list");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
-    const response = await GET(createTestRequest(connectorsUrl(slug)));
+    const response = await GET(createTestRequest(connectorsUrl()));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -44,10 +44,10 @@ describe("GET /api/zero/connectors", () => {
 
   it("should return connectors when present", async () => {
     const userId = uniqueId("zcon-has");
-    const { slug, orgId } = await setupOrg(userId);
+    const { orgId } = await setupOrg(userId);
     await context.createConnector(orgId, { userId, type: "github" });
 
-    const response = await GET(createTestRequest(connectorsUrl(slug)));
+    const response = await GET(createTestRequest(connectorsUrl()));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -61,7 +61,7 @@ describe("GET /api/zero/connectors", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/connectors?org=test"),
+      createTestRequest("http://localhost:3000/api/zero/connectors"),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
@@ -22,8 +22,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function computerUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/connectors/computer?org=${slug}`;
+function computerUrl(): string {
+  return `http://localhost:3000/api/zero/connectors/computer`;
 }
 
 function setupNgrokMocks() {
@@ -103,8 +103,8 @@ function setupNgrokMocks() {
   return calls;
 }
 
-function createPostRequest(slug: string) {
-  return createTestRequest(computerUrl(slug), {
+function createPostRequest() {
+  return createTestRequest(computerUrl(), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: "{}",
@@ -120,7 +120,7 @@ describe("POST /api/zero/connectors/computer", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest(computerUrl("test"), {
+      createTestRequest(computerUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: "{}",
@@ -131,10 +131,10 @@ describe("POST /api/zero/connectors/computer", () => {
 
   it("should create computer connector", async () => {
     const userId = uniqueId("zcomp-create");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     const ngrokCalls = setupNgrokMocks();
 
-    const response = await POST(createPostRequest(slug));
+    const response = await POST(createPostRequest());
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -152,13 +152,13 @@ describe("POST /api/zero/connectors/computer", () => {
 
   it("should return 409 if connector already exists", async () => {
     const userId = uniqueId("zcomp-dup");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     setupNgrokMocks();
 
-    const response1 = await POST(createPostRequest(slug));
+    const response1 = await POST(createPostRequest());
     expect(response1.status).toBe(200);
 
-    const response2 = await POST(createPostRequest(slug));
+    const response2 = await POST(createPostRequest());
     expect(response2.status).toBe(409);
   });
 });
@@ -171,26 +171,26 @@ describe("GET /api/zero/connectors/computer", () => {
   it("should return 401 when not authenticated", async () => {
     mockClerk({ userId: null });
 
-    const response = await GET(createTestRequest(computerUrl("test")));
+    const response = await GET(createTestRequest(computerUrl()));
     expect(response.status).toBe(401);
   });
 
   it("should return 404 if connector not found", async () => {
     const userId = uniqueId("zcomp-nf");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
-    const response = await GET(createTestRequest(computerUrl(slug)));
+    const response = await GET(createTestRequest(computerUrl()));
     expect(response.status).toBe(404);
   });
 
   it("should return connector details", async () => {
     const userId = uniqueId("zcomp-get");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     setupNgrokMocks();
 
-    await POST(createPostRequest(slug));
+    await POST(createPostRequest());
 
-    const response = await GET(createTestRequest(computerUrl(slug)));
+    const response = await GET(createTestRequest(computerUrl()));
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -208,30 +208,30 @@ describe("DELETE /api/zero/connectors/computer", () => {
     mockClerk({ userId: null });
 
     const response = await DELETE(
-      createTestRequest(computerUrl("test"), { method: "DELETE" }),
+      createTestRequest(computerUrl(), { method: "DELETE" }),
     );
     expect(response.status).toBe(401);
   });
 
   it("should return 404 if connector not found", async () => {
     const userId = uniqueId("zcomp-del-nf");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await DELETE(
-      createTestRequest(computerUrl(slug), { method: "DELETE" }),
+      createTestRequest(computerUrl(), { method: "DELETE" }),
     );
     expect(response.status).toBe(404);
   });
 
   it("should delete connector and clean up", async () => {
     const userId = uniqueId("zcomp-del");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     const ngrokCalls = setupNgrokMocks();
 
-    await POST(createPostRequest(slug));
+    await POST(createPostRequest());
 
     const response = await DELETE(
-      createTestRequest(computerUrl(slug), { method: "DELETE" }),
+      createTestRequest(computerUrl(), { method: "DELETE" }),
     );
     expect(response.status).toBe(204);
 
@@ -240,7 +240,7 @@ describe("DELETE /api/zero/connectors/computer", () => {
     expect(ngrokCalls.deleteReservedDomain).toEqual(["rd_test_abc"]);
 
     // Verify GET returns 404
-    const getResponse = await GET(createTestRequest(computerUrl(slug)));
+    const getResponse = await GET(createTestRequest(computerUrl()));
     expect(getResponse.status).toBe(404);
   });
 });

--- a/turbo/apps/web/app/api/zero/connectors/computer/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/route.ts
@@ -22,7 +22,7 @@ import {
 } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroComputerConnectorContract, {
-  create: async ({ headers }, { request }) => {
+  create: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -30,8 +30,7 @@ const router = tsr.router(zeroComputerConnectorContract, {
     const { userId } = authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       const result = await createComputerConnector(org.orgId, userId);
       return { status: 200 as const, body: result };
     } catch (error) {
@@ -45,15 +44,14 @@ const router = tsr.router(zeroComputerConnectorContract, {
     }
   },
 
-  get: async ({ headers }, { request }) => {
+  get: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     const connector = await getConnector(org.orgId, userId, "computer");
 
     if (!connector) {
@@ -63,7 +61,7 @@ const router = tsr.router(zeroComputerConnectorContract, {
     return { status: 200 as const, body: connector };
   },
 
-  delete: async ({ headers }, { request }) => {
+  delete: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -71,8 +69,7 @@ const router = tsr.router(zeroComputerConnectorContract, {
     const { userId } = authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       await deleteComputerConnector(org.orgId, userId);
       return { status: 204 as const, body: undefined };
     } catch (error) {

--- a/turbo/apps/web/app/api/zero/connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/route.ts
@@ -17,15 +17,14 @@ import { listConnectors } from "../../../../src/lib/connector/connector-service"
 import { getConfiguredConnectorTypes } from "../../../../src/lib/connector/provider-registry";
 
 const router = tsr.router(zeroConnectorsMainContract, {
-  list: async ({ headers }, { request }) => {
+  list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     const connectorList = await listConnectors(org.orgId, userId);
     const configuredTypes = getConfiguredConnectorTypes(
       globalThis.services.env,

--- a/turbo/apps/web/app/api/zero/default-agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/default-agent/__tests__/route.test.ts
@@ -12,12 +12,9 @@ import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 
 const context = testContext();
 
-function putDefaultAgent(orgSlug: string | undefined, agentId: string | null) {
-  const url = orgSlug
-    ? `http://localhost:3000/api/zero/default-agent?org=${orgSlug}`
-    : "http://localhost:3000/api/zero/default-agent";
+function putDefaultAgent(agentId: string | null) {
   return PUT(
-    createTestRequest(url, {
+    createTestRequest("http://localhost:3000/api/zero/default-agent", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ agentId }),
@@ -32,7 +29,7 @@ describe("PUT /api/zero/default-agent", () => {
 
   it("should require authentication", async () => {
     mockClerk({ userId: null });
-    const response = await putDefaultAgent(undefined, null);
+    const response = await putDefaultAgent(null);
     expect(response.status).toBe(401);
   });
 
@@ -40,7 +37,7 @@ describe("PUT /api/zero/default-agent", () => {
     await context.setupUser();
     const compose = await createTestCompose("test-agent");
 
-    const response = await putDefaultAgent(undefined, compose.composeId);
+    const response = await putDefaultAgent(compose.composeId);
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -52,10 +49,10 @@ describe("PUT /api/zero/default-agent", () => {
     const compose = await createTestCompose("test-agent");
 
     // Set first
-    await putDefaultAgent(undefined, compose.composeId);
+    await putDefaultAgent(compose.composeId);
 
     // Attempt to unset — blocked by 409 guard
-    const response = await putDefaultAgent(undefined, null);
+    const response = await putDefaultAgent(null);
     expect(response.status).toBe(409);
 
     const data = await response.json();
@@ -71,7 +68,7 @@ describe("PUT /api/zero/default-agent", () => {
 
     // The member user resolves to their own org where they ARE admin,
     // but they don't have the compose. Test that agent-not-in-org returns 404.
-    const response = await putDefaultAgent(undefined, compose.composeId);
+    const response = await putDefaultAgent(compose.composeId);
     expect(response.status).toBe(404);
   });
 
@@ -80,7 +77,6 @@ describe("PUT /api/zero/default-agent", () => {
 
     // Use a random UUID that doesn't exist
     const response = await putDefaultAgent(
-      undefined,
       "00000000-0000-0000-0000-000000000000",
     );
     expect(response.status).toBe(404);
@@ -90,7 +86,7 @@ describe("PUT /api/zero/default-agent", () => {
     const { orgId } = await context.setupUser();
     const compose = await createTestCompose("test-agent");
 
-    await putDefaultAgent(undefined, compose.composeId);
+    await putDefaultAgent(compose.composeId);
 
     // Verify the value was persisted to the org table (stored as zero agent UUID)
     const storedId = await getOrgDefaultAgent(orgId);
@@ -101,10 +97,10 @@ describe("PUT /api/zero/default-agent", () => {
     const { orgId } = await context.setupUser();
     const compose = await createTestCompose("test-agent");
 
-    await putDefaultAgent(undefined, compose.composeId);
+    await putDefaultAgent(compose.composeId);
 
     // Attempt to unset — should be rejected with 409
-    const response = await putDefaultAgent(undefined, null);
+    const response = await putDefaultAgent(null);
     expect(response.status).toBe(409);
 
     // org table should still have the original value (stored as zero agent UUID)
@@ -117,11 +113,11 @@ describe("PUT /api/zero/default-agent", () => {
     const compose = await createTestCompose("test-agent");
 
     // Set default
-    const response1 = await putDefaultAgent(undefined, compose.composeId);
+    const response1 = await putDefaultAgent(compose.composeId);
     expect(response1.status).toBe(200);
 
     // Attempt to set again — blocked by 409 guard
-    const response2 = await putDefaultAgent(undefined, compose.composeId);
+    const response2 = await putDefaultAgent(compose.composeId);
     expect(response2.status).toBe(409);
 
     const data = await response2.json();
@@ -133,7 +129,7 @@ describe("PUT /api/zero/default-agent", () => {
     const compose1 = await createTestCompose("agent-1");
 
     // Set first default agent
-    const response1 = await putDefaultAgent(undefined, compose1.composeId);
+    const response1 = await putDefaultAgent(compose1.composeId);
     expect(response1.status).toBe(200);
 
     // Delete the compose from DB (simulating user deleting the agent)
@@ -141,7 +137,7 @@ describe("PUT /api/zero/default-agent", () => {
 
     // Setting a new default should succeed since the old one no longer exists
     const compose2 = await createTestCompose("agent-2");
-    const response2 = await putDefaultAgent(undefined, compose2.composeId);
+    const response2 = await putDefaultAgent(compose2.composeId);
     expect(response2.status).toBe(200);
 
     const data = await response2.json();
@@ -153,7 +149,7 @@ describe("PUT /api/zero/default-agent", () => {
     const compose = await createTestCompose("test-agent");
 
     // No default agent configured yet — should succeed
-    const response = await putDefaultAgent(undefined, compose.composeId);
+    const response = await putDefaultAgent(compose.composeId);
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -168,7 +164,7 @@ describe("PUT /api/zero/default-agent", () => {
     await deleteOrgRow(orgId);
 
     // The upsert should create the org row and set the default agent
-    const response = await putDefaultAgent(undefined, compose.composeId);
+    const response = await putDefaultAgent(compose.composeId);
     expect(response.status).toBe(200);
 
     const data = await response.json();

--- a/turbo/apps/web/app/api/zero/default-agent/route.ts
+++ b/turbo/apps/web/app/api/zero/default-agent/route.ts
@@ -12,7 +12,7 @@ import { orgMetadata as orgTable } from "../../../../src/db/schema/org-metadata"
 import { eq, and } from "drizzle-orm";
 
 const router = tsr.router(orgDefaultAgentContract, {
-  setDefaultAgent: async ({ query, body, headers }) => {
+  setDefaultAgent: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -25,7 +25,7 @@ const router = tsr.router(orgDefaultAgentContract, {
       };
     }
 
-    const { org, member } = await resolveOrg(authCtx, undefined, query.org);
+    const { org, member } = await resolveOrg(authCtx);
 
     if (member.role !== "admin") {
       return {

--- a/turbo/apps/web/app/api/zero/firewall-access-requests/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/firewall-access-requests/__tests__/route.test.ts
@@ -333,7 +333,7 @@ describe("GET /api/zero/firewall-access-requests", () => {
   });
 
   it("should include requesterName from Clerk user data", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     // Override Clerk mock to return user with a name
     mockClerk({
@@ -349,14 +349,9 @@ describe("GET /api/zero/firewall-access-requests", () => {
         permission: "issues:read",
       },
       testCliToken,
-      testOrgSlug,
     );
 
-    const response = await listAccessRequests(
-      agent.agentId,
-      testCliToken,
-      testOrgSlug,
-    );
+    const response = await listAccessRequests(agent.agentId, testCliToken);
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -365,7 +360,7 @@ describe("GET /api/zero/firewall-access-requests", () => {
   });
 
   it("should return null requesterName when Clerk has no name data", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     await createAccessRequest(
       {
@@ -374,14 +369,9 @@ describe("GET /api/zero/firewall-access-requests", () => {
         permission: "issues:read",
       },
       testCliToken,
-      testOrgSlug,
     );
 
-    const response = await listAccessRequests(
-      agent.agentId,
-      testCliToken,
-      testOrgSlug,
-    );
+    const response = await listAccessRequests(agent.agentId, testCliToken);
 
     expect(response.status).toBe(200);
     const data = await response.json();

--- a/turbo/apps/web/app/api/zero/firewall-access-requests/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/firewall-access-requests/__tests__/route.test.ts
@@ -14,13 +14,12 @@ import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 const context = testContext();
 
 let testCliToken: string;
-let testOrgSlug: string;
 let testOrgId: string;
 let testUserId: string;
 
-function createAgent(token: string, orgSlug: string) {
+function createAgent(token: string) {
   return postAgent(
-    createTestRequest(`http://localhost:3000/api/zero/agents?org=${orgSlug}`, {
+    createTestRequest(`http://localhost:3000/api/zero/agents`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -31,14 +30,10 @@ function createAgent(token: string, orgSlug: string) {
   );
 }
 
-function createAccessRequest(
-  body: Record<string, unknown>,
-  token: string,
-  orgSlug: string,
-) {
+function createAccessRequest(body: Record<string, unknown>, token: string) {
   return POST(
     createTestRequest(
-      `http://localhost:3000/api/zero/firewall-access-requests?org=${orgSlug}`,
+      `http://localhost:3000/api/zero/firewall-access-requests`,
       {
         method: "POST",
         headers: {
@@ -51,16 +46,11 @@ function createAccessRequest(
   );
 }
 
-function listAccessRequests(
-  agentId: string,
-  token: string,
-  orgSlug: string,
-  status?: string,
-) {
+function listAccessRequests(agentId: string, token: string, status?: string) {
   const statusParam = status ? `&status=${status}` : "";
   return GET(
     createTestRequest(
-      `http://localhost:3000/api/zero/firewall-access-requests?org=${orgSlug}&agentId=${agentId}${statusParam}`,
+      `http://localhost:3000/api/zero/firewall-access-requests?agentId=${agentId}${statusParam}`,
       {
         method: "GET",
         headers: { Authorization: `Bearer ${token}` },
@@ -69,14 +59,10 @@ function listAccessRequests(
   );
 }
 
-function resolveAccessRequest(
-  body: Record<string, unknown>,
-  token: string,
-  orgSlug: string,
-) {
+function resolveAccessRequest(body: Record<string, unknown>, token: string) {
   return PUT(
     createTestRequest(
-      `http://localhost:3000/api/zero/firewall-access-requests?org=${orgSlug}`,
+      `http://localhost:3000/api/zero/firewall-access-requests`,
       {
         method: "PUT",
         headers: {
@@ -97,7 +83,6 @@ beforeEach(async () => {
   testUserId = user.userId;
   testOrgId = user.orgId;
   testCliToken = await createTestCliToken(user.userId);
-  testOrgSlug = `org-${user.userId.slice(-8)}`;
 
   await insertOrgMembersCacheEntry({
     orgId: testOrgId,
@@ -108,7 +93,7 @@ beforeEach(async () => {
 
 describe("POST /api/zero/firewall-access-requests", () => {
   it("should create a firewall access request", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     const response = await createAccessRequest(
       {
@@ -118,7 +103,6 @@ describe("POST /api/zero/firewall-access-requests", () => {
         reason: "Need to read issues",
       },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(201);
@@ -134,7 +118,7 @@ describe("POST /api/zero/firewall-access-requests", () => {
   });
 
   it("should dedup pending requests by updating reason", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     const first = await (
       await createAccessRequest(
@@ -145,7 +129,6 @@ describe("POST /api/zero/firewall-access-requests", () => {
           reason: "First reason",
         },
         testCliToken,
-        testOrgSlug,
       )
     ).json();
 
@@ -158,7 +141,6 @@ describe("POST /api/zero/firewall-access-requests", () => {
           reason: "Updated reason",
         },
         testCliToken,
-        testOrgSlug,
       )
     ).json();
 
@@ -168,7 +150,7 @@ describe("POST /api/zero/firewall-access-requests", () => {
   });
 
   it("should return 400 for unknown firewall ref", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     const response = await createAccessRequest(
       {
@@ -177,7 +159,6 @@ describe("POST /api/zero/firewall-access-requests", () => {
         permission: "read",
       },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(400);
@@ -193,7 +174,6 @@ describe("POST /api/zero/firewall-access-requests", () => {
         permission: "issues:read",
       },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(404);
@@ -209,17 +189,20 @@ describe("POST /api/zero/firewall-access-requests", () => {
         permission: "issues:read",
       },
       "no-token",
-      testOrgSlug,
     );
 
     expect(response.status).toBe(401);
   });
 
   it("should allow non-admin members to create requests", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     const member = await context.setupUser({ prefix: "member" });
-    const memberToken = await createTestCliToken(member.userId);
+    const memberToken = await createTestCliToken(
+      member.userId,
+      undefined,
+      testOrgId,
+    );
     await insertOrgMembersCacheEntry({
       orgId: testOrgId,
       userId: member.userId,
@@ -233,7 +216,6 @@ describe("POST /api/zero/firewall-access-requests", () => {
         permission: "issues:read",
       },
       memberToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(201);
@@ -244,7 +226,7 @@ describe("POST /api/zero/firewall-access-requests", () => {
 
 describe("GET /api/zero/firewall-access-requests", () => {
   it("should list access requests for an agent", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     await createAccessRequest(
       {
@@ -253,14 +235,9 @@ describe("GET /api/zero/firewall-access-requests", () => {
         permission: "issues:read",
       },
       testCliToken,
-      testOrgSlug,
     );
 
-    const response = await listAccessRequests(
-      agent.agentId,
-      testCliToken,
-      testOrgSlug,
-    );
+    const response = await listAccessRequests(agent.agentId, testCliToken);
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -269,7 +246,7 @@ describe("GET /api/zero/firewall-access-requests", () => {
   });
 
   it("should filter by status", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     await createAccessRequest(
       {
@@ -278,14 +255,12 @@ describe("GET /api/zero/firewall-access-requests", () => {
         permission: "issues:read",
       },
       testCliToken,
-      testOrgSlug,
     );
 
     // No approved requests yet
     const response = await listAccessRequests(
       agent.agentId,
       testCliToken,
-      testOrgSlug,
       "approved",
     );
 
@@ -297,7 +272,7 @@ describe("GET /api/zero/firewall-access-requests", () => {
   it("should return 400 when agentId is missing", async () => {
     const response = await GET(
       createTestRequest(
-        `http://localhost:3000/api/zero/firewall-access-requests?org=${testOrgSlug}`,
+        `http://localhost:3000/api/zero/firewall-access-requests`,
         {
           method: "GET",
           headers: { Authorization: `Bearer ${testCliToken}` },
@@ -311,7 +286,7 @@ describe("GET /api/zero/firewall-access-requests", () => {
   });
 
   it("members should only see own requests", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     // Admin creates a request
     await createAccessRequest(
@@ -321,12 +296,15 @@ describe("GET /api/zero/firewall-access-requests", () => {
         permission: "issues:read",
       },
       testCliToken,
-      testOrgSlug,
     );
 
     // Member creates a request
     const member = await context.setupUser({ prefix: "member" });
-    const memberToken = await createTestCliToken(member.userId);
+    const memberToken = await createTestCliToken(
+      member.userId,
+      undefined,
+      testOrgId,
+    );
     await insertOrgMembersCacheEntry({
       orgId: testOrgId,
       userId: member.userId,
@@ -340,25 +318,16 @@ describe("GET /api/zero/firewall-access-requests", () => {
         permission: "channels:read",
       },
       memberToken,
-      testOrgSlug,
     );
 
     // Member should only see their own request
-    const memberList = await listAccessRequests(
-      agent.agentId,
-      memberToken,
-      testOrgSlug,
-    );
+    const memberList = await listAccessRequests(agent.agentId, memberToken);
     const memberData = await memberList.json();
     expect(memberData).toHaveLength(1);
     expect(memberData[0].firewallRef).toBe("slack");
 
     // Admin should see all requests
-    const adminList = await listAccessRequests(
-      agent.agentId,
-      testCliToken,
-      testOrgSlug,
-    );
+    const adminList = await listAccessRequests(agent.agentId, testCliToken);
     const adminData = await adminList.json();
     expect(adminData).toHaveLength(2);
   });
@@ -423,7 +392,7 @@ describe("GET /api/zero/firewall-access-requests", () => {
 
 describe("PUT /api/zero/firewall-access-requests", () => {
   it("should approve a request and update firewall policies", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     const created = await (
       await createAccessRequest(
@@ -434,14 +403,12 @@ describe("PUT /api/zero/firewall-access-requests", () => {
           reason: "Need access",
         },
         testCliToken,
-        testOrgSlug,
       )
     ).json();
 
     const response = await resolveAccessRequest(
       { requestId: created.id, action: "approve" },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(200);
@@ -454,7 +421,7 @@ describe("PUT /api/zero/firewall-access-requests", () => {
     const { GET: getAgentById } = await import("../../agents/[id]/route");
     const agentRes = await getAgentById(
       createTestRequest(
-        `http://localhost:3000/api/zero/agents/${agent.agentId}?org=${testOrgSlug}`,
+        `http://localhost:3000/api/zero/agents/${agent.agentId}`,
         {
           method: "GET",
           headers: { Authorization: `Bearer ${testCliToken}` },
@@ -468,7 +435,7 @@ describe("PUT /api/zero/firewall-access-requests", () => {
   });
 
   it("should reject a request without updating policies", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     const created = await (
       await createAccessRequest(
@@ -478,14 +445,12 @@ describe("PUT /api/zero/firewall-access-requests", () => {
           permission: "issues:read",
         },
         testCliToken,
-        testOrgSlug,
       )
     ).json();
 
     const response = await resolveAccessRequest(
       { requestId: created.id, action: "reject" },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(200);
@@ -496,7 +461,7 @@ describe("PUT /api/zero/firewall-access-requests", () => {
     const { GET: getAgentById } = await import("../../agents/[id]/route");
     const agentRes = await getAgentById(
       createTestRequest(
-        `http://localhost:3000/api/zero/agents/${agent.agentId}?org=${testOrgSlug}`,
+        `http://localhost:3000/api/zero/agents/${agent.agentId}`,
         {
           method: "GET",
           headers: { Authorization: `Bearer ${testCliToken}` },
@@ -508,7 +473,7 @@ describe("PUT /api/zero/firewall-access-requests", () => {
   });
 
   it("should return 403 for non-admin users", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     const created = await (
       await createAccessRequest(
@@ -518,12 +483,15 @@ describe("PUT /api/zero/firewall-access-requests", () => {
           permission: "issues:read",
         },
         testCliToken,
-        testOrgSlug,
       )
     ).json();
 
     const member = await context.setupUser({ prefix: "member" });
-    const memberToken = await createTestCliToken(member.userId);
+    const memberToken = await createTestCliToken(
+      member.userId,
+      undefined,
+      testOrgId,
+    );
     await insertOrgMembersCacheEntry({
       orgId: testOrgId,
       userId: member.userId,
@@ -533,7 +501,6 @@ describe("PUT /api/zero/firewall-access-requests", () => {
     const response = await resolveAccessRequest(
       { requestId: created.id, action: "approve" },
       memberToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(403);
@@ -548,14 +515,13 @@ describe("PUT /api/zero/firewall-access-requests", () => {
         action: "approve",
       },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(404);
   });
 
   it("should return 400 for already resolved request", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     const created = await (
       await createAccessRequest(
@@ -565,7 +531,6 @@ describe("PUT /api/zero/firewall-access-requests", () => {
           permission: "issues:read",
         },
         testCliToken,
-        testOrgSlug,
       )
     ).json();
 
@@ -573,14 +538,12 @@ describe("PUT /api/zero/firewall-access-requests", () => {
     await resolveAccessRequest(
       { requestId: created.id, action: "approve" },
       testCliToken,
-      testOrgSlug,
     );
 
     // Try to reject the same request
     const response = await resolveAccessRequest(
       { requestId: created.id, action: "reject" },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(400);
@@ -589,25 +552,22 @@ describe("PUT /api/zero/firewall-access-requests", () => {
   });
 
   it("should preserve existing firewall policies when approving", async () => {
-    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+    const agent = await (await createAgent(testCliToken)).json();
 
     // Set initial policies via firewall-policies endpoint
     const { PUT: putPolicies } = await import("../../firewall-policies/route");
     await putPolicies(
-      createTestRequest(
-        `http://localhost:3000/api/zero/firewall-policies?org=${testOrgSlug}`,
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${testCliToken}`,
-          },
-          body: JSON.stringify({
-            agentId: agent.agentId,
-            policies: { slack: { "channels:read": "allow" } },
-          }),
+      createTestRequest(`http://localhost:3000/api/zero/firewall-policies`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${testCliToken}`,
         },
-      ),
+        body: JSON.stringify({
+          agentId: agent.agentId,
+          policies: { slack: { "channels:read": "allow" } },
+        }),
+      }),
     );
 
     // Create and approve a github request
@@ -619,21 +579,19 @@ describe("PUT /api/zero/firewall-access-requests", () => {
           permission: "issues:read",
         },
         testCliToken,
-        testOrgSlug,
       )
     ).json();
 
     await resolveAccessRequest(
       { requestId: created.id, action: "approve" },
       testCliToken,
-      testOrgSlug,
     );
 
     // Verify both policies exist
     const { GET: getAgentById } = await import("../../agents/[id]/route");
     const agentRes = await getAgentById(
       createTestRequest(
-        `http://localhost:3000/api/zero/agents/${agent.agentId}?org=${testOrgSlug}`,
+        `http://localhost:3000/api/zero/agents/${agent.agentId}`,
         {
           method: "GET",
           headers: { Authorization: `Bearer ${testCliToken}` },

--- a/turbo/apps/web/app/api/zero/firewall-policies/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/firewall-policies/__tests__/route.test.ts
@@ -97,9 +97,7 @@ describe("PUT /api/zero/firewall-policies", () => {
   });
 
   it("should persist policies across reads", async () => {
-    const created = await (
-      await postAgent({}, testCliToken)
-    ).json();
+    const created = await (await postAgent({}, testCliToken)).json();
 
     const policies = {
       slack: { "channels:read": "allow", "chat:write": "ask" },
@@ -115,16 +113,10 @@ describe("PUT /api/zero/firewall-policies", () => {
   });
 
   it("should overwrite previous policies", async () => {
-    const created = await (
-      await postAgent({}, testCliToken)
-    ).json();
+    const created = await (await postAgent({}, testCliToken)).json();
 
     const first = { github: { "issues:read": "allow" } };
-    await putPolicies(
-      created.agentId,
-      { policies: first },
-      testCliToken,
-    );
+    await putPolicies(created.agentId, { policies: first }, testCliToken);
 
     const second = { slack: { "channels:read": "deny" } };
     const response = await putPolicies(
@@ -139,13 +131,15 @@ describe("PUT /api/zero/firewall-policies", () => {
   });
 
   it("should return 403 for non-admin users", async () => {
-    const created = await (
-      await postAgent({}, testCliToken)
-    ).json();
+    const created = await (await postAgent({}, testCliToken)).json();
 
     // Create a non-admin user
     const member = await context.setupUser({ prefix: "member-user" });
-    const memberToken = await createTestCliToken(member.userId);
+    const memberToken = await createTestCliToken(
+      member.userId,
+      undefined,
+      testOrgId,
+    );
 
     // Grant member role in the same org
     await insertOrgMembersCacheEntry({
@@ -166,9 +160,7 @@ describe("PUT /api/zero/firewall-policies", () => {
   });
 
   it("should return 400 for unknown firewall ref", async () => {
-    const created = await (
-      await postAgent({}, testCliToken)
-    ).json();
+    const created = await (await postAgent({}, testCliToken)).json();
 
     const response = await putPolicies(
       created.agentId,
@@ -183,9 +175,7 @@ describe("PUT /api/zero/firewall-policies", () => {
   });
 
   it("should return 400 for unknown permission name", async () => {
-    const created = await (
-      await postAgent({}, testCliToken)
-    ).json();
+    const created = await (await postAgent({}, testCliToken)).json();
 
     const response = await putPolicies(
       created.agentId,
@@ -224,9 +214,7 @@ describe("PUT /api/zero/firewall-policies", () => {
   });
 
   it("should accept empty policies", async () => {
-    const created = await (
-      await postAgent({}, testCliToken)
-    ).json();
+    const created = await (await postAgent({}, testCliToken)).json();
 
     const response = await putPolicies(
       created.agentId,
@@ -247,9 +235,7 @@ describe("PUT /api/zero/firewall-policies", () => {
   });
 
   it("should return full agent response shape", async () => {
-    const created = await (
-      await postAgent({}, testCliToken)
-    ).json();
+    const created = await (await postAgent({}, testCliToken)).json();
 
     const policies = { github: { "issues:read": "allow" } };
     const response = await putPolicies(
@@ -270,26 +256,14 @@ describe("PUT /api/zero/firewall-policies", () => {
   });
 
   it("should isolate policies between different agents", async () => {
-    const agent1 = await (
-      await postAgent({}, testCliToken)
-    ).json();
-    const agent2 = await (
-      await postAgent({}, testCliToken)
-    ).json();
+    const agent1 = await (await postAgent({}, testCliToken)).json();
+    const agent2 = await (await postAgent({}, testCliToken)).json();
 
     const policies1 = { github: { "issues:read": "allow" } };
     const policies2 = { slack: { "channels:read": "deny" } };
 
-    await putPolicies(
-      agent1.agentId,
-      { policies: policies1 },
-      testCliToken,
-    );
-    await putPolicies(
-      agent2.agentId,
-      { policies: policies2 },
-      testCliToken,
-    );
+    await putPolicies(agent1.agentId, { policies: policies1 }, testCliToken);
+    await putPolicies(agent2.agentId, { policies: policies2 }, testCliToken);
 
     const get1 = await getAgent(agent1.agentId, testCliToken);
     const get2 = await getAgent(agent2.agentId, testCliToken);

--- a/turbo/apps/web/app/api/zero/firewall-policies/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/firewall-policies/__tests__/route.test.ts
@@ -15,18 +15,12 @@ import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
 const context = testContext();
 
 let testCliToken: string;
-let testOrgSlug: string;
 let testOrgId: string;
 let testUserId: string;
 
-function postAgent(
-  body: Record<string, unknown>,
-  token: string,
-  orgSlug?: string,
-) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function postAgent(body: Record<string, unknown>, token: string) {
   return POST(
-    createTestRequest(`http://localhost:3000/api/zero/agents${orgParam}`, {
+    createTestRequest("http://localhost:3000/api/zero/agents", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -37,16 +31,12 @@ function postAgent(
   );
 }
 
-function getAgent(name: string, token: string, orgSlug?: string) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function getAgent(name: string, token: string) {
   return GET(
-    createTestRequest(
-      `http://localhost:3000/api/zero/agents/${name}${orgParam}`,
-      {
-        method: "GET",
-        headers: { Authorization: `Bearer ${token}` },
-      },
-    ),
+    createTestRequest(`http://localhost:3000/api/zero/agents/${name}`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    }),
   );
 }
 
@@ -54,21 +44,16 @@ function putPolicies(
   agentId: string,
   body: Record<string, unknown>,
   token: string,
-  orgSlug?: string,
 ) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
   return putFirewallPolicies(
-    createTestRequest(
-      `http://localhost:3000/api/zero/firewall-policies${orgParam}`,
-      {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ agentId, ...body }),
+    createTestRequest("http://localhost:3000/api/zero/firewall-policies", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
       },
-    ),
+      body: JSON.stringify({ agentId, ...body }),
+    }),
   );
 }
 
@@ -81,7 +66,6 @@ describe("PUT /api/zero/firewall-policies", () => {
     testUserId = user.userId;
     testOrgId = user.orgId;
     testCliToken = await createTestCliToken(user.userId);
-    testOrgSlug = `org-${user.userId.slice(-8)}`;
 
     // Default test user is admin
     await insertOrgMembersCacheEntry({
@@ -92,7 +76,7 @@ describe("PUT /api/zero/firewall-policies", () => {
   });
 
   it("should persist firewall policies for an agent", async () => {
-    const createRes = await postAgent({}, testCliToken, testOrgSlug);
+    const createRes = await postAgent({}, testCliToken);
     expect(createRes.status).toBe(201);
     const created = await createRes.json();
 
@@ -104,7 +88,6 @@ describe("PUT /api/zero/firewall-policies", () => {
       created.agentId,
       { policies },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(200);
@@ -115,17 +98,17 @@ describe("PUT /api/zero/firewall-policies", () => {
 
   it("should persist policies across reads", async () => {
     const created = await (
-      await postAgent({}, testCliToken, testOrgSlug)
+      await postAgent({}, testCliToken)
     ).json();
 
     const policies = {
       slack: { "channels:read": "allow", "chat:write": "ask" },
     };
 
-    await putPolicies(created.agentId, { policies }, testCliToken, testOrgSlug);
+    await putPolicies(created.agentId, { policies }, testCliToken);
 
     // Read back via GET
-    const getRes = await getAgent(created.agentId, testCliToken, testOrgSlug);
+    const getRes = await getAgent(created.agentId, testCliToken);
     expect(getRes.status).toBe(200);
     const fetched = await getRes.json();
     expect(fetched.firewallPolicies).toStrictEqual(policies);
@@ -133,7 +116,7 @@ describe("PUT /api/zero/firewall-policies", () => {
 
   it("should overwrite previous policies", async () => {
     const created = await (
-      await postAgent({}, testCliToken, testOrgSlug)
+      await postAgent({}, testCliToken)
     ).json();
 
     const first = { github: { "issues:read": "allow" } };
@@ -141,7 +124,6 @@ describe("PUT /api/zero/firewall-policies", () => {
       created.agentId,
       { policies: first },
       testCliToken,
-      testOrgSlug,
     );
 
     const second = { slack: { "channels:read": "deny" } };
@@ -149,7 +131,6 @@ describe("PUT /api/zero/firewall-policies", () => {
       created.agentId,
       { policies: second },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(200);
@@ -159,7 +140,7 @@ describe("PUT /api/zero/firewall-policies", () => {
 
   it("should return 403 for non-admin users", async () => {
     const created = await (
-      await postAgent({}, testCliToken, testOrgSlug)
+      await postAgent({}, testCliToken)
     ).json();
 
     // Create a non-admin user
@@ -177,7 +158,6 @@ describe("PUT /api/zero/firewall-policies", () => {
       created.agentId,
       { policies: { github: { "issues:read": "allow" } } },
       memberToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(403);
@@ -187,14 +167,13 @@ describe("PUT /api/zero/firewall-policies", () => {
 
   it("should return 400 for unknown firewall ref", async () => {
     const created = await (
-      await postAgent({}, testCliToken, testOrgSlug)
+      await postAgent({}, testCliToken)
     ).json();
 
     const response = await putPolicies(
       created.agentId,
       { policies: { "nonexistent-firewall": { "perm:read": "allow" } } },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(400);
@@ -205,14 +184,13 @@ describe("PUT /api/zero/firewall-policies", () => {
 
   it("should return 400 for unknown permission name", async () => {
     const created = await (
-      await postAgent({}, testCliToken, testOrgSlug)
+      await postAgent({}, testCliToken)
     ).json();
 
     const response = await putPolicies(
       created.agentId,
       { policies: { github: { "totally-fake-permission": "allow" } } },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(400);
@@ -226,7 +204,6 @@ describe("PUT /api/zero/firewall-policies", () => {
       "00000000-0000-0000-0000-000000000000",
       { policies: { github: { "issues:read": "allow" } } },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(404);
@@ -248,14 +225,13 @@ describe("PUT /api/zero/firewall-policies", () => {
 
   it("should accept empty policies", async () => {
     const created = await (
-      await postAgent({}, testCliToken, testOrgSlug)
+      await postAgent({}, testCliToken)
     ).json();
 
     const response = await putPolicies(
       created.agentId,
       { policies: {} },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(200);
@@ -264,7 +240,7 @@ describe("PUT /api/zero/firewall-policies", () => {
   });
 
   it("should return firewallPolicies as null for new agents", async () => {
-    const createRes = await postAgent({}, testCliToken, testOrgSlug);
+    const createRes = await postAgent({}, testCliToken);
     expect(createRes.status).toBe(201);
     const data = await createRes.json();
     expect(data.firewallPolicies).toBeNull();
@@ -272,7 +248,7 @@ describe("PUT /api/zero/firewall-policies", () => {
 
   it("should return full agent response shape", async () => {
     const created = await (
-      await postAgent({}, testCliToken, testOrgSlug)
+      await postAgent({}, testCliToken)
     ).json();
 
     const policies = { github: { "issues:read": "allow" } };
@@ -280,7 +256,6 @@ describe("PUT /api/zero/firewall-policies", () => {
       created.agentId,
       { policies },
       testCliToken,
-      testOrgSlug,
     );
 
     expect(response.status).toBe(200);
@@ -296,10 +271,10 @@ describe("PUT /api/zero/firewall-policies", () => {
 
   it("should isolate policies between different agents", async () => {
     const agent1 = await (
-      await postAgent({}, testCliToken, testOrgSlug)
+      await postAgent({}, testCliToken)
     ).json();
     const agent2 = await (
-      await postAgent({}, testCliToken, testOrgSlug)
+      await postAgent({}, testCliToken)
     ).json();
 
     const policies1 = { github: { "issues:read": "allow" } };
@@ -309,17 +284,15 @@ describe("PUT /api/zero/firewall-policies", () => {
       agent1.agentId,
       { policies: policies1 },
       testCliToken,
-      testOrgSlug,
     );
     await putPolicies(
       agent2.agentId,
       { policies: policies2 },
       testCliToken,
-      testOrgSlug,
     );
 
-    const get1 = await getAgent(agent1.agentId, testCliToken, testOrgSlug);
-    const get2 = await getAgent(agent2.agentId, testCliToken, testOrgSlug);
+    const get1 = await getAgent(agent1.agentId, testCliToken);
+    const get2 = await getAgent(agent2.agentId, testCliToken);
 
     expect((await get1.json()).firewallPolicies).toStrictEqual(policies1);
     expect((await get2.json()).firewallPolicies).toStrictEqual(policies2);

--- a/turbo/apps/web/app/api/zero/firewall-policies/route.ts
+++ b/turbo/apps/web/app/api/zero/firewall-policies/route.ts
@@ -47,7 +47,7 @@ function validatePolicies(policies: FirewallPolicies): string | null {
 }
 
 const router = tsr.router(zeroAgentFirewallPoliciesContract, {
-  update: async ({ body, headers }, { request }) => {
+  update: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -55,8 +55,7 @@ const router = tsr.router(zeroAgentFirewallPoliciesContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     if (member.role !== "admin") {
       return {

--- a/turbo/apps/web/app/api/zero/integrations/slack/connect/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/connect/route.ts
@@ -44,8 +44,7 @@ export async function GET(request: Request) {
   }
 
   const { userId } = authCtx;
-  const orgSlug = new URL(request.url).searchParams.get("org");
-  const { org, member } = await resolveOrg(authCtx, orgSlug);
+  const { org, member } = await resolveOrg(authCtx);
 
   // Find installation for this org, then find user's connection via workspace
   const [orgInstallation] = await globalThis.services.db
@@ -130,8 +129,7 @@ export async function POST(request: Request) {
   const { workspaceId, slackUserId, channelId, threadTs } = parseResult.data;
 
   // Resolve org and check membership
-  const orgSlug = new URL(request.url).searchParams.get("org");
-  const { org, member } = await resolveOrg(authCtx, orgSlug);
+  const { org, member } = await resolveOrg(authCtx);
 
   // Check installation exists
   const [installation] = await globalThis.services.db
@@ -196,7 +194,7 @@ export async function POST(request: Request) {
     // Check if user is a member of the workspace's org but has the wrong active org
     let isMemberOfTargetOrg = false;
     try {
-      await resolveOrg(authCtx, null, installation.orgId);
+      await resolveOrg(authCtx, installation.orgId);
       isMemberOfTargetOrg = true;
     } catch {
       // Not a member

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
@@ -32,7 +32,7 @@ function isSlackPlatformError(
 }
 
 const router = tsr.router(integrationsSlackMessageContract, {
-  sendMessage: async ({ body, headers }, { request }) => {
+  sendMessage: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -63,8 +63,7 @@ const router = tsr.router(integrationsSlackMessageContract, {
       }
       orgId = sandboxRun.orgId;
     } else {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       orgId = org.orgId;
     }
 

--- a/turbo/apps/web/app/api/zero/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/route.ts
@@ -54,8 +54,7 @@ export async function GET(request: Request) {
   }
 
   const { userId } = authCtx;
-  const orgSlug = new URL(request.url).searchParams.get("org");
-  const { org, member } = await resolveOrg(authCtx, orgSlug);
+  const { org, member } = await resolveOrg(authCtx);
 
   const db = globalThis.services.db;
 
@@ -148,19 +147,15 @@ export async function DELETE(request: Request) {
 
   const url = new URL(request.url);
   const action = url.searchParams.get("action");
-  const orgSlug = url.searchParams.get("org");
 
   if (action === "uninstall") {
-    return handleUninstall(authCtx, orgSlug);
+    return handleUninstall(authCtx);
   }
-  return handleDisconnect(authCtx, orgSlug);
+  return handleDisconnect(authCtx);
 }
 
-async function handleUninstall(
-  authCtx: { userId: string },
-  orgSlug: string | null,
-) {
-  const { org, member } = await resolveOrg(authCtx, orgSlug);
+async function handleUninstall(authCtx: { userId: string }) {
+  const { org, member } = await resolveOrg(authCtx);
 
   if (member.role !== "admin") {
     return NextResponse.json(
@@ -350,12 +345,9 @@ function buildScopeFields(
   return { scopeMismatch, reinstallUrl };
 }
 
-async function handleDisconnect(
-  authCtx: { userId: string },
-  orgSlug: string | null,
-) {
+async function handleDisconnect(authCtx: { userId: string }) {
   const { userId } = authCtx;
-  const { org } = await resolveOrg(authCtx, orgSlug);
+  const { org } = await resolveOrg(authCtx);
   const { SECRETS_ENCRYPTION_KEY } = env();
   const db = globalThis.services.db;
 

--- a/turbo/apps/web/app/api/zero/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/[id]/route.ts
@@ -163,7 +163,7 @@ function buildLogDetailBody(result: {
 }
 
 const router = tsr.router(logsByIdContract, {
-  getById: async ({ params, headers }, { request }) => {
+  getById: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -174,9 +174,8 @@ const router = tsr.router(logsByIdContract, {
 
     // Resolve active org from JWT / CLI token / default
     let orgId: string;
-    const orgSlug = new URL(request.url).searchParams.get("org");
     try {
-      const { org: resolvedOrg } = await resolveOrg(authCtx, orgSlug);
+      const { org: resolvedOrg } = await resolveOrg(authCtx);
       orgId = resolvedOrg.orgId;
     } catch (error) {
       if (isNotFound(error) || isForbidden(error)) {

--- a/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
@@ -274,7 +274,7 @@ describe("GET /api/zero/logs", () => {
     expect(returnedIds).not.toContain(otherRunId);
   });
 
-  describe("name and org filter", () => {
+  describe("name filter", () => {
     let agentName: string;
     let nameComposeId: string;
 
@@ -297,17 +297,6 @@ describe("GET /api/zero/logs", () => {
       expect(response.status).toBe(200);
       expect(data.data).toHaveLength(1);
       expect(data.data[0].agentId).toBe(nameComposeId);
-    });
-
-    it("should return empty when name matches but org does not", async () => {
-      const request = createTestRequest(
-        `http://localhost:3000/api/zero/logs?name=${agentName}&org=nonexistent-org`,
-      );
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.data).toEqual([]);
     });
 
     it("should include orgSlug in response", async () => {

--- a/turbo/apps/web/app/api/zero/logs/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/route.ts
@@ -229,7 +229,7 @@ const router = tsr.router(logsListContract, {
     // Resolve active org — always scope logs to the user's current org
     let orgId: string;
     try {
-      const { org } = await resolveOrg(authCtx, query.org);
+      const { org } = await resolveOrg(authCtx);
       orgId = org.orgId;
     } catch (error) {
       if (isNotFound(error) || isForbidden(error)) {

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/default/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/default/route.ts
@@ -20,14 +20,13 @@ import { isNotFound } from "../../../../../../src/lib/errors";
 const log = logger("api:zero-model-providers");
 
 const router = tsr.router(zeroModelProvidersDefaultContract, {
-  setDefault: async ({ params, headers }, { request }) => {
+  setDefault: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     if (member.role !== "admin") {
       return createErrorResponse(

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/model/route.ts
@@ -20,14 +20,13 @@ import { isNotFound } from "../../../../../../src/lib/errors";
 const log = logger("api:zero-model-providers");
 
 const router = tsr.router(zeroModelProvidersUpdateModelContract, {
-  updateModel: async ({ params, body, headers }, { request }) => {
+  updateModel: async ({ params, body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     if (member.role !== "admin") {
       return createErrorResponse(

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/route.ts
@@ -20,14 +20,13 @@ import { isNotFound } from "../../../../../src/lib/errors";
 const log = logger("api:zero-model-providers");
 
 const router = tsr.router(zeroModelProvidersByTypeContract, {
-  delete: async ({ params, headers }, { request }) => {
+  delete: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     if (member.role !== "admin") {
       return createErrorResponse(

--- a/turbo/apps/web/app/api/zero/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/route.ts
@@ -26,14 +26,13 @@ import { isBadRequest } from "../../../../src/lib/errors";
 const log = logger("api:zero-model-providers");
 
 const router = tsr.router(zeroModelProvidersMainContract, {
-  list: async ({ headers }, { request }) => {
+  list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     const providers = await listOrgModelProviders(org.orgId);
 
     return {
@@ -55,14 +54,13 @@ const router = tsr.router(zeroModelProvidersMainContract, {
     };
   },
 
-  upsert: async ({ body, headers }, { request }) => {
+  upsert: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     if (member.role !== "admin") {
       return createErrorResponse(

--- a/turbo/apps/web/app/api/zero/onboarding/status/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/status/route.ts
@@ -98,7 +98,7 @@ async function resolveDefaultAgent(
 }
 
 const router = tsr.router(onboardingStatusContract, {
-  getStatus: async ({ headers }, { request }) => {
+  getStatus: async ({ headers }) => {
     initServices();
 
     const authCtx = await getAuthContext(headers.authorization);
@@ -116,9 +116,8 @@ const router = tsr.router(onboardingStatusContract, {
     let defaultAgent: DefaultAgentInfo | null = null;
     let isAdmin = false;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
     try {
-      const { org: resolvedOrg, member } = await resolveOrg(authCtx, orgSlug);
+      const { org: resolvedOrg, member } = await resolveOrg(authCtx);
       hasOrg = true;
       resolvedOrgId = resolvedOrg.orgId;
       isAdmin = member.role === "admin";

--- a/turbo/apps/web/app/api/zero/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/__tests__/route.test.ts
@@ -20,8 +20,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function orgUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/org?org=${slug}`;
+function orgUrl(): string {
+  return `http://localhost:3000/api/zero/org`;
 }
 
 describe("GET /api/zero/org", () => {
@@ -33,7 +33,7 @@ describe("GET /api/zero/org", () => {
     const userId = uniqueId("zorg-get");
     const { slug } = await setupOrg(userId);
 
-    const response = await GET(createTestRequest(orgUrl(slug)));
+    const response = await GET(createTestRequest(orgUrl()));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -44,11 +44,14 @@ describe("GET /api/zero/org", () => {
 
   it("should return 404 when org not found", async () => {
     const userId = uniqueId("zorg-nf");
-    mockClerk({ userId, orgId: `org_mock_${userId}`, orgRole: "org:admin" });
+    mockClerk({
+      userId,
+      orgId: `org_mock_${userId}`,
+      orgRole: "org:admin",
+      clerkOrgs: [],
+    });
 
-    const response = await GET(
-      createTestRequest(orgUrl("nonexistent-org-slug")),
-    );
+    const response = await GET(createTestRequest(orgUrl()));
     expect(response.status).toBe(404);
   });
 
@@ -56,7 +59,7 @@ describe("GET /api/zero/org", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/org?org=test"),
+      createTestRequest("http://localhost:3000/api/zero/org"),
     );
     expect(response.status).toBe(401);
   });
@@ -69,10 +72,10 @@ describe("PUT /api/zero/org", () => {
 
   it("should update org name and return 200", async () => {
     const userId = uniqueId("zorg-upd");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await PUT(
-      createTestRequest(orgUrl(slug), {
+      createTestRequest(orgUrl(), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: "Updated Org Name" }),
@@ -88,10 +91,10 @@ describe("PUT /api/zero/org", () => {
 
   it("should return 400 when changing slug without force", async () => {
     const userId = uniqueId("zorg-noforce");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await PUT(
-      createTestRequest(orgUrl(slug), {
+      createTestRequest(orgUrl(), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ slug: "new-slug-name" }),
@@ -104,7 +107,7 @@ describe("PUT /api/zero/org", () => {
     mockClerk({ userId: null });
 
     const response = await PUT(
-      createTestRequest("http://localhost:3000/api/zero/org?org=test", {
+      createTestRequest("http://localhost:3000/api/zero/org", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: "Test" }),
@@ -115,10 +118,15 @@ describe("PUT /api/zero/org", () => {
 
   it("should return 404 when org not found", async () => {
     const userId = uniqueId("zorg-upd-nf");
-    mockClerk({ userId, orgId: `org_mock_${userId}`, orgRole: "org:admin" });
+    mockClerk({
+      userId,
+      orgId: `org_mock_${userId}`,
+      orgRole: "org:admin",
+      clerkOrgs: [],
+    });
 
     const response = await PUT(
-      createTestRequest(orgUrl("nonexistent-org-slug"), {
+      createTestRequest(orgUrl(), {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name: "Test" }),

--- a/turbo/apps/web/app/api/zero/org/delete/route.ts
+++ b/turbo/apps/web/app/api/zero/org/delete/route.ts
@@ -18,15 +18,14 @@ import {
 } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroOrgDeleteContract, {
-  delete: async ({ headers, body }, { request }) => {
+  delete: async ({ headers, body }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
 
       // Verify the slug matches as a safety check
       if (body.slug !== org.slug) {

--- a/turbo/apps/web/app/api/zero/org/domains/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/__tests__/route.test.ts
@@ -20,8 +20,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function domainsUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/org/domains?org=${slug}`;
+function domainsUrl(): string {
+  return `http://localhost:3000/api/zero/org/domains`;
 }
 
 describe("GET /api/zero/org/domains", () => {
@@ -31,9 +31,9 @@ describe("GET /api/zero/org/domains", () => {
 
   it("should return domain list for an admin", async () => {
     const userId = uniqueId("dom-get");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
-    const response = await GET(createTestRequest(domainsUrl(slug)));
+    const response = await GET(createTestRequest(domainsUrl()));
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -47,7 +47,7 @@ describe("GET /api/zero/org/domains", () => {
     mockClerk({ userId, orgId, orgRole: "org:member" });
     await createTestOrg(slug);
 
-    const response = await GET(createTestRequest(domainsUrl(slug)));
+    const response = await GET(createTestRequest(domainsUrl()));
 
     expect(response.status).toBe(403);
   });
@@ -55,7 +55,7 @@ describe("GET /api/zero/org/domains", () => {
   it("should return 401 when not authenticated", async () => {
     mockClerk({ userId: null });
 
-    const response = await GET(createTestRequest(domainsUrl("any-org")));
+    const response = await GET(createTestRequest(domainsUrl()));
 
     expect(response.status).toBe(401);
   });
@@ -68,10 +68,10 @@ describe("POST /api/zero/org/domains", () => {
 
   it("should add a domain for an admin", async () => {
     const userId = uniqueId("dom-add");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await POST(
-      createTestRequest(domainsUrl(slug), {
+      createTestRequest(domainsUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -94,7 +94,7 @@ describe("POST /api/zero/org/domains", () => {
     await createTestOrg(slug);
 
     const response = await POST(
-      createTestRequest(domainsUrl(slug), {
+      createTestRequest(domainsUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -111,7 +111,7 @@ describe("POST /api/zero/org/domains", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest(domainsUrl("any-org"), {
+      createTestRequest(domainsUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -132,10 +132,10 @@ describe("DELETE /api/zero/org/domains", () => {
 
   it("should remove a domain for an admin", async () => {
     const userId = uniqueId("dom-del");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await DELETE(
-      createTestRequest(domainsUrl(slug), {
+      createTestRequest(domainsUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ domainId: "domain_test123" }),
@@ -155,7 +155,7 @@ describe("DELETE /api/zero/org/domains", () => {
     await createTestOrg(slug);
 
     const response = await DELETE(
-      createTestRequest(domainsUrl(slug), {
+      createTestRequest(domainsUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ domainId: "domain_test123" }),
@@ -169,7 +169,7 @@ describe("DELETE /api/zero/org/domains", () => {
     mockClerk({ userId: null });
 
     const response = await DELETE(
-      createTestRequest(domainsUrl("any-org"), {
+      createTestRequest(domainsUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ domainId: "domain_test123" }),
@@ -187,10 +187,10 @@ describe("PATCH /api/zero/org/domains (setVerified)", () => {
 
   it("should verify a domain for an admin", async () => {
     const userId = uniqueId("dom-verify");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await PATCH(
-      createTestRequest(domainsUrl(slug), {
+      createTestRequest(domainsUrl(), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ domainId: "domain_test123", verified: true }),
@@ -204,10 +204,10 @@ describe("PATCH /api/zero/org/domains (setVerified)", () => {
 
   it("should unverify a domain for an admin", async () => {
     const userId = uniqueId("dom-unverify");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await PATCH(
-      createTestRequest(domainsUrl(slug), {
+      createTestRequest(domainsUrl(), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ domainId: "domain_test123", verified: false }),
@@ -227,7 +227,7 @@ describe("PATCH /api/zero/org/domains (setVerified)", () => {
     await createTestOrg(slug);
 
     const response = await PATCH(
-      createTestRequest(domainsUrl(slug), {
+      createTestRequest(domainsUrl(), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ domainId: "domain_test123", verified: true }),
@@ -241,7 +241,7 @@ describe("PATCH /api/zero/org/domains (setVerified)", () => {
     mockClerk({ userId: null });
 
     const response = await PATCH(
-      createTestRequest(domainsUrl("any-org"), {
+      createTestRequest(domainsUrl(), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ domainId: "domain_test123", verified: true }),

--- a/turbo/apps/web/app/api/zero/org/domains/route.ts
+++ b/turbo/apps/web/app/api/zero/org/domains/route.ts
@@ -19,15 +19,14 @@ import {
 import { isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroOrgDomainsContract, {
-  list: async ({ headers }, { request }) => {
+  list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       const result = await getOrgDomains(org.orgId, member.role);
       return { status: 200 as const, body: result };
     } catch (error) {
@@ -38,15 +37,14 @@ const router = tsr.router(zeroOrgDomainsContract, {
     }
   },
 
-  add: async ({ headers, body }, { request }) => {
+  add: async ({ headers, body }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       await addOrgDomain(
         org.orgId,
         member.role,
@@ -65,15 +63,14 @@ const router = tsr.router(zeroOrgDomainsContract, {
     }
   },
 
-  remove: async ({ headers, body }, { request }) => {
+  remove: async ({ headers, body }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       await removeOrgDomain(org.orgId, member.role, body.domainId);
       return {
         status: 200 as const,
@@ -86,15 +83,14 @@ const router = tsr.router(zeroOrgDomainsContract, {
       throw error;
     }
   },
-  setVerified: async ({ headers, body }, { request }) => {
+  setVerified: async ({ headers, body }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       await setOrgDomainVerified(
         org.orgId,
         member.role,

--- a/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
@@ -20,8 +20,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function inviteUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/org/invite?org=${slug}`;
+function inviteUrl(): string {
+  return `http://localhost:3000/api/zero/org/invite`;
 }
 
 describe("POST /api/zero/org/invite (invite)", () => {
@@ -31,10 +31,10 @@ describe("POST /api/zero/org/invite (invite)", () => {
 
   it("should invite a member for an admin", async () => {
     const userId = uniqueId("inv-ok");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await POST(
-      createTestRequest(inviteUrl(slug), {
+      createTestRequest(inviteUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: "newuser@example.com" }),
@@ -54,7 +54,7 @@ describe("POST /api/zero/org/invite (invite)", () => {
     await createTestOrg(slug);
 
     const response = await POST(
-      createTestRequest(inviteUrl(slug), {
+      createTestRequest(inviteUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: "newuser@example.com" }),
@@ -68,7 +68,7 @@ describe("POST /api/zero/org/invite (invite)", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest(inviteUrl("any-org"), {
+      createTestRequest(inviteUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: "newuser@example.com" }),
@@ -86,10 +86,10 @@ describe("DELETE /api/zero/org/invite (revoke)", () => {
 
   it("should revoke an invitation for an admin", async () => {
     const userId = uniqueId("rev-ok");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await DELETE(
-      createTestRequest(inviteUrl(slug), {
+      createTestRequest(inviteUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ invitationId: "inv_test123" }),
@@ -109,7 +109,7 @@ describe("DELETE /api/zero/org/invite (revoke)", () => {
     await createTestOrg(slug);
 
     const response = await DELETE(
-      createTestRequest(inviteUrl(slug), {
+      createTestRequest(inviteUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ invitationId: "inv_test123" }),
@@ -123,7 +123,7 @@ describe("DELETE /api/zero/org/invite (revoke)", () => {
     mockClerk({ userId: null });
 
     const response = await DELETE(
-      createTestRequest(inviteUrl("any-org"), {
+      createTestRequest(inviteUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ invitationId: "inv_test123" }),
@@ -135,10 +135,15 @@ describe("DELETE /api/zero/org/invite (revoke)", () => {
 
   it("should return 404 when org not found", async () => {
     const userId = uniqueId("rev-nf");
-    mockClerk({ userId, orgId: `org_mock_${userId}`, orgRole: "org:admin" });
+    mockClerk({
+      userId,
+      orgId: `org_mock_${userId}`,
+      orgRole: "org:admin",
+      clerkOrgs: [],
+    });
 
     const response = await DELETE(
-      createTestRequest(inviteUrl("nonexistent-org-slug"), {
+      createTestRequest(inviteUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ invitationId: "inv_test123" }),

--- a/turbo/apps/web/app/api/zero/org/invite/route.ts
+++ b/turbo/apps/web/app/api/zero/org/invite/route.ts
@@ -21,15 +21,14 @@ import {
 } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroOrgInviteContract, {
-  invite: async ({ headers, body }, { request }) => {
+  invite: async ({ headers, body }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       await inviteMember(authCtx.userId, org.orgId, member.role, body.email);
       return {
         status: 200 as const,
@@ -49,15 +48,14 @@ const router = tsr.router(zeroOrgInviteContract, {
     }
   },
 
-  revoke: async ({ headers, body }, { request }) => {
+  revoke: async ({ headers, body }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       await revokeInvitation(org.orgId, member.role, body.invitationId);
       return {
         status: 200 as const,

--- a/turbo/apps/web/app/api/zero/org/leave/route.ts
+++ b/turbo/apps/web/app/api/zero/org/leave/route.ts
@@ -18,15 +18,14 @@ import {
 } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroOrgLeaveContract, {
-  leave: async ({ headers }, { request }) => {
+  leave: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       await leaveOrg(authCtx.userId, org.orgId, member.role);
       return { status: 200 as const, body: { message: "Left org" } };
     } catch (error) {

--- a/turbo/apps/web/app/api/zero/org/logo/route.ts
+++ b/turbo/apps/web/app/api/zero/org/logo/route.ts
@@ -38,8 +38,7 @@ export async function GET(request: NextRequest) {
   if (!authCtx) return errorJson("Not authenticated", 401);
 
   try {
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: resolvedOrg } = await resolveOrg(authCtx, orgSlug);
+    const { org: resolvedOrg } = await resolveOrg(authCtx);
 
     const client = await clerkClient();
     const clerkOrg = await client.organizations.getOrganization({
@@ -70,8 +69,7 @@ export async function POST(request: NextRequest) {
   if (!authCtx) return errorJson("Not authenticated", 401);
 
   try {
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: resolvedOrg, member } = await resolveOrg(authCtx, orgSlug);
+    const { org: resolvedOrg, member } = await resolveOrg(authCtx);
 
     if (member.role !== "admin") {
       return errorJson("Only admins can upload the logo", 403);
@@ -123,8 +121,7 @@ export async function DELETE(request: NextRequest) {
   if (!authCtx) return errorJson("Not authenticated", 401);
 
   try {
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org: resolvedOrg, member } = await resolveOrg(authCtx, orgSlug);
+    const { org: resolvedOrg, member } = await resolveOrg(authCtx);
 
     if (member.role !== "admin") {
       return errorJson("Only admins can remove the logo", 403);

--- a/turbo/apps/web/app/api/zero/org/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/members/__tests__/route.test.ts
@@ -22,8 +22,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function membersUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/org/members?org=${slug}`;
+function membersUrl(): string {
+  return `http://localhost:3000/api/zero/org/members`;
 }
 
 describe("GET /api/zero/org/members", () => {
@@ -33,7 +33,7 @@ describe("GET /api/zero/org/members", () => {
 
   it("should return members list for an admin", async () => {
     const userId = uniqueId("mem-get");
-    const { slug, orgId } = await setupOrg(userId);
+    const { orgId } = await setupOrg(userId);
 
     server.use(
       http.get(
@@ -42,7 +42,7 @@ describe("GET /api/zero/org/members", () => {
       ),
     );
 
-    const response = await GET(createTestRequest(membersUrl(slug)));
+    const response = await GET(createTestRequest(membersUrl()));
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -53,7 +53,7 @@ describe("GET /api/zero/org/members", () => {
 
   it("should include membership requests when pending requests exist", async () => {
     const userId = uniqueId("mem-mreq");
-    const { slug, orgId } = await setupOrg(userId);
+    const { orgId } = await setupOrg(userId);
     const requestUserId = `req-user-${userId}`;
 
     server.use(
@@ -72,7 +72,7 @@ describe("GET /api/zero/org/members", () => {
       ),
     );
 
-    const response = await GET(createTestRequest(membersUrl(slug)));
+    const response = await GET(createTestRequest(membersUrl()));
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -85,18 +85,21 @@ describe("GET /api/zero/org/members", () => {
   it("should return 401 when not authenticated", async () => {
     mockClerk({ userId: null });
 
-    const response = await GET(createTestRequest(membersUrl("any-org")));
+    const response = await GET(createTestRequest(membersUrl()));
 
     expect(response.status).toBe(401);
   });
 
   it("should return 404 when org not found", async () => {
     const userId = uniqueId("mem-nf");
-    mockClerk({ userId, orgId: `org_mock_${userId}`, orgRole: "org:admin" });
+    mockClerk({
+      userId,
+      orgId: `org_mock_${userId}`,
+      orgRole: "org:admin",
+      clerkOrgs: [],
+    });
 
-    const response = await GET(
-      createTestRequest(membersUrl("nonexistent-org-slug")),
-    );
+    const response = await GET(createTestRequest(membersUrl()));
 
     expect(response.status).toBe(404);
   });
@@ -113,7 +116,7 @@ describe("GET /api/zero/org/members", () => {
     });
     await createTestOrg(slug);
 
-    const response = await GET(createTestRequest(membersUrl(slug)));
+    const response = await GET(createTestRequest(membersUrl()));
 
     expect(response.status).toBe(200);
     const data = await response.json();

--- a/turbo/apps/web/app/api/zero/org/members/credit-cap/route.ts
+++ b/turbo/apps/web/app/api/zero/org/members/credit-cap/route.ts
@@ -33,7 +33,6 @@ export async function GET(request: Request) {
   }
 
   const url = new URL(request.url);
-  const orgSlug = url.searchParams.get("org");
   const userId = url.searchParams.get("userId");
 
   if (!userId) {
@@ -43,7 +42,7 @@ export async function GET(request: Request) {
     );
   }
 
-  const { org } = await resolveOrg(authResult, orgSlug);
+  const { org } = await resolveOrg(authResult);
   const result = await getMemberCreditCap(org.orgId, userId);
 
   return NextResponse.json({
@@ -69,8 +68,7 @@ export async function PUT(request: Request) {
     return NextResponse.json(authResult.body, { status: authResult.status });
   }
 
-  const orgSlug = new URL(request.url).searchParams.get("org");
-  const { org, member } = await resolveOrg(authResult, orgSlug);
+  const { org, member } = await resolveOrg(authResult);
 
   // Only admins can update credit caps
   if (member.role !== "admin") {

--- a/turbo/apps/web/app/api/zero/org/members/route.ts
+++ b/turbo/apps/web/app/api/zero/org/members/route.ts
@@ -22,15 +22,14 @@ import {
 } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroOrgMembersContract, {
-  members: async ({ headers }, { request }) => {
+  members: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       const status = await getOrgMembers(authCtx.userId, org.orgId, org.slug);
       return { status: 200 as const, body: status };
     } catch (error) {
@@ -47,15 +46,14 @@ const router = tsr.router(zeroOrgMembersContract, {
     }
   },
 
-  updateRole: async ({ headers, body }, { request }) => {
+  updateRole: async ({ headers, body }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       await updateMemberRole(
         authCtx.userId,
         org.orgId,
@@ -81,15 +79,14 @@ const router = tsr.router(zeroOrgMembersContract, {
     }
   },
 
-  removeMember: async ({ headers, body }, { request }) => {
+  removeMember: async ({ headers, body }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       await removeMember(authCtx.userId, org.orgId, member.role, body.email);
       return {
         status: 200 as const,

--- a/turbo/apps/web/app/api/zero/org/membership-requests/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/membership-requests/__tests__/route.test.ts
@@ -22,8 +22,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function membershipRequestsUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/org/membership-requests?org=${slug}`;
+function membershipRequestsUrl(): string {
+  return `http://localhost:3000/api/zero/org/membership-requests`;
 }
 
 describe("POST /api/zero/org/membership-requests (accept)", () => {
@@ -33,7 +33,7 @@ describe("POST /api/zero/org/membership-requests (accept)", () => {
 
   it("should accept a membership request for an admin", async () => {
     const userId = uniqueId("mreq-acc");
-    const { orgId, slug } = await setupOrg(userId);
+    const { orgId } = await setupOrg(userId);
 
     server.use(
       http.post(
@@ -43,7 +43,7 @@ describe("POST /api/zero/org/membership-requests (accept)", () => {
     );
 
     const response = await POST(
-      createTestRequest(membershipRequestsUrl(slug), {
+      createTestRequest(membershipRequestsUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ requestId: "req_test123" }),
@@ -57,7 +57,7 @@ describe("POST /api/zero/org/membership-requests (accept)", () => {
 
   it("should return 400 when Clerk API rejects the accept request", async () => {
     const userId = uniqueId("mreq-acc-fail");
-    const { orgId, slug } = await setupOrg(userId);
+    const { orgId } = await setupOrg(userId);
 
     server.use(
       http.post(
@@ -67,7 +67,7 @@ describe("POST /api/zero/org/membership-requests (accept)", () => {
     );
 
     const response = await POST(
-      createTestRequest(membershipRequestsUrl(slug), {
+      createTestRequest(membershipRequestsUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ requestId: "req_invalid" }),
@@ -85,7 +85,7 @@ describe("POST /api/zero/org/membership-requests (accept)", () => {
     await createTestOrg(slug);
 
     const response = await POST(
-      createTestRequest(membershipRequestsUrl(slug), {
+      createTestRequest(membershipRequestsUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ requestId: "req_test123" }),
@@ -99,7 +99,7 @@ describe("POST /api/zero/org/membership-requests (accept)", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest(membershipRequestsUrl("any-org"), {
+      createTestRequest(membershipRequestsUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ requestId: "req_test123" }),
@@ -117,7 +117,7 @@ describe("DELETE /api/zero/org/membership-requests (reject)", () => {
 
   it("should reject a membership request for an admin", async () => {
     const userId = uniqueId("mreq-rej");
-    const { orgId, slug } = await setupOrg(userId);
+    const { orgId } = await setupOrg(userId);
 
     server.use(
       http.post(
@@ -127,7 +127,7 @@ describe("DELETE /api/zero/org/membership-requests (reject)", () => {
     );
 
     const response = await DELETE(
-      createTestRequest(membershipRequestsUrl(slug), {
+      createTestRequest(membershipRequestsUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ requestId: "req_test456" }),
@@ -141,7 +141,7 @@ describe("DELETE /api/zero/org/membership-requests (reject)", () => {
 
   it("should return 400 when Clerk API rejects the reject request", async () => {
     const userId = uniqueId("mreq-rej-fail");
-    const { orgId, slug } = await setupOrg(userId);
+    const { orgId } = await setupOrg(userId);
 
     server.use(
       http.post(
@@ -151,7 +151,7 @@ describe("DELETE /api/zero/org/membership-requests (reject)", () => {
     );
 
     const response = await DELETE(
-      createTestRequest(membershipRequestsUrl(slug), {
+      createTestRequest(membershipRequestsUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ requestId: "req_invalid" }),
@@ -169,7 +169,7 @@ describe("DELETE /api/zero/org/membership-requests (reject)", () => {
     await createTestOrg(slug);
 
     const response = await DELETE(
-      createTestRequest(membershipRequestsUrl(slug), {
+      createTestRequest(membershipRequestsUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ requestId: "req_test456" }),
@@ -183,7 +183,7 @@ describe("DELETE /api/zero/org/membership-requests (reject)", () => {
     mockClerk({ userId: null });
 
     const response = await DELETE(
-      createTestRequest(membershipRequestsUrl("any-org"), {
+      createTestRequest(membershipRequestsUrl(), {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ requestId: "req_test456" }),

--- a/turbo/apps/web/app/api/zero/org/membership-requests/route.ts
+++ b/turbo/apps/web/app/api/zero/org/membership-requests/route.ts
@@ -20,15 +20,14 @@ import {
 import { isBadRequest, isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroOrgMembershipRequestsContract, {
-  accept: async ({ headers, body }, { request }) => {
+  accept: async ({ headers, body }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       await acceptMembershipRequest(org.orgId, member.role, body.requestId);
       return {
         status: 200 as const,
@@ -45,15 +44,14 @@ const router = tsr.router(zeroOrgMembershipRequestsContract, {
     }
   },
 
-  reject: async ({ headers, body }, { request }) => {
+  reject: async ({ headers, body }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org, member } = await resolveOrg(authCtx, orgSlug);
+      const { org, member } = await resolveOrg(authCtx);
       await rejectMembershipRequest(org.orgId, member.role, body.requestId);
       return {
         status: 200 as const,

--- a/turbo/apps/web/app/api/zero/org/route.ts
+++ b/turbo/apps/web/app/api/zero/org/route.ts
@@ -18,16 +18,14 @@ import {
 } from "../../../../src/lib/errors";
 
 const router = tsr.router(zeroOrgContract, {
-  get: async ({ headers }, { request }) => {
+  get: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-
     try {
-      const { org: resolvedOrg, member } = await resolveOrg(authCtx, orgSlug);
+      const { org: resolvedOrg, member } = await resolveOrg(authCtx);
 
       return {
         status: 200 as const,
@@ -47,17 +45,15 @@ const router = tsr.router(zeroOrgContract, {
     }
   },
 
-  update: async ({ body, headers }, { request }) => {
+  update: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-
     try {
-      const { org: resolvedOrg } = await resolveOrg(authCtx, orgSlug);
+      const { org: resolvedOrg } = await resolveOrg(authCtx);
       const updatedOrg = await updateOrg(resolvedOrg.orgId, userId, {
         slug: body.slug,
         name: body.name,

--- a/turbo/apps/web/app/api/zero/queue-position/route.ts
+++ b/turbo/apps/web/app/api/zero/queue-position/route.ts
@@ -35,8 +35,7 @@ export async function GET(request: Request) {
     );
   }
 
-  const orgSlug = url.searchParams.get("org");
-  const org = await resolveOrgOrNull(authCtx, orgSlug);
+  const org = await resolveOrgOrNull(authCtx);
 
   // Verify the run belongs to this user and org
   const [run] = await globalThis.services.db

--- a/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/__tests__/route.test.ts
@@ -24,8 +24,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function runUrl(slug: string, runId: string): string {
-  return `http://localhost:3000/api/zero/runs/${runId}?org=${slug}`;
+function runUrl(runId: string): string {
+  return `http://localhost:3000/api/zero/runs/${runId}`;
 }
 
 describe("GET /api/zero/runs/:id", () => {
@@ -35,14 +35,14 @@ describe("GET /api/zero/runs/:id", () => {
 
   it("should return run details", async () => {
     const userId = uniqueId("zrun-get");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zrun")}`);
     const { runId } = await createTestRunInDb(userId, compose.composeId, {
       status: "running",
       prompt: "test prompt",
     });
 
-    const response = await GET(createTestRequest(runUrl(slug, runId)));
+    const response = await GET(createTestRequest(runUrl(runId)));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -53,9 +53,9 @@ describe("GET /api/zero/runs/:id", () => {
 
   it("should return 404 when run not found", async () => {
     const userId = uniqueId("zrun-nf");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
-    const response = await GET(createTestRequest(runUrl(slug, randomUUID())));
+    const response = await GET(createTestRequest(runUrl(randomUUID())));
     expect(response.status).toBe(404);
   });
 
@@ -63,7 +63,7 @@ describe("GET /api/zero/runs/:id", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/runs/some-id?org=test"),
+      createTestRequest("http://localhost:3000/api/zero/runs/some-id"),
     );
     expect(response.status).toBe(401);
   });
@@ -73,12 +73,9 @@ describe("GET /api/zero/runs/:id", () => {
     const token = await generateSandboxToken("user-1", "run-1");
 
     const response = await GET(
-      createTestRequest(
-        "http://localhost:3000/api/zero/runs/some-id?org=test",
-        {
-          headers: { Authorization: `Bearer ${token}` },
-        },
-      ),
+      createTestRequest("http://localhost:3000/api/zero/runs/some-id", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
     );
     expect(response.status).toBe(403);
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/__tests__/route.test.ts
@@ -24,8 +24,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function cancelUrl(slug: string, runId: string): string {
-  return `http://localhost:3000/api/zero/runs/${runId}/cancel?org=${slug}`;
+function cancelUrl(runId: string): string {
+  return `http://localhost:3000/api/zero/runs/${runId}/cancel`;
 }
 
 describe("POST /api/zero/runs/:id/cancel", () => {
@@ -35,14 +35,14 @@ describe("POST /api/zero/runs/:id/cancel", () => {
 
   it("should cancel a running run", async () => {
     const userId = uniqueId("zcanc-ok");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
     const { runId } = await createTestRunInDb(userId, compose.composeId, {
       status: "running",
     });
 
     const response = await POST(
-      createTestRequest(cancelUrl(slug, runId), { method: "POST" }),
+      createTestRequest(cancelUrl(runId), { method: "POST" }),
     );
     expect(response.status).toBe(200);
 
@@ -53,7 +53,7 @@ describe("POST /api/zero/runs/:id/cancel", () => {
 
   it("should return 400 when run already completed", async () => {
     const userId = uniqueId("zcanc-done");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zcanc")}`);
     const { runId } = await createTestRunInDb(userId, compose.composeId, {
       status: "completed",
@@ -61,17 +61,17 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     });
 
     const response = await POST(
-      createTestRequest(cancelUrl(slug, runId), { method: "POST" }),
+      createTestRequest(cancelUrl(runId), { method: "POST" }),
     );
     expect(response.status).toBe(400);
   });
 
   it("should return 404 when run not found", async () => {
     const userId = uniqueId("zcanc-nf");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await POST(
-      createTestRequest(cancelUrl(slug, randomUUID()), {
+      createTestRequest(cancelUrl(randomUUID()), {
         method: "POST",
       }),
     );
@@ -82,10 +82,9 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest(
-        "http://localhost:3000/api/zero/runs/some-id/cancel?org=test",
-        { method: "POST" },
-      ),
+      createTestRequest("http://localhost:3000/api/zero/runs/some-id/cancel", {
+        method: "POST",
+      }),
     );
     expect(response.status).toBe(401);
   });
@@ -95,13 +94,10 @@ describe("POST /api/zero/runs/:id/cancel", () => {
     const token = await generateSandboxToken("user-1", "run-1");
 
     const response = await POST(
-      createTestRequest(
-        "http://localhost:3000/api/zero/runs/some-id/cancel?org=test",
-        {
-          method: "POST",
-          headers: { Authorization: `Bearer ${token}` },
-        },
-      ),
+      createTestRequest("http://localhost:3000/api/zero/runs/some-id/cancel", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      }),
     );
     expect(response.status).toBe(403);
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
@@ -19,7 +19,7 @@ import { isNotFound, isBadRequest } from "../../../../../../src/lib/errors";
 import { after } from "next/server";
 
 const router = tsr.router(zeroRunsCancelContract, {
-  cancel: async ({ params, headers }, { request }) => {
+  cancel: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -28,8 +28,7 @@ const router = tsr.router(zeroRunsCancelContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     try {
       const result = await cancelRun(params.id, userId, org.orgId);

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -24,8 +24,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function contextUrl(slug: string, runId: string): string {
-  return `http://localhost:3000/api/zero/runs/${runId}/context?org=${slug}`;
+function contextUrl(runId: string): string {
+  return `http://localhost:3000/api/zero/runs/${runId}/context`;
 }
 
 function makeSnapshot(runId: string, userId: string): RunContextSnapshot {
@@ -80,7 +80,7 @@ describe("GET /api/zero/runs/:id/context", () => {
 
   it("should return run context snapshot", async () => {
     const userId = uniqueId("zctx-get");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zctx")}`);
     const { runId } = await createTestRunInDb(userId, compose.composeId, {
       status: "running",
@@ -90,7 +90,7 @@ describe("GET /api/zero/runs/:id/context", () => {
     const snapshot = makeSnapshot(runId, userId);
     context.mocks.axiom.queryAxiom.mockResolvedValue([snapshot]);
 
-    const response = await GET(createTestRequest(contextUrl(slug, runId)));
+    const response = await GET(createTestRequest(contextUrl(runId)));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -109,11 +109,9 @@ describe("GET /api/zero/runs/:id/context", () => {
 
   it("should return 404 when run not found", async () => {
     const userId = uniqueId("zctx-nf");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
-    const response = await GET(
-      createTestRequest(contextUrl(slug, randomUUID())),
-    );
+    const response = await GET(createTestRequest(contextUrl(randomUUID())));
     expect(response.status).toBe(404);
 
     const data = await response.json();
@@ -122,7 +120,7 @@ describe("GET /api/zero/runs/:id/context", () => {
 
   it("should return 404 when context not available", async () => {
     const userId = uniqueId("zctx-nc");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zctx")}`);
     const { runId } = await createTestRunInDb(userId, compose.composeId, {
       status: "running",
@@ -130,7 +128,7 @@ describe("GET /api/zero/runs/:id/context", () => {
 
     context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
-    const response = await GET(createTestRequest(contextUrl(slug, runId)));
+    const response = await GET(createTestRequest(contextUrl(runId)));
     expect(response.status).toBe(404);
 
     const data = await response.json();
@@ -141,9 +139,7 @@ describe("GET /api/zero/runs/:id/context", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest(
-        "http://localhost:3000/api/zero/runs/some-id/context?org=test",
-      ),
+      createTestRequest("http://localhost:3000/api/zero/runs/some-id/context"),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
@@ -14,7 +14,7 @@ import { getRunById } from "../../../../../../src/lib/run/run-service";
 import { queryRunContext } from "../../../../../../src/lib/run/run-context-service";
 
 const router = tsr.router(zeroRunContextContract, {
-  getContext: async ({ params, headers }, { request }) => {
+  getContext: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -23,8 +23,7 @@ const router = tsr.router(zeroRunContextContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const run = await getRunById(params.id, userId, org.orgId);
     if (!run) {

--- a/turbo/apps/web/app/api/zero/runs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/route.ts
@@ -13,7 +13,7 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { getRunById } from "../../../../../src/lib/run/run-service";
 
 const router = tsr.router(zeroRunsByIdContract, {
-  getById: async ({ params, headers }, { request }) => {
+  getById: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -22,8 +22,7 @@ const router = tsr.router(zeroRunsByIdContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const run = await getRunById(params.id, userId, org.orgId);
     if (!run) {

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/__tests__/route.test.ts
@@ -24,8 +24,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function telemetryUrl(slug: string, runId: string): string {
-  return `http://localhost:3000/api/zero/runs/${runId}/telemetry/agent?org=${slug}&limit=10&order=desc`;
+function telemetryUrl(runId: string): string {
+  return `http://localhost:3000/api/zero/runs/${runId}/telemetry/agent?limit=10&order=desc`;
 }
 
 describe("GET /api/zero/runs/:id/telemetry/agent", () => {
@@ -35,7 +35,7 @@ describe("GET /api/zero/runs/:id/telemetry/agent", () => {
 
   it("should return agent events for a run", async () => {
     const userId = uniqueId("ztele-get");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("ztele")}`);
     const { runId } = await createTestRunInDb(userId, compose.composeId, {
       status: "running",
@@ -43,7 +43,7 @@ describe("GET /api/zero/runs/:id/telemetry/agent", () => {
 
     context.mocks.axiom.queryAxiom.mockResolvedValue([]);
 
-    const response = await GET(createTestRequest(telemetryUrl(slug, runId)));
+    const response = await GET(createTestRequest(telemetryUrl(runId)));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -54,11 +54,9 @@ describe("GET /api/zero/runs/:id/telemetry/agent", () => {
 
   it("should return 404 when run not found", async () => {
     const userId = uniqueId("ztele-nf");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
-    const response = await GET(
-      createTestRequest(telemetryUrl(slug, randomUUID())),
-    );
+    const response = await GET(createTestRequest(telemetryUrl(randomUUID())));
     expect(response.status).toBe(404);
   });
 
@@ -67,7 +65,7 @@ describe("GET /api/zero/runs/:id/telemetry/agent", () => {
 
     const response = await GET(
       createTestRequest(
-        `http://localhost:3000/api/zero/runs/${randomUUID()}/telemetry/agent?org=test&limit=10&order=desc`,
+        `http://localhost:3000/api/zero/runs/${randomUUID()}/telemetry/agent?limit=10&order=desc`,
       ),
     );
     expect(response.status).toBe(401);
@@ -79,7 +77,7 @@ describe("GET /api/zero/runs/:id/telemetry/agent", () => {
 
     const response = await GET(
       createTestRequest(
-        `http://localhost:3000/api/zero/runs/${randomUUID()}/telemetry/agent?org=test&limit=10&order=desc`,
+        `http://localhost:3000/api/zero/runs/${randomUUID()}/telemetry/agent?limit=10&order=desc`,
         {
           headers: { Authorization: `Bearer ${token}` },
         },

--- a/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/telemetry/agent/route.ts
@@ -14,7 +14,7 @@ import { getRunAgentEvents } from "../../../../../../../src/lib/run/run-telemetr
 import { isNotFound } from "../../../../../../../src/lib/errors";
 
 const router = tsr.router(zeroRunAgentEventsContract, {
-  getAgentEvents: async ({ params, query, headers }, { request }) => {
+  getAgentEvents: async ({ params, query, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -23,8 +23,7 @@ const router = tsr.router(zeroRunAgentEventsContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     try {
       const result = await getRunAgentEvents(

--- a/turbo/apps/web/app/api/zero/runs/queue/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/__tests__/route.test.ts
@@ -23,8 +23,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function queueUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/runs/queue?org=${slug}`;
+function queueUrl(): string {
+  return `http://localhost:3000/api/zero/runs/queue`;
 }
 
 describe("GET /api/zero/runs/queue", () => {
@@ -34,9 +34,9 @@ describe("GET /api/zero/runs/queue", () => {
 
   it("should return queue status with concurrency info", async () => {
     const userId = uniqueId("zqueue-get");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
-    const response = await GET(createTestRequest(queueUrl(slug)));
+    const response = await GET(createTestRequest(queueUrl()));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -51,13 +51,13 @@ describe("GET /api/zero/runs/queue", () => {
 
   it("should include running tasks in response", async () => {
     const userId = uniqueId("zqueue-run");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zqueue")}`);
     await createTestRunInDb(userId, compose.composeId, {
       status: "running",
     });
 
-    const response = await GET(createTestRequest(queueUrl(slug)));
+    const response = await GET(createTestRequest(queueUrl()));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -70,7 +70,7 @@ describe("GET /api/zero/runs/queue", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/runs/queue?org=test"),
+      createTestRequest("http://localhost:3000/api/zero/runs/queue"),
     );
     expect(response.status).toBe(401);
   });
@@ -80,7 +80,7 @@ describe("GET /api/zero/runs/queue", () => {
     const token = await generateSandboxToken("user-1", "run-1");
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/runs/queue?org=test", {
+      createTestRequest("http://localhost:3000/api/zero/runs/queue", {
         headers: { Authorization: `Bearer ${token}` },
       }),
     );

--- a/turbo/apps/web/app/api/zero/runs/queue/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/queue/route.ts
@@ -13,7 +13,7 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { getRunQueueStatus } from "../../../../../src/lib/zero/zero-queue-service";
 
 const router = tsr.router(zeroRunsQueueContract, {
-  getQueue: async ({ headers }, { request }) => {
+  getQueue: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -22,8 +22,7 @@ const router = tsr.router(zeroRunsQueueContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     const orgTier = orgTierSchema.parse(org.tier);
 
     const result = await getRunQueueStatus(userId, org.orgId, orgTier);

--- a/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
@@ -27,7 +27,6 @@ async function setupOrg(userId: string) {
 }
 
 describe("DELETE /api/zero/schedules/:name", () => {
-  let slug: string;
   let orgId: string;
   let testComposeId: string;
   let testZeroAgentId: string;
@@ -36,7 +35,6 @@ describe("DELETE /api/zero/schedules/:name", () => {
     context.setupMocks();
     const user = await context.setupUser();
     const org = await setupOrg(user.userId);
-    slug = org.slug;
     orgId = org.orgId;
 
     const agentName = `zero-sched-del-${Date.now()}`;
@@ -54,7 +52,7 @@ describe("DELETE /api/zero/schedules/:name", () => {
 
     const response = await DELETE(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/to-delete?agentId=${testZeroAgentId}&org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/to-delete?agentId=${testZeroAgentId}`,
         { method: "DELETE" },
       ),
     );
@@ -65,7 +63,7 @@ describe("DELETE /api/zero/schedules/:name", () => {
   it("should return 404 for non-existent schedule", async () => {
     const response = await DELETE(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/non-existent?agentId=${testZeroAgentId}&org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/non-existent?agentId=${testZeroAgentId}`,
         { method: "DELETE" },
       ),
     );
@@ -83,7 +81,7 @@ describe("DELETE /api/zero/schedules/:name", () => {
 
     const response = await DELETE(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/del-agent-id?agentId=${testComposeId}&org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/del-agent-id?agentId=${testComposeId}`,
         { method: "DELETE" },
       ),
     );
@@ -96,7 +94,7 @@ describe("DELETE /api/zero/schedules/:name", () => {
 
     const response = await DELETE(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/any?agentId=${testZeroAgentId}&org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/any?agentId=${testZeroAgentId}`,
         { method: "DELETE" },
       ),
     );

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/__tests__/route.test.ts
@@ -29,7 +29,6 @@ async function setupOrg(userId: string) {
 }
 
 describe("POST /api/zero/schedules/:name/disable", () => {
-  let slug: string;
   let orgId: string;
   let testComposeId: string;
   let testZeroAgentId: string;
@@ -38,7 +37,6 @@ describe("POST /api/zero/schedules/:name/disable", () => {
     context.setupMocks();
     const user = await context.setupUser();
     const org = await setupOrg(user.userId);
-    slug = org.slug;
     orgId = org.orgId;
 
     const agentName = `zero-sched-disable-${Date.now()}`;
@@ -60,7 +58,7 @@ describe("POST /api/zero/schedules/:name/disable", () => {
 
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/to-disable/disable?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/to-disable/disable`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -78,7 +76,7 @@ describe("POST /api/zero/schedules/:name/disable", () => {
   it("should return 404 for non-existent schedule", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/non-existent/disable?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/non-existent/disable`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -105,7 +103,7 @@ describe("POST /api/zero/schedules/:name/disable", () => {
 
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/dis-agentid/disable?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/dis-agentid/disable`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -123,7 +121,7 @@ describe("POST /api/zero/schedules/:name/disable", () => {
   it("should return 400 for invalid body", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/any/disable?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/any/disable`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -143,7 +141,7 @@ describe("POST /api/zero/schedules/:name/disable", () => {
 
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/any/disable?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/any/disable`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/disable/route.ts
@@ -29,10 +29,9 @@ export async function POST(
   }
   const { userId } = authCtx;
 
-  const orgSlug = new URL(request.url).searchParams.get("org");
   const {
     org: { orgId },
-  } = await resolveOrg(authCtx, orgSlug);
+  } = await resolveOrg(authCtx);
 
   const parsed = bodySchema.safeParse(await request.json());
   if (!parsed.success) {

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/__tests__/route.test.ts
@@ -28,7 +28,6 @@ async function setupOrg(userId: string) {
 }
 
 describe("POST /api/zero/schedules/:name/enable", () => {
-  let slug: string;
   let orgId: string;
   let testComposeId: string;
   let testZeroAgentId: string;
@@ -37,7 +36,6 @@ describe("POST /api/zero/schedules/:name/enable", () => {
     context.setupMocks();
     const user = await context.setupUser();
     const org = await setupOrg(user.userId);
-    slug = org.slug;
     orgId = org.orgId;
 
     const agentName = `zero-sched-enable-${Date.now()}`;
@@ -58,7 +56,7 @@ describe("POST /api/zero/schedules/:name/enable", () => {
 
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/to-enable/enable?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/to-enable/enable`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -76,7 +74,7 @@ describe("POST /api/zero/schedules/:name/enable", () => {
   it("should return 404 for non-existent schedule", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/non-existent/enable?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/non-existent/enable`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -99,7 +97,7 @@ describe("POST /api/zero/schedules/:name/enable", () => {
 
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules/enable-agentid/enable?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules/enable-agentid/enable`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -116,14 +114,11 @@ describe("POST /api/zero/schedules/:name/enable", () => {
 
   it("should return 400 for invalid body", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules/any/enable?org=${slug}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({}),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules/any/enable`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
       { params: Promise.resolve({ name: "any" }) },
     );
     const data = await response.json();
@@ -136,14 +131,11 @@ describe("POST /api/zero/schedules/:name/enable", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules/any/enable?org=${slug}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agentId: testZeroAgentId }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules/any/enable`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testZeroAgentId }),
+      }),
       { params: Promise.resolve({ name: "any" }) },
     );
 

--- a/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/enable/route.ts
@@ -29,10 +29,9 @@ export async function POST(
   }
   const { userId } = authCtx;
 
-  const orgSlug = new URL(request.url).searchParams.get("org");
   const {
     org: { orgId },
-  } = await resolveOrg(authCtx, orgSlug);
+  } = await resolveOrg(authCtx);
 
   const parsed = bodySchema.safeParse(await request.json());
   if (!parsed.success) {

--- a/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
@@ -14,7 +14,7 @@ import { deleteSchedule } from "../../../../../src/lib/schedule";
 import { isNotFound } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroSchedulesByNameContract, {
-  delete: async ({ params, query, headers }, { request }) => {
+  delete: async ({ params, query, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -24,10 +24,9 @@ const router = tsr.router(zeroSchedulesByNameContract, {
     const { userId } = authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
       const {
         org: { orgId },
-      } = await resolveOrg(authCtx, orgSlug);
+      } = await resolveOrg(authCtx);
 
       await deleteSchedule(userId, orgId, query.agentId, params.name);
 

--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -57,20 +57,17 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
   it("should create schedule and return 201", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "daily-zero",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
-            prompt: "Run daily",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "daily-zero",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Run daily",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -87,20 +84,17 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
     });
 
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "update-zero",
-            cronExpression: "0 10 * * *",
-            timezone: "UTC",
-            prompt: "Updated",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "update-zero",
+          cronExpression: "0 10 * * *",
+          timezone: "UTC",
+          prompt: "Updated",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -111,20 +105,17 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
   it("should return 400 for non-existent agent", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: "00000000-0000-0000-0000-000000000000",
-            name: "will-fail",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
-            prompt: "Test",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: "00000000-0000-0000-0000-000000000000",
+          name: "will-fail",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Test",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -134,20 +125,17 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
   it("should create schedule with agentId", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testComposeId,
-            name: "agent-id-test",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
-            prompt: "Run via agentId",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testComposeId,
+          name: "agent-id-test",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Run via agentId",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -160,20 +148,17 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "unauth",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
-            prompt: "Test",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "unauth",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Test",
+        }),
+      }),
     );
 
     expect(response.status).toBe(401);
@@ -182,21 +167,18 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   it("should create one-time schedule with atTime", async () => {
     const futureDate = new Date(Date.now() + 86_400_000).toISOString();
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "one-time-test",
-            atTime: futureDate,
-            timezone: "UTC",
-            prompt: "Run once",
-            enabled: true,
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "one-time-test",
+          atTime: futureDate,
+          timezone: "UTC",
+          prompt: "Run once",
+          enabled: true,
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -207,20 +189,17 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
   it("should create loop schedule with intervalSeconds", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "loop-test",
-            intervalSeconds: 300,
-            timezone: "UTC",
-            prompt: "Loop every 5 minutes",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "loop-test",
+          intervalSeconds: 300,
+          timezone: "UTC",
+          prompt: "Loop every 5 minutes",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -231,20 +210,17 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
   it("should reject invalid timezone", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "bad-tz",
-            cronExpression: "0 9 * * *",
-            timezone: "Invalid/Timezone",
-            prompt: "Bad timezone",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "bad-tz",
+          cronExpression: "0 9 * * *",
+          timezone: "Invalid/Timezone",
+          prompt: "Bad timezone",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -255,21 +231,18 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   it("should reject enabled one-time schedule with past atTime", async () => {
     const pastDate = new Date(Date.now() - 86_400_000).toISOString();
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "past-time",
-            atTime: pastDate,
-            timezone: "UTC",
-            prompt: "Past schedule",
-            enabled: true,
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "past-time",
+          atTime: pastDate,
+          timezone: "UTC",
+          prompt: "Past schedule",
+          enabled: true,
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -279,23 +252,20 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
   it("should create schedule with notification settings", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "notify-test",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
-            prompt: "With notifications",
-            notifyEmail: false,
-            notifySlack: true,
-            notifySlackChannelId: "C12345",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "notify-test",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "With notifications",
+          notifyEmail: false,
+          notifySlack: true,
+          notifySlackChannelId: "C12345",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -312,20 +282,17 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
     });
 
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "type-change",
-            intervalSeconds: 600,
-            timezone: "UTC",
-            prompt: "Now loop",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "type-change",
+          intervalSeconds: 600,
+          timezone: "UTC",
+          prompt: "Now loop",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -343,22 +310,19 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
     });
 
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "update-notify",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
-            prompt: "Notification update",
-            notifyEmail: false,
-            notifySlack: false,
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "update-notify",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "Notification update",
+          notifyEmail: false,
+          notifySlack: false,
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -369,20 +333,17 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
   it("should create schedule with non-UTC timezone", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "tokyo-sched",
-            cronExpression: "0 9 * * *",
-            timezone: "Asia/Tokyo",
-            prompt: "Tokyo schedule",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "tokyo-sched",
+          cronExpression: "0 9 * * *",
+          timezone: "Asia/Tokyo",
+          prompt: "Tokyo schedule",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -393,21 +354,18 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
   it("should create schedule with description", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentId: testZeroAgentId,
-            name: "desc-test",
-            cronExpression: "0 9 * * *",
-            timezone: "UTC",
-            prompt: "With description",
-            description: "Custom description for schedule",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testZeroAgentId,
+          name: "desc-test",
+          cronExpression: "0 9 * * *",
+          timezone: "UTC",
+          prompt: "With description",
+          description: "Custom description for schedule",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -453,9 +411,7 @@ describe("GET /api/zero/schedules - List Schedules", () => {
 
   it("should return empty array for invalid org", async () => {
     const response = await GET(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules`,
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`),
     );
     const data = await response.json();
 

--- a/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/__tests__/route.test.ts
@@ -25,11 +25,10 @@ async function setupOrg(userId: string) {
   mockClerk({ userId, orgId, orgRole: "org:admin" });
   await createTestOrg(slug);
 
-  return { slug, orgId };
+  return { orgId };
 }
 
 describe("POST /api/zero/schedules - Deploy Schedule", () => {
-  let slug: string;
   let orgId: string;
   let testComposeId: string;
   let testZeroAgentId: string;
@@ -37,9 +36,8 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   beforeEach(async () => {
     context.setupMocks();
     const user = await context.setupUser();
-    const org = await setupOrg(user.userId);
-    slug = org.slug;
-    orgId = org.orgId;
+    const { orgId: oid } = await setupOrg(user.userId);
+    orgId = oid;
 
     const agentName = `zero-sched-deploy-${Date.now()}`;
     const { composeId } = await createTestCompose(agentName);
@@ -60,7 +58,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   it("should create schedule and return 201", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -90,7 +88,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -114,7 +112,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   it("should return 400 for non-existent agent", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -137,7 +135,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   it("should create schedule with agentId", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -163,7 +161,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -185,7 +183,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
     const futureDate = new Date(Date.now() + 86_400_000).toISOString();
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -210,7 +208,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   it("should create loop schedule with intervalSeconds", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -234,7 +232,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   it("should reject invalid timezone", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -258,7 +256,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
     const pastDate = new Date(Date.now() - 86_400_000).toISOString();
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -282,7 +280,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   it("should create schedule with notification settings", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -315,7 +313,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -346,7 +344,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -372,7 +370,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   it("should create schedule with non-UTC timezone", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -396,7 +394,7 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
   it("should create schedule with description", async () => {
     const response = await POST(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=${slug}`,
+        `http://localhost:3000/api/zero/schedules`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -419,16 +417,14 @@ describe("POST /api/zero/schedules - Deploy Schedule", () => {
 });
 
 describe("GET /api/zero/schedules - List Schedules", () => {
-  let slug: string;
   let orgId: string;
   let testComposeId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     const user = await context.setupUser();
-    const org = await setupOrg(user.userId);
-    slug = org.slug;
-    orgId = org.orgId;
+    const { orgId: oid } = await setupOrg(user.userId);
+    orgId = oid;
 
     const agentName = `zero-sched-list-${Date.now()}`;
     const { composeId } = await createTestCompose(agentName);
@@ -447,7 +443,7 @@ describe("GET /api/zero/schedules - List Schedules", () => {
     });
 
     const response = await GET(
-      createTestRequest(`http://localhost:3000/api/zero/schedules?org=${slug}`),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`),
     );
     const data = await response.json();
 
@@ -458,7 +454,7 @@ describe("GET /api/zero/schedules - List Schedules", () => {
   it("should return empty array for invalid org", async () => {
     const response = await GET(
       createTestRequest(
-        `http://localhost:3000/api/zero/schedules?org=non-existent-org`,
+        `http://localhost:3000/api/zero/schedules`,
       ),
     );
     const data = await response.json();
@@ -471,7 +467,7 @@ describe("GET /api/zero/schedules - List Schedules", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest(`http://localhost:3000/api/zero/schedules?org=${slug}`),
+      createTestRequest(`http://localhost:3000/api/zero/schedules`),
     );
 
     expect(response.status).toBe(401);

--- a/turbo/apps/web/app/api/zero/schedules/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/route.ts
@@ -19,7 +19,7 @@ import {
 } from "../../../../src/lib/errors";
 
 const router = tsr.router(zeroSchedulesMainContract, {
-  deploy: async ({ body, headers }, { request }) => {
+  deploy: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -29,10 +29,9 @@ const router = tsr.router(zeroSchedulesMainContract, {
     const { userId } = authCtx;
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
       const {
         org: { orgId },
-      } = await resolveOrg(authCtx, orgSlug);
+      } = await resolveOrg(authCtx);
 
       const result = await deploySchedule(userId, orgId, {
         name: body.name,
@@ -87,7 +86,7 @@ const router = tsr.router(zeroSchedulesMainContract, {
     }
   },
 
-  list: async ({ headers }, { request }) => {
+  list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -96,10 +95,9 @@ const router = tsr.router(zeroSchedulesMainContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
     let orgId: string;
     try {
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       orgId = org.orgId;
     } catch (error) {
       if (isNotFound(error) || isForbidden(error) || isBadRequest(error)) {

--- a/turbo/apps/web/app/api/zero/schedules/run/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/run/__tests__/route.test.ts
@@ -27,7 +27,6 @@ async function setupOrg(userId: string) {
 }
 
 describe("POST /api/zero/schedules/run", () => {
-  let slug: string;
   let orgId: string;
   let testComposeId: string;
 
@@ -35,7 +34,6 @@ describe("POST /api/zero/schedules/run", () => {
     context.setupMocks();
     const user = await context.setupUser();
     const org = await setupOrg(user.userId);
-    slug = org.slug;
     orgId = org.orgId;
 
     const agentName = uniqueId("run-agent");
@@ -52,14 +50,11 @@ describe("POST /api/zero/schedules/run", () => {
     await enableTestSchedule(testComposeId, "run-test");
 
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules/run?org=${slug}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ scheduleId: schedule.id }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scheduleId: schedule.id }),
+      }),
     );
     const data = await response.json();
 
@@ -70,16 +65,13 @@ describe("POST /api/zero/schedules/run", () => {
 
   it("should return 404 for non-existent schedule", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules/run?org=${slug}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            scheduleId: "00000000-0000-0000-0000-000000000000",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scheduleId: "00000000-0000-0000-0000-000000000000",
+        }),
+      }),
     );
     const data = await response.json();
 
@@ -96,27 +88,21 @@ describe("POST /api/zero/schedules/run", () => {
 
     // Execute once to create a run and set lastRunId
     const firstResponse = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules/run?org=${slug}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ scheduleId: schedule.id }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scheduleId: schedule.id }),
+      }),
     );
     expect(firstResponse.status).toBe(201);
 
     // Try to run again while previous run is still active (pending/running)
     const secondResponse = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules/run?org=${slug}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ scheduleId: schedule.id }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scheduleId: schedule.id }),
+      }),
     );
     const data = await secondResponse.json();
 
@@ -126,14 +112,11 @@ describe("POST /api/zero/schedules/run", () => {
 
   it("should return 400 for invalid body (missing scheduleId)", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules/run?org=${slug}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({}),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }),
     );
     const data = await response.json();
 
@@ -143,14 +126,11 @@ describe("POST /api/zero/schedules/run", () => {
 
   it("should return 400 for invalid scheduleId format", async () => {
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules/run?org=${slug}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ scheduleId: "not-a-uuid" }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scheduleId: "not-a-uuid" }),
+      }),
     );
     const data = await response.json();
 
@@ -162,16 +142,13 @@ describe("POST /api/zero/schedules/run", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest(
-        `http://localhost:3000/api/zero/schedules/run?org=${slug}`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            scheduleId: "00000000-0000-0000-0000-000000000000",
-          }),
-        },
-      ),
+      createTestRequest(`http://localhost:3000/api/zero/schedules/run`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scheduleId: "00000000-0000-0000-0000-000000000000",
+        }),
+      }),
     );
 
     expect(response.status).toBe(401);

--- a/turbo/apps/web/app/api/zero/secrets/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/secrets/[name]/__tests__/route.test.ts
@@ -26,12 +26,12 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function secretUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/secrets?org=${slug}`;
+function secretUrl(): string {
+  return `http://localhost:3000/api/zero/secrets`;
 }
 
-function secretByNameUrl(slug: string, name: string): string {
-  return `http://localhost:3000/api/zero/secrets/${name}?org=${slug}`;
+function secretByNameUrl(name: string): string {
+  return `http://localhost:3000/api/zero/secrets/${name}`;
 }
 
 describe("DELETE /api/zero/secrets/:name", () => {
@@ -41,11 +41,11 @@ describe("DELETE /api/zero/secrets/:name", () => {
 
   it("should delete secret successfully", async () => {
     const userId = uniqueId("zsec-del-ok");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     // Create a secret
     await POST(
-      createTestRequest(secretUrl(slug), {
+      createTestRequest(secretUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -57,14 +57,14 @@ describe("DELETE /api/zero/secrets/:name", () => {
 
     // Verify it exists via GET list
     const listResponse = await GET(
-      createTestRequest(secretUrl(slug), { method: "GET" }),
+      createTestRequest(secretUrl(), { method: "GET" }),
     );
     const listData = await listResponse.json();
     expect(listData.secrets).toHaveLength(1);
 
     // Delete it
     const deleteResponse = await DELETE(
-      createTestRequest(secretByNameUrl(slug, "DELETE_ME"), {
+      createTestRequest(secretByNameUrl("DELETE_ME"), {
         method: "DELETE",
       }),
     );
@@ -72,7 +72,7 @@ describe("DELETE /api/zero/secrets/:name", () => {
 
     // Verify it's gone
     const listResponse2 = await GET(
-      createTestRequest(secretUrl(slug), { method: "GET" }),
+      createTestRequest(secretUrl(), { method: "GET" }),
     );
     const listData2 = await listResponse2.json();
     expect(listData2.secrets).toEqual([]);
@@ -80,10 +80,10 @@ describe("DELETE /api/zero/secrets/:name", () => {
 
   it("should return 404 for nonexistent secret", async () => {
     const userId = uniqueId("zsec-del-404");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await DELETE(
-      createTestRequest(secretByNameUrl(slug, "NONEXISTENT"), {
+      createTestRequest(secretByNameUrl("NONEXISTENT"), {
         method: "DELETE",
       }),
     );
@@ -97,10 +97,9 @@ describe("DELETE /api/zero/secrets/:name", () => {
     mockClerk({ userId: null });
 
     const response = await DELETE(
-      createTestRequest(
-        "http://localhost:3000/api/zero/secrets/ANY_KEY?org=test",
-        { method: "DELETE" },
-      ),
+      createTestRequest("http://localhost:3000/api/zero/secrets/ANY_KEY", {
+        method: "DELETE",
+      }),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/apps/web/app/api/zero/secrets/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/secrets/[name]/route.ts
@@ -17,7 +17,7 @@ import { isNotFound } from "../../../../../src/lib/errors";
 const log = logger("api:zero-secrets");
 
 const router = tsr.router(zeroSecretsByNameContract, {
-  delete: async ({ params, headers }, { request }) => {
+  delete: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -27,8 +27,7 @@ const router = tsr.router(zeroSecretsByNameContract, {
     log.debug("deleting secret", { userId, name: params.name });
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       await deleteSecret(org.orgId, userId, params.name);
 
       return {

--- a/turbo/apps/web/app/api/zero/secrets/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/secrets/__tests__/route.test.ts
@@ -25,8 +25,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function secretUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/secrets?org=${slug}`;
+function secretUrl(): string {
+  return `http://localhost:3000/api/zero/secrets`;
 }
 
 describe("GET /api/zero/secrets", () => {
@@ -36,10 +36,10 @@ describe("GET /api/zero/secrets", () => {
 
   it("should return empty array when no secrets exist", async () => {
     const userId = uniqueId("zsec-empty");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await GET(
-      createTestRequest(secretUrl(slug), { method: "GET" }),
+      createTestRequest(secretUrl(), { method: "GET" }),
     );
     expect(response.status).toBe(200);
 
@@ -49,11 +49,11 @@ describe("GET /api/zero/secrets", () => {
 
   it("should list secrets for authenticated user", async () => {
     const userId = uniqueId("zsec-list");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     // Create a secret first
     await POST(
-      createTestRequest(secretUrl(slug), {
+      createTestRequest(secretUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -65,7 +65,7 @@ describe("GET /api/zero/secrets", () => {
     );
 
     const response = await GET(
-      createTestRequest(secretUrl(slug), { method: "GET" }),
+      createTestRequest(secretUrl(), { method: "GET" }),
     );
     expect(response.status).toBe(200);
 
@@ -86,7 +86,7 @@ describe("GET /api/zero/secrets", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/secrets?org=test", {
+      createTestRequest("http://localhost:3000/api/zero/secrets", {
         method: "GET",
       }),
     );
@@ -101,10 +101,10 @@ describe("POST /api/zero/secrets", () => {
 
   it("should create a secret as admin", async () => {
     const userId = uniqueId("zsec-create");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await POST(
-      createTestRequest(secretUrl(slug), {
+      createTestRequest(secretUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -127,11 +127,11 @@ describe("POST /api/zero/secrets", () => {
 
   it("should update an existing secret", async () => {
     const userId = uniqueId("zsec-update");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     // Create
     await POST(
-      createTestRequest(secretUrl(slug), {
+      createTestRequest(secretUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -143,7 +143,7 @@ describe("POST /api/zero/secrets", () => {
 
     // Update
     const response = await POST(
-      createTestRequest(secretUrl(slug), {
+      createTestRequest(secretUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -164,7 +164,7 @@ describe("POST /api/zero/secrets", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest("http://localhost:3000/api/zero/secrets?org=test", {
+      createTestRequest("http://localhost:3000/api/zero/secrets", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -178,10 +178,10 @@ describe("POST /api/zero/secrets", () => {
 
   it("should reject invalid secret name", async () => {
     const userId = uniqueId("zsec-invalid");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await POST(
-      createTestRequest(secretUrl(slug), {
+      createTestRequest(secretUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/turbo/apps/web/app/api/zero/secrets/route.ts
+++ b/turbo/apps/web/app/api/zero/secrets/route.ts
@@ -20,15 +20,14 @@ import { isBadRequest } from "../../../../src/lib/errors";
 const log = logger("api:zero-secrets");
 
 const router = tsr.router(zeroSecretsContract, {
-  list: async ({ headers }, { request }) => {
+  list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     const secrets = await listSecrets(org.orgId, userId);
 
     return {
@@ -46,7 +45,7 @@ const router = tsr.router(zeroSecretsContract, {
     };
   },
 
-  set: async ({ body, headers }, { request }) => {
+  set: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -58,8 +57,7 @@ const router = tsr.router(zeroSecretsContract, {
     log.debug("setting secret", { userId, name });
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       const secret = await setSecret(
         org.orgId,
         userId,

--- a/turbo/apps/web/app/api/zero/sessions/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/sessions/[id]/__tests__/route.test.ts
@@ -23,8 +23,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function sessionUrl(slug: string, sessionId: string): string {
-  return `http://localhost:3000/api/zero/sessions/${sessionId}?org=${slug}`;
+function sessionUrl(sessionId: string): string {
+  return `http://localhost:3000/api/zero/sessions/${sessionId}`;
 }
 
 describe("GET /api/zero/sessions/:id", () => {
@@ -34,11 +34,11 @@ describe("GET /api/zero/sessions/:id", () => {
 
   it("should return session details", async () => {
     const userId = uniqueId("zsess-get");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
     const compose = await createTestCompose(`agent-${uniqueId("zsess")}`);
     const session = await createTestAgentSession(userId, compose.composeId);
 
-    const response = await GET(createTestRequest(sessionUrl(slug, session.id)));
+    const response = await GET(createTestRequest(sessionUrl(session.id)));
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -50,11 +50,9 @@ describe("GET /api/zero/sessions/:id", () => {
 
   it("should return 404 when session not found", async () => {
     const userId = uniqueId("zsess-nf");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
-    const response = await GET(
-      createTestRequest(sessionUrl(slug, randomUUID())),
-    );
+    const response = await GET(createTestRequest(sessionUrl(randomUUID())));
     expect(response.status).toBe(404);
   });
 
@@ -62,9 +60,7 @@ describe("GET /api/zero/sessions/:id", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest(
-        "http://localhost:3000/api/zero/sessions/some-id?org=test",
-      ),
+      createTestRequest("http://localhost:3000/api/zero/sessions/some-id"),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/apps/web/app/api/zero/sessions/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/sessions/[id]/route.ts
@@ -14,15 +14,14 @@ import { getSessionResponse } from "../../../../../src/lib/agent-session/agent-s
 import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroSessionsByIdContract, {
-  getById: async ({ params, headers }, { request }) => {
+  getById: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     try {
       const { agentComposeId, ...rest } = await getSessionResponse(

--- a/turbo/apps/web/app/api/zero/skills/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/skills/[name]/route.ts
@@ -42,7 +42,7 @@ const log = logger("api:zero-skills:detail");
 const SKILL_FILENAME = "SKILL.md";
 
 const router = tsr.router(zeroSkillsDetailContract, {
-  get: async ({ params, headers }, { request }) => {
+  get: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -50,8 +50,7 @@ const router = tsr.router(zeroSkillsDetailContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Look up skill metadata
     const [skill] = await globalThis.services.db
@@ -158,7 +157,7 @@ const router = tsr.router(zeroSkillsDetailContract, {
     };
   },
 
-  update: async ({ params, body, headers }, { request }) => {
+  update: async ({ params, body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -166,8 +165,7 @@ const router = tsr.router(zeroSkillsDetailContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Look up skill
     const [skill] = await globalThis.services.db
@@ -216,7 +214,7 @@ const router = tsr.router(zeroSkillsDetailContract, {
     };
   },
 
-  delete: async ({ params, headers }, { request }) => {
+  delete: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -225,8 +223,7 @@ const router = tsr.router(zeroSkillsDetailContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Look up skill
     const [skill] = await globalThis.services.db

--- a/turbo/apps/web/app/api/zero/skills/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/skills/[name]/route.ts
@@ -282,7 +282,6 @@ const router = tsr.router(zeroSkillsDetailContract, {
         await serverSideCompose({
           userId,
           orgId: org.orgId,
-          orgSlug: org.slug,
           content,
         });
       } catch (e) {

--- a/turbo/apps/web/app/api/zero/skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/skills/__tests__/route.test.ts
@@ -26,10 +26,7 @@ const context = testContext();
 let user: UserContext;
 let testCliToken: string;
 
-function postSkillReq(
-  body: Record<string, unknown>,
-  token: string,
-) {
+function postSkillReq(body: Record<string, unknown>, token: string) {
   return postSkill(
     createTestRequest(`http://localhost:3000/api/zero/skills`, {
       method: "POST",
@@ -53,13 +50,10 @@ function listSkillsReq(token: string) {
 
 function getSkillReq(name: string, token: string) {
   return getSkill(
-    createTestRequest(
-      `http://localhost:3000/api/zero/skills/${name}`,
-      {
-        method: "GET",
-        headers: { Authorization: `Bearer ${token}` },
-      },
-    ),
+    createTestRequest(`http://localhost:3000/api/zero/skills/${name}`, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}` },
+    }),
   );
 }
 
@@ -69,29 +63,23 @@ function putSkillReq(
   token: string,
 ) {
   return putSkill(
-    createTestRequest(
-      `http://localhost:3000/api/zero/skills/${name}`,
-      {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(body),
+    createTestRequest(`http://localhost:3000/api/zero/skills/${name}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
       },
-    ),
+      body: JSON.stringify(body),
+    }),
   );
 }
 
 function deleteSkillReq(name: string, token: string) {
   return deleteSkill(
-    createTestRequest(
-      `http://localhost:3000/api/zero/skills/${name}`,
-      {
-        method: "DELETE",
-        headers: { Authorization: `Bearer ${token}` },
-      },
-    ),
+    createTestRequest(`http://localhost:3000/api/zero/skills/${name}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    }),
   );
 }
 
@@ -230,10 +218,7 @@ describe("Zero Skills API (org-level)", () => {
         },
         testCliToken,
       );
-      await postSkillReq(
-        { name: "skill-two", content: "# Two" },
-        testCliToken,
-      );
+      await postSkillReq({ name: "skill-two", content: "# Two" }, testCliToken);
 
       const response = await listSkillsReq(testCliToken);
 
@@ -270,10 +255,7 @@ describe("Zero Skills API (org-level)", () => {
     });
 
     it("should return 404 for non-existent skill", async () => {
-      const response = await getSkillReq(
-        "no-such-skill",
-        testCliToken,
-      );
+      const response = await getSkillReq("no-such-skill", testCliToken);
 
       expect(response.status).toBe(404);
     });
@@ -316,10 +298,7 @@ describe("Zero Skills API (org-level)", () => {
         testCliToken,
       );
 
-      const response = await deleteSkillReq(
-        "my-skill",
-        testCliToken,
-      );
+      const response = await deleteSkillReq("my-skill", testCliToken);
 
       expect(response.status).toBe(204);
 
@@ -352,10 +331,7 @@ describe("Zero Skills API (org-level)", () => {
       await bindCustomSkillToAgent(agent2.agentId, "shared-skill");
 
       // Delete the skill at org level
-      const response = await deleteSkillReq(
-        "shared-skill",
-        testCliToken,
-      );
+      const response = await deleteSkillReq("shared-skill", testCliToken);
 
       expect(response.status).toBe(204);
 
@@ -366,10 +342,7 @@ describe("Zero Skills API (org-level)", () => {
     });
 
     it("should return 404 for non-existent skill", async () => {
-      const response = await deleteSkillReq(
-        "no-such-skill",
-        testCliToken,
-      );
+      const response = await deleteSkillReq("no-such-skill", testCliToken);
 
       expect(response.status).toBe(404);
     });

--- a/turbo/apps/web/app/api/zero/skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/skills/__tests__/route.test.ts
@@ -25,16 +25,13 @@ const context = testContext();
 
 let user: UserContext;
 let testCliToken: string;
-let testOrgSlug: string;
 
 function postSkillReq(
   body: Record<string, unknown>,
   token: string,
-  orgSlug?: string,
 ) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
   return postSkill(
-    createTestRequest(`http://localhost:3000/api/zero/skills${orgParam}`, {
+    createTestRequest(`http://localhost:3000/api/zero/skills`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -45,21 +42,19 @@ function postSkillReq(
   );
 }
 
-function listSkillsReq(token: string, orgSlug?: string) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function listSkillsReq(token: string) {
   return listSkills(
-    createTestRequest(`http://localhost:3000/api/zero/skills${orgParam}`, {
+    createTestRequest(`http://localhost:3000/api/zero/skills`, {
       method: "GET",
       headers: { Authorization: `Bearer ${token}` },
     }),
   );
 }
 
-function getSkillReq(name: string, token: string, orgSlug?: string) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function getSkillReq(name: string, token: string) {
   return getSkill(
     createTestRequest(
-      `http://localhost:3000/api/zero/skills/${name}${orgParam}`,
+      `http://localhost:3000/api/zero/skills/${name}`,
       {
         method: "GET",
         headers: { Authorization: `Bearer ${token}` },
@@ -72,12 +67,10 @@ function putSkillReq(
   name: string,
   body: Record<string, unknown>,
   token: string,
-  orgSlug?: string,
 ) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
   return putSkill(
     createTestRequest(
-      `http://localhost:3000/api/zero/skills/${name}${orgParam}`,
+      `http://localhost:3000/api/zero/skills/${name}`,
       {
         method: "PUT",
         headers: {
@@ -90,11 +83,10 @@ function putSkillReq(
   );
 }
 
-function deleteSkillReq(name: string, token: string, orgSlug?: string) {
-  const orgParam = orgSlug ? `?org=${orgSlug}` : "";
+function deleteSkillReq(name: string, token: string) {
   return deleteSkill(
     createTestRequest(
-      `http://localhost:3000/api/zero/skills/${name}${orgParam}`,
+      `http://localhost:3000/api/zero/skills/${name}`,
       {
         method: "DELETE",
         headers: { Authorization: `Bearer ${token}` },
@@ -126,7 +118,6 @@ describe("Zero Skills API (org-level)", () => {
     await seedSeedSkills();
     user = await context.setupUser();
     testCliToken = await createTestCliToken(user.userId);
-    testOrgSlug = `org-${user.userId.slice(-8)}`;
   });
 
   describe("POST /api/zero/skills", () => {
@@ -134,7 +125,6 @@ describe("Zero Skills API (org-level)", () => {
       const response = await postSkillReq(
         { name: "my-skill", content: "# My Skill\nHello" },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(201);
@@ -153,7 +143,6 @@ describe("Zero Skills API (org-level)", () => {
           description: "A useful skill",
         },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(201);
@@ -173,11 +162,10 @@ describe("Zero Skills API (org-level)", () => {
       await postSkillReq(
         { name: "unbound-skill", content: "# Content" },
         testCliToken,
-        testOrgSlug,
       );
 
       // Verify skill exists in org list
-      const listRes = await listSkillsReq(testCliToken, testOrgSlug);
+      const listRes = await listSkillsReq(testCliToken);
       const skills = await listRes.json();
       expect(
         skills.some((s: { name: string }) => s.name === "unbound-skill"),
@@ -192,13 +180,11 @@ describe("Zero Skills API (org-level)", () => {
       await postSkillReq(
         { name: "my-skill", content: "# Content" },
         testCliToken,
-        testOrgSlug,
       );
 
       const response = await postSkillReq(
         { name: "my-skill", content: "# Other" },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(409);
@@ -208,7 +194,6 @@ describe("Zero Skills API (org-level)", () => {
       const response = await postSkillReq(
         { name: "deep-dive", content: "# Content" },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(409);
@@ -228,7 +213,7 @@ describe("Zero Skills API (org-level)", () => {
 
   describe("GET /api/zero/skills", () => {
     it("should return empty array when no skills", async () => {
-      const response = await listSkillsReq(testCliToken, testOrgSlug);
+      const response = await listSkillsReq(testCliToken);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -244,15 +229,13 @@ describe("Zero Skills API (org-level)", () => {
           description: "First skill",
         },
         testCliToken,
-        testOrgSlug,
       );
       await postSkillReq(
         { name: "skill-two", content: "# Two" },
         testCliToken,
-        testOrgSlug,
       );
 
-      const response = await listSkillsReq(testCliToken, testOrgSlug);
+      const response = await listSkillsReq(testCliToken);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -273,12 +256,11 @@ describe("Zero Skills API (org-level)", () => {
           displayName: "My Skill",
         },
         testCliToken,
-        testOrgSlug,
       );
 
       mockSkillContent("# My Skill Content");
 
-      const response = await getSkillReq("my-skill", testCliToken, testOrgSlug);
+      const response = await getSkillReq("my-skill", testCliToken);
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -291,7 +273,6 @@ describe("Zero Skills API (org-level)", () => {
       const response = await getSkillReq(
         "no-such-skill",
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(404);
@@ -303,14 +284,12 @@ describe("Zero Skills API (org-level)", () => {
       await postSkillReq(
         { name: "my-skill", content: "# Original" },
         testCliToken,
-        testOrgSlug,
       );
 
       const response = await putSkillReq(
         "my-skill",
         { content: "# Updated Content" },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(200);
@@ -324,7 +303,6 @@ describe("Zero Skills API (org-level)", () => {
         "no-such-skill",
         { content: "# Content" },
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(404);
@@ -336,19 +314,17 @@ describe("Zero Skills API (org-level)", () => {
       await postSkillReq(
         { name: "my-skill", content: "# Content" },
         testCliToken,
-        testOrgSlug,
       );
 
       const response = await deleteSkillReq(
         "my-skill",
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(204);
 
       // Verify skill is removed from list
-      const listRes = await listSkillsReq(testCliToken, testOrgSlug);
+      const listRes = await listSkillsReq(testCliToken);
       const data = await listRes.json();
       expect(data).toEqual([]);
     });
@@ -358,7 +334,6 @@ describe("Zero Skills API (org-level)", () => {
       await postSkillReq(
         { name: "shared-skill", content: "# Shared" },
         testCliToken,
-        testOrgSlug,
       );
 
       // Bind to two agents
@@ -380,13 +355,12 @@ describe("Zero Skills API (org-level)", () => {
       const response = await deleteSkillReq(
         "shared-skill",
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(204);
 
       // Verify skill is gone from org
-      const listRes = await listSkillsReq(testCliToken, testOrgSlug);
+      const listRes = await listSkillsReq(testCliToken);
       const data = await listRes.json();
       expect(data).toEqual([]);
     });
@@ -395,7 +369,6 @@ describe("Zero Skills API (org-level)", () => {
       const response = await deleteSkillReq(
         "no-such-skill",
         testCliToken,
-        testOrgSlug,
       );
 
       expect(response.status).toBe(404);

--- a/turbo/apps/web/app/api/zero/slack/channels/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/channels/route.ts
@@ -25,8 +25,7 @@ export async function GET(request: Request) {
     );
   }
 
-  const orgSlug = new URL(request.url).searchParams.get("org");
-  const { org } = await resolveOrg(authCtx, orgSlug);
+  const { org } = await resolveOrg(authCtx);
 
   const db = globalThis.services.db;
 

--- a/turbo/apps/web/app/api/zero/slack/connect/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/connect/route.ts
@@ -59,8 +59,7 @@ export async function GET(request: Request) {
   }
 
   if (!installation.orgId) {
-    const orgSlug = url.searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     if (member.role !== "admin") {
       return NextResponse.redirect(
@@ -107,7 +106,7 @@ export async function GET(request: Request) {
     // Distinguish: is the user a member of the workspace's org at all?
     let isMember = false;
     try {
-      await resolveOrg(authCtx, null, installation.orgId);
+      await resolveOrg(authCtx, installation.orgId);
       isMember = true;
     } catch {
       // Not a member
@@ -122,7 +121,7 @@ export async function GET(request: Request) {
     );
   }
 
-  const { org, member } = await resolveOrg(authCtx, null, installation.orgId);
+  const { org, member } = await resolveOrg(authCtx, installation.orgId);
 
   if (member.role === "admin") {
     await adminConnect({

--- a/turbo/apps/web/app/api/zero/usage/members/route.ts
+++ b/turbo/apps/web/app/api/zero/usage/members/route.ts
@@ -13,14 +13,13 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { getUsageMembers } from "../../../../../src/lib/billing/usage-service";
 
 const router = tsr.router(zeroUsageMembersContract, {
-  get: async ({ headers }, { request }) => {
+  get: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const response = await getUsageMembers(org.orgId);
 

--- a/turbo/apps/web/app/api/zero/user-preferences/route.ts
+++ b/turbo/apps/web/app/api/zero/user-preferences/route.ts
@@ -17,14 +17,13 @@ import {
 import { isBadRequest } from "../../../../src/lib/errors";
 
 const router = tsr.router(zeroUserPreferencesContract, {
-  get: async ({ headers }, { request }) => {
+  get: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const prefs = await getUserPreferences(org.orgId, authCtx.userId);
 
@@ -38,14 +37,13 @@ const router = tsr.router(zeroUserPreferencesContract, {
     };
   },
 
-  update: async ({ body, headers }, { request }) => {
+  update: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     try {
       const prefs = await updateUserPreferences(org.orgId, authCtx.userId, {

--- a/turbo/apps/web/app/api/zero/variables/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/variables/[name]/__tests__/route.test.ts
@@ -26,12 +26,12 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function variableUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/variables?org=${slug}`;
+function variableUrl(): string {
+  return `http://localhost:3000/api/zero/variables`;
 }
 
-function variableByNameUrl(slug: string, name: string): string {
-  return `http://localhost:3000/api/zero/variables/${name}?org=${slug}`;
+function variableByNameUrl(name: string): string {
+  return `http://localhost:3000/api/zero/variables/${name}`;
 }
 
 describe("DELETE /api/zero/variables/:name", () => {
@@ -41,11 +41,11 @@ describe("DELETE /api/zero/variables/:name", () => {
 
   it("should delete variable successfully", async () => {
     const userId = uniqueId("zvar-del-ok");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     // Create a variable
     await POST(
-      createTestRequest(variableUrl(slug), {
+      createTestRequest(variableUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -57,14 +57,14 @@ describe("DELETE /api/zero/variables/:name", () => {
 
     // Verify it exists via GET list
     const listResponse = await GET(
-      createTestRequest(variableUrl(slug), { method: "GET" }),
+      createTestRequest(variableUrl(), { method: "GET" }),
     );
     const listData = await listResponse.json();
     expect(listData.variables).toHaveLength(1);
 
     // Delete it
     const deleteResponse = await DELETE(
-      createTestRequest(variableByNameUrl(slug, "DELETE_ME"), {
+      createTestRequest(variableByNameUrl("DELETE_ME"), {
         method: "DELETE",
       }),
     );
@@ -72,7 +72,7 @@ describe("DELETE /api/zero/variables/:name", () => {
 
     // Verify it's gone
     const listResponse2 = await GET(
-      createTestRequest(variableUrl(slug), { method: "GET" }),
+      createTestRequest(variableUrl(), { method: "GET" }),
     );
     const listData2 = await listResponse2.json();
     expect(listData2.variables).toEqual([]);
@@ -80,10 +80,10 @@ describe("DELETE /api/zero/variables/:name", () => {
 
   it("should return 404 for nonexistent variable", async () => {
     const userId = uniqueId("zvar-del-404");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await DELETE(
-      createTestRequest(variableByNameUrl(slug, "NONEXISTENT"), {
+      createTestRequest(variableByNameUrl("NONEXISTENT"), {
         method: "DELETE",
       }),
     );
@@ -97,10 +97,9 @@ describe("DELETE /api/zero/variables/:name", () => {
     mockClerk({ userId: null });
 
     const response = await DELETE(
-      createTestRequest(
-        "http://localhost:3000/api/zero/variables/ANY_VAR?org=test",
-        { method: "DELETE" },
-      ),
+      createTestRequest("http://localhost:3000/api/zero/variables/ANY_VAR", {
+        method: "DELETE",
+      }),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/apps/web/app/api/zero/variables/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/variables/[name]/route.ts
@@ -17,7 +17,7 @@ import { isNotFound } from "../../../../../src/lib/errors";
 const log = logger("api:zero-variables");
 
 const router = tsr.router(zeroVariablesByNameContract, {
-  delete: async ({ params, headers }, { request }) => {
+  delete: async ({ params, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -27,8 +27,7 @@ const router = tsr.router(zeroVariablesByNameContract, {
     log.debug("deleting variable", { userId, name: params.name });
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       await deleteVariable(org.orgId, userId, params.name);
 
       return {

--- a/turbo/apps/web/app/api/zero/variables/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/variables/__tests__/route.test.ts
@@ -25,8 +25,8 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function variableUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/variables?org=${slug}`;
+function variableUrl(): string {
+  return `http://localhost:3000/api/zero/variables`;
 }
 
 describe("GET /api/zero/variables", () => {
@@ -36,10 +36,10 @@ describe("GET /api/zero/variables", () => {
 
   it("should return empty array when no variables exist", async () => {
     const userId = uniqueId("zvar-empty");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await GET(
-      createTestRequest(variableUrl(slug), { method: "GET" }),
+      createTestRequest(variableUrl(), { method: "GET" }),
     );
     expect(response.status).toBe(200);
 
@@ -49,11 +49,11 @@ describe("GET /api/zero/variables", () => {
 
   it("should list variables for authenticated user", async () => {
     const userId = uniqueId("zvar-list");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     // Create a variable first
     await POST(
-      createTestRequest(variableUrl(slug), {
+      createTestRequest(variableUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -65,7 +65,7 @@ describe("GET /api/zero/variables", () => {
     );
 
     const response = await GET(
-      createTestRequest(variableUrl(slug), { method: "GET" }),
+      createTestRequest(variableUrl(), { method: "GET" }),
     );
     expect(response.status).toBe(200);
 
@@ -83,7 +83,7 @@ describe("GET /api/zero/variables", () => {
     mockClerk({ userId: null });
 
     const response = await GET(
-      createTestRequest("http://localhost:3000/api/zero/variables?org=test", {
+      createTestRequest("http://localhost:3000/api/zero/variables", {
         method: "GET",
       }),
     );
@@ -98,10 +98,10 @@ describe("POST /api/zero/variables", () => {
 
   it("should create a variable as admin", async () => {
     const userId = uniqueId("zvar-create");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await POST(
-      createTestRequest(variableUrl(slug), {
+      createTestRequest(variableUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -124,11 +124,11 @@ describe("POST /api/zero/variables", () => {
 
   it("should update an existing variable", async () => {
     const userId = uniqueId("zvar-update");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     // Create
     await POST(
-      createTestRequest(variableUrl(slug), {
+      createTestRequest(variableUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -140,7 +140,7 @@ describe("POST /api/zero/variables", () => {
 
     // Update
     const response = await POST(
-      createTestRequest(variableUrl(slug), {
+      createTestRequest(variableUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -162,7 +162,7 @@ describe("POST /api/zero/variables", () => {
     mockClerk({ userId: null });
 
     const response = await POST(
-      createTestRequest("http://localhost:3000/api/zero/variables?org=test", {
+      createTestRequest("http://localhost:3000/api/zero/variables", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -176,10 +176,10 @@ describe("POST /api/zero/variables", () => {
 
   it("should reject invalid variable name", async () => {
     const userId = uniqueId("zvar-invalid");
-    const { slug } = await setupOrg(userId);
+    await setupOrg(userId);
 
     const response = await POST(
-      createTestRequest(variableUrl(slug), {
+      createTestRequest(variableUrl(), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/turbo/apps/web/app/api/zero/variables/route.ts
+++ b/turbo/apps/web/app/api/zero/variables/route.ts
@@ -20,15 +20,14 @@ import { isBadRequest } from "../../../../src/lib/errors";
 const log = logger("api:zero-variables");
 
 const router = tsr.router(zeroVariablesContract, {
-  list: async ({ headers }, { request }) => {
+  list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     const vars = await listVariables(org.orgId, userId);
 
     return {
@@ -46,7 +45,7 @@ const router = tsr.router(zeroVariablesContract, {
     };
   },
 
-  set: async ({ body, headers }, { request }) => {
+  set: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization);
@@ -58,8 +57,7 @@ const router = tsr.router(zeroVariablesContract, {
     log.debug("setting variable", { userId, name });
 
     try {
-      const orgSlug = new URL(request.url).searchParams.get("org");
-      const { org } = await resolveOrg(authCtx, orgSlug);
+      const { org } = await resolveOrg(authCtx);
       const variable = await setVariable(
         org.orgId,
         userId,

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -229,7 +229,7 @@ export async function createTestCliToken(
   // Generate CLI JWT containing userId, orgId, and tokenId for revocation checks
   const token = await generateCliToken(
     userId,
-    orgId ?? "org_test_default",
+    orgId ?? `org_mock_${userId}`,
     tokenId,
   );
 

--- a/turbo/apps/web/src/__tests__/org-model-providers-api.test.ts
+++ b/turbo/apps/web/src/__tests__/org-model-providers-api.test.ts
@@ -23,8 +23,8 @@ async function setupOrg(userId: string, role: "org:admin" | "org:member") {
   return { slug, orgId };
 }
 
-function orgUrl(path: string, slug: string): string {
-  return `http://localhost:3000/api/zero/model-providers${path}?org=${slug}`;
+function orgUrl(path: string): string {
+  return `http://localhost:3000/api/zero/model-providers${path}`;
 }
 
 describe("Org model-provider API", () => {
@@ -35,9 +35,9 @@ describe("Org model-provider API", () => {
   describe("GET /api/zero/model-providers", () => {
     it("should return empty list initially", async () => {
       const userId = uniqueId("omp-list");
-      const { slug } = await setupOrg(userId, "org:admin");
+      await setupOrg(userId, "org:admin");
 
-      const response = await GET(createTestRequest(orgUrl("", slug)));
+      const response = await GET(createTestRequest(orgUrl("")));
       expect(response.status).toBe(200);
 
       const data = await response.json();
@@ -46,9 +46,9 @@ describe("Org model-provider API", () => {
 
     it("should allow member to list org providers", async () => {
       const userId = uniqueId("omp-member-list");
-      const { slug } = await setupOrg(userId, "org:member");
+      await setupOrg(userId, "org:member");
 
-      const response = await GET(createTestRequest(orgUrl("", slug)));
+      const response = await GET(createTestRequest(orgUrl("")));
       expect(response.status).toBe(200);
 
       const data = await response.json();
@@ -59,9 +59,7 @@ describe("Org model-provider API", () => {
       mockClerk({ userId: null });
 
       const response = await GET(
-        createTestRequest(
-          "http://localhost:3000/api/zero/model-providers?org=test",
-        ),
+        createTestRequest("http://localhost:3000/api/zero/model-providers"),
       );
       expect(response.status).toBe(401);
     });
@@ -70,10 +68,10 @@ describe("Org model-provider API", () => {
   describe("POST /api/zero/model-providers", () => {
     it("should create org provider as admin", async () => {
       const userId = uniqueId("omp-create");
-      const { slug } = await setupOrg(userId, "org:admin");
+      await setupOrg(userId, "org:admin");
 
       const response = await POST(
-        createTestRequest(orgUrl("", slug), {
+        createTestRequest(orgUrl(""), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -93,11 +91,11 @@ describe("Org model-provider API", () => {
 
     it("should update existing org provider", async () => {
       const userId = uniqueId("omp-update");
-      const { slug } = await setupOrg(userId, "org:admin");
+      await setupOrg(userId, "org:admin");
 
       // Create
       await POST(
-        createTestRequest(orgUrl("", slug), {
+        createTestRequest(orgUrl(""), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -109,7 +107,7 @@ describe("Org model-provider API", () => {
 
       // Update
       const response = await POST(
-        createTestRequest(orgUrl("", slug), {
+        createTestRequest(orgUrl(""), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -126,10 +124,10 @@ describe("Org model-provider API", () => {
 
     it("should return 403 for non-admin member", async () => {
       const userId = uniqueId("omp-member-put");
-      const { slug } = await setupOrg(userId, "org:member");
+      await setupOrg(userId, "org:member");
 
       const response = await POST(
-        createTestRequest(orgUrl("", slug), {
+        createTestRequest(orgUrl(""), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -148,17 +146,14 @@ describe("Org model-provider API", () => {
       mockClerk({ userId: null });
 
       const response = await POST(
-        createTestRequest(
-          "http://localhost:3000/api/zero/model-providers?org=test",
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              type: "anthropic-api-key",
-              secret: "test-key",
-            }),
-          },
-        ),
+        createTestRequest("http://localhost:3000/api/zero/model-providers", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "anthropic-api-key",
+            secret: "test-key",
+          }),
+        }),
       );
       expect(response.status).toBe(401);
     });
@@ -167,11 +162,11 @@ describe("Org model-provider API", () => {
   describe("DELETE /api/zero/model-providers/:type", () => {
     it("should delete org provider as admin", async () => {
       const userId = uniqueId("omp-delete");
-      const { slug } = await setupOrg(userId, "org:admin");
+      await setupOrg(userId, "org:admin");
 
       // Create first
       await POST(
-        createTestRequest(orgUrl("", slug), {
+        createTestRequest(orgUrl(""), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -183,24 +178,24 @@ describe("Org model-provider API", () => {
 
       // Delete
       const response = await DELETE(
-        createTestRequest(orgUrl("/anthropic-api-key", slug), {
+        createTestRequest(orgUrl("/anthropic-api-key"), {
           method: "DELETE",
         }),
       );
       expect(response.status).toBe(204);
 
       // Verify deletion
-      const listRes = await GET(createTestRequest(orgUrl("", slug)));
+      const listRes = await GET(createTestRequest(orgUrl("")));
       const listData = await listRes.json();
       expect(listData.modelProviders).toEqual([]);
     });
 
     it("should return 404 for non-existent provider", async () => {
       const userId = uniqueId("omp-del-404");
-      const { slug } = await setupOrg(userId, "org:admin");
+      await setupOrg(userId, "org:admin");
 
       const response = await DELETE(
-        createTestRequest(orgUrl("/anthropic-api-key", slug), {
+        createTestRequest(orgUrl("/anthropic-api-key"), {
           method: "DELETE",
         }),
       );
@@ -209,10 +204,10 @@ describe("Org model-provider API", () => {
 
     it("should return 403 for non-admin member", async () => {
       const userId = uniqueId("omp-del-member");
-      const { slug } = await setupOrg(userId, "org:member");
+      await setupOrg(userId, "org:member");
 
       const response = await DELETE(
-        createTestRequest(orgUrl("/anthropic-api-key", slug), {
+        createTestRequest(orgUrl("/anthropic-api-key"), {
           method: "DELETE",
         }),
       );
@@ -223,11 +218,11 @@ describe("Org model-provider API", () => {
   describe("POST /api/zero/model-providers/:type/default", () => {
     it("should set org provider as default", async () => {
       const userId = uniqueId("omp-default");
-      const { slug } = await setupOrg(userId, "org:admin");
+      await setupOrg(userId, "org:admin");
 
       // Create two providers
       await POST(
-        createTestRequest(orgUrl("", slug), {
+        createTestRequest(orgUrl(""), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -237,7 +232,7 @@ describe("Org model-provider API", () => {
         }),
       );
       await POST(
-        createTestRequest(orgUrl("", slug), {
+        createTestRequest(orgUrl(""), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -249,7 +244,7 @@ describe("Org model-provider API", () => {
 
       // Set second as default
       const response = await setDefaultRoute(
-        createTestRequest(orgUrl("/claude-code-oauth-token/default", slug), {
+        createTestRequest(orgUrl("/claude-code-oauth-token/default"), {
           method: "POST",
         }),
       );
@@ -260,7 +255,7 @@ describe("Org model-provider API", () => {
       expect(data.type).toBe("claude-code-oauth-token");
 
       // Verify first is no longer default
-      const listRes = await GET(createTestRequest(orgUrl("", slug)));
+      const listRes = await GET(createTestRequest(orgUrl("")));
       const listData = await listRes.json();
       const anthropic = listData.modelProviders.find(
         (p: { type: string }) => p.type === "anthropic-api-key",
@@ -271,10 +266,10 @@ describe("Org model-provider API", () => {
 
     it("should return 403 for non-admin member", async () => {
       const userId = uniqueId("omp-def-member");
-      const { slug } = await setupOrg(userId, "org:member");
+      await setupOrg(userId, "org:member");
 
       const response = await setDefaultRoute(
-        createTestRequest(orgUrl("/anthropic-api-key/default", slug), {
+        createTestRequest(orgUrl("/anthropic-api-key/default"), {
           method: "POST",
         }),
       );
@@ -285,11 +280,11 @@ describe("Org model-provider API", () => {
   describe("list after CRUD operations", () => {
     it("should list created org providers", async () => {
       const userId = uniqueId("omp-listcrud");
-      const { slug } = await setupOrg(userId, "org:admin");
+      await setupOrg(userId, "org:admin");
 
       // Create a provider
       await POST(
-        createTestRequest(orgUrl("", slug), {
+        createTestRequest(orgUrl(""), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -299,7 +294,7 @@ describe("Org model-provider API", () => {
         }),
       );
 
-      const response = await GET(createTestRequest(orgUrl("", slug)));
+      const response = await GET(createTestRequest(orgUrl("")));
       expect(response.status).toBe(200);
 
       const data = await response.json();

--- a/turbo/apps/web/src/__tests__/vm0-provider.test.ts
+++ b/turbo/apps/web/src/__tests__/vm0-provider.test.ts
@@ -36,8 +36,8 @@ async function setupOrg(
   return { slug: orgSlug, orgId };
 }
 
-function orgUrl(slug: string): string {
-  return `http://localhost:3000/api/zero/model-providers?org=${slug}`;
+function orgUrl(): string {
+  return `http://localhost:3000/api/zero/model-providers`;
 }
 
 describe("VM0 managed model provider", () => {
@@ -48,10 +48,10 @@ describe("VM0 managed model provider", () => {
   describe("API route: org slug check", () => {
     it("should create vm0 provider for vm0 org without secret", async () => {
       const userId = uniqueId("vm0-create");
-      const { slug } = await setupOrg(userId, "org:admin", "vm0");
+      await setupOrg(userId, "org:admin", "vm0");
 
       const response = await POST(
-        createTestRequest(orgUrl(slug), {
+        createTestRequest(orgUrl(), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -72,10 +72,10 @@ describe("VM0 managed model provider", () => {
 
     it("should create vm0 provider for any org without secret", async () => {
       const userId = uniqueId("vm0-any-org");
-      const { slug } = await setupOrg(userId, "org:admin", "my-org");
+      await setupOrg(userId, "org:admin", "my-org");
 
       const response = await POST(
-        createTestRequest(orgUrl(slug), {
+        createTestRequest(orgUrl(), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({

--- a/turbo/apps/web/src/lib/compose/server-side-compose.ts
+++ b/turbo/apps/web/src/lib/compose/server-side-compose.ts
@@ -147,7 +147,6 @@ async function upsertComposeRecord(params: {
 export async function serverSideCompose(params: {
   userId: string;
   orgId: string;
-  orgSlug: string;
   content: Record<string, unknown>;
   instructions?: string;
 }): Promise<{

--- a/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/resolve-org.test.ts
@@ -46,45 +46,7 @@ describe("resolveOrg", () => {
     context.setupMocks();
   });
 
-  it("tier 1: orgSlug takes priority over orgId from session", async () => {
-    const { userId } = await context.setupUser();
-
-    // Create two additional orgs — set up Clerk orgs BEFORE creating orgs
-    const slug1 = uniqueId("org");
-    const slug2 = uniqueId("org");
-    mockClerk({
-      userId,
-      clerkOrgs: [
-        // Include the org from setupUser so it's already matched
-        {
-          id: `org_mock_${userId}`,
-          slug: `org-${userId}`,
-          name: `org-${userId}`,
-        },
-        ...testOrgs(slug1, slug2),
-      ],
-    });
-    await createTestOrg(slug1);
-    await createTestOrg(slug2);
-
-    // Mock session with orgId pointing to org2
-    mockClerk({
-      userId,
-      orgId: `org_mock_${slug2}`,
-      clerkOrgs: testOrgs(slug1, slug2),
-    });
-
-    // Resolve with explicit slug for org1 — should return org1, not org2
-    const result = await resolveOrg(
-      authCtx({ userId, orgId: `org_mock_${slug2}` }),
-      slug1,
-    );
-
-    expect(result.org.orgId).toBe(`org_mock_${slug1}`);
-    expect(result.org.orgId).not.toBe(`org_mock_${slug2}`);
-  });
-
-  it("tier 2: auto-detects orgId from AuthContext", async () => {
+  it("auto-detects orgId from AuthContext", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");
 
@@ -108,7 +70,7 @@ describe("resolveOrg", () => {
     expect(result.org.slug).toBe(slug);
   });
 
-  it("tier 2: explicit orgId parameter takes precedence over session", async () => {
+  it("explicit orgId parameter takes precedence over session", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");
 
@@ -126,7 +88,6 @@ describe("resolveOrg", () => {
     // Pass explicit orgId matching the org
     const result = await resolveOrg(
       authCtx({ userId, orgId: "org_session_different" }),
-      null,
       `org_mock_${slug}`,
     );
 
@@ -166,7 +127,7 @@ describe("resolveOrg", () => {
     ).rejects.toThrow();
   });
 
-  it("tier 2: resolves correct org when user has multiple orgs", async () => {
+  it("resolves correct org when user has multiple orgs", async () => {
     const userId = uniqueId("test-user");
     const slug1 = uniqueId("org");
     const slug2 = uniqueId("org");
@@ -289,7 +250,7 @@ describe("resolveOrg", () => {
     expect(result.member.userId).toBe(userId);
   });
 
-  it("throws 403 when user is not a Clerk org member", async () => {
+  it("throws when user is not a member of the org", async () => {
     const userId = uniqueId("test-user");
     const otherUserId = uniqueId("other-user");
     const slug = uniqueId("org");
@@ -301,16 +262,18 @@ describe("resolveOrg", () => {
     // Mock as different user who is NOT in the org
     mockClerk({
       userId: otherUserId,
-      orgId: null,
+      orgId: `org_mock_${slug}`,
       clerkOrgs: [], // No orgs
     });
 
+    // Throws because the other user cannot resolve this org
+    // (either "not found" from org cache miss, or "not a member" from membership check)
     await expect(
-      resolveOrg(authCtx({ userId: otherUserId }), slug),
-    ).rejects.toThrow("You are not a member of this organization");
+      resolveOrg(authCtx({ userId: otherUserId, orgId: `org_mock_${slug}` })),
+    ).rejects.toThrow();
   });
 
-  it("?org= param resolves org by orgId", async () => {
+  it("explicit orgId resolves org", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");
 
@@ -325,41 +288,13 @@ describe("resolveOrg", () => {
       clerkOrgs: testOrgs(slug),
     });
 
-    // Pass orgId directly (simulates ?org= being passed as 3rd arg)
+    // Pass orgId directly
     const result = await resolveOrg(
       authCtx({ userId, orgId: "org_session_different" }),
-      null,
       `org_mock_${slug}`,
     );
 
     expect(result.org.orgId).toBe(`org_mock_${slug}`);
     expect(result.org.slug).toBe(slug);
-  });
-
-  it("orgSlug takes priority over orgId", async () => {
-    const userId = uniqueId("test-user");
-    const slug1 = uniqueId("org");
-    const slug2 = uniqueId("org");
-
-    // Set up two Clerk orgs BEFORE creating orgs
-    mockClerk({ userId, clerkOrgs: testOrgs(slug1, slug2) });
-    await createTestOrg(slug1);
-    await createTestOrg(slug2);
-
-    mockClerk({
-      userId,
-      orgId: `org_mock_${slug1}`,
-      clerkOrgs: testOrgs(slug1, slug2),
-    });
-
-    // Pass both orgSlug and orgId — orgSlug should win
-    const result = await resolveOrg(
-      authCtx({ userId, orgId: `org_mock_${slug1}` }),
-      slug1,
-      `org_mock_${slug2}`,
-    );
-
-    expect(result.org.orgId).toBe(`org_mock_${slug1}`);
-    expect(result.org.slug).toBe(slug1);
   });
 });

--- a/turbo/apps/web/src/lib/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/org/resolve-org.ts
@@ -1,12 +1,5 @@
-import {
-  forbidden,
-  badRequest,
-  isBadRequest,
-  notFound,
-  isNotFound,
-  isForbidden,
-} from "../errors";
-import { getOrgBySlug, getOrgData } from "./org-cache-service";
+import { forbidden, badRequest, isBadRequest, isNotFound } from "../errors";
+import { getOrgData } from "./org-cache-service";
 import { verifyMembershipCached } from "./org-membership-cache";
 import type { AuthContext } from "../auth/get-auth-context";
 
@@ -110,13 +103,9 @@ async function verifyMembership(
 /**
  * Resolve org from request context using org_cache + org table.
  *
- * Requires explicit org context — either an orgSlug (?org= query param),
- * an explicit orgId, or an AuthContext with active org. Does NOT guess
- * the user's org from cache or Clerk API.
- *
- * Resolution order:
- * 1. orgSlug (?org=<slug> query param) -> org_cache lookup, verify membership
- * 2. orgId (explicit param or AuthContext) -> org_cache lookup, verify membership
+ * Requires explicit org context — either an explicit orgId or an
+ * AuthContext with active org. Does NOT guess the user's org from
+ * cache or Clerk API.
  *
  * Tier is always read from the org table (source of truth).
  *
@@ -124,19 +113,8 @@ async function verifyMembership(
  */
 export async function resolveOrg(
   authCtx: AuthContext,
-  orgSlug?: string | null,
   orgId?: string | null,
 ): Promise<{ org: ResolvedOrg; member: ResolvedMember }> {
-  // 1. Explicit org selection via ?org= query param (highest priority)
-  if (orgSlug) {
-    const orgData = await getOrgBySlug(orgSlug);
-    if (!orgData) throw notFound("Org not found");
-
-    const member = await verifyMembership(orgData, authCtx);
-    return { org: orgData, member };
-  }
-
-  // 2. Explicit orgId — use provided value or auto-detect from AuthContext.
   const effectiveOrgId = orgId ?? authCtx.orgId ?? null;
   if (effectiveOrgId) {
     const orgData = await getOrgData(effectiveOrgId);
@@ -144,9 +122,8 @@ export async function resolveOrg(
     return { org: orgData, member };
   }
 
-  // No explicit org context available — require callers to provide one
   throw badRequest(
-    "Explicit org context required — pass ?org= query parameter or ensure active org in session",
+    "Explicit org context required — ensure active org in session",
   );
 }
 
@@ -159,35 +136,12 @@ export async function resolveOrg(
  */
 export async function resolveOrgOrNull(
   authCtx: AuthContext,
-  orgSlug?: string | null,
 ): Promise<ResolvedOrg | null> {
   try {
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
     return org;
   } catch (error) {
     if (isNotFound(error) || isBadRequest(error)) return null;
-    throw error;
-  }
-}
-
-/**
- * Resolve the caller's org ID from the request's ?org= query parameter.
- *
- * Returns null if the org cannot be resolved (not found, forbidden, or user
- * is not a member). Use this in endpoints that need to compare the caller's
- * org against a resource's org without leaking information about whether the
- * resource exists.
- */
-export async function resolveCallerOrgId(
-  authCtx: AuthContext,
-  request: Request,
-): Promise<string | null> {
-  const orgSlug = new URL(request.url).searchParams.get("org");
-  try {
-    const { org } = await resolveOrg(authCtx, orgSlug);
-    return org.orgId;
-  } catch (error) {
-    if (isNotFound(error) || isForbidden(error)) return null;
     throw error;
   }
 }

--- a/turbo/apps/web/src/lib/schedule/__tests__/notification-control.test.ts
+++ b/turbo/apps/web/src/lib/schedule/__tests__/notification-control.test.ts
@@ -30,13 +30,12 @@ const context = testContext();
  */
 async function createDueSchedule(
   agentId: string,
-  slug: string,
   name: string,
   options: { notifyEmail: boolean; notifySlack: boolean },
 ): Promise<string> {
   // Create schedule via zero API with notification settings
   const createReq = createTestRequest(
-    `http://localhost:3000/api/zero/schedules?org=${slug}`,
+    `http://localhost:3000/api/zero/schedules`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -57,7 +56,7 @@ async function createDueSchedule(
 
   // Enable the schedule
   const enableReq = createTestRequest(
-    `http://localhost:3000/api/zero/schedules/${encodeURIComponent(name)}/enable?org=${slug}`,
+    `http://localhost:3000/api/zero/schedules/${encodeURIComponent(name)}/enable`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -86,7 +85,7 @@ describe("Schedule notification control - per-schedule settings", () => {
     context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
     user = await context.setupUser();
 
-    // Set up org with explicit slug for zero schedule routes
+    // Set up org
     slug = uniqueId("notify");
     mockClerk({ userId: user.userId, orgId: user.orgId, orgRole: "org:admin" });
     await createTestOrg(slug);
@@ -110,7 +109,7 @@ describe("Schedule notification control - per-schedule settings", () => {
   });
 
   it("should register both email and slack callbacks when schedule has both enabled", async () => {
-    const scheduleId = await createDueSchedule(agentId, slug, "both-on", {
+    const scheduleId = await createDueSchedule(agentId, "both-on", {
       notifyEmail: true,
       notifySlack: true,
     });
@@ -132,7 +131,7 @@ describe("Schedule notification control - per-schedule settings", () => {
   });
 
   it("should NOT register email callback when schedule notifyEmail is false", async () => {
-    const scheduleId = await createDueSchedule(agentId, slug, "email-off", {
+    const scheduleId = await createDueSchedule(agentId, "email-off", {
       notifyEmail: false,
       notifySlack: true,
     });
@@ -154,7 +153,7 @@ describe("Schedule notification control - per-schedule settings", () => {
   });
 
   it("should NOT register slack callback when schedule notifySlack is false", async () => {
-    const scheduleId = await createDueSchedule(agentId, slug, "slack-off", {
+    const scheduleId = await createDueSchedule(agentId, "slack-off", {
       notifyEmail: true,
       notifySlack: false,
     });
@@ -176,7 +175,7 @@ describe("Schedule notification control - per-schedule settings", () => {
   });
 
   it("should NOT register any notification callbacks when both are off", async () => {
-    const scheduleId = await createDueSchedule(agentId, slug, "silent", {
+    const scheduleId = await createDueSchedule(agentId, "silent", {
       notifyEmail: false,
       notifySlack: false,
     });
@@ -214,7 +213,7 @@ describe("Schedule notification control - per-schedule settings", () => {
     const agentId2 = await getTestZeroAgentId(user2.orgId, agentName2);
 
     const createReq = createTestRequest(
-      `http://localhost:3000/api/zero/schedules?org=${slug2}`,
+      `http://localhost:3000/api/zero/schedules`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -252,7 +251,7 @@ describe("Schedule notification control - per-schedule settings", () => {
     const agentId2 = await getTestZeroAgentId(user2.orgId, agentName2);
 
     const createReq = createTestRequest(
-      `http://localhost:3000/api/zero/schedules?org=${slug2}`,
+      `http://localhost:3000/api/zero/schedules`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -223,7 +223,6 @@ export const composesMainContract = c.router({
     headers: authHeadersSchema,
     query: z.object({
       name: z.string().min(1, "Missing name query parameter"),
-      org: z.string().optional(),
     }),
     responses: {
       200: composeResponseSchema,
@@ -357,15 +356,13 @@ export const composesListContract = c.router({
   /**
    * GET /api/agent/composes/list?org={org}
    * List all agent composes for an org
-   * If org is not provided, uses the authenticated user's default org
+   * Uses the authenticated user's active org.
    */
   list: {
     method: "GET",
     path: "/api/agent/composes/list",
     headers: authHeadersSchema,
-    query: z.object({
-      org: z.string().optional(),
-    }),
+    query: z.object({}),
     responses: {
       200: z.object({
         composes: z.array(composeListItemSchema),

--- a/turbo/packages/core/src/contracts/logs.ts
+++ b/turbo/packages/core/src/contracts/logs.ts
@@ -135,7 +135,7 @@ export const logsListContract = c.router({
       search: z.string().optional(),
       agent: z.string().optional(),
       name: z.string().optional(),
-      org: z.string().optional(),
+
       status: logStatusSchema.optional(),
       triggerSource: triggerSourceSchema.optional(),
       scheduleId: z.string().uuid().optional(),

--- a/turbo/packages/core/src/contracts/orgs.ts
+++ b/turbo/packages/core/src/contracts/orgs.ts
@@ -56,7 +56,7 @@ export type UpdateOrgRequest = z.infer<typeof updateOrgRequestSchema>;
  */
 export const orgDefaultAgentContract = c.router({
   /**
-   * PUT /api/zero/default-agent?org={slug}
+   * PUT /api/zero/default-agent
    * Set or unset the default agent for an org.
    * Only org admins can perform this action.
    * The agent must belong to the same org.
@@ -65,9 +65,7 @@ export const orgDefaultAgentContract = c.router({
     method: "PUT",
     path: "/api/zero/default-agent",
     headers: authHeadersSchema,
-    query: z.object({
-      org: z.string().optional(),
-    }),
+    query: z.object({}),
     body: z.object({
       agentId: z.uuid().nullable(),
     }),

--- a/turbo/packages/core/src/contracts/zero-composes.ts
+++ b/turbo/packages/core/src/contracts/zero-composes.ts
@@ -16,7 +16,6 @@ export const zeroComposesMainContract = c.router({
     headers: authHeadersSchema,
     query: z.object({
       name: z.string().min(1, "Missing name query parameter"),
-      org: z.string().optional(),
     }),
     responses: {
       200: composeResponseSchema,
@@ -76,9 +75,7 @@ export const zeroComposesListContract = c.router({
     method: "GET",
     path: "/api/zero/composes/list",
     headers: authHeadersSchema,
-    query: z.object({
-      org: z.string().optional(),
-    }),
+    query: z.object({}),
     responses: {
       200: z.object({
         composes: z.array(composeListItemSchema),


### PR DESCRIPTION
## Summary

- Remove the redundant `?org=<slug>` query parameter from all ~74 API routes — org context now comes exclusively from `AuthContext.orgId` (set by Clerk session, CLI token, or sandbox token)
- Simplify `resolveOrg(authCtx, orgSlug?, orgId?)` to `resolveOrg(authCtx, orgId?)` and delete `resolveCallerOrgId()`
- Remove `org` field from 6 ts-rest API contracts and the CLI `org/name` cross-org identifier format
- Remove dead `orgSlug` param from `serverSideCompose()`
- Net deletion of ~650 lines of boilerplate across 136 files

Closes #7257

## Test plan

- [x] `pnpm check-types` — all workspaces pass (7/7)
- [x] `pnpm turbo run lint` — 0 errors, 0 warnings
- [x] `pnpm vitest` — no new test failures (all regressions are pre-existing on main)
- [x] `pnpm knip` — no unused exports or dependencies
- [ ] CI passes (lint, test, deploy, cli-e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)