### PR TITLE
fix: use --help in cli help text examples instead of inline args

### DIFF
--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -96,9 +96,9 @@ program
     `
 Examples:
   Missing a token?       zero doctor missing-token <TOKEN_NAME>
-  Delegate to teammate?  zero run <agent-id> "your task"
-  Send a Slack message?  zero slack message send -c <channel> -t "text"
-  Set up a schedule?     zero schedule setup <agent-id>
+  Delegate to teammate?  zero run --help
+  Send a Slack message?  zero slack message send --help
+  Set up a schedule?     zero schedule setup --help
   Update yourself?       zero agent --help
   Check your identity?   zero whoami`,
   );


### PR DESCRIPTION
## Summary
- Update CLI help text examples to show `--help` flags instead of inline command arguments
- Makes examples more discoverable — users can run the `--help` command to see full usage

## Test plan
- [ ] Run `zero --help` and verify updated examples display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)