### PR TITLE
feat(firewalls): support vars templates in firewall auth headers

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -430,6 +430,7 @@ def _fetch_firewall_headers_sync(
     auth_headers: dict,
     sandbox_token: str,
     secret_connector_map: dict | None = None,
+    vars_map: dict | None = None,
 ) -> dict:
     """Synchronous helper — runs in a thread to avoid blocking the event loop."""
     api_url = get_api_url()
@@ -437,6 +438,8 @@ def _fetch_firewall_headers_sync(
     body: dict = {"encryptedSecrets": encrypted_secrets, "authHeaders": auth_headers}
     if secret_connector_map:
         body["secretConnectorMap"] = secret_connector_map
+    if vars_map:
+        body["vars"] = vars_map
     data = json.dumps(body).encode()
     req = urllib.request.Request(
         url,
@@ -458,6 +461,7 @@ async def fetch_firewall_headers(
     auth_headers: dict,
     sandbox_token: str,
     secret_connector_map: dict | None = None,
+    vars_map: dict | None = None,
 ) -> dict:
     """Resolve auth headers via server-side decryption.
 
@@ -472,6 +476,7 @@ async def fetch_firewall_headers(
         auth_headers,
         sandbox_token,
         secret_connector_map,
+        vars_map,
     )
 
 
@@ -496,6 +501,7 @@ async def get_firewall_headers(
     auth_headers: dict,
     sandbox_token: str,
     secret_connector_map: dict | None = None,
+    vars_map: dict | None = None,
 ) -> dict:
     """Get firewall auth headers with TTL-based caching.
 
@@ -527,7 +533,7 @@ async def get_firewall_headers(
                 return hit
 
         result = await fetch_firewall_headers(
-            encrypted_secrets, auth_headers, sandbox_token, secret_connector_map
+            encrypted_secrets, auth_headers, sandbox_token, secret_connector_map, vars_map
         )
         headers = result["headers"]
         resolved_secrets = result.get("resolvedSecrets", [])
@@ -556,6 +562,7 @@ async def handle_firewall_request(
     encrypted_secrets = vm_info.get("encryptedSecrets")
     auth_headers = api_entry.get("auth", {}).get("headers", {})
     secret_connector_map = vm_info.get("secretConnectorMap")
+    vars_map = vm_info.get("vars")
 
     # Store metadata upfront — shared across ALLOW/ERROR paths
     flow.metadata["firewall_base"] = firewall_base
@@ -586,7 +593,13 @@ async def handle_firewall_request(
 
     try:
         token_meta = await get_firewall_headers(
-            run_id, api_id, encrypted_secrets, auth_headers, sandbox_token, secret_connector_map
+            run_id,
+            api_id,
+            encrypted_secrets,
+            auth_headers,
+            sandbox_token,
+            secret_connector_map,
+            vars_map,
         )
     except Exception as e:
         ctx.log.error(f"[{run_id}] Firewall header fetch failed: {e}")

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -907,7 +907,7 @@ class TestGetFirewallHeaders:
 
         assert headers["headers"] == mock_headers
         assert headers["cache_hit"] is False
-        mock_fetch.assert_called_once_with(encrypted, auth_templates, "tok-xyz", None)
+        mock_fetch.assert_called_once_with(encrypted, auth_templates, "tok-xyz", None, None)
 
         # Verify the cache was populated
         cache_key = ("run-1", "https://api.github.com")

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -197,6 +197,7 @@ async fn run_sandbox(
         firewalls: None,
         encrypted_secrets: None,
         secret_connector_map: None,
+        vars: None,
     };
     if let Err(e) = mitm.register_vm(&source_ip, &registration).await {
         warn!(error = %e, "failed to register VM in proxy");

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -127,6 +127,7 @@ async fn execute_inner(
         firewalls: context.experimental_firewalls.as_deref(),
         encrypted_secrets: context.encrypted_secrets.as_deref(),
         secret_connector_map: context.secret_connector_map.as_ref(),
+        vars: context.vars.as_ref(),
     };
     if let Err(e) = config.registry.register_vm(&source_ip, &registration).await {
         warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -30,6 +30,7 @@ struct VmEntry {
     firewalls: Option<Vec<Firewall>>,
     encrypted_secrets: Option<String>,
     secret_connector_map: Option<HashMap<String, String>>,
+    vars: Option<HashMap<String, String>>,
 }
 
 /// Parameters for registering a VM in the proxy registry.
@@ -41,6 +42,7 @@ pub struct VmRegistration<'a> {
     pub firewalls: Option<&'a [Firewall]>,
     pub encrypted_secrets: Option<&'a str>,
     pub secret_connector_map: Option<&'a HashMap<String, String>>,
+    pub vars: Option<&'a HashMap<String, String>>,
 }
 
 /// Embedded mitmproxy addon script (compiled into the binary).
@@ -440,6 +442,7 @@ impl ProxyRegistryHandle {
                 firewalls,
                 encrypted_secrets: registration.encrypted_secrets.map(String::from),
                 secret_connector_map: registration.secret_connector_map.cloned(),
+                vars: registration.vars.cloned(),
             },
         );
         registry.updated_at = now;
@@ -516,6 +519,7 @@ mod tests {
                 firewalls: None,
                 encrypted_secrets: None,
                 secret_connector_map: None,
+                vars: None,
             },
         );
         write_registry(&registry_path, &registry).await.unwrap();
@@ -562,6 +566,7 @@ mod tests {
             firewalls: None,
             encrypted_secrets: None,
             secret_connector_map: None,
+            vars: None,
         };
         handle
             .register_vm("10.200.0.2", &registration)
@@ -581,6 +586,7 @@ mod tests {
             firewalls: None,
             encrypted_secrets: None,
             secret_connector_map: None,
+            vars: None,
         };
         handle
             .register_vm("10.200.0.2", &registration2)
@@ -633,6 +639,7 @@ mod tests {
                     firewalls: None,
                     encrypted_secrets: None,
                     secret_connector_map: None,
+                    vars: None,
                 };
                 h.register_vm(&ip, &registration).await.unwrap();
             });
@@ -692,6 +699,7 @@ mod tests {
             firewalls: Some(&firewall_entries),
             encrypted_secrets: None,
             secret_connector_map: None,
+            vars: None,
         };
         handle
             .register_vm("10.200.0.5", &registration)
@@ -757,6 +765,7 @@ mod tests {
             firewalls: None,
             encrypted_secrets: Some("iv_b64:tag_b64:data_b64"),
             secret_connector_map: None,
+            vars: None,
         };
         handle
             .register_vm("10.200.0.6", &registration)

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -37,9 +37,7 @@ pub struct ExecutionContext {
     // Deserialized for forward compatibility but not consumed by runner.
     #[serde(default, rename = "agentComposeVersionId")]
     pub _agent_compose_version_id: Option<String>,
-    // Vars are expanded into environment at compose time via ${{ vars.XXX }} templates.
-    // Not read by runner — tested via environment field instead.
-    #[allow(dead_code)]
+    // Vars are passed to the proxy registry for auth header template resolution.
     #[serde(default)]
     pub vars: Option<HashMap<String, String>>,
     // Checkpoint resume not yet implemented

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/__tests__/route.test.ts
@@ -211,6 +211,97 @@ describe("POST /api/webhooks/agent/firewall/auth", () => {
     });
   });
 
+  describe("Vars resolution", () => {
+    it("should resolve ${{ vars.X }} templates", async () => {
+      const encrypted = encryptTestSecrets({ TOKEN: "secret-value" });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              "X-User-Email": "${{ vars.USER_EMAIL }}",
+            },
+            vars: { USER_EMAIL: "user@example.com" },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers["X-User-Email"]).toBe("user@example.com");
+      // Vars should NOT appear in resolvedSecrets
+      expect(data.resolvedSecrets).toEqual([]);
+    });
+
+    it("should resolve mixed secrets and vars in the same header", async () => {
+      const encrypted = encryptTestSecrets({ API_TOKEN: "my-token" });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization:
+                "Basic ${{ vars.USERNAME }}:${{ secrets.API_TOKEN }}",
+            },
+            vars: { USERNAME: "admin" },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers.Authorization).toBe("Basic admin:my-token");
+      expect(data.resolvedSecrets).toEqual(["API_TOKEN"]);
+    });
+
+    it("should resolve missing var to empty string", async () => {
+      const encrypted = encryptTestSecrets({ TOKEN: "value" });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              "X-Missing": "${{ vars.NONEXISTENT }}",
+            },
+            vars: {},
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers["X-Missing"]).toBe("");
+    });
+
+    it("should work without vars field (backward compatible)", async () => {
+      const encrypted = encryptTestSecrets({
+        GITHUB_TOKEN: "ghp_test_token_123",
+      });
+
+      const response = await POST(
+        makeRequest(
+          {
+            encryptedSecrets: encrypted,
+            authHeaders: {
+              Authorization: "Bearer ${{ secrets.GITHUB_TOKEN }}",
+            },
+          },
+          testToken,
+        ),
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.headers.Authorization).toBe("Bearer ghp_test_token_123");
+    });
+  });
+
   describe("Token refresh with secretConnectorMap", () => {
     const NOTION_TOKEN_URL = "https://api.notion.com/v1/oauth/token";
 

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -18,12 +18,16 @@ const bodySchema = z.object({
   encryptedSecrets: z.string().min(1),
   authHeaders: z.record(z.string(), z.string()),
   secretConnectorMap: z.record(z.string(), z.string()).optional(),
+  vars: z.record(z.string(), z.string()).optional(),
 });
 
 const log = logger("webhook:firewall-auth");
 
 /** Matches ${{ secrets.KEY_NAME }} template placeholders in auth header values. */
 const SECRET_TEMPLATE_RE = /\$\{\{\s*secrets\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
+
+/** Matches ${{ secrets.X }} or ${{ vars.X }} template placeholders. */
+const TEMPLATE_RE = /\$\{\{\s*(secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
 /**
  * Load refresh tokens from DB into the secrets map.
@@ -229,25 +233,34 @@ async function refreshExpiredTokens(
 }
 
 /**
- * Resolve ${{ secrets.XXX }} templates with decrypted secret values.
+ * Resolve ${{ secrets.XXX }} and ${{ vars.XXX }} templates in auth header values.
  */
 function resolveTemplates(
   authHeaders: Record<string, string>,
   secrets: Record<string, string>,
+  vars: Record<string, string>,
   runId: string,
 ): { headers: Record<string, string>; resolvedSecrets: string[] } {
   const resolvedKeys = new Set<string>();
   const headers: Record<string, string> = {};
   for (const [name, template] of Object.entries(authHeaders)) {
     headers[name] = template.replace(
-      SECRET_TEMPLATE_RE,
-      (_match, key: string) => {
-        resolvedKeys.add(key);
-        if (!(key in secrets)) {
-          log.warn(`[${runId}] No secret value for "${key}" in template`);
+      TEMPLATE_RE,
+      (_match, namespace: string, key: string) => {
+        if (namespace === "secrets") {
+          resolvedKeys.add(key);
+          if (!(key in secrets)) {
+            log.warn(`[${runId}] No secret value for "${key}" in template`);
+            return "";
+          }
+          return secrets[key] ?? "";
+        }
+        // namespace === "vars"
+        if (!(key in vars)) {
+          log.warn(`[${runId}] No var value for "${key}" in template`);
           return "";
         }
-        return secrets[key] ?? "";
+        return vars[key] ?? "";
       },
     );
   }
@@ -264,7 +277,7 @@ function resolveTemplates(
  * on demand and an expiresAt timestamp is returned for addon-side TTL caching.
  *
  * Auth: Sandbox JWT
- * Body: { encryptedSecrets, authHeaders, secretConnectorMap? }
+ * Body: { encryptedSecrets, authHeaders, secretConnectorMap?, vars? }
  * Response: { headers, expiresAt? } or 502 { error } when token refresh fails
  */
 export async function POST(request: Request) {
@@ -310,7 +323,8 @@ export async function POST(request: Request) {
       { status: 400 },
     );
   }
-  const { encryptedSecrets, authHeaders, secretConnectorMap } = parsed.data;
+  const { encryptedSecrets, authHeaders, secretConnectorMap, vars } =
+    parsed.data;
 
   // Decrypt secrets
   let secrets: Record<string, string> | null;
@@ -374,6 +388,7 @@ export async function POST(request: Request) {
   const { headers, resolvedSecrets } = resolveTemplates(
     authHeaders,
     secrets,
+    vars ?? {},
     auth.runId,
   );
 

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -23,9 +23,6 @@ const bodySchema = z.object({
 
 const log = logger("webhook:firewall-auth");
 
-/** Matches ${{ secrets.KEY_NAME }} template placeholders in auth header values. */
-const SECRET_TEMPLATE_RE = /\$\{\{\s*secrets\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
-
 /** Matches ${{ secrets.X }} or ${{ vars.X }} template placeholders. */
 const TEMPLATE_RE = /\$\{\{\s*(secrets|vars)\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}/g;
 
@@ -346,8 +343,8 @@ export async function POST(request: Request) {
   // Collect which secret keys are referenced in auth templates
   const referencedKeys = new Set<string>();
   for (const template of Object.values(authHeaders)) {
-    for (const match of template.matchAll(SECRET_TEMPLATE_RE)) {
-      if (match[1]) referencedKeys.add(match[1]);
+    for (const match of template.matchAll(TEMPLATE_RE)) {
+      if (match[1] === "secrets" && match[2]) referencedKeys.add(match[2]);
     }
   }
 

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -250,14 +250,14 @@ function resolveTemplates(
             log.warn(`[${runId}] No secret value for "${key}" in template`);
             return "";
           }
-          return secrets[key] ?? "";
+          return secrets[key];
         }
         // namespace === "vars"
         if (!(key in vars)) {
           log.warn(`[${runId}] No var value for "${key}" in template`);
           return "";
         }
-        return vars[key] ?? "";
+        return vars[key];
       },
     );
   }

--- a/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/firewall/auth/route.ts
@@ -250,14 +250,14 @@ function resolveTemplates(
             log.warn(`[${runId}] No secret value for "${key}" in template`);
             return "";
           }
-          return secrets[key];
+          return secrets[key] ?? "";
         }
         // namespace === "vars"
         if (!(key in vars)) {
           log.warn(`[${runId}] No var value for "${key}" in template`);
           return "";
         }
-        return vars[key];
+        return vars[key] ?? "";
       },
     );
   }


### PR DESCRIPTION
## Summary
- Add `${{ vars.X }}` template support to firewall auth headers alongside existing `${{ secrets.X }}`
- Server endpoint uses unified regex to resolve both namespaces in one pass
- Runner passes vars from ExecutionContext through proxy registry to addon
- Fully backward compatible: `vars` field is optional at every layer

## Changes by layer
1. **Server** (`firewall/auth/route.ts`): `vars` in request schema, unified `TEMPLATE_RE` regex, updated `resolveTemplates`
2. **Runner** (`proxy.rs`, `types.rs`): `vars` in `VmRegistration`/`VmEntry`, written to registry JSON
3. **Proxy** (`mitm_addon.py`): reads `vars` from registry, forwards in POST body
4. **Tests**: 4 new test cases for vars resolution, mixed templates, missing vars, backward compat

Closes #7438

## Test plan
- [x] 25 tests pass (21 existing + 4 new vars tests)
- [x] Cargo clippy clean
- [x] Knip clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)