### PR TITLE
refactor: ban test timeout parameters via eslint no-restricted-syntax

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -76,6 +76,27 @@ export default [
     files: ["**/__tests__/**/*.{ts,tsx}"],
     rules: {
       "ccstate/prefer-user-event": "error",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression[callee.name=/^(it|test)$/][arguments.2.type='Literal']",
+          message:
+            "Do not set test timeout. The default timeout (5000ms) is sufficient — a single test should complete within 500ms. Polling intervals are reduced to 10ms in tests, so do not rely on extending timeout to fix flaky tests. Find and fix the underlying timing issue instead.",
+        },
+        {
+          selector:
+            "CallExpression[callee.name='describe'][arguments.2.type='Literal']",
+          message:
+            "Do not set test timeout. The default timeout (5000ms) is sufficient — a single test should complete within 500ms. Polling intervals are reduced to 10ms in tests, so do not rely on extending timeout to fix flaky tests. Find and fix the underlying timing issue instead.",
+        },
+        {
+          selector:
+            "CallExpression[callee.name='waitFor'] > ObjectExpression > Property[key.name='timeout']",
+          message:
+            "Do not set test timeout. The default timeout (5000ms) is sufficient — a single test should complete within 500ms. Polling intervals are reduced to 10ms in tests, so do not rely on extending timeout to fix flaky tests. Find and fix the underlying timing issue instead.",
+        },
+      ],
     },
   },
   // Allow new AbortController in signal infrastructure, test helpers, and

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-stale.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-detail-stale.test.tsx
@@ -190,5 +190,5 @@ describe("activity detail stale data", () => {
         screen.getByRole("heading", { name: "Agent Two" }),
       ).toBeInTheDocument();
     });
-  }, 20_000);
+  });
 });

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-navigation.test.tsx
@@ -121,5 +121,5 @@ describe("activity navigation", () => {
 
     // Verify the detail content is visible (duration)
     expect(screen.getByText("9.0s")).toBeInTheDocument();
-  }, 15_000);
+  });
 });

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-error.test.ts
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-error.test.ts
@@ -36,5 +36,5 @@ describe("activity page error", () => {
     expect(
       screen.getByText("Something went wrong. Please try again later."),
     ).toBeInTheDocument();
-  }, 10_000);
+  });
 });

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-routing.test.ts
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-page-routing.test.ts
@@ -136,7 +136,7 @@ describe("activity page routing", () => {
 
     // Verify detail content loaded (duration)
     expect(screen.getByText("3.0s")).toBeInTheDocument();
-  }, 10_000);
+  });
 
   it("should navigate back to list from detail breadcrumb", async () => {
     const user = userEvent.setup();
@@ -175,7 +175,7 @@ describe("activity page routing", () => {
         screen.getByRole("heading", { name: "Activity" }),
       ).toBeInTheDocument();
     });
-  }, 10_000);
+  });
 
   it("should display 'Agent (displayName)' for delegated runs with triggerAgentName", async () => {
     server.use(
@@ -229,5 +229,5 @@ describe("activity page routing", () => {
     await waitFor(() => {
       expect(screen.getByText("Agent (Parent Bot)")).toBeInTheDocument();
     });
-  }, 10_000);
+  });
 });

--- a/turbo/apps/platform/src/views/activity-page/__tests__/activity-refresh.test.tsx
+++ b/turbo/apps/platform/src/views/activity-page/__tests__/activity-refresh.test.tsx
@@ -129,5 +129,5 @@ describe("activity list refresh on navigation", () => {
 
     // Verify that a new fetch was triggered after re-navigation
     expect(fetchCount).toBeGreaterThan(initialFetchCount);
-  }, 20_000);
+  });
 });

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-to-activity-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-to-activity-navigation.test.tsx
@@ -138,7 +138,7 @@ describe("queue to activity navigation", () => {
     });
 
     expect(screen.getByText("4.0s")).toBeInTheDocument();
-  }, 15_000);
+  });
 
   it("should initialize activity page when clicking View logs in waiting table", async () => {
     const user = userEvent.setup();
@@ -164,5 +164,5 @@ describe("queue to activity navigation", () => {
     });
 
     expect(screen.getByText("4.0s")).toBeInTheDocument();
-  }, 15_000);
+  });
 });

--- a/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
@@ -62,5 +62,5 @@ describe("link component new-tab behavior", () => {
     });
 
     openSpy.mockRestore();
