### PR TITLE
ci: restrict cli e2e jobs to merge queue only

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1109,7 +1109,7 @@ jobs:
     needs: [prepare, deploy-web, deploy-app]
     if: |
       always() &&
-      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+      github.event_name == 'merge_group' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
@@ -1250,7 +1250,7 @@ jobs:
         test-other,
       ]
     if: |
-      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+      github.event_name == 'merge_group' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||
@@ -1746,7 +1746,7 @@ jobs:
         e2e-runner-bootstrap,
       ]
     if: |
-      github.event_name != 'push' &&
+      github.event_name == 'merge_group' &&
       needs.prepare.outputs.job-ref != '' && (
         needs.prepare.outputs.web-changed == 'true' ||
         needs.prepare.outputs.cli-changed == 'true' ||


### PR DESCRIPTION
## Summary
- Cherry-pick of 45edd8db8 — skip cli-e2e-01-serial, cli-e2e-02-browser, and cli-e2e-03-runner on PR and push events
- These jobs now only run in the merge queue, reducing CI time for regular PRs while still gating merges

## Test plan
- [ ] Verify CI workflow runs correctly on this PR (cli-e2e jobs should be skipped)
- [ ] Confirm merge queue still triggers cli-e2e jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)