### PR TITLE
fix(platform): prevent stale empty events from skipping activity skeleton

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -265,7 +265,9 @@ export const zeroActivityDetail$ = computed(async (get) => {
 export const zeroActivityEvents$ = computed(async (get) => {
   const run = get(internalActiveRunLoop$);
   if (!run) {
-    return [] as AgentEvent[];
+    // Return null (not []) so useLastLoadable won't treat a stale empty array
+    // as "hasData" while the real events are still loading.
+    return null;
   }
   const pages = await get(run.pagedEventsList$);
   if (pages.length === 0) {

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -331,8 +331,12 @@ export function ZeroActivityDetailPage() {
   const setStepSearch = useSet(setZeroActivityStepSearch$);
   const features = useLastResolved(featureSwitch$);
 
-  // Skeleton until both detail and initial events are loaded
-  const eventsReady = eventsLoadable.state === "hasData";
+  // Skeleton until both detail and initial events are loaded.
+  // Events signal returns null when the run loop hasn't been set up yet;
+  // useLastLoadable would keep the stale null as "hasData" which correctly
+  // prevents the page from rendering with an empty steps list.
+  const eventsReady =
+    eventsLoadable.state === "hasData" && eventsLoadable.data !== null;
   if (!detail || isStale || !eventsReady) {
     if (detailLoadable.state === "hasError") {
       return <ActivityNotFound />;
@@ -340,7 +344,7 @@ export function ZeroActivityDetailPage() {
     return <ActivitySkeleton />;
   }
 
-  const events: AgentEvent[] = eventsLoadable.data;
+  const events: AgentEvent[] = eventsLoadable.data ?? [];
 
   const allMessages = groupEventsIntoMessages(events);
 

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -306,6 +306,37 @@ function ActivityHeaderCard({
   );
 }
 
+function prepareRenderData(
+  detail: { prompt: string | null; appendSystemPrompt: string | null },
+  rawEvents: AgentEvent[] | null,
+  stepSearch: string,
+  features: Record<FeatureSwitchKey, boolean> | undefined,
+) {
+  const events: AgentEvent[] = rawEvents ?? [];
+  const allMessages = groupEventsIntoMessages(events);
+  const visibleMessages = allMessages.filter((message, index) =>
+    isVisibleMessage(message, allMessages[index + 1]),
+  );
+  const messages = visibleMessages.filter((m) =>
+    groupedMessageMatchesSearch(m, stepSearch.trim()),
+  );
+  const showModelDetail = features?.[FeatureSwitchKey.ModelDetail] ?? false;
+  const prompt = detail.prompt ?? "";
+  const appendSystemPrompt = detail.appendSystemPrompt ?? "";
+  const showSystemPrompt =
+    (features?.[FeatureSwitchKey.ShowSystemPrompt] ?? false) &&
+    appendSystemPrompt.trim().length > 0;
+  return {
+    events,
+    visibleMessages,
+    messages,
+    showModelDetail,
+    prompt,
+    appendSystemPrompt,
+    showSystemPrompt,
+  };
+}
+
 function resolveDisplayName(
   detail: { displayName: string | null; agentId: string | null } | null,
   isStale: boolean,
@@ -344,26 +375,15 @@ export function ZeroActivityDetailPage() {
     return <ActivitySkeleton />;
   }
 
-  const events: AgentEvent[] = eventsLoadable.data ?? [];
-
-  const allMessages = groupEventsIntoMessages(events);
-
-  // Filter out text-only assistant messages right before result (redundant)
-  const visibleMessages = allMessages.filter((message, index) =>
-    isVisibleMessage(message, allMessages[index + 1]),
-  );
-
-  const messages = visibleMessages.filter((m) =>
-    groupedMessageMatchesSearch(m, stepSearch.trim()),
-  );
-
-  const showModelDetail = features?.[FeatureSwitchKey.ModelDetail] ?? false;
-
-  const prompt = detail.prompt ?? "";
-  const appendSystemPrompt = detail.appendSystemPrompt ?? "";
-  const showSystemPrompt =
-    (features?.[FeatureSwitchKey.ShowSystemPrompt] ?? false) &&
-    appendSystemPrompt.trim().length > 0;
+  const {
+    events,
+    visibleMessages,
+    messages,
+    showModelDetail,
+    prompt,
+    showSystemPrompt,
+    appendSystemPrompt,
+  } = prepareRenderData(detail, eventsLoadable.data, stepSearch, features);
   const status: LogStatus = detail.status;
   const time = formatLogTime(detail.createdAt);
   const duration = formatDuration(detail.startedAt, detail.completedAt);


### PR DESCRIPTION
## Summary
- Return `null` instead of `[]` from `zeroActivityEvents$` when the run loop is not yet initialized, so `useLastLoadable` does not treat a stale empty array as loaded data
- Add a `!== null` check in `ZeroActivityDetailPage` so the skeleton stays visible until real events arrive
- Prevents the activity detail page from briefly rendering with an empty steps list during navigation between runs

## Test plan
- [ ] Navigate between different activity runs and verify the skeleton is shown until events load
- [ ] Verify that the activity detail page renders correctly once events are loaded
- [ ] Confirm no flash of empty content when switching between runs

Generated with [Claude Code](https://claude.com/claude-code)