### PR TITLE
feat: add activity log list feature switch to gate sidebar and breadcrumb visibility

### DIFF
--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-stale.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-stale.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
+import { FeatureSwitchKey } from "@vm0/core";
 import type {
   LogDetail,
   AgentEventsResponse,
@@ -149,6 +150,7 @@ describe("activity detail stale data", () => {
     await setupPage({
       context,
       path: "/activity/a0000000-0000-4000-a000-000000000001",
+      featureSwitches: { [FeatureSwitchKey.ActivityLogList]: true },
     });
 
     // Wait for first detail to load

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-routing.test.ts
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-routing.test.ts
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
+import { FeatureSwitchKey } from "@vm0/core";
 import type {
   LogDetail,
   AgentEventsResponse,
@@ -144,6 +145,7 @@ describe("activity page routing", () => {
     await setupPage({
       context,
       path: "/activity",
+      featureSwitches: { [FeatureSwitchKey.ActivityLogList]: true },
     });
 
     // Wait for list

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-refresh.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-refresh.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
+import { FeatureSwitchKey } from "@vm0/core";
 
 const context = testContext();
 
@@ -81,7 +82,11 @@ describe("activity list refresh on navigation", () => {
     );
 
     // Navigate to activity page
-    await setupPage({ context, path: "/activity" });
+    await setupPage({
+      context,
+      path: "/activity",
+      featureSwitches: { [FeatureSwitchKey.ActivityLogList]: true },
+    });
 
     // Wait for the activity heading and list data to render
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-to-activity-agent-retention.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-to-activity-agent-retention.test.tsx
@@ -6,6 +6,7 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
+import { FeatureSwitchKey } from "@vm0/core";
 
 const context = testContext();
 
@@ -56,7 +57,11 @@ describe("talk to activity agent retention", () => {
     mockTwoAgents();
 
     // Navigate to non-default agent (bar)
-    await setupPage({ context, path: "/talk/agent-bar-id" });
+    await setupPage({
+      context,
+      path: "/talk/agent-bar-id",
+      featureSwitches: { [FeatureSwitchKey.ActivityLogList]: true },
+    });
 
     // Wait for sidebar to show "bar" as the active chat agent
     await waitFor(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page.test.tsx
@@ -87,6 +87,46 @@ describe("zeroActivityDetailPage", () => {
     expect(screen.getByText("9.0s")).toBeInTheDocument();
   }, 10_000);
 
+  it("should hide Activity breadcrumb when ActivityLogList switch is off", async () => {
+    mockActivityDetailAPI();
+
+    await setupPage({
+      context,
+      path: "/activity/a0000000-0000-4000-a000-000000000001",
+      featureSwitches: { [FeatureSwitchKey.ActivityLogList]: false },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Test Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    // The breadcrumb link to /activity should not be present
+    const activityLinks = screen.queryAllByRole("link", { name: /Activity/i });
+    expect(activityLinks).toHaveLength(0);
+  }, 10_000);
+
+  it("should show Activity breadcrumb when ActivityLogList switch is on", async () => {
+    mockActivityDetailAPI();
+
+    await setupPage({
+      context,
+      path: "/activity/a0000000-0000-4000-a000-000000000001",
+      featureSwitches: { [FeatureSwitchKey.ActivityLogList]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Test Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    // The breadcrumb link to /activity should be present
+    const activityLinks = screen.queryAllByRole("link", { name: /Activity/i });
+    expect(activityLinks.length).toBeGreaterThan(0);
+  }, 10_000);
+
   it("should render schedule source as a clickable link when scheduleId is present", async () => {
     const logDetail: LogDetail = {
       id: "a0000000-0000-4000-a000-000000000002",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar.test.tsx
@@ -135,6 +135,34 @@ describe("zero sidebar", () => {
     expect(features[FeatureSwitchKey.DataExport]).toBeFalsy();
   });
 
+  it("should hide Activity logs when ActivityLogList switch is off", async () => {
+    mockAPIs();
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.ActivityLogList]: false },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Agents")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Activity logs")).not.toBeInTheDocument();
+  });
+
+  it("should show Activity logs when ActivityLogList switch is on", async () => {
+    mockAPIs();
+    await setupPage({
+      context,
+      path: "/",
+      featureSwitches: { [FeatureSwitchKey.ActivityLogList]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Agents")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Activity logs")).toBeInTheDocument();
+  });
+
   it("should filter chat sessions when searching", async () => {
     const user = userEvent.setup();
     mockAPIs();

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-context-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-context-page.tsx
@@ -1,4 +1,4 @@
-import { useLastLoadable, useGet } from "ccstate-react";
+import { useLastLoadable, useGet, useLastResolved } from "ccstate-react";
 import { IconChartLine } from "@tabler/icons-react";
 import {
   Table,
@@ -9,9 +9,11 @@ import {
   TableRow,
   Skeleton,
 } from "@vm0/ui";
+import { FeatureSwitchKey } from "@vm0/core";
 import { Link } from "../router/link.tsx";
 import { currentRunId$ } from "../../signals/activity-page/activity-signals.ts";
 import { zeroActivityContext$ } from "../../signals/activity-page/activity-context-signals.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
 
 // ---------------------------------------------------------------------------
 // Section components
@@ -247,16 +249,21 @@ export function ZeroActivityContextPage() {
 // ---------------------------------------------------------------------------
 
 function Breadcrumb({ runId }: { runId: string | null }) {
+  const features = useLastResolved(featureSwitch$);
   return (
     <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
-      <Link
-        pathname="/activity"
-        className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-muted hover:text-foreground transition-colors no-underline text-inherit"
-      >
-        <IconChartLine size={14} stroke={1.5} className="shrink-0" />
-        Activity
-      </Link>
-      <span className="text-muted-foreground/40 select-none">/</span>
+      {features?.[FeatureSwitchKey.ActivityLogList] && (
+        <>
+          <Link
+            pathname="/activity"
+            className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-muted hover:text-foreground transition-colors no-underline text-inherit"
+          >
+            <IconChartLine size={14} stroke={1.5} className="shrink-0" />
+            Activity
+          </Link>
+          <span className="text-muted-foreground/40 select-none">/</span>
+        </>
+      )}
       {runId && (
         <>
           <Link

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -123,11 +123,16 @@ function ActivityBreadcrumbLink() {
 }
 
 function ActivityNotFound() {
+  const features = useLastResolved(featureSwitch$);
   return (
     <div className="h-full flex flex-col min-h-0">
       <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
-        <ActivityBreadcrumbLink />
-        <span className="text-muted-foreground/40 select-none">/</span>
+        {features?.[FeatureSwitchKey.ActivityLogList] && (
+          <>
+            <ActivityBreadcrumbLink />
+            <span className="text-muted-foreground/40 select-none">/</span>
+          </>
+        )}
         <span className="rounded-md px-1.5 py-0.5 text-foreground font-medium">
           Log
         </span>
@@ -393,8 +398,12 @@ export function ZeroActivityDetailPage() {
     <div className="h-full flex flex-col min-h-0 overflow-hidden">
       <div className="flex-1 flex flex-col min-h-0 overflow-auto">
         <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
-          <ActivityBreadcrumbLink />
-          <span className="text-muted-foreground/40 select-none">/</span>
+          {features?.[FeatureSwitchKey.ActivityLogList] && (
+            <>
+              <ActivityBreadcrumbLink />
+              <span className="text-muted-foreground/40 select-none">/</span>
+            </>
+          )}
           <span className="rounded-md px-1.5 py-0.5 text-foreground font-medium truncate">
             {displayName}
           </span>
@@ -458,12 +467,17 @@ export function ZeroActivityDetailPage() {
 }
 
 function ActivitySkeleton() {
+  const features = useLastResolved(featureSwitch$);
   return (
     <div className="h-full flex flex-col min-h-0 overflow-hidden">
       <div className="flex-1 flex flex-col min-h-0 overflow-auto">
         <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
-          <ActivityBreadcrumbLink />
-          <span className="text-muted-foreground/40 select-none">/</span>
+          {features?.[FeatureSwitchKey.ActivityLogList] && (
+            <>
+              <ActivityBreadcrumbLink />
+              <span className="text-muted-foreground/40 select-none">/</span>
+            </>
+          )}
           <div className="h-4 w-20 rounded bg-muted/50 animate-pulse" />
         </nav>
         <div className="mx-auto max-w-[900px] px-4 sm:px-6 pt-4 pb-8 w-full">

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -1221,7 +1221,11 @@ export function ZeroSidebar() {
       return a !== undefined;
     });
 
-  const manageNav = MANAGE_NAV.map((item) => {
+  const manageNav = MANAGE_NAV.filter((item) => {
+    return (
+      item.id !== "activity" || features?.[FeatureSwitchKey.ActivityLogList]
+    );
+  }).map((item) => {
     return {
       ...item,
       label: item.label.replace("Zero", displayName),

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -41,4 +41,5 @@ export enum FeatureSwitchKey {
   CreditAddOn = "creditAddOn",
   ModelDetail = "modelDetail",
   RunContext = "runContext",
+  ActivityLogList = "activityLogList",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -279,6 +279,11 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabledUserHashes: STAFF_USER_HASHES,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.ActivityLogList]: {
+    maintainer: "ethan@vm0.ai",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary

- Add `ActivityLogList` feature switch (enabled only for vm0 staff org) that controls visibility of the "Activity logs" sidebar entry and `/activity` breadcrumb links
- Gate sidebar entry via inline filter on `MANAGE_NAV` items
- Gate breadcrumb links in activity detail page (`ZeroActivityDetailPage`, `ActivityNotFound`, `ActivitySkeleton`) and activity context page (`Breadcrumb`)
- Add tests for sidebar and detail page breadcrumb feature switch gating

Closes #7424

## Test plan

- [x] Sidebar hides "Activity logs" when switch is off (test added)
- [x] Sidebar shows "Activity logs" when switch is on (test added)
- [x] Detail page breadcrumb hides `/activity` link when switch is off (test added)
- [x] Detail page breadcrumb shows `/activity` link when switch is on (test added)
- [x] All existing tests pass
- [x] Type checks pass
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)