### PR TITLE
refactor(platform): remove defensive try-catch patterns from zero-chat signals

### DIFF
--- a/.claude/skills/ccstate/SKILL.md
+++ b/.claude/skills/ccstate/SKILL.md
@@ -248,6 +248,109 @@ afterEach(() => {
 });
 ```
 
+## Extracting Shared Logic from Commands
+
+When two or more commands share duplicated logic, extract it into a **sub-command** (`command()`), not a plain function that receives `get`/`set`.
+
+### Why not a plain function?
+
+A plain helper that accepts `get` or `set` as parameters breaks the ccstate contract — `get`/`set` are scoped to the command callback and should not leak out. The ESLint rule `ccstate/...` flags this. More importantly, a plain function cannot participate in the signal/reactive graph.
+
+### Pattern: Extract a sub-command
+
+```typescript
+// ❌ Plain function receiving get — breaks ccstate contract
+async function sendRequest(
+  get: Getter,
+  agentId: string,
+  prompt: string,
+): Promise<Result> {
+  const client = get(zeroClient$)(contract);
+  return await client.send({ body: { agentId, prompt } });
+}
+
+// ✅ Sub-command — get/set stay inside the command callback
+const sendRequest$ = command(
+  async ({ get }, agentId: string, prompt: string): Promise<Result> => {
+    const client = get(zeroClient$)(contract);
+    return await client.send({ body: { agentId, prompt } });
+  },
+);
+
+// Caller
+const doSomething$ = command(async ({ set }, signal: AbortSignal) => {
+  const result = await set(sendRequest$, agentId, prompt);
+  signal.throwIfAborted();
+  // ...
+});
+```
+
+### Handling AbortSignal in sub-commands
+
+**Pass `signal` explicitly and use `fetchOptions: { signal }` for HTTP calls.** This ensures the request is cancelled when the caller's signal aborts.
+
+```typescript
+const sendRequest$ = command(
+  async (
+    { get },
+    agentId: string,
+    prompt: string,
+    signal: AbortSignal,
+  ): Promise<Result> => {
+    const client = get(zeroClient$)(contract);
+    const result = await client.send({
+      body: { agentId, prompt },
+      fetchOptions: { signal },       // ← cancel HTTP on abort
+    });
+
+    if (result.status !== 201) {
+      throw new Error(`Failed (${result.status})`);
+    }
+    return result.body;
+  },
+);
+```
+
+The caller passes its own signal through:
+
+```typescript
+const parentCommand$ = command(async ({ set }, signal: AbortSignal) => {
+  const result = await set(sendRequest$, agentId, prompt, signal);
+  // No need for signal.throwIfAborted() here — if signal was aborted,
+  // the fetch inside sendRequest$ already threw an AbortError.
+  // Only add throwIfAborted() after operations that DON'T accept a signal.
+});
+```
+
+### When to use `signal.throwIfAborted()`
+
+Use it **after any `await` that does NOT accept a signal** — i.e., after operations that will complete even if the caller wants to abort:
+
+```typescript
+const example$ = command(async ({ get, set }, signal: AbortSignal) => {
+  // ✅ fetch accepts signal → no throwIfAborted needed after
+  const result = await set(sendRequest$, data, signal);
+
+  // ✅ get() on a computed is synchronous-ish but doesn't accept signal
+  const thread = await get(currentThread$);
+  signal.throwIfAborted();  // ← needed: get() doesn't know about our signal
+
+  // ✅ set() on a sub-command that passes signal through → no throwIfAborted needed
+  await set(anotherCommand$, thread.id, signal);
+});
+```
+
+**Rule of thumb:** If the awaited operation receives your signal, it will throw on abort itself. If it doesn't, check manually after.
+
+### Decomposition strategy
+
+When extracting shared logic from two commands:
+
+1. **Identify the shared block** — usually preparation (validate + transform) and/or execution (send + error handling)
+2. **Extract each block as a sub-command** — one for preparation, one for execution
+3. **Keep post-execution logic in the original commands** — navigation, reload, run loop setup, etc. are caller-specific
+4. **Pass signal as the last parameter** by convention
+
 ## MSW Handler URL Matching
 
 Default MSW handlers must use wildcard prefix `*/` to match absolute URLs:

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { delay } from "signal-timers";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
@@ -12,7 +12,6 @@ import {
   setZeroChatInput$,
   clearZeroChatInput$,
   startNewZeroSession$,
-  sendNewThreadMessage$,
   sendExistingThreadMessage$,
   loadSessionFromSnapshot$,
   zeroChatAttachments$,
@@ -312,117 +311,6 @@ describe("zero-chat signals", () => {
     });
   });
 
-  describe("sendNewThreadMessage$ error recovery", () => {
-    it("should clear optimistic messages when API returns 400", async () => {
-      server.use(
-        http.get("*/api/zero/chat-threads", () => {
-          return HttpResponse.json({ threads: [] });
-        }),
-        http.post("*/api/zero/chat/messages", () => {
-          return HttpResponse.json(
-            { error: { message: "Bad request", code: "BAD_REQUEST" } },
-            { status: 400 },
-          );
-        }),
-      );
-
-      await setup();
-
-      await expect(
-        context.store.set(
-          sendNewThreadMessage$,
-          "c0000000-0000-4000-a000-000000000001",
-          "Hello",
-          undefined,
-          context.signal,
-        ),
-      ).rejects.toThrow();
-
-      const messages = await context.store.get(zeroChatMessages$);
-      expect(messages).toHaveLength(0);
-    });
-
-    it("should clear optimistic messages when API returns 500", async () => {
-      server.use(
-        http.get("*/api/zero/chat-threads", () => {
-          return HttpResponse.json({ threads: [] });
-        }),
-        http.post("*/api/zero/chat/messages", () => {
-          return HttpResponse.json(
-            {
-              error: {
-                message: "Internal server error",
-                code: "INTERNAL_SERVER_ERROR",
-              },
-            },
-            { status: 500 },
-          );
-        }),
-      );
-
-      await setup();
-
-      await expect(
-        context.store.set(
-          sendNewThreadMessage$,
-          "c0000000-0000-4000-a000-000000000001",
-          "Hello",
-          undefined,
-          context.signal,
-        ),
-      ).rejects.toThrow();
-
-      const messages = await context.store.get(zeroChatMessages$);
-      expect(messages).toHaveLength(0);
-    });
-  });
-
-  describe("sendExistingThreadMessage$ error recovery", () => {
-    it("should clear optimistic messages when API returns 400", async () => {
-      server.use(
-        http.get("*/api/zero/chat-threads", () => {
-          return HttpResponse.json({ threads: [] });
-        }),
-        http.get("*/api/zero/chat-threads/:id", () => {
-          return HttpResponse.json({
-            id: "thread-err",
-            title: null,
-            agentId: "c0000000-0000-4000-a000-000000000001",
-            chatMessages: [],
-            latestSessionId: null,
-            unsavedRuns: [],
-            createdAt: "2026-03-10T00:00:00Z",
-            updatedAt: "2026-03-10T00:00:00Z",
-          });
-        }),
-        http.post("*/api/zero/chat/messages", () => {
-          return HttpResponse.json(
-            { error: { message: "Bad request", code: "BAD_REQUEST" } },
-            { status: 400 },
-          );
-        }),
-      );
-
-      await setupPage({
-        context,
-        path: "/chat/thread-err",
-        withoutRender: true,
-      });
-
-      await expect(
-        context.store.set(
-          sendExistingThreadMessage$,
-          "Hello",
-          undefined,
-          context.signal,
-        ),
-      ).rejects.toThrow();
-
-      const messages = await context.store.get(zeroChatMessages$);
-      expect(messages).toHaveLength(0);
-    });
-  });
-
   describe("startNewZeroSession$", () => {
     it("should reset all chat state", async () => {
       await setup();
@@ -650,12 +538,12 @@ describe("zero-chat signals", () => {
         )
         .catch(() => {});
 
-      // Wait for both placeholders
-      await delay(10);
-      const before = context.store.get(zeroChatAttachments$);
-      expect(before).toHaveLength(2);
+      await vi.waitFor(() => {
+        const before = context.store.get(zeroChatAttachments$);
+        expect(before).toHaveLength(2);
+      });
 
-      // Cancel the first upload via removeZeroAttachment$ (which calls cancel$)
+      const before = context.store.get(zeroChatAttachments$);
       context.store.set(removeZeroAttachment$, before[0]!);
 
       await Promise.all([promise1, promise2]);
@@ -665,31 +553,6 @@ describe("zero-chat signals", () => {
       expect(after).toHaveLength(1);
       const info = await context.store.get(after[0]!.fileInfo$);
       expect(info?.url).toContain("example.com");
-    });
-
-    it("should remove placeholder on upload failure", async () => {
-      server.use(
-        http.post("*/api/zero/uploads", () => {
-          return HttpResponse.json(
-            {
-              error: {
-                message: "Internal server error",
-                code: "INTERNAL_SERVER_ERROR",
-              },
-            },
-            { status: 500 },
-          );
-        }),
-      );
-      await setup();
-
-      await context.store.set(
-        uploadZeroAttachment$,
-        createTestFile(),
-        context.signal,
-      );
-
-      expect(context.store.get(zeroChatAttachments$)).toHaveLength(0);
     });
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -1,10 +1,7 @@
 import { command, computed, state, type Command, type Computed } from "ccstate";
-import { throwIfAbort, resetSignal, createDeferredPromise } from "../utils.ts";
-import { logger } from "../log.ts";
+import { resetSignal, createDeferredPromise } from "../utils.ts";
 import { chatThreadId$ } from "./zero-nav.ts";
 import { fetch$ } from "../fetch.ts";
-
-const L = logger("ChatDraft");
 
 // ---------------------------------------------------------------------------
 // Attachment types (moved from zero-chat.ts)

--- a/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-draft.ts
@@ -133,18 +133,7 @@ function createDraftSignals(): DraftSignals {
         return [...prev, attachment];
       });
 
-      try {
-        await set(attachment.upload$, signal);
-      } catch (error) {
-        throwIfAbort(error);
-        L.error("Upload failed:", error);
-        set(attachment.cancel$);
-        set(internalAttachments$, (prev) => {
-          return prev.filter((a) => {
-            return a !== attachment;
-          });
-        });
-      }
+      await set(attachment.upload$, signal);
     },
   );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -1,6 +1,6 @@
 import { command, computed, state, type Computed } from "ccstate";
 import type { AgentEvent, LogStatus } from "./log-types.ts";
-import { resetSignal, throwIfAbort } from "../utils.ts";
+import { resetSignal } from "../utils.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { logger } from "../log.ts";
@@ -795,31 +795,54 @@ function handleSendError(result: {
   throw new Error(message);
 }
 
-export const sendNewThreadMessage$ = command(
+interface PreparedMessage {
+  fullPrompt: string;
+  modelProvider: string | undefined;
+}
+
+const prepareChatMessage$ = command(
   async (
-    { get, set },
-    agentId: string,
+    { set },
     prompt: string,
     options: { modelProvider?: string } | undefined,
     signal: AbortSignal,
-  ) => {
+  ): Promise<PreparedMessage | null> => {
     if (!prompt.trim()) {
-      return;
+      return null;
     }
 
     const { fullPrompt } = await set(prepareUserMessage$, prompt, signal);
     signal.throwIfAborted();
 
-    const modelProvider = resolveModelProvider(options?.modelProvider);
+    return {
+      fullPrompt,
+      modelProvider: resolveModelProvider(options?.modelProvider),
+    };
+  },
+);
+
+const sendChatMessageRequest$ = command(
+  async (
+    { get },
+    agentId: string,
+    prepared: PreparedMessage,
+    threadId: string | null,
+    signal: AbortSignal,
+  ): Promise<{ threadId: string; runId: string }> => {
     const client = get(zeroClient$)(chatMessagesContract);
     const result = await client.send({
       body: {
         agentId,
-        prompt: fullPrompt,
-        ...(modelProvider && { modelProvider }),
+        prompt: prepared.fullPrompt,
+        ...(threadId && { threadId }),
+        ...(prepared.modelProvider && {
+          modelProvider: prepared.modelProvider,
+        }),
+      },
+      fetchOptions: {
+        signal,
       },
     });
-    signal.throwIfAborted();
 
     if (result.status !== 201) {
       if (
@@ -831,9 +854,34 @@ export const sendNewThreadMessage$ = command(
       }
       throw new Error(`Failed to send message (${result.status})`);
     }
-    set(reloadChatThreads$);
 
-    set(navigateToChat$, result.body.threadId);
+    return result.body;
+  },
+);
+
+export const sendNewThreadMessage$ = command(
+  async (
+    { set },
+    agentId: string,
+    prompt: string,
+    options: { modelProvider?: string } | undefined,
+    signal: AbortSignal,
+  ) => {
+    const prepared = await set(prepareChatMessage$, prompt, options, signal);
+    if (!prepared) {
+      return;
+    }
+
+    const { threadId } = await set(
+      sendChatMessageRequest$,
+      agentId,
+      prepared,
+      null,
+      signal,
+    );
+
+    set(reloadChatThreads$);
+    set(navigateToChat$, threadId);
   },
 );
 
@@ -849,37 +897,22 @@ export const sendExistingThreadMessage$ = command(
     signal.throwIfAborted();
     const agentId = thread?.agentId;
 
-    if (!threadId || !agentId || !prompt.trim()) {
+    if (!threadId || !agentId) {
       return;
     }
 
-    const { fullPrompt } = await set(prepareUserMessage$, prompt, signal);
-    signal.throwIfAborted();
-
-    const modelProvider = resolveModelProvider(options?.modelProvider);
-    const client = get(zeroClient$)(chatMessagesContract);
-    const result = await client.send({
-      body: {
-        agentId,
-        prompt: fullPrompt,
-        threadId,
-        ...(modelProvider && { modelProvider }),
-      },
-    });
-    signal.throwIfAborted();
-
-    if (result.status !== 201) {
-      if (
-        result.status === 400 ||
-        result.status === 403 ||
-        result.status === 404
-      ) {
-        handleSendError(result);
-      }
-      throw new Error(`Failed to send message (${result.status})`);
+    const prepared = await set(prepareChatMessage$, prompt, options, signal);
+    if (!prepared) {
+      return;
     }
 
-    const { runId } = result.body;
+    const { runId } = await set(
+      sendChatMessageRequest$,
+      agentId,
+      prepared,
+      threadId,
+      signal,
+    );
 
     set(internalReloadChatThreads$, (n) => {
       return n + 1;

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -693,14 +693,7 @@ const internalCreateNewChatSession$ = command(
     }
 
     const createClient = get(zeroClient$);
-    let thread;
-    try {
-      thread = await createChatThread(createClient, resolvedComposeId);
-    } catch (error) {
-      throwIfAbort(error);
-      toast.error("Failed to create new chat session");
-      return;
-    }
+    const thread = await createChatThread(createClient, resolvedComposeId);
 
     set(reloadChatThreads$);
     set(navigateToChat$, thread.id);
@@ -817,40 +810,30 @@ export const sendNewThreadMessage$ = command(
     const { fullPrompt } = await set(prepareUserMessage$, prompt, signal);
     signal.throwIfAborted();
 
-    try {
-      const modelProvider = resolveModelProvider(options?.modelProvider);
-      const client = get(zeroClient$)(chatMessagesContract);
-      const result = await client.send({
-        body: {
-          agentId,
-          prompt: fullPrompt,
-          ...(modelProvider && { modelProvider }),
-        },
-      });
-      signal.throwIfAborted();
+    const modelProvider = resolveModelProvider(options?.modelProvider);
+    const client = get(zeroClient$)(chatMessagesContract);
+    const result = await client.send({
+      body: {
+        agentId,
+        prompt: fullPrompt,
+        ...(modelProvider && { modelProvider }),
+      },
+    });
+    signal.throwIfAborted();
 
-      if (result.status !== 201) {
-        if (
-          result.status === 400 ||
-          result.status === 403 ||
-          result.status === 404
-        ) {
-          handleSendError(result);
-        }
-        throw new Error(`Failed to send message (${result.status})`);
+    if (result.status !== 201) {
+      if (
+        result.status === 400 ||
+        result.status === 403 ||
+        result.status === 404
+      ) {
+        handleSendError(result);
       }
-      set(reloadChatThreads$);
-
-      set(navigateToChat$, result.body.threadId);
-    } catch (error) {
-      throwIfAbort(error);
-      // Clear optimistic messages so stale user input does not persist in the UI
-      set(internalLocalMessages$, []);
-      toast.error(
-        error instanceof Error ? error.message : "Failed to send message",
-      );
-      throw error;
+      throw new Error(`Failed to send message (${result.status})`);
     }
+    set(reloadChatThreads$);
+
+    set(navigateToChat$, result.body.threadId);
   },
 );
 
@@ -873,65 +856,55 @@ export const sendExistingThreadMessage$ = command(
     const { fullPrompt } = await set(prepareUserMessage$, prompt, signal);
     signal.throwIfAborted();
 
-    try {
-      const modelProvider = resolveModelProvider(options?.modelProvider);
-      const client = get(zeroClient$)(chatMessagesContract);
-      const result = await client.send({
-        body: {
-          agentId,
-          prompt: fullPrompt,
-          threadId,
-          ...(modelProvider && { modelProvider }),
-        },
-      });
-      signal.throwIfAborted();
+    const modelProvider = resolveModelProvider(options?.modelProvider);
+    const client = get(zeroClient$)(chatMessagesContract);
+    const result = await client.send({
+      body: {
+        agentId,
+        prompt: fullPrompt,
+        threadId,
+        ...(modelProvider && { modelProvider }),
+      },
+    });
+    signal.throwIfAborted();
 
-      if (result.status !== 201) {
-        if (
-          result.status === 400 ||
-          result.status === 403 ||
-          result.status === 404
-        ) {
-          handleSendError(result);
-        }
-        throw new Error(`Failed to send message (${result.status})`);
+    if (result.status !== 201) {
+      if (
+        result.status === 400 ||
+        result.status === 403 ||
+        result.status === 404
+      ) {
+        handleSendError(result);
       }
-
-      const { runId } = result.body;
-
-      set(internalReloadChatThreads$, (n) => {
-        return n + 1;
-      });
-      set(reloadCurrentThread$, (n) => {
-        return n + 1;
-      });
-
-      const { assistantMessage } = createActiveRunMessage(runId, prompt);
-      set(internalLocalMessages$, (prev) => {
-        return [...prev, assistantMessage];
-      });
-
-      const runLoop = assistantMessage.runLoop;
-      if (!runLoop) {
-        return;
-      }
-
-      await set(runLoop.beginLoop$, signal);
-      set(internalReloadChatThreads$, (n) => {
-        return n + 1;
-      });
-      set(reloadCurrentThread$, (n) => {
-        return n + 1;
-      });
-    } catch (error) {
-      throwIfAbort(error);
-      // Clear optimistic messages so stale user input does not persist in the UI
-      set(internalLocalMessages$, []);
-      toast.error(
-        error instanceof Error ? error.message : "Failed to send message",
-      );
-      throw error;
+      throw new Error(`Failed to send message (${result.status})`);
     }
+
+    const { runId } = result.body;
+
+    set(internalReloadChatThreads$, (n) => {
+      return n + 1;
+    });
+    set(reloadCurrentThread$, (n) => {
+      return n + 1;
+    });
+
+    const { assistantMessage } = createActiveRunMessage(runId, prompt);
+    set(internalLocalMessages$, (prev) => {
+      return [...prev, assistantMessage];
+    });
+
+    const runLoop = assistantMessage.runLoop;
+    if (!runLoop) {
+      return;
+    }
+
+    await set(runLoop.beginLoop$, signal);
+    set(internalReloadChatThreads$, (n) => {
+      return n + 1;
+    });
+    set(reloadCurrentThread$, (n) => {
+      return n + 1;
+    });
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -177,44 +177,7 @@ describe("sidebar new chat navigation", () => {
     await waitFor(() => {
       expect(pathname()).toBe("/chat/delayed-thread-id");
     });
-  }, 15_000);
-
-  it("should handle API failure gracefully", async () => {
-    const user = userEvent.setup();
-    mockSubagentAPIs();
-    // Override POST to return error
-    server.use(
-      http.post("*/api/zero/chat-threads", () => {
-        return HttpResponse.json(
-          {
-            error: {
-              message: "Internal server error",
-              code: "INTERNAL_SERVER_ERROR",
-            },
-          },
-          { status: 500 },
-        );
-      }),
-    );
-
-    await setupPage({ context, path: "/team" });
-
-    const initialPath = pathname();
-
-    const newChatButton = await waitFor(() => {
-      return screen.getByLabelText("New chat with Zero");
-    });
-
-    await user.click(newChatButton);
-
-    // Wait for the request to complete (button should become enabled again)
-    await waitFor(() => {
-      expect(newChatButton).not.toBeDisabled();
-    });
-
-    // Should not have navigated
-    expect(pathname()).toBe(initialPath);
-  }, 15_000);
+  });
 
   it("should show new chat entry in sidebar and focus textarea after creating new chat", async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary

- Remove defensive try-catch blocks from `sendNewThreadMessage$`, `sendExistingThreadMessage$`, `internalCreateNewChatSession$`, and `uploadZeroAttachment$` in zero-chat signals
- Let errors propagate naturally per project principles (avoid defensive programming)
- Remove associated error recovery tests that validated the removed defensive patterns
- Replace flaky `delay(10)` with `vi.waitFor` in attachment cancellation test

## Test plan

- [ ] Verify existing zero-chat tests pass
- [ ] Verify sidebar navigation tests pass
- [ ] Confirm no regressions in chat message sending flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)