### PR TITLE
feat(ansible): add nbd kernel module to runner provisioning

### DIFF
--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -58,9 +58,30 @@
         mode: '0666'
       become: true
 
+    - name: Load nbd kernel module
+      community.general.modprobe:
+        name: nbd
+        params: nbds_max=256
+        state: present
+      become: true
+
+    - name: Persist nbd module across reboots
+      copy:
+        dest: /etc/modules-load.d/nbd.conf
+        content: "nbd\n"
+        mode: '0644'
+      become: true
+
+    - name: Persist nbd module options across reboots
+      copy:
+        dest: /etc/modprobe.d/nbd.conf
+        content: "options nbd nbds_max=256\n"
+        mode: '0644'
+      become: true
+
     # When groups change, the current SSH session still has the old group list.
     # Reset the connection so subsequent playbooks (deploy-runner) pick up the
-    # new membership (e.g. 'disk' group needed to open /dev/loopN).
+    # new membership (e.g. 'disk' group needed to open /dev/nbdN).
     - name: Reset SSH connection to pick up new group membership
       meta: reset_connection
       when: group_change.changed


### PR DESCRIPTION
## Summary

- Load `nbd` kernel module with `nbds_max=256` during runner provisioning
- Persist module and options across reboots via `/etc/modules-load.d/` and `/etc/modprobe.d/`
- Update comment: `disk` group is now for `/dev/nbdN` (was `/dev/loopN`)

## Context

nbd-cow (replacing dm-snapshot in #7406) requires the `nbd` kernel module. Without it loaded with the correct `nbds_max`, snapshot creation fails:

```
create NBD COW device: I/O error: device size stuck at 0 after 5 connect retries on nbd0
```

## Test plan

- [ ] Run `ansible-playbook -i "dev-1.aws.vm3.ai," playbooks/provision-runner.yml` and verify:
  - `lsmod | grep nbd` shows module loaded
  - `cat /sys/module/nbd/parameters/nbds_max` shows 256
  - `/etc/modules-load.d/nbd.conf` and `/etc/modprobe.d/nbd.conf` exist
- [ ] Reboot host and verify module auto-loads with correct params

🤖 Generated with [Claude Code](https://claude.com/claude-code)