### PR TITLE
feat(cli): add zero doctor firewall-deny command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for zero doctor firewall-deny command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Real (internal): All CLI code, firewall configs from @vm0/core
+ * - No external API calls — this command only reads local firewall config
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { firewallDenyCommand } from "../firewall-deny";
+
+describe("zero doctor firewall-deny command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("known ref with matching permission", () => {
+    it("should output permission name and URL for a matching request", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/owner/repo/pulls",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "GitHub firewall blocked GET /repos/owner/repo/pulls",
+      );
+      expect(logCalls).toContain('covered by the "');
+      expect(logCalls).toContain(
+        "https://app.vm0.ai/firewall-allow/agent-abc-123?",
+      );
+      expect(logCalls).toContain("ref=github");
+      expect(logCalls).toContain("permission=");
+    });
+  });
+
+  describe("known ref with no matching permission", () => {
+    it("should output URL without permission param for unmatched path", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--method",
+        "DELETE",
+        "--path",
+        "/some/nonexistent/endpoint/that/will/never/match",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("GitHub firewall blocked DELETE");
+      expect(logCalls).toContain("No named permission was found");
+      expect(logCalls).not.toContain("permission=");
+    });
+  });
+
+  describe("unknown ref", () => {
+    it("should exit with error for unrecognized firewall ref", async () => {
+      await expect(async () => {
+        await firewallDenyCommand.parseAsync([
+          "node",
+          "cli",
+          "unknown_service",
+          "--method",
+          "GET",
+          "--path",
+          "/foo",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Unknown firewall connector type: unknown_service",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("URL transformation", () => {
+    it("should transform www.vm0.ai to app.vm0.ai", async () => {
+      vi.stubEnv("VM0_API_URL", "https://www.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-1");
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/owner/repo/pulls",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("https://app.vm0.ai/firewall-allow/agent-1?");
+    });
+
+    it("should transform tunnel -www suffix to -app", async () => {
+      vi.stubEnv("VM0_API_URL", "https://tunnel-yuma-vm0-www.vm7.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-1");
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/owner/repo/pulls",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "https://tunnel-yuma-vm0-app.vm7.ai/firewall-allow/agent-1?",
+      );
+    });
+  });
+
+  describe("ZERO_AGENT_ID presence/absence", () => {
+    it("should use /firewall-allow/:agentId when ZERO_AGENT_ID is set", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "my-agent-id");
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/owner/repo/pulls",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("/firewall-allow/my-agent-id?");
+    });
+
+    it("should use /firewall-allow when ZERO_AGENT_ID is not set", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "");
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/owner/repo/pulls",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("/firewall-allow?");
+      expect(logCalls).not.toContain("/firewall-allow/");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
@@ -20,6 +20,7 @@ describe("zero doctor firewall-deny command", () => {
     .mockImplementation(() => {});
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
@@ -46,8 +46,8 @@ describe("zero doctor firewall-deny command", () => {
         "GitHub firewall blocked GET /repos/owner/repo/pulls",
       );
       expect(logCalls).toContain('covered by the "');
-      expect(logCalls).toContain(
-        "https://app.vm0.ai/firewall-allow/agent-abc-123?",
+      expect(logCalls).toMatch(
+        /\[Allow GitHub access\]\(https:\/\/app\.vm0\.ai\/firewall-allow\/agent-abc-123\?/,
       );
       expect(logCalls).toContain("ref=github");
       expect(logCalls).toContain("permission=");

--- a/turbo/apps/cli/src/commands/zero/doctor/firewall-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/firewall-deny.ts
@@ -77,7 +77,9 @@ Notes:
           console.log("No named permission was found covering this request.");
         }
 
-        console.log(`Ask the user to allow it at: ${url}`);
+        console.log(
+          `Ask the user to allow it at: [Allow ${label} access](${url})`,
+        );
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/doctor/firewall-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/firewall-deny.ts
@@ -1,0 +1,83 @@
+import { Command, Option } from "commander";
+import {
+  isFirewallConnectorType,
+  getConnectorFirewall,
+  findMatchingPermissions,
+  CONNECTOR_TYPES,
+} from "@vm0/core";
+import { withErrorHandler } from "../../../lib/command";
+import { getPlatformOrigin } from "./platform-url";
+
+export const firewallDenyCommand = new Command()
+  .name("firewall-deny")
+  .description(
+    "Diagnose a firewall denial and find the permission that covers it",
+  )
+  .argument("<firewall-ref>", "The firewall connector type (e.g. github)")
+  .addOption(
+    new Option(
+      "--method <method>",
+      "The denied HTTP method",
+    ).makeOptionMandatory(),
+  )
+  .addOption(
+    new Option("--path <path>", "The denied path").makeOptionMandatory(),
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero doctor firewall-deny github --method GET --path /repos/owner/repo/pulls
+  zero doctor firewall-deny slack --method POST --path /chat.postMessage
+
+Notes:
+  - Identifies which named permission covers a denied request
+  - Outputs a platform URL for the user to allow the permission`,
+  )
+  .action(
+    withErrorHandler(
+      async (firewallRef: string, opts: { method: string; path: string }) => {
+        if (!isFirewallConnectorType(firewallRef)) {
+          throw new Error(`Unknown firewall connector type: ${firewallRef}`);
+        }
+
+        const { label } = CONNECTOR_TYPES[firewallRef];
+        const config = getConnectorFirewall(firewallRef);
+        const permissions = findMatchingPermissions(
+          opts.method,
+          opts.path,
+          config,
+        );
+
+        const platformOrigin = await getPlatformOrigin();
+        const agentId = process.env.ZERO_AGENT_ID;
+
+        const urlParams = new URLSearchParams({
+          ref: firewallRef,
+          method: opts.method,
+          path: opts.path,
+        });
+
+        if (permissions.length > 0) {
+          urlParams.set("permission", permissions[0]!);
+        }
+
+        const pagePath = agentId
+          ? `/firewall-allow/${agentId}`
+          : "/firewall-allow";
+        const url = `${platformOrigin}${pagePath}?${urlParams.toString()}`;
+
+        console.log(
+          `The ${label} firewall blocked ${opts.method} ${opts.path}.`,
+        );
+
+        if (permissions.length > 0) {
+          console.log(`This is covered by the "${permissions[0]}" permission.`);
+        } else {
+          console.log("No named permission was found covering this request.");
+        }
+
+        console.log(`Ask the user to allow it at: ${url}`);
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/doctor/index.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/index.ts
@@ -1,17 +1,20 @@
 import { Command } from "commander";
 import { missingTokenCommand } from "./missing-token";
+import { firewallDenyCommand } from "./firewall-deny";
 
 export const zeroDoctorCommand = new Command()
   .name("doctor")
-  .description("Diagnose runtime issues (missing tokens, connectors)")
+  .description("Diagnose runtime issues (missing tokens, firewall denials)")
   .addCommand(missingTokenCommand)
+  .addCommand(firewallDenyCommand)
   .addHelpText(
     "after",
     `
 Examples:
   Missing an API key?    zero doctor missing-token GITHUB_TOKEN
+  Firewall blocked?      zero doctor firewall-deny github --method GET --path /repos/owner/repo
 
 Notes:
-  - Use this when your task fails due to a missing environment variable
-  - The doctor will identify which connector provides the token and give the user a link to connect it`,
+  - Use this when your task fails due to a missing environment variable or firewall denial
+  - The doctor will identify the issue and give the user a link to resolve it`,
   );

--- a/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
@@ -8,28 +8,7 @@ import { getApiUrl } from "../../../lib/api/config";
 import { getZeroConnector } from "../../../lib/api/domains/zero-connectors";
 import { getZeroAgentUserConnectors } from "../../../lib/api/domains/zero-agents";
 import { withErrorHandler } from "../../../lib/command";
-
-/**
- * Transform the API host to the platform (app) host.
- *
- *   www.vm0.ai                    → app.vm0.ai
- *   platform.vm0.ai               → app.vm0.ai
- *   tunnel-user-host-www.vm7.ai   → tunnel-user-host-app.vm7.ai
- *   custom.example.com            → app.custom.example.com
- */
-function toPlatformUrl(apiUrl: string): URL {
-  const parsed = new URL(apiUrl);
-  const parts = parsed.hostname.split(".");
-  if (parts[0]!.endsWith("-www")) {
-    parts[0] = parts[0]!.slice(0, -"-www".length) + "-app";
-  } else if (parts[0] === "www" || parts[0] === "platform") {
-    parts[0] = "app";
-  } else if (parts[0] !== "app" && parts[0] !== "localhost") {
-    parts.unshift("app");
-  }
-  parsed.hostname = parts.join(".");
-  return parsed;
-}
+import { toPlatformUrl } from "./platform-url";
 
 export const missingTokenCommand = new Command()
   .name("missing-token")

--- a/turbo/apps/cli/src/commands/zero/doctor/platform-url.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/platform-url.ts
@@ -1,0 +1,28 @@
+import { getApiUrl } from "../../../lib/api/config";
+
+/**
+ * Transform the API host to the platform (app) host.
+ *
+ *   www.vm0.ai                    → app.vm0.ai
+ *   platform.vm0.ai               → app.vm0.ai
+ *   tunnel-user-host-www.vm7.ai   → tunnel-user-host-app.vm7.ai
+ *   custom.example.com            → app.custom.example.com
+ */
+export function toPlatformUrl(apiUrl: string): URL {
+  const parsed = new URL(apiUrl);
+  const parts = parsed.hostname.split(".");
+  if (parts[0]!.endsWith("-www")) {
+    parts[0] = parts[0]!.slice(0, -"-www".length) + "-app";
+  } else if (parts[0] === "www" || parts[0] === "platform") {
+    parts[0] = "app";
+  } else if (parts[0] !== "app" && parts[0] !== "localhost") {
+    parts.unshift("app");
+  }
+  parsed.hostname = parts.join(".");
+  return parsed;
+}
+
+export async function getPlatformOrigin(): Promise<string> {
+  const apiUrl = await getApiUrl();
+  return toPlatformUrl(apiUrl).origin;
+}


### PR DESCRIPTION
## Summary
- Add `zero doctor firewall-deny <ref> --method <METHOD> --path <PATH>` subcommand that diagnoses firewall denials
- Identifies the named permission covering a denied request using `findMatchingPermissions()` from `@vm0/core`
- Outputs a platform URL (`/firewall-allow/:agentId`) for the user to allow the permission
- Extracts `toPlatformUrl` into shared `platform-url.ts` to avoid duplication with `missing-token`

Closes #7316
Parent: #7312

## Test plan
- [x] 7 integration tests covering: matching permission, no match, unknown ref, URL transformation, ZERO_AGENT_ID presence/absence
- [x] Existing `missing-token` tests still pass after refactoring shared URL utility

🤖 Generated with [Claude Code](https://claude.com/claude-code)