-  }, 15_000);
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-to-activity-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-to-activity-navigation.test.tsx
@@ -142,5 +142,5 @@ describe("chat to activity navigation", () => {
 
     // Verify the detail content loaded (duration: 4.0s)
     expect(screen.getByText("4.0s")).toBeInTheDocument();
-  }, 15_000);
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-to-queue-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-to-queue-navigation.test.tsx
@@ -82,5 +82,5 @@ describe("chat to queue navigation", () => {
     await waitFor(() => {
       expect(screen.getByText("Queue Agent")).toBeInTheDocument();
     });
-  }, 15_000);
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-usage-tab.test.tsx
@@ -319,12 +319,9 @@ describe("org usage tab - expiring credits warning", () => {
     const progressbar = screen.getByRole("progressbar");
     await user.hover(progressbar.closest("[class*='group']")!);
 
-    await waitFor(
-      () => {
-        expect(screen.getByText("5,000")).toBeInTheDocument();
-      },
-      { timeout: 5000 },
-    );
+    await waitFor(() => {
+      expect(screen.getByText("5,000")).toBeInTheDocument();
+    });
 
     expect(screen.getByText(/Expiring on/)).toBeInTheDocument();
   });
@@ -361,12 +358,9 @@ describe("org usage tab - expiring credits warning", () => {
     const progressbar = screen.getByRole("progressbar");
     await user.hover(progressbar.closest("[class*='group']")!);
 
-    await waitFor(
-      () => {
-        expect(screen.getByText("Credit breakdown")).toBeInTheDocument();
-      },
-      { timeout: 5000 },
-    );
+    await waitFor(() => {
+      expect(screen.getByText("Credit breakdown")).toBeInTheDocument();
+    });
 
     expect(screen.queryByText(/Expiring on/)).not.toBeInTheDocument();
   });
@@ -398,12 +392,9 @@ describe("org usage tab - expiring credits warning", () => {
     const progressbar = screen.getByRole("progressbar");
     await user.hover(progressbar.closest("[class*='group']")!);
 
-    await waitFor(
-      () => {
-        expect(screen.getByText("Credit breakdown")).toBeInTheDocument();
-      },
-      { timeout: 5000 },
-    );
+    await waitFor(() => {
+      expect(screen.getByText("Credit breakdown")).toBeInTheDocument();
+    });
 
     expect(screen.queryByText(/Expiring on/)).not.toBeInTheDocument();
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/prompt-param-injection.test.tsx
@@ -24,12 +24,9 @@ describe("prompt query parameter injection", () => {
     await setupPage({ context, path: "/?prompt=Hello%20world" });
 
     // Should redirect to /talk/:id and show the prompt in the input
-    const textarea = await waitFor(
-      () => {
-        return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
-      },
-      { timeout: 5000 },
-    );
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
 
     expect(textarea).toHaveValue("Hello world");
   });
@@ -41,12 +38,9 @@ describe("prompt query parameter injection", () => {
       path: "/talk/c0000000-0000-4000-a000-000000000001?prompt=Set%20up%20a%20daily%20report",
     });
 
-    const textarea = await waitFor(
-      () => {
-        return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
-      },
-      { timeout: 5000 },
-    );
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
 
     expect(textarea).toHaveValue("Set up a daily report");
   });
@@ -58,12 +52,9 @@ describe("prompt query parameter injection", () => {
       path: "/talk/c0000000-0000-4000-a000-000000000001?prompt=test",
     });
 
-    await waitFor(
-      () => {
-        expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
-      },
-      { timeout: 5000 },
-    );
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeInTheDocument();
+    });
 
     // The prompt param should be removed from the URL
     expect(search()).not.toContain("prompt=");
@@ -76,12 +67,9 @@ describe("prompt query parameter injection", () => {
       path: "/talk/c0000000-0000-4000-a000-000000000001",
     });
 
-    const textarea = await waitFor(
-      () => {
-        return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
-      },
-      { timeout: 5000 },
-    );
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
 
     expect(textarea).toHaveValue("");
   });
