### PR TITLE
fix: preserve custom skill volumes in instructions update

### DIFF
--- a/turbo/apps/web/app/api/zero/agents/[id]/instructions/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/instructions/route.ts
@@ -223,12 +223,14 @@ const router = tsr.router(zeroAgentInstructionsContract, {
         id: agentComposes.id,
         name: agentComposes.name,
         content: agentComposeVersions.content,
+        customSkills: zeroAgents.customSkills,
       })
       .from(agentComposes)
       .leftJoin(
         agentComposeVersions,
         eq(agentComposes.headVersionId, agentComposeVersions.id),
       )
+      .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
       .where(
         and(
           eq(agentComposes.orgId, org.orgId),
@@ -259,7 +261,12 @@ const router = tsr.router(zeroAgentInstructionsContract, {
 
     // Rebuild compose from scratch so environment templates stay current,
     // then overlay new instructions.
-    const content = buildComposeContent(compose.name);
+    const content = buildComposeContent(
+      compose.name,
+      (compose.customSkills ?? []).map((name) => {
+        return { name };
+      }),
+    );
 
     const result = await serverSideCompose({
       userId,

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -488,6 +488,36 @@ describe("Zero Agents API", () => {
       expect(agentEnv.ZERO_TOKEN).toBe("${{ secrets.ZERO_TOKEN }}");
     });
 
+    it("should preserve custom skill volumes after instructions update", async () => {
+      const createResponse = await postAgent(
+        { customSkills: ["my-skill"] },
+        testCliToken,
+      );
+      const created = await createResponse.json();
+
+      const response = await putAgentInstructions(
+        created.agentId,
+        { content: "# Updated instructions" },
+        testCliToken,
+      );
+      expect(response.status).toBe(200);
+
+      const content = await getTestComposeVersionContent(created.agentId);
+      const volumes = content?.volumes as
+        | Record<string, { name: string; version: string }>
+        | undefined;
+      expect(volumes?.["custom-skill-my-skill"]).toEqual({
+        name: "custom-skill@my-skill",
+        version: "latest",
+      });
+
+      const agents = content?.agents as Record<string, { volumes: string[] }>;
+      const agentVolumes = Object.values(agents)[0]!.volumes;
+      expect(agentVolumes).toContain(
+        "custom-skill-my-skill:/home/user/.claude/skills/my-skill",
+      );
+    });
+
     it("should return 404 for unknown agent", async () => {
       const response = await putAgentInstructions(
         "00000000-0000-0000-0000-000000000000",


### PR DESCRIPTION
## Summary

- Fix `PUT /api/zero/agents/:id/instructions` silently dropping custom skill volume mounts from compose
- JOIN `zeroAgents` in the existing compose query to fetch `customSkills` and pass them to `buildComposeContent()`
- Add integration test verifying custom skill volumes survive an instructions update

Closes #7467

## Test plan

- [x] Integration test: create agent with custom skills → update instructions → verify volumes preserved
- [x] All 55 existing tests pass
- [x] Lint, type-check, and knip all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)