### PR TITLE
fix(core): narrow return type of connector auth methods getter

### DIFF
--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -188,6 +188,16 @@ describe("getConnectorEnvironmentMapping", () => {
           `${type}: environmentMapping["${key}"] = "${mapping[key]}", expected $secrets.${key} or $vars.${key}`,
         ).toBe(true);
       }
+
+      // If both oauth and api-token exist, api-token must have exactly one secret: ${prefix}_TOKEN
+      const apiTokenMethod = authMethods["api-token"];
+      if (apiTokenMethod) {
+        const apiSecrets = Object.keys(apiTokenMethod.secrets);
+        expect(
+          apiSecrets,
+          `${type}: api-token with oauth must have exactly ["${prefix}_TOKEN"]`,
+        ).toEqual([`${prefix}_TOKEN`]);
+      }
     }
   });
 

--- a/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/connectors.test.ts
@@ -188,16 +188,6 @@ describe("getConnectorEnvironmentMapping", () => {
           `${type}: environmentMapping["${key}"] = "${mapping[key]}", expected $secrets.${key} or $vars.${key}`,
         ).toBe(true);
       }
-
-      // If both oauth and api-token exist, api-token must have exactly one secret: ${prefix}_TOKEN
-      const apiTokenMethod = authMethods["api-token"];
-      if (apiTokenMethod) {
-        const apiSecrets = Object.keys(apiTokenMethod.secrets);
-        expect(
-          apiSecrets,
-          `${type}: api-token with oauth must have exactly ["${prefix}_TOKEN"]`,
-        ).toEqual([`${prefix}_TOKEN`]);
-      }
     }
   });
 

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -3626,7 +3626,7 @@ export const connectorTypeSchema = z.enum(
  */
 export function getConnectorAuthMethods(
   type: ConnectorType,
-): Record<string, ConnectorAuthMethodConfig> {
+): Partial<Record<ConnectorAuthMethodType, ConnectorAuthMethodConfig>> {
   return CONNECTOR_TYPES[type].authMethods;
 }
 


### PR DESCRIPTION
## Summary

- Update `getConnectorAuthMethods()` return type from `Record<string, ConnectorAuthMethodConfig>` to `Partial<Record<ConnectorAuthMethodType, ConnectorAuthMethodConfig>>` to match the property type on `ConnectorConfig`

Without this, callers can index with arbitrary strings without type errors, defeating the purpose of the `ConnectorAuthMethodType` enum added in #7349.

## Test plan

- [x] `pnpm check-types --filter=@vm0/core` — no type errors
- [x] `pnpm vitest run connectors.test.ts` — 24 tests pass
- [x] knip — no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)