### PR TITLE
feat: add custom skills binding to agent create and edit flow

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -73,6 +73,33 @@ describe("zero agent create command", () => {
       expect(logCalls).toContain("github");
     });
 
+    it("should create agent with custom skills and include them in request body", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/agents",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(mockAgent, { status: 201 });
+          },
+        ),
+      );
+
+      await createCommand.parseAsync([
+        "node",
+        "cli",
+        "--skills",
+        "my-skill,other-skill",
+        "--display-name",
+        "New Agent",
+      ]);
+
+      expect(capturedBody?.customSkills).toEqual(["my-skill", "other-skill"]);
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("my-skill");
+      expect(logCalls).toContain("other-skill");
+    });
+
     describe("with instructions file", () => {
       let instructionsPath: string;
 

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/edit.test.ts
@@ -73,6 +73,34 @@ describe("zero agent edit command", () => {
       expect(logCalls).toContain("updated");
     });
 
+    it("should update custom skills and include them in request body", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.put(
+          "http://localhost:3000/api/zero/agents/my-agent",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(mockAgent);
+          },
+        ),
+      );
+
+      await editCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--skills",
+        "my-skill, other-skill",
+      ]);
+
+      expect(capturedBody?.customSkills).toEqual(["my-skill", "other-skill"]);
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("updated");
+    });
+
     describe("with instructions file", () => {
       let instructionsPath: string;
 

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -15,6 +15,10 @@ export const createCommand = new Command()
     "--connectors <items>",
     "Comma-separated connector types to enable for this agent (e.g. github,linear)",
   )
+  .option(
+    "--skills <items>",
+    "Comma-separated custom skill names to attach (e.g. my-skill,other-skill)",
+  )
   .option("--display-name <name>", "Agent display name")
   .option("--description <text>", "Agent description")
   .option(
@@ -28,21 +32,28 @@ export const createCommand = new Command()
 Examples:
   Minimal:               zero agent create --display-name "My Agent"
   With connectors:       zero agent create --connectors github,linear --display-name "My Agent"
+  With skills:           zero agent create --skills my-skill,other-skill --display-name "My Agent"
   With instructions:     zero agent create --connectors github --instructions-file ./instructions.md`,
   )
   .action(
     withErrorHandler(
       async (options: {
         connectors?: string;
+        skills?: string;
         displayName?: string;
         description?: string;
         sound?: string;
         instructionsFile?: string;
       }) => {
+        const customSkills = options.skills
+          ? options.skills.split(",").map((s) => s.trim())
+          : undefined;
+
         const agent = await createZeroAgent({
           displayName: options.displayName,
           description: options.description,
           sound: options.sound,
+          customSkills,
         });
 
         if (options.connectors) {
@@ -59,6 +70,9 @@ Examples:
         console.log(`  Agent ID:     ${agent.agentId}`);
         if (options.connectors) {
           console.log(`  Connectors:   ${options.connectors}`);
+        }
+        if (customSkills?.length) {
+          console.log(`  Skills:       ${customSkills.join(", ")}`);
         }
         if (agent.displayName) {
           console.log(`  Display Name: ${agent.displayName}`);

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -18,6 +18,10 @@ export const editCommand = new Command()
     "--sound <tone>",
     "New tone: professional, friendly, direct, supportive",
   )
+  .option(
+    "--skills <items>",
+    "Comma-separated custom skill names to attach (replaces existing)",
+  )
   .option("--instructions-file <path>", "Path to new instructions file")
   .addHelpText(
     "after",
@@ -25,6 +29,7 @@ export const editCommand = new Command()
 Examples:
   Update description:      zero agent edit <agent-id> --description "new role"
   Update tone:             zero agent edit <agent-id> --sound friendly
+  Update skills:           zero agent edit <agent-id> --skills my-skill,other-skill
   Update instructions:     zero agent edit <agent-id> --instructions-file ./instructions.md
   Update yourself:         zero agent edit $ZERO_AGENT_ID --description "new role"
 
@@ -40,22 +45,28 @@ Notes:
           displayName?: string;
           description?: string;
           sound?: string;
+          skills?: string;
           instructionsFile?: string;
         },
       ) => {
         const hasAgentUpdate =
           options.displayName !== undefined ||
           options.description !== undefined ||
-          options.sound !== undefined;
+          options.sound !== undefined ||
+          options.skills !== undefined;
 
         if (!hasAgentUpdate && !options.instructionsFile) {
           throw new Error(
-            "At least one option is required (--display-name, --description, --sound, --instructions-file)",
+            "At least one option is required (--display-name, --description, --sound, --skills, --instructions-file)",
           );
         }
 
         if (hasAgentUpdate) {
           const current = await getZeroAgent(agentId);
+
+          const customSkills = options.skills
+            ? options.skills.split(",").map((s) => s.trim())
+            : undefined;
 
           await updateZeroAgent(agentId, {
             displayName:
@@ -70,6 +81,7 @@ Notes:
               options.sound !== undefined
                 ? options.sound
                 : (current.sound ?? undefined),
+            customSkills,
           });
         }
 

--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -125,10 +125,13 @@ const router = tsr.router(zeroAgentsByIdContract, {
     );
     if (forbidden) return forbidden;
 
+    // Use provided customSkills if present, otherwise keep existing
+    const customSkills = body.customSkills ?? existing.customSkills ?? [];
+
     // Build compose content (all connector skills included, plus custom skills)
     const content = buildComposeContent(
       existing.name,
-      (existing.customSkills ?? []).map((name) => ({ name })),
+      customSkills.map((name) => ({ name })),
     );
 
     // Run synchronous compose
@@ -164,6 +167,7 @@ const router = tsr.router(zeroAgentsByIdContract, {
         description: body.description ?? null,
         sound: body.sound ?? null,
         avatarUrl: body.avatarUrl ?? null,
+        customSkills,
       })
       .onConflictDoUpdate({
         target: [zeroAgents.orgId, zeroAgents.name],
@@ -178,6 +182,9 @@ const router = tsr.router(zeroAgentsByIdContract, {
           ...(body.sound !== undefined && { sound: body.sound }),
           ...(body.avatarUrl !== undefined && {
             avatarUrl: body.avatarUrl,
+          }),
+          ...(body.customSkills !== undefined && {
+            customSkills: body.customSkills,
           }),
         },
       });

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -240,6 +240,32 @@ describe("Zero Agents API", () => {
       expect(agentEnv.GITHUB_TOKEN).toBe("${{ secrets.GITHUB_TOKEN }}");
     });
 
+    it("should create an agent with custom skills and include them in response and compose", async () => {
+      const response = await postAgent(
+        { customSkills: ["my-skill", "data-tool"] },
+        testCliToken,
+        testOrgSlug,
+      );
+
+      expect(response.status).toBe(201);
+      const data = await response.json();
+      expect(data.customSkills).toEqual(["my-skill", "data-tool"]);
+
+      // Verify compose content includes custom skill volumes
+      const content = await getTestComposeVersionContent(data.agentId);
+      const volumes = content?.volumes as
+        | Record<string, { name: string; version: string }>
+        | undefined;
+      expect(volumes?.["custom-skill-my-skill"]).toEqual({
+        name: "custom-skill@my-skill",
+        version: "latest",
+      });
+      expect(volumes?.["custom-skill-data-tool"]).toEqual({
+        name: "custom-skill@data-tool",
+        version: "latest",
+      });
+    });
+
     it("should return 422 when skills are not cached", async () => {
       await clearSkillsData();
 
@@ -386,6 +412,60 @@ describe("Zero Agents API", () => {
       expect(agentEnv.GITHUB_TOKEN).toBe("${{ secrets.GITHUB_TOKEN }}");
       expect(agentEnv.ZERO_AGENT_ID).toBe("${{ vars.ZERO_AGENT_ID }}");
       expect(agentEnv.ZERO_TOKEN).toBe("${{ secrets.ZERO_TOKEN }}");
+    });
+
+    it("should update custom skills and reflect in compose volumes", async () => {
+      const created = await (
+        await postAgent({}, testCliToken, testOrgSlug)
+      ).json();
+
+      const response = await putAgent(
+        created.agentId,
+        { customSkills: ["my-skill", "data-tool"] },
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(200);
+
+      // Verify skills are persisted
+      const getRes = await getAgent(created.agentId, testCliToken, testOrgSlug);
+      const fetched = await getRes.json();
+      expect(fetched.customSkills).toEqual(["my-skill", "data-tool"]);
+
+      // Verify compose content includes custom skill volumes
+      const content = await getTestComposeVersionContent(created.agentId);
+      const volumes = content?.volumes as
+        | Record<string, { name: string; version: string }>
+        | undefined;
+      expect(volumes?.["custom-skill-my-skill"]).toEqual({
+        name: "custom-skill@my-skill",
+        version: "latest",
+      });
+    });
+
+    it("should preserve existing custom skills when not provided in update", async () => {
+      // Create with custom skills
+      const created = await (
+        await postAgent(
+          { customSkills: ["my-skill"] },
+          testCliToken,
+          testOrgSlug,
+        )
+      ).json();
+
+      // Update without customSkills field
+      const response = await putAgent(
+        created.agentId,
+        { displayName: "Updated" },
+        testCliToken,
+        testOrgSlug,
+      );
+      expect(response.status).toBe(200);
+
+      // Verify skills are preserved
+      const getRes = await getAgent(created.agentId, testCliToken, testOrgSlug);
+      const fetched = await getRes.json();
+      expect(fetched.customSkills).toEqual(["my-skill"]);
     });
 
     it("should return 404 for unknown agent", async () => {

--- a/turbo/apps/web/app/api/zero/agents/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/route.ts
@@ -34,8 +34,13 @@ const router = tsr.router(zeroAgentsMainContract, {
     // Generate UUID agent name
     const agentName = crypto.randomUUID();
 
+    const customSkills = body.customSkills ?? [];
+
     // Build compose content (always includes all connector skills)
-    const content = buildComposeContent(agentName);
+    const content = buildComposeContent(
+      agentName,
+      customSkills.map((name) => ({ name })),
+    );
 
     // Run synchronous compose (pass empty instructions so the
     // agent-instructions storage record is created — without it,
@@ -72,6 +77,7 @@ const router = tsr.router(zeroAgentsMainContract, {
         description: body.description ?? null,
         sound: body.sound ?? null,
         avatarUrl: body.avatarUrl ?? null,
+        customSkills,
       })
       .onConflictDoUpdate({
         target: [zeroAgents.orgId, zeroAgents.name],
@@ -80,6 +86,7 @@ const router = tsr.router(zeroAgentsMainContract, {
           description: body.description ?? null,
           sound: body.sound ?? null,
           avatarUrl: body.avatarUrl ?? null,
+          customSkills,
           updatedAt: new Date(),
         },
       });
@@ -95,7 +102,7 @@ const router = tsr.router(zeroAgentsMainContract, {
         sound: body.sound ?? null,
         avatarUrl: body.avatarUrl ?? null,
         firewallPolicies: null,
-        customSkills: [],
+        customSkills,
       },
     };
   },

--- a/turbo/packages/core/src/contracts/zero-agents.ts
+++ b/turbo/packages/core/src/contracts/zero-agents.ts
@@ -26,6 +26,7 @@ export const zeroAgentRequestSchema = z.object({
   displayName: z.string().optional(),
   sound: z.string().optional(),
   avatarUrl: z.string().optional(),
+  customSkills: z.array(z.string()).optional(),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/zero-agents.ts
+++ b/turbo/packages/core/src/contracts/zero-agents.ts
@@ -6,6 +6,17 @@ import { firewallPoliciesSchema } from "./firewalls";
 const c = initContract();
 
 /**
+ * Custom skill name validation regex.
+ * Must be lowercase alphanumeric with hyphens, no leading/trailing hyphens.
+ * Minimum 2 characters.
+ */
+export const zeroAgentCustomSkillNameSchema = z
+  .string()
+  .min(2)
+  .max(64)
+  .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
+
+/**
  * Zero agent response schema
  */
 export const zeroAgentResponseSchema = z.object({
@@ -26,7 +37,7 @@ export const zeroAgentRequestSchema = z.object({
   displayName: z.string().optional(),
   sound: z.string().optional(),
   avatarUrl: z.string().optional(),
-  customSkills: z.array(z.string()).optional(),
+  customSkills: z.array(zeroAgentCustomSkillNameSchema).optional(),
 });
 
 /**
@@ -210,17 +221,6 @@ export const zeroAgentInstructionsContract = c.router({
     summary: "Update zero agent instructions",
   },
 });
-
-/**
- * Custom skill name validation regex.
- * Must be lowercase alphanumeric with hyphens, no leading/trailing hyphens.
- * Minimum 2 characters.
- */
-export const zeroAgentCustomSkillNameSchema = z
-  .string()
-  .min(2)
-  .max(64)
-  .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$/);
 
 /**
  * Custom skill metadata schema


### PR DESCRIPTION
## Summary
- Add `customSkills` field to `zeroAgentRequestSchema` in core contracts
- Wire `customSkills` through POST `/api/zero/agents` (create) and PUT `/api/zero/agents/:id` (update) — persists to DB and rebuilds compose content
- Add `--skills <items>` CLI option to `zero agent create` and `zero agent edit`

Closes #7188

## Test plan
- [x] All 868 CLI tests pass
- [x] Lint clean across web, cli, core
- [x] Knip finds no unused exports
- [ ] CI pipeline (build + test + deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)