### PR TITLE
fix: prevent sidebar session list flicker during refresh

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -987,7 +987,7 @@ export function ZeroSidebar() {
   const onRecentSelect = (chatThreadId: string) => navigateToChat(chatThreadId);
   const selectedRecentId = useGet(chatThreadId$);
   const onAccountAction = useSet(handleZeroAccountAction$);
-  const recentSessionsLoadable = useLoadable(zeroSessionList$);
+  const recentSessionsLoadable = useLastLoadable(zeroSessionList$);
   const recentSessions =
     recentSessionsLoadable.state === "hasData"
       ? recentSessionsLoadable.data


### PR DESCRIPTION
## Summary
- Switch from `useLoadable` to `useLastLoadable` for recent sessions in the Zero sidebar
- This preserves previous session list data while new data loads, preventing UI flicker during refreshes

## Test plan
- [ ] Open the Zero page and verify the sidebar session list loads correctly
- [ ] Trigger a session list refresh and confirm no flickering occurs
- [ ] Verify session list still updates with new data after refresh completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)