### PR TITLE
fix: auto-save connector toggles with loading spinner and scoped drafts

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
-import { setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  setupPage,
+  updateTestPathname$,
+} from "../../../__tests__/page-helper.ts";
 import { allConnectorTypes$ } from "../settings/connectors.ts";
+import { zeroAddedConnectors$, addZeroConnector$ } from "../zero-connectors.ts";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 
 const context = testContext();
@@ -86,5 +90,66 @@ describe("connectors", () => {
     // GitHub should be connected and at position 0
     expect(connectorTypes[0].type).toBe("github" as ConnectorType);
     expect(connectorTypes[0].connected).toBeTruthy();
+  });
+});
+
+describe("zero connectors — agent switch discards local draft", () => {
+  it("should return seeded connectors for new agent after switching", async () => {
+    // Mock two agents with different user-connector permissions
+    server.use(
+      http.get("*/api/zero/agents/agent-a", () => {
+        return HttpResponse.json({
+          name: "agent-a",
+          agentId: "uuid-a",
+          description: null,
+          displayName: "Agent A",
+          sound: null,
+          avatarUrl: null,
+          firewallPolicies: null,
+        });
+      }),
+      http.get("*/api/zero/agents/agent-b", () => {
+        return HttpResponse.json({
+          name: "agent-b",
+          agentId: "uuid-b",
+          description: null,
+          displayName: "Agent B",
+          sound: null,
+          avatarUrl: null,
+          firewallPolicies: null,
+        });
+      }),
+      http.get("*/api/zero/agents/:id/user-connectors", ({ params }) => {
+        if (params["id"] === "uuid-a" || params["id"] === "agent-a") {
+          return HttpResponse.json({ enabledTypes: ["github"] });
+        }
+        return HttpResponse.json({ enabledTypes: ["slack"] });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/team/agent-a",
+      withoutRender: true,
+    });
+
+    // Agent A should have github as seeded connector
+    const initialConnectors = await context.store.get(zeroAddedConnectors$);
+    expect(initialConnectors).toEqual(["github"]);
+
+    // Add a local connector for agent A
+    await context.store.set(addZeroConnector$, "notion", context.signal);
+
+    const afterAdd = await context.store.get(zeroAddedConnectors$);
+    expect(afterAdd).toContain("notion");
+    expect(afterAdd).toContain("github");
+
+    // Switch to agent B by updating the pathname
+    context.store.set(updateTestPathname$, "/team/agent-b");
+
+    // Local draft should be discarded; agent B's seeded connectors should show
+    const agentBConnectors = await context.store.get(zeroAddedConnectors$);
+    expect(agentBConnectors).toEqual(["slack"]);
+    expect(agentBConnectors).not.toContain("notion");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-connectors.test.ts
@@ -135,7 +135,7 @@ describe("zero connectors — agent switch discards local draft", () => {
 
     // Agent A should have github as seeded connector
     const initialConnectors = await context.store.get(zeroAddedConnectors$);
-    expect(initialConnectors).toEqual(["github"]);
+    expect(initialConnectors).toStrictEqual(["github"]);
 
     // Add a local connector for agent A
     await context.store.set(addZeroConnector$, "notion", context.signal);
@@ -149,7 +149,7 @@ describe("zero connectors — agent switch discards local draft", () => {
 
     // Local draft should be discarded; agent B's seeded connectors should show
     const agentBConnectors = await context.store.get(zeroAddedConnectors$);
-    expect(agentBConnectors).toEqual(["slack"]);
+    expect(agentBConnectors).toStrictEqual(["slack"]);
     expect(agentBConnectors).not.toContain("notion");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-job-detail.test.ts
@@ -26,6 +26,7 @@ import {
   zeroJobUpdateSettings$,
   zeroJobSettingsSaving$,
   zeroJobAddedConnectors$,
+  zeroJobConnectorsLoading$,
   zeroJobConnectorsDirty$,
   addZeroJobConnector$,
   removeZeroJobConnector$,
@@ -1082,6 +1083,12 @@ describe("zero-job-detail signals", () => {
       const connectors = context.store.get(zeroJobAddedConnectors$);
       expect(connectors).toStrictEqual(["search"]);
       expect(context.store.get(zeroJobConnectorsDirty$)).toBeFalsy();
+    });
+
+    it("should report loading=false after connectors are fetched", async () => {
+      await setupWithAgent();
+
+      expect(context.store.get(zeroJobConnectorsLoading$)).toBeFalsy();
     });
 
     it("should add and remove connectors with dirty tracking", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -45,8 +45,11 @@ const zeroAgent$ = computed(async (get) => {
 
 const internalSaving$ = state(false);
 
-// null = not initialized (fallback to seeded), string[] = user's local draft
-const internalAddedConnectors$ = state<string[] | null>(null);
+// Local draft tagged with the agent it belongs to; discarded on agent switch.
+const internalAddedConnectors$ = state<{
+  agentId: string;
+  connectors: string[];
+} | null>(null);
 
 /** User connector permissions for this agent from the user-connectors API. */
 const seededConnectors$ = computed(async (get) => {
@@ -64,9 +67,10 @@ const seededConnectors$ = computed(async (get) => {
 
 /** Added connectors: local draft takes precedence, otherwise seeded from agent. */
 export const zeroAddedConnectors$ = computed(async (get) => {
+  const agentId = await get(zeroAgentId$);
   const local = get(internalAddedConnectors$);
-  if (local !== null) {
-    return local;
+  if (local !== null && local.agentId === agentId) {
+    return local.connectors;
   }
   return await get(seededConnectors$);
 });
@@ -74,22 +78,32 @@ export const zeroAddedConnectors$ = computed(async (get) => {
 /** Add a connector (local only, no compose job). */
 export const addZeroConnector$ = command(
   async ({ get, set }, name: string, _signal: AbortSignal) => {
-    if (get(internalAddedConnectors$) === null) {
-      set(internalAddedConnectors$, await get(seededConnectors$));
-    }
-    set(internalAddedConnectors$, (prev) => [...(prev ?? []), name]);
+    const agentId = await get(zeroAgentId$);
+    const local = get(internalAddedConnectors$);
+    const base =
+      local !== null && local.agentId === agentId
+        ? local.connectors
+        : await get(seededConnectors$);
+    set(internalAddedConnectors$, {
+      agentId: agentId ?? "",
+      connectors: [...base, name],
+    });
   },
 );
 
 /** Remove a connector (local only, no compose job). */
 export const removeZeroConnector$ = command(
   async ({ get, set }, name: string, _signal: AbortSignal) => {
-    if (get(internalAddedConnectors$) === null) {
-      set(internalAddedConnectors$, await get(seededConnectors$));
-    }
-    set(internalAddedConnectors$, (prev) =>
-      (prev ?? []).filter((n) => n !== name),
-    );
+    const agentId = await get(zeroAgentId$);
+    const local = get(internalAddedConnectors$);
+    const base =
+      local !== null && local.agentId === agentId
+        ? local.connectors
+        : await get(seededConnectors$);
+    set(internalAddedConnectors$, {
+      agentId: agentId ?? "",
+      connectors: base.filter((n) => n !== name),
+    });
   },
 );
 
@@ -98,7 +112,8 @@ export const saveZeroConnectors$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(internalSaving$, true);
     try {
-      const newConnectors = get(internalAddedConnectors$) ?? [];
+      const local = get(internalAddedConnectors$);
+      const newConnectors = local?.connectors ?? [];
       await set(syncConnectorsToCompose$, newConnectors, signal);
       // Reset to null so seeded picks up the new agent state
       set(internalAddedConnectors$, null);

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -383,6 +383,10 @@ const seededConnectors$ = computed(
   (get) => get(userConnectorPermissionsState$).enabledTypes,
 );
 
+export const zeroJobConnectorsLoading$ = computed(
+  (get) => get(userConnectorPermissionsState$).loading,
+);
+
 export const zeroJobAddedConnectors$ = computed((get) => {
   const local = get(internalAddedConnectors$);
   if (local !== null) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
@@ -107,7 +107,7 @@ describe("zero authorization tab — toggle rows", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: "Grant GitHub" }),
+        screen.getByRole("switch", { name: "Grant GitHub access" }),
       ).toBeInTheDocument();
     });
   });
@@ -120,7 +120,7 @@ describe("zero authorization tab — toggle rows", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: "Revoke GitHub" }),
+        screen.getByRole("switch", { name: "Revoke GitHub access" }),
       ).toBeInTheDocument();
     });
   });
@@ -161,17 +161,17 @@ describe("zero authorization tab — multiple connectors", () => {
 
     // GitHub is enabled, Slack is not
     expect(
-      screen.getByRole("button", { name: "Revoke GitHub" }),
+      screen.getByRole("switch", { name: "Revoke GitHub access" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Grant Slack" }),
+      screen.getByRole("switch", { name: "Grant Slack access" }),
     ).toBeInTheDocument();
   });
 });
 
 /**
  * Render the default agent's authorization tab as a non-admin member.
- * This triggers readOnly=true (hideProfileAndInstructions) in ZeroJobDetailPage.
+ * Connector permissions are user-level, so toggles remain interactive.
  */
 async function renderTeamPageAsMember(
   orgConnectors: ConnectorResponse[],
@@ -220,20 +220,20 @@ async function renderTeamPageAsMember(
   await setupPage({ context, path: "/team/zero" });
 }
 
-describe("zero authorization tab — readOnly behavior (member on default agent)", () => {
-  it("shows toggle row but disables it when readOnly", async () => {
+describe("zero authorization tab — member on default agent", () => {
+  it("toggle is interactive (not disabled) because connector permissions are user-level", async () => {
     await renderTeamPageAsMember(
       [makeConnector({ type: "github", oauthScopes: ["repo", "project"] })],
       ["github"],
     );
 
     const toggleRow = await waitFor(() =>
-      screen.getByRole("button", { name: "Revoke GitHub" }),
+      screen.getByRole("switch", { name: "Revoke GitHub access" }),
     );
-    expect(toggleRow).toBeDisabled();
+    expect(toggleRow).not.toBeDisabled();
   });
 
-  it("shows empty state when readOnly and no org connectors", async () => {
+  it("shows empty state when no org connectors", async () => {
     await renderTeamPageAsMember([], []);
 
     await waitFor(() => {
@@ -241,7 +241,7 @@ describe("zero authorization tab — readOnly behavior (member on default agent)
     });
   });
 
-  it("shows toggle row for enabled connector when readOnly", async () => {
+  it("shows toggle row for enabled connector", async () => {
     await renderTeamPageAsMember(
       [makeConnector({ type: "github", oauthScopes: ["repo", "project"] })],
       ["github"],
@@ -251,7 +251,7 @@ describe("zero authorization tab — readOnly behavior (member on default agent)
       expect(screen.getByText("GitHub")).toBeInTheDocument();
     });
     expect(
-      screen.getByRole("button", { name: "Revoke GitHub" }),
+      screen.getByRole("switch", { name: "Revoke GitHub access" }),
     ).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from "react";
+import { useState, type ChangeEvent } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   IconArrowUp,
@@ -18,7 +18,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Switch,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -48,6 +47,7 @@ import {
   justConnectedTypes$,
   clearJustConnectedTypes$,
 } from "../../signals/zero-page/settings/connectors.ts";
+import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   zeroAddedConnectors$,
@@ -141,11 +141,15 @@ function ConnectorTriggerIcons({
 
 function ConnectorsPopoverButton({
   agentConnectors,
+  connectorsLoading,
+  savingType,
   onOpenAddDialog,
   onToggle,
   displayName,
 }: {
   agentConnectors: ComposerConnectorItem[];
+  connectorsLoading: boolean;
+  savingType: string | null;
   onOpenAddDialog: () => void;
   onToggle: (type: string, checked: boolean) => void;
   displayName: string;
@@ -171,13 +175,23 @@ function ConnectorsPopoverButton({
         </Tooltip>
       </TooltipProvider>
       <PopoverContent side="top" align="start" className="w-72 p-0 rounded-lg">
-        {agentConnectors.length > 0 && (
-          <div className="py-1">
-            <div className="px-3 pt-2 pb-1">
-              <span className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
-                Services for {displayName}
-              </span>
+        <div className="py-1">
+          <div className="px-3 pt-2 pb-1">
+            <span className="text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider">
+              Services for {displayName}
+            </span>
+          </div>
+          {connectorsLoading ? (
+            <div className="flex flex-col animate-pulse">
+              {Array.from({ length: 3 }, (_, i) => (
+                <div key={i} className="flex items-center gap-2 px-3 py-2">
+                  <span className="h-4 w-4 shrink-0 rounded bg-muted/50" />
+                  <span className="h-3.5 w-20 rounded bg-muted/50 flex-1" />
+                  <span className="h-3 w-6 rounded-full bg-muted/50" />
+                </div>
+              ))}
             </div>
+          ) : agentConnectors.length > 0 ? (
             <div className="flex flex-col">
               {agentConnectors.map((item) => (
                 <div
@@ -193,21 +207,22 @@ function ConnectorsPopoverButton({
                   <span className="text-sm flex-1 truncate text-foreground">
                     {item.label}
                   </span>
-                  <Switch
+                  <LoadingSwitch
                     checked={item.added}
                     onCheckedChange={(checked) => onToggle(item.type, checked)}
-                    size="sm"
-                    aria-label={`${item.added ? "Remove" : "Add"} ${item.label}`}
+                    loading={savingType === item.type}
+                    ariaLabel={`${item.added ? "Remove" : "Add"} ${item.label}`}
                   />
                 </div>
               ))}
             </div>
-          </div>
-        )}
+          ) : null}
+        </div>
         <div
           className={cn(
             "p-1 flex flex-col",
-            agentConnectors.length > 0 && "border-t border-border/50",
+            (agentConnectors.length > 0 || connectorsLoading) &&
+              "border-t border-border/50",
           )}
         >
           <button
@@ -272,6 +287,12 @@ export function ZeroChatComposer({
   const clearOptimistic = useSet(clearJustConnectedTypes$);
   const navigate = useSet(detachedNavigateTo$);
 
+  const [savingType, setSavingType] = useState<string | null>(null);
+
+  const connectorsLoading =
+    allTypesLoadable.state !== "hasData" ||
+    addedConnectorsLoadable.state !== "hasData";
+
   const allConnectors =
     allTypesLoadable.state === "hasData" ? allTypesLoadable.data : [];
   const connectorMap = new Map(allConnectors.map((c) => [c.type, c]));
@@ -311,31 +332,24 @@ export function ZeroChatComposer({
   };
 
   const handleToggle = (type: string, checked: boolean) => {
-    if (checked) {
-      detach(
-        (async () => {
+    setSavingType(type);
+    detach(
+      (async () => {
+        if (checked) {
           await addConnector(type, pageSignal);
-          try {
-            await saveConnectors(pageSignal);
-          } catch (error) {
-            throwIfAbort(error);
-          }
-        })(),
-        Reason.DomCallback,
-      );
-    } else {
-      detach(
-        (async () => {
+        } else {
           await removeConnector(type, pageSignal);
-          try {
-            await saveConnectors(pageSignal);
-          } catch (error) {
-            throwIfAbort(error);
-          }
-        })(),
-        Reason.DomCallback,
-      );
-    }
+        }
+        try {
+          await saveConnectors(pageSignal);
+        } catch (error) {
+          throwIfAbort(error);
+        } finally {
+          setSavingType(null);
+        }
+      })(),
+      Reason.DomCallback,
+    );
   };
 
   const handleSend = () => {
@@ -428,6 +442,8 @@ export function ZeroChatComposer({
                 </button>
                 <ConnectorsPopoverButton
                   agentConnectors={agentConnectors}
+                  connectorsLoading={connectorsLoading}
+                  savingType={savingType}
                   onOpenAddDialog={() => navigate("/connectors")}
                   onToggle={handleToggle}
                   displayName={displayName}

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -27,11 +27,11 @@ import {
   TooltipTrigger,
   Card,
   CardContent,
-  Switch,
   cn,
 } from "@vm0/ui";
 import { ZeroScheduleTab } from "./zero-schedule-tab.tsx";
 import { ZeroInstructionsTab } from "./zero-instructions-tab.tsx";
+import { LoadingSwitch } from "../components/loading-switch.tsx";
 import { ZeroSettingsTab } from "./zero-settings-tab.tsx";
 
 import { TONE_OPTIONS, type Tone } from "./zero-tone-constants.ts";
@@ -58,11 +58,10 @@ import {
   zeroJobSettingsSaving$,
   deleteZeroJobAgent$,
   zeroJobAddedConnectors$,
-  zeroJobConnectorsDirty$,
+  zeroJobConnectorsLoading$,
   addZeroJobConnector$,
   removeZeroJobConnector$,
   saveZeroJobConnectors$,
-  discardZeroJobConnectors$,
   zeroJobActiveTab$,
   setZeroJobActiveTab$,
   zeroJobFirewallPolicies$,
@@ -90,7 +89,6 @@ import {
   allConnectorTypes$,
   type ConnectorTypeWithStatus,
 } from "../../signals/zero-page/settings/connectors.ts";
-import { ZeroUnsavedBar } from "./zero-unsaved-bar.tsx";
 import { toast } from "@vm0/ui/components/ui/sonner";
 
 // ---------------------------------------------------------------------------
@@ -283,7 +281,7 @@ function PermissionRow({
   connector,
   enabled,
   onToggle,
-  readOnly,
+  loading,
   showManage,
   onManage,
   isLast,
@@ -291,24 +289,14 @@ function PermissionRow({
   connector: ConnectorTypeWithStatus;
   enabled: boolean;
   onToggle: (checked: boolean) => void;
-  readOnly?: boolean;
+  loading?: boolean;
   showManage?: boolean;
   onManage?: () => void;
   isLast?: boolean;
 }) {
   return (
     <>
-      <button
-        type="button"
-        disabled={readOnly}
-        onClick={() => onToggle(!enabled)}
-        className={cn(
-          "flex items-center gap-3 px-5 py-4 w-full text-left transition-colors",
-          !readOnly && "hover:bg-muted/40 cursor-pointer",
-          readOnly && "cursor-default",
-        )}
-        aria-label={`${enabled ? "Revoke" : "Grant"} ${connector.label}`}
-      >
+      <div className="flex items-center gap-3 px-5 py-4 w-full text-left transition-colors">
         <ConnectorIcon type={connector.type} size={20} />
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
@@ -339,13 +327,9 @@ function PermissionRow({
                   <span
                     role="button"
                     tabIndex={0}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onManage?.();
-                    }}
+                    onClick={() => onManage?.()}
                     onKeyDown={(e) => {
                       if (e.key === "Enter" || e.key === " ") {
-                        e.stopPropagation();
                         e.preventDefault();
                         onManage?.();
                       }
@@ -362,17 +346,14 @@ function PermissionRow({
               </Tooltip>
             </TooltipProvider>
           )}
-          <span onClick={(e) => e.stopPropagation()} className="inline-flex">
-            <Switch
-              checked={enabled}
-              onCheckedChange={(checked) => onToggle(checked)}
-              disabled={readOnly}
-              size="sm"
-              aria-label={`${enabled ? "Revoke" : "Grant"} ${connector.label} access`}
-            />
-          </span>
+          <LoadingSwitch
+            checked={enabled}
+            onCheckedChange={(checked) => onToggle(checked)}
+            loading={loading}
+            ariaLabel={`${enabled ? "Revoke" : "Grant"} ${connector.label} access`}
+          />
         </div>
-      </button>
+      </div>
       {!isLast && <div className="mx-5 border-b border-border/50" />}
     </>
   );
@@ -385,19 +366,14 @@ function PermissionRow({
 function JobPermissionsTab({
   agentId,
   displayName,
-  readOnly,
 }: {
   agentId: string;
   displayName: string;
-  readOnly?: boolean;
 }) {
   const addedConnectors = useGet(zeroJobAddedConnectors$);
   const addConnector = useSet(addZeroJobConnector$);
   const removeConnector = useSet(removeZeroJobConnector$);
-  const connectorsDirty = useGet(zeroJobConnectorsDirty$);
-  const connectorsSaving = useGet(zeroJobSettingsSaving$);
   const saveConnectors = useSet(saveZeroJobConnectors$);
-  const discardConnectors = useSet(discardZeroJobConnectors$);
   const pageSignal = useGet(pageSignal$);
   const firewallPolicies = useGet(zeroJobFirewallPolicies$);
   const setFirewallPolicies = useSet(setZeroJobFirewallPolicies$);
@@ -405,9 +381,12 @@ function JobPermissionsTab({
   const [firewallType, setFirewallType] = useState<ConnectorType | null>(null);
   const [search, setSearch] = useState("");
   const [searchActive, setSearchActive] = useState(false);
+  const [savingType, setSavingType] = useState<string | null>(null);
 
   const adminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin = adminLoadable.state === "hasData" && adminLoadable.data;
+
+  const connectorsLoading = useGet(zeroJobConnectorsLoading$);
 
   const allTypesLoadable = useLastLoadable(allConnectorTypes$);
   const allConnectors =
@@ -427,9 +406,14 @@ function JobPermissionsTab({
     } else {
       removeConnector(type);
     }
+    setSavingType(type);
+    detach(
+      saveConnectors(pageSignal).finally(() => setSavingType(null)),
+      Reason.DomCallback,
+    );
   };
 
-  if (allTypesLoadable.state !== "hasData") {
+  if (allTypesLoadable.state !== "hasData" || connectorsLoading) {
     return (
       <div className="mx-auto max-w-[900px]">
         <div className="rounded-[var(--zero-card-radius)] border-[0.7px] border-[hsl(var(--gray-400))] bg-card animate-pulse">
@@ -535,7 +519,7 @@ function JobPermissionsTab({
                   connector={c}
                   enabled={addedSet.has(c.type)}
                   onToggle={(checked) => handleToggle(c.type, checked)}
-                  readOnly={readOnly}
+                  loading={savingType === c.type}
                   showManage={isAdmin && hasFirewallPermissions(c.type)}
                   onManage={() => setFirewallType(c.type)}
                   isLast={i === filteredConnectors.length - 1}
@@ -565,16 +549,6 @@ function JobPermissionsTab({
                 toast.success("Permissions updated");
               }}
               onClose={() => setFirewallType(null)}
-            />
-          )}
-
-          {!readOnly && (connectorsDirty || connectorsSaving) && (
-            <ZeroUnsavedBar
-              onDiscard={() => discardConnectors()}
-              onSave={() =>
-                detach(saveConnectors(pageSignal), Reason.DomCallback)
-              }
-              saving={connectorsSaving}
             />
           )}
         </>
@@ -764,11 +738,7 @@ export function ZeroJobDetailPage({ agentId }: ZeroJobDetailPageProps) {
 
       <main className="shrink-0 px-4 sm:px-6 pt-4 pb-16">
         {activeTab === "authorization" && (
-          <JobPermissionsTab
-            agentId={agentId}
-            displayName={displayName}
-            readOnly={hideProfileAndInstructions}
-          />
+          <JobPermissionsTab agentId={agentId} displayName={displayName} />
         )}
 
         {activeTab === "schedule" && (


### PR DESCRIPTION
## Summary
- Reduce connector toggle hot zone from entire row to just the Switch component on the team detail authorization tab
- Auto-save on toggle with inline loading spinner (`LoadingSwitch`) instead of showing an unsaved bar — applied to both team detail page and chat composer popover
- Tag local connector drafts with `agentId` to prevent stale state when switching between agents
- Add skeleton loading state for connectors in the chat composer popover
- Remove `readOnly` restriction from authorization tab since connector permissions are user-level
- Add `zeroJobConnectorsLoading$` signal for connectors loading state

## Test plan
- [x] All 48 existing tests pass
- [x] New test: agent switch discards local connector draft (`zero-connectors.test.ts`)
- [x] New test: `zeroJobConnectorsLoading$` reports loading=false after fetch (`zero-job-detail.test.ts`)
- [x] Updated tests: role="switch" assertions match new toggle-only hot zone (`zero-connector-card.test.tsx`)
- [x] Updated tests: member toggle is interactive (not disabled) since permissions are user-level
- [ ] Manual: toggle a connector on team detail page — verify spinner appears on the toggle during save
- [ ] Manual: toggle a connector in chat composer popover — verify same spinner behavior
- [ ] Manual: switch between agents — verify connector state resets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)