### PR TITLE
refactor(core): unify connector environment mapping to single top-level field

### DIFF
--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -1,6 +1,7 @@
 import { eq, and, inArray } from "drizzle-orm";
 import {
   CONNECTOR_TYPES,
+  type ConnectorAuthMethodType,
   type ConnectorType,
   type ConnectorResponse,
   connectorTypeSchema,
@@ -424,7 +425,8 @@ export async function deleteConnector(
 
     const secretNames: string[] = [];
     const config = CONNECTOR_TYPES[type];
-    const authMethodConfig = config.authMethods[existing.authMethod];
+    const authMethodConfig =
+      config.authMethods[existing.authMethod as ConnectorAuthMethodType];
     if (authMethodConfig) {
       secretNames.push(...Object.keys(authMethodConfig.secrets));
     }

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -141,9 +141,13 @@ describe("getConnectorEnvironmentMapping", () => {
               s.includes(`${prefix}_REFRESH_TOKEN`),
       );
 
-      // environmentMapping: all values point to $secrets.XXX_ACCESS_TOKEN
+      // environmentMapping: must contain XXX_TOKEN, all values -> $secrets.XXX_ACCESS_TOKEN
       const mapping = getConnectorEnvironmentMapping(type);
       const expectedRef = `$secrets.${prefix}_ACCESS_TOKEN`;
+      expect(
+        mapping[`${prefix}_TOKEN`],
+        `${type}: environmentMapping must include ${prefix}_TOKEN`,
+      ).toBe(expectedRef);
       for (const [key, value] of Object.entries(mapping)) {
         expect(
           value,

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -5,6 +5,8 @@ import {
   getConnectorTypeForSecretName,
   getConnectorEnvironmentMapping,
   getConnectorProvidedSecretNames,
+  getConnectorAuthMethods,
+  getConnectorOAuthConfig,
   connectorTypeSchema,
 } from "../connectors";
 
@@ -108,6 +110,60 @@ describe("getConnectorEnvironmentMapping", () => {
       GH_TOKEN: "$secrets.GITHUB_ACCESS_TOKEN",
       GITHUB_TOKEN: "$secrets.GITHUB_ACCESS_TOKEN",
     });
+  });
+
+  it("OAuth connectors have consistent secrets and environmentMapping naming", () => {
+    for (const type of connectorTypeSchema.options) {
+      const oauthConfig = getConnectorOAuthConfig(type);
+      if (!oauthConfig) continue;
+
+      const authMethods = getConnectorAuthMethods(type);
+      const oauthMethod = authMethods["oauth"];
+      if (!oauthMethod) continue;
+
+      const secretNames = Object.keys(oauthMethod.secrets);
+      const mapping = getConnectorEnvironmentMapping(type);
+
+      // OAuth secrets must include exactly one XXX_ACCESS_TOKEN
+      const accessTokens = secretNames.filter((s) =>
+        s.endsWith("_ACCESS_TOKEN"),
+      );
+      expect(
+        accessTokens.length,
+        `${type}: oauth secrets must have exactly one _ACCESS_TOKEN key, got: ${secretNames.join(", ")}`,
+      ).toBe(1);
+
+      // If refresh token exists, must be exactly one with matching prefix
+      const prefix = accessTokens[0]!.replace(/_ACCESS_TOKEN$/, "");
+      const refreshTokens = secretNames.filter((s) =>
+        s.endsWith("_REFRESH_TOKEN"),
+      );
+      expect(
+        refreshTokens.length,
+        `${type}: must have 0 or 1 _REFRESH_TOKEN, got: ${refreshTokens.join(", ")}`,
+      ).toBeLessThanOrEqual(1);
+      if (refreshTokens.length === 1) {
+        expect(
+          refreshTokens[0],
+          `${type}: refresh token must be ${prefix}_REFRESH_TOKEN`,
+        ).toBe(`${prefix}_REFRESH_TOKEN`);
+      }
+
+      // environmentMapping must map XXX_TOKEN -> $secrets.XXX_ACCESS_TOKEN (same prefix)
+      expect(
+        mapping[`${prefix}_TOKEN`],
+        `${type}: environmentMapping must map ${prefix}_TOKEN -> $secrets.${prefix}_ACCESS_TOKEN`,
+      ).toBe(`$secrets.${prefix}_ACCESS_TOKEN`);
+
+      // environmentMapping must only contain mappings to the same access token
+      const expectedValue = `$secrets.${prefix}_ACCESS_TOKEN`;
+      for (const [key, value] of Object.entries(mapping)) {
+        expect(
+          value,
+          `${type}: environmentMapping["${key}"] must point to ${expectedValue}`,
+        ).toBe(expectedValue);
+      }
+    }
   });
 
   it("all mapping values use $secrets. or $vars. prefix", () => {

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -163,6 +163,16 @@ describe("getConnectorEnvironmentMapping", () => {
           `${type}: environmentMapping["${key}"] must point to ${expectedValue}`,
         ).toBe(expectedValue);
       }
+
+      // If both oauth and api-token exist, api-token must have exactly one secret: ${prefix}_TOKEN
+      const apiTokenMethod = authMethods["api-token"];
+      if (apiTokenMethod) {
+        const apiSecrets = Object.keys(apiTokenMethod.secrets);
+        expect(
+          apiSecrets,
+          `${type}: api-token with oauth must have exactly ["${prefix}_TOKEN"]`,
+        ).toEqual([`${prefix}_TOKEN`]);
+      }
     }
   });
 

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -113,65 +113,46 @@ describe("getConnectorEnvironmentMapping", () => {
   });
 
   it("OAuth connectors have consistent secrets and environmentMapping naming", () => {
+    // All naming derives from a single prefix XXX:
+    //   oauth secrets:      XXX_ACCESS_TOKEN (required), XXX_REFRESH_TOKEN (optional)
+    //   environmentMapping: all values -> $secrets.XXX_ACCESS_TOKEN
+    //   api-token secrets:  XXX_TOKEN (if api-token auth method exists)
     for (const type of connectorTypeSchema.options) {
-      const oauthConfig = getConnectorOAuthConfig(type);
-      if (!oauthConfig) continue;
-
+      if (!getConnectorOAuthConfig(type)) continue;
       const authMethods = getConnectorAuthMethods(type);
-      const oauthMethod = authMethods["oauth"];
-      if (!oauthMethod) continue;
+      if (!authMethods["oauth"]) continue;
 
-      const secretNames = Object.keys(oauthMethod.secrets);
+      const oauthSecrets = Object.keys(authMethods["oauth"].secrets);
+      const prefix = oauthSecrets
+        .find((s) => s.endsWith("_ACCESS_TOKEN"))
+        ?.replace(/_ACCESS_TOKEN$/, "");
+      expect(
+        prefix,
+        `${type}: oauth secrets must include an _ACCESS_TOKEN key`,
+      ).toBeDefined();
+
+      // oauth secrets: exactly {XXX_ACCESS_TOKEN} or {XXX_ACCESS_TOKEN, XXX_REFRESH_TOKEN}
+      const allowed = [`${prefix}_ACCESS_TOKEN`, `${prefix}_REFRESH_TOKEN`];
+      expect(
+        oauthSecrets.every((s) => allowed.includes(s)),
+        `${type}: unexpected oauth secrets: ${oauthSecrets.join(", ")}`,
+      ).toBe(true);
+
+      // environmentMapping: all values point to $secrets.XXX_ACCESS_TOKEN
       const mapping = getConnectorEnvironmentMapping(type);
-
-      // OAuth secrets must include exactly one XXX_ACCESS_TOKEN
-      const accessTokens = secretNames.filter((s) =>
-        s.endsWith("_ACCESS_TOKEN"),
-      );
-      expect(
-        accessTokens.length,
-        `${type}: oauth secrets must have exactly one _ACCESS_TOKEN key, got: ${secretNames.join(", ")}`,
-      ).toBe(1);
-
-      // OAuth secrets must only be XXX_ACCESS_TOKEN and optionally XXX_REFRESH_TOKEN
-      const prefix = accessTokens[0]!.replace(/_ACCESS_TOKEN$/, "");
-      const allowed = new Set([
-        `${prefix}_ACCESS_TOKEN`,
-        `${prefix}_REFRESH_TOKEN`,
-      ]);
-      for (const name of secretNames) {
-        expect(
-          allowed.has(name),
-          `${type}: unexpected oauth secret "${name}", allowed: ${[...allowed].join(", ")}`,
-        ).toBe(true);
-      }
-      expect(
-        secretNames.length,
-        `${type}: oauth secrets must have 1 or 2 entries, got: ${secretNames.join(", ")}`,
-      ).toBeLessThanOrEqual(2);
-
-      // environmentMapping must map XXX_TOKEN -> $secrets.XXX_ACCESS_TOKEN (same prefix)
-      expect(
-        mapping[`${prefix}_TOKEN`],
-        `${type}: environmentMapping must map ${prefix}_TOKEN -> $secrets.${prefix}_ACCESS_TOKEN`,
-      ).toBe(`$secrets.${prefix}_ACCESS_TOKEN`);
-
-      // environmentMapping must only contain mappings to the same access token
-      const expectedValue = `$secrets.${prefix}_ACCESS_TOKEN`;
+      const expectedRef = `$secrets.${prefix}_ACCESS_TOKEN`;
       for (const [key, value] of Object.entries(mapping)) {
         expect(
           value,
-          `${type}: environmentMapping["${key}"] must point to ${expectedValue}`,
-        ).toBe(expectedValue);
+          `${type}: environmentMapping["${key}"] must be ${expectedRef}`,
+        ).toBe(expectedRef);
       }
 
-      // If both oauth and api-token exist, api-token must have exactly one secret: ${prefix}_TOKEN
-      const apiTokenMethod = authMethods["api-token"];
-      if (apiTokenMethod) {
-        const apiSecrets = Object.keys(apiTokenMethod.secrets);
+      // api-token (if exists): exactly one secret XXX_TOKEN
+      if (authMethods["api-token"]) {
         expect(
-          apiSecrets,
-          `${type}: api-token with oauth must have exactly ["${prefix}_TOKEN"]`,
+          Object.keys(authMethods["api-token"].secrets),
+          `${type}: api-token must have exactly ["${prefix}_TOKEN"]`,
         ).toEqual([`${prefix}_TOKEN`]);
       }
     }

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -131,12 +131,15 @@ describe("getConnectorEnvironmentMapping", () => {
         `${type}: oauth secrets must include an _ACCESS_TOKEN key`,
       ).toBeDefined();
 
-      // oauth secrets: exactly {XXX_ACCESS_TOKEN} or {XXX_ACCESS_TOKEN, XXX_REFRESH_TOKEN}
-      const allowed = [`${prefix}_ACCESS_TOKEN`, `${prefix}_REFRESH_TOKEN`];
-      expect(
-        oauthSecrets.every((s) => allowed.includes(s)),
-        `${type}: unexpected oauth secrets: ${oauthSecrets.join(", ")}`,
-      ).toBe(true);
+      // oauth secrets: exactly [XXX_ACCESS_TOKEN] or [XXX_ACCESS_TOKEN, XXX_REFRESH_TOKEN]
+      expect(oauthSecrets, `${type}: unexpected oauth secrets`).toSatisfy(
+        (s: string[]) =>
+          s.length === 1
+            ? s[0] === `${prefix}_ACCESS_TOKEN`
+            : s.length === 2 &&
+              s.includes(`${prefix}_ACCESS_TOKEN`) &&
+              s.includes(`${prefix}_REFRESH_TOKEN`),
+      );
 
       // environmentMapping: all values point to $secrets.XXX_ACCESS_TOKEN
       const mapping = getConnectorEnvironmentMapping(type);

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -165,6 +165,32 @@ describe("getConnectorEnvironmentMapping", () => {
     }
   });
 
+  it("api-token-only connectors expose all secrets via environmentMapping with same name", () => {
+    for (const type of connectorTypeSchema.options) {
+      const authMethods = getConnectorAuthMethods(type);
+      if (authMethods["oauth"] || !authMethods["api-token"]) continue;
+      if (getConnectorOAuthConfig(type)) continue;
+
+      const secrets = Object.keys(authMethods["api-token"].secrets);
+      const mapping = getConnectorEnvironmentMapping(type);
+      const mapKeys = Object.keys(mapping);
+
+      // mapping keys must be exactly the same set as secrets
+      expect(
+        mapKeys.sort(),
+        `${type}: environmentMapping keys must match api-token secrets`,
+      ).toEqual(secrets.sort());
+
+      // each mapping value must be $secrets.KEY or $vars.KEY (same name)
+      for (const key of secrets) {
+        expect(
+          mapping[key] === `$secrets.${key}` || mapping[key] === `$vars.${key}`,
+          `${type}: environmentMapping["${key}"] = "${mapping[key]}", expected $secrets.${key} or $vars.${key}`,
+        ).toBe(true);
+      }
+    }
+  });
+
   it("all mapping values use $secrets. or $vars. prefix", () => {
     for (const type of connectorTypeSchema.options) {
       const mapping = getConnectorEnvironmentMapping(type);

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -133,21 +133,22 @@ describe("getConnectorEnvironmentMapping", () => {
         `${type}: oauth secrets must have exactly one _ACCESS_TOKEN key, got: ${secretNames.join(", ")}`,
       ).toBe(1);
 
-      // If refresh token exists, must be exactly one with matching prefix
+      // OAuth secrets must only be XXX_ACCESS_TOKEN and optionally XXX_REFRESH_TOKEN
       const prefix = accessTokens[0]!.replace(/_ACCESS_TOKEN$/, "");
-      const refreshTokens = secretNames.filter((s) =>
-        s.endsWith("_REFRESH_TOKEN"),
-      );
-      expect(
-        refreshTokens.length,
-        `${type}: must have 0 or 1 _REFRESH_TOKEN, got: ${refreshTokens.join(", ")}`,
-      ).toBeLessThanOrEqual(1);
-      if (refreshTokens.length === 1) {
+      const allowed = new Set([
+        `${prefix}_ACCESS_TOKEN`,
+        `${prefix}_REFRESH_TOKEN`,
+      ]);
+      for (const name of secretNames) {
         expect(
-          refreshTokens[0],
-          `${type}: refresh token must be ${prefix}_REFRESH_TOKEN`,
-        ).toBe(`${prefix}_REFRESH_TOKEN`);
+          allowed.has(name),
+          `${type}: unexpected oauth secret "${name}", allowed: ${[...allowed].join(", ")}`,
+        ).toBe(true);
       }
+      expect(
+        secretNames.length,
+        `${type}: oauth secrets must have 1 or 2 entries, got: ${secretNames.join(", ")}`,
+      ).toBeLessThanOrEqual(2);
 
       // environmentMapping must map XXX_TOKEN -> $secrets.XXX_ACCESS_TOKEN (same prefix)
       expect(

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -31,6 +31,8 @@ export interface ConnectorOAuthConfig {
   scopes: string[];
 }
 
+export type ConnectorAuthMethodType = "oauth" | "api-token" | "api";
+
 /**
  * Base configuration shape for all connector types.
  */
@@ -38,8 +40,10 @@ export interface ConnectorConfig {
   readonly label: string;
   readonly helpText: string;
   readonly featureFlag?: FeatureSwitchKey;
-  readonly authMethods: Record<string, ConnectorAuthMethodConfig>;
-  readonly defaultAuthMethod?: string;
+  readonly authMethods: Partial<
+    Record<ConnectorAuthMethodType, ConnectorAuthMethodConfig>
+  >;
+  readonly defaultAuthMethod?: ConnectorAuthMethodType;
   readonly oauth?: ConnectorOAuthConfig;
   /** Environment mapping declaring which env vars this connector provides. */
   readonly environmentMapping: Record<string, string>;
@@ -3631,7 +3635,7 @@ export function getConnectorAuthMethods(
  */
 export function getConnectorDefaultAuthMethod(
   type: ConnectorType,
-): string | undefined {
+): ConnectorAuthMethodType | undefined {
   return CONNECTOR_TYPES[type].defaultAuthMethod;
 }
 
@@ -3640,7 +3644,7 @@ export function getConnectorDefaultAuthMethod(
  */
 export function getConnectorSecretsForAuthMethod(
   type: ConnectorType,
-  authMethod: string,
+  authMethod: ConnectorAuthMethodType,
 ): Record<string, ConnectorSecretConfig> | undefined {
   const authMethods = getConnectorAuthMethods(type);
   return authMethods[authMethod]?.secrets;
@@ -3651,7 +3655,7 @@ export function getConnectorSecretsForAuthMethod(
  */
 export function getConnectorSecretNames(
   type: ConnectorType,
-  authMethod: string,
+  authMethod: ConnectorAuthMethodType,
 ): string[] {
   const secrets = getConnectorSecretsForAuthMethod(type, authMethod);
   return secrets ? Object.keys(secrets) : [];

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -24,20 +24,11 @@ export interface ConnectorAuthMethodConfig {
 
 /**
  * OAuth configuration for connectors that support OAuth flow.
- *
- * `environmentMapping` lives here because it only applies to the OAuth path:
- * OAuth stores secrets under internal names (e.g. `FIGMA_ACCESS_TOKEN`) that
- * need to be mapped to the env var names skills expect (e.g. `FIGMA_TOKEN`).
- * API-token connectors store secrets directly under the target name, so they
- * don't need any mapping.
- *
- * `$secrets.X` in mapping values looks up secret X from the connector's secrets.
  */
 export interface ConnectorOAuthConfig {
   authorizationUrl?: string;
   tokenUrl: string;
   scopes: string[];
-  environmentMapping: Record<string, string>;
 }
 
 /**
@@ -49,11 +40,9 @@ export interface ConnectorConfig {
   readonly featureFlag?: FeatureSwitchKey;
   readonly authMethods: Record<string, ConnectorAuthMethodConfig>;
   readonly defaultAuthMethod?: string;
-  /** Non-OAuth environment mapping (e.g. computer connector bridge credentials). */
-  readonly bridgeMapping?: Record<string, string>;
   readonly oauth?: ConnectorOAuthConfig;
-  /** Top-level environment mapping declaring which env vars this connector provides. */
-  readonly environmentMapping?: Record<string, string>;
+  /** Environment mapping declaring which env vars this connector provides. */
+  readonly environmentMapping: Record<string, string>;
 }
 
 /**
@@ -123,9 +112,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://app.ahrefs.com/api/auth",
       tokenUrl: "https://app.ahrefs.com/api/token",
       scopes: ["api"],
-      environmentMapping: {
-        AHREFS_TOKEN: "$secrets.AHREFS_ACCESS_TOKEN",
-      },
     },
   },
   agentmail: {
@@ -187,9 +173,6 @@ const CONNECTOR_TYPES_DEF = {
         "schema.bases:write",
         "user.email:read",
       ],
-      environmentMapping: {
-        AIRTABLE_TOKEN: "$secrets.AIRTABLE_ACCESS_TOKEN",
-      },
     },
   },
   github: {
@@ -217,10 +200,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://github.com/login/oauth/authorize",
       tokenUrl: "https://github.com/login/oauth/access_token",
       scopes: ["repo", "project"],
-      environmentMapping: {
-        GH_TOKEN: "$secrets.GITHUB_ACCESS_TOKEN",
-        GITHUB_TOKEN: "$secrets.GITHUB_ACCESS_TOKEN",
-      },
     },
   },
   notion: {
@@ -250,9 +229,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://api.notion.com/v1/oauth/authorize",
       tokenUrl: "https://api.notion.com/v1/oauth/token",
       scopes: [],
-      environmentMapping: {
-        NOTION_TOKEN: "$secrets.NOTION_ACCESS_TOKEN",
-      },
     },
   },
   gmail: {
@@ -282,9 +258,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenUrl: "https://oauth2.googleapis.com/token",
       scopes: ["https://www.googleapis.com/auth/gmail.modify"],
-      environmentMapping: {
-        GMAIL_TOKEN: "$secrets.GMAIL_ACCESS_TOKEN",
-      },
     },
   },
   "google-sheets": {
@@ -317,9 +290,6 @@ const CONNECTOR_TYPES_DEF = {
         "https://www.googleapis.com/auth/spreadsheets",
         "https://www.googleapis.com/auth/userinfo.email",
       ],
-      environmentMapping: {
-        GOOGLE_SHEETS_TOKEN: "$secrets.GOOGLE_SHEETS_ACCESS_TOKEN",
-      },
     },
   },
   "google-docs": {
@@ -352,9 +322,6 @@ const CONNECTOR_TYPES_DEF = {
         "https://www.googleapis.com/auth/documents",
         "https://www.googleapis.com/auth/userinfo.email",
       ],
-      environmentMapping: {
-        GOOGLE_DOCS_TOKEN: "$secrets.GOOGLE_DOCS_ACCESS_TOKEN",
-      },
     },
   },
   "google-drive": {
@@ -387,9 +354,6 @@ const CONNECTOR_TYPES_DEF = {
         "https://www.googleapis.com/auth/drive",
         "https://www.googleapis.com/auth/userinfo.email",
       ],
-      environmentMapping: {
-        GOOGLE_DRIVE_TOKEN: "$secrets.GOOGLE_DRIVE_ACCESS_TOKEN",
-      },
     },
   },
   "google-calendar": {
@@ -423,9 +387,6 @@ const CONNECTOR_TYPES_DEF = {
         "https://www.googleapis.com/auth/calendar",
         "https://www.googleapis.com/auth/userinfo.email",
       ],
-      environmentMapping: {
-        GOOGLE_CALENDAR_TOKEN: "$secrets.GOOGLE_CALENDAR_ACCESS_TOKEN",
-      },
     },
   },
   close: {
@@ -457,9 +418,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://app.close.com/oauth2/authorize/",
       tokenUrl: "https://api.close.com/oauth2/token/",
       scopes: ["all.full_access", "offline_access"],
-      environmentMapping: {
-        CLOSE_TOKEN: "$secrets.CLOSE_ACCESS_TOKEN",
-      },
     },
   },
   "hugging-face": {
@@ -569,9 +527,6 @@ const CONNECTOR_TYPES_DEF = {
         "crm.schemas.contacts.read",
         "settings.users.read",
       ],
-      environmentMapping: {
-        HUBSPOT_TOKEN: "$secrets.HUBSPOT_ACCESS_TOKEN",
-      },
     },
   },
   computer: {
@@ -605,11 +560,6 @@ const CONNECTOR_TYPES_DEF = {
       },
     },
     defaultAuthMethod: "api",
-    bridgeMapping: {
-      COMPUTER_CONNECTOR_BRIDGE_TOKEN:
-        "$secrets.COMPUTER_CONNECTOR_BRIDGE_TOKEN",
-      COMPUTER_CONNECTOR_DOMAIN: "$secrets.COMPUTER_CONNECTOR_DOMAIN",
-    },
   },
   slack: {
     label: "Slack",
@@ -675,9 +625,6 @@ const CONNECTOR_TYPES_DEF = {
         // Custom emoji (low priority)
         "emoji:read",
       ],
-      environmentMapping: {
-        SLACK_TOKEN: "$secrets.SLACK_ACCESS_TOKEN",
-      },
     },
   },
   docusign: {
@@ -709,9 +656,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://account.docusign.com/oauth/auth",
       tokenUrl: "https://account.docusign.com/oauth/token",
       scopes: ["signature", "extended", "openid"],
-      environmentMapping: {
-        DOCUSIGN_TOKEN: "$secrets.DOCUSIGN_ACCESS_TOKEN",
-      },
     },
   },
   dropbox: {
@@ -756,9 +700,6 @@ const CONNECTOR_TYPES_DEF = {
         "files.metadata.read",
         "files.content.read",
       ],
-      environmentMapping: {
-        DROPBOX_TOKEN: "$secrets.DROPBOX_ACCESS_TOKEN",
-      },
     },
   },
   linear: {
@@ -794,9 +735,6 @@ const CONNECTOR_TYPES_DEF = {
         "comments:create",
         "timeSchedule:write",
       ],
-      environmentMapping: {
-        LINEAR_TOKEN: "$secrets.LINEAR_ACCESS_TOKEN",
-      },
     },
   },
   intercom: {
@@ -1087,9 +1025,6 @@ const CONNECTOR_TYPES_DEF = {
         "invoice-adjustments:read",
         "invoice-adjustments:write",
       ],
-      environmentMapping: {
-        DEEL_TOKEN: "$secrets.DEEL_ACCESS_TOKEN",
-      },
     },
   },
   deepseek: {
@@ -1305,9 +1240,6 @@ const CONNECTOR_TYPES_DEF = {
         "library_assets:read",
         "library_content:read",
       ],
-      environmentMapping: {
-        FIGMA_TOKEN: "$secrets.FIGMA_ACCESS_TOKEN",
-      },
     },
   },
   mercury: {
@@ -1351,9 +1283,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://oauth2.mercury.com/oauth2/auth",
       tokenUrl: "https://oauth2.mercury.com/oauth2/token",
       scopes: ["offline_access"],
-      environmentMapping: {
-        MERCURY_TOKEN: "$secrets.MERCURY_ACCESS_TOKEN",
-      },
     },
   },
   minimax: {
@@ -1478,9 +1407,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://www.reddit.com/api/v1/authorize",
       tokenUrl: "https://www.reddit.com/api/v1/access_token",
       scopes: ["identity", "read"],
-      environmentMapping: {
-        REDDIT_TOKEN: "$secrets.REDDIT_ACCESS_TOKEN",
-      },
     },
   },
   strava: {
@@ -1516,9 +1442,6 @@ const CONNECTOR_TYPES_DEF = {
         "activity:read_all",
         "activity:write",
       ],
-      environmentMapping: {
-        STRAVA_TOKEN: "$secrets.STRAVA_ACCESS_TOKEN",
-      },
     },
   },
   x: {
@@ -1573,9 +1496,6 @@ const CONNECTOR_TYPES_DEF = {
         "dm.write", // Send and manage Direct Messages for you.
         "media.write", // Upload media.
       ],
-      environmentMapping: {
-        X_TOKEN: "$secrets.X_ACCESS_TOKEN",
-      },
     },
   },
   neon: {
@@ -1624,9 +1544,6 @@ const CONNECTOR_TYPES_DEF = {
         "urn:neoncloud:projects:update",
         "urn:neoncloud:projects:delete",
       ],
-      environmentMapping: {
-        NEON_TOKEN: "$secrets.NEON_ACCESS_TOKEN",
-      },
     },
   },
   gamma: {
@@ -1681,9 +1598,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://connect.garmin.com/oauth2Confirm",
       tokenUrl: "https://diauth.garmin.com/di-oauth2-service/oauth/token",
       scopes: [],
-      environmentMapping: {
-        GARMIN_CONNECT_TOKEN: "$secrets.GARMIN_CONNECT_ACCESS_TOKEN",
-      },
     },
   },
   vercel: {
@@ -1709,9 +1623,6 @@ const CONNECTOR_TYPES_DEF = {
     oauth: {
       tokenUrl: "https://api.vercel.com/v2/oauth/access_token",
       scopes: [],
-      environmentMapping: {
-        VERCEL_TOKEN: "$secrets.VERCEL_ACCESS_TOKEN",
-      },
     },
   },
   sentry: {
@@ -1749,9 +1660,6 @@ const CONNECTOR_TYPES_DEF = {
         "event:read",
         "event:write",
       ],
-      environmentMapping: {
-        SENTRY_TOKEN: "$secrets.SENTRY_ACCESS_TOKEN",
-      },
     },
   },
   posthog: {
@@ -1818,9 +1726,6 @@ const CONNECTOR_TYPES_DEF = {
         "survey:write",
         "error_tracking:read",
       ],
-      environmentMapping: {
-        POSTHOG_TOKEN: "$secrets.POSTHOG_ACCESS_TOKEN",
-      },
     },
   },
   productlane: {
@@ -1846,6 +1751,9 @@ const CONNECTOR_TYPES_DEF = {
   },
   "intervals-icu": {
     label: "Intervals.icu",
+    environmentMapping: {
+      INTERVALS_ICU_TOKEN: "$secrets.INTERVALS_ICU_ACCESS_TOKEN",
+    },
     helpText:
       "Connect your Intervals.icu account to access training, activity, wellness, and calendar data",
     authMethods: {
@@ -1865,9 +1773,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://intervals.icu/oauth/authorize",
       tokenUrl: "https://intervals.icu/api/oauth/token",
       scopes: ["ACTIVITY", "WELLNESS", "CALENDAR", "SETTINGS", "LIBRARY"],
-      environmentMapping: {
-        INTERVALS_ICU_TOKEN: "$secrets.INTERVALS_ICU_ACCESS_TOKEN",
-      },
     },
   },
   monday: {
@@ -1913,9 +1818,6 @@ const CONNECTOR_TYPES_DEF = {
         "tags:read",
         "teams:read",
       ],
-      environmentMapping: {
-        MONDAY_TOKEN: "$secrets.MONDAY_ACCESS_TOKEN",
-      },
     },
   },
   calendly: {
@@ -1983,9 +1885,6 @@ const CONNECTOR_TYPES_DEF = {
         "folder:write",
         "profile:read",
       ],
-      environmentMapping: {
-        CANVA_TOKEN: "$secrets.CANVA_ACCESS_TOKEN",
-      },
     },
   },
   "cal-com": {
@@ -2062,9 +1961,6 @@ const CONNECTOR_TYPES_DEF = {
         "assets",
         "projects",
       ],
-      environmentMapping: {
-        XERO_TOKEN: "$secrets.XERO_ACCESS_TOKEN",
-      },
     },
   },
   supabase: {
@@ -2119,9 +2015,6 @@ const CONNECTOR_TYPES_DEF = {
         "environment:read",
         "domains:read",
       ],
-      environmentMapping: {
-        SUPABASE_TOKEN: "$secrets.SUPABASE_ACCESS_TOKEN",
-      },
     },
   },
   todoist: {
@@ -2148,9 +2041,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://todoist.com/oauth/authorize",
       tokenUrl: "https://todoist.com/oauth/access_token",
       scopes: ["data:read_write", "data:delete", "project:delete"],
-      environmentMapping: {
-        TODOIST_TOKEN: "$secrets.TODOIST_ACCESS_TOKEN",
-      },
     },
   },
   webflow: {
@@ -2204,9 +2094,6 @@ const CONNECTOR_TYPES_DEF = {
         "custom_code:read",
         "custom_code:write",
       ],
-      environmentMapping: {
-        WEBFLOW_TOKEN: "$secrets.WEBFLOW_ACCESS_TOKEN",
-      },
     },
   },
   wrike: {
@@ -2258,9 +2145,6 @@ const CONNECTOR_TYPES_DEF = {
         "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
       scopes: ["Mail.ReadWrite", "Mail.Send", "User.Read", "offline_access"],
-      environmentMapping: {
-        OUTLOOK_MAIL_TOKEN: "$secrets.OUTLOOK_MAIL_ACCESS_TOKEN",
-      },
     },
   },
   "outlook-calendar": {
@@ -2293,9 +2177,6 @@ const CONNECTOR_TYPES_DEF = {
         "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
       tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
       scopes: ["Calendars.ReadWrite", "User.Read", "offline_access"],
-      environmentMapping: {
-        OUTLOOK_CALENDAR_TOKEN: "$secrets.OUTLOOK_CALENDAR_ACCESS_TOKEN",
-      },
     },
   },
   asana: {
@@ -2326,9 +2207,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://app.asana.com/-/oauth_authorize",
       tokenUrl: "https://app.asana.com/-/oauth_token",
       scopes: [],
-      environmentMapping: {
-        ASANA_TOKEN: "$secrets.ASANA_ACCESS_TOKEN",
-      },
     },
   },
   atlassian: {
@@ -2397,9 +2275,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://www.facebook.com/v22.0/dialog/oauth",
       tokenUrl: "https://graph.facebook.com/v22.0/oauth/access_token",
       scopes: ["ads_management", "ads_read", "business_management"],
-      environmentMapping: {
-        META_ADS_TOKEN: "$secrets.META_ADS_ACCESS_TOKEN",
-      },
     },
   },
   stripe: {
@@ -2431,9 +2306,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://connect.stripe.com/oauth/authorize",
       tokenUrl: "https://connect.stripe.com/oauth/token",
       scopes: ["read_write"],
-      environmentMapping: {
-        STRIPE_TOKEN: "$secrets.STRIPE_ACCESS_TOKEN",
-      },
     },
   },
   openai: {
@@ -2556,10 +2428,6 @@ const CONNECTOR_TYPES_DEF = {
       authorizationUrl: "https://login.mailchimp.com/oauth2/authorize",
       tokenUrl: "https://login.mailchimp.com/oauth2/token",
       scopes: [],
-      environmentMapping: {
-        MAILCHIMP_TOKEN: "$secrets.MAILCHIMP_ACCESS_TOKEN",
-        MAILCHIMP_DC: "$vars.MAILCHIMP_DC",
-      },
     },
   },
   chatwoot: {
@@ -3599,6 +3467,9 @@ const CONNECTOR_TYPES_DEF = {
   },
   spotify: {
     label: "Spotify",
+    environmentMapping: {
+      SPOTIFY_TOKEN: "$secrets.SPOTIFY_ACCESS_TOKEN",
+    },
     featureFlag: FeatureSwitchKey.SpotifyConnector,
     helpText:
       "Connect your Spotify account to manage playlists, control playback, and access music data",
@@ -3643,9 +3514,6 @@ const CONNECTOR_TYPES_DEF = {
         "user-read-email",
         "user-read-private",
       ],
-      environmentMapping: {
-        SPOTIFY_TOKEN: "$secrets.SPOTIFY_ACCESS_TOKEN",
-      },
     },
   },
   "slack-webhook": {
@@ -3791,20 +3659,11 @@ export function getConnectorSecretNames(
 
 /**
  * Get environment mapping for a connector type.
- *
- * Reads from top-level `environmentMapping` first, then falls back to
- * `oauth.environmentMapping` and `bridgeMapping` for backward compatibility.
  */
 export function getConnectorEnvironmentMapping(
   type: ConnectorType,
 ): Record<string, string> {
-  const config = CONNECTOR_TYPES[type];
-  return (
-    config.environmentMapping ??
-    config.oauth?.environmentMapping ??
-    config.bridgeMapping ??
-    {}
-  );
+  return CONNECTOR_TYPES[type].environmentMapping;
 }
 
 /**

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -383,6 +383,7 @@ export {
   type ConnectorConfig,
   type ConnectorSecretConfig,
   type ConnectorAuthMethodConfig,
+  type ConnectorAuthMethodType,
   type ConnectorOAuthConfig,
   computerConnectorCreateResponseSchema,
   type ComputerConnectorCreateResponse,


### PR DESCRIPTION
## Summary

- Remove duplicate `oauth.environmentMapping` (40 instances) and `bridgeMapping` (1 instance), consolidating all 127 connectors to use a single required top-level `environmentMapping` field
- Simplify `getConnectorEnvironmentMapping()` from a three-way fallback chain to a direct property access
- Add `ConnectorAuthMethodType` enum (`"oauth" | "api-token" | "api"`) to constrain `authMethods` keys
- Make `environmentMapping` required on `ConnectorConfig`
- Update `getConnectorAuthMethods()` return type to match `Partial<Record<ConnectorAuthMethodType, ...>>`
- Add tests validating OAuth connector naming conventions and api-token-only connector mapping consistency

## Test plan

- [x] `connectors.test.ts` — 24 tests pass (including new naming convention tests)
- [x] `firewall-secret-consistency.test.ts` — 117 tests pass
- [x] `pnpm check-types --filter=@vm0/core` — no type errors
- [x] `pnpm turbo run lint --filter=@vm0/core` — no lint issues
- [x] knip — no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)