### PR TITLE
feat(runner): run runner as root, remove all sudo wrappers

### DIFF
--- a/.claude/skills/dev-runner/SKILL.md
+++ b/.claude/skills/dev-runner/SKILL.md
@@ -132,7 +132,7 @@ source "$PROJECT_ROOT/scripts/.env.local"
 
 RUNNER_GROUP="${RUNNER_DEFAULT_GROUP:?}"
 RUNNER_NAME="${RUNNER_GROUP##*/}"
-RUNNER_BIN="~/.vm0-runner/bin/${RUNNER_NAME}/runner"
+RUNNER_BIN="sudo /var/lib/vm0-runner/bin/${RUNNER_NAME}/runner"
 
 "$PROJECT_ROOT/scripts/cf-ssh.sh" "$RUNNER_LOCAL_HOST" \
   -l "${RUNNER_LOCAL_USER:-ubuntu}" \

--- a/.claude/skills/runner-testing/skill.md
+++ b/.claude/skills/runner-testing/skill.md
@@ -56,7 +56,7 @@ In local mode, webhooks go nowhere (no web server), but VM execution still works
 | `vm0/default` | 2 | 2048 MB | CLI agent, code generation, browser automation |
 
 Profile definitions: `crates/runner/src/profile.rs`
-Runner config on host: `~/.vm0-runner/runners/<name>/runner.yaml`
+Runner config on host: `/var/lib/vm0-runner/runners/<name>/runner.yaml`
 
 ## Testing Workflow
 
@@ -87,10 +87,10 @@ Job logs are stored on the metal host:
 
 ```bash
 # System log (guest-agent output including command results)
-scripts/cf-ssh.sh <host> -- 'cat ~/.vm0-runner/logs/system-<run-id>.log'
+scripts/cf-ssh.sh <host> -- 'sudo cat /var/lib/vm0-runner/logs/system-<run-id>.log'
 
 # Network log (mitmproxy HTTP activity)
-scripts/cf-ssh.sh <host> -- 'cat ~/.vm0-runner/logs/network-<run-id>.jsonl'
+scripts/cf-ssh.sh <host> -- 'sudo cat /var/lib/vm0-runner/logs/network-<run-id>.jsonl'
 
 # Runner service log
 scripts/cf-ssh.sh <host> -- 'journalctl -u vm0-runner-<name> --since "5 minutes ago"'
@@ -122,7 +122,7 @@ Example: 16 vCPU / 32 GB host can run:
 scripts/cf-ssh.sh <host> [-- <command>]
 
 # Examples
-scripts/cf-ssh.sh local-1.aws.vm3.ai -- 'cat ~/.vm0-runner/runners/<name>/status.json'
+scripts/cf-ssh.sh local-1.aws.vm3.ai -- 'sudo cat /var/lib/vm0-runner/runners/<name>/status.json'
 scripts/cf-ssh.sh local-1.aws.vm3.ai -- 'nproc && free -m'
 ```
 
