### PR TITLE
refactor(platform): extract per-thread chat draft state

### DIFF
--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -120,7 +120,10 @@
       }
     },
     {
-      "files": ["src/signals/zero-page/zero-chat.ts"],
+      "files": [
+        "src/signals/zero-page/zero-chat.ts",
+        "src/signals/zero-page/chat-draft.ts"
+      ],
       "rules": {
         "no-restricted-imports": [
           "deny",

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -1,0 +1,287 @@
+import { command, computed, state, type Command, type Computed } from "ccstate";
+import { throwIfAbort, resetSignal, createDeferredPromise } from "../utils.ts";
+import { logger } from "../log.ts";
+import { chatThreadId$ } from "./zero-nav.ts";
+import { fetch$ } from "../fetch.ts";
+
+const L = logger("ChatDraft");
+
+// ---------------------------------------------------------------------------
+// Attachment types (moved from zero-chat.ts)
+// ---------------------------------------------------------------------------
+
+interface FileInfo {
+  id: string;
+  url: string;
+}
+
+export interface ZeroChatAttachment {
+  filename: string;
+  contentType: string;
+  size: number;
+  /** Reactive file info (id + url) — loading while uploading, hasData when done. */
+  fileInfo$: Computed<Promise<FileInfo | null>>;
+  /** Cancel the in-flight upload. Always safe to call (no-op if already completed). */
+  cancel$: Command<void, []>;
+  /** Start the upload. Accepts an external signal for cascade abort (e.g. page navigation). */
+  upload$: Command<Promise<void>, [AbortSignal]>;
+}
+
+function createChatAttachment(file: File): ZeroChatAttachment {
+  const resetSignal$ = resetSignal();
+  const internalPromise$ = state<Promise<FileInfo> | null>(null);
+
+  const fileInfo$ = computed(async (get) => {
+    const promise = get(internalPromise$);
+    if (promise === null) {
+      return null;
+    }
+    return await promise;
+  });
+
+  const cancel$ = command(({ set }) => {
+    set(resetSignal$);
+  });
+
+  const upload$ = command(async ({ get, set }, signal: AbortSignal) => {
+    const fetchFn = get(fetch$);
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const uploadSignal = set(resetSignal$, signal);
+    const deferred = createDeferredPromise<FileInfo>(uploadSignal);
+    set(internalPromise$, deferred.promise);
+
+    const res = await fetchFn("/api/zero/uploads", {
+      method: "POST",
+      body: formData,
+      signal: uploadSignal,
+    });
+    signal.throwIfAborted();
+
+    if (!res.ok) {
+      const err = (await res.json().catch(() => null)) as {
+        error?: { message?: string };
+      } | null;
+      throw new Error(
+        err?.error?.message ?? `Upload failed: ${res.statusText}`,
+      );
+    }
+
+    const data = (await res.json()) as {
+      id: string;
+      filename: string;
+      contentType: string;
+      size: number;
+      url: string;
+    };
+
+    deferred.resolve({ id: data.id, url: data.url });
+  });
+
+  return {
+    filename: file.name,
+    contentType: file.type,
+    size: file.size,
+    fileInfo$,
+    cancel$,
+    upload$,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DraftSignals — encapsulates per-thread composer state
+// ---------------------------------------------------------------------------
+
+interface DraftSignals {
+  input$: Computed<string>;
+  setInput$: Command<void, [string]>;
+  attachments$: Computed<ZeroChatAttachment[]>;
+  uploadAttachment$: Command<Promise<void>, [File, AbortSignal]>;
+  removeAttachment$: Command<void, [ZeroChatAttachment]>;
+  selectedModel$: Computed<string>;
+  setSelectedModel$: Command<void, [string]>;
+  dragOver$: Computed<boolean>;
+  setDragOver$: Command<void, [boolean]>;
+  /** Reset all draft state (input, attachments, model). Called after send. */
+  clear$: Command<void, []>;
+}
+
+function createDraftSignals(): DraftSignals {
+  const internalInput$ = state("");
+  const internalAttachments$ = state<ZeroChatAttachment[]>([]);
+  const internalSelectedModel$ = state("default");
+  const internalDragOver$ = state(false);
+
+  const input$ = computed((get) => get(internalInput$));
+  const setInput$ = command(({ set }, value: string) => {
+    set(internalInput$, value);
+  });
+
+  const attachments$ = computed((get) => get(internalAttachments$));
+
+  const uploadAttachment$ = command(
+    async ({ set }, file: File, signal: AbortSignal) => {
+      const attachment = createChatAttachment(file);
+      set(internalAttachments$, (prev) => [...prev, attachment]);
+
+      try {
+        await set(attachment.upload$, signal);
+      } catch (error) {
+        throwIfAbort(error);
+        L.error("Upload failed:", error);
+        set(attachment.cancel$);
+        set(internalAttachments$, (prev) =>
+          prev.filter((a) => a !== attachment),
+        );
+      }
+    },
+  );
+
+  const removeAttachment$ = command(
+    ({ set }, attachment: ZeroChatAttachment) => {
+      set(attachment.cancel$);
+      set(internalAttachments$, (prev) => prev.filter((a) => a !== attachment));
+    },
+  );
+
+  const selectedModel$ = computed((get) => get(internalSelectedModel$));
+  const setSelectedModel$ = command(({ set }, value: string) => {
+    set(internalSelectedModel$, value);
+  });
+
+  const dragOver$ = computed((get) => get(internalDragOver$));
+  const setDragOver$ = command(({ set }, value: boolean) => {
+    set(internalDragOver$, value);
+  });
+
+  const clear$ = command(({ get, set }) => {
+    set(internalInput$, "");
+    // Cancel all pending uploads before clearing
+    for (const attachment of get(internalAttachments$)) {
+      set(attachment.cancel$);
+    }
+    set(internalAttachments$, []);
+    set(internalSelectedModel$, "default");
+    set(internalDragOver$, false);
+  });
+
+  return {
+    input$,
+    setInput$,
+    attachments$,
+    uploadAttachment$,
+    removeAttachment$,
+    selectedModel$,
+    setSelectedModel$,
+    dragOver$,
+    setDragOver$,
+    clear$,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Draft storage — per-thread map + talk-page singleton
+// ---------------------------------------------------------------------------
+
+const internalDraftMap$ = state<Record<string, DraftSignals>>({});
+
+const internalTalkDraft$ = state(createDraftSignals());
+
+export const talkDraft$ = computed((get) => get(internalTalkDraft$));
+
+export const ensureDraft$ = command(
+  ({ get, set }, threadId: string): DraftSignals => {
+    const map = get(internalDraftMap$);
+    const existing = map[threadId];
+    if (existing) {
+      return existing;
+    }
+    const draft = createDraftSignals();
+    set(internalDraftMap$, { ...map, [threadId]: draft });
+    return draft;
+  },
+);
+
+/**
+ * The current draft for the active route.
+ * Returns `talkDraft$` when there is no chatThreadId (talk page / landing),
+ * or the thread's draft from the map (null if `ensureDraft$` hasn't been called yet).
+ */
+export const currentDraft$ = computed((get) => {
+  const threadId = get(chatThreadId$);
+  if (!threadId) {
+    return get(talkDraft$);
+  }
+  return get(internalDraftMap$)[threadId] ?? null;
+});
+
+// ---------------------------------------------------------------------------
+// Convenience signals — backward-compatible API
+// ---------------------------------------------------------------------------
+
+export const zeroChatInput$ = computed((get) => {
+  const draft = get(currentDraft$);
+  return draft ? get(draft.input$) : "";
+});
+
+export const setZeroChatInput$ = command(({ get, set }, value: string) => {
+  const draft = get(currentDraft$);
+  if (draft) {
+    set(draft.setInput$, value);
+  }
+});
+
+export const clearZeroChatInput$ = command(({ get, set }) => {
+  const draft = get(currentDraft$);
+  if (draft) {
+    set(draft.setInput$, "");
+  }
+});
+
+export const zeroChatAttachments$ = computed((get) => {
+  const draft = get(currentDraft$);
+  return draft ? get(draft.attachments$) : [];
+});
+
+export const uploadZeroAttachment$ = command(
+  async ({ get, set }, file: File, signal: AbortSignal) => {
+    const draft = get(currentDraft$);
+    if (draft) {
+      await set(draft.uploadAttachment$, file, signal);
+    }
+  },
+);
+
+export const removeZeroAttachment$ = command(
+  ({ get, set }, attachment: ZeroChatAttachment) => {
+    const draft = get(currentDraft$);
+    if (draft) {
+      set(draft.removeAttachment$, attachment);
+    }
+  },
+);
+
+export const zeroDragOver$ = computed((get) => {
+  const draft = get(currentDraft$);
+  return draft ? get(draft.dragOver$) : false;
+});
+
+export const setZeroDragOver$ = command(({ get, set }, value: boolean) => {
+  const draft = get(currentDraft$);
+  if (draft) {
+    set(draft.setDragOver$, value);
+  }
+});
+
+export const draftSelectedModel$ = computed((get) => {
+  const draft = get(currentDraft$);
+  return draft ? get(draft.selectedModel$) : "default";
+});
+
+export const setDraftSelectedModel$ = command(({ get, set }, value: string) => {
+  const draft = get(currentDraft$);
+  if (draft) {
+    set(draft.setSelectedModel$, value);
+  }
+});

--- a/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
@@ -14,6 +14,7 @@ import { loadInitialData$ } from "./zero-page.ts";
 import { syncModelPreference$ } from "./zero-model-preference.ts";
 import { detach, Reason } from "../utils.ts";
 import { zeroChatAgentId$ } from "./zero-active-agent.ts";
+import { currentDraft$, ensureDraft$ } from "./chat-draft.ts";
 
 export const setupChatSessionPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -28,6 +29,12 @@ export const setupChatSessionPage$ = command(
     }
 
     set(resetLocalMessages$);
+
+    // Ensure a draft exists for this thread
+    const threadId = get(chatThreadId$);
+    if (threadId && !get(currentDraft$)) {
+      set(ensureDraft$, threadId);
+    }
 
     // Update title with session preview
     const sessionId = get(chatThreadId$);

--- a/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
@@ -8,7 +8,7 @@ import { syncModelPreference$ } from "./zero-model-preference.ts";
 import { onboardGuard$ } from "./onboard-guard.ts";
 import { loadInitialData$, resolveAgentById$ } from "./zero-page.ts";
 import { currentAgentId$ } from "./agent.ts";
-import { setChatPageInput$ } from "./zero-chat-page.ts";
+import { talkDraft$ } from "./chat-draft.ts";
 import { defaultAgentId$, agentDisplayName$ } from "./zero-agent-name.ts";
 import { zeroSubagents$ } from "./zero-agents.ts";
 import { setSidebarChatAgent$ } from "./zero-nav.ts";
@@ -17,6 +17,9 @@ export const setupTalkPage$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(updatePage$, createElement(ZeroTalkPage));
     set(updateDocumentTitle$, "Chat");
+
+    // Reset the talk draft on entrance
+    set(get(talkDraft$).clear$);
 
     await set(loadInitialData$, signal);
 
@@ -58,7 +61,7 @@ export const setupTalkPage$ = command(
     const params = get(searchParams$);
     const prompt = params.get("prompt");
     if (prompt) {
-      set(setChatPageInput$, prompt);
+      set(get(talkDraft$).setInput$, prompt);
       const next = new URLSearchParams(params);
       next.delete("prompt");
       set(updateSearchParams$, next);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat-page.ts
@@ -1,4 +1,5 @@
 import { command, computed, state } from "ccstate";
+import { talkDraft$ } from "./chat-draft.ts";
 
 // ---------------------------------------------------------------------------
 // Landing page local UI state for ZeroChatPage
@@ -6,10 +7,10 @@ import { command, computed, state } from "ccstate";
 
 const INITIAL_TAGLINE_INDEX = Math.floor(Math.random() * 18);
 
-const internalInput$ = state("");
-export const chatPageInput$ = computed((get) => get(internalInput$));
-export const setChatPageInput$ = command(({ set }, value: string) => {
-  set(internalInput$, value);
+/** Talk page input — delegates to the talk draft. */
+export const chatPageInput$ = computed((get) => get(get(talkDraft$).input$));
+export const setChatPageInput$ = command(({ get, set }, value: string) => {
+  set(get(talkDraft$).setInput$, value);
 });
 
 const internalTaglineIndex$ = state(INITIAL_TAGLINE_INDEX);

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -1,10 +1,14 @@
-import { command, computed, state, type Command, type Computed } from "ccstate";
+import { command, computed, state, type Computed } from "ccstate";
 import { delay } from "signal-timers";
 import type { AgentEvent, LogStatus } from "./log-types.ts";
-import { fetch$ } from "../fetch.ts";
-import { throwIfAbort, resetSignal, createDeferredPromise } from "../utils.ts";
+import { throwIfAbort, resetSignal } from "../utils.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { logger } from "../log.ts";
+import {
+  currentDraft$,
+  talkDraft$,
+  type ZeroChatAttachment,
+} from "./chat-draft.ts";
 import {
   createRunLoop,
   poolInterval$,
@@ -25,6 +29,19 @@ import {
   type SummaryEntry,
 } from "@vm0/core";
 import { zeroClient$, type ZeroClientFactory } from "../api-client.ts";
+
+// Re-export draft signals so existing imports from zero-chat.ts keep working
+export {
+  zeroChatInput$,
+  setZeroChatInput$,
+  clearZeroChatInput$,
+  zeroChatAttachments$,
+  uploadZeroAttachment$,
+  removeZeroAttachment$,
+  zeroDragOver$,
+  setZeroDragOver$,
+  type ZeroChatAttachment,
+} from "./chat-draft.ts";
 
 const L = logger("ZeroChat");
 
@@ -579,131 +596,8 @@ const chatSessionSnapshot$ = computed(
   },
 );
 
-// Chat input
-const internalChatInput$ = state("");
-export const zeroChatInput$ = computed((get) => get(internalChatInput$));
-
-export const setZeroChatInput$ = command(({ set }, value: string) => {
-  set(internalChatInput$, value);
-});
-
-export const clearZeroChatInput$ = command(({ set }) => {
-  set(internalChatInput$, "");
-});
-
-// Attachments
-interface FileInfo {
-  id: string;
-  url: string;
-}
-
-export interface ZeroChatAttachment {
-  filename: string;
-  contentType: string;
-  size: number;
-  /** Reactive file info (id + url) — loading while uploading, hasData when done. */
-  fileInfo$: Computed<Promise<FileInfo | null>>;
-  /** Cancel the in-flight upload. Always safe to call (no-op if already completed). */
-  cancel$: Command<void, []>;
-  /** Start the upload. Accepts an external signal for cascade abort (e.g. page navigation). */
-  upload$: Command<Promise<void>, [AbortSignal]>;
-}
-
-function createChatAttachment(file: File): ZeroChatAttachment {
-  const resetSignal$ = resetSignal();
-  const internalPromise$ = state<Promise<FileInfo> | null>(null);
-
-  const fileInfo$ = computed(async (get) => {
-    const promise = get(internalPromise$);
-    if (promise === null) {
-      return null;
-    }
-    return await promise;
-  });
-
-  const cancel$ = command(({ set }) => {
-    set(resetSignal$);
-  });
-
-  const upload$ = command(async ({ get, set }, signal: AbortSignal) => {
-    const fetchFn = get(fetch$);
-    const formData = new FormData();
-    formData.append("file", file);
-
-    const uploadSignal = set(resetSignal$, signal);
-    const deferred = createDeferredPromise<FileInfo>(uploadSignal);
-    set(internalPromise$, deferred.promise);
-
-    const res = await fetchFn("/api/zero/uploads", {
-      method: "POST",
-      body: formData,
-      signal: uploadSignal,
-    });
-    signal.throwIfAborted();
-
-    if (!res.ok) {
-      const err = (await res.json().catch(() => null)) as {
-        error?: { message?: string };
-      } | null;
-      throw new Error(
-        err?.error?.message ?? `Upload failed: ${res.statusText}`,
-      );
-    }
-
-    const data = (await res.json()) as {
-      id: string;
-      filename: string;
-      contentType: string;
-      size: number;
-      url: string;
-    };
-
-    deferred.resolve({ id: data.id, url: data.url });
-  });
-
-  return {
-    filename: file.name,
-    contentType: file.type,
-    size: file.size,
-    fileInfo$,
-    cancel$,
-    upload$,
-  };
-}
-
-const internalAttachments$ = state<ZeroChatAttachment[]>([]);
-export const zeroChatAttachments$ = computed((get) =>
-  get(internalAttachments$),
-);
-
-const internalDragOver$ = state(false);
-export const zeroDragOver$ = computed((get) => get(internalDragOver$));
-export const setZeroDragOver$ = command(({ set }, value: boolean) => {
-  set(internalDragOver$, value);
-});
-
-export const uploadZeroAttachment$ = command(
-  async ({ set }, file: File, signal: AbortSignal) => {
-    const attachment = createChatAttachment(file);
-    set(internalAttachments$, (prev) => [...prev, attachment]);
-
-    try {
-      await set(attachment.upload$, signal);
-    } catch (error) {
-      throwIfAbort(error);
-      L.error("Upload failed:", error);
-      set(attachment.cancel$);
-      set(internalAttachments$, (prev) => prev.filter((a) => a !== attachment));
-    }
-  },
-);
-
-export const removeZeroAttachment$ = command(
-  ({ set }, attachment: ZeroChatAttachment) => {
-    set(attachment.cancel$);
-    set(internalAttachments$, (prev) => prev.filter((a) => a !== attachment));
-  },
-);
+// Chat input and attachments are now managed per-draft in chat-draft.ts.
+// Convenience signals are re-exported at the top of this file.
 
 /**
  * Load session data from the snapshot computed and populate state.
@@ -745,13 +639,14 @@ export const loadSessionFromSnapshot$ = command(
   },
 );
 
-export const startNewZeroSession$ = command(({ set }) => {
+export const startNewZeroSession$ = command(({ get, set }) => {
   // Abort any in-flight send/polling from the previous session
   set(resetTalkSendSignal$);
 
   set(internalLocalMessages$, []);
 
-  set(internalChatInput$, "");
+  // Clear the talk draft (input, attachments, model)
+  set(get(talkDraft$).clear$);
 });
 
 // ---------------------------------------------------------------------------
@@ -807,7 +702,9 @@ const prepareUserMessage$ = command(
     prompt: string,
     signal: AbortSignal,
   ): Promise<{ fullPrompt: string }> => {
-    const allAttachments = get(internalAttachments$);
+    // Capture the current draft before any async work
+    const draft = get(currentDraft$);
+    const allAttachments = draft ? get(draft.attachments$) : [];
     const allInfos = await Promise.all(
       allAttachments.map((a) => get(a.fileInfo$)),
     );
@@ -817,8 +714,12 @@ const prepareUserMessage$ = command(
     const ready = allAttachments
       .map((a, i) => ({ attachment: a, info: allInfos[i] }))
       .filter(
-        (r): r is { attachment: ZeroChatAttachment; info: FileInfo } =>
-          r.info !== null,
+        (
+          r,
+        ): r is {
+          attachment: ZeroChatAttachment;
+          info: { id: string; url: string };
+        } => r.info !== null,
       );
 
     let fullPrompt = prompt.trim();
@@ -845,7 +746,11 @@ const prepareUserMessage$ = command(
           : undefined,
     };
     set(internalLocalMessages$, (prev) => [...prev, userMessage]);
-    set(internalAttachments$, []);
+
+    // Clear the draft after preparing the message
+    if (draft) {
+      set(draft.clear$);
+    }
 
     return { fullPrompt };
   },

--- a/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
@@ -1,4 +1,5 @@
-import { command, computed, state } from "ccstate";
+import { command } from "ccstate";
+import { currentDraft$ } from "./chat-draft.ts";
 import { currentAgentId$ } from "./agent.ts";
 
 function readModelPreference(key: string): string {
@@ -21,28 +22,27 @@ function modelStorageKey(agentId: string | null): string {
 }
 
 // ---------------------------------------------------------------------------
-// State
+// State — now delegated to per-draft signals in chat-draft.ts
 // ---------------------------------------------------------------------------
 
-const internalSelectedModel$ = state("default");
-
-/** Currently selected model provider for the active agent. */
-export const selectedModel$ = computed((get) => get(internalSelectedModel$));
-
-/** Set the selected model provider. */
-export const setSelectedModel$ = command(({ set }, value: string) => {
-  set(internalSelectedModel$, value);
-});
+// Re-export convenience signals so existing imports keep working
+export {
+  draftSelectedModel$ as selectedModel$,
+  setDraftSelectedModel$ as setSelectedModel$,
+} from "./chat-draft.ts";
 
 /**
  * Sync model preference from localStorage for the current agent.
- * Called from each route's setup function on navigation — eliminates the
- * prevAgentId + queueMicrotask pattern entirely.
+ * Called from each route's setup function on navigation — writes to the
+ * current draft's model selection.
  */
 export const syncModelPreference$ = command(({ get, set }) => {
   const agentId = get(currentAgentId$);
   const key = modelStorageKey(agentId);
-  set(internalSelectedModel$, readModelPreference(key));
+  const draft = get(currentDraft$);
+  if (draft) {
+    set(draft.setSelectedModel$, readModelPreference(key));
+  }
 });
 
 /**
@@ -52,6 +52,9 @@ export const syncModelPreference$ = command(({ get, set }) => {
 export const persistModelPreference$ = command(({ get }) => {
   const agentId = get(currentAgentId$);
   const key = modelStorageKey(agentId);
-  const value = get(internalSelectedModel$);
-  writeModelPreference(key, value);
+  const draft = get(currentDraft$);
+  if (draft) {
+    const value = get(draft.selectedModel$);
+    writeModelPreference(key, value);
+  }
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-activity-line-visibility.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-activity-line-visibility.test.tsx
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { mockChatLifecycle, makeToolUseEvent } from "./chat-test-helpers.ts";
+
+const context = testContext();
+
+describe("activity line visibility while run is still running", () => {
+  it("should keep showing activity line when result arrives but run is still running", async () => {
+    const ctrl = mockChatLifecycle({
+      threadId: "thread-activity-vis",
+      chatMessages: [
+        {
+          role: "user",
+          content: "Previous message",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+      unsavedRuns: [
+        {
+          runId: "run-test-1",
+          status: "running",
+          prompt: "Do a complex multi-step task",
+          error: null,
+        },
+      ],
+    });
+
+    await setupPage({ context, path: "/chat/thread-activity-vis" });
+
+    // Wait for the active run to appear with thinking state
+    await waitFor(() => {
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
+    });
+
+    // Add tool use events so the activity line shows summary steps
+    ctrl.setEvents([
+      makeToolUseEvent("Bash", { command: "ls" }, 1),
+      {
+        sequenceNumber: 2,
+        eventType: "result",
+        eventData: { result: "Here is the first part of the answer." },
+        createdAt: "2026-03-10T00:00:30Z",
+      },
+      makeToolUseEvent("Read", { path: "/tmp/data.txt" }, 3),
+    ]);
+
+    // The result content should appear
+    await waitFor(() => {
+      expect(
+        screen.getByText("Here is the first part of the answer."),
+      ).toBeInTheDocument();
+    });
+
+    // BUG: The activity line (shimmer text or summary steps) should still be
+    // visible because run status is still "running". Currently, the
+    // StaticAssistantMessage decision tree hides the activity line as soon as
+    // message.content becomes non-empty, regardless of run status.
+    const shimmer = document.querySelector(".zero-shimmer-text");
+    expect(shimmer).toBeInTheDocument();
+  });
+
+  it("should hide activity line only after run reaches terminal status", async () => {
+    const ctrl = mockChatLifecycle({
+      threadId: "thread-activity-terminal",
+      chatMessages: [],
+      unsavedRuns: [
+        {
+          runId: "run-test-1",
+          status: "running",
+          prompt: "Hello",
+          error: null,
+        },
+      ],
+    });
+
+    await setupPage({ context, path: "/chat/thread-activity-terminal" });
+
+    // Thinking state initially
+    await waitFor(() => {
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
+    });
+
+    // A result event arrives while run is still "running"
+    ctrl.setEvents([
+      {
+        sequenceNumber: 1,
+        eventType: "result",
+        eventData: { result: "Intermediate result" },
+        createdAt: "2026-03-10T00:00:10Z",
+      },
+    ]);
+
+    // Result content should be displayed
+    await waitFor(() => {
+      expect(screen.getByText("Intermediate result")).toBeInTheDocument();
+    });
+
+    // Activity line should still be visible (run is "running")
+    expect(document.querySelector(".zero-shimmer-text")).toBeInTheDocument();
+
+    // Now complete the run — activity line should disappear
+    ctrl.completeRun("Final result");
+
+    await waitFor(() => {
+      expect(screen.getByText("Final result")).toBeInTheDocument();
+    });
+
+    // After completion, no more shimmer/activity
+    await waitFor(() => {
+      expect(
+        document.querySelector(".zero-shimmer-text"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, fireEvent } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { PLACEHOLDER } from "./chat-test-helpers.ts";
+
+const context = testContext();
+
+function mockThreads() {
+  server.use(
+    http.get("*/api/zero/chat-threads/:id", ({ params }) => {
+      const id = params.id as string;
+      return HttpResponse.json({
+        id,
+        title: null,
+        agentId: "c0000000-0000-4000-a000-000000000001",
+        chatMessages: [],
+        latestSessionId: null,
+        unsavedRuns: [],
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () =>
+      HttpResponse.json({ threads: [] }),
+    ),
+  );
+}
+
+function getTextarea(): HTMLTextAreaElement {
+  return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+}
+
+describe("chat draft persistence across thread navigation", () => {
+  it("should preserve input text when switching between threads", async () => {
+    mockThreads();
+    await setupPage({ context, path: "/chat/thread-1" });
+
+    await waitFor(() => {
+      expect(getTextarea()).toBeInTheDocument();
+    });
+
+    // Type on thread-1
+    fireEvent.change(getTextarea(), {
+      target: { value: "draft for thread 1" },
+    });
+    expect(getTextarea().value).toBe("draft for thread 1");
+
+    // Navigate to thread-2
+    context.store.set(detachedNavigateTo$, "/chat/:chatThreadId", {
+      pathParams: { chatThreadId: "thread-2" },
+    });
+
+    // thread-2 textarea should be empty
+    await waitFor(() => {
+      expect(getTextarea().value).toBe("");
+    });
+
+    // Type on thread-2
+    fireEvent.change(getTextarea(), {
+      target: { value: "draft for thread 2" },
+    });
+
+    // Navigate back to thread-1 — draft restored
+    context.store.set(detachedNavigateTo$, "/chat/:chatThreadId", {
+      pathParams: { chatThreadId: "thread-1" },
+    });
+
+    await waitFor(() => {
+      expect(getTextarea().value).toBe("draft for thread 1");
+    });
+
+    // Navigate back to thread-2 — draft restored
+    context.store.set(detachedNavigateTo$, "/chat/:chatThreadId", {
+      pathParams: { chatThreadId: "thread-2" },
+    });
+
+    await waitFor(() => {
+      expect(getTextarea().value).toBe("draft for thread 2");
+    });
+  });
+
+  it("should not leak thread draft into a different thread", async () => {
+    mockThreads();
+    await setupPage({ context, path: "/chat/thread-a" });
+
+    await waitFor(() => {
+      expect(getTextarea()).toBeInTheDocument();
+    });
+
+    fireEvent.change(getTextarea(), {
+      target: { value: "only for thread-a" },
+    });
+
+    context.store.set(detachedNavigateTo$, "/chat/:chatThreadId", {
+      pathParams: { chatThreadId: "thread-b" },
+    });
+
+    await waitFor(() => {
+      expect(getTextarea().value).toBe("");
+    });
+  });
+
+  it("should complete upload after switching away and show it on return", async () => {
+    // Deferred upload handler — resolve manually
+    let resolveUpload: (() => void) | null = null;
+    const uploadStarted = new Promise<void>((r) => {
+      resolveUpload = r;
+    });
+
+    let uploadRequestResolve: ((value: Response) => void) | null = null;
+
+    server.use(
+      http.get("*/api/zero/chat-threads/:id", ({ params }) => {
+        const id = params.id as string;
+        return HttpResponse.json({
+          id,
+          title: null,
+          agentId: "c0000000-0000-4000-a000-000000000001",
+          chatMessages: [],
+          latestSessionId: null,
+          unsavedRuns: [],
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () =>
+        HttpResponse.json({ threads: [] }),
+      ),
+      http.post("*/api/zero/uploads", () => {
+        // Signal that the upload request has arrived
+        resolveUpload?.();
+
+        // Return a promise that we resolve later
+        return new Promise<Response>((resolve) => {
+          uploadRequestResolve = (resp) => resolve(resp);
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/chat/thread-1" });
+
+    await waitFor(() => {
+      expect(getTextarea()).toBeInTheDocument();
+    });
+
+    // Trigger file upload via the hidden file input
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File(["img-data"], "photo.png", { type: "image/png" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    // Wait for upload request to arrive at MSW
+    await uploadStarted;
+
+    // Attachment chip should be visible with uploading state
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Cancel upload photo.png"),
+      ).toBeInTheDocument();
+    });
+
+    // Navigate to thread-2 while upload is in-flight
+    context.store.set(detachedNavigateTo$, "/chat/:chatThreadId", {
+      pathParams: { chatThreadId: "thread-2" },
+    });
+
+    // thread-2 should have no attachment chips
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/photo\.png/)).toBeNull();
+    });
+
+    // Now resolve the upload on the server side
+    uploadRequestResolve!(
+      HttpResponse.json({
+        id: "upload-1",
+        filename: "photo.png",
+        contentType: "image/png",
+        size: 1024,
+        url: "https://example.com/photo.png",
+      }),
+    );
+
+    // Navigate back to thread-1
+    context.store.set(detachedNavigateTo$, "/chat/:chatThreadId", {
+      pathParams: { chatThreadId: "thread-1" },
+    });
+
+    // The upload should now be complete — "Remove" instead of "Cancel upload"
+    await waitFor(() => {
+      expect(screen.getByLabelText("Remove photo.png")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-draft.test.tsx
@@ -107,8 +107,8 @@ describe("chat draft persistence across thread navigation", () => {
   it("should complete upload after switching away and show it on return", async () => {
     // Deferred upload handler — resolve manually
     let resolveUpload: (() => void) | null = null;
-    const uploadStarted = new Promise<void>((r) => {
-      resolveUpload = r;
+    const uploadStarted = new Promise<void>((resolve) => {
+      resolveUpload = resolve;
     });
 
     let uploadRequestResolve: ((value: Response) => void) | null = null;

--- a/turbo/apps/platform/src/views/zero-page/use-file-upload-handlers.ts
+++ b/turbo/apps/platform/src/views/zero-page/use-file-upload-handlers.ts
@@ -1,6 +1,6 @@
 import type { ClipboardEvent, DragEvent } from "react";
 import { useGet, useSet } from "ccstate-react";
-import { pageSignal$ } from "../../signals/page-signal.ts";
+import { rootSignal$ } from "../../signals/root-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   uploadZeroAttachment$,
@@ -20,7 +20,7 @@ export function useFileUploadHandlers(): FileUploadHandlers {
   const uploadAttachment = useSet(uploadZeroAttachment$);
   const dragOver = useGet(zeroDragOver$);
   const setDragOver = useSet(setZeroDragOver$);
-  const pageSignal = useGet(pageSignal$);
+  const { signal: rootSignal } = useGet(rootSignal$);
 
   const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
     const items = e.clipboardData?.items;
@@ -32,7 +32,7 @@ export function useFileUploadHandlers(): FileUploadHandlers {
         const file = item.getAsFile();
         if (file) {
           e.preventDefault();
-          detach(uploadAttachment(file, pageSignal), Reason.DomCallback);
+          detach(uploadAttachment(file, rootSignal), Reason.DomCallback);
         }
       }
     }
@@ -46,7 +46,7 @@ export function useFileUploadHandlers(): FileUploadHandlers {
       return;
     }
     for (const file of files) {
-      detach(uploadAttachment(file, pageSignal), Reason.DomCallback);
+      detach(uploadAttachment(file, rootSignal), Reason.DomCallback);
     }
   };
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -49,6 +49,7 @@ import {
   clearJustConnectedTypes$,
 } from "../../signals/zero-page/settings/connectors.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
+import { rootSignal$ } from "../../signals/root-signal.ts";
 import {
   zeroAddedConnectors$,
   addZeroConnector$,
@@ -259,6 +260,9 @@ export function ZeroChatComposer({
   const { modelOptions, selectedModel, setSelectedModel, persistSelection } =
     useModelSelection();
 
+  // Upload signal — uses rootSignal so uploads survive page navigation
+  const { signal: rootSignal } = useGet(rootSignal$);
+
   // Connectors
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const addedConnectorsLoadable = useLastLoadable(zeroAddedConnectors$);
@@ -363,7 +367,7 @@ export function ZeroChatComposer({
       return;
     }
     for (const file of files) {
-      detach(uploadAttachment(file, pageSignal), Reason.DomCallback);
+      detach(uploadAttachment(file, rootSignal), Reason.DomCallback);
     }
     e.target.value = "";
   };

--- a/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-ideation-page.tsx
@@ -8,7 +8,6 @@ import {
 import { Card, CardContent, cn, Input } from "@vm0/ui";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { getCategories } from "./zero-ideation-data.ts";
-import { setChatPageInput$ } from "../../signals/zero-page/zero-chat-page.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { currentAgentId$ } from "../../signals/zero-page/agent.ts";
 import { SidebarLayout } from "./sidebar-layout.tsx";
@@ -19,7 +18,6 @@ export function ZeroIdeationPage() {
   const categories = getCategories().slice(0, 5);
   const [activeTab, setActiveTab] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
-  const setInput = useSet(setChatPageInput$);
   const navigate = useSet(detachedNavigateTo$);
   const agentId = useGet(currentAgentId$);
 
@@ -51,8 +49,15 @@ export function ZeroIdeationPage() {
           .filter((c) => c.cases.length > 0);
 
   const handleSelectPrompt = (prompt: string) => {
-    setInput(prompt);
-    navigateToChat();
+    const searchParams = new URLSearchParams({ prompt });
+    if (agentId) {
+      navigate("/talk/:agentId", {
+        pathParams: { agentId: agentId },
+        searchParams,
+      });
+    } else {
+      navigate("/", { searchParams });
+    }
   };
 
   const handleBack = () => {


### PR DESCRIPTION
## Summary
- Extract composer state (input, attachments, model selection, drag-over) from global singletons into a per-draft signal architecture (`chat-draft.ts`)
- Each chat thread now maintains isolated draft state via `ensureDraft$`, while the talk/landing page uses a dedicated `talkDraft$` singleton
- Backward-compatible convenience signals (`zeroChatInput$`, `zeroChatAttachments$`, etc.) are re-exported so existing consumers continue working unchanged

## Test plan
- [ ] Verify talk page composer retains input/attachments across interactions
- [ ] Verify session chat page gets isolated draft state per thread
- [ ] Verify file uploads use `rootSignal` and survive page navigation
- [ ] Run existing tests: `pnpm vitest --run` in platform package

🤖 Generated with [Claude Code](https://claude.com/claude-code)