@@ -90,11 +78,8 @@ describe("prompt query parameter injection", () => {
     mockChatAPI();
     await setupPage({ context, path: "/?prompt=hello" });
 
-    await waitFor(
-      () => {
-        expect(pathname()).toMatch(/^\/talk\//);
-      },
-      { timeout: 5000 },
-    );
+    await waitFor(() => {
+      expect(pathname()).toMatch(/^\/talk\//);
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-agent-scoping.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-agent-scoping.test.tsx
@@ -98,7 +98,7 @@ describe("sidebar agent scoping (#7239)", () => {
     expect(screen.getByText("Chats with Beta Bot")).toBeInTheDocument();
     // Alpha thread must NOT appear
     expect(screen.queryByText("Alpha thread")).not.toBeInTheDocument();
-  }, 15_000);
+  });
 
   it("should switch back to first agent after visiting second agent", async () => {
     mockTwoAgents();
@@ -120,7 +120,7 @@ describe("sidebar agent scoping (#7239)", () => {
       expect(screen.getByText("Alpha thread")).toBeInTheDocument();
     });
     expect(screen.queryByText("Beta thread")).not.toBeInTheDocument();
-  }, 15_000);
+  });
 
   it("should retain agent scope when navigating to a non-chat page and back", async () => {
     mockTwoAgents();
@@ -141,7 +141,7 @@ describe("sidebar agent scoping (#7239)", () => {
     });
     expect(screen.getByText("Beta thread")).toBeInTheDocument();
     expect(screen.queryByText("Alpha thread")).not.toBeInTheDocument();
-  }, 15_000);
+  });
 
   it("should update sidebar to show agent chats when navigating to /team/:agentId profile page", async () => {
     mockTwoAgents();
@@ -163,5 +163,5 @@ describe("sidebar agent scoping (#7239)", () => {
     });
     expect(screen.getByText("Beta thread")).toBeInTheDocument();
     expect(screen.queryByText("Alpha thread")).not.toBeInTheDocument();
-  }, 15_000);
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -177,7 +177,7 @@ describe("sidebar new chat navigation", () => {
     await waitFor(() => {
       expect(pathname()).toBe("/chat/delayed-thread-id");
     });
-  }, 15_000);
+  });
 
   it("should handle API failure gracefully", async () => {
     const user = userEvent.setup();
@@ -214,7 +214,7 @@ describe("sidebar new chat navigation", () => {
 
     // Should not have navigated
     expect(pathname()).toBe(initialPath);
-  }, 15_000);
+  });
 
   it("should show new chat entry in sidebar and focus textarea after creating new chat", async () => {
     const user = userEvent.setup();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
@@ -106,7 +106,7 @@ describe("talk navigation", () => {
     await waitFor(() => {
       expect(pathname()).toBe("/chat/new-thread-id-123");
     });
-  }, 15_000);
+  });
 
   it("should navigate to /chat/:chatThreadId after completing onboarding and sending auto-intro", async () => {
     const user = userEvent.setup();
@@ -257,5 +257,5 @@ describe("talk navigation", () => {
     await waitFor(() => {
       expect(pathname()).toBe("/chat/new-thread-id-123");
     });
-  }, 15_000);
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-to-activity-agent-retention.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-to-activity-agent-retention.test.tsx
@@ -64,12 +64,9 @@ describe("talk to activity agent retention", () => {
     });
 
     // Wait for sidebar to show "bar" as the active chat agent
-    await waitFor(
-      () => {
-        expect(screen.getByLabelText("New chat with bar")).toBeInTheDocument();
-      },
-      { timeout: 5000 },
-    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("New chat with bar")).toBeInTheDocument();
+    });
 
     // Click the "Activity logs" nav tab in the sidebar
     const activityNavLink = screen.getByRole("link", {
@@ -78,20 +75,14 @@ describe("talk to activity agent retention", () => {
     await user.click(activityNavLink);
 
     // Wait for navigation to /activity to complete
-    await waitFor(
-      () => {
-        expect(pathname()).toBe("/activity");
-      },
-      { timeout: 5000 },
-    );
+    await waitFor(() => {
+      expect(pathname()).toBe("/activity");
+    });
 
     // After navigating to /activity, the sidebar should still show "chat with bar"
     // (the last visited agent), not "chat with foo" (the default agent)
-    await waitFor(
-      () => {
-        expect(screen.getByLabelText("New chat with bar")).toBeInTheDocument();
-      },
-      { timeout: 5000 },
-    );
-  }, 15_000);
+    await waitFor(() => {
+      expect(screen.getByLabelText("New chat with bar")).toBeInTheDocument();
+    });
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page.test.tsx
@@ -85,7 +85,7 @@ describe("zeroActivityDetailPage", () => {
 
     // Verify the header card rendered with run details
     expect(screen.getByText("9.0s")).toBeInTheDocument();
-  }, 10_000);
+  });
 
   it("should hide Activity breadcrumb when ActivityLogList switch is off", async () => {
     mockActivityDetailAPI();
@@ -105,7 +105,7 @@ describe("zeroActivityDetailPage", () => {
     // The breadcrumb link to /activity should not be present
     const activityLinks = screen.queryAllByRole("link", { name: /Activity/i });
     expect(activityLinks).toHaveLength(0);
-  }, 10_000);
+  });
 
   it("should show Activity breadcrumb when ActivityLogList switch is on", async () => {
     mockActivityDetailAPI();
@@ -125,7 +125,7 @@ describe("zeroActivityDetailPage", () => {
     // The breadcrumb link to /activity should be present
     const activityLinks = screen.queryAllByRole("link", { name: /Activity/i });
     expect(activityLinks.length).toBeGreaterThan(0);
-  }, 10_000);
+  });
 
   it("should render schedule source as a clickable link when scheduleId is present", async () => {
     const logDetail: LogDetail = {
@@ -180,7 +180,7 @@ describe("zeroActivityDetailPage", () => {
     const scheduleLink = screen.getByRole("link", { name: "Schedule" });
     expect(scheduleLink).toBeInTheDocument();
     expect(scheduleLink.getAttribute("href")).toBe("/schedule/sched-abc-123");
-  }, 10_000);
+  });
 
   it("should render schedule source as plain text when scheduleId is null", async () => {
     const logDetail: LogDetail = {
@@ -234,7 +234,7 @@ describe("zeroActivityDetailPage", () => {
     // "Schedule" should be plain text, not a link
     expect(screen.getByText("Schedule")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Schedule" })).toBeNull();
-  }, 10_000);
+  });
 
   it("should render non-schedule source as plain text", async () => {
     mockActivityDetailAPI();
@@ -253,7 +253,7 @@ describe("zeroActivityDetailPage", () => {
     // "Web" source should be plain text, not a link
     expect(screen.getByText("Web")).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Web" })).toBeNull();
-  }, 10_000);
+  });
 
   it("should not truncate system prompt containing unknown HTML-like tags", async () => {
     const logDetail: LogDetail = {
@@ -317,7 +317,7 @@ describe("zeroActivityDetailPage", () => {
         screen.getAllByText(/This line must not be lost/).length,
       ).toBeGreaterThan(0);
     });
-  }, 10_000);
+  });
 
   it("should display selectedModel when ModelDetail feature is enabled", async () => {
     const logDetail: LogDetail = {
@@ -371,7 +371,7 @@ describe("zeroActivityDetailPage", () => {
 
     // selectedModel should be displayed as the model label
     expect(screen.getByText("claude-sonnet-4.5")).toBeInTheDocument();
-  }, 10_000);
+  });
 
   it("should display provider label when ModelDetail feature is disabled", async () => {
     const logDetail: LogDetail = {
@@ -426,7 +426,7 @@ describe("zeroActivityDetailPage", () => {
     // Provider label should be displayed, not selectedModel
     expect(screen.getByText("Anthropic API Key")).toBeInTheDocument();
     expect(screen.queryByText("claude-sonnet-4.5")).toBeNull();
-  }, 10_000);
+  });
 
   it("should fallback to provider label when ModelDetail is enabled but selectedModel is null", async () => {
     const logDetail: LogDetail = {
@@ -480,5 +480,5 @@ describe("zeroActivityDetailPage", () => {
 
     // Should fallback to provider label when selectedModel is null
     expect(screen.getByText("Anthropic API Key")).toBeInTheDocument();
-  }, 10_000);
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
@@ -122,7 +122,7 @@ describe("chatListDialog", () => {
     await waitFor(() => {
       expect(pathname()).toBe("/chat/new-thread-from-dialog");
     });
-  }, 15_000);
+  });
 
   it("should navigate to chat when clicking an unpinned agent", async () => {
     const user = userEvent.setup();
@@ -141,7 +141,7 @@ describe("chatListDialog", () => {
     await waitFor(() => {
       expect(pathname()).toBe("/chat/new-thread-from-dialog");
     });
-  }, 15_000);
+  });
 
   it("should render unpinned agent avatars without reduced opacity", async () => {
     const user = userEvent.setup();
@@ -159,7 +159,7 @@ describe("chatListDialog", () => {
     // Find the unpinned agent's avatar image within the dialog
     const unpinnedAvatar = within(dialog).getByAltText("Unpinned Agent");
     expect(unpinnedAvatar.className).not.toContain("opacity-60");
-  }, 15_000);
+  });
 
   it("should navigate to chat when clicking the lead agent", async () => {
     const user = userEvent.setup();
@@ -180,5 +180,5 @@ describe("chatListDialog", () => {
     await waitFor(() => {
       expect(pathname()).toBe("/chat/new-thread-from-dialog");
     });
-  }, 15_000);
+  });
 });


### PR DESCRIPTION
## Summary
- Add 3 `no-restricted-syntax` ESLint selectors to platform app test file override to ban timeout parameters on `it`/`test`/`describe` and `waitFor`
- Remove all 46 existing violations (11 `waitFor` timeouts + 35 test-level timeouts) across 17 test files
- All tests pass within the default 5000ms timeout

## Test plan
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes (`pnpm check-types`)
- [x] All 52 tests across 17 affected files pass within default timeout

Closes #7444

🤖 Generated with [Claude Code](https://claude.com/claude-code)