### PR TITLE
fix: set instruction card background to bg-card instead of bg-transparent

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
@@ -185,7 +185,7 @@ export function TiptapInstructionsEditor({
 
   return (
     <div
-      className={`relative rounded-xl zero-border bg-transparent transition-colors focus-within:border-primary ${disabled ? "opacity-60 pointer-events-none" : ""}`}
+      className={`relative rounded-xl zero-border bg-card transition-colors focus-within:border-primary ${disabled ? "opacity-60 pointer-events-none" : ""}`}
     >
       {editor && (
         <BubbleMenu

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -705,34 +705,18 @@ export function ZeroJobDetailPage({ agentId }: ZeroJobDetailPageProps) {
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-6 pb-3">
         <div className="mx-auto max-w-[900px]">
           <div className="flex items-center gap-4">
-            <div className="relative shrink-0">
-              {currentAvatar ? (
-                <img
-                  src={currentAvatar}
-                  alt={displayName}
-                  className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
-                />
-              ) : (
-                <div
-                  className="h-14 w-14 rounded-full bg-muted sm:h-16 sm:w-16"
-                  aria-hidden
-                />
-              )}
-              <button
-                type="button"
-                onClick={() =>
-                  nav("/talk/:agentId", { pathParams: { agentId } })
-                }
-                aria-label={`Chat with ${displayName}`}
-                className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full bg-background zero-border shadow-sm hover:bg-accent transition-colors"
-              >
-                <IconMessageCircle
-                  size={13}
-                  stroke={1.5}
-                  className="text-foreground"
-                />
-              </button>
-            </div>
+            {currentAvatar ? (
+              <img
+                src={currentAvatar}
+                alt={displayName}
+                className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
+              />
+            ) : (
+              <div
+                className="h-14 w-14 shrink-0 rounded-full bg-muted sm:h-16 sm:w-16"
+                aria-hidden
+              />
+            )}
             <div className="min-w-0">
               <h1 className="text-xl font-semibold tracking-tight text-foreground">
                 {displayName}
@@ -743,12 +727,21 @@ export function ZeroJobDetailPage({ agentId }: ZeroJobDetailPageProps) {
             </div>
           </div>
 
-          <div className="mt-4 flex h-9 items-center gap-6">
+          <div className="mt-4 flex h-9 items-center gap-4">
             <AgentTabNav
               activeTab={activeTab}
               onTabChange={setActiveTab}
               showProfileAndInstructions={!hideProfileAndInstructions}
             />
+            <button
+              type="button"
+              onClick={() => nav("/talk/:agentId", { pathParams: { agentId } })}
+              aria-label={`Chat with ${displayName}`}
+              className="ml-auto flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+            >
+              <IconMessageCircle size={16} stroke={1.5} />
+              Chat
+            </button>
           </div>
         </div>
       </header>

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -19,6 +19,7 @@ import {
   IconMessageCircle,
 } from "@tabler/icons-react";
 import {
+  Button,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -733,15 +734,16 @@ export function ZeroJobDetailPage({ agentId }: ZeroJobDetailPageProps) {
               onTabChange={setActiveTab}
               showProfileAndInstructions={!hideProfileAndInstructions}
             />
-            <button
-              type="button"
+            <Button
+              variant="outline"
+              size="sm"
+              className="ml-auto zero-btn-morandi gap-1.5"
               onClick={() => nav("/talk/:agentId", { pathParams: { agentId } })}
               aria-label={`Chat with ${displayName}`}
-              className="ml-auto flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
             >
-              <IconMessageCircle size={16} stroke={1.5} />
-              Chat
-            </button>
+              <IconMessageCircle size={14} stroke={2} />
+              Chat with {displayName}
+            </Button>
           </div>
         </div>
       </header>

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -16,6 +16,7 @@ import {
   IconAdjustmentsHorizontal,
   IconSearch,
   IconX,
+  IconMessageCircle,
 } from "@tabler/icons-react";
 import {
   Tabs,
@@ -704,18 +705,34 @@ export function ZeroJobDetailPage({ agentId }: ZeroJobDetailPageProps) {
       <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-6 pb-3">
         <div className="mx-auto max-w-[900px]">
           <div className="flex items-center gap-4">
-            {currentAvatar ? (
-              <img
-                src={currentAvatar}
-                alt={displayName}
-                className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
-              />
-            ) : (
-              <div
-                className="h-14 w-14 shrink-0 rounded-full bg-muted sm:h-16 sm:w-16"
-                aria-hidden
-              />
-            )}
+            <div className="relative shrink-0">
+              {currentAvatar ? (
+                <img
+                  src={currentAvatar}
+                  alt={displayName}
+                  className="h-14 w-14 rounded-full object-cover object-top sm:h-16 sm:w-16"
+                />
+              ) : (
+                <div
+                  className="h-14 w-14 rounded-full bg-muted sm:h-16 sm:w-16"
+                  aria-hidden
+                />
+              )}
+              <button
+                type="button"
+                onClick={() =>
+                  nav("/talk/:agentId", { pathParams: { agentId } })
+                }
+                aria-label={`Chat with ${displayName}`}
+                className="absolute -bottom-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full bg-background zero-border shadow-sm hover:bg-accent transition-colors"
+              >
+                <IconMessageCircle
+                  size={13}
+                  stroke={1.5}
+                  className="text-foreground"
+                />
+              </button>
+            </div>
             <div className="min-w-0">
               <h1 className="text-xl font-semibold tracking-tight text-foreground">
                 {displayName}


### PR DESCRIPTION
## Summary
- Changes the `TiptapInstructionsEditor` card background from `bg-transparent` to `bg-card` to give the instruction card a proper background color

## Test plan
- [ ] Open the zero page and verify the instructions editor card now shows the correct card background color
- [ ] Verify there are no visual regressions in light and dark mode