### PR TITLE
refactor: remove orgSlug from logs list response and contract

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/v1-runs.ts
+++ b/turbo/apps/platform/src/mocks/handlers/v1-runs.ts
@@ -85,7 +85,6 @@ export const appLogsHandlers = [
           sessionId: log.sessionId,
           agentId: log.agentId,
           displayName: null,
-          orgSlug: null,
           framework: log.framework,
           triggerSource: null,
           triggerAgentName: null,

--- a/turbo/apps/platform/src/signals/schedule-page/__tests__/schedule-run-history.test.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/__tests__/schedule-run-history.test.ts
@@ -43,7 +43,6 @@ function logsResponse(
         sessionId: null,
         agentId: "test-agent",
         displayName: "Test Agent",
-        orgSlug: null,
         framework: null,
         status: "completed",
         triggerSource: "schedule",

--- a/turbo/apps/platform/src/signals/zero-page/log-types.ts
+++ b/turbo/apps/platform/src/signals/zero-page/log-types.ts
@@ -36,7 +36,6 @@ export interface LogEntry {
   sessionId: string | null;
   agentId: string | null;
   displayName: string | null;
-  orgSlug: string | null;
   framework: string | null;
   triggerSource: TriggerSource | null;
   triggerAgentName: string | null;

--- a/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
@@ -307,19 +307,6 @@ describe("GET /api/zero/logs", () => {
       expect(data.data[0].agentId).toBe(nameComposeId);
     });
 
-    it("should include orgSlug in response", async () => {
-      const request = createTestRequest(
-        `http://localhost:3000/api/zero/logs?name=${agentName}`,
-      );
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.data).toHaveLength(1);
-      expect(data.data[0].orgSlug).toBeDefined();
-      expect(typeof data.data[0].orgSlug).toBe("string");
-    });
-
     it("name param should take precedence over agent param", async () => {
       const request = createTestRequest(
         `http://localhost:3000/api/zero/logs?name=${agentName}&agent=nonexistent`,

--- a/turbo/apps/web/app/api/zero/logs/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/route.ts
@@ -25,11 +25,9 @@ import { zeroAgents } from "../../../../src/db/schema/zero-agent";
 import { zeroRuns } from "../../../../src/db/schema/zero-run";
 import { alias } from "drizzle-orm/pg-core";
 import { conversations } from "../../../../src/db/schema/conversation";
-import { getOrgData } from "../../../../src/lib/org/org-cache-service";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { isNotFound, isForbidden } from "../../../../src/lib/errors";
-import { logger } from "../../../../src/lib/logger";
 import {
   eq,
   and,
@@ -41,8 +39,6 @@ import {
   isNotNull,
   type SQL,
 } from "drizzle-orm";
-
-const log = logger("api:zero:logs");
 
 /** Alias for the zero_agents table to resolve the triggering agent's display name. */
 const triggerAgentAlias = alias(zeroAgents, "trigger_agent");
@@ -325,33 +321,6 @@ const router = tsr.router(logsListContract, {
       .orderBy(desc(agentRuns.createdAt), desc(agentRuns.id))
       .limit(limit + 1);
 
-    // Resolve org slugs via org cache (skip orgs that fail lookup)
-    const uniqueOrgIds = [
-      ...new Set(
-        runs
-          .filter((r) => {
-            return r.orgId;
-          })
-          .map((r) => {
-            return r.orgId!;
-          }),
-      ),
-    ];
-    const slugMap = new Map<string, string>();
-    await Promise.all(
-      uniqueOrgIds.map(async (id) => {
-        try {
-          const data = await getOrgData(id);
-          slugMap.set(id, data.slug);
-        } catch (err) {
-          log.warn("failed to resolve org slug for run", {
-            orgId: id,
-            error: err,
-          });
-        }
-      }),
-    );
-
     const [totalCount, filters] = await Promise.all([
       getTotalCount(userId, query, orgId),
       getAvailableFilters(userId, orgId),
@@ -378,7 +347,6 @@ const router = tsr.router(logsListContract, {
             sessionId: run.sessionId ?? null,
             agentId: run.composeId ?? null,
             displayName: run.displayName ?? null,
-            orgSlug: run.orgId ? (slugMap.get(run.orgId) ?? null) : null,
             framework: extractFramework(run.composeContent),
             triggerSource: (run.triggerSource ?? "cli") as TriggerSource,
             triggerAgentName: run.triggerAgentName ?? null,

--- a/turbo/packages/core/src/contracts/logs.ts
+++ b/turbo/packages/core/src/contracts/logs.ts
@@ -60,7 +60,6 @@ const logEntrySchema = z.object({
   sessionId: z.string().nullable(),
   agentId: z.string().nullable(),
   displayName: z.string().nullable(),
-  orgSlug: z.string().nullable(),
   framework: z.string().nullable(),
   triggerSource: triggerSourceSchema.nullable(),
   triggerAgentName: z.string().nullable(),


### PR DESCRIPTION
## Summary

Closes #7451

- Remove `orgSlug` field from `logEntrySchema` in core contracts and `LogEntry` interface in frontend types
- Remove `slugMap` construction and `getOrgData()` calls from the logs API route, eliminating unnecessary DB overhead per request
- Remove the dedicated "should include orgSlug in response" integration test and clean up all affected test fixtures and mock handlers

Part of the ongoing org slug cleanup initiative (#7257, #7286, #7294, #7436).

## Test plan

- [x] `pnpm turbo run lint` passes
- [x] `pnpm check-types` passes (no new type errors)
- [x] `pnpm vitest` passes (logs route tests: 39/39, schedule-run-history: 15/15)
- [x] `pnpm knip` passes (no unused exports/dependencies)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)