### PR TITLE
feat(platform): add network logs page to activity detail

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-network-page-setup.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-network-page-setup.ts
@@ -1,0 +1,21 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroActivityNetworkPageWrapper } from "../../views/activity-page/zero-activity-network-page-wrapper.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+
+export const setupActivityNetworkPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(updatePage$, createElement(ZeroActivityNetworkPageWrapper));
+    set(updateDocumentTitle$, "Network Logs");
+
+    await set(initZeroOnboarding$, signal);
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+
+    signal.throwIfAborted();
+  },
+);

--- a/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
@@ -1,0 +1,26 @@
+import { computed } from "ccstate";
+import { zeroRunNetworkLogsContract } from "@vm0/core";
+import { zeroClient$ } from "../api-client.ts";
+import { currentRunId$ } from "./activity-signals.ts";
+
+/**
+ * Network logs fetched from Axiom via the zero network API.
+ * Returns null if network logs are not available.
+ */
+export const zeroActivityNetworkLogs$ = computed(async (get) => {
+  const runId = get(currentRunId$);
+  if (!runId) {
+    return null;
+  }
+
+  const client = get(zeroClient$)(zeroRunNetworkLogsContract);
+  const result = await client.getNetworkLogs({
+    params: { id: runId },
+    query: { limit: 500, order: "asc" },
+  });
+
+  if (result.status !== 200) {
+    return null;
+  }
+  return result.body;
+});

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -14,6 +14,7 @@ import { setupQueuePage$ } from "./queue-page/queue-page-setup.ts";
 import { setupActivityPage$ } from "./activity-page/activity-page-setup.ts";
 import { setupActivityDetailPage$ } from "./activity-page/activity-detail-page-setup.ts";
 import { setupActivityContextPage$ } from "./activity-page/activity-context-page-setup.ts";
+import { setupActivityNetworkPage$ } from "./activity-page/activity-network-page-setup.ts";
 import { setupTeamPage$ } from "./team-page/team-page-setup.ts";
 import { setupTeamDetailPage$ } from "./team-page/team-detail-page-setup.ts";
 import { setupWorksPage$ } from "./works-page/works-page-setup.ts";
