### PR TITLE
feat: add chat thread deletion

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -2,6 +2,7 @@ import { command, computed, state, type Computed } from "ccstate";
 import { delay } from "signal-timers";
 import type { AgentEvent, LogStatus } from "./log-types.ts";
 import { throwIfAbort, resetSignal } from "../utils.ts";
+import { detachedNavigateTo$ } from "../route.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { logger } from "../log.ts";
 import {
@@ -314,6 +315,34 @@ export const zeroSessionList$ = computed(async (get) => {
 
 export const zeroSessionListLoading$ = computed(() => false);
 export const zeroSessionListError$ = computed(() => null as string | null);
+
+/** Delete a chat thread and refresh the sidebar list. */
+export const deleteChatThread$ = command(
+  async ({ get, set }, threadId: string, signal: AbortSignal) => {
+    const client = get(zeroClient$)(chatThreadByIdContract);
+    const result = await client.delete({
+      params: { id: threadId },
+      body: undefined,
+    });
+    signal.throwIfAborted();
+
+    if (result.status !== 204) {
+      const msg =
+        result.status === 401 || result.status === 404
+          ? result.body.error.message
+          : `status ${result.status}`;
+      throw new Error(`Delete failed: ${msg}`);
+    }
+
+    toast.success("Chat deleted");
+    set(reloadChatThreadList$, (n) => n + 1);
+
+    // If the user is viewing the deleted thread, navigate to landing page
+    if (get(chatThreadId$) === threadId) {
+      set(detachedNavigateTo$, "/");
+    }
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Session snapshot — async computed derived from URL

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -322,7 +322,6 @@ export const deleteChatThread$ = command(
     const client = get(zeroClient$)(chatThreadByIdContract);
     const result = await client.delete({
       params: { id: threadId },
-      body: undefined,
     });
     signal.throwIfAborted();
 
@@ -335,12 +334,13 @@ export const deleteChatThread$ = command(
     }
 
     toast.success("Chat deleted");
-    set(reloadChatThreadList$, (n) => n + 1);
 
-    // If the user is viewing the deleted thread, navigate to landing page
+    // Navigate away first so currentChatThread$ won't re-fetch the deleted thread
     if (get(chatThreadId$) === threadId) {
       set(detachedNavigateTo$, "/");
     }
+
+    set(reloadChatThreadList$, (n) => n + 1);
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -41,7 +41,16 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  Button,
 } from "@vm0/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@vm0/ui/components/ui/dialog";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import slackIcon from "./components/settings/icons/slack.svg";
 import { clerk$, user$ } from "../../signals/auth.ts";
@@ -449,42 +458,93 @@ function ChatThreadItem({
 }) {
   const setDelete = useSet(deleteChatThread$);
   const pageSignal = useGet(pageSignal$);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
-  function handleDelete(e: React.MouseEvent) {
+  function handleDeleteClick(e: React.MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
+    setConfirmOpen(true);
+  }
+
+  function confirmDelete() {
+    setConfirmOpen(false);
     detach(setDelete(session.id, pageSignal), Reason.DomCallback);
   }
 
   return (
-    <Link
-      pathname="/chat/:chatThreadId"
-      options={{ pathParams: { chatThreadId: session.id } }}
-      onClick={(e) => {
-        if (e.metaKey || e.ctrlKey || e.shiftKey) {
-          return;
-        }
-        e.preventDefault();
-        onSelect?.(session.id);
-      }}
-      className={`group/thread flex h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors ${
-        isSelected
-          ? "bg-gray-200 text-gray-900 font-medium"
-          : "text-sidebar-foreground hover:bg-sidebar-accent"
-      }`}
-    >
-      <span className="truncate min-w-0 flex-1">
-        {session.preview ?? "New chat"}
-      </span>
-      <button
-        type="button"
-        onClick={handleDelete}
-        className="shrink-0 hidden group-hover/thread:flex items-center justify-center h-5 w-5 rounded text-sidebar-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-colors"
-        aria-label="Delete chat"
+    <>
+      <div className="group relative">
+        <Link
+          pathname="/chat/:chatThreadId"
+          options={{ pathParams: { chatThreadId: session.id } }}
+          onClick={(e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey) {
+              return;
+            }
+            e.preventDefault();
+            onSelect?.(session.id);
+          }}
+          className={`flex h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors ${
+            isSelected
+              ? "bg-gray-200 text-gray-900 font-medium"
+              : "text-sidebar-foreground hover:bg-sidebar-accent"
+          }`}
+        >
+          <span className="truncate min-w-0 flex-1">
+            {session.preview ?? "New chat"}
+          </span>
+        </Link>
+        <div className="absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleDeleteClick}
+                  className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 ${
+                    isSelected
+                      ? "text-slate-500 hover:text-slate-900 hover:bg-slate-300"
+                      : "text-sidebar-foreground/80 hover:text-foreground hover:bg-sidebar-foreground/10"
+                  }`}
+                  aria-label="Delete chat"
+                >
+                  <IconTrash size={12} stroke={2} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p className="text-xs">Delete chat</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+      </div>
+      <Dialog
+        open={confirmOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setConfirmOpen(false);
+          }
+        }}
       >
-        <IconTrash size={13} stroke={2} />
-      </button>
-    </Link>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete chat?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete this chat. This action cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -25,6 +25,7 @@ import {
   IconLayoutSidebarLeftCollapse,
   IconDatabaseExport,
   IconPlug,
+  IconTrash,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey, type ChatThreadListItem } from "@vm0/core";
 import {
@@ -65,6 +66,7 @@ import {
   zeroSessionList$,
   createNewChatSession$,
   creatingNewSession$,
+  deleteChatThread$,
 } from "../../signals/zero-page/zero-chat.ts";
 import {
   pinnedAgentIds$,
@@ -436,6 +438,56 @@ function AccountDropdown({
   );
 }
 
+function ChatThreadItem({
+  session,
+  isSelected,
+  onSelect,
+}: {
+  session: ChatThreadListItem;
+  isSelected: boolean;
+  onSelect?: (id: string) => void;
+}) {
+  const setDelete = useSet(deleteChatThread$);
+  const pageSignal = useGet(pageSignal$);
+
+  function handleDelete(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    detach(setDelete(session.id, pageSignal), Reason.DomCallback);
+  }
+
+  return (
+    <Link
+      pathname="/chat/:chatThreadId"
+      options={{ pathParams: { chatThreadId: session.id } }}
+      onClick={(e) => {
+        if (e.metaKey || e.ctrlKey || e.shiftKey) {
+          return;
+        }
+        e.preventDefault();
+        onSelect?.(session.id);
+      }}
+      className={`group/thread flex h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors ${
+        isSelected
+          ? "bg-gray-200 text-gray-900 font-medium"
+          : "text-sidebar-foreground hover:bg-sidebar-accent"
+      }`}
+    >
+      <span className="truncate min-w-0 flex-1">
+        {session.preview ?? "New chat"}
+      </span>
+      <button
+        type="button"
+        onClick={handleDelete}
+        className="shrink-0 hidden group-hover/thread:flex items-center justify-center h-5 w-5 rounded text-sidebar-foreground/50 hover:text-destructive hover:bg-destructive/10 transition-colors"
+        aria-label="Delete chat"
+      >
+        <IconTrash size={13} stroke={2} />
+      </button>
+    </Link>
+  );
+}
+
 function RecentChatSection({
   currentChatAgentId,
   displayName,
@@ -612,27 +664,12 @@ function RecentChatSection({
               </p>
             ) : (
               filteredSessions.map((session) => (
-                <Link
+                <ChatThreadItem
                   key={session.id}
-                  pathname="/chat/:chatThreadId"
-                  options={{ pathParams: { chatThreadId: session.id } }}
-                  onClick={(e) => {
-                    if (e.metaKey || e.ctrlKey || e.shiftKey) {
-                      return;
-                    }
-                    e.preventDefault();
-                    onRecentSelect?.(session.id);
-                  }}
-                  className={`flex h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors ${
-                    selectedRecentId === session.id
-                      ? "bg-gray-200 text-gray-900 font-medium"
-                      : "text-sidebar-foreground hover:bg-sidebar-accent"
-                  }`}
-                >
-                  <span className="truncate min-w-0 flex-1">
-                    {session.preview ?? "New chat"}
-                  </span>
-                </Link>
+                  session={session}
+                  isSelected={selectedRecentId === session.id}
+                  onSelect={onRecentSelect}
+                />
               ))
             )}
           </div>

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { GET } from "../route";
+import { GET, DELETE } from "../route";
 import { GET as listThreads, POST } from "../../route";
 import {
   createTestRequest,
@@ -249,5 +249,103 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     expect(listResponse.status).toBe(200);
     expect(listData.threads).toHaveLength(1);
     expect(listData.threads[0].title).toBe("After AI update");
+  });
+});
+
+describe("DELETE /api/zero/chat-threads/:id - Delete Thread", () => {
+  let testComposeId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+
+    const { composeId } = await createTestCompose(uniqueId("chat-delete"));
+    testComposeId = composeId;
+  });
+
+  it("should require authentication", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/chat-threads/some-id",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.message).toContain("Not authenticated");
+  });
+
+  it("should return 404 for non-existent thread", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/chat-threads/00000000-0000-0000-0000-000000000000",
+      { method: "DELETE" },
+    );
+    const response = await DELETE(request);
+
+    expect(response.status).toBe(404);
+  });
+
+  it("should delete a thread and remove it from the list", async () => {
+    // Create a thread
+    const createResponse = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "To delete" }),
+      }),
+    );
+    const { id: threadId } = await createResponse.json();
+
+    // Delete the thread
+    const deleteResponse = await DELETE(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+        { method: "DELETE" },
+      ),
+    );
+    expect(deleteResponse.status).toBe(204);
+
+    // Verify it's gone from GET
+    const getResponse = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+      ),
+    );
+    expect(getResponse.status).toBe(404);
+
+    // Verify it's gone from list
+    const listResponse = await listThreads(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads?agentId=${testComposeId}`,
+      ),
+    );
+    const listData = await listResponse.json();
+    expect(listData.threads).toHaveLength(0);
+  });
+
+  it("should not allow deleting another user's thread", async () => {
+    // Create a thread as user 1
+    const createResponse = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "Private" }),
+      }),
+    );
+    const { id: threadId } = await createResponse.json();
+
+    // Switch to user 2
+    await context.setupUser({ prefix: "other-user" });
+
+    // Try to delete as user 2
+    const deleteResponse = await DELETE(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+        { method: "DELETE" },
+      ),
+    );
+    expect(deleteResponse.status).toBe(404);
   });
 });

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -325,6 +325,29 @@ describe("DELETE /api/zero/chat-threads/:id - Delete Thread", () => {
     expect(listData.threads).toHaveLength(0);
   });
 
