### PR TITLE
fix: replace default placeholder fallback with realistic fill pattern

### DIFF
--- a/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
+++ b/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
@@ -152,7 +152,9 @@ describe("expandEnvironmentFromCompose — firewall env vars", () => {
     );
 
     expect(environment).toBeDefined();
-    expect(environment!.AIRTABLE_TOKEN).toBe("VM0_PLACEHOLDER_AIRTABLE_TOKEN");
+    expect(environment!.AIRTABLE_TOKEN).toBe(
+      "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe",
+    );
   });
 });
 

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -66,7 +66,8 @@ function buildFirewallPlaceholders(
     const secretNames = extractSecretNamesFromApis(fw.apis);
     for (const secretName of secretNames) {
       placeholders[secretName] =
-        fw.placeholders?.[secretName] ?? `VM0_PLACEHOLDER_${secretName}`;
+        fw.placeholders?.[secretName] ??
+        "c0ffee5afe10ca1c0ffee5afe10ca1c0ffee5afe";
     }
     // Connector firewalls carry expanded placeholders that cover raw OAuth
     // secret names and aliased env vars beyond what auth templates reference.


### PR DESCRIPTION
## Summary
- Replace `VM0_PLACEHOLDER_${secretName}` fallback with `c0ffee5afe10ca1...` fill pattern
- Follows the word vocabulary defined in `firewalls-generator/README.md`
- Companion to #7332 which fixed all custom placeholders but missed this runtime fallback

Closes #7055

## Test plan
- [x] expand-environment tests pass (11/11)
- [ ] Verify fallback is used when firewall config has no custom placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)