@@ -138,12 +138,12 @@ Usually mitmproxy upstream TLS verification failure. Check the system log for `C
 mitmproxy cannot verify upstream server's TLS certificate. The standalone mitmproxy binary bundles its own CA store which may be incomplete. The runner passes `ssl_verify_upstream_trusted_ca=/etc/ssl/certs/ca-certificates.crt` to use the host's system CA store instead.
 
 #### No network log file
-If `~/.vm0-runner/logs/network-<run-id>.jsonl` doesn't exist, mitmproxy didn't intercept the traffic at HTTP level. Check:
-1. Is the VM registered in proxy registry? (`cat ~/.vm0-runner/runners/<name>/proxy-registry.json`)
+If `/var/lib/vm0-runner/logs/network-<run-id>.jsonl` doesn't exist, mitmproxy didn't intercept the traffic at HTTP level. Check:
+1. Is the VM registered in proxy registry? (`sudo cat /var/lib/vm0-runner/runners/<name>/proxy-registry.json`)
 2. Are iptables rules redirecting the VM's subnet to the correct mitmproxy port?
 
 #### Job stuck / not picked up
-In local mode, runner watches `~/.vm0-runner/groups/<group>/` for `.job` files. Check:
+In local mode, runner watches `/var/lib/vm0-runner/groups/<group>/` for `.job` files. Check:
 1. Is the runner service running? `systemctl status vm0-runner-<name>`
 2. Is it in local mode? Check for `--local` in the service command
 

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -429,30 +429,31 @@ jobs:
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
-          BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
+          BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"
           TARGET_DIR="crates/target/${TARGET_TRIPLE}/${CARGO_PROFILE}"
 
           # Clean previous run artifacts and upload runner (guests are embedded)
           echo "=== Deploying runner to ${HOST}:${BIN_DIR} ==="
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "rm -rf ${BIN_DIR} ~/.vm0-runner/runners/${JOB_REF}-bench ~/.vm0-runner/runners/${JOB_REF}-local && mkdir -p ${BIN_DIR}"
-          scp "${TARGET_DIR}/runner" "${REMOTE}:${BIN_DIR}/"
+          ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} /var/lib/vm0-runner/runners/${JOB_REF}-bench /var/lib/vm0-runner/runners/${JOB_REF}-local && sudo mkdir -p ${BIN_DIR}"
+          scp "${TARGET_DIR}/runner" "${REMOTE}:/tmp/runner-upload"
+          ssh "$REMOTE" "sudo mv /tmp/runner-upload ${BIN_DIR}/runner && sudo chmod 755 ${BIN_DIR}/runner"
 
           # Clean up old rootfs/snapshots, keep the 3 most recent deploys
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "${BIN_DIR}/runner gc --keep-latest 3"
+          ssh "$REMOTE" "sudo ${BIN_DIR}/runner gc --keep-latest 3"
 
           # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
           echo "=== Running setup ==="
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "${BIN_DIR}/runner setup"
+          ssh "$REMOTE" "sudo ${BIN_DIR}/runner setup"
 
           # Run build (rootfs via Docker + snapshot via Firecracker)
           # Use tee to stream output in real-time while capturing for hash extraction
           echo "=== Building vm0/default ==="
           BUILD_LOG_DEFAULT=$(mktemp)
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG_DEFAULT"
+          ssh "$REMOTE" "sudo ${BIN_DIR}/runner build --profile vm0/default" | tee "$BUILD_LOG_DEFAULT"
           DEFAULT_ROOTFS_HASH=$(grep '^rootfs_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
           DEFAULT_SNAPSHOT_HASH=$(grep '^snapshot_hash=' "$BUILD_LOG_DEFAULT" | cut -d= -f2)
           rm -f "$BUILD_LOG_DEFAULT"
@@ -489,13 +490,13 @@ jobs:
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
-          BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
+          BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"
           # shellcheck disable=SC2088
-          RUNNER_DIR="~/.vm0-runner/runners/${JOB_REF}-bench"
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-bench"
 
           echo "=== Generating config ==="
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "${BIN_DIR}/runner config \
+          ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
             --profile vm0/default \
             --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
             --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -507,14 +508,14 @@ jobs:
 
           echo "=== Running benchmark (default) ==="
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "${BIN_DIR}/runner benchmark \
+          ssh "$REMOTE" "sudo ${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
             --profile vm0/default \
             'curl -sf --max-time 10 https://httpbin.org/get'"
 
           echo "=== Running benchmark (browser automation) ==="
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "${BIN_DIR}/runner benchmark \
+          ssh "$REMOTE" "sudo ${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
             --profile vm0/default \
             'agent-browser open https://github.com/ && agent-browser get title && agent-browser close'"
@@ -544,11 +545,11 @@ jobs:
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
-          BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
+          BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"
 
           echo "=== Generating config ==="
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "${BIN_DIR}/runner config \
+          ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
             --profile vm0/default \
             --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
             --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -562,7 +563,7 @@ jobs:
           echo "=== Running exec test ==="
           ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
           BIN_DIR=$1; JOB_REF=$2
-          RUNNER_DIR="$HOME/.vm0-runner/runners/${JOB_REF}-exec"
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-exec"
           SVC="${JOB_REF}-exec"
           GROUP="vm0/exec-${JOB_REF}"
 
@@ -570,25 +571,25 @@ jobs:
 
           cleanup() {
             echo "--- Cleanup ---"
-            "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
           }
           trap cleanup EXIT
 
           # Start transient runner service
           echo "--- Starting runner ---"
-          "$BIN_DIR/runner" service start --name "$SVC" \
+          sudo "$BIN_DIR/runner" service start --name "$SVC" \
             --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true
 
           # Submit a long-running job in background (keeps sandbox alive during tests)
           echo "--- Submitting long-running job ---"
-          "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &
+          sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &
 
           # Wait for OUR runner's sandbox to have a control socket.
           # Read the run ID from our runner's status.json (not from /run/vm0/sock/)
           # to avoid matching sandboxes from parallel CI jobs (benchmark, upgrade).
           echo "--- Waiting for sandbox control socket ---"
           for i in $(seq 1 60); do
-            RUN_ID=$(grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' \
+            RUN_ID=$(sudo grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' \
               "$RUNNER_DIR/status.json" 2>/dev/null | head -1)
             [ -n "$RUN_ID" ] && [ -S "/run/vm0/sock/$RUN_ID/control.sock" ] && break
             RUN_ID=""
@@ -599,24 +600,24 @@ jobs:
 
           # Test 1: basic exec
           echo "--- Test: basic exec ---"
-          OUTPUT=$("$BIN_DIR/runner" exec "$RUN_ID" -- echo hello-from-exec)
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- echo hello-from-exec)
           echo "$OUTPUT" | grep -q "hello-from-exec" || fail "expected 'hello-from-exec', got: $OUTPUT"
           echo "PASS: basic exec"
 
           # Test 2: exit code propagation
           echo "--- Test: exit code propagation ---"
-          "$BIN_DIR/runner" exec "$RUN_ID" -- false && fail "expected non-zero exit"
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- false && fail "expected non-zero exit"
           echo "PASS: exit code propagation"
 
           # Test 3: prefix matching
           echo "--- Test: prefix matching ---"
           PREFIX=$(echo "$RUN_ID" | cut -c1-8)
-          OUTPUT=$("$BIN_DIR/runner" exec "$PREFIX" -- hostname)
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$PREFIX" -- hostname)
           [ -n "$OUTPUT" ] || fail "prefix match returned empty output"
           echo "PASS: prefix matching"
 
           # Stop transient service (kills sandbox, submit terminates naturally)
-          "$BIN_DIR/runner" service stop --name "$SVC"
+          sudo "$BIN_DIR/runner" service stop --name "$SVC"
           trap - EXIT
 
           echo "=== Exec test passed ==="
@@ -647,11 +648,11 @@ jobs:
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
-          BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
+          BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"
 
           echo "=== Generating config ==="
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "${BIN_DIR}/runner config \
+          ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
             --profile vm0/default \
             --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
             --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -665,7 +666,7 @@ jobs:
           echo "=== Running cancel test ==="
           ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
           BIN_DIR=$1; JOB_REF=$2
-          RUNNER_DIR="$HOME/.vm0-runner/runners/${JOB_REF}-cancel"
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-cancel"
           SVC="${JOB_REF}-cancel"
           GROUP="vm0/cancel-${JOB_REF}"
 
@@ -673,24 +674,24 @@ jobs:
 
           cleanup() {
             echo "--- Cleanup ---"
-            "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
           }
           trap cleanup EXIT
 
           # Start transient runner service
           echo "--- Starting runner ---"
-          "$BIN_DIR/runner" service start --name "$SVC" \
+          sudo "$BIN_DIR/runner" service start --name "$SVC" \
             --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true
 
           # Submit a long-running job in background
           echo "--- Submitting long-running job ---"
-          "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &
+          sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &
           SUBMIT_PID=$!
 
           # Wait for sandbox to be running
           echo "--- Waiting for sandbox ---"
           for i in $(seq 1 60); do
-            RUN_ID=$(grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' \
+            RUN_ID=$(sudo grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' \
               "$RUNNER_DIR/status.json" 2>/dev/null | head -1)
             [ -n "$RUN_ID" ] && [ -S "/run/vm0/sock/$RUN_ID/control.sock" ] && break
             RUN_ID=""
@@ -701,7 +702,7 @@ jobs:
 
           # Test 1: cancel the job via runner local cancel
           echo "--- Test: runner local cancel ---"
-          "$BIN_DIR/runner" local cancel --group "$GROUP" "$RUN_ID" || fail "cancel command failed"
+          sudo "$BIN_DIR/runner" local cancel --group "$GROUP" "$RUN_ID" || fail "cancel command failed"
           echo "PASS: cancel command succeeded"
 
           # Test 2: submit should exit quickly (not after 300s timeout)
@@ -718,7 +719,7 @@ jobs:
           echo "PASS: submit exited with non-zero after cancel (${ELAPSED}s)"
 
           # Stop transient service
-          "$BIN_DIR/runner" service stop --name "$SVC"
+          sudo "$BIN_DIR/runner" service stop --name "$SVC"
           trap - EXIT
 
           echo "=== Cancel test passed ==="
@@ -749,11 +750,11 @@ jobs:
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
-          BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
+          BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"
 
           echo "=== Generating config ==="
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "${BIN_DIR}/runner config \
+          ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
             --profile vm0/default \
             --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
             --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -767,7 +768,7 @@ jobs:
           echo "=== Running balloon test ==="
           ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
           BIN_DIR=$1; JOB_REF=$2
-          RUNNER_DIR="$HOME/.vm0-runner/runners/${JOB_REF}-balloon"
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-balloon"
           SVC="${JOB_REF}-balloon"
           GROUP="vm0/balloon-${JOB_REF}"
 
@@ -775,23 +776,23 @@ jobs:
 
           cleanup() {
             echo "--- Cleanup ---"
-            "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
           }
           trap cleanup EXIT
 
           # Start transient runner service
           echo "--- Starting runner ---"
-          "$BIN_DIR/runner" service start --name "$SVC" \
+          sudo "$BIN_DIR/runner" service start --name "$SVC" \
             --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true
 
           # Submit a long-running job in background (keeps sandbox alive during tests)
           echo "--- Submitting long-running job ---"
-          "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &
+          sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 120 && echo done' &
 
           # Wait for sandbox control socket
           echo "--- Waiting for sandbox control socket ---"
           for i in $(seq 1 60); do
-            RUN_ID=$(grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' \
+            RUN_ID=$(sudo grep -oE '[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}' \
               "$RUNNER_DIR/status.json" 2>/dev/null | head -1)
             [ -n "$RUN_ID" ] && [ -S "/run/vm0/sock/$RUN_ID/control.sock" ] && break
             RUN_ID=""
@@ -804,13 +805,13 @@ jobs:
 
           # Helper: read current balloon actual_mib
           balloon_mib() {
-            curl -sf --unix-socket "$API_SOCK" http://localhost/balloon/statistics \
+            sudo curl -sf --unix-socket "$API_SOCK" http://localhost/balloon/statistics \
               | jq '.actual_mib // 0' 2>/dev/null || echo 0
           }
 
           # Helper: read guest MemAvailable in kB
           guest_avail_kb() {
-            "$BIN_DIR/runner" exec "$RUN_ID" -- grep MemAvailable /proc/meminfo \
+            sudo "$BIN_DIR/runner" exec "$RUN_ID" -- grep MemAvailable /proc/meminfo \
               | tr -s ' ' | cut -d' ' -f2
           }
 
@@ -856,9 +857,9 @@ jobs:
           # Write script via base64 to avoid quoting issues with runner exec.
           echo "--- Test 2: balloon deflate under memory pressure ---"
           ALLOC_B64=$(printf 'import ctypes,time\nb=bytearray(300*1024*1024)\nctypes.memset((ctypes.c_char*len(b)).from_buffer(b),1,len(b))\ntime.sleep(120)\n' | base64 -w0)
-          "$BIN_DIR/runner" exec "$RUN_ID" -- "echo $ALLOC_B64 | base64 -d > /tmp/alloc.py"
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- "echo $ALLOC_B64 | base64 -d > /tmp/alloc.py"
           # Run allocator in guest foreground, host background
-          "$BIN_DIR/runner" exec "$RUN_ID" -- python3 /tmp/alloc.py &
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- python3 /tmp/alloc.py &
           ALLOC_PID=$!
 
           # Wait for balloon to deflate (actual_mib decreases)
@@ -879,7 +880,7 @@ jobs:
           # then kill host-side exec. The pkill may fail with "Operation not permitted"
           # but the host-side kill terminates the vsock session which kills the process.
           echo "--- Test 3: balloon re-inflate after pressure release ---"
-          "$BIN_DIR/runner" exec "$RUN_ID" -- "pkill -f alloc.py" 2>/dev/null || true
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- "pkill -f alloc.py" 2>/dev/null || true
           kill $ALLOC_PID 2>/dev/null || true
           wait $ALLOC_PID 2>/dev/null || true
 
@@ -898,7 +899,7 @@ jobs:
           echo "PASS: balloon re-inflated from ${DEFLATE_MIB} to ${ACTUAL} MiB (midpoint=${MIDPOINT})"
 
           # Stop transient service
-          "$BIN_DIR/runner" service stop --name "$SVC"
+          sudo "$BIN_DIR/runner" service stop --name "$SVC"
           trap - EXIT
 
           echo "=== Balloon test passed ==="
@@ -929,13 +930,13 @@ jobs:
         run: |
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
-          BIN_DIR="~/.vm0-runner/bin/${JOB_REF}"
+          BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"
           GROUP="vm0/upgrade-${JOB_REF}"
 
           echo "=== Generating configs for runner A and B ==="
           for SUFFIX in upgrade-a upgrade-b; do
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "${BIN_DIR}/runner config \
+            ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
               --profile vm0/default \
               --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
               --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -950,8 +951,8 @@ jobs:
           echo "=== Running upgrade test ==="
           ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" "${GROUP}" <<'REMOTE_SCRIPT'
           BIN_DIR=$1; JOB_REF=$2; GROUP=$3
-          RUNNER_DIR_A="$HOME/.vm0-runner/runners/${JOB_REF}-upgrade-a"
-          RUNNER_DIR_B="$HOME/.vm0-runner/runners/${JOB_REF}-upgrade-b"
+          RUNNER_DIR_A="/var/lib/vm0-runner/runners/${JOB_REF}-upgrade-a"
+          RUNNER_DIR_B="/var/lib/vm0-runner/runners/${JOB_REF}-upgrade-b"
           SVC_A="${JOB_REF}-upgrade-a"
           SVC_B="${JOB_REF}-upgrade-b"
 
@@ -960,8 +961,8 @@ jobs:
 
           cleanup() {
             echo "--- Cleanup: uninstalling services ---"
-            "$BIN_DIR/runner" service uninstall --name "$SVC_A" 2>/dev/null || true
-            "$BIN_DIR/runner" service uninstall --name "$SVC_B" 2>/dev/null || true
+            sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A" 2>/dev/null || true
+            sudo "$BIN_DIR/runner" service uninstall --name "$SVC_B" 2>/dev/null || true
             if [ "$FAILED" -ne 0 ]; then
               echo "--- Cleanup: dumping logs (test failed) ---"
               journalctl --unit "vm0-runner-${SVC_A}" --lines 50 --no-pager 2>/dev/null || true
@@ -971,32 +972,32 @@ jobs:
           trap cleanup EXIT
 
           # Pre-cleanup: uninstall leftover services from previous CI runs
-          "$BIN_DIR/runner" service uninstall --name "$SVC_A" 2>/dev/null || true
-          "$BIN_DIR/runner" service uninstall --name "$SVC_B" 2>/dev/null || true
+          sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A" 2>/dev/null || true
+          sudo "$BIN_DIR/runner" service uninstall --name "$SVC_B" 2>/dev/null || true
 
           # 1. Install runner A
           echo "--- Installing runner A ---"
-          "$BIN_DIR/runner" service install --name "$SVC_A" \
+          sudo "$BIN_DIR/runner" service install --name "$SVC_A" \
             --config "$RUNNER_DIR_A/runner.yaml" --local --env USE_MOCK_CLAUDE=true
 
           # 2. Submit job 1 (background, long-running) → only A running
           echo "--- Submit job 1 (only A, long-running) ---"
-          "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 12 && echo job1' &
+          sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 12 && echo job1' &
           SUBMIT1_PID=$!
 
           # 3. Install runner B while job 1 still in-flight on A
           echo "--- Installing runner B ---"
-          "$BIN_DIR/runner" service install --name "$SVC_B" \
+          sudo "$BIN_DIR/runner" service install --name "$SVC_B" \
             --config "$RUNNER_DIR_B/runner.yaml" --local --env USE_MOCK_CLAUDE=true
 
           # 4. Submit job 2 (background, long-running) → A and B compete
           echo "--- Submit job 2 (A and B compete, long-running) ---"
-          "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 12 && echo job2' &
+          sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'sleep 12 && echo job2' &
           SUBMIT2_PID=$!
 
           # 5. Drain A while jobs may be in-flight
           echo "--- Draining runner A ---"
-          "$BIN_DIR/runner" service drain --name "$SVC_A"
+          sudo "$BIN_DIR/runner" service drain --name "$SVC_A"
 
           # 6. Verify both jobs complete despite drain
           echo "--- Waiting for job 1 ---"
@@ -1006,17 +1007,17 @@ jobs:
 
           # 7. Uninstall A (systemctl stop blocks until drain finishes)
           echo "--- Uninstalling runner A ---"
-          "$BIN_DIR/runner" service uninstall --name "$SVC_A"
+          sudo "$BIN_DIR/runner" service uninstall --name "$SVC_A"
 
           # 8. Submit job 3 → only B is left
           echo "--- Submit job 3 (only B) ---"
-          "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'echo job3' || fail "Job 3 failed"
+          sudo "$BIN_DIR/runner" local submit --group "$GROUP" --prompt 'echo job3' || fail "Job 3 failed"
 
           # 9. Drain and uninstall B
           echo "--- Draining runner B ---"
-          "$BIN_DIR/runner" service drain --name "$SVC_B"
+          sudo "$BIN_DIR/runner" service drain --name "$SVC_B"
           echo "--- Uninstalling runner B ---"
-          "$BIN_DIR/runner" service uninstall --name "$SVC_B"
+          sudo "$BIN_DIR/runner" service uninstall --name "$SVC_B"
           trap - EXIT
 
           echo "=== Upgrade test passed ==="

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -437,6 +437,7 @@ jobs:
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} /var/lib/vm0-runner/runners/${JOB_REF}-bench /var/lib/vm0-runner/runners/${JOB_REF}-local && sudo mkdir -p ${BIN_DIR}"
           scp "${TARGET_DIR}/runner" "${REMOTE}:/tmp/runner-upload"
+          # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo mv /tmp/runner-upload ${BIN_DIR}/runner && sudo chmod 755 ${BIN_DIR}/runner"
 
           # Clean up old rootfs/snapshots, keep the 3 most recent deploys

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -436,9 +436,9 @@ jobs:
           echo "=== Deploying runner to ${HOST}:${BIN_DIR} ==="
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} /var/lib/vm0-runner/runners/${JOB_REF}-bench /var/lib/vm0-runner/runners/${JOB_REF}-local && sudo mkdir -p ${BIN_DIR}"
-          scp "${TARGET_DIR}/runner" "${REMOTE}:/tmp/runner-upload"
+          scp "${TARGET_DIR}/runner" "${REMOTE}:/tmp/runner-upload-${JOB_REF}"
           # shellcheck disable=SC2029
-          ssh "$REMOTE" "sudo mv /tmp/runner-upload ${BIN_DIR}/runner && sudo chmod 755 ${BIN_DIR}/runner"
+          ssh "$REMOTE" "sudo mv /tmp/runner-upload-${JOB_REF} ${BIN_DIR}/runner && sudo chmod 755 ${BIN_DIR}/runner"
 
           # Clean up old rootfs/snapshots, keep the 3 most recent deploys
           # shellcheck disable=SC2029

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -436,9 +436,7 @@ jobs:
           echo "=== Deploying runner to ${HOST}:${BIN_DIR} ==="
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} /var/lib/vm0-runner/runners/${JOB_REF}-bench /var/lib/vm0-runner/runners/${JOB_REF}-local && sudo mkdir -p ${BIN_DIR}"
-          scp "${TARGET_DIR}/runner" "${REMOTE}:/tmp/runner-upload-${JOB_REF}"
-          # shellcheck disable=SC2029
-          ssh "$REMOTE" "sudo mv /tmp/runner-upload-${JOB_REF} ${BIN_DIR}/runner && sudo chmod 755 ${BIN_DIR}/runner"
+          < "${TARGET_DIR}/runner" ssh "$REMOTE" "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner"
 
           # Clean up old rootfs/snapshots, keep the 3 most recent deploys
           # shellcheck disable=SC2029

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -436,6 +436,7 @@ jobs:
           echo "=== Deploying runner to ${HOST}:${BIN_DIR} ==="
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} /var/lib/vm0-runner/runners/${JOB_REF}-bench /var/lib/vm0-runner/runners/${JOB_REF}-local && sudo mkdir -p ${BIN_DIR}"
+          # shellcheck disable=SC2029
           < "${TARGET_DIR}/runner" ssh "$REMOTE" "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner"
 
           # Clean up old rootfs/snapshots, keep the 3 most recent deploys

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1033,6 +1033,7 @@ jobs:
           has_warnings=false
           for host in $(echo "$AWS_METAL_RUNNER_HOSTS" | tr ',' ' '); do
             [ -z "$host" ] && continue
+            # shellcheck disable=SC2029
             if ! ssh "${AWS_METAL_RUNNER_USER}@${host}" "sudo ${RUNNER_BIN} doctor" 2>&1; then
               has_warnings=true
             fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1029,13 +1029,11 @@ jobs:
           AWS_METAL_RUNNER_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           RUNNER_VERSION: ${{ needs.release-please.outputs.runner_rs_version }}
         run: |
-          RUNNER_BIN="\$HOME/.vm0-runner/bin/v${RUNNER_VERSION}/runner"
+          RUNNER_BIN="/var/lib/vm0-runner/bin/v${RUNNER_VERSION}/runner"
           has_warnings=false
           for host in $(echo "$AWS_METAL_RUNNER_HOSTS" | tr ',' ' '); do
             [ -z "$host" ] && continue
-            # RUNNER_BIN contains \$HOME (remote) + version (local), so mixed expansion is intentional
-            # shellcheck disable=SC2029
-            if ! ssh "${AWS_METAL_RUNNER_USER}@${host}" "${RUNNER_BIN} doctor" 2>&1; then
+            if ! ssh "${AWS_METAL_RUNNER_USER}@${host}" "sudo ${RUNNER_BIN} doctor" 2>&1; then
               has_warnings=true
             fi
           done

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1502,9 +1502,9 @@ jobs:
             # Clean previous run artifacts and upload runner (guests are embedded)
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} ${RUNNER_DIR} && sudo mkdir -p ${BIN_DIR}"
-            scp "${TARGET_DIR}/runner" "${REMOTE}:/tmp/runner-upload"
+            scp "${TARGET_DIR}/runner" "${REMOTE}:/tmp/runner-upload-${RUNNER_NAME}"
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "sudo mv /tmp/runner-upload ${BIN_DIR}/runner && sudo chmod 755 ${BIN_DIR}/runner"
+            ssh "$REMOTE" "sudo mv /tmp/runner-upload-${RUNNER_NAME} ${BIN_DIR}/runner && sudo chmod 755 ${BIN_DIR}/runner"
 
             # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles)
             # shellcheck disable=SC2029

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1503,6 +1503,7 @@ jobs:
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} ${RUNNER_DIR} && sudo mkdir -p ${BIN_DIR}"
             scp "${TARGET_DIR}/runner" "${REMOTE}:/tmp/runner-upload"
+            # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo mv /tmp/runner-upload ${BIN_DIR}/runner && sudo chmod 755 ${BIN_DIR}/runner"
 
             # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles)

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1422,8 +1422,8 @@ jobs:
           METAL_HOSTS: ${{ secrets.AWS_METAL_RUNNER_HOSTS }}
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
         run: |
-          echo "bin-dir=~/.vm0-runner/bin/${JOB_REF}" >> "$GITHUB_OUTPUT"
-          echo "runner-dir=~/.vm0-runner/runners/${JOB_REF}" >> "$GITHUB_OUTPUT"
+          echo "bin-dir=/var/lib/vm0-runner/bin/${JOB_REF}" >> "$GITHUB_OUTPUT"
+          echo "runner-dir=/var/lib/vm0-runner/runners/${JOB_REF}" >> "$GITHUB_OUTPUT"
           NUM_HOSTS=$(echo "$METAL_HOSTS" | tr ',' '\n' | grep -c .)
           if [ "$NUM_HOSTS" -lt 1 ]; then
             echo "::error::AWS_METAL_RUNNER_HOSTS is empty"
@@ -1501,20 +1501,21 @@ jobs:
 
             # Clean previous run artifacts and upload runner (guests are embedded)
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "rm -rf ${BIN_DIR} ${RUNNER_DIR} && mkdir -p ${BIN_DIR}"
-            scp "${TARGET_DIR}/runner" "${REMOTE}:${BIN_DIR}/"
+            ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} ${RUNNER_DIR} && sudo mkdir -p ${BIN_DIR}"
+            scp "${TARGET_DIR}/runner" "${REMOTE}:/tmp/runner-upload"
+            ssh "$REMOTE" "sudo mv /tmp/runner-upload ${BIN_DIR}/runner && sudo chmod 755 ${BIN_DIR}/runner"
 
             # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles)
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "${BIN_DIR}/runner gc --keep-latest 6"
+            ssh "$REMOTE" "sudo ${BIN_DIR}/runner gc --keep-latest 6"
 
             # Run setup (downloads firecracker/kernel/mitmdump, cached + idempotent)
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "${BIN_DIR}/runner setup"
+            ssh "$REMOTE" "sudo ${BIN_DIR}/runner setup"
 
             # Run build to create rootfs + snapshot (outputs hashes to stdout)
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "${BIN_DIR}/runner build --profile vm0/default"
+            ssh "$REMOTE" "sudo ${BIN_DIR}/runner build --profile vm0/default"
             echo "=== Done deploying to ${HOST} ==="
           }
 
@@ -1616,7 +1617,7 @@ jobs:
 
             # Generate runner.yaml with real preview URL (no build needed, uses cached hashes)
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "${BIN_DIR}/runner config \
+            ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
               --profile vm0/default \
               --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
               --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
@@ -1630,11 +1631,11 @@ jobs:
             # Stop any existing service from a previous run (e.g., re-run after test failure).
             # Ignore errors if not running.
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "${BIN_DIR}/runner service stop --name ${RUNNER_NAME}" 2>/dev/null || true
+            ssh "$REMOTE" "sudo ${BIN_DIR}/runner service stop --name ${RUNNER_NAME}" 2>/dev/null || true
 
             # Start as systemd transient service
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "${BIN_DIR}/runner service start \
+            ssh "$REMOTE" "sudo ${BIN_DIR}/runner service start \
               --name ${RUNNER_NAME} \
               --config ${RUNNER_DIR}/runner.yaml \
               --env VERCEL_AUTOMATION_BYPASS_SECRET=${VERCEL_BYPASS} \
@@ -1643,7 +1644,7 @@ jobs:
             # Health check — wait for runner startup, then verify
             sleep 5
             # shellcheck disable=SC2029
-            ssh "$REMOTE" "${BIN_DIR}/runner doctor --name ${RUNNER_NAME}"
+            ssh "$REMOTE" "sudo ${BIN_DIR}/runner doctor --name ${RUNNER_NAME}"
             echo "=== Runner started on ${HOST} ==="
           }
 

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1502,6 +1502,7 @@ jobs:
             # Clean previous run artifacts and upload runner (guests are embedded)
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} ${RUNNER_DIR} && sudo mkdir -p ${BIN_DIR}"
+            # shellcheck disable=SC2029
             < "${TARGET_DIR}/runner" ssh "$REMOTE" "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner"
 
             # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles)

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1502,9 +1502,7 @@ jobs:
             # Clean previous run artifacts and upload runner (guests are embedded)
             # shellcheck disable=SC2029
             ssh "$REMOTE" "sudo rm -rf ${BIN_DIR} ${RUNNER_DIR} && sudo mkdir -p ${BIN_DIR}"
-            scp "${TARGET_DIR}/runner" "${REMOTE}:/tmp/runner-upload-${RUNNER_NAME}"
-            # shellcheck disable=SC2029
-            ssh "$REMOTE" "sudo mv /tmp/runner-upload-${RUNNER_NAME} ${BIN_DIR}/runner && sudo chmod 755 ${BIN_DIR}/runner"
+            < "${TARGET_DIR}/runner" ssh "$REMOTE" "sudo install -m 755 /dev/stdin ${BIN_DIR}/runner"
 
             # Clean up old rootfs/snapshots, keep the 6 most recent (3 deploys × 2 profiles)
             # shellcheck disable=SC2029

--- a/ansible/playbooks/cleanup-crates-runner.yml
+++ b/ansible/playbooks/cleanup-crates-runner.yml
@@ -13,9 +13,10 @@
 
 - name: Cleanup Crates Runner
   hosts: all
+  become: true
 
   vars:
-    base_dir: "{{ ansible_facts['env']['HOME'] }}/.vm0-runner"
+    base_dir: /var/lib/vm0-runner
     bin_dir: "{{ base_dir }}/bin/{{ job_ref }}"
 
   tasks:
@@ -28,54 +29,44 @@
     - name: Stop persistent service upgrade-a
       command: systemctl stop vm0-runner-{{ job_ref }}-upgrade-a.service
       ignore_errors: true
-      become: true
 
     - name: Disable persistent service upgrade-a
       command: systemctl disable vm0-runner-{{ job_ref }}-upgrade-a.service
       ignore_errors: true
-      become: true
 
     - name: Remove unit file upgrade-a
       file:
         path: /etc/systemd/system/vm0-runner-{{ job_ref }}-upgrade-a.service
         state: absent
-      become: true
 
     - name: Stop persistent service upgrade-b
       command: systemctl stop vm0-runner-{{ job_ref }}-upgrade-b.service
       ignore_errors: true
-      become: true
 
     - name: Disable persistent service upgrade-b
       command: systemctl disable vm0-runner-{{ job_ref }}-upgrade-b.service
       ignore_errors: true
-      become: true
 
     - name: Remove unit file upgrade-b
       file:
         path: /etc/systemd/system/vm0-runner-{{ job_ref }}-upgrade-b.service
         state: absent
-      become: true
 
     - name: Stop transient service exec
       command: systemctl stop vm0-runner-{{ job_ref }}-exec.service
       ignore_errors: true
-      become: true
 
     - name: Stop transient service balloon
       command: systemctl stop vm0-runner-{{ job_ref }}-balloon.service
       ignore_errors: true
-      become: true
 
     - name: Stop transient service cancel
       command: systemctl stop vm0-runner-{{ job_ref }}-cancel.service
       ignore_errors: true
-      become: true
 
     - name: Reload systemd daemon
       command: systemctl daemon-reload
       ignore_errors: true
-      become: true
 
     - name: Remove directories
       file:

--- a/ansible/playbooks/cleanup-turbo-runner.yml
+++ b/ansible/playbooks/cleanup-turbo-runner.yml
@@ -13,9 +13,10 @@
 
 - name: Cleanup Turbo Runner
   hosts: all
+  become: true
 
   vars:
-    base_dir: "{{ ansible_facts['env']['HOME'] }}/.vm0-runner"
+    base_dir: /var/lib/vm0-runner
     bin_dir: "{{ base_dir }}/bin/{{ job_ref }}"
     runner_dir: "{{ base_dir }}/runners/{{ job_ref }}"
 
@@ -36,7 +37,6 @@
       command: systemctl stop {{ item }}
       loop: "{{ running_services.stdout_lines | default([]) }}"
       ignore_errors: true
-      become: true
 
     - name: Remove binary directory
       file:

--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -19,13 +19,14 @@
 - name: Deploy VM0 Runner
   hosts: all
   serial: 1
+  become: true
 
   vars:
     runner_name: "v{{ runner_version }}"
     runner_group: vm0/production
-    home_dir: "{{ ansible_facts['env']['HOME'] }}"
-    bin_dir: "{{ home_dir }}/.vm0-runner/bin/{{ runner_name }}"
-    runner_dir: "{{ home_dir }}/.vm0-runner/runners/{{ runner_name }}"
+    data_dir: /var/lib/vm0-runner
+    bin_dir: "{{ data_dir }}/bin/{{ runner_name }}"
+    runner_dir: "{{ data_dir }}/runners/{{ runner_name }}"
 
   tasks:
     # ========================================

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -41,13 +41,12 @@
       when: docker_check.rc != 0
       become: true
 
-    - name: Add user to docker, kvm and disk groups
+    - name: Add user to docker and kvm groups
       user:
         name: "{{ ansible_user }}"
         groups:
           - docker
           - kvm
-          - disk
         append: true
       become: true
       register: group_change
@@ -60,7 +59,7 @@
 
     # When groups change, the current SSH session still has the old group list.
     # Reset the connection so subsequent playbooks (deploy-runner) pick up the
-    # new membership (e.g. 'disk' group needed to open /dev/loopN).
+    # new membership.
     - name: Reset SSH connection to pick up new group membership
       meta: reset_connection
       when: group_change.changed

--- a/crates/block-cow/src/blockdev.rs
+++ b/crates/block-cow/src/blockdev.rs
@@ -6,7 +6,7 @@ use crate::error::Result;
 /// Get the size of a block device in 512-byte sectors.
 pub fn get_size_sectors(device: &Path) -> Result<u64> {
     let dev_str = device.to_string_lossy();
-    let stdout = command::sudo("blockdev", &["--getsz", &dev_str])?;
+    let stdout = command::run("blockdev", &["--getsz", &dev_str])?;
     stdout.parse::<u64>().map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,

--- a/crates/block-cow/src/command.rs
+++ b/crates/block-cow/src/command.rs
@@ -2,18 +2,14 @@ use std::process::Command;
 
 use crate::error::{BlockCowError, Result};
 
-/// Run a command via sudo and return stdout on success, or a descriptive error
+/// Run a command directly and return stdout on success, or a descriptive error
 /// on failure.
 ///
 /// All block-cow operations (`losetup`, `dmsetup`, `blockdev`) require root
-/// privileges. The runner process runs as a regular user and delegates
-/// privilege escalation to sudo.
-pub fn sudo(program: &str, args: &[&str]) -> Result<String> {
-    let mut sudo_args = vec![program];
-    sudo_args.extend_from_slice(args);
-
-    let output = Command::new("sudo")
-        .args(&sudo_args)
+/// privileges. The runner process runs as root.
+pub fn run(program: &str, args: &[&str]) -> Result<String> {
+    let output = Command::new(program)
+        .args(args)
         .output()
         .map_err(|e| BlockCowError::Command {
             program: program.to_owned(),

--- a/crates/block-cow/src/device.rs
+++ b/crates/block-cow/src/device.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use tracing::{info, warn};
+use tracing::{info, trace, warn};
 
 use crate::dmsetup;
 use crate::error::{BlockCowError, Result};
@@ -357,8 +357,28 @@ impl CowDevice {
         // so we don't contribute to the open count.  Firecracker may still
         // have the device open — if so, dmsetup remove fails with EBUSY
         // and we bail to let the caller retry.
+        //
+        // After dropping the holder fd, udev may briefly open the device to
+        // rescan metadata. Retry a few times with a short sleep to let
+        // transient openers (udev) release their references.
         self._device_holder = None;
-        dmsetup::remove(&cow_name)?;
+        let mut remove_ok = false;
+        for attempt in 0..3u32 {
+            match dmsetup::remove(&cow_name) {
+                Ok(()) => {
+                    remove_ok = true;
+                    break;
+                }
+                Err(e) if attempt < 2 => {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    trace!(id = self.id, attempt, error = %e, "dmsetup remove busy, retrying");
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        if !remove_ok {
+            return Err(BlockCowError::NotActive(self.id.clone()));
+        }
 
         // Snapshot is gone — past the point of no return. Mark inactive
         // so Drop won't retry the (already succeeded) snapshot removal.

--- a/crates/block-cow/src/device.rs
+++ b/crates/block-cow/src/device.rs
@@ -362,22 +362,15 @@ impl CowDevice {
         // rescan metadata. Retry a few times with a short sleep to let
         // transient openers (udev) release their references.
         self._device_holder = None;
-        let mut remove_ok = false;
         for attempt in 0..3u32 {
             match dmsetup::remove(&cow_name) {
-                Ok(()) => {
-                    remove_ok = true;
-                    break;
-                }
+                Ok(()) => break,
                 Err(e) if attempt < 2 => {
                     std::thread::sleep(std::time::Duration::from_millis(50));
                     trace!(id = self.id, attempt, error = %e, "dmsetup remove busy, retrying");
                 }
                 Err(e) => return Err(e),
             }
-        }
-        if !remove_ok {
-            return Err(BlockCowError::NotActive(self.id.clone()));
         }
 
         // Snapshot is gone — past the point of no return. Mark inactive

--- a/crates/block-cow/src/dmsetup.rs
+++ b/crates/block-cow/src/dmsetup.rs
@@ -11,8 +11,7 @@ const DM_DEV_PREFIX: &str = "/dev/mapper/";
 /// `chunk_size` is in 512-byte sectors (e.g. 8 = 4KB chunks).
 /// Returns the path to the created snapshot device.
 ///
-/// The device is created as `root:disk 0660`; the runner user must be
-/// in the `disk` group to open it.
+/// The device is created as `root:disk 0660`.
 pub fn create_snapshot(
     name: &str,
     origin: &str,
@@ -21,7 +20,7 @@ pub fn create_snapshot(
     chunk_size: u32,
 ) -> Result<PathBuf> {
     let table = format!("0 {sectors} snapshot {origin} {cow_device} P {chunk_size}");
-    command::sudo("dmsetup", &["create", name, "--table", &table])?;
+    command::run("dmsetup", &["create", name, "--table", &table])?;
     Ok(PathBuf::from(format!("{DM_DEV_PREFIX}{name}")))
 }
 
@@ -30,12 +29,12 @@ pub fn create_snapshot(
 /// Format: `<used_sectors>/<total_sectors> <metadata_sectors>`
 /// Useful for debugging COW usage after sandbox execution.
 pub fn status(name: &str) -> Result<String> {
-    command::sudo("dmsetup", &["status", name])
+    command::run("dmsetup", &["status", name])
 }
 
 /// Remove a device mapper target.
 pub fn remove(name: &str) -> Result<()> {
-    command::sudo("dmsetup", &["remove", name])?;
+    command::run("dmsetup", &["remove", name])?;
     Ok(())
 }
 
@@ -46,6 +45,6 @@ pub fn remove(name: &str) -> Result<()> {
 /// their file descriptors.  Returns success immediately even if the
 /// device is currently busy.
 pub fn remove_deferred(name: &str) -> Result<()> {
-    command::sudo("dmsetup", &["remove", "--force", name])?;
+    command::run("dmsetup", &["remove", "--force", name])?;
     Ok(())
 }

--- a/crates/block-cow/src/losetup.rs
+++ b/crates/block-cow/src/losetup.rs
@@ -88,7 +88,7 @@ pub fn attach(file_path: &Path, read_only: bool) -> Result<LoopDevice> {
     }
     args.push(&file_str);
 
-    let stdout = command::sudo("losetup", &args)?;
+    let stdout = command::run("losetup", &args)?;
     let path = PathBuf::from(&stdout);
 
     // Open immediately so the loop's kernel open count is > 0 before
@@ -112,7 +112,7 @@ pub fn attach(file_path: &Path, read_only: bool) -> Result<LoopDevice> {
 /// Detach a loop device by path (low-level helper).
 fn detach_by_path(loop_device: &Path) -> Result<()> {
     let dev_str = loop_device.to_string_lossy();
-    command::sudo("losetup", &["--detach", &dev_str])?;
+    command::run("losetup", &["--detach", &dev_str])?;
     Ok(())
 }
 

--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -240,6 +240,9 @@ create_ext4() {
   EXT4_MOUNT_DIR=$(mktemp -d)
   sudo mount -o loop "$TMP_ROOTFS_PATH" "$EXT4_MOUNT_DIR"
   sudo cp -a "$EXTRACT_DIR"/. "$EXT4_MOUNT_DIR"/
+  # mktemp -d creates 0700 directories; cp -a preserves that on the ext4
+  # root inode, locking out non-root users. Restore standard 0755.
+  sudo chmod 755 "$EXT4_MOUNT_DIR"
   sudo umount "$EXT4_MOUNT_DIR"
   rmdir "$EXT4_MOUNT_DIR"
   EXT4_MOUNT_DIR=""

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -83,6 +83,14 @@ sudo mount -o loop,ro "$ROOTFS" "$MOUNT_DIR"
 
 errors=()
 
+# Check root directory permissions (must be 0755 for non-root users to access files)
+root_perms=$(stat -c%a "$MOUNT_DIR")
+if [[ "$root_perms" == "755" ]]; then
+  echo "  root dir: 0755"
+else
+  errors+=("root directory has permissions 0${root_perms}, expected 0755")
+fi
+
 # Check python3
 if [[ -f "${MOUNT_DIR}/usr/bin/python3" ]]; then
   echo "  python3: found"

--- a/crates/runner/src/ca.rs
+++ b/crates/runner/src/ca.rs
@@ -7,7 +7,7 @@ const CA_CERT: &str = "mitmproxy-ca-cert.pem";
 const CA_KEY: &str = "mitmproxy-ca-key.pem";
 const CA_COMBINED: &str = "mitmproxy-ca.pem";
 
-/// Ensure CA certificates exist at `~/.vm0-runner/ca/`.
+/// Ensure CA certificates exist at `/var/lib/vm0-runner/ca/`.
 ///
 /// Generates a self-signed RSA 4096 CA via openssl if the files don't
 /// already exist. Idempotent — safe to call on every build.

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -30,7 +30,7 @@ pub struct ConfigArgs {
     /// Runner group in vm0/<name> format (e.g. "vm0/production")
     #[arg(long)]
     group: String,
-    /// Runner directory name (under ~/.vm0-runner/runners/)
+    /// Runner directory name (under /var/lib/vm0-runner/runners/)
     #[arg(long)]
     runner_dirname: String,
 

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -1511,7 +1511,7 @@ mod tests {
 
         let w = Warning::OrphanLoopDevice {
             device: "/dev/loop5".into(),
-            backing: "/home/ubuntu/.vm0-runner/workspaces/x/cow.img".into(),
+            backing: "/var/lib/vm0-runner/workspaces/x/cow.img".into(),
             runner_name: Some("pr-100-1".into()),
         };
         assert!(w.to_string().contains("/dev/loop5"));
@@ -1680,9 +1680,7 @@ Major, minor:      253, 0";
     #[test]
     fn extract_sandbox_id_from_cow_path() {
         assert_eq!(
-            extract_sandbox_id(
-                "/home/ubuntu/.vm0-runner/runners/pr-123/workspaces/abc-def/cow.img"
-            ),
+            extract_sandbox_id("/var/lib/vm0-runner/runners/pr-123/workspaces/abc-def/cow.img"),
             Some("abc-def")
         );
     }
@@ -1691,7 +1689,7 @@ Major, minor:      253, 0";
     fn extract_sandbox_id_from_deleted_cow_path() {
         assert_eq!(
             extract_sandbox_id(
-                "/home/ubuntu/.vm0-runner/runners/pr-123/workspaces/abc-def/cow.img (deleted)"
+                "/var/lib/vm0-runner/runners/pr-123/workspaces/abc-def/cow.img (deleted)"
             ),
             Some("abc-def")
         );
@@ -1700,7 +1698,7 @@ Major, minor:      253, 0";
     #[test]
     fn extract_sandbox_id_returns_none_for_rootfs() {
         assert_eq!(
-            extract_sandbox_id("/home/ubuntu/.vm0-runner/rootfs/560c452/rootfs.ext4"),
+            extract_sandbox_id("/var/lib/vm0-runner/rootfs/560c452/rootfs.ext4"),
             None
         );
     }

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -865,8 +865,8 @@ async fn detect_block_cow_orphans(
     let mut warnings = Vec::new();
 
     // 1. List dm-snapshot targets
-    let dm_output = match tokio::process::Command::new("sudo")
-        .args(["dmsetup", "ls", "--target", "snapshot"])
+    let dm_output = match tokio::process::Command::new("dmsetup")
+        .args(["ls", "--target", "snapshot"])
         .output()
         .await
     {
@@ -932,8 +932,8 @@ async fn detect_block_cow_orphans(
         }
     };
 
-    let loop_output = match tokio::process::Command::new("sudo")
-        .args(["losetup", "-a"])
+    let loop_output = match tokio::process::Command::new("losetup")
+        .args(["-a"])
         .output()
         .await
     {
@@ -1020,8 +1020,8 @@ fn find_runner_for_dm_target(
 
 /// Check if a dm target has no openers (`Open count: 0` in `dmsetup info`).
 async fn dm_target_has_no_openers(name: &str) -> bool {
-    let output = match tokio::process::Command::new("sudo")
-        .args(["dmsetup", "info", name])
+    let output = match tokio::process::Command::new("dmsetup")
+        .args(["info", name])
         .output()
         .await
     {
@@ -1093,8 +1093,8 @@ fn runner_is_alive(runner_name: &Option<String>, reports: &[RunnerReport]) -> bo
 
 /// Check if a loop device still exists.
 async fn loop_device_exists(device: &str) -> bool {
-    match tokio::process::Command::new("sudo")
-        .args(["losetup", device])
+    match tokio::process::Command::new("losetup")
+        .args([device])
         .output()
         .await
     {

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -474,7 +474,7 @@ async fn gc_versions(home: &HomePaths, dry_run: bool) -> RunnerResult<Vec<String
 ///
 /// Two passes:
 /// 1. Remove orphaned `cow-*` dm-snapshot targets (`dmsetup remove`).
-/// 2. Detach orphaned loop devices backing files under `~/.vm0-runner/`.
+/// 2. Detach orphaned loop devices backing files under `/var/lib/vm0-runner/`.
 ///    After pass 1 frees dm-snapshot references, previously-busy COW
 ///    loop devices become detachable.  Since Linux v3.7, `losetup -d`
 ///    sets AUTOCLEAR instead of returning EBUSY, but the device stays
@@ -503,7 +503,7 @@ fn gc_block_cow(dry_run: bool) -> RunnerResult<u32> {
     // Pass 2: detach orphaned loop devices.
     //
     // Try to detach ALL loop devices whose backing files are under
-    // `~/.vm0-runner/`.  Since Linux v3.7, `losetup -d` on a busy
+    // `/var/lib/vm0-runner/`.  Since Linux v3.7, `losetup -d` on a busy
     // device sets LO_FLAGS_AUTOCLEAR and returns success instead of
     // EBUSY, so the call may "succeed" for active devices too.
     // This is harmless — the device stays alive as long as any
@@ -563,10 +563,10 @@ pub(crate) fn parse_dm_targets(output: &Option<String>, prefix: &str) -> Vec<Str
         .collect()
 }
 
-/// Run `sudo dmsetup ls --target <target_type>`, return stdout if successful.
+/// Run `dmsetup ls --target <target_type>`, return stdout if successful.
 fn dmsetup_ls(target_type: &str) -> Option<String> {
-    let output = match std::process::Command::new("sudo")
-        .args(["dmsetup", "ls", "--target", target_type])
+    let output = match std::process::Command::new("dmsetup")
+        .args(["ls", "--target", target_type])
         .output()
     {
         Ok(o) => o,
@@ -583,10 +583,10 @@ fn dmsetup_ls(target_type: &str) -> Option<String> {
     Some(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-/// Run `sudo dmsetup remove <name>`, return true if successful.
+/// Run `dmsetup remove <name>`, return true if successful.
 fn dmsetup_remove(name: &str) -> bool {
-    match std::process::Command::new("sudo")
-        .args(["dmsetup", "remove", name])
+    match std::process::Command::new("dmsetup")
+        .args(["remove", name])
         .output()
     {
         Ok(o) if o.status.success() => true,
@@ -602,12 +602,9 @@ fn dmsetup_remove(name: &str) -> bool {
     }
 }
 
-/// Run `sudo losetup -a`, return stdout if successful.
+/// Run `losetup -a`, return stdout if successful.
 fn losetup_list() -> Option<String> {
-    let output = match std::process::Command::new("sudo")
-        .args(["losetup", "-a"])
-        .output()
-    {
+    let output = match std::process::Command::new("losetup").args(["-a"]).output() {
         Ok(o) => o,
         Err(e) => {
             warn!(error = %e, "losetup not available — skipping loop device GC");
@@ -653,10 +650,10 @@ pub(crate) fn parse_losetup<'a>(
         .collect()
 }
 
-/// Run `sudo losetup -d <device>`, return true if successful.
+/// Run `losetup -d <device>`, return true if successful.
 fn losetup_detach(device: &str) -> bool {
-    match std::process::Command::new("sudo")
-        .args(["losetup", "-d", device])
+    match std::process::Command::new("losetup")
+        .args(["-d", device])
         .output()
     {
         Ok(o) if o.status.success() => true,

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -523,7 +523,18 @@ fn gc_block_cow(dry_run: bool) -> RunnerResult<u32> {
         Ok(paths) => format!("{}/", paths.root().display()),
         Err(_) => return Ok(removed),
     };
-    for (loop_dev, backing) in parse_losetup(&losetup_list(), &runner_root) {
+    let losetup_output = losetup_list();
+    // Also clean up loop devices from the legacy data directory
+    // ($HOME/.vm0-runner/) left behind by older runner versions.
+    let legacy_root = format!(
+        "{}/.vm0-runner/",
+        std::env::var("HOME").unwrap_or_else(|_| "/root".to_owned())
+    );
+    let mut loops = parse_losetup(&losetup_output, &runner_root);
+    if legacy_root != runner_root {
+        loops.extend(parse_losetup(&losetup_output, &legacy_root));
+    }
+    for (loop_dev, backing) in loops {
         if dry_run {
             info!(loop_dev, backing, "would detach orphaned loop device");
             removed += 1;
@@ -631,7 +642,7 @@ pub(crate) fn parse_losetup<'a>(
     stdout
         .lines()
         .filter_map(|line| {
-            // Format: "/dev/loop5: [0048]:2345 (/home/ubuntu/.vm0-runner/...)"
+            // Format: "/dev/loop5: [0048]:2345 (/var/lib/vm0-runner/...)"
             let (dev, rest) = line.split_once(':')?;
             let start = rest.find('(')?;
             let end = rest.rfind(')')?;
@@ -1298,46 +1309,43 @@ mod tests {
     #[test]
     fn parse_losetup_filters_by_prefix() {
         let output = Some(
-            "/dev/loop1: [0048]:123 (/home/ubuntu/.vm0-runner/rootfs/abc/rootfs.ext4)\n\
-             /dev/loop5: [0048]:456 (/home/ubuntu/.vm0-runner/runners/pr-123/workspaces/xxx/cow.img)\n\
+            "/dev/loop1: [0048]:123 (/var/lib/vm0-runner/rootfs/abc/rootfs.ext4)\n\
+             /dev/loop5: [0048]:456 (/var/lib/vm0-runner/runners/pr-123/workspaces/xxx/cow.img)\n\
              /dev/loop0: [0048]:789 (/var/lib/snapd/snaps/amazon-ssm-agent_11798.snap)\n"
                 .to_string(),
         );
-        let pairs = parse_losetup(&output, "/home/ubuntu/.vm0-runner/");
+        let pairs = parse_losetup(&output, "/var/lib/vm0-runner/");
         assert_eq!(pairs.len(), 2);
         assert_eq!(pairs[0].0, "/dev/loop1");
-        assert_eq!(
-            pairs[0].1,
-            "/home/ubuntu/.vm0-runner/rootfs/abc/rootfs.ext4"
-        );
+        assert_eq!(pairs[0].1, "/var/lib/vm0-runner/rootfs/abc/rootfs.ext4");
         assert_eq!(pairs[1].0, "/dev/loop5");
     }
 
     #[test]
     fn parse_losetup_deleted_files() {
         let output = Some(
-            "/dev/loop347: [0048]:123 (/home/ubuntu/.vm0-runner/runners/pr-6521/workspaces/xxx/cow.img (deleted))\n"
+            "/dev/loop347: [0048]:123 (/var/lib/vm0-runner/runners/pr-6521/workspaces/xxx/cow.img (deleted))\n"
                 .to_string(),
         );
-        let pairs = parse_losetup(&output, "/home/ubuntu/.vm0-runner/");
+        let pairs = parse_losetup(&output, "/var/lib/vm0-runner/");
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].0, "/dev/loop347");
         assert_eq!(
             pairs[0].1,
-            "/home/ubuntu/.vm0-runner/runners/pr-6521/workspaces/xxx/cow.img (deleted)"
+            "/var/lib/vm0-runner/runners/pr-6521/workspaces/xxx/cow.img (deleted)"
         );
     }
 
     #[test]
     fn parse_losetup_none() {
-        let pairs = parse_losetup(&None, "/home/ubuntu/.vm0-runner/");
+        let pairs = parse_losetup(&None, "/var/lib/vm0-runner/");
         assert!(pairs.is_empty());
     }
 
     #[test]
     fn parse_losetup_empty() {
         let output = Some(String::new());
-        let pairs = parse_losetup(&output, "/home/ubuntu/.vm0-runner/");
+        let pairs = parse_losetup(&output, "/var/lib/vm0-runner/");
         assert!(pairs.is_empty());
     }
 }

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -21,7 +21,7 @@ const CANCEL_GRACE: Duration = Duration::from_secs(10);
 
 #[derive(Args)]
 pub struct SubmitArgs {
-    /// Runner group name (writes job to ~/.vm0-runner/groups/{group}/)
+    /// Runner group name (writes job to /var/lib/vm0-runner/groups/{group}/)
     #[arg(long)]
     group: String,
     /// Job prompt

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -132,7 +132,6 @@ fn generate_unit_file(
     unit: &str,
     exe_path: &Path,
     config_path: &Path,
-    user: &str,
     env_vars: &[String],
     local: bool,
 ) -> String {
@@ -155,7 +154,6 @@ Restart=on-failure
 RestartSec=5
 KillSignal=SIGTERM
 TimeoutStopSec=300
-User={user}
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier={unit}
@@ -181,10 +179,9 @@ fn validate_env_vars(vars: &[String]) -> RunnerResult<()> {
     Ok(())
 }
 
-/// Run `sudo systemctl <args>` and check exit status.
+/// Run `systemctl <args>` and check exit status.
 async fn run_systemctl(args: &[&str]) -> RunnerResult<()> {
-    let status = tokio::process::Command::new("sudo")
-        .arg("systemctl")
+    let status = tokio::process::Command::new("systemctl")
         .args(args)
         .status()
         .await
@@ -197,35 +194,10 @@ async fn run_systemctl(args: &[&str]) -> RunnerResult<()> {
     Ok(())
 }
 
-/// Write a unit file via `sudo tee`.
-async fn write_unit_file(path: &Path, content: &str) -> RunnerResult<()> {
-    use tokio::io::AsyncWriteExt;
-
-    let mut child = tokio::process::Command::new("sudo")
-        .args(["tee", &path.to_string_lossy()])
-        .stdin(std::process::Stdio::piped())
-        .stdout(std::process::Stdio::null())
-        .spawn()
-        .map_err(|e| RunnerError::Internal(format!("spawn sudo tee: {e}")))?;
-
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(content.as_bytes())
-            .await
-            .map_err(|e| RunnerError::Internal(format!("write unit file: {e}")))?;
-    }
-
-    let status = child
-        .wait()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("wait sudo tee: {e}")))?;
-    if !status.success() {
-        return Err(RunnerError::Internal(format!(
-            "sudo tee {} failed: {status}",
-            path.display()
-        )));
-    }
-    Ok(())
+/// Write a unit file directly (running as root).
+fn write_unit_file(path: &Path, content: &str) -> RunnerResult<()> {
+    std::fs::write(path, content)
+        .map_err(|e| RunnerError::Internal(format!("write {}: {e}", path.display())))
 }
 
 /// Check whether a systemd unit is active (running or activating).
@@ -274,17 +246,14 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
     let config_path = resolve_config_path(&args.config)?;
     let exe_path =
         std::env::current_exe().map_err(|e| RunnerError::Internal(format!("current_exe: {e}")))?;
-    let uid = nix::unistd::getuid();
 
     let unit_arg = format!("--unit={unit}");
     let desc_arg = format!("--description=VM0 Runner ({unit})");
     let syslog_arg = format!("--property=SyslogIdentifier={unit}");
-    let uid_arg = format!("--uid={uid}");
-    let mut cmd = tokio::process::Command::new("sudo");
+    let mut cmd = tokio::process::Command::new("systemd-run");
     cmd.args([
-        "systemd-run",
-        &unit_arg,
-        &desc_arg,
+        &*unit_arg,
+        &*desc_arg,
         "--property=Type=exec",
         "--property=Restart=on-failure",
         "--property=RestartSec=5",
@@ -292,8 +261,7 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
         "--property=StandardError=journal",
         "--property=KillSignal=SIGTERM",
         "--property=TimeoutStopSec=300",
-        &syslog_arg,
-        &uid_arg,
+        &*syslog_arg,
     ]);
     for entry in &args.env {
         cmd.arg(format!("--setenv={entry}"));
@@ -339,17 +307,11 @@ async fn install(args: ServiceRunArgs) -> RunnerResult<()> {
     let config_path = resolve_config_path(&args.config)?;
     let exe_path =
         std::env::current_exe().map_err(|e| RunnerError::Internal(format!("current_exe: {e}")))?;
-    let uid = nix::unistd::getuid();
-    let user = nix::unistd::User::from_uid(uid)
-        .map_err(|e| RunnerError::Internal(format!("lookup user for uid {uid}: {e}")))?
-        .ok_or_else(|| RunnerError::Internal(format!("no user found for uid {uid}")))?
-        .name;
 
-    let unit_content =
-        generate_unit_file(&unit, &exe_path, &config_path, &user, &args.env, args.local);
+    let unit_content = generate_unit_file(&unit, &exe_path, &config_path, &args.env, args.local);
     let upath = unit_file_path(&unit);
 
-    write_unit_file(&upath, &unit_content).await?;
+    write_unit_file(&upath, &unit_content)?;
 
     run_systemctl(&["daemon-reload"]).await?;
     let svc = format!("{unit}.service");
@@ -372,11 +334,9 @@ pub(crate) async fn uninstall_service(suffix: &str) -> RunnerResult<()> {
 
     // Remove the unit file if it exists.
     let upath = unit_file_path(&unit);
-    let rm_result = tokio::process::Command::new("sudo")
-        .args(["rm", "-f", &upath.to_string_lossy()])
-        .status()
-        .await;
-    if let Err(e) = rm_result {
+    if upath.exists()
+        && let Err(e) = std::fs::remove_file(&upath)
+    {
         warn!(unit = %unit, error = %e, "failed to remove unit file");
     }
 
@@ -494,17 +454,16 @@ mod tests {
     fn test_generate_unit_file() {
         let content = generate_unit_file(
             "vm0-runner-v0.1.0",
-            Path::new("/home/ubuntu/.vm0-runner/bin/v0.1.0/vm0-runner"),
+            Path::new("/var/lib/vm0-runner/bin/v0.1.0/vm0-runner"),
             Path::new("/home/ubuntu/runner.yaml"),
-            "ubuntu",
             &[],
             false,
         );
         assert!(content.contains("Description=VM0 Runner (vm0-runner-v0.1.0)"));
         assert!(content.contains(
-            "ExecStart=\"/home/ubuntu/.vm0-runner/bin/v0.1.0/vm0-runner\" start --config \"/home/ubuntu/runner.yaml\"\n"
+            "ExecStart=\"/var/lib/vm0-runner/bin/v0.1.0/vm0-runner\" start --config \"/home/ubuntu/runner.yaml\"\n"
         ));
-        assert!(content.contains("User=ubuntu"));
+        assert!(!content.contains("User="));
         assert!(content.contains("SyslogIdentifier=vm0-runner-v0.1.0"));
         assert!(content.contains("Restart=on-failure"));
         assert!(content.contains("TimeoutStopSec=300"));
@@ -523,9 +482,8 @@ mod tests {
         ];
         let content = generate_unit_file(
             "vm0-runner-v0.1.0",
-            Path::new("/home/ubuntu/.vm0-runner/bin/v0.1.0/vm0-runner"),
+            Path::new("/var/lib/vm0-runner/bin/v0.1.0/vm0-runner"),
             Path::new("/home/ubuntu/runner.yaml"),
-            "ubuntu",
             &env,
             false,
         );
@@ -541,14 +499,13 @@ mod tests {
             "vm0-runner-v0.1.0",
             Path::new("/opt/my runner/vm0-runner"),
             Path::new("/opt/my config/runner.yaml"),
-            "deploy-user",
             &[],
             false,
         );
         assert!(content.contains(
             "ExecStart=\"/opt/my runner/vm0-runner\" start --config \"/opt/my config/runner.yaml\""
         ));
-        assert!(content.contains("User=deploy-user"));
+        assert!(!content.contains("User="));
     }
 
     #[test]
@@ -557,7 +514,6 @@ mod tests {
             "vm0-runner-v0.1.0",
             Path::new("/usr/bin/runner"),
             Path::new("/etc/runner.yaml"),
-            "ubuntu",
             &[],
             true,
         );

--- a/crates/runner/src/cmd/setup.rs
+++ b/crates/runner/src/cmd/setup.rs
@@ -25,7 +25,6 @@ pub async fn run_setup() -> RunnerResult<()> {
     download_mitmdump(&paths, arch).await?;
     check_system_ca_bundle()?;
     check_kvm();
-    check_disk_group();
 
     if !missing_required.is_empty() {
         return Err(RunnerError::Config(format!(
@@ -463,25 +462,6 @@ fn check_system_ca_bundle() -> RunnerResult<()> {
             "system CA bundle not found at {SYSTEM_CA_BUNDLE} — \
              install ca-certificates: sudo apt install ca-certificates"
         )))
-    }
-}
-
-/// Check that the current user is in the `disk` group, required to open
-/// loop devices and dm devices (`root:disk 0660`) without sudo.
-fn check_disk_group() {
-    let output = std::process::Command::new("id").arg("-Gn").output();
-    match output {
-        Ok(o) if o.status.success() => {
-            let groups = String::from_utf8_lossy(&o.stdout);
-            if groups.split_whitespace().any(|g| g == "disk") {
-                tracing::info!("[OK] user is in disk group");
-            } else {
-                tracing::warn!("user is not in disk group — run: sudo usermod -aG disk $USER");
-            }
-        }
-        _ => {
-            tracing::warn!("could not check group membership");
-        }
     }
 }
 

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -237,7 +237,7 @@ mod tests {
         dir: &std::path::Path,
         profiles: &[(&str, Option<&str>)], // (rootfs_hash, snapshot_hash)
     ) -> HomePaths {
-        let home = HomePaths::with_root(dir.join(".vm0-runner"));
+        let home = HomePaths::with_root(dir.join("vm0-runner"));
         for &(rootfs_hash, snapshot_hash) in profiles {
             let rootfs = RootfsPaths::new(&home, rootfs_hash).rootfs();
             tokio::fs::create_dir_all(rootfs.parent().unwrap())

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -436,10 +436,7 @@ fn dmesg_indicates_oom(stdout: &str) -> bool {
 /// blocking if sudo hangs.
 async fn check_host_oom(pid: u32) -> bool {
     let result = tokio::time::timeout(Duration::from_secs(5), async {
-        tokio::process::Command::new("sudo")
-            .args(["-n", "dmesg"])
-            .output()
-            .await
+        tokio::process::Command::new("dmesg").output().await
     })
     .await;
     match result {
@@ -447,11 +444,11 @@ async fn check_host_oom(pid: u32) -> bool {
             host_dmesg_indicates_oom(&String::from_utf8_lossy(&out.stdout), pid)
         }
         Ok(Ok(out)) => {
-            warn!(pid, exit_code = out.status.code(), "sudo dmesg failed");
+            warn!(pid, exit_code = out.status.code(), "dmesg failed");
             false
         }
         Ok(Err(e)) => {
-            warn!(pid, error = %e, "failed to run sudo dmesg for OOM check");
+            warn!(pid, error = %e, "failed to run dmesg for OOM check");
             false
         }
         Err(_) => {

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -2,7 +2,7 @@
 //! and write matching entries to per-run network JSONL files.
 //!
 //! The iptables rule added by `sandbox-fc` logs non-TCP packets with prefix
-//! `VM0:<peer_ip>:`. This module tails `sudo dmesg -w`, parses those entries,
+//! `VM0:<peer_ip>:`. This module tails `dmesg -w`, parses those entries,
 //! looks up the network log path via an in-memory IP map, and appends a
 //! JSON line matching the format used by the mitmproxy addon.
 
@@ -45,7 +45,7 @@ impl KmsgHandle {
     }
 }
 
-/// Spawn a background async task that tails `sudo dmesg -w` and writes
+/// Spawn a background async task that tails `dmesg -w` and writes
 /// network log entries. Returns a handle; call [`KmsgHandle::stop`] during
 /// shutdown so the tokio runtime can exit cleanly.
 pub fn spawn(ip_log_map: IpLogMap) -> KmsgHandle {
@@ -59,20 +59,17 @@ pub fn spawn(ip_log_map: IpLogMap) -> KmsgHandle {
     KmsgHandle { cancel, task }
 }
 
-/// Async loop that reads kernel log messages via `sudo dmesg -w`.
+/// Async loop that reads kernel log messages via `dmesg -w`.
 ///
-/// Reading `/dev/kmsg` directly requires `CAP_SYSLOG` when
-/// `dmesg_restrict=1` (the default on hardened systems). Using `sudo dmesg -w`
-/// avoids this while following new messages in real-time. The runner already
-/// uses sudo for iptables and other privileged operations.
+/// The runner runs as root, so `dmesg -w` works directly without sudo.
 ///
 /// `dmesg -w` outputs lines like:
 /// ```text
 /// [12345.678901] VM0:10.200.0.2:IN=vm0-ve-00-00 OUT=ens5 SRC=10.200.0.2 DST=8.8.8.8 LEN=64 ...
 /// ```
 async fn run_async(ip_log_map: &IpLogMap, cancel: CancellationToken) -> std::io::Result<()> {
-    let mut child = tokio::process::Command::new("sudo")
-        .args(["dmesg", "-w"])
+    let mut child = tokio::process::Command::new("dmesg")
+        .args(["-w"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
@@ -82,7 +79,7 @@ async fn run_async(ip_log_map: &IpLogMap, cancel: CancellationToken) -> std::io:
         .take()
         .ok_or_else(|| std::io::Error::other("failed to capture dmesg stdout"))?;
 
-    // Log stderr in a background task so sudo errors are visible.
+    // Log stderr in a background task so dmesg errors are visible.
     // Shares the cancel token so the task exits promptly on shutdown,
     // dropping the pipe and allowing the orphaned dmesg to receive SIGPIPE.
     if let Some(stderr) = child.stderr.take() {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -186,8 +186,8 @@ async fn main() -> ExitCode {
         .add_integration(sentry::integrations::panic::PanicIntegration::default()),
     ));
 
-    if nix::unistd::getuid().is_root() {
-        eprintln!("error: runner must not be run as root (it calls sudo internally as needed)");
+    if !nix::unistd::getuid().is_root() {
+        eprintln!("error: runner must be run as root");
         return ExitCode::FAILURE;
     }
 

--- a/crates/runner/src/paths.rs
+++ b/crates/runner/src/paths.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
-use crate::error::{RunnerError, RunnerResult};
+use crate::error::RunnerResult;
 
 /// Update a directory's mtime to now, so `runner gc` treats it as recently used.
 pub fn touch_mtime(dir: &Path) {
@@ -51,17 +51,15 @@ impl RunnerPaths {
     }
 }
 
-/// Paths rooted at ~/.vm0-runner/.
+/// Paths rooted at /var/lib/vm0-runner/.
 pub struct HomePaths {
     root: PathBuf,
 }
 
 impl HomePaths {
     pub fn new() -> RunnerResult<Self> {
-        let home = std::env::var("HOME")
-            .map_err(|_| RunnerError::Config("HOME environment variable not set".into()))?;
         Ok(Self {
-            root: PathBuf::from(home).join(".vm0-runner"),
+            root: PathBuf::from("/var/lib/vm0-runner"),
         })
     }
 

--- a/crates/runner/src/process.rs
+++ b/crates/runner/src/process.rs
@@ -317,8 +317,7 @@ mod tests {
 
     #[test]
     fn parse_runner_start_cmdline() {
-        let cmdline =
-            "/home/ubuntu/.vm0-runner/bin/runner start --config /data/runner-01/config.yaml";
+        let cmdline = "/var/lib/vm0-runner/bin/runner start --config /data/runner-01/config.yaml";
         let (config, subcmd) = parse_runner_cmdline(cmdline).unwrap();
         assert_eq!(config, Path::new("/data/runner-01/config.yaml"));
         assert_eq!(subcmd, "start");
@@ -367,7 +366,7 @@ mod tests {
     #[test]
     fn is_firecracker_full_path() {
         assert!(is_firecracker_cmdline(
-            "/home/ubuntu/.vm0-runner/firecracker/v1.10.1/firecracker --no-api"
+            "/var/lib/vm0-runner/firecracker/v1.10.1/firecracker --no-api"
         ));
     }
 

--- a/crates/sandbox-fc/src/command.rs
+++ b/crates/sandbox-fc/src/command.rs
@@ -9,21 +9,9 @@ pub struct CommandError {
     pub detail: String,
 }
 
-/// How a command should be executed.
-#[derive(Debug, Clone, Copy)]
-pub enum Privilege {
-    /// Prefix with `sudo`.
-    Sudo,
-    /// Run as the current user.
-    User,
-}
-
-/// Format a human-readable display string for a direct command invocation.
-fn format_command_display(program: &str, args: &[&str], privilege: Privilege) -> String {
-    let mut parts = Vec::with_capacity(args.len() + 2);
-    if matches!(privilege, Privilege::Sudo) {
-        parts.push("sudo");
-    }
+/// Format a human-readable display string for a command invocation.
+fn format_command_display(program: &str, args: &[&str]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
     parts.push(program);
     parts.extend_from_slice(args);
     parts.join(" ")
@@ -33,22 +21,11 @@ fn format_command_display(program: &str, args: &[&str], privilege: Privilege) ->
 ///
 /// Invokes the program binary directly with the given arguments.
 /// Returns trimmed stdout on success.
-pub async fn exec(
-    program: &str,
-    args: &[&str],
-    privilege: Privilege,
-) -> Result<String, CommandError> {
-    let cmd_display = format_command_display(program, args, privilege);
+pub async fn exec(program: &str, args: &[&str]) -> Result<String, CommandError> {
+    let cmd_display = format_command_display(program, args);
     trace!(command = %cmd_display, "exec");
 
-    let output = match privilege {
-        Privilege::Sudo => {
-            let mut sudo_args = vec![program];
-            sudo_args.extend_from_slice(args);
-            Command::new("sudo").args(&sudo_args).output().await
-        }
-        Privilege::User => Command::new(program).args(args).output().await,
-    };
+    let output = Command::new(program).args(args).output().await;
 
     let output = output.map_err(|e| CommandError {
         command: cmd_display.clone(),
@@ -68,18 +45,11 @@ pub async fn exec(
 }
 
 /// Execute a command, ignoring any errors.
-pub async fn exec_ignore_errors(program: &str, args: &[&str], privilege: Privilege) {
-    let cmd_display = format_command_display(program, args, privilege);
+pub async fn exec_ignore_errors(program: &str, args: &[&str]) {
+    let cmd_display = format_command_display(program, args);
     trace!(command = %cmd_display, "exec_ignore_errors");
 
-    let output = match privilege {
-        Privilege::Sudo => {
-            let mut sudo_args = vec![program];
-            sudo_args.extend_from_slice(args);
-            Command::new("sudo").args(&sudo_args).output().await
-        }
-        Privilege::User => Command::new(program).args(args).output().await,
-    };
+    let output = Command::new(program).args(args).output().await;
 
     match output {
         Ok(o) if !o.status.success() => {
@@ -98,34 +68,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn format_command_display_user() {
-        let display = format_command_display("mkfs.ext4", &["-F", "-q", "/tmp/x"], Privilege::User);
+    fn format_command_display_simple() {
+        let display = format_command_display("mkfs.ext4", &["-F", "-q", "/tmp/x"]);
         assert_eq!(display, "mkfs.ext4 -F -q /tmp/x");
-    }
-
-    #[test]
-    fn format_command_display_sudo() {
-        let display = format_command_display("kill", &["-9", "1234"], Privilege::Sudo);
-        assert_eq!(display, "sudo kill -9 1234");
     }
 
     #[tokio::test]
     async fn exec_returns_trimmed_stdout() {
-        let output = exec("echo", &["hello"], Privilege::User).await.unwrap();
+        let output = exec("echo", &["hello"]).await.unwrap();
         assert_eq!(output, "hello");
     }
 
     #[tokio::test]
     async fn exec_captures_multiline_output() {
-        let output = exec("printf", &["a\\nb\\nc"], Privilege::User)
-            .await
-            .unwrap();
+        let output = exec("printf", &["a\\nb\\nc"]).await.unwrap();
         assert_eq!(output, "a\nb\nc");
     }
 
     #[tokio::test]
     async fn exec_returns_error_on_failure() {
-        let err = exec("false", &[], Privilege::User).await.unwrap_err();
+        let err = exec("false", &[]).await.unwrap_err();
         assert!(
             err.command.contains("false"),
             "command was: {}",
@@ -135,7 +97,7 @@ mod tests {
 
     #[tokio::test]
     async fn exec_error_contains_stderr() {
-        let err = exec("bash", &["-c", "echo oops >&2; exit 1"], Privilege::User)
+        let err = exec("bash", &["-c", "echo oops >&2; exit 1"])
             .await
             .unwrap_err();
         assert!(err.detail.contains("oops"), "detail was: {}", err.detail);
@@ -143,19 +105,17 @@ mod tests {
 
     #[tokio::test]
     async fn exec_passes_multiple_args() {
-        let output = exec("printf", &["%s-%s", "a", "b"], Privilege::User)
-            .await
-            .unwrap();
+        let output = exec("printf", &["%s-%s", "a", "b"]).await.unwrap();
         assert_eq!(output, "a-b");
     }
 
     #[tokio::test]
     async fn exec_ignore_errors_does_not_panic_on_failure() {
-        exec_ignore_errors("false", &[], Privilege::User).await;
+        exec_ignore_errors("false", &[]).await;
     }
 
     #[tokio::test]
     async fn exec_ignore_errors_does_not_panic_on_success() {
-        exec_ignore_errors("true", &[], Privilege::User).await;
+        exec_ignore_errors("true", &[]).await;
     }
 }

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -526,17 +526,21 @@ fn acquire_pool_lock(locks: &LockPaths) -> Result<(u32, Flock<File>)> {
         // Open for writing without O_CREAT first, fall back to create.
         // This avoids EACCES from fs.protected_regular=2 on sticky-bit
         // directories (/var/lock) when the file is owned by another user.
-        let file = File::options()
-            .write(true)
-            .open(&path)
-            .or_else(|_| {
-                File::options()
-                    .write(true)
-                    .create(true)
-                    .truncate(false)
-                    .open(&path)
-            })
-            .map_err(|e| NetworkError::LockOpen(format!("{}: {e}", path.display())))?;
+        let file = match File::options().write(true).open(&path).or_else(|_| {
+            File::options()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&path)
+        }) {
+            Ok(f) => f,
+            Err(e) => {
+                // Skip indices whose lock file is inaccessible (e.g. owned by
+                // another user under fs.protected_regular=2).
+                warn!(index, %e, "cannot open pool lock, skipping index");
+                continue;
+            }
+        };
         match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
             Ok(lock) => {
                 info!(index, "acquired pool index lock");

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -523,11 +523,19 @@ async fn flush_conntrack(peer_ip: &str) {
 fn acquire_pool_lock(locks: &LockPaths) -> Result<(u32, Flock<File>)> {
     for index in 0..MAX_POOLS {
         let path = locks.netns_pool(index);
+        // Open for writing without O_CREAT first, fall back to create.
+        // This avoids EACCES from fs.protected_regular=2 on sticky-bit
+        // directories (/var/lock) when the file is owned by another user.
         let file = File::options()
             .write(true)
-            .create(true)
-            .truncate(false)
             .open(&path)
+            .or_else(|_| {
+                File::options()
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(&path)
+            })
             .map_err(|e| NetworkError::LockOpen(format!("{}: {e}", path.display())))?;
         match Flock::lock(file, FlockArg::LockExclusiveNonblock) {
             Ok(lock) => {

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -40,7 +40,7 @@ use std::fs::File;
 use nix::fcntl::{Flock, FlockArg};
 use tracing::{error, info, trace, warn};
 
-use crate::command::{Privilege, exec, exec_ignore_errors};
+use crate::command::{exec, exec_ignore_errors};
 use crate::paths::LockPaths;
 
 use super::GUEST_NETWORK;
@@ -165,15 +165,15 @@ fn is_hex2(s: &str) -> bool {
 // Network operations
 // ---------------------------------------------------------------------------
 
-/// Shorthand: run `sudo ip <args>`, discard stdout.
-async fn sudo_ip(args: &[&str]) -> Result<()> {
-    exec("ip", args, Privilege::Sudo).await?;
+/// Shorthand: run `ip <args>`, discard stdout.
+async fn exec_ip(args: &[&str]) -> Result<()> {
+    exec("ip", args).await?;
     Ok(())
 }
 
-/// Shorthand: run `sudo iptables <args>`, discard stdout.
-async fn sudo_iptables(args: &[&str]) -> Result<()> {
-    exec("iptables", args, Privilege::Sudo).await?;
+/// Shorthand: run `iptables <args>`, discard stdout.
+async fn exec_iptables(args: &[&str]) -> Result<()> {
+    exec("iptables", args).await?;
     Ok(())
 }
 
@@ -184,17 +184,17 @@ async fn create_netns_with_tap(
     tap_mac: &str,
     gateway_ip_with_prefix: &str,
 ) -> Result<()> {
-    sudo_ip(&["netns", "add", ns_name]).await?;
-    sudo_ip(&[
+    exec_ip(&["netns", "add", ns_name]).await?;
+    exec_ip(&[
         "netns", "exec", ns_name, "ip", "tuntap", "add", tap_name, "mode", "tap",
     ])
     .await?;
     // Set a fixed MAC so guest ARP cache from snapshots stays valid after restore.
-    sudo_ip(&[
+    exec_ip(&[
         "netns", "exec", ns_name, "ip", "link", "set", tap_name, "address", tap_mac,
     ])
     .await?;
-    sudo_ip(&[
+    exec_ip(&[
         "netns",
         "exec",
         ns_name,
@@ -206,11 +206,11 @@ async fn create_netns_with_tap(
         tap_name,
     ])
     .await?;
-    sudo_ip(&[
+    exec_ip(&[
         "netns", "exec", ns_name, "ip", "link", "set", tap_name, "up",
     ])
     .await?;
-    sudo_ip(&["netns", "exec", ns_name, "ip", "link", "set", "lo", "up"]).await?;
+    exec_ip(&["netns", "exec", ns_name, "ip", "link", "set", "lo", "up"]).await?;
     Ok(())
 }
 
@@ -223,7 +223,7 @@ async fn setup_veth_pair(
 ) -> Result<()> {
     let peer_cidr = format!("{peer_ip}/30");
     let host_cidr = format!("{host_ip}/30");
-    sudo_ip(&[
+    exec_ip(&[
         "link",
         "add",
         host_device,
@@ -236,7 +236,7 @@ async fn setup_veth_pair(
         name,
     ])
     .await?;
-    sudo_ip(&[
+    exec_ip(&[
         "netns",
         "exec",
         name,
@@ -248,7 +248,7 @@ async fn setup_veth_pair(
         PEER_DEVICE,
     ])
     .await?;
-    sudo_ip(&[
+    exec_ip(&[
         "netns",
         "exec",
         name,
@@ -259,8 +259,8 @@ async fn setup_veth_pair(
         "up",
     ])
     .await?;
-    sudo_ip(&["addr", "add", &host_cidr, "dev", host_device]).await?;
-    sudo_ip(&["link", "set", host_device, "up"]).await?;
+    exec_ip(&["addr", "add", &host_cidr, "dev", host_device]).await?;
+    exec_ip(&["link", "set", host_device, "up"]).await?;
     Ok(())
 }
 
@@ -272,11 +272,11 @@ async fn setup_namespace_routing(
     prefix_len: u8,
 ) -> Result<()> {
     let src = format!("{gateway_ip}/{prefix_len}");
-    sudo_ip(&[
+    exec_ip(&[
         "netns", "exec", name, "ip", "route", "add", "default", "via", host_ip,
     ])
     .await?;
-    sudo_ip(&[
+    exec_ip(&[
         "netns",
         "exec",
         name,
@@ -293,7 +293,7 @@ async fn setup_namespace_routing(
         "MASQUERADE",
     ])
     .await?;
-    sudo_ip(&[
+    exec_ip(&[
         "netns",
         "exec",
         name,
@@ -313,7 +313,7 @@ async fn setup_host_iptables(
     default_iface: &str,
 ) -> Result<()> {
     let src = format!("{peer_ip}/30");
-    sudo_iptables(&[
+    exec_iptables(&[
         "-t",
         "nat",
         "-A",
@@ -330,7 +330,7 @@ async fn setup_host_iptables(
         name,
     ])
     .await?;
-    sudo_iptables(&[
+    exec_iptables(&[
         "-A",
         "FORWARD",
         "-i",
@@ -345,7 +345,7 @@ async fn setup_host_iptables(
         name,
     ])
     .await?;
-    sudo_iptables(&[
+    exec_iptables(&[
         "-A",
         "FORWARD",
         "-i",
@@ -375,7 +375,7 @@ async fn setup_host_iptables(
 async fn add_proxy_redirect_rule(name: &str, peer_ip: &str, proxy_port: u16) -> Result<()> {
     let src = format!("{peer_ip}/30");
     let port_str = proxy_port.to_string();
-    sudo_iptables(&[
+    exec_iptables(&[
         "-t",
         "nat",
         "-A",
@@ -410,7 +410,7 @@ async fn add_proxy_redirect_rule(name: &str, peer_ip: &str, proxy_port: u16) -> 
 async fn add_non_tcp_log_rule(name: &str, peer_ip: &str) -> Result<()> {
     let src = format!("{peer_ip}/30");
     let prefix = format!("VM0:{peer_ip}:");
-    sudo_iptables(&[
+    exec_iptables(&[
         "-I",
         "FORWARD",
         "1",
@@ -441,7 +441,7 @@ async fn add_non_tcp_log_rule(name: &str, peer_ip: &str) -> Result<()> {
 }
 
 async fn get_default_interface() -> Result<String> {
-    let result = exec("ip", &["route", "get", "8.8.8.8"], Privilege::User).await?;
+    let result = exec("ip", &["route", "get", "8.8.8.8"]).await?;
     let iface = result
         .split_whitespace()
         .skip_while(|&w| w != "dev")
@@ -460,7 +460,7 @@ async fn delete_iptables_rules_by_comment(comment: &str) {
 }
 
 async fn delete_iptables_from_table(table: &str, comment: &str) {
-    let output = match exec("iptables-save", &["-t", table], Privilege::Sudo).await {
+    let output = match exec("iptables-save", &["-t", table]).await {
         Ok(output) => output,
         Err(e) => {
             trace!(table, error = %e, "failed to read iptables rules, skipping cleanup");
@@ -479,7 +479,7 @@ async fn delete_iptables_from_table(table: &str, comment: &str) {
         let rule = line.replacen("-A ", "-D ", 1);
         let mut args: Vec<&str> = vec!["-t", table];
         args.extend(rule.split_whitespace().map(|t| t.trim_matches('"')));
-        exec_ignore_errors("iptables", &args, Privilege::Sudo).await;
+        exec_ignore_errors("iptables", &args).await;
     }
 }
 
@@ -490,8 +490,8 @@ async fn delete_namespace_resources(ns_name: &str, host_device: &str) {
     let del_link_args = ["link", "del", host_device];
     let del_ns_args = ["netns", "del", ns_name];
     tokio::join!(
-        exec_ignore_errors("ip", &del_link_args, Privilege::Sudo),
-        exec_ignore_errors("ip", &del_ns_args, Privilege::Sudo),
+        exec_ignore_errors("ip", &del_link_args),
+        exec_ignore_errors("ip", &del_ns_args),
     );
     info!(name = %ns_name, "namespace deleted");
 }
@@ -506,8 +506,8 @@ async fn flush_conntrack(peer_ip: &str) {
     let src_args = ["-D", "-s", peer_ip];
     let dst_args = ["-D", "-d", peer_ip];
     tokio::join!(
-        exec_ignore_errors("conntrack", &src_args, Privilege::Sudo),
-        exec_ignore_errors("conntrack", &dst_args, Privilege::Sudo),
+        exec_ignore_errors("conntrack", &src_args),
+        exec_ignore_errors("conntrack", &dst_args),
     );
 }
 
@@ -590,7 +590,7 @@ impl NetnsPool {
         info!(index, buffer = BUFFER_SIZE, "initializing namespace pool");
 
         // Enable host-level IP forwarding (idempotent, needed once per host).
-        exec("sysctl", &["-w", "net.ipv4.ip_forward=1"], Privilege::Sudo).await?;
+        exec("sysctl", &["-w", "net.ipv4.ip_forward=1"]).await?;
 
         // Clean up orphaned namespaces from a previous process that used the same index.
         cleanup_namespaces_by_index(index).await;
@@ -1059,7 +1059,7 @@ pub async fn cleanup_namespaces_by_index(index: u32) {
     delete_iptables_rules_by_comment(&prefix).await;
 
     // 2. Discover and delete any remaining namespaces (+ their veth devices).
-    let Ok(output) = exec("ip", &["netns", "list"], Privilege::Sudo).await else {
+    let Ok(output) = exec("ip", &["netns", "list"]).await else {
         error!(index, "failed to list namespaces for cleanup");
         return;
     };

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 
 use sandbox::SandboxError;
 
-use crate::command::{Privilege, exec};
 use crate::config::SnapshotConfig;
 use crate::paths::RUNTIME_DIR;
 
@@ -20,7 +19,7 @@ pub(crate) struct PrerequisiteConfig<'a> {
 
 /// Verify that all required system prerequisites are present.
 ///
-/// Checks firecracker binary, kernel, rootfs, `/dev/kvm`, network commands, and sudo access.
+/// Checks firecracker binary, kernel, rootfs, `/dev/kvm`, and network commands.
 /// Collects all failures and returns them in a single `BackendNotAvailable` error.
 pub(crate) async fn check_prerequisites(
     config: &PrerequisiteConfig<'_>,
@@ -38,8 +37,7 @@ pub(crate) async fn check_prerequisites(
     }
     check_kvm(&mut errors);
     check_required_commands(config, &mut errors);
-    check_sudo(&mut errors).await;
-    ensure_runtime_dir(&mut errors).await;
+    ensure_runtime_dir(&mut errors);
 
     if errors.is_empty() {
         Ok(())
@@ -90,34 +88,15 @@ fn check_required_commands(_config: &PrerequisiteConfig<'_>, errors: &mut Vec<St
     }
 }
 
-async fn check_sudo(errors: &mut Vec<String>) {
-    if exec("sudo", &["-n", "true"], Privilege::User)
-        .await
-        .is_err()
-    {
-        errors.push(
-            "root/sudo access required for network configuration; \
-             please run with sudo or configure sudoers"
-                .to_string(),
-        );
-    }
-}
-
 /// Create `/run/vm0` with mode 1777 (world-writable + sticky bit) if needed.
 ///
-/// `/run` is a tmpfs owned by root, so we need sudo. The operation is idempotent.
-async fn ensure_runtime_dir(errors: &mut Vec<String>) {
-    if exec("mkdir", &["-p", RUNTIME_DIR], Privilege::Sudo)
-        .await
-        .is_err()
-    {
-        errors.push(format!("failed to create {RUNTIME_DIR}"));
+/// Running as root, we can create and chmod directly without sudo.
+fn ensure_runtime_dir(errors: &mut Vec<String>) {
+    if let Err(e) = std::fs::create_dir_all(RUNTIME_DIR) {
+        errors.push(format!("failed to create {RUNTIME_DIR}: {e}"));
         return;
     }
-    if exec("chmod", &["1777", RUNTIME_DIR], Privilege::Sudo)
-        .await
-        .is_err()
-    {
-        errors.push(format!("failed to chmod {RUNTIME_DIR}"));
+    if let Err(e) = std::fs::set_permissions(RUNTIME_DIR, std::fs::Permissions::from_mode(0o1777)) {
+        errors.push(format!("failed to chmod {RUNTIME_DIR}: {e}"));
     }
 }

--- a/crates/sandbox-fc/src/process.rs
+++ b/crates/sandbox-fc/src/process.rs
@@ -1,5 +1,3 @@
-use crate::command::CommandError;
-
 /// Kill the entire process group of `child` via `killpg(SIGKILL)`.
 ///
 /// Requires the child to have been spawned with `process_group(0)` so that its
@@ -12,19 +10,4 @@ pub(crate) fn kill_process_group(child: &tokio::process::Child) {
         let pgid = nix::unistd::Pid::from_raw(pid);
         let _ = nix::sys::signal::killpg(pgid, nix::sys::signal::Signal::SIGKILL);
     }
-}
-
-/// Get the current username via `getuid()`.
-pub(crate) fn current_username() -> Result<String, CommandError> {
-    let uid = nix::unistd::getuid();
-    let user = nix::unistd::User::from_uid(uid)
-        .map_err(|e| CommandError {
-            command: "getuid".into(),
-            detail: format!("lookup uid {uid}: {e}"),
-        })?
-        .ok_or_else(|| CommandError {
-            command: "getuid".into(),
-            detail: format!("no user for uid {uid}"),
-        })?;
-    Ok(user.name)
 }

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -189,22 +189,16 @@ impl FirecrackerSandbox {
             .await
             .map_err(|e| SandboxError::StartFailed(format!("write config: {e}")))?;
 
-        let username = current_username()?;
         let api_sock = self.sock_paths.api_sock();
 
-        // Use `exec` to replace the bash process with firecracker, keeping all
-        // descendants in the same process group so `kill_process_group` can
-        // reach them (same pattern as start_from_snapshot and snapshot.rs).
-        let inner_cmd =
-            r#"exec ip netns exec "$1" sudo -u "$2" "$3" --config-file "$4" --api-sock "$5""#;
-
-        let mut child = tokio::process::Command::new("sudo")
-            .args(["bash", "-c", inner_cmd, "_"])
-            .arg(&self.network.name) // $1
-            .arg(&username) // $2
-            .arg(&self.factory_config.binary_path) // $3
-            .arg(self.sandbox_paths.config()) // $4
-            .arg(&api_sock) // $5
+        let mut child = tokio::process::Command::new("ip")
+            .args(["netns", "exec"])
+            .arg(&self.network.name)
+            .arg(&self.factory_config.binary_path)
+            .args(["--config-file"])
+            .arg(self.sandbox_paths.config())
+            .args(["--api-sock"])
+            .arg(&api_sock)
             .current_dir(self.sandbox_paths.workspace())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
@@ -253,8 +247,6 @@ impl FirecrackerSandbox {
             .snapshot
             .as_ref()
             .ok_or_else(|| SandboxError::StartFailed("missing snapshot config".into()))?;
-
-        let username = current_username()?;
 
         // Ensure bind mount target directories exist.
         tokio::fs::create_dir_all(&snapshot.vsock_bind_dir)
@@ -306,18 +298,17 @@ impl FirecrackerSandbox {
         // namespace (e.g. from a crashed snapshot creation).
         // `test -e || touch` creates the file only if missing (first use
         // or after manual cleanup), never deleting an existing one.
-        let inner_cmd = r#"umount "$4" 2>/dev/null; test -e "$4" || touch "$4"; mount --bind "$1" "$2" && mount --bind "$3" "$4" && exec ip netns exec "$5" sudo -u "$6" "$7" --api-sock "$8""#;
+        let inner_cmd = r#"umount "$4" 2>/dev/null; test -e "$4" || touch "$4"; mount --bind "$1" "$2" && mount --bind "$3" "$4" && exec ip netns exec "$5" "$6" --api-sock "$7""#;
 
-        let mut child = tokio::process::Command::new("sudo")
-            .args(["unshare", "--mount", "bash", "-c", inner_cmd, "_"])
+        let mut child = tokio::process::Command::new("unshare")
+            .args(["--mount", "bash", "-c", inner_cmd, "_"])
             .arg(self.sock_paths.vsock_dir()) // $1
             .arg(&snapshot.vsock_bind_dir) // $2
             .arg(cow_device_path) // $3
             .arg(&snapshot.drive_bind_path) // $4
             .arg(&self.network.name) // $5
-            .arg(&username) // $6
-            .arg(&self.factory_config.binary_path) // $7
-            .arg(&api_sock) // $8
+            .arg(&self.factory_config.binary_path) // $6
+            .arg(&api_sock) // $7
             .current_dir(self.sandbox_paths.workspace())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
@@ -455,11 +446,6 @@ fn monitor_process(
             }
         });
     }
-}
-
-/// Get the current username via `getuid()`.
-fn current_username() -> sandbox::Result<String> {
-    crate::process::current_username().map_err(|e| SandboxError::StartFailed(e.to_string()))
 }
 
 #[async_trait]

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -15,7 +15,6 @@ use crate::factory::{InvariantConfig, config_hash};
 use crate::network::{NetnsPool, NetnsPoolConfig};
 use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 use crate::prerequisites;
-use crate::process;
 use crate::process::kill_process_group;
 
 /// Timeout for waiting for the Firecracker API socket after process spawn.
@@ -83,10 +82,10 @@ pub async fn create_snapshot(
         .cow_device_bind()
         .display()
         .to_string();
-    command::exec_ignore_errors("umount", &[stale_bind.as_str()], command::Privilege::Sudo).await;
+    command::exec_ignore_errors("umount", &[stale_bind.as_str()]).await;
 
     let output_str = config.output_dir.display().to_string();
-    command::exec_ignore_errors("rm", &["-rf", &output_str], command::Privilege::Sudo).await;
+    command::exec_ignore_errors("rm", &["-rf", &output_str]).await;
     tokio::fs::create_dir_all(&work).await?;
 
     // Socket directory under /run, keyed by config id so concurrent builds don't collide.
@@ -196,28 +195,19 @@ async fn run_snapshot_workflow(
         .await
         .map_err(|e| SnapshotError::Setup(format!("mkdir sock dir: {e}")))?;
     let api_sock = sock_paths.api_sock();
-    let username = process::current_username().map_err(|e| SnapshotError::Setup(e.to_string()))?;
-
     info!(
         netns = %network.name,
         binary = %config.binary_path.display(),
         api_sock = %api_sock.display(),
-        user = %username,
         "spawning firecracker"
     );
 
-    // Use `exec` to replace the bash process with firecracker, keeping all
-    // descendants in the same process group so `kill_process_group` can
-    // reach them.  Without `exec`, `sudo` creates a new process group for
-    // the inner `sudo -u` child, which escapes `killpg` and becomes orphan.
-    let inner_cmd = r#"exec ip netns exec "$1" sudo -u "$2" "$3" --api-sock "$4""#;
-
-    let mut child = tokio::process::Command::new("sudo")
-        .args(["bash", "-c", inner_cmd, "_"])
-        .arg(&network.name) // $1
-        .arg(&username) // $2
-        .arg(&config.binary_path) // $3
-        .arg(&api_sock) // $4
+    let mut child = tokio::process::Command::new("ip")
+        .args(["netns", "exec"])
+        .arg(&network.name)
+        .arg(&config.binary_path)
+        .args(["--api-sock"])
+        .arg(&api_sock)
         .current_dir(paths.workspace())
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
@@ -276,12 +266,7 @@ async fn run_snapshot_workflow(
         let mut last_err = None;
         for attempt in 0..DESTROY_RETRIES {
             // Umount the bind mount first (may fail if FC still holds a ref).
-            command::exec_ignore_errors(
-                "umount",
-                &[drive_bind_str.as_str()],
-                command::Privilege::Sudo,
-            )
-            .await;
+            command::exec_ignore_errors("umount", &[drive_bind_str.as_str()]).await;
 
             match cow_device.destroy_keep_cow() {
                 Ok(()) => {
@@ -313,12 +298,7 @@ async fn run_snapshot_workflow(
         tokio::fs::rename(&cow_file, &output.cow()).await?;
     } else {
         // Error path: best-effort umount before Drop cleans up the device.
-        command::exec_ignore_errors(
-            "umount",
-            &[drive_bind_str.as_str()],
-            command::Privilege::Sudo,
-        )
-        .await;
+        command::exec_ignore_errors("umount", &[drive_bind_str.as_str()]).await;
     }
     // On error, cow_device is dropped → Drop calls destroy() (best-effort).
 
@@ -347,13 +327,9 @@ async fn run_with_firecracker(
     tokio::fs::write(&drive_bind, b"").await?;
     let cow_device_str = cow_device.device_path().display().to_string();
     let drive_bind_str = drive_bind.display().to_string();
-    command::exec(
-        "mount",
-        &["--bind", &cow_device_str, &drive_bind_str],
-        command::Privilege::Sudo,
-    )
-    .await
-    .map_err(|e| SnapshotError::Setup(format!("bind mount COW device: {e}")))?;
+    command::exec("mount", &["--bind", &cow_device_str, &drive_bind_str])
+        .await
+        .map_err(|e| SnapshotError::Setup(format!("bind mount COW device: {e}")))?;
 
     // 6. Configure VM via API (6 parallel PUT calls).
     let inv = InvariantConfig::new();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,7 +164,7 @@ sandbox:
 
 **Shared Read-Only Base**:
 - ext4 rootfs (~500MB-1GB)
-- Content-addressed: `~/.vm0-runner/rootfs/{hash}/rootfs.ext4`
+- Content-addressed: `/var/lib/vm0-runner/rootfs/{hash}/rootfs.ext4`
 - Shared across all VMs via dm-snapshot
 - Built from Dockerfile via `build-rootfs.sh`
 

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -79,7 +79,7 @@ cmd_deploy() {
   # Upload
   log "Deploying to $SSH_USER@$HOST..."
   ssh_cmd "sudo mkdir -p $REMOTE_BIN_DIR"
-  cat "$BINARY" | ssh_cmd "sudo tee $REMOTE_BIN_DIR/runner > /dev/null && sudo chmod 755 $REMOTE_BIN_DIR/runner"
+  cat "$BINARY" | ssh_cmd "sudo install -m 755 /dev/stdin $REMOTE_BIN_DIR/runner"
 
   # Setup (idempotent, downloads firecracker/kernel if missing)
   log "Running setup..."

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -33,9 +33,9 @@ RUNNER_GROUP="${RUNNER_DEFAULT_GROUP:?RUNNER_DEFAULT_GROUP not set in $ENV_FILE}
 # vm0/local-alice-macbook -> alice-macbook
 RUNNER_NAME="${RUNNER_GROUP##*/}"
 
-REMOTE_BIN_DIR=".vm0-runner/bin/${RUNNER_NAME}"
-RUNNER_BIN="~/$REMOTE_BIN_DIR/runner"
-RUNNER_DIR="~/.vm0-runner/runners/$RUNNER_NAME"
+REMOTE_BIN_DIR="/var/lib/vm0-runner/bin/${RUNNER_NAME}"
+RUNNER_BIN="sudo $REMOTE_BIN_DIR/runner"
+RUNNER_DIR="/var/lib/vm0-runner/runners/$RUNNER_NAME"
 
 CF_SSH="$SCRIPT_DIR/cf-ssh.sh"
 SSH_KEY="$PROJECT_ROOT/.certs/vm0-metal-local.pem"
@@ -78,8 +78,8 @@ cmd_deploy() {
 
   # Upload
   log "Deploying to $SSH_USER@$HOST..."
-  ssh_cmd "mkdir -p ~/$REMOTE_BIN_DIR"
-  cat "$BINARY" | ssh_cmd "cat > ~/$REMOTE_BIN_DIR/runner && chmod 755 ~/$REMOTE_BIN_DIR/runner"
+  ssh_cmd "sudo mkdir -p $REMOTE_BIN_DIR"
+  cat "$BINARY" | ssh_cmd "sudo tee $REMOTE_BIN_DIR/runner > /dev/null && sudo chmod 755 $REMOTE_BIN_DIR/runner"
 
   # Setup (idempotent, downloads firecracker/kernel if missing)
   log "Running setup..."
@@ -160,7 +160,7 @@ cmd_remove() {
   log "Removing runner $RUNNER_NAME from $HOST..."
 
   ssh_cmd "$RUNNER_BIN service stop --name $RUNNER_NAME 2>/dev/null || true"
-  ssh_cmd "rm -rf ~/$REMOTE_BIN_DIR $RUNNER_DIR"
+  ssh_cmd "sudo rm -rf $REMOTE_BIN_DIR $RUNNER_DIR"
 
   log "Done! Runner $RUNNER_NAME removed from $HOST"
 }


### PR DESCRIPTION
## Summary

Closes #7423

Switch the runner from "non-root + sudo internally" to "run as root". Same model as [e2b](https://github.com/e2b-dev/infra).

- **Require root** in `main.rs` — error if not root
- **Data dir** hardcoded to `/var/lib/vm0-runner` (FHS-compliant, consistent with Docker/containerd/kubelet)
- **Delete `Privilege` enum** and all sudo subprocess wrappers (~50 sudo calls per sandbox lifecycle eliminated)
- **Simplify firecracker spawn chain**: `sudo → bash → ip netns exec → sudo -u → firecracker` (5 processes) → `ip netns exec → firecracker` (2 processes)
- **Remove `current_username()`** — only used for `sudo -u`, no longer needed
- **Remove `check_disk_group`/`check_sudo`** from setup/prerequisites
- **Replace `sudo tee`/`sudo rm`** with direct fs operations in service.rs
- **Remove `User=`** from systemd unit template, `--uid` from `systemd-run`
- **Update ansible** playbooks with `become: true` and `/var/lib/vm0-runner` paths
- **Update CI** workflows with `sudo` prefix, new paths, and scp-via-tmp pattern
- **30 files changed, -458 lines, +253 lines** (net -205 lines)

## Test plan

- [ ] `cargo build` passes
- [ ] `cargo clippy` passes
- [ ] `cargo test` passes (693 tests, 0 failures)
- [ ] CI runner-benchmark job passes on metal host
- [ ] CI runner-exec/cancel/balloon/upgrade jobs pass on metal host
- [ ] Verify `ps aux | grep runner` shows root on metal host
- [ ] Verify `ps aux | grep firecracker` shows root on metal host

🤖 Generated with [Claude Code](https://claude.com/claude-code)