+  it("should return 204 with no body (no content-type: application/json)", async () => {
+    const createResponse = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId: testComposeId, title: "No body" }),
+      }),
+    );
+    const { id: threadId } = await createResponse.json();
+
+    const deleteResponse = await DELETE(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+        { method: "DELETE" },
+      ),
+    );
+    expect(deleteResponse.status).toBe(204);
+    // The contract uses c.noBody() so the response must not have a JSON
+    // content-type header — otherwise ts-rest clients crash parsing empty body.
+    const ct = deleteResponse.headers.get("content-type");
+    expect(ct === null || !ct.includes("application/json")).toBe(true);
+  });
+
   it("should not allow deleting another user's thread", async () => {
     // Create a thread as user 1
     const createResponse = await POST(

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/route.ts
@@ -9,6 +9,7 @@ import { getUserId } from "../../../../../src/lib/auth/get-auth-context";
 import {
   getChatThread,
   getChatThreadMessages,
+  deleteChatThread,
 } from "../../../../../src/lib/chat-thread";
 import { isNotFound } from "../../../../../src/lib/errors";
 
@@ -56,10 +57,38 @@ const router = tsr.router(chatThreadByIdContract, {
       throw error;
     }
   },
+  delete: async ({ params, headers }) => {
+    initServices();
+
+    const userId = await getUserId(headers.authorization);
+    if (!userId) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
+    }
+
+    try {
+      await deleteChatThread(params.id, userId);
+      return { status: 204 as const, body: undefined };
+    } catch (error) {
+      if (isNotFound(error)) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Chat thread not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      throw error;
+    }
+  },
 });
 
 const handler = createHandler(chatThreadByIdContract, router, {
   errorHandler: createSafeErrorHandler("zero-chat-thread-by-id"),
 });
 
