### PR TITLE
fix(runner): prevent orphaned mitmdump via PR_SET_PDEATHSIG

### DIFF
--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true, features = ["serde", "now"] }
 clap = { workspace = true, features = ["derive", "env"] }
-nix = { workspace = true, features = ["user", "signal", "fs"] }
+nix = { workspace = true, features = ["user", "signal", "fs", "process"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -268,6 +268,17 @@ pub(crate) async fn spawn_mitmdump(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
+    // SAFETY: `set_pdeathsig` calls `prctl(PR_SET_PDEATHSIG)` which is
+    // async-signal-safe. This ensures the kernel sends SIGKILL to the
+    // mitmdump child when the parent runner process dies, preventing
+    // orphaned processes after runner crashes or restarts.
+    unsafe {
+        cmd.pre_exec(|| {
+            nix::sys::prctl::set_pdeathsig(nix::sys::signal::Signal::SIGKILL)
+                .map_err(std::io::Error::from)
+        });
+    }
+
     info!(port, bin = %config.mitmdump_bin.display(), "starting mitmdump");
 
     let mut child = cmd


### PR DESCRIPTION
## Summary
- Set `PR_SET_PDEATHSIG(SIGKILL)` on the mitmdump child process via `pre_exec` hook
- When the parent runner process dies (crash, SIGKILL, panic), the kernel automatically sends SIGKILL to mitmdump
- Prevents orphaned mitmdump processes that accumulate after runner crashes or restarts in transient systemd services

Closes #6948

## Test plan
- [x] All 271 runner tests pass
- [x] Clippy clean, format clean
- [ ] Deploy to dev runner and verify: kill runner → mitmdump dies immediately (no orphan)
- [ ] Verify normal stop path unchanged: `mitm.stop()` SIGTERM still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)