### PR TITLE
fix(e2e): add wait_for_log helper to poll for async log ingestion

### DIFF
--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -40,6 +40,59 @@ VOLEOF
     cd - >/dev/null
 }
 
+# Retry `vm0 logs --all` until output contains ALL expected strings or timeout.
+# Sets $output and $status for subsequent assert_* calls.
+# Automatically appends --all to fetch complete logs on each attempt.
+# Usage: wait_for_log [vm0 logs args...] -- <expected1> [expected2...]
+# Example: wait_for_log "$RUN_ID" --system -- "Tool timeout" "WebFetch"
+# Example: wait_for_log "$RUN_ID" --network -- "TCP" ":22" ":443"
+wait_for_log() {
+    local -a _wfl_args=()
+    local -a _wfl_expected=()
+    local _wfl_sep_found=false
+    for arg in "$@"; do
+        if [[ "$arg" == "--" ]]; then
+            _wfl_sep_found=true
+        elif $_wfl_sep_found; then
+            _wfl_expected+=("$arg")
+        else
+            _wfl_args+=("$arg")
+        fi
+    done
+    if [[ ${#_wfl_expected[@]} -eq 0 ]]; then
+        echo "# wait_for_log: no expected strings after --"
+        return 1
+    fi
+    local _wfl_timeout=30
+    local _wfl_elapsed=0
+    while (( _wfl_elapsed < _wfl_timeout )); do
+        # Append --all for non-search commands to fetch complete logs
+        if [[ "${_wfl_args[0]:-}" == "search" ]]; then
+            output="$($VM0_CLI logs "${_wfl_args[@]}" 2>&1)"
+        else
+            output="$($VM0_CLI logs "${_wfl_args[@]}" --all 2>&1)"
+        fi
+        status=$?
+        if [[ "$status" -eq 0 ]]; then
+            local _wfl_all=true
+            for _wfl_e in "${_wfl_expected[@]}"; do
+                if [[ "$output" != *"$_wfl_e"* ]]; then
+                    _wfl_all=false
+                    break
+                fi
+            done
+            if $_wfl_all; then
+                return 0
+            fi
+        fi
+        sleep 2
+        (( _wfl_elapsed += 2 ))
+    done
+    echo "# Timed out (${_wfl_timeout}s) waiting for log containing: ${_wfl_expected[*]}"
+    echo "# Last output: $output"
+    return 1
+}
+
 # Cleanup test volume directory
 cleanup_test_volume() {
     if [ -n "$TEST_VOLUME_DIR" ] && [ -d "$TEST_VOLUME_DIR" ]; then

--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -63,7 +63,7 @@ wait_for_log() {
         echo "# wait_for_log: no expected strings after --"
         return 1
     fi
-    local _wfl_timeout=30
+    local _wfl_timeout=20
     local _wfl_elapsed=0
     while (( _wfl_elapsed < _wfl_timeout )); do
         # Append --all for non-search commands to fetch complete logs

--- a/e2e/tests/03-runner/t15-vm0-telemetry.bats
+++ b/e2e/tests/03-runner/t15-vm0-telemetry.bats
@@ -105,52 +105,26 @@ teardown() {
 
     # Step 4: Verify vm0 logs command (default: agent events)
     echo "# Step 4: Fetching agent events (default)..."
-    run $VM0_CLI logs "$RUN_ID"
-
-    assert_success
-
-    # Default output shows agent events - verify event type markers are present
     # Mock-claude produces: Claude Code Started, text, tool calls, Completed
-    assert_output --partial "▷ Claude Code Started"
-    assert_output --partial "◆ Claude Code Completed"
+    wait_for_log "$RUN_ID" -- "▷ Claude Code Started" "◆ Claude Code Completed"
     echo "# Agent events contain expected event types"
 
     # Step 5: Verify --agent option explicitly shows agent events
     echo "# Step 5: Testing --agent option..."
-    run $VM0_CLI logs "$RUN_ID" --agent
-
-    assert_success
-    assert_output --partial "▷ Claude Code Started"
+    wait_for_log "$RUN_ID" --agent -- "▷ Claude Code Started"
     echo "# --agent option works correctly"
 
     # Step 6: Verify --system option shows system logs
     echo "# Step 6: Testing --system option..."
-    run $VM0_CLI logs "$RUN_ID" --system --tail 100
-
-    assert_success
     # System log should contain sandbox log entries with INFO level
     # Format: [TIMESTAMP] [INFO] [sandbox:run-agent] message
-    assert_output --partial "[INFO]"
-    assert_output --partial "[sandbox:"
+    wait_for_log "$RUN_ID" --system -- "[INFO]" "[sandbox:"
     echo "# System log contains expected log format"
 
     # Step 7: Verify --metrics option shows resource metrics
     echo "# Step 7: Testing --metrics option..."
-    run $VM0_CLI logs "$RUN_ID" --metrics --tail 100
-
-    assert_success
-    # Metrics may take time to collect, so check if either:
-    # 1. Metrics are available (contains CPU/Mem/Disk)
-    # 2. Or "No metrics found" message is shown (acceptable for quick runs)
-    if echo "$output" | grep -q "No metrics found"; then
-        echo "# Metrics not yet available (acceptable for quick runs)"
-    else
-        # If metrics are available, verify format
-        assert_output --partial "CPU:"
-        assert_output --partial "Mem:"
-        assert_output --partial "Disk:"
-        echo "# Metrics contain expected resource data"
-    fi
+    wait_for_log "$RUN_ID" --metrics -- "CPU:" "Mem:" "Disk:"
+    echo "# Metrics contain expected resource data"
 
     # Step 8: Verify --tail option limits output
     echo "# Step 8: Testing --tail option..."

--- a/e2e/tests/03-runner/t36-vm0-logs-search.bats
+++ b/e2e/tests/03-runner/t36-vm0-logs-search.bats
@@ -107,9 +107,7 @@ teardown() {
     # Step 4: Search for keyword scoped to this run
     echo "# Step 4: Searching for 'hello from agent' in run events..."
     SHORT_ID="${RUN_ID:0:8}"
-    run $VM0_CLI logs search "hello from agent" --run "$RUN_ID" --since 1h
-    assert_success
-    assert_output --partial "$SHORT_ID"
+    wait_for_log search "hello from agent" --run "$RUN_ID" --since 1h -- "$SHORT_ID"
 
     # Step 5: Search for non-matching keyword shows empty guidance
     echo "# Step 5: Testing empty results guidance..."

--- a/e2e/tests/03-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-runner/t42-firewall-placeholder.bats
@@ -167,7 +167,5 @@ EOF
         return 1
     }
 
-    run $VM0_CLI logs "$RUN_ID" --network --all
-    assert_success
-    assert_output --partial "GITHUB_TOKEN"
+    wait_for_log "$RUN_ID" --network -- "GITHUB_TOKEN"
 }

--- a/e2e/tests/03-runner/t43-firewall-dynamic-base-url.bats
+++ b/e2e/tests/03-runner/t43-firewall-dynamic-base-url.bats
@@ -124,8 +124,6 @@ EOF
         return 1
     }
 
-    run $VM0_CLI logs "$RUN_ID" --network --tail 100
-    assert_success
     # ALLOW: proxy matched zendesk firewall and forwarded
-    assert_output --partial "[zendesk]"
+    wait_for_log "$RUN_ID" --network -- "[zendesk]"
 }

--- a/e2e/tests/03-runner/t43-stuck-tool-watchdog.bats
+++ b/e2e/tests/03-runner/t43-stuck-tool-watchdog.bats
@@ -61,8 +61,5 @@ EOF
     }
 
     echo "# Step 4: Verify system logs contain tool timeout error..."
-    run $VM0_CLI logs "$RUN_ID" --system
-    assert_success
-    assert_output --partial "Tool timeout"
-    assert_output --partial "WebFetch"
+    wait_for_log "$RUN_ID" --system -- "Tool timeout" "WebFetch"
 }

--- a/e2e/tests/03-runner/t45-vm0-network-logging.bats
+++ b/e2e/tests/03-runner/t45-vm0-network-logging.bats
@@ -62,12 +62,8 @@ EOF
         return 1
     }
 