@@ -81,6 +82,10 @@ const ROUTE_CONFIG = [
   {
     path: "/queue",
     setup: setupAuthPageWrapper(setupQueuePage$),
+  },
+  {
+    path: "/activity/:runId/network",
+    setup: setupAuthPageWrapper(setupActivityNetworkPage$),
   },
   {
     path: "/activity/:runId/context",

--- a/turbo/apps/platform/src/types/route.ts
+++ b/turbo/apps/platform/src/types/route.ts
@@ -4,6 +4,7 @@ export type RoutePath =
   | "/:tab"
   | "/activity"
   | "/activity/:runId/context"
+  | "/activity/:runId/network"
   | "/activity/:runId"
   | "/chat/:chatThreadId"
   | "/team"

--- a/turbo/apps/platform/src/views/activity-page/zero-activity-network-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/activity-page/zero-activity-network-page-wrapper.tsx
@@ -1,0 +1,10 @@
+import { SidebarLayout } from "../zero-page/sidebar-layout.tsx";
+import { ZeroActivityNetworkPage } from "../zero-page/zero-activity-network-page.tsx";
+
+export function ZeroActivityNetworkPageWrapper() {
+  return (
+    <SidebarLayout>
+      <ZeroActivityNetworkPage />
+    </SidebarLayout>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -10,6 +10,7 @@ import {
   IconDownload,
   IconChartLine,
   IconFileAnalytics,
+  IconWorldWww,
 } from "@tabler/icons-react";
 import {
   Button,
@@ -165,6 +166,7 @@ function ActivityHeaderCard({
   time,
   events,
   showContextLink,
+  showNetworkLink,
   showModelDetail,
 }: {
   displayName: string;
@@ -183,6 +185,7 @@ function ActivityHeaderCard({
   time: string;
   events: AgentEvent[];
   showContextLink?: boolean;
+  showNetworkLink?: boolean;
   showModelDetail: boolean;
 }) {
   return (
@@ -200,6 +203,16 @@ function ActivityHeaderCard({
             >
               <IconFileAnalytics size={14} stroke={1.5} />
               Context
+            </Link>
+          )}
+          {showNetworkLink && (
+            <Link
+              pathname="/activity/:runId/network"
+              options={{ pathParams: { runId: detail.id } }}
+              className="inline-flex items-center h-8 shrink-0 gap-1 rounded-lg px-3 text-sm text-muted-foreground hover:text-foreground hover:bg-accent transition-colors no-underline"
+            >
+              <IconWorldWww size={14} stroke={1.5} />
+              Network
             </Link>
           )}
         </div>
@@ -424,6 +437,7 @@ export function ZeroActivityDetailPage() {
             time={time}
             events={events}
             showContextLink={features?.[FeatureSwitchKey.RunContext]}
+            showNetworkLink={features?.[FeatureSwitchKey.RunNetwork]}
             showModelDetail={showModelDetail}
           />
 

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-network-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-network-page.tsx
@@ -1,0 +1,383 @@
+import { useState } from "react";
+import { useLastLoadable, useGet, useLastResolved } from "ccstate-react";
+import { IconWorldWww, IconChartLine } from "@tabler/icons-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Skeleton,
+} from "@vm0/ui";
+import { FeatureSwitchKey, type NetworkLogEntry } from "@vm0/core";
+import { Link } from "../router/link.tsx";
+import { currentRunId$ } from "../../signals/activity-page/activity-signals.ts";
+import { zeroActivityNetworkLogs$ } from "../../signals/activity-page/activity-network-signals.ts";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTime(timestamp: string): string {
+  const d = new Date(timestamp);
+  const h = String(d.getHours()).padStart(2, "0");
+  const m = String(d.getMinutes()).padStart(2, "0");
+  const s = String(d.getSeconds()).padStart(2, "0");
+  const ms = String(d.getMilliseconds()).padStart(3, "0");
+  return `${h}:${m}:${s}.${ms}`;
+}
+
+function formatSize(bytes: number | undefined | null): string {
+  if (bytes === null || bytes === undefined) {
+    return "—";
+  }
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function formatLatency(ms: number | undefined | null): string {
+  if (ms === null || ms === undefined) {
+    return "—";
+  }
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function entryType(entry: NetworkLogEntry): string {
+  if (entry.action === "DENY") {
+    return "DENY";
+  }
+  if (entry.type === "tcp") {
+    return "TCP";
+  }
+  if (entry.type && entry.type !== "http") {
+    return entry.type.toUpperCase();
+  }
+  return "HTTP";
+}
+
+function typeColor(type: string): string {
+  if (type === "HTTP") {
+    return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
+  }
+  if (type === "TCP") {
+    return "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400";
+  }
+  if (type === "UDP" || type === "ICMP") {
+    return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400";
+  }
+  if (type === "DENY") {
+    return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+  }
+  return "bg-muted text-muted-foreground";
+}
+
+function statusColor(status: number | undefined): string {
+  if (!status) {
+    return "text-muted-foreground";
+  }
+  if (status < 300) {
+    return "text-green-600 dark:text-green-400";
+  }
+  if (status < 400) {
+    return "text-yellow-600 dark:text-yellow-400";
+  }
+  return "text-red-600 dark:text-red-400";
+}
+
+function latencyColor(ms: number | undefined | null): string {
+  if (ms === null || ms === undefined) {
+    return "text-muted-foreground";
+  }
+  if (ms < 500) {
+    return "text-green-600 dark:text-green-400";
+  }
+  if (ms < 2000) {
+    return "text-yellow-600 dark:text-yellow-400";
+  }
+  return "text-red-600 dark:text-red-400";
+}
+
+// ---------------------------------------------------------------------------
+// Row components
+// ---------------------------------------------------------------------------
+
+function TypeBadge({ type }: { type: string }) {
+  const color = typeColor(type);
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold leading-none ${color}`}
+    >
+      {type}
+    </span>
+  );
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value.join(", ") : "—";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+function collectDetails(entry: NetworkLogEntry): [string, string][] {
+  return [
+    ["Timestamp", entry.timestamp],
+    ["Type", formatValue(entry.type)],
+    ["Action", formatValue(entry.action)],
+    ["Method", formatValue(entry.method)],
+    ["URL", formatValue(entry.url)],
+    ["Host", formatValue(entry.host)],
+    ["Port", formatValue(entry.port)],
+    ["Status", formatValue(entry.status)],
+    ["Latency", formatLatency(entry.latency_ms)],
+    ["Request Size", formatSize(entry.request_size)],
+    ["Response Size", formatSize(entry.response_size)],
+    ["Firewall", formatValue(entry.firewall_name)],
+    ["Firewall Ref", formatValue(entry.firewall_ref)],
+    ["Firewall Permission", formatValue(entry.firewall_permission)],
+    ["Firewall Rule Match", formatValue(entry.firewall_rule_match)],
+    ["Firewall Base URL", formatValue(entry.firewall_base)],
+    ["Firewall Params", formatValue(entry.firewall_params)],
+    ["Firewall Error", formatValue(entry.firewall_error)],
+    ["Resolved Secrets", formatValue(entry.token_resolved_secrets)],
+    ["Refreshed Connectors", formatValue(entry.token_refreshed_connectors)],
+    ["Refreshed Secrets", formatValue(entry.token_refreshed_secrets)],
+    ["Cache Hit", formatValue(entry.token_cache_hit)],
+    ["Error", formatValue(entry.error)],
+  ];
+}
+
+function NetworkLogRowDetail({ entry }: { entry: NetworkLogEntry }) {
+  const details = collectDetails(entry);
+
+  if (details.length === 0) {
+    return null;
+  }
+
+  return (
+    <TableRow>
+      <td colSpan={7} className="bg-muted/30 px-8 py-2">
+        <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+          {details.map(([label, value]) => {
+            return (
+              <div key={label} className="contents">
+                <span className="text-muted-foreground font-medium">
+                  {label}
+                </span>
+                <span className="font-mono break-all">{value}</span>
+              </div>
+            );
+          })}
+        </div>
+      </td>
+    </TableRow>
+  );
+}
+
+function NetworkLogRow({ entry }: { entry: NetworkLogEntry }) {
+  const [expanded, setExpanded] = useState(false);
+  const type = entryType(entry);
+  const isHttp = type === "HTTP" || type === "DENY";
+
+  const target = isHttp
+    ? (entry.url ?? "—")
+    : `${entry.host ?? "unknown"}:${entry.port ?? 0}`;
+
+  return (
+    <>
+      <TableRow
+        className="cursor-pointer hover:bg-muted/50"
+        onClick={() => {
+          setExpanded((prev) => {
+            return !prev;
+          });
+        }}
+      >
+        <TableCell className="font-mono text-xs text-muted-foreground whitespace-nowrap">
+          {formatTime(entry.timestamp)}
+        </TableCell>
+        <TableCell>
+          <TypeBadge type={type} />
+        </TableCell>
+        <TableCell className="font-mono text-xs whitespace-nowrap">
+          {isHttp ? (entry.method ?? "—") : "—"}
+        </TableCell>
+        <TableCell className="font-mono text-xs truncate max-w-[400px]">
+          {target}
+        </TableCell>
+        <TableCell
+          className={`font-mono text-xs whitespace-nowrap ${statusColor(entry.status)}`}
+        >
+          {entry.status ?? "—"}
+        </TableCell>
+        <TableCell
+          className={`font-mono text-xs whitespace-nowrap ${latencyColor(entry.latency_ms)}`}
+        >
+          {formatLatency(entry.latency_ms)}
+        </TableCell>
+        <TableCell className="text-xs text-cyan-600 dark:text-cyan-400 truncate max-w-[120px]">
+          {entry.firewall_name ?? ""}
+        </TableCell>
+      </TableRow>
+      {expanded && <NetworkLogRowDetail entry={entry} />}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+export function ZeroActivityNetworkPage() {
+  const currentRunId = useGet(currentRunId$);
+  const logsLoadable = useLastLoadable(zeroActivityNetworkLogs$);
+
+  if (logsLoadable.state === "loading" || logsLoadable.state === "hasError") {
+    return <NetworkSkeleton runId={currentRunId} />;
+  }
+
+  const data = logsLoadable.data;
+  if (!data || data.networkLogs.length === 0) {
+    return <NetworkEmpty runId={currentRunId} />;
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-0 overflow-hidden">
+      <div className="flex-1 flex flex-col min-h-0 overflow-auto">
+        <Breadcrumb runId={currentRunId} />
+        <div className="mx-auto w-full max-w-[1200px] px-4 sm:px-6 pt-4 pb-8">
+          {data.hasMore && (
+            <p className="text-xs text-muted-foreground mb-3">
+              Showing first {data.networkLogs.length} entries. Some entries may
+              be truncated.
+            </p>
+          )}
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[100px]">Time</TableHead>
+                <TableHead className="w-[60px]">Type</TableHead>
+                <TableHead className="w-[60px]">Method</TableHead>
+                <TableHead>URL / Host</TableHead>
+                <TableHead className="w-[60px]">Status</TableHead>
+                <TableHead className="w-[80px]">Latency</TableHead>
+                <TableHead className="w-[100px]">Firewall</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.networkLogs.map((entry) => {
+                return (
+                  <NetworkLogRow
+                    key={`${entry.timestamp}-${entry.type}-${entry.method}-${entry.host}-${entry.port}-${entry.url}-${entry.status}`}
+                    entry={entry}
+                  />
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared components
+// ---------------------------------------------------------------------------
+
+function Breadcrumb({ runId }: { runId: string | null }) {
+  const features = useLastResolved(featureSwitch$);
+  return (
+    <nav className="shrink-0 flex items-center gap-1 px-4 pt-4 text-sm text-muted-foreground">
+      {features?.[FeatureSwitchKey.ActivityLogList] && (
+        <>
+          <Link
+            pathname="/activity"
+            className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 hover:bg-muted hover:text-foreground transition-colors no-underline text-inherit"
+          >
+            <IconChartLine size={14} stroke={1.5} className="shrink-0" />
+            Activity
+          </Link>
+          <span className="text-muted-foreground/40 select-none">/</span>
+        </>
+      )}
+      {runId && (
+        <>
+          <Link
+            pathname="/activity/:runId"
+            options={{ pathParams: { runId } }}
+            className="rounded-md px-1.5 py-0.5 hover:bg-muted hover:text-foreground transition-colors no-underline text-inherit"
+          >
+            Run
+          </Link>
+          <span className="text-muted-foreground/40 select-none">/</span>
+        </>
+      )}
+      <span className="rounded-md px-1.5 py-0.5 text-foreground font-medium">
+        Network
+      </span>
+    </nav>
+  );
+}
+
+function NetworkEmpty({ runId }: { runId: string | null }) {
+  return (
+    <div className="h-full flex flex-col min-h-0">
+      <Breadcrumb runId={runId} />
+      <div className="flex-1 flex flex-col items-center justify-center gap-3 pb-20">
+        <IconWorldWww
+          size={32}
+          stroke={1.5}
+          className="text-muted-foreground"
+        />
+        <h2 className="text-lg font-semibold text-foreground">
+          No network logs
+        </h2>
+        <p className="text-sm text-muted-foreground text-center max-w-sm">
+          No network traffic was recorded for this run.
+        </p>
+        {runId && (
+          <Link
+            pathname="/activity/:runId"
+            options={{ pathParams: { runId } }}
+            className="mt-2 inline-flex items-center justify-center rounded-md border px-3 py-1.5 text-sm font-medium no-underline text-inherit hover:bg-accent"
+          >
+            Back to run
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function NetworkSkeleton({ runId }: { runId: string | null }) {
+  return (
+    <div className="h-full flex flex-col min-h-0">
+      <Breadcrumb runId={runId} />
+      <div className="mx-auto w-full max-w-[1200px] px-4 sm:px-6 pt-4 pb-8 flex flex-col gap-2">
+        {Array.from({ length: 8 }, (_, i) => {
+          return <Skeleton key={i} className="h-8 w-full" />;
+        })}
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-network-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-network-page.tsx
@@ -284,13 +284,9 @@ export function ZeroActivityNetworkPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {data.networkLogs.map((entry) => {
-                return (
-                  <NetworkLogRow
-                    key={`${entry.timestamp}-${entry.type}-${entry.method}-${entry.host}-${entry.port}-${entry.url}-${entry.status}`}
-                    entry={entry}
-                  />
-                );
+              {data.networkLogs.map((entry, idx) => {
+                const key = `${entry.timestamp}-${entry.type}-${entry.host}-${entry.port}-${entry.url}-${idx}`;
+                return <NetworkLogRow key={key} entry={entry} />;
               })}
             </TableBody>
           </Table>

--- a/turbo/apps/web/app/api/zero/runs/[id]/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/network/__tests__/route.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { randomUUID } from "crypto";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestOrg,
+  createTestCompose,
+  createTestRunInDb,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("znet");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function networkUrl(runId: string): string {
+  return `http://localhost:3000/api/zero/runs/${runId}/network`;
+}
+
+function makeAxiomEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    _time: "2026-04-01T10:00:00Z",
+    runId: "test-run",
+    userId: "test-user",
+    type: "http",
+    action: "ALLOW",
+    method: "GET",
+    url: "https://api.example.com/data",
+    host: "api.example.com",
+    port: 443,
+    status: 200,
+    latency_ms: 150,
+    request_size: 100,
+    response_size: 2048,
+    ...overrides,
+  };
+}
+
+describe("GET /api/zero/runs/:id/network", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should return network logs for a run", async () => {
+    const userId = uniqueId("znet-get");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("znet")}`);
+    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+      status: "completed",
+    });
+
+    const httpEvent = makeAxiomEvent({ runId, userId });
+    const tcpEvent = makeAxiomEvent({
+      runId,
+      userId,
+      type: "tcp",
+      action: undefined,
+      method: undefined,
+      url: undefined,
+      status: undefined,
+      host: "redis.example.com",
+      port: 6379,
+    });
+
+    context.mocks.axiom.queryAxiom.mockResolvedValue([httpEvent, tcpEvent]);
+
+    const response = await GET(createTestRequest(networkUrl(runId)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.networkLogs).toHaveLength(2);
+    expect(data.hasMore).toBe(false);
+
+    expect(data.networkLogs[0].type).toBe("http");
+    expect(data.networkLogs[0].method).toBe("GET");
+    expect(data.networkLogs[0].url).toBe("https://api.example.com/data");
+    expect(data.networkLogs[0].status).toBe(200);
+
+    expect(data.networkLogs[1].type).toBe("tcp");
+    expect(data.networkLogs[1].host).toBe("redis.example.com");
+    expect(data.networkLogs[1].port).toBe(6379);
+  });
+
+  it("should return empty array when no logs", async () => {
+    const userId = uniqueId("znet-empty");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("znet")}`);
+    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+      status: "completed",
+    });
+
+    context.mocks.axiom.queryAxiom.mockResolvedValue([]);
+
+    const response = await GET(createTestRequest(networkUrl(runId)));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.networkLogs).toEqual([]);
+    expect(data.hasMore).toBe(false);
+  });
+
+  it("should return 404 when run not found", async () => {
+    const userId = uniqueId("znet-nf");
+    await setupOrg(userId);
+
+    const response = await GET(createTestRequest(networkUrl(randomUUID())));
+    expect(response.status).toBe(404);
+
+    const data = await response.json();
+    expect(data.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await GET(
+      createTestRequest("http://localhost:3000/api/zero/runs/some-id/network"),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("should set hasMore when results exceed limit", async () => {
+    const userId = uniqueId("znet-more");
+    await setupOrg(userId);
+    const compose = await createTestCompose(`agent-${uniqueId("znet")}`);
+    const { runId } = await createTestRunInDb(userId, compose.composeId, {
+      status: "completed",
+    });
+
+    // Query with limit=2, return 3 events to trigger hasMore
+    const events = Array.from({ length: 3 }, (_, i) => {
+      return makeAxiomEvent({
+        runId,
+        userId,
+        url: `https://api.example.com/${i}`,
+      });
+    });
+    context.mocks.axiom.queryAxiom.mockResolvedValue(events);
+
+    const url = `${networkUrl(runId)}?limit=2`;
+    const response = await GET(createTestRequest(url));
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.networkLogs).toHaveLength(2);
+    expect(data.hasMore).toBe(true);
+  });
+});

--- a/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
@@ -1,0 +1,133 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../../src/lib/ts-rest-handler";
+import { zeroRunNetworkLogsContract } from "@vm0/core";
+import { initServices } from "../../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
+import { getRunById } from "../../../../../../src/lib/run/run-service";
+import {
+  queryAxiom,
+  getDatasetName,
+  DATASETS,
+} from "../../../../../../src/lib/axiom";
+
+/**
+ * Axiom network event (MITM proxy)
+ * [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
+ */
+interface AxiomNetworkEvent {
+  _time: string;
+  runId: string;
+  userId: string;
+  type?: string;
+  action?: "ALLOW" | "DENY";
+  host?: string;
+  port?: number;
+  method?: string;
+  url?: string;
+  status?: number;
+  latency_ms?: number;
+  request_size?: number;
+  response_size?: number;
+  firewall_base?: string;
+  firewall_name?: string;
+  firewall_ref?: string;
+  firewall_permission?: string;
+  firewall_rule_match?: string;
+  firewall_params?: Record<string, string>;
+  firewall_error?: string;
+  token_resolved_secrets?: string[];
+  token_refreshed_connectors?: string[];
+  token_refreshed_secrets?: string[];
+  token_cache_hit?: boolean;
+  error?: string;
+}
+
+const router = tsr.router(zeroRunNetworkLogsContract, {
+  getNetworkLogs: async ({ params, query, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const { org } = await resolveOrg(authCtx);
+
+    const run = await getRunById(params.id, userId, org.orgId);
+    if (!run) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
+    }
+
+    const { since, limit, order } = query;
+
+    const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_NETWORK);
+    const sinceFilter = since
+      ? `| where _time > datetime("${new Date(since).toISOString()}")`
+      : "";
+    const apl = `['${dataset}']
+| where runId == "${params.id}"
+${sinceFilter}
+| order by _time ${order}
+| limit ${limit + 1}`;
+
+    const events = await queryAxiom<AxiomNetworkEvent>(apl);
+
+    const hasMore = events.length > limit;
+    const records = hasMore ? events.slice(0, limit) : events;
+
+    const networkLogs = records.map((e) => {
+      return {
+        timestamp: e._time,
+        type: e.type,
+        action: e.action,
+        host: e.host,
+        port: e.port,
+        method: e.method,
+        url: e.url,
+        status: e.status,
+        latency_ms: e.latency_ms,
+        request_size: e.request_size,
+        response_size: e.response_size,
+        firewall_base: e.firewall_base,
+        firewall_name: e.firewall_name,
+        firewall_ref: e.firewall_ref,
+        firewall_permission: e.firewall_permission,
+        firewall_rule_match: e.firewall_rule_match,
+        firewall_params: e.firewall_params,
+        firewall_error: e.firewall_error,
+        token_resolved_secrets: e.token_resolved_secrets,
+        token_refreshed_connectors: e.token_refreshed_connectors,
+        token_refreshed_secrets: e.token_refreshed_secrets,
+        token_cache_hit: e.token_cache_hit,
+        error: e.error,
+      };
+    });
+
+    return {
+      status: 200 as const,
+      body: {
+        networkLogs,
+        hasMore,
+      },
+    };
+  },
+});
+
+const handler = createHandler(zeroRunNetworkLogsContract, router, {
+  errorHandler: createSafeErrorHandler("zero-runs:network"),
+});
+
+export { handler as GET };

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -588,12 +588,14 @@ export {
   zeroRunsQueueContract,
   zeroRunAgentEventsContract,
   zeroRunContextContract,
+  zeroRunNetworkLogsContract,
   type ZeroRunsMainContract,
   type ZeroRunsByIdContract,
   type ZeroRunsCancelContract,
   type ZeroRunsQueueContract,
   type ZeroRunAgentEventsContract,
   type ZeroRunContextContract,
+  type ZeroRunNetworkLogsContract,
   type RunContextResponse,
 } from "./zero-runs";
 export {

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -8,6 +8,7 @@ import {
   agentEventsResponseSchema,
   queueResponseSchema,
   unifiedRunRequestSchema,
+  networkLogsResponseSchema,
 } from "./runs";
 
 /**
@@ -217,6 +218,33 @@ export const zeroRunContextContract = c.router({
   },
 });
 
+/**
+ * Zero run network logs contract (GET /api/zero/runs/:id/network)
+ * Returns mitmproxy network logs for a run
+ */
+export const zeroRunNetworkLogsContract = c.router({
+  getNetworkLogs: {
+    method: "GET",
+    path: "/api/zero/runs/:id/network",
+    headers: authHeadersSchema,
+    pathParams: z.object({
+      id: z.string().min(1, "Run ID is required"),
+    }),
+    query: z.object({
+      since: z.coerce.number().optional(),
+      limit: z.coerce.number().min(1).max(500).default(500),
+      order: z.enum(["asc", "desc"]).default("asc"),
+    }),
+    responses: {
+      200: networkLogsResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get network logs for a run",
+  },
+});
+
 // Inferred types from Zod schemas
 export type RunContextResponse = z.infer<typeof runContextResponseSchema>;
 
@@ -227,3 +255,4 @@ export type ZeroRunsCancelContract = typeof zeroRunsCancelContract;
 export type ZeroRunsQueueContract = typeof zeroRunsQueueContract;
 export type ZeroRunAgentEventsContract = typeof zeroRunAgentEventsContract;
 export type ZeroRunContextContract = typeof zeroRunContextContract;
+export type ZeroRunNetworkLogsContract = typeof zeroRunNetworkLogsContract;

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -41,5 +41,6 @@ export enum FeatureSwitchKey {
   CreditAddOn = "creditAddOn",
   ModelDetail = "modelDetail",
   RunContext = "runContext",
+  RunNetwork = "runNetwork",
   ActivityLogList = "activityLogList",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -279,6 +279,11 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabledUserHashes: STAFF_USER_HASHES,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.RunNetwork]: {
+    maintainer: "liangyou@vm0.ai",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ActivityLogList]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,


### PR DESCRIPTION
## Summary
- Add `/activity/:runId/network` page to display mitmproxy network logs
- New zero API route `GET /api/zero/runs/:id/network` with `requireAuth` + `agent-run:read`
- Type-aware table: HTTP/TCP/UDP/DENY entries with color-coded badges, status, latency
- Click to expand row shows all 23 fields
- New `FeatureSwitchKey.RunNetwork` feature switch (staff-only)
- "Network" link on activity detail page header, next to "Context"

Closes #7439

## Test plan
- [ ] 5 API integration tests pass (happy path, empty, 404, 401, hasMore)
- [ ] Network page renders with real data on local dev
- [ ] Feature switch controls Network link visibility
- [ ] Expandable rows show all fields correctly
- [ ] TCP/UDP/DENY entries render with correct badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)