### PR TITLE
feat(firewalls): add rule matching utility for permission identification

### DIFF
--- a/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import {
+  matchFirewallPath,
+  findMatchingPermissions,
+} from "../firewall-rule-matcher";
+import type { FirewallConfig } from "../firewalls";
+
+describe("matchFirewallPath", () => {
+  it("matches exact literal path", () => {
+    expect(matchFirewallPath("/api/v1/users", "/api/v1/users")).toEqual({});
+  });
+
+  it("matches single segment params", () => {
+    expect(
+      matchFirewallPath(
+        "/repos/myorg/myrepo/pulls",
+        "/repos/{owner}/{repo}/pulls",
+      ),
+    ).toEqual({ owner: "myorg", repo: "myrepo" });
+  });
+
+  it("matches greedy + (one or more)", () => {
+    expect(
+      matchFirewallPath(
+        "/repos/a/b/git/ref/heads/main",
+        "/repos/{owner}/{repo}/git/{rest+}",
+      ),
+    ).toEqual({ owner: "a", repo: "b", rest: "ref/heads/main" });
+  });
+
+  it("fails greedy + when no segments remain", () => {
+    expect(
+      matchFirewallPath("/repos/a/b/git", "/repos/{owner}/{repo}/git/{rest+}"),
+    ).toBeNull();
+  });
+
+  it("matches greedy * (zero or more) with segments", () => {
+    expect(matchFirewallPath("/anything/here", "/{path*}")).toEqual({
+      path: "anything/here",
+    });
+  });
+
+  it("matches greedy * with zero segments", () => {
+    expect(matchFirewallPath("/", "/{path*}")).toEqual({ path: "" });
+  });
+
+  it("returns null on literal mismatch", () => {
+    expect(matchFirewallPath("/api/v2/users", "/api/v1/users")).toBeNull();
+  });
+
+  it("returns null when path is too short", () => {
+    expect(
+      matchFirewallPath("/repos/myorg", "/repos/{owner}/{repo}/pulls"),
+    ).toBeNull();
+  });
+
+  it("returns null when path is too long (no greedy)", () => {
+    expect(
+      matchFirewallPath(
+        "/repos/myorg/myrepo/pulls/123",
+        "/repos/{owner}/{repo}/pulls",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null on empty path vs non-empty pattern", () => {
+    expect(matchFirewallPath("/", "/api/v1")).toBeNull();
+  });
+
+  it("handles paths with trailing slashes", () => {
+    expect(matchFirewallPath("/api/v1/users/", "/api/v1/users")).toEqual({});
+  });
+
+  it("handles multiple params in a row", () => {
+    expect(
+      matchFirewallPath(
+        "/orgs/acme/insights/api/route-stats/user/42",
+        "/orgs/{org}/insights/api/route-stats/{actor_type}/{actor_id}",
+      ),
+    ).toEqual({ org: "acme", actor_type: "user", actor_id: "42" });
+  });
+});
+
+describe("findMatchingPermissions", () => {
+  const config: FirewallConfig = {
+    name: "test-firewall",
+    apis: [
+      {
+        base: "https://api.example.com",
+        auth: { headers: { Authorization: "Bearer token" } },
+        permissions: [
+          {
+            name: "repos:read",
+            rules: [
+              "GET /repos/{owner}/{repo}",
+              "GET /repos/{owner}/{repo}/pulls",
+            ],
+          },
+          {
+            name: "repos:write",
+            rules: ["POST /repos/{owner}/{repo}/pulls"],
+          },
+          {
+            name: "issues:read",
+            rules: ["GET /repos/{owner}/{repo}/issues"],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("finds matching permission for GET request", () => {
+    expect(
+      findMatchingPermissions("GET", "/repos/myorg/myrepo/pulls", config),
+    ).toEqual(["repos:read"]);
+  });
+
+  it("finds matching permission for POST request", () => {
+    expect(
+      findMatchingPermissions("POST", "/repos/myorg/myrepo/pulls", config),
+    ).toEqual(["repos:write"]);
+  });
+
+  it("returns empty array when method does not match", () => {
+    expect(
+      findMatchingPermissions("DELETE", "/repos/myorg/myrepo/pulls", config),
+    ).toEqual([]);
+  });
+
+  it("returns empty array when path does not match", () => {
+    expect(
+      findMatchingPermissions("GET", "/repos/myorg/myrepo/comments", config),
+    ).toEqual([]);
+  });
+
+  it("handles case-insensitive method matching", () => {
+    expect(
+      findMatchingPermissions("get", "/repos/myorg/myrepo/pulls", config),
+    ).toEqual(["repos:read"]);
+  });
+
+  it("matches ANY method rule", () => {
+    const anyConfig: FirewallConfig = {
+      name: "any-test",
+      apis: [
+        {
+          base: "https://example.com",
+          auth: { headers: {} },
+          permissions: [{ name: "full-access", rules: ["ANY /{path*}"] }],
+        },
+      ],
+    };
+    expect(findMatchingPermissions("GET", "/anything/here", anyConfig)).toEqual(
+      ["full-access"],
+    );
+    expect(findMatchingPermissions("POST", "/other", anyConfig)).toEqual([
+      "full-access",
+    ]);
+  });
+
+  it("returns multiple permissions when rules overlap", () => {
+    const overlapConfig: FirewallConfig = {
+      name: "overlap",
+      apis: [
+        {
+          base: "https://example.com",
+          auth: { headers: {} },
+          permissions: [
+            { name: "specific", rules: ["GET /api/users"] },
+            { name: "catchall", rules: ["ANY /{path*}"] },
+          ],
+        },
+      ],
+    };
+    expect(findMatchingPermissions("GET", "/api/users", overlapConfig)).toEqual(
+      ["specific", "catchall"],
+    );
+  });
+
+  it("returns empty array for config with no permissions", () => {
+    const emptyConfig: FirewallConfig = {
+      name: "empty",
+      apis: [
+        {
+          base: "https://example.com",
+          auth: { headers: {} },
+        },
+      ],
+    };
+    expect(findMatchingPermissions("GET", "/anything", emptyConfig)).toEqual(
+      [],
+    );
+  });
+
+  it("deduplicates permissions across multiple api entries", () => {
+    const multiApi: FirewallConfig = {
+      name: "multi",
+      apis: [
+        {
+          base: "https://api1.example.com",
+          auth: { headers: {} },
+          permissions: [{ name: "shared-perm", rules: ["GET /data"] }],
+        },
+        {
+          base: "https://api2.example.com",
+          auth: { headers: {} },
+          permissions: [{ name: "shared-perm", rules: ["GET /data"] }],
+        },
+      ],
+    };
+    expect(findMatchingPermissions("GET", "/data", multiApi)).toEqual([
+      "shared-perm",
+    ]);
+  });
+});

--- a/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
+++ b/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
@@ -1,0 +1,96 @@
+import type { FirewallConfig } from "./firewalls";
+
+/**
+ * Parameter segment pattern: `{name}`, `{name+}`, or `{name*}`.
+ */
+const PARAM_SEG = /^\{([^}]+)\}$/;
+
+/**
+ * Match a URL path against a rule path pattern.
+ *
+ * Ported from the Python MITM addon's `match_path()` function
+ * (crates/runner/mitm-addon/src/mitm_addon.py).
+ *
+ * - Literal segments must match exactly (case-sensitive).
+ * - `{name}` matches a single non-empty path segment.
+ * - `{name+}` matches the rest of the path (one or more segments). Must be last.
+ * - `{name*}` matches the rest of the path (zero or more segments). Must be last.
+ *
+ * Returns extracted parameters on match, or null on mismatch.
+ */
+export function matchFirewallPath(
+  path: string,
+  pattern: string,
+): Record<string, string> | null {
+  const pathSegs = path.split("/").filter(Boolean);
+  const patternSegs = pattern.split("/").filter(Boolean);
+
+  const params: Record<string, string> = {};
+  let pi = 0;
+
+  for (const seg of patternSegs) {
+    const m = PARAM_SEG.exec(seg);
+    if (m) {
+      const name = m[1]!;
+      if (name.endsWith("+")) {
+        // Greedy: consume rest (1+)
+        if (pi >= pathSegs.length) return null;
+        params[name.slice(0, -1)] = pathSegs.slice(pi).join("/");
+        return params;
+      }
+      if (name.endsWith("*")) {
+        // Greedy: consume rest (0+)
+        params[name.slice(0, -1)] = pathSegs.slice(pi).join("/");
+        return params;
+      }
+      // Single segment
+      if (pi >= pathSegs.length) return null;
+      params[name] = pathSegs[pi]!;
+      pi++;
+    } else {
+      // Literal
+      if (pi >= pathSegs.length || pathSegs[pi] !== seg) return null;
+      pi++;
+    }
+  }
+
+  // All pattern segments consumed; path must also be fully consumed
+  if (pi !== pathSegs.length) return null;
+  return params;
+}
+
+/**
+ * Find all permission names from a firewall config whose rules match
+ * the given HTTP method and relative path.
+ *
+ * Method matching is case-insensitive. The special method `ANY` matches
+ * any HTTP method.
+ */
+export function findMatchingPermissions(
+  method: string,
+  path: string,
+  config: FirewallConfig,
+): string[] {
+  const upperMethod = method.toUpperCase();
+  const matched = new Set<string>();
+
+  for (const api of config.apis) {
+    if (!api.permissions) continue;
+    for (const perm of api.permissions) {
+      if (matched.has(perm.name)) continue;
+      for (const rule of perm.rules) {
+        const spaceIdx = rule.indexOf(" ");
+        if (spaceIdx === -1) continue;
+        const ruleMethod = rule.slice(0, spaceIdx).toUpperCase();
+        const rulePath = rule.slice(spaceIdx + 1);
+        if (ruleMethod !== "ANY" && ruleMethod !== upperMethod) continue;
+        if (matchFirewallPath(path, rulePath) !== null) {
+          matched.add(perm.name);
+          break;
+        }
+      }
+    }
+  }
+
+  return [...matched];
+}

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -418,6 +418,11 @@ export {
 } from "./firewall-expander";
 
 export {
+  matchFirewallPath,
+  findMatchingPermissions,
+} from "./firewall-rule-matcher";
+
+export {
   userPreferencesResponseSchema,
   updateUserPreferencesRequestSchema,
   type UserPreferencesResponse,


### PR DESCRIPTION
## Summary

- Port Python MITM addon's `match_path()` to TypeScript as `matchFirewallPath()` in `@vm0/core`
- Add `findMatchingPermissions()` to identify which named permissions cover a denied `METHOD /path` request
- Supports `{param}`, `{param+}` (greedy 1+), `{param*}` (greedy 0+) path patterns

## Context

Part of #7312 (firewall deny doctor). This utility enables the CLI `zero doctor firewall-deny` command to tell users exactly which permission to enable when a firewall blocks a request.

Closes #7313

## Test plan

- [x] 13 tests for `matchFirewallPath` (literals, params, greedy +/*, edge cases)
- [x] 8 tests for `findMatchingPermissions` (method matching, ANY, overlaps, dedup, empty)
- [x] Lint, type check, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)