### PR TITLE
fix: add zero skills schema to db exports

### DIFF
--- a/turbo/apps/web/src/db/db.ts
+++ b/turbo/apps/web/src/db/db.ts
@@ -48,6 +48,7 @@ import * as zeroRunSchema from "./schema/zero-run";
 import * as zeroAgentSessionSchema from "./schema/zero-agent-session";
 import * as storageVersionLineageSchema from "./schema/storage-version-lineage";
 import * as vm0ApiKeySchema from "./schema/vm0-api-key";
+import * as zeroSkillSchema from "./schema/zero-skill";
 
 export const schema = {
   ...userSchema,
@@ -100,4 +101,5 @@ export const schema = {
   ...zeroAgentSessionSchema,
   ...storageVersionLineageSchema,
   ...vm0ApiKeySchema,
+  ...zeroSkillSchema,
 };


### PR DESCRIPTION
## Summary
- Add missing `zeroSkillSchema` import and spread in `turbo/apps/web/src/db/db.ts`
- The `zeroSkills` table was defined in `schema/zero-skill.ts` but never exported through the schema object, making it inaccessible via `globalThis.services.db`

## Test plan
- [x] Knip passes (no unused exports)
- [x] Prettier passes
- [ ] CI build and type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)