### PR TITLE
refactor: remove --connectors flag from zero agent create

### DIFF
--- a/e2e/tests/01-serial/ser-t05-zero-agent.bats
+++ b/e2e/tests/01-serial/ser-t05-zero-agent.bats
@@ -34,7 +34,7 @@ teardown_file() {
     # BATS_TEST_TIMEOUT is 30s, so budget: 3 attempts * ~2s call + 2 * 3s sleep = ~12s
     local max_attempts=3
     for ((attempt=1; attempt<=max_attempts; attempt++)); do
-        run $ZERO_CLI agent create --connectors github --display-name "E2E Test Agent" --description "Created by E2E test"
+        run $ZERO_CLI agent create --display-name "E2E Test Agent" --description "Created by E2E test"
         if [[ "$status" -eq 0 ]]; then
             break
         fi
@@ -68,7 +68,6 @@ teardown_file() {
     run $ZERO_CLI agent view "$name"
     assert_success
     assert_output --partial "$name"
-    assert_output --partial "Connectors:"
     assert_output --partial "Description:"
 }
 

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/create.test.ts
@@ -21,7 +21,6 @@ const mockAgent = {
   displayName: "New Agent",
   description: null,
   sound: null,
-  connectors: ["github"],
 };
 
 describe("zero agent create command", () => {
@@ -46,31 +45,23 @@ describe("zero agent create command", () => {
   });
 
   describe("successful create", () => {
-    it("should create agent with required connectors", async () => {
+    it("should create agent with display name", async () => {
       server.use(
         http.post("http://localhost:3000/api/zero/agents", () => {
           return HttpResponse.json(mockAgent, { status: 201 });
         }),
-        http.put(
-          "http://localhost:3000/api/zero/agents/comp_xyz789/user-connectors",
-          () => {
-            return HttpResponse.json({ enabledTypes: ["github"] });
-          },
-        ),
       );
 
       await createCommand.parseAsync([
         "node",
         "cli",
-        "--connectors",
-        "github",
         "--display-name",
         "New Agent",
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("comp_xyz789");
-      expect(logCalls).toContain("github");
+      expect(logCalls).toContain("created");
     });
 
     it("should create agent with custom skills and include them in request body", async () => {
@@ -119,12 +110,6 @@ describe("zero agent create command", () => {
             return HttpResponse.json(mockAgent, { status: 201 });
           }),
           http.put(
-            "http://localhost:3000/api/zero/agents/comp_xyz789/user-connectors",
-            () => {
-              return HttpResponse.json({ enabledTypes: ["github"] });
-            },
-          ),
-          http.put(
             "http://localhost:3000/api/zero/agents/comp_xyz789/instructions",
             async ({ request }) => {
               const body = (await request.json()) as { content: string };
@@ -137,8 +122,8 @@ describe("zero agent create command", () => {
         await createCommand.parseAsync([
           "node",
           "cli",
-          "--connectors",
-          "github",
+          "--display-name",
+          "New Agent",
           "--instructions-file",
           instructionsPath,
         ]);
@@ -166,8 +151,8 @@ describe("zero agent create command", () => {
         await createCommand.parseAsync([
           "node",
           "cli",
-          "--connectors",
-          "github",
+          "--display-name",
+          "Test",
         ]);
       }).rejects.toThrow("process.exit called");
 

--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -1,20 +1,12 @@
 import { Command } from "commander";
 import { readFileSync } from "node:fs";
 import chalk from "chalk";
-import {
-  createZeroAgent,
-  setZeroAgentUserConnectors,
-  updateZeroAgentInstructions,
-} from "../../../lib/api";
+import { createZeroAgent, updateZeroAgentInstructions } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 
 export const createCommand = new Command()
   .name("create")
   .description("Create a new zero agent")
-  .option(
-    "--connectors <items>",
-    "Comma-separated connector types to enable for this agent (e.g. github,linear)",
-  )
   .option(
     "--skills <items>",
     "Comma-separated custom skill names to attach (e.g. my-skill,other-skill)",
@@ -31,14 +23,12 @@ export const createCommand = new Command()
     `
 Examples:
   Minimal:               zero agent create --display-name "My Agent"
-  With connectors:       zero agent create --connectors github,linear --display-name "My Agent"
   With skills:           zero agent create --skills my-skill,other-skill --display-name "My Agent"
-  With instructions:     zero agent create --connectors github --instructions-file ./instructions.md`,
+  With instructions:     zero agent create --display-name "My Agent" --instructions-file ./instructions.md`,
   )
   .action(
     withErrorHandler(
       async (options: {
-        connectors?: string;
         skills?: string;
         displayName?: string;
         description?: string;
@@ -58,13 +48,6 @@ Examples:
           customSkills,
         });
 
-        if (options.connectors) {
-          const connectors = options.connectors.split(",").map((s) => {
-            return s.trim();
-          });
-          await setZeroAgentUserConnectors(agent.agentId, connectors);
-        }
-
         if (options.instructionsFile) {
           const content = readFileSync(options.instructionsFile, "utf-8");
           await updateZeroAgentInstructions(agent.agentId, content);
@@ -72,9 +55,6 @@ Examples:
 
         console.log(chalk.green(`✓ Agent "${agent.agentId}" created`));
         console.log(`  Agent ID:     ${agent.agentId}`);
-        if (options.connectors) {
-          console.log(`  Connectors:   ${options.connectors}`);
-        }
         if (customSkills?.length) {
           console.log(`  Skills:       ${customSkills.join(", ")}`);
         }

--- a/turbo/apps/cli/src/lib/api/domains/zero-agents.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-agents.ts
@@ -78,23 +78,6 @@ export async function getZeroAgentUserConnectors(
   );
 }
 
-export async function setZeroAgentUserConnectors(
-  id: string,
-  enabledTypes: string[],
-): Promise<void> {
-  const config = await getClientConfig();
-  const client = initClient(zeroUserConnectorsContract, config);
-  const result = await client.update({
-    params: { id },
-    body: { enabledTypes },
-  });
-  if (result.status === 200) return;
-  handleError(
-    result,
-    `Failed to set connector permissions for zero agent "${id}"`,
-  );
-}
-
 export async function updateZeroAgentInstructions(
   id: string,
   content: string,

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -104,7 +104,6 @@ export {
   getZeroAgentInstructions,
   updateZeroAgentInstructions,
   getZeroAgentUserConnectors,
-  setZeroAgentUserConnectors,
 } from "./domains/zero-agents";
 
 // Domain modules - Zero Skills (org-level)


### PR DESCRIPTION
## Summary
- Remove `--connectors` option from `zero agent create` command — user connector permissions are now managed exclusively via Web UI
- Remove unused `setZeroAgentUserConnectors` function from CLI API layer
- Update tests to no longer reference connectors

Follows the precedent set by PR #7324 which already removed `--connectors` from `zero agent edit`.

Closes #7381

## Test plan
- [x] All 4 existing create command tests pass (rewritten without connector references)
- [x] Lint passes
- [x] Type check passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)