### PR TITLE
refactor(platform): extract onboarding completion logic into ccstate signals

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  onboardingDisplayName$,
+  onboardingError$,
+  onboardingAddToSlack$,
+  onboardingContinueWeb$,
+} from "../zero-onboarding-actions.ts";
+import {
+  setZeroAgentName$,
+  zeroOnboardingStep$,
+  zeroSaving$,
+} from "../zero-onboarding.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
+
+function mockAdminOnboarding() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: false,
+        defaultAgentId: null,
+        defaultAgentMetadata: null,
+        defaultAgentSkills: [],
+      });
+    }),
+  );
+}
+
+function mockMemberOnboarding() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: false,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+        defaultAgentMetadata: { displayName: "TeamBot" },
+        defaultAgentSkills: [],
+      });
+    }),
+  );
+}
+
+function mockAdminCompletionApis() {
+  server.use(
+    http.put("*/api/zero/org", () => {
+      return HttpResponse.json({ id: "org_1", slug: "test", name: "Test" });
+    }),
+    http.post("*/api/zero/model-providers", () => {
+      return HttpResponse.json(
+        {
+          provider: {
+            id: "a0000000-0000-4000-a000-000000000099",
+            type: "vm0",
+            framework: "claude-code",
+            secretName: null,
+            authMethod: null,
+            secretNames: null,
+            isDefault: true,
+            selectedModel: null,
+            createdAt: "2026-03-01T00:00:00Z",
+            updatedAt: "2026-03-01T00:00:00Z",
+          },
+          created: true,
+        },
+        { status: 201 },
+      );
+    }),
+    http.post("*/api/zero/agents", () => {
+      return HttpResponse.json(
+        {
+          name: "zero",
+          agentId: MOCK_AGENT_ID,
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          firewallPolicies: null,
+        },
+        { status: 201 },
+      );
+    }),
+    http.put(`*/api/zero/agents/${MOCK_AGENT_ID}/instructions`, () => {
+      return HttpResponse.json({
+        name: "zero",
+        agentId: MOCK_AGENT_ID,
+        description: null,
+        displayName: null,
+        sound: null,
+        avatarUrl: null,
+        firewallPolicies: null,
+      });
+    }),
+    http.put("*/api/zero/default-agent", () => {
+      return HttpResponse.json({ agentId: MOCK_AGENT_ID });
+    }),
+    http.post("*/api/zero/onboarding/complete", () => {
+      return HttpResponse.json({ ok: true });
+    }),
+    http.post("*/api/zero/chat/messages", () => {
+      return HttpResponse.json(
+        {
+          runId: "run-1",
+          threadId: "thread-1",
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+        { status: 201 },
+      );
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+function mockMemberCompletionApis() {
+  server.use(
+    http.post("*/api/zero/onboarding/complete", () => {
+      return HttpResponse.json({ ok: true });
+    }),
+    http.post("*/api/zero/chat/messages", () => {
+      return HttpResponse.json(
+        {
+          runId: "run-1",
+          threadId: "thread-1",
+          status: "pending",
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+        { status: 201 },
+      );
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// onboardingDisplayName$
+// ---------------------------------------------------------------------------
+
+describe("onboardingDisplayName$", () => {
+  it("should return agent name for admin", async () => {
+    mockAdminOnboarding();
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    context.store.set(setZeroAgentName$, "My Agent");
+
+    const name = await context.store.get(onboardingDisplayName$);
+    expect(name).toBe("My Agent");
+  });
+
+  it("should return default agent display name for member", async () => {
+    mockMemberOnboarding();
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const name = await context.store.get(onboardingDisplayName$);
+    expect(name).toBe("TeamBot");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onboardingError$
+// ---------------------------------------------------------------------------
+
+describe("onboardingError$", () => {
+  it("should return null for member even if error exists", async () => {
+    mockMemberOnboarding();
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const error = await context.store.get(onboardingError$);
+    expect(error).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onboardingAddToSlack$
+// ---------------------------------------------------------------------------
+
+describe("onboardingAddToSlack$", () => {
+  it("should navigate to /works for admin", async () => {
+    mockAdminOnboarding();
+    mockAdminCompletionApis();
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    // Switch status to complete after the command runs
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: true,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: MOCK_AGENT_ID,
+          defaultAgentMetadata: null,
+          defaultAgentSkills: [],
+        });
+      }),
+    );
+
+    await context.store.set(onboardingAddToSlack$, context.signal);
+
+    expect(pathname()).toBe("/works");
+    expect(context.store.get(zeroSaving$)).toBeFalsy();
+  });
+
+  it("should navigate to /works for member", async () => {
+    mockMemberOnboarding();
+    mockMemberCompletionApis();
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    // Switch status to complete
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: false,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+          defaultAgentMetadata: { displayName: "TeamBot" },
+          defaultAgentSkills: [],
+        });
+      }),
+    );
+
+    await context.store.set(onboardingAddToSlack$, context.signal);
+
+    expect(pathname()).toBe("/works");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onboardingContinueWeb$
+// ---------------------------------------------------------------------------
+
+describe("onboardingContinueWeb$", () => {
+  it("should navigate to / and reset saving for admin", async () => {
+    mockAdminOnboarding();
+    mockAdminCompletionApis();
+    await setupPage({ context, path: "/onboarding", withoutRender: true });
+
+    // Switch status to complete
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: true,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: MOCK_AGENT_ID,
+          defaultAgentMetadata: null,
+          defaultAgentSkills: [],
+        });
+      }),
+    );
+
+    await context.store.set(onboardingContinueWeb$, context.signal);
+
+    expect(pathname()).toBe("/");
+    expect(context.store.get(zeroSaving$)).toBeFalsy();
+    // Step is set to "done" by dismissZeroOnboarding$
+    await expect(context.store.get(zeroOnboardingStep$)).resolves.toBe("done");
+  });
+
+  it("should navigate to / for member", async () => {
+    mockMemberOnboarding();
+    mockMemberCompletionApis();
+    await setupPage({ context, path: "/onboarding", withoutRender: true });
+
+    // Switch status to complete
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: false,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+          defaultAgentMetadata: { displayName: "TeamBot" },
+          defaultAgentSkills: [],
+        });
+      }),
+    );
+
+    await context.store.set(onboardingContinueWeb$, context.signal);
+
+    expect(pathname()).toBe("/");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -1,0 +1,140 @@
+import { command, computed } from "ccstate";
+import {
+  zeroNeedsOnboarding$,
+  zeroAgentName$,
+  zeroSaving$,
+  zeroOnboardingError$,
+  completeZeroOnboarding$,
+  completeMemberOnboarding$,
+  dismissZeroOnboarding$,
+  clearZeroOnboardingError$,
+} from "./zero-onboarding.ts";
+import { agentDisplayName$ } from "./zero-agent-name.ts";
+import { sendNewThreadMessage$, startNewZeroSession$ } from "./zero-chat.ts";
+import { detachedNavigateTo$ } from "../route.ts";
+import { slackOrgData$ } from "./zero-slack.ts";
+import { reloadBillingStatus$ } from "./billing.ts";
+import { detach, Reason } from "../utils.ts";
+
+// ---------------------------------------------------------------------------
+// Derived state for WhereToWorkContent
+// ---------------------------------------------------------------------------
+
+/**
+ * Display name shown in the "Where to work" step.
+ * Admin sees the name they typed; member sees the default agent's display name.
+ */
+export const onboardingDisplayName$ = computed(async (get) => {
+  const isAdmin = await get(zeroNeedsOnboarding$);
+  if (isAdmin) {
+    return get(zeroAgentName$);
+  }
+  return await get(agentDisplayName$);
+});
+
+/**
+ * Onboarding saving state — re-exported for convenience so WhereToWorkContent
+ * can import from a single file.
+ */
+export const onboardingSaving$ = zeroSaving$;
+
+/**
+ * Error to display in the "Where to work" step.
+ * Only admin sees errors; member path never surfaces them.
+ */
+export const onboardingError$ = computed(async (get) => {
+  const isAdmin = await get(zeroNeedsOnboarding$);
+  if (!isAdmin) {
+    return null;
+  }
+  return get(zeroOnboardingError$);
+});
+
+// ---------------------------------------------------------------------------
+// Action commands for WhereToWorkContent
+// ---------------------------------------------------------------------------
+
+/**
+ * Complete onboarding and navigate to Slack setup.
+ * Admin: create agent → reload billing → open Slack install URL → /works
+ * Member: mark complete → /works
+ */
+export const onboardingAddToSlack$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(clearZeroOnboardingError$);
+    const isAdmin = await get(zeroNeedsOnboarding$);
+    signal.throwIfAborted();
+
+    if (isAdmin) {
+      const result = await set(completeZeroOnboarding$, signal);
+      if (!result) {
+        return;
+      }
+      set(reloadBillingStatus$);
+      set(dismissZeroOnboarding$);
+
+      const slackData = get(slackOrgData$);
+      if (slackData?.isAdmin && slackData.installUrl) {
+        const url = new URL(slackData.installUrl, window.location.origin);
+        url.searchParams.set("_t", String(Date.now()));
+        window.open(url.toString(), "_blank");
+      }
+
+      set(detachedNavigateTo$, "/works");
+    } else {
+      await set(completeMemberOnboarding$, signal);
+      set(detachedNavigateTo$, "/works");
+    }
+  },
+);
+
+/**
+ * Complete onboarding and start a web chat session.
+ * Admin: create agent → reload billing → navigate home → send intro message
+ * Member: mark complete → navigate home → send intro message
+ */
+export const onboardingContinueWeb$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(clearZeroOnboardingError$);
+    const isAdmin = await get(zeroNeedsOnboarding$);
+    signal.throwIfAborted();
+
+    if (isAdmin) {
+      const agentId = await set(completeZeroOnboarding$, signal);
+      if (!agentId) {
+        return;
+      }
+      set(reloadBillingStatus$);
+      set(detachedNavigateTo$, "/");
+      set(startNewZeroSession$);
+      detach(
+        set(
+          sendNewThreadMessage$,
+          agentId,
+          "Who are you and what can you do?",
+          undefined,
+          signal,
+        ),
+        Reason.DomCallback,
+      );
+      set(dismissZeroOnboarding$);
+    } else {
+      const agentId = await set(completeMemberOnboarding$, signal);
+      if (!agentId) {
+        return;
+      }
+      set(detachedNavigateTo$, "/");
+      set(startNewZeroSession$);
+      detach(
+        set(
+          sendNewThreadMessage$,
+          agentId,
+          "Who are you and what can you do?",
+          undefined,
+          signal,
+        ),
+        Reason.DomCallback,
+      );
+    }
+  },
+);

--- a/turbo/apps/platform/src/views/onboarding-page/onboarding-page.tsx
+++ b/turbo/apps/platform/src/views/onboarding-page/onboarding-page.tsx
@@ -5,7 +5,6 @@ import {
   zeroNeedsOnboarding$,
   zeroNeedsMemberOnboarding$,
 } from "../../signals/zero-page/zero-onboarding.ts";
-import { agentDisplayName$ } from "../../signals/zero-page/zero-agent-name.ts";
 
 export function OnboardingPage() {
   const userLoadable = useLoadable(user$);
@@ -20,19 +19,11 @@ export function OnboardingPage() {
   const isMember =
     memberOnboarding.state === "hasData" && memberOnboarding.data === true;
 
-  const agentDisplayNameLoadable = useLastLoadable(agentDisplayName$);
-  const agentDisplayName =
-    agentDisplayNameLoadable.state === "hasData"
-      ? agentDisplayNameLoadable.data
-      : "Zero";
-
   const showOnboarding = isLoggedIn && (isAdmin || isMember);
 
   return (
     <div className="h-dvh w-full">
-      {showOnboarding && (
-        <ZeroOnboarding isAdmin={isAdmin} displayName={agentDisplayName} />
-      )}
+      {showOnboarding && <ZeroOnboarding isAdmin={isAdmin} />}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { mockChatLifecycle } from "./chat-test-helpers.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
+const MOCK_THREAD_ID = "thread-test-1";
+
+function mockAdminOnboardingApis() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: false,
+        defaultAgentId: null,
+        defaultAgentMetadata: null,
+        defaultAgentSkills: [],
+      });
+    }),
+    http.put("*/api/zero/org", () => {
+      return HttpResponse.json({
+        id: "org_1",
+        slug: "test-workspace",
+        name: "Test Workspace",
+      });
+    }),
+    http.post("*/api/zero/model-providers", () => {
+      return HttpResponse.json(
+        {
+          provider: {
+            id: "a0000000-0000-4000-a000-000000000099",
+            type: "vm0",
+            framework: "claude-code",
+            secretName: null,
+            authMethod: null,
+            secretNames: null,
+            isDefault: true,
+            selectedModel: null,
+            createdAt: "2026-03-01T00:00:00Z",
+            updatedAt: "2026-03-01T00:00:00Z",
+          },
+          created: true,
+        },
+        { status: 201 },
+      );
+    }),
+    http.post("*/api/zero/agents", () => {
+      return HttpResponse.json(
+        {
+          name: "zero",
+          agentId: MOCK_AGENT_ID,
+          description: null,
+          displayName: null,
+          sound: null,
+          avatarUrl: null,
+          connectors: [],
+          firewallPolicies: null,
+        },
+        { status: 201 },
+      );
+    }),
+    http.put("*/api/zero/agents/:name/instructions", () => {
+      return HttpResponse.json({
+        name: "zero",
+        agentId: MOCK_AGENT_ID,
+        description: null,
+        displayName: null,
+        sound: null,
+        avatarUrl: null,
+        connectors: [],
+        firewallPolicies: null,
+      });
+    }),
+    http.put("*/api/zero/default-agent", () => {
+      return HttpResponse.json({ agentId: MOCK_AGENT_ID });
+    }),
+    http.post("*/api/zero/onboarding/complete", () => {
+      return HttpResponse.json({ ok: true });
+    }),
+  );
+}
+
+function switchToOnboardingComplete() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: false,
+        isAdmin: true,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: MOCK_AGENT_ID,
+        defaultAgentMetadata: null,
+        defaultAgentSkills: [],
+      });
+    }),
+  );
+}
+
+function mockAdminOnboardingWithChat() {
+  mockAdminOnboardingApis();
+  const ctrl = mockChatLifecycle({ threadId: MOCK_THREAD_ID });
+
+  return {
+    ctrl,
+    completeOnboarding: switchToOnboardingComplete,
+  };
+}
+
+function mockMemberOnboardingWithChat() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: false,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+        defaultAgentMetadata: { displayName: "Zero" },
+        defaultAgentSkills: [],
+      });
+    }),
+    http.post("*/api/zero/onboarding/complete", () => {
+      return HttpResponse.json({ ok: true });
+    }),
+  );
+
+  const ctrl = mockChatLifecycle({ threadId: MOCK_THREAD_ID });
+
+  return {
+    ctrl,
+    completeOnboarding: () => {
+      server.use(
+        http.get("*/api/zero/onboarding/status", () => {
+          return HttpResponse.json({
+            needsOnboarding: false,
+            isAdmin: false,
+            hasOrg: true,
+            hasDefaultAgent: true,
+            defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+            defaultAgentMetadata: { displayName: "Zero" },
+            defaultAgentSkills: [],
+          });
+        }),
+      );
+    },
+  };
+}
+
+async function walkAdminToWhereStep(user: ReturnType<typeof userEvent.setup>) {
+  await waitFor(() => {
+    expect(screen.getByText(/Name your workspace/)).toBeInTheDocument();
+  });
+
+  const input = screen.getByPlaceholderText("e.g. Acme Corp");
+  await user.clear(input);
+  await user.type(input, "Test Workspace");
+  await user.click(screen.getByText("Next"));
+
+  await waitFor(() => {
+    expect(screen.getByText("Choose your tools")).toBeInTheDocument();
+  });
+  await user.click(screen.getByText("Next"));
+
+  await waitFor(() => {
+    expect(screen.getByText("Connect your apps")).toBeInTheDocument();
+  });
+  await user.click(screen.getByText("Next"));
+
+  await waitFor(() => {
+    expect(
+      screen.getByText(/Where would you like to work with/),
+    ).toBeInTheDocument();
+  });
+}
+
+describe("onboarding continue in web → chat page", () => {
+  it("should navigate to /chat/:threadId after admin completes full onboarding", async () => {
+    const user = userEvent.setup();
+    const mock = mockAdminOnboardingWithChat();
+
+    await setupPage({ context, path: "/onboarding" });
+    await walkAdminToWhereStep(user);
+
+    mock.completeOnboarding();
+
+    await user.click(screen.getByRole("button", { name: /Continue in web/ }));
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/chat/${MOCK_THREAD_ID}`);
+    });
+
+    mock.ctrl.completeRun("I am Zero, your AI teammate.");
+  });
+
+  it("should navigate to /chat/:threadId after member completes onboarding", async () => {
+    const user = userEvent.setup();
+    const mock = mockMemberOnboardingWithChat();
+
+    await setupPage({ context, path: "/onboarding" });
+
+    // Member with no connectors skips directly to step 4
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Where would you like to work with/),
+      ).toBeInTheDocument();
+    });
+
+    mock.completeOnboarding();
+
+    await user.click(screen.getByRole("button", { name: /Continue in web/ }));
+
+    await waitFor(() => {
+      expect(pathname()).toBe(`/chat/${MOCK_THREAD_ID}`);
+    });
+
+    mock.ctrl.completeRun("I am Zero, your AI teammate.");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Continue in Slack
+// ---------------------------------------------------------------------------
+
+function mockMemberOnboardingForSlack() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: false,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+        defaultAgentMetadata: { displayName: "Zero" },
+        defaultAgentSkills: [],
+      });
+    }),
+    http.post("*/api/zero/onboarding/complete", () => {
+      return HttpResponse.json({ ok: true });
+    }),
+  );
+
+  return {
+    completeOnboarding: () => {
+      server.use(
+        http.get("*/api/zero/onboarding/status", () => {
+          return HttpResponse.json({
+            needsOnboarding: false,
+            isAdmin: false,
+            hasOrg: true,
+            hasDefaultAgent: true,
+            defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+            defaultAgentMetadata: { displayName: "Zero" },
+            defaultAgentSkills: [],
+          });
+        }),
+      );
+    },
+  };
+}
+
+describe("onboarding add to Slack → works page", () => {
+  it("should navigate to /works after admin completes onboarding via Slack", async () => {
+    const user = userEvent.setup();
+    mockAdminOnboardingApis();
+
+    await setupPage({ context, path: "/onboarding" });
+    await walkAdminToWhereStep(user);
+
+    switchToOnboardingComplete();
+
+    await user.click(screen.getByRole("button", { name: /Add .+ to Slack/ }));
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/works");
+    });
+  });
+
+  it("should navigate to /works after member completes onboarding via Slack", async () => {
+    const user = userEvent.setup();
+    const mock = mockMemberOnboardingForSlack();
+
+    await setupPage({ context, path: "/onboarding" });
+
+    // Member with no connectors skips directly to step 4
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Where would you like to work with/),
+      ).toBeInTheDocument();
+    });
+
+    mock.completeOnboarding();
+
+    await user.click(screen.getByRole("button", { name: /Add .+ to Slack/ }));
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/works");
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import {
   useGet,
-  useLoadable,
   useSet,
   useLastLoadable,
   useLastResolved,
@@ -15,25 +14,20 @@ import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import {
   zeroOnboardingStep$,
-  zeroAgentName$,
   zeroWorkspaceName$,
-  zeroSaving$,
   setZeroStep$,
   setZeroWorkspaceName$,
-  completeZeroOnboarding$,
-  dismissZeroOnboarding$,
   zeroSelectedConnectors$,
   toggleZeroConnector$,
-  zeroOnboardingError$,
-  clearZeroOnboardingError$,
-  completeMemberOnboarding$,
   zeroOnboardingStatus$,
 } from "../../signals/zero-page/zero-onboarding.ts";
 import {
-  sendNewThreadMessage$,
-  startNewZeroSession$,
-} from "../../signals/zero-page/zero-chat.ts";
-import { detachedNavigateTo$ } from "../../signals/route.ts";
+  onboardingDisplayName$,
+  onboardingSaving$,
+  onboardingError$,
+  onboardingAddToSlack$,
+  onboardingContinueWeb$,
+} from "../../signals/zero-page/zero-onboarding-actions.ts";
 import {
   allConnectorTypes$,
   connectConnector$,
@@ -43,8 +37,6 @@ import {
 } from "../../signals/zero-page/settings/connectors.ts";
 import { ConnectModal } from "./components/settings/add-connection-dialog.tsx";
 import { pageSignal$ } from "../../signals/page-signal.ts";
-import { slackOrgData$ } from "../../signals/zero-page/zero-slack.ts";
-import { reloadBillingStatus$ } from "../../signals/zero-page/billing.ts";
 import {
   IconCircleCheck,
   IconCircleCheckFilled,
@@ -326,21 +318,13 @@ function ConnectStepContent({
 // Where to work step content
 // ---------------------------------------------------------------------------
 
-function WhereToWorkContent({
-  name,
-  zeroAvatarSrc,
-  onAddToSlack,
-  onContinueWeb,
-  saving,
-  error,
-}: {
-  name: string;
-  zeroAvatarSrc: string | null;
-  onAddToSlack: () => void;
-  onContinueWeb: () => void;
-  saving: boolean;
-  error: string | null;
-}) {
+function WhereToWorkContent() {
+  const name = useLastResolved(onboardingDisplayName$) ?? "Zero";
+  const saving = useGet(onboardingSaving$);
+  const error = useLastResolved(onboardingError$) ?? null;
+  const addToSlack = useSet(onboardingAddToSlack$);
+  const continueWeb = useSet(onboardingContinueWeb$);
+
   return (
     <>
       <h2 className="text-2xl font-semibold tracking-tight">
@@ -359,7 +343,12 @@ function WhereToWorkContent({
       <div className="flex flex-col gap-5 w-full">
         <button
           type="button"
-          onClick={onAddToSlack}
+          onClick={() => {
+            return detach(
+              addToSlack(new AbortController().signal),
+              Reason.DomCallback,
+            );
+          }}
           disabled={saving}
           className="flex items-center gap-4 rounded-xl bg-card px-6 py-6 text-left transition-colors hover:bg-muted/30 disabled:opacity-50 zero-border"
         >
@@ -378,21 +367,22 @@ function WhereToWorkContent({
         </button>
         <button
           type="button"
-          onClick={onContinueWeb}
+          onClick={() => {
+            return detach(
+              continueWeb(new AbortController().signal),
+              Reason.DomCallback,
+            );
+          }}
           disabled={saving}
           className="flex items-center gap-4 rounded-xl bg-card px-6 py-6 text-left transition-colors hover:bg-muted/30 disabled:opacity-50 zero-border"
         >
           <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg overflow-hidden">
-            {zeroAvatarSrc ? (
-              <img
-                src={zeroAvatarSrc}
-                alt=""
-                role="presentation"
-                className="h-10 w-10 rounded-lg object-cover object-top"
-              />
-            ) : (
-              <div className="h-10 w-10 rounded-lg bg-muted" aria-hidden />
-            )}
+            <img
+              src={zeroAvatarImg}
+              alt=""
+              role="presentation"
+              className="h-10 w-10 rounded-lg object-cover object-top"
+            />
           </span>
           <div className="min-w-0 flex-1">
             <span className="block text-sm font-semibold text-foreground">
@@ -912,133 +902,19 @@ function resolveVisibleSteps(
   return hasMemberConnectors ? ["3", "4"] : ["4"];
 }
 
-// ---------------------------------------------------------------------------
-// Onboarding completion handlers (hook)
-// ---------------------------------------------------------------------------
-
-function useOnboardingHandlers(isAdmin: boolean) {
-  const completeOnboarding = useSet(completeZeroOnboarding$);
-  const completeMember = useSet(completeMemberOnboarding$);
-  const dismissOnboarding = useSet(dismissZeroOnboarding$);
-  const sendNewThread = useSet(sendNewThreadMessage$);
-  const startNewSession = useSet(startNewZeroSession$);
-  const navigate = useSet(detachedNavigateTo$);
-  const clearOnboardingError = useSet(clearZeroOnboardingError$);
-  const reloadBilling = useSet(reloadBillingStatus$);
-  const slackDataLoadable = useLoadable(slackOrgData$);
-  const slackData =
-    slackDataLoadable.state === "hasData" ? slackDataLoadable.data : null;
-
-  const handleAddToSlack = () => {
-    clearOnboardingError();
-    if (isAdmin) {
-      const controller = new AbortController();
-      detach(
-        (async () => {
-          const result = await completeOnboarding(controller.signal);
-          if (!result) {
-            return;
-          }
-          reloadBilling();
-          dismissOnboarding();
-          if (slackData?.isAdmin && slackData.installUrl) {
-            const url = new URL(slackData.installUrl, window.location.origin);
-            url.searchParams.set("_t", String(Date.now()));
-            window.open(url.toString(), "_blank");
-          }
-          navigate("/works");
-        })(),
-        Reason.DomCallback,
-      );
-    } else {
-      const controller = new AbortController();
-      detach(
-        (async () => {
-          await completeMember(controller.signal);
-          navigate("/works");
-        })(),
-        Reason.DomCallback,
-      );
-    }
-  };
-
-  const handleContinueWithWeb = () => {
-    clearOnboardingError();
-    const controller = new AbortController();
-    if (isAdmin) {
-      detach(
-        (async () => {
-          const agentId = await completeOnboarding(controller.signal);
-          if (!agentId) {
-            return;
-          }
-          reloadBilling();
-          navigate("/");
-          startNewSession();
-          // Use controller.signal instead of pageSignal: navigate("/") aborts
-          // the onboarding page signal via resetRouteSignal$, so pageSignal is
-          // already dead by the time sendNewThread runs.
-          detach(
-            sendNewThread(
-              agentId,
-              "Who are you and what can you do?",
-              undefined,
-              controller.signal,
-            ),
-            Reason.DomCallback,
-          );
-          dismissOnboarding();
-        })(),
-        Reason.DomCallback,
-      );
-    } else {
-      detach(
-        (async () => {
-          const agentId = await completeMember(controller.signal);
-          if (!agentId) {
-            return;
-          }
-          navigate("/");
-          startNewSession();
-          detach(
-            sendNewThread(
-              agentId,
-              "Who are you and what can you do?",
-              undefined,
-              controller.signal,
-            ),
-            Reason.DomCallback,
-          );
-        })(),
-        Reason.DomCallback,
-      );
-    }
-  };
-
-  return { handleAddToSlack, handleContinueWithWeb };
-}
-
 /** Zero onboarding — used for both admin and member flows. */
 export function ZeroOnboarding({
   zeroAvatarSrc = zeroAvatarImg,
   isAdmin,
-  displayName = "Zero",
 }: {
   zeroAvatarSrc?: string | null;
   isAdmin: boolean;
-  displayName?: string;
 }) {
   const step = useLastResolved(zeroOnboardingStep$);
   const setStep = useSet(setZeroStep$);
-  const agentName = useGet(zeroAgentName$);
-  const saving = useGet(zeroSaving$);
   const adminSelectedConnectors = useGet(zeroSelectedConnectors$);
-  const onboardingError = useGet(zeroOnboardingError$);
   const selectedConnectorType = useGet(selectedConnectorType$);
   const setSelected = useSet(setSelectedConnectorType$);
-
-  const { handleAddToSlack, handleContinueWithWeb } =
-    useOnboardingHandlers(isAdmin);
 
   // Member: resolve org's configured connectors from default agent skills
   const onboardingStatus = useLastResolved(zeroOnboardingStatus$);
@@ -1081,9 +957,6 @@ export function ZeroOnboarding({
   const effectiveConnectors = isAdmin
     ? adminSelectedConnectors
     : memberConnectorTypes;
-
-  // Display name for WhereToWorkContent
-  const name = isAdmin ? agentName : displayName;
 
   return (
     <>
@@ -1169,14 +1042,7 @@ export function ZeroOnboarding({
             return setStep("3");
           }}
         >
-          <WhereToWorkContent
-            name={name}
-            zeroAvatarSrc={zeroAvatarSrc}
-            onAddToSlack={handleAddToSlack}
-            onContinueWeb={handleContinueWithWeb}
-            saving={saving}
-            error={isAdmin ? onboardingError : null}
-          />
+          <WhereToWorkContent />
         </OnboardingPage>
       )}
     </>


### PR DESCRIPTION
## Summary
- Extract `useOnboardingHandlers` hook from `zero-onboarding.tsx` into a dedicated `zero-onboarding-actions.ts` signal module with `onboardingAddToSlack$` and `onboardingContinueWeb$` commands
- `WhereToWorkContent` now sources state (`onboardingDisplayName$`, `onboardingSaving$`, `onboardingError$`) and actions directly from signals, eliminating prop-drilling through `ZeroOnboarding` and `OnboardingPage`
- Remove unused `displayName` prop from `ZeroOnboarding` and `agentDisplayName$` import from `OnboardingPage`

## Test plan
- [x] Signal-level integration tests for `onboardingDisplayName$`, `onboardingError$`, `onboardingAddToSlack$`, `onboardingContinueWeb$`
- [x] E2E-style render test for admin and member "Continue in web" flow navigating to `/chat/:threadId`
- [x] E2E-style render test for admin and member "Add to Slack" flow navigating to `/works`

🤖 Generated with [Claude Code](https://claude.com/claude-code)