### PR TITLE
feat(platform): pre-fill connector search from query param

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
@@ -104,7 +104,7 @@ describe("zero doctor missing-token command", () => {
       );
       expect(logCalls).toContain("not authorized");
       expect(logCalls).toContain(
-        "[Authorize GitHub](https://app.vm0.ai/team/agent-abc-123?tab=authorization)",
+        "[Authorize GitHub](https://app.vm0.ai/team/agent-abc-123?tab=authorization&connector=github)",
       );
     });
   });

--- a/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
@@ -66,7 +66,7 @@ Notes:
       } else if (!hasPermission) {
         // Connected but not authorized for this agent — direct to authorization tab
         const path = agentId ? `/team/${agentId}` : "/team";
-        const url = `${platformUrl.origin}${path}?tab=authorization`;
+        const url = `${platformUrl.origin}${path}?tab=authorization&connector=${connectorType}`;
         console.log(
           `The ${label} connector is connected but not authorized for this agent. Ask the user to enable it at: [Authorize ${label}](${url})`,
         );

--- a/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-job-detail.ts
@@ -54,6 +54,11 @@ function getInitialTab(): string {
   return isValidTab(tab) ? tab : "authorization";
 }
 
+export function getInitialConnectorSearch(): string {
+  const params = new URLSearchParams(search());
+  return params.get("connector") ?? "";
+}
+
 const internalActiveTab$ = state("authorization");
 
 export const zeroJobActiveTab$ = computed((get) => get(internalActiveTab$));

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-connector-card.test.tsx
@@ -12,6 +12,35 @@ import {
 
 const context = testContext();
 
+async function renderTeamPageWithConnectorParam(
+  orgConnectors: ConnectorResponse[],
+  enabledTypes: string[],
+  connectorParam: string,
+) {
+  mockConnectors(orgConnectors);
+  server.use(
+    http.get("*/api/zero/agents/zero", () => {
+      return HttpResponse.json({
+        name: "zero",
+        agentId: "compose-1",
+        description: null,
+        displayName: null,
+        sound: null,
+        avatarUrl: null,
+        firewallPolicies: null,
+      });
+    }),
+    http.get("*/api/zero/agents/compose-1/user-connectors", () => {
+      return HttpResponse.json({ enabledTypes });
+    }),
+  );
+
+  await setupPage({
+    context,
+    path: `/team/zero?tab=authorization&connector=${connectorParam}`,
+  });
+}
+
 function connectorUuid(type: string): string {
   const map: Record<string, string> = {
     github: "a0000000-0000-4000-a000-000000000001",
@@ -253,5 +282,40 @@ describe("zero authorization tab — member on default agent", () => {
     expect(
       screen.getByRole("switch", { name: "Revoke GitHub access" }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("zero authorization tab — connector query param pre-fill", () => {
+  it("filters to matching connector when connector query param is set", async () => {
+    await renderTeamPageWithConnectorParam(
+      [
+        makeConnector({ type: "github", oauthScopes: ["repo"] }),
+        makeConnector({ type: "slack" }),
+      ],
+      ["github"],
+      "github",
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Slack")).not.toBeInTheDocument();
+  });
+
+  it("shows search input pre-filled with connector query param value", async () => {
+    await renderTeamPageWithConnectorParam(
+      [makeConnector({ type: "github", oauthScopes: ["repo"] })],
+      [],
+      "github",
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("Search connectors..."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText("Search connectors...")).toHaveValue(
+      "github",
+    );
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -68,6 +68,7 @@ import {
   setZeroJobActiveTab$,
   zeroJobFirewallPolicies$,
   setZeroJobFirewallPolicies$,
+  getInitialConnectorSearch,
 } from "../../signals/zero-page/zero-job-detail.ts";
 import type { AgentDetail } from "../../signals/zero-page/agent-types.ts";
 import { runScheduleNow$ } from "../../signals/zero-page/zero-schedule.ts";
@@ -381,8 +382,10 @@ function JobPermissionsTab({
   const setFirewallPolicies = useSet(setZeroJobFirewallPolicies$);
   const saveFirewallPol = useSet(saveFirewallPolicies$);
   const [firewallType, setFirewallType] = useState<ConnectorType | null>(null);
-  const [search, setSearch] = useState("");
-  const [searchActive, setSearchActive] = useState(false);
+  const [search, setSearch] = useState(getInitialConnectorSearch);
+  const [searchActive, setSearchActive] = useState(
+    () => getInitialConnectorSearch().length > 0,
+  );
   const [savingType, setSavingType] = useState<string | null>(null);
 
   const adminLoadable = useLoadable(isOrgAdmin$);
@@ -396,9 +399,12 @@ function JobPermissionsTab({
 
   const connectedConnectors = allConnectors.filter((c) => c.connected);
   const filteredConnectors = search
-    ? connectedConnectors.filter((c) =>
-        c.label.toLowerCase().includes(search.toLowerCase()),
-      )
+    ? connectedConnectors.filter((c) => {
+        const q = search.toLowerCase();
+        return (
+          c.label.toLowerCase().includes(q) || c.type.toLowerCase().includes(q)
+        );
+      })
     : connectedConnectors;
   const addedSet = new Set(addedConnectors);
 


### PR DESCRIPTION
## Summary

- Authorization page reads `connector` query param and pre-fills the search input, auto-filtering the connector list
- Filter now matches on both connector label and type (previously label only)
- `zero doctor missing-token` appends `&connector={type}` to authorization URLs

Closes #7391

## Test plan

- [x] CLI: `missing-token` test updated to verify new URL format with connector param
- [x] Platform: integration tests verify search pre-fill and filtering from query param
- [x] All 20 tests pass (9 CLI + 11 platform connector card tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)