### PR TITLE
feat(platform): add account dropdown to onboarding page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -52,6 +52,9 @@ import {
   IconSearch,
 } from "@tabler/icons-react";
 import { detach, Reason } from "../../signals/utils.ts";
+import { AccountDropdown } from "./zero-sidebar.tsx";
+import { VM0ClerkProvider } from "../clerk/clerk-provider.tsx";
+import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
 
 // ---------------------------------------------------------------------------
 // Progress bar
@@ -642,6 +645,7 @@ function OnboardingPage({
   selectedConnectors?: string[];
   children: React.ReactNode;
 }) {
+  const onAccountAction = useSet(handleZeroAccountAction$);
   const illustration = getStepIllustration(stepKey);
   const showOrbit = stepKey === "connectors" && selectedConnectors;
   const showChat = stepKey === "workspace";
@@ -749,6 +753,16 @@ function OnboardingPage({
               )}
             </>
           )}
+        </div>
+
+        {/* Account dropdown — bottom-left of left panel, left-4 offsets the button's p-2 so the avatar aligns with the logo above */}
+        <div className="absolute bottom-6 left-4 z-20">
+          <VM0ClerkProvider>
+            <AccountDropdown
+              onAccountAction={onAccountAction}
+              hidePreferences
+            />
+          </VM0ClerkProvider>
         </div>
       </div>
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -214,12 +214,14 @@ function useAccountSessions() {
   return { user, clerk, accounts };
 }
 
-function AccountDropdown({
+export function AccountDropdown({
   onAccountAction,
   collapsed = false,
+  hidePreferences = false,
 }: {
   onAccountAction?: (action: ZeroAccountAction) => void;
   collapsed?: boolean;
+  hidePreferences?: boolean;
 }) {
   const { user, clerk, accounts } = useAccountSessions();
   const features = useLastResolved(featureSwitch$);
@@ -265,7 +267,7 @@ function AccountDropdown({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className={`rounded-lg transition-colors duration-200 ${
+          className={`rounded-lg transition-colors duration-200 focus:outline-none ${
             collapsed
               ? "inline-flex h-8 w-8 shrink-0 items-center justify-center p-0 hover:bg-sidebar-accent/50"
               : "flex w-full items-center gap-2 p-2 text-left hover:bg-sidebar-accent/50"
@@ -321,18 +323,22 @@ function AccountDropdown({
         )}
 
         {/* Preferences (standalone) */}
-        <DropdownMenuItem
-          onClick={() => handleAccountAction("preferences")}
-          className="gap-3 px-3 py-2.5 rounded-lg"
-        >
-          <IconAdjustmentsHorizontal
-            size={18}
-            stroke={1.5}
-            className="text-muted-foreground"
-          />
-          <span>Preferences</span>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
+        {!hidePreferences && (
+          <>
+            <DropdownMenuItem
+              onClick={() => handleAccountAction("preferences")}
+              className="gap-3 px-3 py-2.5 rounded-lg"
+            >
+              <IconAdjustmentsHorizontal
+                size={18}
+                stroke={1.5}
+                className="text-muted-foreground"
+              />
+              <span>Preferences</span>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
 
         {/* Account management group */}
         {hasOthers ? (


### PR DESCRIPTION
## Summary

- Add `AccountDropdown` to the bottom-left of the onboarding page left panel
- Export `AccountDropdown` from `zero-sidebar.tsx` for reuse
- Add `hidePreferences` prop to hide Preferences option during onboarding
- Fix blue focus outline on account dropdown trigger button after mouse click

## Test plan

- [ ] Open onboarding page — account component appears in bottom-left of left panel
- [ ] Click account avatar — menu shows Add account, Manage account, Sign out (no Preferences)
- [ ] Normal sidebar account menu still shows all 4 options including Preferences
- [ ] No blue focus ring after clicking the account trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)