### PR TITLE
docs: add skill references to cli help text and agent tools prompt

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/index.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/index.ts
@@ -24,7 +24,7 @@ Examples:
   Add a custom skill:    zero agent edit $ZERO_AGENT_ID --add-skill my-skill
   Remove a skill:        zero agent edit $ZERO_AGENT_ID --remove-skill my-skill
 
-Skills:
+Notes:
   Custom skills are org-level resources managed with 'zero skill' commands.
   Use --add-skill/--remove-skill to bind or unbind skills from an agent.`,
   );

--- a/turbo/apps/cli/src/commands/zero/agent/index.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/index.ts
@@ -25,6 +25,5 @@ Examples:
   Remove a skill:        zero agent edit $ZERO_AGENT_ID --remove-skill my-skill
 
 Notes:
-  Custom skills are org-level resources managed with 'zero skill' commands.
-  Use --add-skill/--remove-skill to bind or unbind skills from an agent.`,
+  Manage custom skills with 'zero skill --help'`,
   );

--- a/turbo/apps/cli/src/commands/zero/agent/index.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/index.ts
@@ -20,5 +20,11 @@ Examples:
   View your config:      zero agent view $ZERO_AGENT_ID --instructions
   Update description:    zero agent edit $ZERO_AGENT_ID --description "new role"
   Update tone:           zero agent edit $ZERO_AGENT_ID --sound friendly
-  Update instructions:   zero agent edit $ZERO_AGENT_ID --instructions-file <path>`,
+  Update instructions:   zero agent edit $ZERO_AGENT_ID --instructions-file <path>
+  Add a custom skill:    zero agent edit $ZERO_AGENT_ID --add-skill my-skill
+  Remove a skill:        zero agent edit $ZERO_AGENT_ID --remove-skill my-skill
+
+Skills:
+  Custom skills are org-level resources managed with 'zero skill' commands.
+  Use --add-skill/--remove-skill to bind or unbind skills from an agent.`,
   );

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -103,6 +103,7 @@ Examples:
   Send a Slack message?  zero slack message send --help
   Set up a schedule?     zero schedule setup --help
   Update yourself?       zero agent --help
+  Manage custom skills?  zero skill --help
   Check your identity?   zero whoami`,
   );
 

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -62,5 +62,6 @@ export function buildAgentToolsPrompt(): string {
     "- When you encounter a missing token or environment variable error, run `zero doctor missing-token <TOKEN_NAME>` to diagnose the issue and get remediation steps for the user.",
     '- When you encounter a 403 error with "firewall_permission_denied", run `zero doctor firewall-deny <FIREWALL_REF> --method <METHOD> --path <PATH>` using the "firewall", "method", and "path" fields from the JSON error response to get remediation steps for the user.',
     "- When you need to update your own configuration (description, tone, or instructions), use `zero agent edit --help`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",
+    "- When you need to manage custom skills, use `zero skill --help`.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Add `zero skill --help` to `zero --help` examples
- Add skill binding examples (`--add-skill`/`--remove-skill`) to `zero agent --help`
- Add skill management hint to sandbox agent tools prompt (`buildAgentToolsPrompt`)

## Test plan
- [ ] `zero --help` shows skill reference
- [ ] `zero agent --help` shows skill binding examples
- [ ] Agent tools prompt includes skill management hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)