### PR TITLE
fix(firewalls): read latest refresh token from db before oauth refresh

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -621,6 +621,58 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
       expect(data.error.connectors).toEqual(["close"]);
     });
 
+    it("should use DB refresh token instead of stale encrypted refresh token", async () => {
+      // Simulate: token is expired and needs refresh, but the refresh token
+      // in encryptedSecrets is stale (rotated by a concurrent request).
+      // DB has the current refresh token. The endpoint must use the DB value.
+      const expiredAt = new Date(Date.now() - 60 * 1000);
+      await setupNotionConnector({
+        tokenExpiresAt: expiredAt,
+        refreshToken: "current-db-refresh-token",
+      });
+
+      // Track which refresh token the provider receives
+      let receivedRefreshToken: string | undefined;
+      server.use(
+        mswHttp.post(NOTION_TOKEN_URL, async ({ request }) => {
+          const body = await request.json();
+          receivedRefreshToken =
+            (body as Record<string, string>).grant_type === "refresh_token"
+              ? (body as Record<string, string>).refresh_token
+              : undefined;
+          return HttpResponse.json({
+            access_token: "new-access-token",
+            expires_in: 3600,
+          });
+        }),
+      );
+
+      // encryptedSecrets has a STALE refresh token
+      const encrypted = encryptTestSecrets({
+        NOTION_ACCESS_TOKEN: "old-access-token",
+        NOTION_REFRESH_TOKEN: "stale-encrypted-refresh-token",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.NOTION_ACCESS_TOKEN }}",
+            },
+            secretConnectorMap: { NOTION_ACCESS_TOKEN: "notion" },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers.Authorization).toBe("Bearer new-access-token");
+      // Must have used the DB refresh token, not the stale encrypted one
+      expect(receivedRefreshToken).toBe("current-db-refresh-token");
+    });
+
     it("should use current DB token when another request already refreshed", async () => {
       // Simulate race condition: token was recently refreshed by another request.
       // DB has fresh expiry (30 min) and fresh token in secrets table,

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -11,6 +11,7 @@ import {
   refreshConnectorAccessToken,
   getConnectorExpiry,
   getConnectorAccessToken,
+  getConnectorRefreshToken,
 } from "../../../../../../src/lib/connector/connector-service";
 
 const bodySchema = z.object({
@@ -23,6 +24,32 @@ const log = logger("webhook:firewall-auth");
 
 /** Matches ${{ secrets.KEY_NAME }} template placeholders in auth header values. */
 const SECRET_TEMPLATE_RE = /\$\{\{\s*secrets\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
+
+/**
+ * Sync latest refresh tokens from DB into the secrets map.
+ * The secrets map originates from a build-time encrypted snapshot and may
+ * contain stale refresh tokens rotated by a concurrent request (#7339).
+ * Mutates `secrets` in place.
+ */
+async function syncRefreshTokensFromDb(
+  connectorTypes: string[],
+  orgId: string,
+  userId: string,
+  secrets: Record<string, string>,
+): Promise<void> {
+  if (connectorTypes.length === 0) return;
+  const results = await Promise.all(
+    connectorTypes.map(async (ct) => ({
+      connectorType: ct,
+      result: await getConnectorRefreshToken(ct, orgId, userId),
+    })),
+  );
+  for (const { result } of results) {
+    if (result) {
+      secrets[result.secretName] = result.token;
+    }
+  }
+}
 
 /**
  * Refresh expired OAuth tokens referenced by auth templates.
@@ -87,6 +114,11 @@ async function refreshExpiredTokens(
     arr.push(envVar);
     envVarsByConnector.set(ct, arr);
   }
+
+  // Sync latest refresh tokens from DB into secrets before refreshing.
+  // The secrets map was decrypted from a build-time snapshot and may contain
+  // stale refresh tokens that were rotated by a concurrent request (#7339).
+  await syncRefreshTokensFromDb(toRefresh, run.orgId, auth.userId, secrets);
 
   const refreshResults = await Promise.all(
     toRefresh.map(async (connectorType) => {

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -39,12 +39,9 @@ async function syncRefreshTokensFromDb(
 ): Promise<void> {
   if (connectorTypes.length === 0) return;
   const results = await Promise.all(
-    connectorTypes.map(async (ct) => ({
-      connectorType: ct,
-      result: await getConnectorRefreshToken(ct, orgId, userId),
-    })),
+    connectorTypes.map((ct) => getConnectorRefreshToken(ct, orgId, userId)),
   );
-  for (const { result } of results) {
+  for (const result of results) {
     if (result) {
       secrets[result.secretName] = result.token;
     }

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -659,6 +659,25 @@ export async function getConnectorAccessToken(
 }
 
 /**
+ * Read the current refresh token for a connector type from the secrets store.
+ * Does NOT trigger a refresh — returns the latest persisted value.
+ * Returns null if the connector has no refresh token support or no stored value.
+ */
+export async function getConnectorRefreshToken(
+  connectorType: string,
+  orgId: string,
+  userId: string,
+): Promise<{ secretName: string; token: string } | null> {
+  const handler =
+    PROVIDER_HANDLERS[connectorType as keyof typeof PROVIDER_HANDLERS];
+  if (!handler?.getRefreshSecretName) return null;
+  const secretName = handler.getRefreshSecretName();
+  const token = await getSecretValue(orgId, userId, secretName, "connector");
+  if (!token) return null;
+  return { secretName, token };
+}
+
+/**
  * Create or update a connector secret (e.g., refresh token)
  */
 async function upsertConnectorSecret(


### PR DESCRIPTION
## Summary
- Fix intermittent OAuth auth failures caused by stale refresh tokens in the firewall auth endpoint
- The `encryptedSecrets` blob is a build-time snapshot; if a concurrent request rotated the refresh token, the snapshot value is invalid
- Before refreshing, sync the latest refresh tokens from DB into the secrets map (same pattern as #7291 for access tokens)

## Test plan
- [ ] Verify type check passes (`pnpm check-types`)
- [ ] Verify lint passes (`pnpm turbo run lint`)
- [ ] Verify existing firewall auth tests pass
- [ ] Manual: trigger two concurrent runs using the same OAuth connector and confirm both complete without `TOKEN_REFRESH_FAILED`

Closes #7339

🤖 Generated with [Claude Code](https://claude.com/claude-code)