### PR TITLE
feat: add chat button on agent profile page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -705,34 +705,18 @@ export function ZeroJobDetailPage({ agentId }: ZeroJobDetailPageProps) {
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-6 pb-3">
         <div className="mx-auto max-w-[900px]">
           <div className="flex items-center gap-4">
-            <div className="relative shrink-0">
-              {currentAvatar ? (
-                <img
-                  src={currentAvatar}
-                  alt={displayName}
-                  className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
-                />
-              ) : (
-                <div
-                  className="h-14 w-14 rounded-full bg-muted sm:h-16 sm:w-16"
-                  aria-hidden
-                />
-              )}
-              <button
-                type="button"
-                onClick={() =>
-                  nav("/talk/:agentId", { pathParams: { agentId } })
-                }
-                aria-label={`Chat with ${displayName}`}
-                className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full bg-background zero-border shadow-sm hover:bg-accent transition-colors"
-              >
-                <IconMessageCircle
-                  size={13}
-                  stroke={1.5}
-                  className="text-foreground"
-                />
-              </button>
-            </div>
+            {currentAvatar ? (
+              <img
+                src={currentAvatar}
+                alt={displayName}
+                className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
+              />
+            ) : (
+              <div
+                className="h-14 w-14 shrink-0 rounded-full bg-muted sm:h-16 sm:w-16"
+                aria-hidden
+              />
+            )}
             <div className="min-w-0">
               <h1 className="text-xl font-semibold tracking-tight text-foreground">
                 {displayName}
@@ -743,12 +727,21 @@ export function ZeroJobDetailPage({ agentId }: ZeroJobDetailPageProps) {
             </div>
           </div>
 
-          <div className="mt-4 flex h-9 items-center gap-6">
+          <div className="mt-4 flex h-9 items-center gap-4">
             <AgentTabNav
               activeTab={activeTab}
               onTabChange={setActiveTab}
               showProfileAndInstructions={!hideProfileAndInstructions}
             />
+            <button
+              type="button"
+              onClick={() => nav("/talk/:agentId", { pathParams: { agentId } })}
+              aria-label={`Chat with ${displayName}`}
+              className="ml-auto flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+            >
+              <IconMessageCircle size={16} stroke={1.5} />
+              Chat
+            </button>
           </div>
         </div>
       </header>

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -19,6 +19,7 @@ import {
   IconMessageCircle,
 } from "@tabler/icons-react";
 import {
+  Button,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -733,15 +734,16 @@ export function ZeroJobDetailPage({ agentId }: ZeroJobDetailPageProps) {
               onTabChange={setActiveTab}
               showProfileAndInstructions={!hideProfileAndInstructions}
             />
-            <button
-              type="button"
+            <Button
+              variant="outline"
+              size="sm"
+              className="ml-auto zero-btn-morandi gap-1.5"
               onClick={() => nav("/talk/:agentId", { pathParams: { agentId } })}
               aria-label={`Chat with ${displayName}`}
-              className="ml-auto flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
             >
-              <IconMessageCircle size={16} stroke={1.5} />
-              Chat
-            </button>
+              <IconMessageCircle size={14} stroke={2} />
+              Chat with {displayName}
+            </Button>
           </div>
         </div>
       </header>

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -16,6 +16,7 @@ import {
   IconAdjustmentsHorizontal,
   IconSearch,
   IconX,
+  IconMessageCircle,
 } from "@tabler/icons-react";
 import {
   Tabs,
@@ -704,18 +705,34 @@ export function ZeroJobDetailPage({ agentId }: ZeroJobDetailPageProps) {
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-6 pb-3">
         <div className="mx-auto max-w-[900px]">
           <div className="flex items-center gap-4">
-            {currentAvatar ? (
-              <img
-                src={currentAvatar}
-                alt={displayName}
-                className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
-              />
-            ) : (
-              <div
-                className="h-14 w-14 shrink-0 rounded-full bg-muted sm:h-16 sm:w-16"
-                aria-hidden
-              />
-            )}
+            <div className="relative shrink-0">
+              {currentAvatar ? (
+                <img
+                  src={currentAvatar}
+                  alt={displayName}
+                  className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
+                />
+              ) : (
+                <div
+                  className="h-14 w-14 rounded-full bg-muted sm:h-16 sm:w-16"
+                  aria-hidden
+                />
+              )}
+              <button
+                type="button"
+                onClick={() =>
+                  nav("/talk/:agentId", { pathParams: { agentId } })
+                }
+                aria-label={`Chat with ${displayName}`}
+                className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full bg-background zero-border shadow-sm hover:bg-accent transition-colors"
+              >
+                <IconMessageCircle
+                  size={13}
+                  stroke={1.5}
+                  className="text-foreground"
+                />
+              </button>
+            </div>
             <div className="min-w-0">
               <h1 className="text-xl font-semibold tracking-tight text-foreground">
                 {displayName}


### PR DESCRIPTION
## Summary

- Adds a \"Chat with {agent name}\" button next to the tab navigation on the agent profile page
- Clicking the button navigates to `/talk/:agentId` to start a conversation with that agent
- Button styled to match the \"Invite people\" button (`variant="outline"` + `zero-btn-morandi`)

## Test plan

- [ ] Navigate to an agent's profile page
- [ ] Verify the \"Chat with {name}\" button appears next to the tabs
- [ ] Click the button and confirm navigation to the chat page for that agent
- [ ] Verify button style matches the \"Invite people\" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)