### PR TITLE
fix(core): add missing oauth auth method to mailchimp connector

### DIFF
--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -2402,12 +2402,21 @@ const CONNECTOR_TYPES_DEF = {
     label: "Mailchimp",
     environmentMapping: {
       MAILCHIMP_TOKEN: "$secrets.MAILCHIMP_ACCESS_TOKEN",
-      MAILCHIMP_DC: "$vars.MAILCHIMP_DC",
     },
     featureFlag: FeatureSwitchKey.MailchimpConnector,
     helpText:
       "Connect your Mailchimp account to manage audiences, campaigns, templates, and automations",
     authMethods: {
+      oauth: {
+        label: "OAuth (Recommended)",
+        helpText: "Sign in with Mailchimp to grant access.",
+        secrets: {
+          MAILCHIMP_ACCESS_TOKEN: {
+            label: "Access Token",
+            required: true,
+          },
+        },
+      },
       "api-token": {
         label: "API Key",
         secrets: {
@@ -2416,18 +2425,10 @@ const CONNECTOR_TYPES_DEF = {
             required: true,
             placeholder: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-us00",
           },
-          MAILCHIMP_DC: {
-            label: "Server Prefix",
-            required: true,
-            type: "variable",
-            placeholder: "us21",
-            helpText:
-              "The datacenter prefix from your API key (e.g., 'us21' from xxxxx-us21)",
-          },
         },
       },
     },
-    defaultAuthMethod: "api-token",
+    defaultAuthMethod: "oauth",
     oauth: {
       authorizationUrl: "https://login.mailchimp.com/oauth2/authorize",
       tokenUrl: "https://login.mailchimp.com/oauth2/token",

--- a/turbo/packages/core/src/firewalls/mailchimp.generated.ts
+++ b/turbo/packages/core/src/firewalls/mailchimp.generated.ts
@@ -14,7 +14,7 @@ export const mailchimpFirewall: FirewallConfig = {
   },
   apis: [
     {
-      base: "https://${{ vars.MAILCHIMP_DC }}.api.mailchimp.com",
+      base: "https://{dc}.api.mailchimp.com",
       auth: {
         headers: {
           Authorization: "Bearer ${{ secrets.MAILCHIMP_TOKEN }}",

--- a/turbo/packages/firewalls-generator/src/mailchimp.ts
+++ b/turbo/packages/firewalls-generator/src/mailchimp.ts
@@ -5,7 +5,7 @@
  *
  * Mailchimp Marketing API v3.0. Base URL is datacenter-specific:
  * https://{dc}.api.mailchimp.com/3.0
- * The datacenter is provided as a variable (${{ vars.MAILCHIMP_DC }}).
+ * The datacenter is matched via a {dc} host parameter.
  */
 
 import { writeOutput } from "./codegen";
@@ -31,7 +31,7 @@ function generateTypeScript(): string {
     "  },",
     "  apis: [",
     "    {",
-    '      base: "https://${{ vars.MAILCHIMP_DC }}.api.mailchimp.com",',
+    '      base: "https://{dc}.api.mailchimp.com",',
     "      auth: {",
     "        headers: {",
     '          Authorization: "Bearer ${{ secrets.MAILCHIMP_TOKEN }}",',


### PR DESCRIPTION
## Summary
- Add `oauth` auth method to mailchimp connector (was missing despite having oauth config and provider handler)
- Remove `MAILCHIMP_DC` variable from connector config and firewall, replaced with `{dc}` host parameter matching
- Set `defaultAuthMethod` to `"oauth"`

Closes #7360

## Test plan
- [x] All 24 connector tests pass (including OAuth naming convention validation)
- [ ] Verify mailchimp OAuth flow works end-to-end in preview
- [ ] Verify mailchimp API key flow still works without MAILCHIMP_DC variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)