-export { handler as GET };
+export { handler as GET, handler as DELETE };

--- a/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
@@ -135,6 +135,24 @@ export async function addRunToThread(
 }
 
 /**
+ * Delete a chat thread with ownership check.
+ * Cascade deletes handle chat_thread_runs cleanup.
+ */
+export async function deleteChatThread(
+  threadId: string,
+  userId: string,
+): Promise<void> {
+  const deleted = await globalThis.services.db
+    .delete(chatThreads)
+    .where(and(eq(chatThreads.id, threadId), eq(chatThreads.userId, userId)))
+    .returning({ id: chatThreads.id });
+
+  if (deleted.length === 0) {
+    throw notFound("Chat thread not found");
+  }
+}
+
+/**
  * Update a chat thread's title.
  */
 export async function updateChatThreadTitle(

--- a/turbo/apps/web/src/lib/chat-thread/index.ts
+++ b/turbo/apps/web/src/lib/chat-thread/index.ts
@@ -5,4 +5,5 @@ export {
   addRunToThread,
   getChatThreadMessages,
   updateChatThreadTitle,
+  deleteChatThread,
 } from "./chat-thread-service";

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -117,12 +117,12 @@ export const chatThreadByIdContract = c.router({
     headers: authHeadersSchema,
     pathParams: z.object({ id: z.string() }),
     responses: {
-      204: z.void(),
+      204: c.noBody(),
       401: apiErrorSchema,
       404: apiErrorSchema,
     },
     summary: "Delete a chat thread",
-    body: z.void(),
+    body: c.noBody(),
   },
 });
 

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -111,6 +111,19 @@ export const chatThreadByIdContract = c.router({
     },
     summary: "Get chat thread detail with messages",
   },
+  delete: {
+    method: "DELETE",
+    path: "/api/zero/chat-threads/:id",
+    headers: authHeadersSchema,
+    pathParams: z.object({ id: z.string() }),
+    responses: {
+      204: z.void(),
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Delete a chat thread",
+    body: z.void(),
+  },
 });
 
 /**


### PR DESCRIPTION
## Summary
- Add DELETE endpoint for chat threads (`DELETE /api/zero/chat-threads/:id`) with ownership verification
- Add hover delete button on sidebar chat thread items (trash icon appears on hover)
- Clicking delete removes the thread, refreshes the sidebar list, and navigates to landing page if viewing the deleted thread
- Add `deleteChatThread` service function with ownership check (cascade deletes handle `chat_thread_runs` cleanup)

## Test plan
- [x] Integration tests: auth required (401), not found (404), successful delete (204), cross-user ownership check (404)
- [x] Verify thread is removed from both GET detail and list endpoints after deletion
- [ ] Manual: hover over a sidebar chat thread item and verify trash icon appears
- [ ] Manual: click delete and verify thread is removed from sidebar and toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)