### PR TITLE
fix(web): exclude raw oauth connector secrets from build context

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -26,9 +26,9 @@ const log = logger("webhook:firewall-auth");
 const SECRET_TEMPLATE_RE = /\$\{\{\s*secrets\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
 /**
- * Sync latest refresh tokens from DB into the secrets map.
- * The secrets map originates from a build-time encrypted snapshot and may
- * contain stale refresh tokens rotated by a concurrent request (#7339).
+ * Load refresh tokens from DB into the secrets map.
+ * The encrypted secrets snapshot only contains mapped env vars (access tokens);
+ * refresh tokens are kept server-side and must be fetched from DB (#7365).
  * Mutates `secrets` in place.
  */
 async function syncRefreshTokensFromDb(
@@ -127,9 +127,9 @@ async function refreshExpiredTokens(
     envVarsByConnector.set(ct, arr);
   }
 
-  // Sync latest refresh tokens from DB into secrets before refreshing.
-  // The secrets map was decrypted from a build-time snapshot and may contain
-  // stale refresh tokens that were rotated by a concurrent request (#7339).
+  // Load refresh tokens from DB into secrets before refreshing.
+  // The encrypted secrets snapshot only contains mapped env vars (access tokens),
+  // not refresh tokens — refresh tokens are kept server-side only (#7365).
   await syncRefreshTokensFromDb(toRefresh, run.orgId, auth.userId, secrets);
 
   const refreshResults = await Promise.all(

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -412,8 +412,6 @@ async function resolveModelProviderSecrets(
  * Result of connector secret resolution
  */
 interface OauthConnectorSecretResult {
-  /** All raw connector secrets (for masking and direct secret reference resolution) */
-  connectorSecrets: Record<string, string> | undefined;
   /** Environment variables mapped from OAuth connectors via environmentMapping */
   injectedEnvVars: Record<string, string> | undefined;
   /** Maps secret names to connector types for refresh-capable OAuth connectors */
@@ -441,7 +439,6 @@ async function resolveOauthConnectorSecrets(
 
   if (userConnectors.length === 0) {
     return {
-      connectorSecrets: undefined,
       injectedEnvVars: undefined,
       secretConnectorMap: undefined,
       connectorTypes: [],
@@ -451,7 +448,6 @@ async function resolveOauthConnectorSecrets(
   const connectorSecrets = await getSecretValues(orgId, userId, "connector");
   if (Object.keys(connectorSecrets).length === 0) {
     return {
-      connectorSecrets: undefined,
       injectedEnvVars: undefined,
       secretConnectorMap: undefined,
       connectorTypes: [],
@@ -544,7 +540,6 @@ async function resolveOauthConnectorSecrets(
   }
 
   return {
-    connectorSecrets,
     injectedEnvVars: allInjectedEnvVars,
     secretConnectorMap:
       Object.keys(secretConnectorMap).length > 0
@@ -786,19 +781,16 @@ async function resolveSecretsAndEnvironment(
   ];
 
   // Single secrets map with explicit priority (later overrides earlier).
-  // All sources are included — extra secrets are harmless for environment expansion
-  // (only referenced ${{ secrets.* }} names are looked up) and for auth resolution
-  // (auth endpoint only resolves templates it receives).
+  // Only mapped env vars from connectors are included — raw connector secrets
+  // (including refresh tokens) are kept server-side and never sent to the runner.
   const hasSecrets =
-    oauthResult.connectorSecrets ||
     oauthResult.injectedEnvVars ||
     modelProviderResult.secrets ||
     dbSecrets ||
     cliSecrets;
   const secrets: Record<string, string> | undefined = hasSecrets
     ? {
-        ...oauthResult.connectorSecrets, // lowest: raw connector secrets
-        ...oauthResult.injectedEnvVars, // connector env mappings override raw
+        ...oauthResult.injectedEnvVars, // connector env mappings (e.g. GITHUB_TOKEN)
         ...modelProviderResult.secrets, // model provider
         ...dbSecrets, // DB user secrets
         ...cliSecrets, // highest: CLI --secrets


### PR DESCRIPTION
## Summary
- Remove raw connector secrets (including OAuth refresh tokens) from the encrypted build context sent to the runner
- Only mapped env vars from `environmentMapping` (e.g. `GITHUB_TOKEN`, `GMAIL_TOKEN`) are now included in the secrets map
- Raw secret names (e.g. `GITHUB_ACCESS_TOKEN`, `GITHUB_REFRESH_TOKEN`) are kept server-side only

## Why
Raw connector secrets — especially long-lived refresh tokens — were unnecessarily included in the encrypted secrets payload stored in `runner_job_queue` and sent to the runner. This exposed sensitive credentials beyond what the sandbox actually needs. (#7365)

## Impact
- **Firewall auth endpoint**: No impact — `syncRefreshTokensFromDb` (#7350) already reads refresh tokens from DB before refreshing, so they don't need to be in the encrypted snapshot
- **Environment expansion**: `${{ secrets.GITHUB_TOKEN }}` (mapped name) still works. `${{ secrets.GITHUB_ACCESS_TOKEN }}` (raw name) will no longer resolve — this is intentional
- **Token refresh at runtime**: `secretConnectorMap` still maps both raw and mapped names to connector types, and the auth endpoint reads tokens from DB

## Test plan
- [ ] Updated test verifies raw secret names are not resolved in build context
- [ ] Existing connector OAuth tests still pass (mapped env vars work as before)
- [ ] CI passes

Closes #7365

🤖 Generated with [Claude Code](https://claude.com/claude-code)