### PR TITLE
feat(firewalls): add custom guidance for slack chat:write firewall deny

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
@@ -99,6 +99,74 @@ describe("zero doctor firewall-deny command", () => {
     });
   });
 
+  describe("slack chat:write custom guidance", () => {
+    it("should output bot alternative guidance for slack chat:write", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "slack",
+        "--method",
+        "POST",
+        "--path",
+        "/chat.postMessage",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "Slack firewall blocked POST /chat.postMessage",
+      );
+      expect(logCalls).toContain('covered by the "chat:write"');
+      expect(logCalls).toContain("AS THE USER's identity");
+      expect(logCalls).toContain("zero slack message send");
+      expect(logCalls).toContain("Only request user approval");
+      // Should still show the approval URL
+      expect(logCalls).toContain("[Allow Slack access]");
+    });
+
+    it("should not output bot guidance for non-chat:write slack permissions", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "slack",
+        "--method",
+        "GET",
+        "--path",
+        "/conversations.list",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Slack firewall blocked");
+      expect(logCalls).not.toContain("AS THE USER's identity");
+      expect(logCalls).not.toContain("zero slack message send");
+    });
+
+    it("should not output bot guidance for non-slack connectors", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/owner/repo/pulls",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("GitHub firewall blocked");
+      expect(logCalls).not.toContain("AS THE USER's identity");
+      expect(logCalls).not.toContain("zero slack message send");
+    });
+  });
+
   describe("URL transformation", () => {
     it("should transform www.vm0.ai to app.vm0.ai", async () => {
       vi.stubEnv("VM0_API_URL", "https://www.vm0.ai");

--- a/turbo/apps/cli/src/commands/zero/doctor/firewall-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/firewall-deny.ts
@@ -77,6 +77,21 @@ Notes:
           console.log("No named permission was found covering this request.");
         }
 
+        // Slack chat:write: strongly recommend bot-based messaging over user identity
+        if (firewallRef === "slack" && permissions[0] === "chat:write") {
+          console.log("");
+          console.log(
+            "IMPORTANT: Granting chat:write allows sending messages AS THE USER's identity, not as a bot.",
+          );
+          console.log(
+            "Use `zero slack message send -c <channel> -t <text>` to send messages as the bot instead — this is the recommended approach for most use cases.",
+          );
+          console.log(
+            "Only request user approval below if acting as the user is specifically required.",
+          );
+          console.log("");
+        }
+
         console.log(
           `Ask the user to allow it at: [Allow ${label} access](${url})`,
         );


### PR DESCRIPTION
## Summary

- When `zero doctor firewall-deny` matches `slack` + `chat:write`, output advisory text strongly recommending `zero slack message send` (bot identity) over requesting the sensitive `chat:write` permission that impersonates the user
- Adds 3 test cases: positive (slack chat:write shows guidance), negative (non-chat:write slack permission), negative (non-slack connector)

Closes #7458

## Test plan

- [x] Existing 7 tests continue to pass
- [x] New test: `slack` + `POST /chat.postMessage` outputs bot alternative guidance
- [x] New test: `slack` + `GET /conversations.list` does NOT output bot guidance
- [x] New test: `github` connector does NOT output bot guidance
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)