### PR TITLE
feat(platform): add error state handling for activity page

### DIFF
--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-error.test.ts
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-error.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+describe("activity page error", () => {
+  it("should show error state when /api/zero/logs returns 500", async () => {
+    server.use(
+      http.get("*/api/zero/logs", () => {
+        return HttpResponse.json(
+          { error: { message: "Internal Server Error", code: "INTERNAL" } },
+          { status: 500 },
+        );
+      }),
+      http.get("*/api/zero/composes/list", () => {
+        return HttpResponse.json({ composes: [] });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/activity" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Failed to load activity data"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Something went wrong. Please try again later."),
+    ).toBeInTheDocument();
+  }, 10_000);
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-page.tsx
@@ -63,6 +63,7 @@ export function ZeroActivityPage() {
       ? dataLoadable.data.pagination.totalPages
       : undefined;
   const isLoading = dataLoadable.state === "loading";
+  const hasError = dataLoadable.state === "hasError";
 
   // Agent filter options: only agents with activity records
   const agentOptions = [
@@ -170,41 +171,57 @@ export function ZeroActivityPage() {
       {/* Scrollable table + pagination area */}
       <div className="flex-1 min-h-0 overflow-auto px-4 sm:px-6 pt-4">
         <div className="mx-auto max-w-[900px]">
-          <div className="zero-card overflow-hidden pb-3">
-            <LogTable
-              logs={logs}
-              isLoading={isLoading}
-              rowsPerPage={rowsPerPage}
-              showSource
-              hasActiveFilter={
-                agentFilter !== "all" ||
-                statusFilter !== "all" ||
-                sourceFilter !== "all"
-              }
-            />
-          </div>
-          {(totalPages === undefined || totalPages > 1) && (
-            <div className="py-4">
-              <Pagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                rowsPerPage={rowsPerPage}
-                hasNext={hasNext}
-                hasPrev={hasPrev}
-                isLoading={isLoading}
-                labelClassName="font-normal text-muted-foreground"
-                buttonClassName="bg-transparent border-border/70"
-                onNextPage={() =>
-                  detach(goToNext(pageSignal), Reason.DomCallback)
-                }
-                onPrevPage={() => goToPrev()}
-                onForwardTwoPages={() =>
-                  detach(goForwardTwo(pageSignal), Reason.DomCallback)
-                }
-                onBackTwoPages={() => goBackTwo()}
-                onRowsPerPageChange={(limit) => setRowsPerPage(limit)}
-              />
+          {hasError ? (
+            <div
+              role="alert"
+              className="zero-card flex flex-col items-center justify-center gap-2 py-16 text-center"
+            >
+              <p className="text-sm font-medium text-destructive">
+                Failed to load activity data
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Something went wrong. Please try again later.
+              </p>
             </div>
+          ) : (
+            <>
+              <div className="zero-card overflow-hidden pb-3">
+                <LogTable
+                  logs={logs}
+                  isLoading={isLoading}
+                  rowsPerPage={rowsPerPage}
+                  showSource
+                  hasActiveFilter={
+                    agentFilter !== "all" ||
+                    statusFilter !== "all" ||
+                    sourceFilter !== "all"
+                  }
+                />
+              </div>
+              {(totalPages === undefined || totalPages > 1) && (
+                <div className="py-4">
+                  <Pagination
+                    currentPage={currentPage}
+                    totalPages={totalPages}
+                    rowsPerPage={rowsPerPage}
+                    hasNext={hasNext}
+                    hasPrev={hasPrev}
+                    isLoading={isLoading}
+                    labelClassName="font-normal text-muted-foreground"
+                    buttonClassName="bg-transparent border-border/70"
+                    onNextPage={() =>
+                      detach(goToNext(pageSignal), Reason.DomCallback)
+                    }
+                    onPrevPage={() => goToPrev()}
+                    onForwardTwoPages={() =>
+                      detach(goForwardTwo(pageSignal), Reason.DomCallback)
+                    }
+                    onBackTwoPages={() => goBackTwo()}
+                    onRowsPerPageChange={(limit) => setRowsPerPage(limit)}
+                  />
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add error state UI to the activity page when `/api/zero/logs` returns an error
- Display a user-friendly error message ("Failed to load activity data") instead of showing a broken/empty table
- Add integration test verifying the error state renders correctly when the API returns 500

## Test plan
- [ ] Verify error alert is displayed when the logs API fails
- [ ] Verify normal table and pagination still render when data loads successfully
- [ ] Run `pnpm vitest` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)