### PR TITLE
fix(guest-agent): use explicit file list for tar to match manifest

### DIFF
--- a/crates/guest-agent/src/artifact.rs
+++ b/crates/guest-agent/src/artifact.rs
@@ -190,7 +190,8 @@ pub async fn create_snapshot(
     let arc_start = std::time::Instant::now();
     let mp = mount_path.to_string();
     let ap = archive_path.clone();
-    let archive_ok = tokio::task::spawn_blocking(move || create_archive(&mp, &ap))
+    let file_paths: Vec<String> = files.iter().map(|f| f.path.clone()).collect();
+    let archive_ok = tokio::task::spawn_blocking(move || create_archive(&mp, &ap, &file_paths))
         .await
         .map_err(|e| AgentError::Execution(format!("archive task panicked: {e}")))?;
     if !archive_ok {
@@ -356,22 +357,47 @@ fn compute_file_hash(path: &Path) -> Result<(String, u64), std::io::Error> {
     Ok((hash, total))
 }
 
-/// Create a tar.gz archive of the directory, excluding `.git` and `.vm0`.
-fn create_archive(dir_path: &str, tar_path: &Path) -> bool {
+/// Create a tar.gz archive containing only the files listed in `file_paths`.
+///
+/// This ensures the archive matches the manifest exactly — no symlinks or other
+/// entries that `walk_dir` skipped will be included.
+fn create_archive(dir_path: &str, tar_path: &Path, file_paths: &[String]) -> bool {
+    if file_paths.is_empty() {
+        // Create empty archive for empty artifacts
+        let output = std::process::Command::new("tar")
+            .args(["-czf", &tar_path.to_string_lossy(), "-T", "/dev/null"])
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .status();
+        return matches!(output, Ok(status) if status.success());
+    }
+
+    // Write NUL-separated file list for tar -T --null (handles filenames with newlines)
+    let list_path = tar_path.with_extension("filelist");
+    let list_content = file_paths.join("\0");
+    if let Err(e) = std::fs::write(&list_path, &list_content) {
+        log_error!(LOG_TAG, "Failed to write file list: {e}");
+        return false;
+    }
+
     let output = std::process::Command::new("tar")
         .args([
             "--hard-dereference",
+            "--null",
             "-czf",
             &tar_path.to_string_lossy(),
-            "--exclude=.git",
-            "--exclude=.vm0",
             "-C",
             dir_path,
-            ".",
+            "-T",
+            &list_path.to_string_lossy(),
         ])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .status();
+
+    // Clean up file list
+    let _ = std::fs::remove_file(&list_path);
+
     match output {
         Ok(status) if status.success() => true,
         Ok(status) => {
@@ -449,5 +475,62 @@ mod tests {
         let hardlink = files.iter().find(|f| f.path == "hardlink.txt").unwrap();
         assert_eq!(original.hash, hardlink.hash);
         assert_eq!(original.size, hardlink.size);
+    }
+
+    #[test]
+    fn archive_excludes_symlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // Regular files
+        std::fs::write(root.join("real.txt"), "hello").unwrap();
+        std::fs::create_dir(root.join("subdir")).unwrap();
+        std::fs::write(root.join("subdir/inner.txt"), "inner").unwrap();
+
+        // Symlinks (should NOT end up in the archive)
+        unix_fs::symlink(root.join("real.txt"), root.join("link.txt")).unwrap();
+        unix_fs::symlink("/nonexistent", root.join("dangling")).unwrap();
+
+        // Collect metadata (skips symlinks)
+        let files = collect_file_metadata(root.to_str().unwrap());
+        let file_paths: Vec<String> = files.iter().map(|f| f.path.clone()).collect();
+
+        // Create archive using only manifest file list
+        let tar_path = dir.path().join("archive.tar.gz");
+        assert!(create_archive(
+            root.to_str().unwrap(),
+            &tar_path,
+            &file_paths
+        ));
+
+        // Extract and verify archive contents match manifest exactly
+        let extract_dir = dir.path().join("extracted");
+        std::fs::create_dir(&extract_dir).unwrap();
+        let status = std::process::Command::new("tar")
+            .args([
+                "-xzf",
+                tar_path.to_str().unwrap(),
+                "-C",
+                extract_dir.to_str().unwrap(),
+            ])
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        // Manifest files should exist
+        assert!(extract_dir.join("real.txt").exists());
+        assert!(extract_dir.join("subdir/inner.txt").exists());
+
+        // Symlinks should NOT exist in the archive
+        assert!(!extract_dir.join("link.txt").exists());
+        assert!(!extract_dir.join("dangling").exists());
+    }
+
+    #[test]
+    fn archive_empty_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let tar_path = dir.path().join("empty.tar.gz");
+        assert!(create_archive("/tmp", &tar_path, &[]));
+        assert!(tar_path.exists());
     }
 }

--- a/crates/guest-agent/src/artifact.rs
+++ b/crates/guest-agent/src/artifact.rs
@@ -374,7 +374,8 @@ fn create_archive(dir_path: &str, tar_path: &Path, file_paths: &[String]) -> boo
 
     // Write NUL-separated file list for tar -T --null (handles filenames with newlines)
     let list_path = tar_path.with_extension("filelist");
-    let list_content = file_paths.join("\0");
+    let mut list_content = file_paths.join("\0");
+    list_content.push('\0'); // trailing NUL for strict NUL-termination
     if let Err(e) = std::fs::write(&list_path, &list_content) {
         log_error!(LOG_TAG, "Failed to write file list: {e}");
         return false;
@@ -524,6 +525,49 @@ mod tests {
         // Symlinks should NOT exist in the archive
         assert!(!extract_dir.join("link.txt").exists());
         assert!(!extract_dir.join("dangling").exists());
+    }
+
+    #[test]
+    fn archive_handles_special_filenames() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        // Files with spaces and special characters
+        std::fs::write(root.join("file with spaces.txt"), "spaces").unwrap();
+        std::fs::create_dir(root.join("dir with spaces")).unwrap();
+        std::fs::write(root.join("dir with spaces/inner.txt"), "inner").unwrap();
+        std::fs::write(root.join("file-with-dashes.txt"), "dashes").unwrap();
+        // File with newline in name
+        std::fs::write(root.join("line1\nline2.txt"), "newline").unwrap();
+
+        let files = collect_file_metadata(root.to_str().unwrap());
+        let file_paths: Vec<String> = files.iter().map(|f| f.path.clone()).collect();
+
+        let tar_path = dir.path().join("archive.tar.gz");
+        assert!(create_archive(
+            root.to_str().unwrap(),
+            &tar_path,
+            &file_paths
+        ));
+
+        // Extract and verify
+        let extract_dir = dir.path().join("extracted");
+        std::fs::create_dir(&extract_dir).unwrap();
+        let status = std::process::Command::new("tar")
+            .args([
+                "-xzf",
+                tar_path.to_str().unwrap(),
+                "-C",
+                extract_dir.to_str().unwrap(),
+            ])
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        assert!(extract_dir.join("file with spaces.txt").exists());
+        assert!(extract_dir.join("dir with spaces/inner.txt").exists());
+        assert!(extract_dir.join("file-with-dashes.txt").exists());
+        assert!(extract_dir.join("line1\nline2.txt").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `create_archive` previously ran `tar ... .` which archived the entire directory including symlinks that `walk_dir` intentionally skips, causing manifest/archive divergence
- Now passes the manifest file list to `tar -T --null`, ensuring the archive contains exactly what the manifest describes
- Added tests for archive-symlink exclusion and empty archive handling

## Related

Closes #7308
Parent issue: #3934

## Test plan

- [x] `cargo test -p guest-agent -- artifact` — 4 tests pass (including 2 new)
- [ ] CI crates build + test

🤖 Generated with [Claude Code](https://claude.com/claude-code)