### PR TITLE
feat(e2e): enlarge browser viewport to 1920x1080 and capture dual light/dark screenshots

### DIFF
--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -52,6 +52,8 @@ browser_setup() {
     E2E_ACCOUNT="$(generate_test_email)"
     export E2E_ACCOUNT
   fi
+
+  agent-browser set viewport 1920 1080
 }
 
 # ---------------------------------------------------------------------------
@@ -75,7 +77,11 @@ step_screenshot() {
   local filename
   filename=$(printf "%02d-%s" "$STEP_NUM" "$label")
   echo "# [$filename] Taking screenshot..." >&3 2>/dev/null || true
-  agent-browser screenshot "$SCREENSHOT_DIR/${filename}.png" 2>/dev/null || true
+  agent-browser set media light 2>/dev/null || true
+  agent-browser screenshot "$SCREENSHOT_DIR/${filename}-light.png" 2>/dev/null || true
+  agent-browser set media dark 2>/dev/null || true
+  agent-browser screenshot "$SCREENSHOT_DIR/${filename}-dark.png" 2>/dev/null || true
+  agent-browser set media light 2>/dev/null || true
   agent-browser snapshot > "$SCREENSHOT_DIR/${filename}.txt" 2>/dev/null || true
 }
 


### PR DESCRIPTION
## Summary

- Set browser viewport to 1920x1080 in `browser_setup()` for full HD screenshots
- Modify `step_screenshot()` to capture both light and dark mode screenshots (`*-light.png` and `*-dark.png`)
- Text snapshot (`.txt`) captured once per step without suffix

Closes #7463

## Test plan

- [ ] CI e2e tests pass with the new screenshot logic
- [ ] Screenshot artifacts contain both `-light.png` and `-dark.png` variants
- [ ] Text snapshots remain unchanged (no suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)