### PR TITLE
fix(web): keep connector firewall entry when all permissions are denied

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -309,7 +309,7 @@ describe("createZeroRun()", () => {
       expect(permNames).not.toContain("chat:write");
     });
 
-    it("should not add firewall entry when all permissions are denied", async () => {
+    it("should keep firewall entry with empty permissions when all are denied", async () => {
       const agentName = uniqueId("fw-allden");
       await createTestCompose(agentName);
       await createTestConnector({ type: "slack" });
@@ -326,13 +326,16 @@ describe("createZeroRun()", () => {
 
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
-      // All denied → no firewall entry
+      // All denied → entry preserved with empty permissions for token injection
       const slackFw = job!.executionContext.experimentalFirewalls?.find(
         (fw) => {
           return fw.ref === "slack";
         },
       );
-      expect(slackFw).toBeUndefined();
+      expect(slackFw).toBeDefined();
+      for (const api of slackFw!.apis) {
+        expect(api.permissions).toEqual([]);
+      }
     });
 
     it("should add multiple firewall entries for multi-ref connector", async () => {

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -997,21 +997,14 @@ function applyConnectorPolicies(
         return refPolicies[perm.name] === "allow";
       });
 
-      if (!allowed || allowed.length === 0) return null;
-
       return {
         base: api.base,
         auth: api.auth,
-        permissions: allowed,
+        permissions: allowed ?? [],
       };
     });
 
-    const validApis = apis.filter((api): api is NonNullable<typeof api> => {
-      return api !== null;
-    });
-    if (validApis.length === 0) continue;
-
-    result.push({ name: fw.name, ref: fw.ref, apis: validApis });
+    result.push({ name: fw.name, ref: fw.ref, apis });
   }
 
   return result;


### PR DESCRIPTION
## Summary
- When all permissions for a connector are denied via firewall policies, the connector firewall entry was completely excluded from the manifest
- This meant the proxy could not match the base URL for token injection (e.g. `Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}`)
- Now the entry is preserved with an empty `permissions` array, so the proxy can still match and inject tokens, but all API calls will be denied

## Test plan
- [ ] Connector with all permissions denied still appears in `experimentalFirewalls`
- [ ] Proxy matches base URL and injects tokens for denied connectors
- [ ] API calls are still denied by the empty permissions list

🤖 Generated with [Claude Code](https://claude.com/claude-code)