### PR TITLE
feat(platform): add firewall-allow page for managing firewall permissions

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -29,6 +29,7 @@ import { setupOnboardingPage$ } from "./onboarding-page/onboarding-page-setup.ts
 import { setupIdeationPage$ } from "./zero-page/ideation-page-setup.ts";
 import { setupConnectorsPage$ } from "./connectors-page/connectors-page-setup.ts";
 import { setupSignInTokenPage$ } from "./sign-in-token-setup.ts";
+import { setupFirewallAllowPage$ } from "./firewall-allow/firewall-allow-page-setup.ts";
 
 /**
  * Catch-all fallback — redirects unknown paths to /.
@@ -112,6 +113,10 @@ const ROUTE_CONFIG = [
   {
     path: "/usage",
     setup: setupAuthPageWrapper(setupUsagePage$),
+  },
+  {
+    path: "/firewall-allow/:agentId",
+    setup: setupAuthPageWrapper(setupFirewallAllowPage$),
   },
   {
     path: "/onboarding",

--- a/turbo/apps/platform/src/signals/firewall-allow/__tests__/firewall-allow-signals.test.ts
+++ b/turbo/apps/platform/src/signals/firewall-allow/__tests__/firewall-allow-signals.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { extractPermissions } from "../firewall-allow-signals.ts";
+
+describe("extractPermissions", () => {
+  it("should return empty array for unknown connector type", () => {
+    expect(extractPermissions("nonexistent")).toStrictEqual([]);
+  });
+
+  it("should return empty array for empty string", () => {
+    expect(extractPermissions("")).toStrictEqual([]);
+  });
+
+  it("should return permissions for a valid connector type", () => {
+    const permissions = extractPermissions("github");
+    expect(permissions.length).toBeGreaterThan(0);
+    // Each permission should have a name
+    for (const p of permissions) {
+      expect(p.name).toBeTruthy();
+    }
+  });
+
+  it("should deduplicate permissions by name", () => {
+    const permissions = extractPermissions("github");
+    const names = permissions.map((p) => p.name);
+    const uniqueNames = [...new Set(names)];
+    expect(names).toStrictEqual(uniqueNames);
+  });
+
+  it("should return permissions with description when available", () => {
+    const permissions = extractPermissions("github");
+    // At least some permissions should have descriptions
+    const withDescription = permissions.filter((p) => p.description);
+    expect(withDescription.length).toBeGreaterThan(0);
+  });
+});

--- a/turbo/apps/platform/src/signals/firewall-allow/firewall-allow-page-setup.ts
+++ b/turbo/apps/platform/src/signals/firewall-allow/firewall-allow-page-setup.ts
@@ -1,0 +1,24 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { FirewallAllowPageWrapper } from "../../views/firewall-allow/firewall-allow-page-wrapper.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { fetchZeroSessionList$ } from "../zero-page/zero-chat.ts";
+
+export const setupFirewallAllowPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(FirewallAllowPageWrapper));
+    set(updateDocumentTitle$, "Firewall Permissions");
+
+    await set(initZeroOnboarding$, signal);
+    signal.throwIfAborted();
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+
+    await set(fetchZeroSessionList$, signal);
+  },
+);

--- a/turbo/apps/platform/src/signals/firewall-allow/firewall-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/firewall-allow/firewall-allow-signals.ts
@@ -8,7 +8,6 @@ import {
   getConnectorFirewall,
   isFirewallConnectorType,
   type FirewallPolicies,
-  type FirewallAccessRequestResponse,
 } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
@@ -111,9 +110,7 @@ export const firewallAccessRequests$ = computed(async (get) => {
   }
 
   // Filter to only requests for this firewall ref
-  return (result.body as FirewallAccessRequestResponse[]).filter(
-    (r) => r.firewallRef === ref,
-  );
+  return result.body.filter((r) => r.firewallRef === ref);
 });
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/signals/firewall-allow/firewall-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/firewall-allow/firewall-allow-signals.ts
@@ -1,0 +1,214 @@
+import { command, computed, state } from "ccstate";
+import {
+  firewallAccessRequestsCreateContract,
+  firewallAccessRequestsListContract,
+  firewallAccessRequestsResolveContract,
+  zeroAgentFirewallPoliciesContract,
+  zeroAgentsByIdContract,
+  getConnectorFirewall,
+  isFirewallConnectorType,
+  type FirewallPolicies,
+  type FirewallAccessRequestResponse,
+} from "@vm0/core";
+import { zeroClient$ } from "../api-client.ts";
+import { pathParams$, searchParams$ } from "../route.ts";
+
+// ---------------------------------------------------------------------------
+// Route params
+// ---------------------------------------------------------------------------
+
+export const firewallAllowAgentId$ = computed((get) => {
+  const params = get(pathParams$);
+  const agentId = params?.agentId;
+  return typeof agentId === "string" ? agentId : null;
+});
+
+export const firewallAllowRef$ = computed((get) => {
+  return get(searchParams$).get("ref") ?? null;
+});
+
+export const firewallAllowPermission$ = computed((get) => {
+  return get(searchParams$).get("permission") ?? null;
+});
+
+export const firewallAllowMethod$ = computed((get) => {
+  return get(searchParams$).get("method") ?? null;
+});
+
+export const firewallAllowPath$ = computed((get) => {
+  return get(searchParams$).get("path") ?? null;
+});
+
+// ---------------------------------------------------------------------------
+// Agent data
+// ---------------------------------------------------------------------------
+
+const internalAgentReload$ = state(0);
+
+export const firewallAllowAgent$ = computed(async (get) => {
+  get(internalAgentReload$);
+  const agentId = get(firewallAllowAgentId$);
+  if (!agentId) {
+    return null;
+  }
+  const client = get(zeroClient$)(zeroAgentsByIdContract);
+  const result = await client.get({ params: { id: agentId } });
+  if (result.status !== 200) {
+    throw new Error(`Failed to fetch agent (${result.status})`);
+  }
+  return result.body;
+});
+
+// ---------------------------------------------------------------------------
+// Permissions list (derived from firewall config)
+// ---------------------------------------------------------------------------
+
+interface FirewallPermission {
+  name: string;
+  description?: string;
+}
+
+export function extractPermissions(ref: string): FirewallPermission[] {
+  if (!isFirewallConnectorType(ref)) {
+    return [];
+  }
+  const config = getConnectorFirewall(ref);
+  const seen = new Map<string, FirewallPermission>();
+  for (const api of config.apis) {
+    if (!api.permissions) {
+      continue;
+    }
+    for (const p of api.permissions) {
+      if (!seen.has(p.name)) {
+        seen.set(p.name, { name: p.name, description: p.description });
+      }
+    }
+  }
+  return [...seen.values()];
+}
+
+// ---------------------------------------------------------------------------
+// Access requests
+// ---------------------------------------------------------------------------
+
+const internalRequestsReload$ = state(0);
+
+export const firewallAccessRequests$ = computed(async (get) => {
+  get(internalRequestsReload$);
+  const agentId = get(firewallAllowAgentId$);
+  const ref = get(firewallAllowRef$);
+  if (!agentId || !ref) {
+    return [];
+  }
+
+  const client = get(zeroClient$)(firewallAccessRequestsListContract);
+  const result = await client.list({
+    query: { agentId, status: "pending" },
+  });
+
+  if (result.status !== 200) {
+    throw new Error(`Failed to fetch access requests (${result.status})`);
+  }
+
+  // Filter to only requests for this firewall ref
+  return (result.body as FirewallAccessRequestResponse[]).filter(
+    (r) => r.firewallRef === ref,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Admin: save firewall policies
+// ---------------------------------------------------------------------------
+
+export const saveFirewallPolicies$ = command(
+  async (
+    { get, set },
+    agentId: string,
+    policies: FirewallPolicies,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(zeroClient$)(zeroAgentFirewallPoliciesContract);
+    const result = await client.update({
+      body: { agentId, policies },
+    });
+    signal.throwIfAborted();
+    if (result.status !== 200) {
+      const detail =
+        result.status === 400 ||
+        result.status === 401 ||
+        result.status === 403 ||
+        result.status === 404
+          ? result.body.error.message
+          : `status ${result.status}`;
+      throw new Error(`Save failed: ${detail}`);
+    }
+    set(internalAgentReload$, (prev) => prev + 1);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Admin: resolve (approve/reject) access request
+// ---------------------------------------------------------------------------
+
+export const resolveAccessRequest$ = command(
+  async (
+    { get, set },
+    requestId: string,
+    action: "approve" | "reject",
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(zeroClient$)(firewallAccessRequestsResolveContract);
+    const result = await client.resolve({
+      body: { requestId, action },
+    });
+    signal.throwIfAborted();
+    if (result.status !== 200) {
+      const detail =
+        result.status === 400 ||
+        result.status === 401 ||
+        result.status === 403 ||
+        result.status === 404
+          ? result.body.error.message
+          : `status ${result.status}`;
+      throw new Error(`Resolve failed: ${detail}`);
+    }
+    set(internalRequestsReload$, (prev) => prev + 1);
+    set(internalAgentReload$, (prev) => prev + 1);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Member: create access request
+// ---------------------------------------------------------------------------
+
+export const createAccessRequest$ = command(
+  async (
+    { get, set },
+    params: {
+      agentId: string;
+      firewallRef: string;
+      permission: string;
+      method?: string;
+      path?: string;
+      reason?: string;
+    },
+    signal: AbortSignal,
+  ): Promise<void> => {
+    const client = get(zeroClient$)(firewallAccessRequestsCreateContract);
+    const result = await client.create({
+      body: params,
+    });
+    signal.throwIfAborted();
+    if (result.status !== 201) {
+      const detail =
+        result.status === 400 ||
+        result.status === 401 ||
+        result.status === 403 ||
+        result.status === 404
+          ? result.body.error.message
+          : `status ${result.status}`;
+      throw new Error(`Request failed: ${detail}`);
+    }
+    set(internalRequestsReload$, (prev) => prev + 1);
+  },
+);

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -19,6 +19,7 @@ export type RoutePath =
   | "/ideas"
   | "/connectors"
   | "/talk/:agentId/ideas"
+  | "/firewall-allow/:agentId"
   | "/onboarding"
   | "/sign-in-token"
   | "/__internal-connector-logos"

--- a/turbo/apps/platform/src/views/firewall-allow/__tests__/firewall-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/firewall-allow/__tests__/firewall-allow-page.test.tsx
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function mockFirewallRequests(requests: unknown[] = []) {
+  server.use(
+    http.get("*/api/zero/firewall-access-requests", () => {
+      return HttpResponse.json(requests);
+    }),
+  );
+}
+
+describe("firewall allow page", () => {
+  it("shows error when ref query param is missing", async () => {
+    await setupPage({
+      context,
+      path: `/firewall-allow/${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Missing agent ID or firewall ref in URL parameters"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows error for unknown firewall ref", async () => {
+    await setupPage({
+      context,
+      path: `/firewall-allow/${AGENT_ID}?ref=unknown-ref`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Unknown firewall: unknown-ref/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders admin focused view with permission param", async () => {
+    mockFirewallRequests();
+
+    await setupPage({
+      context,
+      path: `/firewall-allow/${AGENT_ID}?ref=github&permission=issues:read`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("issues:read")).toBeInTheDocument();
+    });
+
+    // Admin should see Save button
+    expect(screen.getByText("Save")).toBeInTheDocument();
+    // Admin should see Allow/Deny toggles
+    expect(screen.getByText("Allow")).toBeInTheDocument();
+    expect(screen.getByText("Deny")).toBeInTheDocument();
+  });
+
+  it("renders admin list view without permission param", async () => {
+    mockFirewallRequests();
+
+    await setupPage({
+      context,
+      path: `/firewall-allow/${AGENT_ID}?ref=github`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions")).toBeInTheDocument();
+    });
+
+    // Should show Save button
+    expect(screen.getByText("Save")).toBeInTheDocument();
+  });
+
+  it("renders member focused view with read-only policy and request access button", async () => {
+    // Override org to return member role
+    server.use(
+      http.get("*/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "org_1",
+          slug: "user-12345678",
+          name: "User 12345678",
+          role: "member",
+        });
+      }),
+    );
+    // Mock agent with the permission denied so Request Access shows
+    server.use(
+      http.get("*/api/zero/agents/:name", ({ params }) => {
+        if (
+          params.name === "instructions" ||
+          (typeof params.name === "string" && params.name.includes("/"))
+        ) {
+          return;
+        }
+        return HttpResponse.json({
+          agentId: AGENT_ID,
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          firewallPolicies: { github: { "issues:read": "deny" } },
+          customSkills: [],
+        });
+      }),
+    );
+    mockFirewallRequests();
+
+    await setupPage({
+      context,
+      path: `/firewall-allow/${AGENT_ID}?ref=github&permission=issues:read`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("issues:read")).toBeInTheDocument();
+    });
+
+    // Member should NOT see Save button
+    expect(screen.queryByText("Save")).not.toBeInTheDocument();
+    // Member should see Request Access button (since policy is deny)
+    expect(screen.getByText("Request Access")).toBeInTheDocument();
+  });
+
+  it("renders member list view without permission param", async () => {
+    server.use(
+      http.get("*/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "org_1",
+          slug: "user-12345678",
+          name: "User 12345678",
+          role: "member",
+        });
+      }),
+    );
+    mockFirewallRequests();
+
+    await setupPage({
+      context,
+      path: `/firewall-allow/${AGENT_ID}?ref=github`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Permissions")).toBeInTheDocument();
+    });
+
+    // Member should NOT see Save button
+    expect(screen.queryByText("Save")).not.toBeInTheDocument();
+  });
+
+  it("shows blocked request context when method and path are present", async () => {
+    mockFirewallRequests();
+
+    await setupPage({
+      context,
+      path: `/firewall-allow/${AGENT_ID}?ref=github&permission=issues:read&method=GET&path=/repos/owner/repo/pulls`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("issues:read")).toBeInTheDocument();
+    });
+
+    // Should show blocked method+path
+    expect(screen.getByText(/GET/)).toBeInTheDocument();
+    expect(screen.getByText(/\/repos\/owner\/repo\/pulls/)).toBeInTheDocument();
+  });
+
+  it("shows pending access requests for admin", async () => {
+    mockFirewallRequests([
+      {
+        id: "d0000000-0000-4000-a000-000000000001",
+        agentId: AGENT_ID,
+        firewallRef: "github",
+        permission: "issues:read",
+        method: null,
+        path: null,
+        reason: "Need to read issues",
+        status: "pending",
+        requesterUserId: "user_abc",
+        requesterName: "Alice Smith",
+        resolvedBy: null,
+        resolvedAt: null,
+        createdAt: "2026-03-10T00:00:00Z",
+      },
+    ]);
+
+    await setupPage({
+      context,
+      path: `/firewall-allow/${AGENT_ID}?ref=github&permission=issues:read`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Need to read issues/)).toBeInTheDocument();
+    expect(screen.getByText("Approve")).toBeInTheDocument();
+    expect(screen.getByText("Reject")).toBeInTheDocument();
+  });
+
+  it("shows connector label in header", async () => {
+    mockFirewallRequests();
+
+    await setupPage({
+      context,
+      path: `/firewall-allow/${AGENT_ID}?ref=github&permission=issues:read`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/GitHub Firewall/)).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/firewall-allow/firewall-allow-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/firewall-allow/firewall-allow-page-wrapper.tsx
@@ -1,0 +1,10 @@
+import { SidebarLayout } from "../zero-page/sidebar-layout.tsx";
+import { FirewallAllowPage } from "./firewall-allow-page.tsx";
+
+export function FirewallAllowPageWrapper() {
+  return (
+    <SidebarLayout>
+      <FirewallAllowPage />
+    </SidebarLayout>
+  );
+}

--- a/turbo/apps/platform/src/views/firewall-allow/firewall-allow-page.tsx
+++ b/turbo/apps/platform/src/views/firewall-allow/firewall-allow-page.tsx
@@ -14,6 +14,7 @@ import {
   CONNECTOR_TYPES,
   getDefaultFirewallPolicies,
   type FirewallPolicies,
+  type FirewallPolicyValue,
 } from "@vm0/core";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
@@ -29,7 +30,6 @@ import {
   resolveAccessRequest$,
   createAccessRequest$,
 } from "../../signals/firewall-allow/firewall-allow-signals.ts";
-import type { PermissionPolicy } from "../../signals/zero-page/settings/firewalls.ts";
 import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 
@@ -47,8 +47,8 @@ function PolicyPill({
   onChange,
   disabled,
 }: {
-  policy: PermissionPolicy;
-  onChange?: (p: PermissionPolicy) => void;
+  policy: FirewallPolicyValue;
+  onChange?: (p: FirewallPolicyValue) => void;
   disabled?: boolean;
 }) {
   return (
@@ -114,9 +114,9 @@ function AdminView({
   const [saving, setSaving] = useState(false);
   const [resolvingId, setResolvingId] = useState<string | null>(null);
 
-  const [policies, setPolicies] = useState<Record<string, PermissionPolicy>>(
+  const [policies, setPolicies] = useState<Record<string, FirewallPolicyValue>>(
     () => {
-      const result: Record<string, PermissionPolicy> = {};
+      const result: Record<string, FirewallPolicyValue> = {};
       for (const p of permissions) {
         result[p.name] =
           agent.firewallPolicies?.[ref]?.[p.name] ??

--- a/turbo/apps/platform/src/views/firewall-allow/firewall-allow-page.tsx
+++ b/turbo/apps/platform/src/views/firewall-allow/firewall-allow-page.tsx
@@ -1,0 +1,596 @@
+import { useState } from "react";
+import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import { Button } from "@vm0/ui";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  IconCheck,
+  IconBan,
+  IconShieldLock,
+  IconAlertTriangle,
+  IconClock,
+} from "@tabler/icons-react";
+import {
+  isFirewallConnectorType,
+  CONNECTOR_TYPES,
+  getDefaultFirewallPolicies,
+  type FirewallPolicies,
+} from "@vm0/core";
+import { isOrgAdmin$ } from "../../signals/org.ts";
+import {
+  firewallAllowAgentId$,
+  firewallAllowRef$,
+  firewallAllowPermission$,
+  firewallAllowMethod$,
+  firewallAllowPath$,
+  firewallAllowAgent$,
+  firewallAccessRequests$,
+  extractPermissions,
+  saveFirewallPolicies$,
+  resolveAccessRequest$,
+  createAccessRequest$,
+} from "../../signals/firewall-allow/firewall-allow-signals.ts";
+import type { PermissionPolicy } from "../../signals/zero-page/settings/firewalls.ts";
+import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.tsx";
+import { detach, Reason } from "../../signals/utils.ts";
+
+// ---------------------------------------------------------------------------
+// PolicyPill (reused from firewall-permissions-dialog pattern)
+// ---------------------------------------------------------------------------
+
+const POLICY_OPTIONS = [
+  { value: "allow" as const, label: "Allow" },
+  { value: "deny" as const, label: "Deny" },
+] as const;
+
+function PolicyPill({
+  policy,
+  onChange,
+  disabled,
+}: {
+  policy: PermissionPolicy;
+  onChange?: (p: PermissionPolicy) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <span className="inline-flex shrink-0 rounded-md overflow-hidden text-xs font-medium zero-border">
+      {POLICY_OPTIONS.map((opt, idx) => (
+        <button
+          key={opt.value}
+          type="button"
+          disabled={disabled}
+          style={
+            idx > 0
+              ? { borderLeft: "0.7px solid hsl(var(--gray-400))" }
+              : undefined
+          }
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onChange?.(opt.value);
+          }}
+          className={`flex items-center gap-1 px-2.5 py-1.5 transition-colors ${
+            policy === opt.value
+              ? "bg-muted text-foreground"
+              : disabled
+                ? "text-muted-foreground/50"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+          } ${disabled ? "cursor-default" : "cursor-pointer"}`}
+        >
+          {opt.value === "allow" && <IconCheck size={12} stroke={2.5} />}
+          {opt.value === "deny" && <IconBan size={12} stroke={2.5} />}
+          {opt.label}
+        </button>
+      ))}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Admin View
+// ---------------------------------------------------------------------------
+
+function AdminView({
+  agentId,
+  ref,
+  highlightPermission,
+  agent,
+}: {
+  agentId: string;
+  ref: string;
+  highlightPermission: string | null;
+  agent: {
+    firewallPolicies: FirewallPolicies | null;
+    displayName: string | null;
+  };
+}) {
+  const permissions = extractPermissions(ref);
+  const defaults = isFirewallConnectorType(ref)
+    ? getDefaultFirewallPolicies(ref)
+    : null;
+  const pageSignal = useGet(pageSignal$);
+  const requestsLoadable = useLastLoadable(firewallAccessRequests$);
+  const setSavePolicies = useSet(saveFirewallPolicies$);
+  const setResolveRequest = useSet(resolveAccessRequest$);
+  const [saving, setSaving] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+
+  const [policies, setPolicies] = useState<Record<string, PermissionPolicy>>(
+    () => {
+      const result: Record<string, PermissionPolicy> = {};
+      for (const p of permissions) {
+        result[p.name] =
+          agent.firewallPolicies?.[ref]?.[p.name] ??
+          defaults?.[p.name] ??
+          "allow";
+      }
+      return result;
+    },
+  );
+
+  const handleSave = () => {
+    const fullPolicies: FirewallPolicies = {
+      ...agent.firewallPolicies,
+      [ref]: policies,
+    };
+    setSaving(true);
+    detach(
+      setSavePolicies(agentId, fullPolicies, pageSignal).finally(() => {
+        setSaving(false);
+      }),
+      Reason.DomCallback,
+    );
+  };
+
+  const handleResolve = (requestId: string, action: "approve" | "reject") => {
+    setResolvingId(requestId);
+    detach(
+      setResolveRequest(requestId, action, pageSignal)
+        .then(() => {
+          if (action === "approve") {
+            // Reflect the approval in local state
+            const request =
+              requestsLoadable.state === "hasData"
+                ? requestsLoadable.data.find((r) => r.id === requestId)
+                : null;
+            if (request) {
+              setPolicies((prev) => ({
+                ...prev,
+                [request.permission]: "allow",
+              }));
+            }
+          }
+        })
+        .finally(() => {
+          setResolvingId(null);
+        }),
+      Reason.DomCallback,
+    );
+  };
+
+  const requests =
+    requestsLoadable.state === "hasData" ? requestsLoadable.data : [];
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Permissions list */}
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-medium text-foreground">Permissions</h2>
+          <Button size="sm" onClick={handleSave} disabled={saving}>
+            {saving ? "Saving..." : "Save"}
+          </Button>
+        </div>
+
+        <div className="zero-border rounded-lg overflow-hidden">
+          {permissions.map((perm, idx) => {
+            const isHighlighted = perm.name === highlightPermission;
+            return (
+              <div key={perm.name}>
+                {idx > 0 && <div className="border-t border-border/40" />}
+                <div
+                  className={`flex items-center gap-2.5 px-4 py-3 transition-colors ${
+                    isHighlighted
+                      ? "bg-yellow-50 dark:bg-yellow-950/20"
+                      : "hover:bg-muted/50"
+                  }`}
+                >
+                  <div className="min-w-0 flex-1">
+                    <code className="text-xs font-medium text-foreground truncate block">
+                      {perm.name}
+                    </code>
+                    {perm.description && (
+                      <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
+                        {perm.description}
+                      </p>
+                    )}
+                  </div>
+                  <PolicyPill
+                    policy={policies[perm.name] ?? "allow"}
+                    onChange={(p) =>
+                      setPolicies((prev) => ({ ...prev, [perm.name]: p }))
+                    }
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Access requests section */}
+      {requests.length > 0 && (
+        <section>
+          <h2 className="text-sm font-medium text-foreground mb-3">
+            <span className="flex items-center gap-1.5">
+              <IconClock size={14} />
+              Pending Access Requests ({requests.length})
+            </span>
+          </h2>
+
+          <div className="zero-border rounded-lg overflow-hidden">
+            {requests.map((req, idx) => (
+              <div key={req.id}>
+                {idx > 0 && <div className="border-t border-border/40" />}
+                <div className="px-4 py-3">
+                  <div className="flex items-center justify-between">
+                    <div className="min-w-0 flex-1">
+                      <code className="text-xs font-medium text-foreground">
+                        {req.permission}
+                      </code>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        Requested by {req.requesterUserId}
+                        {req.reason && (
+                          <>
+                            {" "}
+                            &mdash; <span className="italic">{req.reason}</span>
+                          </>
+                        )}
+                      </p>
+                    </div>
+                    <div className="flex gap-2 shrink-0 ml-3">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleResolve(req.id, "reject")}
+                        disabled={resolvingId === req.id}
+                      >
+                        <IconBan size={12} />
+                        Reject
+                      </Button>
+                      <Button
+                        size="sm"
+                        onClick={() => handleResolve(req.id, "approve")}
+                        disabled={resolvingId === req.id}
+                      >
+                        <IconCheck size={12} />
+                        Approve
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Member View
+// ---------------------------------------------------------------------------
+
+function MemberView({
+  agentId,
+  ref,
+  highlightPermission,
+  method,
+  path,
+  agent,
+}: {
+  agentId: string;
+  ref: string;
+  highlightPermission: string | null;
+  method: string | null;
+  path: string | null;
+  agent: { firewallPolicies: FirewallPolicies | null };
+}) {
+  const permissions = extractPermissions(ref);
+  const defaults = isFirewallConnectorType(ref)
+    ? getDefaultFirewallPolicies(ref)
+    : null;
+  const pageSignal = useGet(pageSignal$);
+  const requestsLoadable = useLastLoadable(firewallAccessRequests$);
+  const setCreateRequest = useSet(createAccessRequest$);
+  const [requestingPermission, setRequestingPermission] = useState<
+    string | null
+  >(null);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const requests =
+    requestsLoadable.state === "hasData" ? requestsLoadable.data : [];
+  const pendingPermissions = new Set(requests.map((r) => r.permission));
+
+  const handleSubmit = (permission: string) => {
+    setSubmitting(true);
+    detach(
+      setCreateRequest(
+        {
+          agentId,
+          firewallRef: ref,
+          permission,
+          method: method ?? undefined,
+          path: path ?? undefined,
+          reason: reason || undefined,
+        },
+        pageSignal,
+      )
+        .then(() => {
+          setRequestingPermission(null);
+          setReason("");
+        })
+        .finally(() => {
+          setSubmitting(false);
+        }),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <section>
+        <h2 className="text-sm font-medium text-foreground mb-3">
+          Permissions
+        </h2>
+
+        <div className="zero-border rounded-lg overflow-hidden">
+          {permissions.map((perm, idx) => {
+            const isHighlighted = perm.name === highlightPermission;
+            const currentPolicy =
+              agent.firewallPolicies?.[ref]?.[perm.name] ??
+              defaults?.[perm.name] ??
+              "allow";
+            const isPending = pendingPermissions.has(perm.name);
+
+            return (
+              <div key={perm.name}>
+                {idx > 0 && <div className="border-t border-border/40" />}
+                <div
+                  className={`px-4 py-3 transition-colors ${
+                    isHighlighted ? "bg-yellow-50 dark:bg-yellow-950/20" : ""
+                  }`}
+                >
+                  <div className="flex items-center gap-2.5">
+                    <div className="min-w-0 flex-1">
+                      <code className="text-xs font-medium text-foreground truncate block">
+                        {perm.name}
+                      </code>
+                      {perm.description && (
+                        <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
+                          {perm.description}
+                        </p>
+                      )}
+                    </div>
+                    <PolicyPill policy={currentPolicy} disabled />
+                    {isHighlighted && currentPolicy !== "allow" && (
+                      <>
+                        {isPending ? (
+                          <span className="text-xs text-amber-600 dark:text-amber-400 flex items-center gap-1 shrink-0">
+                            <IconClock size={12} />
+                            Pending
+                          </span>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => setRequestingPermission(perm.name)}
+                          >
+                            Request Access
+                          </Button>
+                        )}
+                      </>
+                    )}
+                  </div>
+
+                  {requestingPermission === perm.name && (
+                    <div className="mt-3 flex flex-col gap-2">
+                      <textarea
+                        placeholder="Reason for access (optional)"
+                        value={reason}
+                        onChange={(e) => setReason(e.target.value)}
+                        rows={2}
+                        className="text-sm w-full rounded-md border border-input bg-background px-3 py-2 ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      />
+                      <div className="flex gap-2 justify-end">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            setRequestingPermission(null);
+                            setReason("");
+                          }}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          size="sm"
+                          onClick={() => handleSubmit(perm.name)}
+                          disabled={submitting}
+                        >
+                          {submitting ? "Submitting..." : "Submit Request"}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Show own pending requests */}
+      {requests.length > 0 && (
+        <section>
+          <h2 className="text-sm font-medium text-foreground mb-3">
+            <span className="flex items-center gap-1.5">
+              <IconClock size={14} />
+              Your Pending Requests ({requests.length})
+            </span>
+          </h2>
+
+          <div className="zero-border rounded-lg overflow-hidden">
+            {requests.map((req, idx) => (
+              <div key={req.id}>
+                {idx > 0 && <div className="border-t border-border/40" />}
+                <div className="px-4 py-3">
+                  <code className="text-xs font-medium text-foreground">
+                    {req.permission}
+                  </code>
+                  {req.reason && (
+                    <p className="text-xs text-muted-foreground mt-0.5 italic">
+                      {req.reason}
+                    </p>
+                  )}
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Submitted {new Date(req.createdAt).toLocaleDateString()}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Page
+// ---------------------------------------------------------------------------
+
+export function FirewallAllowPage() {
+  const agentId = useGet(firewallAllowAgentId$);
+  const ref = useGet(firewallAllowRef$);
+  const highlightPermission = useGet(firewallAllowPermission$);
+  const method = useGet(firewallAllowMethod$);
+  const path = useGet(firewallAllowPath$);
+
+  const agentLoadable = useLastLoadable(firewallAllowAgent$);
+  const isAdminLoadable = useLastLoadable(isOrgAdmin$);
+
+  if (!agentId || !ref) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-muted-foreground">
+        <div className="flex flex-col items-center gap-2">
+          <IconAlertTriangle size={24} />
+          <p className="text-sm">
+            Missing agent ID or firewall ref in URL parameters
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isFirewallConnectorType(ref)) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-muted-foreground">
+        <div className="flex flex-col items-center gap-2">
+          <IconAlertTriangle size={24} />
+          <p className="text-sm">Unknown firewall: {ref}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (
+    agentLoadable.state === "loading" ||
+    isAdminLoadable.state === "loading"
+  ) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-muted-foreground">
+        <p className="text-sm">Loading...</p>
+      </div>
+    );
+  }
+
+  if (agentLoadable.state === "hasError") {
+    return (
+      <div className="flex flex-1 items-center justify-center text-muted-foreground">
+        <div className="flex flex-col items-center gap-2">
+          <IconAlertTriangle size={24} />
+          <p className="text-sm">Failed to load agent</p>
+        </div>
+      </div>
+    );
+  }
+
+  const agent = agentLoadable.data;
+  if (!agent) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-muted-foreground">
+        <p className="text-sm">Agent not found</p>
+      </div>
+    );
+  }
+
+  const isAdmin =
+    isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
+  const connectorLabel = CONNECTOR_TYPES[ref]?.label ?? ref;
+  const agentDisplayName = agent.displayName ?? agentId;
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      {/* Header */}
+      <header className="px-6 pt-6 pb-4">
+        <div className="flex items-center gap-3 mb-2">
+          <ConnectorIcon type={ref} size={28} />
+          <div>
+            <h1 className="text-base font-semibold text-foreground flex items-center gap-2">
+              <IconShieldLock size={18} />
+              {connectorLabel} Firewall Permissions
+            </h1>
+            <p className="text-xs text-muted-foreground">
+              for {agentDisplayName}
+            </p>
+          </div>
+        </div>
+
+        {/* Context banner for blocked requests */}
+        {method && path && (
+          <div className="mt-3 rounded-lg bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 px-4 py-2.5">
+            <p className="text-xs text-amber-800 dark:text-amber-200 flex items-center gap-1.5">
+              <IconAlertTriangle size={14} />A request was blocked:{" "}
+              <code className="font-mono font-medium">
+                {method} {path}
+              </code>
+            </p>
+          </div>
+        )}
+      </header>
+
+      {/* Main content */}
+      <main className="flex-1 overflow-auto px-6 pb-6">
+        {isAdmin ? (
+          <AdminView
+            agentId={agentId}
+            ref={ref}
+            highlightPermission={highlightPermission}
+            agent={agent}
+          />
+        ) : (
+          <MemberView
+            agentId={agentId}
+            ref={ref}
+            highlightPermission={highlightPermission}
+            method={method}
+            path={path}
+            agent={agent}
+          />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/firewall-allow/firewall-allow-page.tsx
+++ b/turbo/apps/platform/src/views/firewall-allow/firewall-allow-page.tsx
@@ -34,7 +34,7 @@ import { ConnectorIcon } from "../zero-page/components/settings/connector-icons.
 import { detach, Reason } from "../../signals/utils.ts";
 
 // ---------------------------------------------------------------------------
-// PolicyPill (reused from firewall-permissions-dialog pattern)
+// PolicyPill
 // ---------------------------------------------------------------------------
 
 const POLICY_OPTIONS = [
@@ -86,18 +86,320 @@ function PolicyPill({
 }
 
 // ---------------------------------------------------------------------------
-// Admin View
+// Focused single-permission admin view
 // ---------------------------------------------------------------------------
 
-function AdminView({
+function AdminFocusedView({
   agentId,
   ref,
-  highlightPermission,
+  permission,
+  agent,
+  method,
+  path,
+}: {
+  agentId: string;
+  ref: string;
+  permission: { name: string; description?: string };
+  agent: { firewallPolicies: FirewallPolicies | null };
+  method: string | null;
+  path: string | null;
+}) {
+  const defaults = isFirewallConnectorType(ref)
+    ? getDefaultFirewallPolicies(ref)
+    : null;
+  const pageSignal = useGet(pageSignal$);
+  const requestsLoadable = useLastLoadable(firewallAccessRequests$);
+  const setSavePolicies = useSet(saveFirewallPolicies$);
+  const setResolveRequest = useSet(resolveAccessRequest$);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
+
+  const currentPolicy =
+    agent.firewallPolicies?.[ref]?.[permission.name] ??
+    defaults?.[permission.name] ??
+    "allow";
+  const [policy, setPolicy] = useState<FirewallPolicyValue>(currentPolicy);
+
+  const handleSave = () => {
+    const fullPolicies: FirewallPolicies = {
+      ...agent.firewallPolicies,
+      [ref]: {
+        ...agent.firewallPolicies?.[ref],
+        [permission.name]: policy,
+      },
+    };
+    setSaving(true);
+    setSaved(false);
+    detach(
+      setSavePolicies(agentId, fullPolicies, pageSignal)
+        .then(() => setSaved(true))
+        .finally(() => setSaving(false)),
+      Reason.DomCallback,
+    );
+  };
+
+  const handleResolve = (requestId: string, action: "approve" | "reject") => {
+    setResolvingId(requestId);
+    detach(
+      setResolveRequest(requestId, action, pageSignal)
+        .then(() => {
+          if (action === "approve") {
+            setPolicy("allow");
+          }
+        })
+        .finally(() => setResolvingId(null)),
+      Reason.DomCallback,
+    );
+  };
+
+  const requests =
+    requestsLoadable.state === "hasData" ? requestsLoadable.data : [];
+  const isDirty = policy !== currentPolicy;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Blocked request context */}
+      {method && path && (
+        <div className="rounded-lg bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 px-3 py-2">
+          <p className="text-xs text-amber-800 dark:text-amber-200 flex items-center gap-1.5">
+            <IconAlertTriangle size={13} />
+            Blocked:{" "}
+            <code className="font-mono font-medium">
+              {method} {path}
+            </code>
+          </p>
+        </div>
+      )}
+
+      {/* Permission card */}
+      <div className="zero-border rounded-lg px-4 py-3">
+        <div className="flex items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <code className="text-sm font-medium text-foreground">
+              {permission.name}
+            </code>
+            {permission.description && (
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {permission.description}
+              </p>
+            )}
+          </div>
+          <PolicyPill policy={policy} onChange={setPolicy} />
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={saving || (!isDirty && !saved)}
+          >
+            {saving ? "Saving..." : saved && !isDirty ? "Saved" : "Save"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Pending access requests */}
+      {requests.length > 0 && (
+        <div className="zero-border rounded-lg overflow-hidden">
+          <div className="px-3 py-2 bg-muted/30 border-b border-border/40">
+            <h3 className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+              <IconClock size={12} />
+              Pending Requests ({requests.length})
+            </h3>
+          </div>
+          {requests.map((req, idx) => (
+            <div key={req.id}>
+              {idx > 0 && <div className="border-t border-border/40" />}
+              <div className="flex items-center gap-2 px-3 py-2">
+                <div className="min-w-0 flex-1">
+                  <span className="text-xs text-foreground">
+                    {req.requesterName ?? req.requesterUserId}
+                  </span>
+                  {req.reason && (
+                    <span className="text-xs text-muted-foreground">
+                      {" "}
+                      &mdash; <span className="italic">{req.reason}</span>
+                    </span>
+                  )}
+                </div>
+                <div className="flex gap-1.5 shrink-0">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleResolve(req.id, "reject")}
+                    disabled={resolvingId === req.id}
+                  >
+                    <IconBan size={12} />
+                    Reject
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={() => handleResolve(req.id, "approve")}
+                    disabled={resolvingId === req.id}
+                  >
+                    <IconCheck size={12} />
+                    Approve
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Focused single-permission member view
+// ---------------------------------------------------------------------------
+
+function MemberFocusedView({
+  agentId,
+  ref,
+  permission,
+  method,
+  path,
   agent,
 }: {
   agentId: string;
   ref: string;
-  highlightPermission: string | null;
+  permission: { name: string; description?: string };
+  method: string | null;
+  path: string | null;
+  agent: { firewallPolicies: FirewallPolicies | null };
+}) {
+  const defaults = isFirewallConnectorType(ref)
+    ? getDefaultFirewallPolicies(ref)
+    : null;
+  const pageSignal = useGet(pageSignal$);
+  const requestsLoadable = useLastLoadable(firewallAccessRequests$);
+  const setCreateRequest = useSet(createAccessRequest$);
+  const [showForm, setShowForm] = useState(false);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const currentPolicy =
+    agent.firewallPolicies?.[ref]?.[permission.name] ??
+    defaults?.[permission.name] ??
+    "allow";
+
+  const requests =
+    requestsLoadable.state === "hasData" ? requestsLoadable.data : [];
+  const isPending = requests.some((r) => r.permission === permission.name);
+
+  const handleSubmit = () => {
+    setSubmitting(true);
+    detach(
+      setCreateRequest(
+        {
+          agentId,
+          firewallRef: ref,
+          permission: permission.name,
+          method: method ?? undefined,
+          path: path ?? undefined,
+          reason: reason || undefined,
+        },
+        pageSignal,
+      )
+        .then(() => {
+          setShowForm(false);
+          setReason("");
+        })
+        .finally(() => setSubmitting(false)),
+      Reason.DomCallback,
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Blocked request context */}
+      {method && path && (
+        <div className="rounded-lg bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 px-3 py-2">
+          <p className="text-xs text-amber-800 dark:text-amber-200 flex items-center gap-1.5">
+            <IconAlertTriangle size={13} />
+            Blocked:{" "}
+            <code className="font-mono font-medium">
+              {method} {path}
+            </code>
+          </p>
+        </div>
+      )}
+
+      {/* Permission card */}
+      <div className="zero-border rounded-lg px-4 py-3">
+        <div className="flex items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <code className="text-sm font-medium text-foreground">
+              {permission.name}
+            </code>
+            {permission.description && (
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {permission.description}
+              </p>
+            )}
+          </div>
+          <PolicyPill policy={currentPolicy} disabled />
+          {currentPolicy !== "allow" && (
+            <>
+              {isPending ? (
+                <span className="text-xs text-amber-600 dark:text-amber-400 flex items-center gap-1 shrink-0">
+                  <IconClock size={12} />
+                  Pending
+                </span>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setShowForm(true)}
+                >
+                  Request Access
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+
+        {showForm && (
+          <div className="mt-3 flex flex-col gap-2 border-t border-border/40 pt-3">
+            <textarea
+              placeholder="Reason for access (optional)"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={2}
+              className="text-sm w-full rounded-md border border-input bg-background px-3 py-2 ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            />
+            <div className="flex gap-2 justify-end">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setShowForm(false);
+                  setReason("");
+                }}
+              >
+                Cancel
+              </Button>
+              <Button size="sm" onClick={handleSubmit} disabled={submitting}>
+                {submitting ? "Submitting..." : "Submit Request"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// List views (fallback when no specific permission in URL)
+// ---------------------------------------------------------------------------
+
+function AdminListView({
+  agentId,
+  ref,
+  agent,
+}: {
+  agentId: string;
+  ref: string;
   agent: {
     firewallPolicies: FirewallPolicies | null;
     displayName: string | null;
@@ -108,11 +410,8 @@ function AdminView({
     ? getDefaultFirewallPolicies(ref)
     : null;
   const pageSignal = useGet(pageSignal$);
-  const requestsLoadable = useLastLoadable(firewallAccessRequests$);
   const setSavePolicies = useSet(saveFirewallPolicies$);
-  const setResolveRequest = useSet(resolveAccessRequest$);
   const [saving, setSaving] = useState(false);
-  const [resolvingId, setResolvingId] = useState<string | null>(null);
 
   const [policies, setPolicies] = useState<Record<string, FirewallPolicyValue>>(
     () => {
@@ -134,335 +433,92 @@ function AdminView({
     };
     setSaving(true);
     detach(
-      setSavePolicies(agentId, fullPolicies, pageSignal).finally(() => {
-        setSaving(false);
-      }),
+      setSavePolicies(agentId, fullPolicies, pageSignal).finally(() =>
+        setSaving(false),
+      ),
       Reason.DomCallback,
     );
   };
-
-  const handleResolve = (requestId: string, action: "approve" | "reject") => {
-    setResolvingId(requestId);
-    detach(
-      setResolveRequest(requestId, action, pageSignal)
-        .then(() => {
-          if (action === "approve") {
-            // Reflect the approval in local state
-            const request =
-              requestsLoadable.state === "hasData"
-                ? requestsLoadable.data.find((r) => r.id === requestId)
-                : null;
-            if (request) {
-              setPolicies((prev) => ({
-                ...prev,
-                [request.permission]: "allow",
-              }));
-            }
-          }
-        })
-        .finally(() => {
-          setResolvingId(null);
-        }),
-      Reason.DomCallback,
-    );
-  };
-
-  const requests =
-    requestsLoadable.state === "hasData" ? requestsLoadable.data : [];
 
   return (
-    <div className="flex flex-col gap-6">
-      {/* Permissions list */}
-      <section>
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-sm font-medium text-foreground">Permissions</h2>
-          <Button size="sm" onClick={handleSave} disabled={saving}>
-            {saving ? "Saving..." : "Save"}
-          </Button>
-        </div>
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-medium text-foreground">Permissions</h2>
+        <Button size="sm" onClick={handleSave} disabled={saving}>
+          {saving ? "Saving..." : "Save"}
+        </Button>
+      </div>
 
-        <div className="zero-border rounded-lg overflow-hidden">
-          {permissions.map((perm, idx) => {
-            const isHighlighted = perm.name === highlightPermission;
-            return (
-              <div key={perm.name}>
-                {idx > 0 && <div className="border-t border-border/40" />}
-                <div
-                  className={`flex items-center gap-2.5 px-4 py-3 transition-colors ${
-                    isHighlighted
-                      ? "bg-yellow-50 dark:bg-yellow-950/20"
-                      : "hover:bg-muted/50"
-                  }`}
-                >
-                  <div className="min-w-0 flex-1">
-                    <code className="text-xs font-medium text-foreground truncate block">
-                      {perm.name}
-                    </code>
-                    {perm.description && (
-                      <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-                        {perm.description}
-                      </p>
-                    )}
-                  </div>
-                  <PolicyPill
-                    policy={policies[perm.name] ?? "allow"}
-                    onChange={(p) =>
-                      setPolicies((prev) => ({ ...prev, [perm.name]: p }))
-                    }
-                  />
-                </div>
+      <div className="zero-border rounded-lg overflow-hidden">
+        {permissions.map((perm, idx) => (
+          <div key={perm.name}>
+            {idx > 0 && <div className="border-t border-border/40" />}
+            <div className="flex items-center gap-2.5 px-3 py-2 hover:bg-muted/50 transition-colors">
+              <div className="min-w-0 flex-1">
+                <code className="text-xs font-medium text-foreground truncate block">
+                  {perm.name}
+                </code>
+                {perm.description && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {perm.description}
+                  </p>
+                )}
               </div>
-            );
-          })}
-        </div>
-      </section>
-
-      {/* Access requests section */}
-      {requests.length > 0 && (
-        <section>
-          <h2 className="text-sm font-medium text-foreground mb-3">
-            <span className="flex items-center gap-1.5">
-              <IconClock size={14} />
-              Pending Access Requests ({requests.length})
-            </span>
-          </h2>
-
-          <div className="zero-border rounded-lg overflow-hidden">
-            {requests.map((req, idx) => (
-              <div key={req.id}>
-                {idx > 0 && <div className="border-t border-border/40" />}
-                <div className="px-4 py-3">
-                  <div className="flex items-center justify-between">
-                    <div className="min-w-0 flex-1">
-                      <code className="text-xs font-medium text-foreground">
-                        {req.permission}
-                      </code>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        Requested by {req.requesterUserId}
-                        {req.reason && (
-                          <>
-                            {" "}
-                            &mdash; <span className="italic">{req.reason}</span>
-                          </>
-                        )}
-                      </p>
-                    </div>
-                    <div className="flex gap-2 shrink-0 ml-3">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => handleResolve(req.id, "reject")}
-                        disabled={resolvingId === req.id}
-                      >
-                        <IconBan size={12} />
-                        Reject
-                      </Button>
-                      <Button
-                        size="sm"
-                        onClick={() => handleResolve(req.id, "approve")}
-                        disabled={resolvingId === req.id}
-                      >
-                        <IconCheck size={12} />
-                        Approve
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ))}
+              <PolicyPill
+                policy={policies[perm.name] ?? "allow"}
+                onChange={(p) =>
+                  setPolicies((prev) => ({ ...prev, [perm.name]: p }))
+                }
+              />
+            </div>
           </div>
-        </section>
-      )}
+        ))}
+      </div>
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Member View
-// ---------------------------------------------------------------------------
-
-function MemberView({
-  agentId,
+function MemberListView({
   ref,
-  highlightPermission,
-  method,
-  path,
   agent,
 }: {
-  agentId: string;
   ref: string;
-  highlightPermission: string | null;
-  method: string | null;
-  path: string | null;
   agent: { firewallPolicies: FirewallPolicies | null };
 }) {
   const permissions = extractPermissions(ref);
   const defaults = isFirewallConnectorType(ref)
     ? getDefaultFirewallPolicies(ref)
     : null;
-  const pageSignal = useGet(pageSignal$);
-  const requestsLoadable = useLastLoadable(firewallAccessRequests$);
-  const setCreateRequest = useSet(createAccessRequest$);
-  const [requestingPermission, setRequestingPermission] = useState<
-    string | null
-  >(null);
-  const [reason, setReason] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-
-  const requests =
-    requestsLoadable.state === "hasData" ? requestsLoadable.data : [];
-  const pendingPermissions = new Set(requests.map((r) => r.permission));
-
-  const handleSubmit = (permission: string) => {
-    setSubmitting(true);
-    detach(
-      setCreateRequest(
-        {
-          agentId,
-          firewallRef: ref,
-          permission,
-          method: method ?? undefined,
-          path: path ?? undefined,
-          reason: reason || undefined,
-        },
-        pageSignal,
-      )
-        .then(() => {
-          setRequestingPermission(null);
-          setReason("");
-        })
-        .finally(() => {
-          setSubmitting(false);
-        }),
-      Reason.DomCallback,
-    );
-  };
 
   return (
-    <div className="flex flex-col gap-6">
-      <section>
-        <h2 className="text-sm font-medium text-foreground mb-3">
-          Permissions
-        </h2>
-
-        <div className="zero-border rounded-lg overflow-hidden">
-          {permissions.map((perm, idx) => {
-            const isHighlighted = perm.name === highlightPermission;
-            const currentPolicy =
-              agent.firewallPolicies?.[ref]?.[perm.name] ??
-              defaults?.[perm.name] ??
-              "allow";
-            const isPending = pendingPermissions.has(perm.name);
-
-            return (
-              <div key={perm.name}>
-                {idx > 0 && <div className="border-t border-border/40" />}
-                <div
-                  className={`px-4 py-3 transition-colors ${
-                    isHighlighted ? "bg-yellow-50 dark:bg-yellow-950/20" : ""
-                  }`}
-                >
-                  <div className="flex items-center gap-2.5">
-                    <div className="min-w-0 flex-1">
-                      <code className="text-xs font-medium text-foreground truncate block">
-                        {perm.name}
-                      </code>
-                      {perm.description && (
-                        <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-                          {perm.description}
-                        </p>
-                      )}
-                    </div>
-                    <PolicyPill policy={currentPolicy} disabled />
-                    {isHighlighted && currentPolicy !== "allow" && (
-                      <>
-                        {isPending ? (
-                          <span className="text-xs text-amber-600 dark:text-amber-400 flex items-center gap-1 shrink-0">
-                            <IconClock size={12} />
-                            Pending
-                          </span>
-                        ) : (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => setRequestingPermission(perm.name)}
-                          >
-                            Request Access
-                          </Button>
-                        )}
-                      </>
-                    )}
-                  </div>
-
-                  {requestingPermission === perm.name && (
-                    <div className="mt-3 flex flex-col gap-2">
-                      <textarea
-                        placeholder="Reason for access (optional)"
-                        value={reason}
-                        onChange={(e) => setReason(e.target.value)}
-                        rows={2}
-                        className="text-sm w-full rounded-md border border-input bg-background px-3 py-2 ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                      />
-                      <div className="flex gap-2 justify-end">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => {
-                            setRequestingPermission(null);
-                            setReason("");
-                          }}
-                        >
-                          Cancel
-                        </Button>
-                        <Button
-                          size="sm"
-                          onClick={() => handleSubmit(perm.name)}
-                          disabled={submitting}
-                        >
-                          {submitting ? "Submitting..." : "Submit Request"}
-                        </Button>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </section>
-
-      {/* Show own pending requests */}
-      {requests.length > 0 && (
-        <section>
-          <h2 className="text-sm font-medium text-foreground mb-3">
-            <span className="flex items-center gap-1.5">
-              <IconClock size={14} />
-              Your Pending Requests ({requests.length})
-            </span>
-          </h2>
-
-          <div className="zero-border rounded-lg overflow-hidden">
-            {requests.map((req, idx) => (
-              <div key={req.id}>
-                {idx > 0 && <div className="border-t border-border/40" />}
-                <div className="px-4 py-3">
-                  <code className="text-xs font-medium text-foreground">
-                    {req.permission}
+    <div className="flex flex-col gap-4">
+      <h2 className="text-sm font-medium text-foreground">Permissions</h2>
+      <div className="zero-border rounded-lg overflow-hidden">
+        {permissions.map((perm, idx) => {
+          const currentPolicy =
+            agent.firewallPolicies?.[ref]?.[perm.name] ??
+            defaults?.[perm.name] ??
+            "allow";
+          return (
+            <div key={perm.name}>
+              {idx > 0 && <div className="border-t border-border/40" />}
+              <div className="flex items-center gap-2.5 px-3 py-2">
+                <div className="min-w-0 flex-1">
+                  <code className="text-xs font-medium text-foreground truncate block">
+                    {perm.name}
                   </code>
-                  {req.reason && (
-                    <p className="text-xs text-muted-foreground mt-0.5 italic">
-                      {req.reason}
+                  {perm.description && (
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {perm.description}
                     </p>
                   )}
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    Submitted {new Date(req.createdAt).toLocaleDateString()}
-                  </p>
                 </div>
+                <PolicyPill policy={currentPolicy} disabled />
               </div>
-            ))}
-          </div>
-        </section>
-      )}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -541,54 +597,52 @@ export function FirewallAllowPage() {
   const connectorLabel = CONNECTOR_TYPES[ref]?.label ?? ref;
   const agentDisplayName = agent.displayName ?? agentId;
 
+  // Find the specific permission if URL specifies one
+  const allPermissions = extractPermissions(ref);
+  const focusedPermission = highlightPermission
+    ? (allPermissions.find((p) => p.name === highlightPermission) ?? null)
+    : null;
+
   return (
     <div className="flex flex-1 flex-col min-h-0">
-      {/* Header */}
-      <header className="px-6 pt-6 pb-4">
-        <div className="flex items-center gap-3 mb-2">
-          <ConnectorIcon type={ref} size={28} />
-          <div>
-            <h1 className="text-base font-semibold text-foreground flex items-center gap-2">
-              <IconShieldLock size={18} />
-              {connectorLabel} Firewall Permissions
-            </h1>
-            <p className="text-xs text-muted-foreground">
-              for {agentDisplayName}
-            </p>
-          </div>
+      <header className="px-6 pt-5 pb-3">
+        <div className="flex items-center gap-2.5">
+          <ConnectorIcon type={ref} size={22} />
+          <h1 className="text-sm font-semibold text-foreground flex items-center gap-1.5">
+            <IconShieldLock size={15} />
+            {connectorLabel} Firewall
+          </h1>
+          <span className="text-xs text-muted-foreground">
+            &middot; {agentDisplayName}
+          </span>
         </div>
-
-        {/* Context banner for blocked requests */}
-        {method && path && (
-          <div className="mt-3 rounded-lg bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800 px-4 py-2.5">
-            <p className="text-xs text-amber-800 dark:text-amber-200 flex items-center gap-1.5">
-              <IconAlertTriangle size={14} />A request was blocked:{" "}
-              <code className="font-mono font-medium">
-                {method} {path}
-              </code>
-            </p>
-          </div>
-        )}
       </header>
 
-      {/* Main content */}
       <main className="flex-1 overflow-auto px-6 pb-6">
-        {isAdmin ? (
-          <AdminView
-            agentId={agentId}
-            ref={ref}
-            highlightPermission={highlightPermission}
-            agent={agent}
-          />
+        {focusedPermission ? (
+          isAdmin ? (
+            <AdminFocusedView
+              agentId={agentId}
+              ref={ref}
+              permission={focusedPermission}
+              agent={agent}
+              method={method}
+              path={path}
+            />
+          ) : (
+            <MemberFocusedView
+              agentId={agentId}
+              ref={ref}
+              permission={focusedPermission}
+              method={method}
+              path={path}
+              agent={agent}
+            />
+          )
+        ) : isAdmin ? (
+          <AdminListView agentId={agentId} ref={ref} agent={agent} />
         ) : (
-          <MemberView
-            agentId={agentId}
-            ref={ref}
-            highlightPermission={highlightPermission}
-            method={method}
-            path={path}
-            agent={agent}
-          />
+          <MemberListView ref={ref} agent={agent} />
         )}
       </main>
     </div>

--- a/turbo/apps/web/app/api/zero/firewall-access-requests/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/firewall-access-requests/__tests__/route.test.ts
@@ -362,6 +362,63 @@ describe("GET /api/zero/firewall-access-requests", () => {
     const adminData = await adminList.json();
     expect(adminData).toHaveLength(2);
   });
+
+  it("should include requesterName from Clerk user data", async () => {
+    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+
+    // Override Clerk mock to return user with a name
+    mockClerk({
+      userId: testUserId,
+      firstName: "Alice",
+      lastName: "Smith",
+    });
+
+    await createAccessRequest(
+      {
+        agentId: agent.agentId,
+        firewallRef: "github",
+        permission: "issues:read",
+      },
+      testCliToken,
+      testOrgSlug,
+    );
+
+    const response = await listAccessRequests(
+      agent.agentId,
+      testCliToken,
+      testOrgSlug,
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveLength(1);
+    expect(data[0].requesterName).toBe("Alice Smith");
+  });
+
+  it("should return null requesterName when Clerk has no name data", async () => {
+    const agent = await (await createAgent(testCliToken, testOrgSlug)).json();
+
+    await createAccessRequest(
+      {
+        agentId: agent.agentId,
+        firewallRef: "github",
+        permission: "issues:read",
+      },
+      testCliToken,
+      testOrgSlug,
+    );
+
+    const response = await listAccessRequests(
+      agent.agentId,
+      testCliToken,
+      testOrgSlug,
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toHaveLength(1);
+    expect(data[0].requesterName).toBeNull();
+  });
 });
 
 describe("PUT /api/zero/firewall-access-requests", () => {

--- a/turbo/apps/web/app/api/zero/firewall-access-requests/route.ts
+++ b/turbo/apps/web/app/api/zero/firewall-access-requests/route.ts
@@ -148,7 +148,7 @@ const createRouter = tsr.router(firewallAccessRequestsCreateContract, {
 
 // --- GET: List Requests ---
 const listRouter = tsr.router(firewallAccessRequestsListContract, {
-  list: async ({ headers }, { request }) => {
+  list: async ({ headers, query }, { request }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -156,24 +156,10 @@ const listRouter = tsr.router(firewallAccessRequestsListContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const url = new URL(request.url);
-    const orgSlug = url.searchParams.get("org");
+    const orgSlug = new URL(request.url).searchParams.get("org");
     const { org, member } = await resolveOrg(authCtx, orgSlug);
 
-    const agentId = url.searchParams.get("agentId");
-    if (!agentId) {
-      return {
-        status: 400 as const,
-        body: {
-          error: {
-            message: "agentId query parameter is required",
-            code: "BAD_REQUEST",
-          },
-        },
-      };
-    }
-
-    const status = url.searchParams.get("status");
+    const { agentId, status } = query;
 
     // Build conditions
     const conditions = [

--- a/turbo/apps/web/app/api/zero/firewall-access-requests/route.ts
+++ b/turbo/apps/web/app/api/zero/firewall-access-requests/route.ts
@@ -19,11 +19,15 @@ import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { zeroAgents } from "../../../../src/db/schema/zero-agent";
 import { firewallAccessRequests } from "../../../../src/db/schema/firewall-access-request";
 import { eq, and } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
 import { logger } from "../../../../src/lib/logger";
 
 const log = logger("api:zero:firewall-access-requests");
 
-function formatRequest(row: typeof firewallAccessRequests.$inferSelect) {
+function formatRequest(
+  row: typeof firewallAccessRequests.$inferSelect,
+  nameMap?: Map<string, string>,
+) {
   return {
     id: row.id,
     agentId: row.agentId,
@@ -34,10 +38,31 @@ function formatRequest(row: typeof firewallAccessRequests.$inferSelect) {
     reason: row.reason ?? null,
     status: row.status as "pending" | "approved" | "rejected",
     requesterUserId: row.requesterUserId,
+    requesterName: nameMap?.get(row.requesterUserId) ?? null,
     resolvedBy: row.resolvedBy ?? null,
     resolvedAt: row.resolvedAt?.toISOString() ?? null,
     createdAt: row.createdAt.toISOString(),
   };
+}
+
+async function resolveUserNames(
+  userIds: string[],
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  if (userIds.length === 0) return map;
+  const unique = [...new Set(userIds)];
+  const client = await clerkClient();
+  const users = await client.users.getUserList({
+    userId: unique,
+    limit: unique.length,
+  });
+  for (const u of users.data) {
+    const name = [u.firstName, u.lastName].filter(Boolean).join(" ");
+    if (name) {
+      map.set(u.id, name);
+    }
+  }
+  return map;
 }
 
 // --- POST: Create Request ---
@@ -183,9 +208,11 @@ const listRouter = tsr.router(firewallAccessRequestsListContract, {
       .from(firewallAccessRequests)
       .where(and(...conditions));
 
+    const nameMap = await resolveUserNames(rows.map((r) => r.requesterUserId));
+
     return {
       status: 200 as const,
-      body: rows.map(formatRequest),
+      body: rows.map((r) => formatRequest(r, nameMap)),
     };
   },
 });

--- a/turbo/apps/web/src/__tests__/clerk-mock.ts
+++ b/turbo/apps/web/src/__tests__/clerk-mock.ts
@@ -59,6 +59,8 @@ let mockUserIds: string[] = [];
 export function mockClerk(options: {
   userId: string | null;
   email?: string;
+  firstName?: string | null;
+  lastName?: string | null;
   orgId?: string | null;
   orgSlug?: string | null;
   orgRole?: string | null;
@@ -140,8 +142,8 @@ export function mockClerk(options: {
                     id: options.userId,
                     emailAddresses: [{ id: "email_1", emailAddress: email }],
                     primaryEmailAddressId: "email_1",
-                    firstName: null,
-                    lastName: null,
+                    firstName: options.firstName ?? null,
+                    lastName: options.lastName ?? null,
                     imageUrl: "",
                   },
                 ],
@@ -155,8 +157,8 @@ export function mockClerk(options: {
                   id: uid,
                   emailAddresses: [{ id: "email_1", emailAddress: email }],
                   primaryEmailAddressId: "email_1",
-                  firstName: null,
-                  lastName: null,
+                  firstName: options.firstName ?? null,
+                  lastName: options.lastName ?? null,
                   imageUrl: "",
                 }));
               return Promise.resolve({ data: matchedUsers });

--- a/turbo/packages/core/src/contracts/zero-agents.ts
+++ b/turbo/packages/core/src/contracts/zero-agents.ts
@@ -372,6 +372,7 @@ export const firewallAccessRequestResponseSchema = z.object({
   reason: z.string().nullable(),
   status: firewallAccessRequestStatusSchema,
   requesterUserId: z.string(),
+  requesterName: z.string().nullable(),
   resolvedBy: z.string().nullable(),
   resolvedAt: z.string().nullable(),
   createdAt: z.string(),

--- a/turbo/packages/core/src/contracts/zero-agents.ts
+++ b/turbo/packages/core/src/contracts/zero-agents.ts
@@ -420,11 +420,17 @@ export const firewallAccessRequestsCreateContract = c.router({
 /**
  * Contract for GET /api/zero/firewall-access-requests (list)
  */
+const firewallAccessRequestsListQuerySchema = z.object({
+  agentId: z.string(),
+  status: z.string().optional(),
+});
+
 export const firewallAccessRequestsListContract = c.router({
   list: {
     method: "GET",
     path: "/api/zero/firewall-access-requests",
     headers: authHeadersSchema,
+    query: firewallAccessRequestsListQuerySchema,
     responses: {
       200: z.array(firewallAccessRequestResponseSchema),
       400: apiErrorSchema,


### PR DESCRIPTION
## Summary
- Add dedicated `/firewall-allow/:agentId` platform page where admins can toggle permission policies (allow/deny) and resolve pending access requests
- Members can view current policies and submit access requests with a reason
- Add query schema to firewall access requests list contract for typed client params

## Changes
- **Signals**: `firewall-allow-signals.ts` with route param accessors, agent/requests data, and admin/member commands
- **Setup**: `firewall-allow-page-setup.ts` with standard page lifecycle (onboarding guard, session fetch)
- **View**: `firewall-allow-page.tsx` with AdminView (policy toggles + request resolution) and MemberView (read-only + request submission)
- **Route**: Registered in `bootstrap.ts` and `route.ts` RoutePath union
- **Contract**: Added query schema to `firewallAccessRequestsListContract` for `agentId`/`status` params
- **API**: Updated list handler to use typed `query` destructuring

## Test plan
- [ ] Verify admin view shows permission toggles and save functionality
- [ ] Verify admin can approve/reject pending access requests
- [ ] Verify member view shows read-only permissions with request access button
- [ ] Verify member can submit access request with reason
- [ ] Verify context banner appears when method+path URL params present
- [ ] Verify error states (missing params, unknown ref, agent not found)

Closes #7318

🤖 Generated with [Claude Code](https://claude.com/claude-code)