### PR TITLE
feat: support zero-token auth with agent:read on connector GET endpoint

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
@@ -73,7 +73,9 @@ describe("zero doctor missing-token command", () => {
         "GH_TOKEN is provided by the GitHub connector",
       );
       expect(logCalls).toContain("not connected");
-      expect(logCalls).toContain("https://app.vm0.ai/connectors");
+      expect(logCalls).toContain(
+        "[Connect GitHub](https://app.vm0.ai/connectors)",
+      );
     });
   });
 
@@ -102,7 +104,7 @@ describe("zero doctor missing-token command", () => {
       );
       expect(logCalls).toContain("not authorized");
       expect(logCalls).toContain(
-        "https://app.vm0.ai/team/agent-abc-123?tab=authorization",
+        "[Authorize GitHub](https://app.vm0.ai/team/agent-abc-123?tab=authorization)",
       );
     });
   });
@@ -129,6 +131,9 @@ describe("zero doctor missing-token command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("connected and authorized");
       expect(logCalls).toContain("still missing");
+      expect(logCalls).toContain(
+        "[Check GitHub status](https://app.vm0.ai/connectors)",
+      );
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
@@ -82,20 +82,20 @@ Notes:
         // Connector not connected at all — direct to connectors page
         const url = `${platformUrl.origin}/connectors`;
         console.log(
-          `The ${label} connector is not connected. Ask the user to connect it at: ${url}`,
+          `The ${label} connector is not connected. Ask the user to connect it at: [Connect ${label}](${url})`,
         );
       } else if (!hasPermission) {
         // Connected but not authorized for this agent — direct to authorization tab
         const path = agentId ? `/team/${agentId}` : "/team";
         const url = `${platformUrl.origin}${path}?tab=authorization`;
         console.log(
-          `The ${label} connector is connected but not authorized for this agent. Ask the user to enable it at: ${url}`,
+          `The ${label} connector is connected but not authorized for this agent. Ask the user to enable it at: [Authorize ${label}](${url})`,
         );
       } else {
         // Both connected and authorized — something else is wrong
         const url = `${platformUrl.origin}/connectors`;
         console.log(
-          `The ${label} connector is connected and authorized, but the token is still missing. Ask the user to check the connector status at: ${url}`,
+          `The ${label} connector is connected and authorized, but the token is still missing. Ask the user to check the connector status at: [Check ${label} status](${url})`,
         );
       }
     }),

--- a/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { DELETE } from "../route";
+import { NextRequest } from "next/server";
+import { randomUUID } from "crypto";
+import { GET, DELETE } from "../route";
 import {
   createTestRequest,
   createTestOrg,
@@ -9,6 +11,7 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { generateZeroToken } from "../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -20,9 +23,70 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function deleteUrl(slug: string, type: string): string {
+function connectorUrl(slug: string, type: string): string {
   return `http://localhost:3000/api/zero/connectors/${type}?org=${slug}`;
 }
+
+describe("GET /api/zero/connectors/:type", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return connector when present", async () => {
+    const userId = uniqueId("zcget-ok");
+    const { slug, orgId } = await setupOrg(userId);
+    await context.createConnector(orgId, { userId, type: "github" });
+
+    const response = await GET(createTestRequest(connectorUrl(slug, "github")));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.type).toBe("github");
+  });
+
+  it("should return 404 when connector not found", async () => {
+    const userId = uniqueId("zcget-nf");
+    const { slug } = await setupOrg(userId);
+
+    const response = await GET(createTestRequest(connectorUrl(slug, "github")));
+    expect(response.status).toBe(404);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest(connectorUrl("test", "github")),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("should allow access with ZERO_TOKEN (agent:read capability)", async () => {
+    const user = await context.setupUser();
+
+    await context.createConnector(user.orgId, {
+      userId: user.userId,
+      type: "github",
+    });
+
+    const orgSlug = `org-${user.userId.slice(-8)}`;
+    const zeroToken = await generateZeroToken(
+      user.userId,
+      randomUUID(),
+      user.orgId,
+    );
+
+    const response = await GET(
+      new NextRequest(connectorUrl(orgSlug, "github"), {
+        headers: { Authorization: `Bearer ${zeroToken}` },
+      }),
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.type).toBe("github");
+  });
+});
 
 describe("DELETE /api/zero/connectors/:type", () => {
   beforeEach(() => {
@@ -35,7 +99,7 @@ describe("DELETE /api/zero/connectors/:type", () => {
     await context.createConnector(orgId, { userId, type: "github" });
 
     const response = await DELETE(
-      createTestRequest(deleteUrl(slug, "github"), { method: "DELETE" }),
+      createTestRequest(connectorUrl(slug, "github"), { method: "DELETE" }),
     );
     expect(response.status).toBe(204);
   });
@@ -45,7 +109,7 @@ describe("DELETE /api/zero/connectors/:type", () => {
     const { slug } = await setupOrg(userId);
 
     const response = await DELETE(
-      createTestRequest(deleteUrl(slug, "github"), { method: "DELETE" }),
+      createTestRequest(connectorUrl(slug, "github"), { method: "DELETE" }),
     );
     expect(response.status).toBe(404);
   });
@@ -54,7 +118,7 @@ describe("DELETE /api/zero/connectors/:type", () => {
     mockClerk({ userId: null });
 
     const response = await DELETE(
-      createTestRequest(deleteUrl("test", "github"), { method: "DELETE" }),
+      createTestRequest(connectorUrl("test", "github"), { method: "DELETE" }),
     );
     expect(response.status).toBe(401);
   });

--- a/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
@@ -20,7 +20,9 @@ const router = tsr.router(zeroConnectorsByTypeContract, {
   get: async ({ params, headers }, { request }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent:read",
+    });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 


### PR DESCRIPTION
## Summary
- Add `requiredCapability: "agent:read"` to the connector GET endpoint's `requireAuth` call, allowing agents with ZERO_TOKEN to read connector data
- Add integration tests for the GET endpoint including standard auth, 404, 401, and ZERO_TOKEN access scenarios
- Rename `deleteUrl` helper to `connectorUrl` since it is now shared across GET and DELETE tests

## Test plan
- [x] Integration test: GET returns connector when present (200)
- [x] Integration test: GET returns 404 when connector not found
- [x] Integration test: GET returns 401 when not authenticated
- [x] Integration test: GET allows access with ZERO_TOKEN bearing agent:read capability
- [x] Existing DELETE tests continue to pass with renamed helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)