### PR TITLE
fix(platform): deduplicate local messages against server-persisted messages

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -185,6 +185,132 @@ describe("zero-chat signals", () => {
       // finalizeCompletedRun$ must have invalidated the thread (at least one reload)
       expect(threadReloadCount).toBeGreaterThan(1);
     });
+
+    it("should not duplicate messages after run completes and server persists them", async () => {
+      const RUN_ID = "a0000000-0000-4000-a000-000000000099";
+      let threadLoadCount = 0;
+
+      server.use(
+        http.get("*/api/zero/chat-threads", () => {
+          return HttpResponse.json({ threads: [] });
+        }),
+        http.get("*/api/zero/chat-threads/:id", () => {
+          threadLoadCount++;
+          // After initial load (empty), subsequent loads return persisted messages
+          // simulating the server having persisted the session callback
+          if (threadLoadCount <= 1) {
+            return HttpResponse.json({
+              id: "thread-dedup",
+              title: null,
+              agentId: "c0000000-0000-4000-a000-000000000001",
+              chatMessages: [],
+              latestSessionId: "session-dedup",
+              unsavedRuns: [],
+              createdAt: "2026-03-10T00:00:00Z",
+              updatedAt: "2026-03-10T00:00:00Z",
+            });
+          }
+          // After run completes, server returns persisted messages
+          return HttpResponse.json({
+            id: "thread-dedup",
+            title: null,
+            agentId: "c0000000-0000-4000-a000-000000000001",
+            chatMessages: [
+              {
+                role: "user",
+                content: "Hello dedup",
+                createdAt: "2026-03-10T00:00:00Z",
+              },
+              {
+                role: "assistant",
+                content: "Hi there!",
+                runId: RUN_ID,
+                createdAt: "2026-03-10T00:00:01Z",
+              },
+            ],
+            latestSessionId: "session-dedup",
+            unsavedRuns: [],
+            createdAt: "2026-03-10T00:00:00Z",
+            updatedAt: "2026-03-10T00:00:01Z",
+          });
+        }),
+        http.post("*/api/zero/chat/messages", () => {
+          return HttpResponse.json(
+            {
+              runId: RUN_ID,
+              threadId: "thread-dedup",
+              status: "running",
+              createdAt: "2026-03-10T00:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+        http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+          return HttpResponse.json({
+            events: [
+              {
+                id: "evt-1",
+                sequenceNumber: 1,
+                eventType: "result",
+                eventData: { result: "Hi there!" },
+                createdAt: "2026-03-10T00:00:01Z",
+              },
+            ],
+            hasMore: false,
+            framework: "claude-code",
+          });
+        }),
+        http.get("*/api/zero/logs/:runId", () => {
+          return HttpResponse.json({
+            id: RUN_ID,
+            sessionId: "session-dedup",
+            agentId: "zero",
+            displayName: null,
+            framework: "claude-code",
+            modelProvider: null,
+            selectedModel: null,
+            triggerSource: "web",
+            triggerAgentName: null,
+            scheduleId: null,
+            status: "completed",
+            prompt: "Hello dedup",
+            appendSystemPrompt: null,
+            error: null,
+            createdAt: "2026-03-10T00:00:00Z",
+            startedAt: "2026-03-10T00:00:00Z",
+            completedAt: "2026-03-10T00:00:01Z",
+            artifact: { name: null, version: null },
+          });
+        }),
+      );
+
+      await setupPage({
+        context,
+        path: "/chat/thread-dedup",
+        withoutRender: true,
+      });
+
+      await context.store.set(
+        sendExistingThreadMessage$,
+        "Hello dedup",
+        undefined,
+        context.signal,
+      );
+
+      await expect(context.store.get(allFinished$)).resolves.toBeTruthy();
+
+      // After run completes, finalizeCompletedRun$ reloads the thread.
+      // Server now returns persisted messages. The local optimistic messages
+      // should be deduplicated against the server messages.
+      const messages = await context.store.get(zeroChatMessages$);
+      const userMessages = messages.filter((m) => m.role === "user");
+      const assistantMessages = messages.filter((m) => m.role === "assistant");
+
+      // There should be exactly one user message and one assistant message,
+      // not duplicates from both server and local sources.
+      expect(userMessages).toHaveLength(1);
+      expect(assistantMessages).toHaveLength(1);
+    });
   });
 
   describe("startNewZeroSession$", () => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -124,7 +124,36 @@ export const zeroChatMessages$ = computed(async (get) => {
   const snapshot = await get(chatSessionSnapshot$);
   const serverMessages = snapshot?.messages ?? [];
   const localMessages = get(internalLocalMessages$);
-  return [...serverMessages, ...localMessages];
+
+  // Deduplicate: if the server already has a message for a given runId,
+  // drop the local copy (server is the canonical source after persistence).
+  const serverRunIds = new Set(
+    serverMessages
+      .filter(
+        (m): m is AssistantChatMessage =>
+          m.role === "assistant" && !!m.legacyRunId,
+      )
+      .map((m) => m.legacyRunId),
+  );
+
+  const skipIndices = new Set<number>();
+  for (let i = 0; i < localMessages.length; i++) {
+    const m = localMessages[i];
+    if (
+      m.role === "assistant" &&
+      m.legacyRunId &&
+      serverRunIds.has(m.legacyRunId)
+    ) {
+      skipIndices.add(i);
+      // Also skip the paired user message immediately before
+      if (i > 0 && localMessages[i - 1].role === "user") {
+        skipIndices.add(i - 1);
+      }
+    }
+  }
+
+  const filteredLocal = localMessages.filter((_, i) => !skipIndices.has(i));
+  return [...serverMessages, ...filteredLocal];
 });
 
 /** Whether all runs have finished (no in-flight runs). */


### PR DESCRIPTION
## Summary
- Fix message duplication in chat when a run completes and the server persists messages
- `zeroChatMessages$` now deduplicates local optimistic messages against server-returned messages by matching on `legacyRunId`
- When a server message already exists for a given `runId`, the corresponding local assistant message and its paired user message are dropped
- Added integration test verifying no duplicate messages appear after run completion

## Test plan
- [ ] Verify the new test `should not duplicate messages after run completes and server persists them` passes
- [ ] Confirm existing zero-chat tests still pass
- [ ] Manual verification: send a chat message, wait for run to complete, check that messages are not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)