### PR TITLE
fix(ci): remove browser e2e cleanup that deletes parallel runner accounts

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1135,34 +1135,6 @@ jobs:
           JOB_REF: ${{ needs.prepare.outputs.job-ref }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
           E2E_ACCOUNT: ${{ needs.prepare.outputs.job-ref }}+clerk_test+browser@vm0-e2e.ai
-      - name: Cleanup test accounts
-        if: always()
-        env:
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
-          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
-        run: |
-          echo "Cleaning up Clerk test accounts..."
-          # List users whose email contains the JOB_REF prefix
-          users=$(curl -sS -X GET \
-            "https://api.clerk.com/v1/users?query=${JOB_REF}%2Bclerk_test&limit=100" \
-            -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
-            -H "Content-Type: application/json")
-
-          # Delete all matching users (no exclusions — all accounts are ephemeral)
-          ids=$(echo "$users" | jq -r '.[].id' 2>/dev/null || true)
-
-          if [ -z "$ids" ]; then
-            echo "No test accounts to clean up"
-          else
-            for uid in $ids; do
-              echo "Deleting user $uid..."
-              curl -sS -X DELETE \
-                "https://api.clerk.com/v1/users/${uid}" \
-                -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
-                -H "Content-Type: application/json" > /dev/null
-            done
-            echo "Cleanup complete"
-          fi
       - name: Upload auth screenshots
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Remove the "Cleanup test accounts" step from `cli-e2e-02-browser` job that deletes ALL Clerk test users matching `JOB_REF+clerk_test` while runner E2E tests are still running in parallel
- This cleanup was causing HTTP 500 in `setup_test_connector` when `resolveTestUserId` couldn't find the already-deleted runner user (see [failed job](https://github.com/vm0-ai/vm0/actions/runs/23834325389/job/69475151031))
- Account cleanup is already handled by `cleanup.yml` → `cleanup-test-users` on PR close

## Test plan

- [ ] Verify `cli-e2e-03-runner` chunk 4 (t42-firewall-placeholder) no longer fails due to missing test user
- [ ] Verify `cleanup.yml` still cleans up all test accounts on PR close

🤖 Generated with [Claude Code](https://claude.com/claude-code)