-    run $VM0_CLI logs "$RUN_ID" --network --tail 100
-    assert_success
     # TCP connections show as IP:port (DNS resolved before TCP layer)
-    assert_output --partial "TCP"
-    assert_output --partial ":22"
-    assert_output --partial ":443"
+    wait_for_log "$RUN_ID" --network -- "TCP" ":22" ":443"
 }
 
 @test "t45-1: udp dns queries appear in network logs" {
@@ -90,14 +86,8 @@ EOF
         return 1
     }
 
-    # Verify network logs contain the HTTP request (proves log pipeline works).
-    run $VM0_CLI logs "$RUN_ID" --network --all
-    assert_success
-    assert_output --partial "example.com"
-
-    # Verify network logs also contain UDP entries from DNS queries.
+    # Verify network logs contain HTTP and UDP entries.
     # formatNetworkOther renders: [timestamp] UDP   <size> <host>:<port>
     # DNS uses port 53, so match both the protocol and port.
-    assert_output --partial "UDP"
-    assert_output --partial ":53"
+    wait_for_log "$RUN_ID" --network -- "example.com" "UDP" ":53"
 }


### PR DESCRIPTION
## Summary
- Add `wait_for_log` helper to `e2e/helpers/setup.bash` that retries `vm0 logs --all` until ALL expected strings appear (30s timeout, 2s interval)
- Replace all bare `vm0 logs` assertions in 6 test files with `wait_for_log` to eliminate flaky failures caused by async Axiom ingestion delay

## Affected tests
- `t43-stuck-tool-watchdog.bats` — system logs
- `t15-vm0-telemetry.bats` — agent events, system logs, metrics
- `t45-vm0-network-logging.bats` — network logs (TCP + UDP)
- `t42-firewall-placeholder.bats` — network logs
- `t43-firewall-dynamic-base-url.bats` — network logs
- `t36-vm0-logs-search.bats` — search results

Closes #7410

## Test plan
- [ ] CI e2e tests pass without flaky log assertion failures
- [ ] `wait_for_log` correctly retries until all expected strings appear
- [ ] `vm0 logs search` calls skip `--all` flag (not supported by search subcommand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)