### PR TITLE
ci: only set strapi url in merge queue events

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -686,7 +686,7 @@ jobs:
           RESEND_WEBHOOK_SECRET: ${{ secrets.RESEND_WEBHOOK_SECRET }}
           RESEND_FROM_DOMAIN: ${{ vars.RESEND_FROM_DOMAIN }}
           VM0_DEFAULT_AGENT: ${{ vars.VM0_DEFAULT_AGENT }}
-          STRAPI_URL: ${{ vars.STRAPI_URL }}
+          STRAPI_URL: ${{ github.event_name == 'merge_group' && vars.STRAPI_URL || '' }}
           GITHUB_APP_SLUG: ${{ vars.VM0_GITHUB_APP_SLUG }}
           GITHUB_APP_ID: ${{ vars.VM0_GITHUB_APP_ID }}
           GITHUB_APP_CLIENT_ID: ${{ vars.VM0_GITHUB_APP_CLIENT_ID }}
@@ -890,7 +890,7 @@ jobs:
             RESEND_WEBHOOK_SECRET=${{ secrets.RESEND_WEBHOOK_SECRET }}
             RESEND_FROM_DOMAIN=${{ vars.RESEND_FROM_DOMAIN }}
             VM0_DEFAULT_AGENT=${{ vars.VM0_DEFAULT_AGENT }}
-            STRAPI_URL=${{ vars.STRAPI_URL }}
+            STRAPI_URL=${{ github.event_name == 'merge_group' && vars.STRAPI_URL || '' }}
             GITHUB_APP_SLUG=${{ vars.VM0_GITHUB_APP_SLUG }}
             GITHUB_APP_ID=${{ vars.VM0_GITHUB_APP_ID }}
             GITHUB_APP_CLIENT_ID=${{ vars.VM0_GITHUB_APP_CLIENT_ID }}


### PR DESCRIPTION
## Summary
- Conditionally set `STRAPI_URL` env var only during `merge_group` events in CI workflow
- For PR checks and other events, `STRAPI_URL` is set to empty string to avoid unnecessary Strapi dependency

## Test plan
- [ ] Verify PR CI checks pass without Strapi URL
- [ ] Verify merge queue builds still receive the correct Strapi URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)