### PR TITLE
fix(ci): correct clerk test user cleanup email pattern matching

### DIFF
--- a/.github/workflows/cleanup-stale.yml
+++ b/.github/workflows/cleanup-stale.yml
@@ -369,7 +369,7 @@ jobs:
               EMAIL=$(echo "$user" | jq -r '.email_addresses[0].email_address // "unknown"')
 
               # Verify email actually matches this PR (Clerk query is fuzzy)
-              if [[ "$EMAIL" != "${JOB_REF}+clerk_test@"* ]]; then
+              if [[ "$EMAIL" != "${JOB_REF}+clerk_test"* ]]; then
                 echo "Skipping $USER_ID ($EMAIL) — does not match ${JOB_REF}"
                 SKIPPED=$((SKIPPED + 1))
                 continue

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -115,7 +115,7 @@ jobs:
             EMAIL=$(echo "$user" | jq -r '.email_addresses[0].email_address // "unknown"')
 
             # Verify email actually matches this PR (Clerk query is fuzzy)
-            if [[ "$EMAIL" != "${JOB_REF}+clerk_test@"* ]]; then
+            if [[ "$EMAIL" != "${JOB_REF}+clerk_test"* ]]; then
               echo "Skipping $USER_ID ($EMAIL) — does not match ${JOB_REF}"
               continue
             fi


### PR DESCRIPTION
## Summary

- Fix bash glob pattern in `cleanup.yml` and `cleanup-stale.yml` that prevented Clerk test user deletion
- Remove `@` from `"${JOB_REF}+clerk_test@"*` so the pattern matches email variants like `+clerk_test+runner@`, `+clerk_test+serial@`, `+clerk_test+browser@`

Closes #7374

## Test plan

- [ ] After merge, trigger `cleanup-stale.yml` via `workflow_dispatch` with `dry-run: true` and verify users are matched (not skipped)
- [ ] Verify cleanup summary shows non-zero deleted count

🤖 Generated with [Claude Code](https://claude.com/claude-code)