### PR TITLE
refactor: remove cross-org agent selection and org slug from integration webhooks

### DIFF
--- a/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
+++ b/turbo/apps/platform/src/mocks/handlers/api-integrations-telegram.ts
@@ -9,7 +9,7 @@ import { http, HttpResponse } from "msw";
 
 interface MockTelegramIntegrationData {
   bot: { id: string; username: string };
-  agent: { id: string; name: string; orgSlug: string } | null;
+  agent: { id: string; name: string } | null;
   isAdmin: boolean;
   environment: {
     requiredSecrets: string[];
@@ -21,7 +21,7 @@ interface MockTelegramIntegrationData {
 
 let mockTelegramData: MockTelegramIntegrationData = {
   bot: { id: "bot_123", username: "test_bot" },
-  agent: { id: "compose_1", name: "default-agent", orgSlug: "test-org" },
+  agent: { id: "compose_1", name: "default-agent" },
   isAdmin: true,
   environment: {
     requiredSecrets: ["ANTHROPIC_API_KEY"],
@@ -37,7 +37,6 @@ export function resetMockTelegramIntegration(): void {
     agent: {
       id: "compose_1",
       name: "default-agent",
-      orgSlug: "test-org",
     },
     isAdmin: true,
     environment: {

--- a/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/integrations/github/__tests__/route.test.ts
@@ -8,7 +8,6 @@ import {
   insertTestGitHubInstallationWithAdmin,
   insertTestGitHubUserLink,
   findTestGitHubInstallationById,
-  findTestComposeWithOrg,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -426,57 +425,6 @@ describe("/api/integrations/github", () => {
       const getData = await getResponse.json();
 
       expect(getData.agent.name).toBe("new-agent");
-    });
-
-    it("should update default agent with org-qualified name", async () => {
-      const userId = uniqueId("gh-user");
-      mockClerk({ userId });
-      await createTestOrg(uniqueId("gh-org"));
-      const { composeId } = await createTestCompose("gh-agent");
-      await insertTestGitHubInstallationWithAdmin(composeId, userId);
-
-      // Create a compose in a different org (simulating an org member agent)
-      const otherUserId = uniqueId("other-user");
-      mockClerk({ userId: otherUserId });
-      await createTestOrg(uniqueId("other-org"));
-      const { composeId: otherComposeId } =
-        await createTestCompose("other-org-agent");
-
-      // Switch back to original user
-      mockClerk({ userId });
-
-      // Look up the other org's slug for the org-qualified name
-      const otherCompose = await findTestComposeWithOrg(otherComposeId);
-
-      const request = createTestRequest(
-        "http://localhost:3000/api/integrations/github",
-        {
-          method: "PATCH",
-          headers: {
-            Authorization: "Bearer test-token",
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            agentName: `${otherCompose!.orgSlug}/${otherCompose!.composeName}`,
-          }),
-        },
-      );
-      const response = await PATCH(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.ok).toBe(true);
-
-      // Verify the agent was updated
-      const getResponse = await GET(
-        createTestRequest("http://localhost:3000/api/integrations/github", {
-          headers: { Authorization: "Bearer test-token" },
-        }),
-      );
-      const getData = await getResponse.json();
-
-      expect(getData.agent.name).toBe(otherCompose!.composeName);
-      expect(getData.agent.orgSlug).toBe(otherCompose!.orgSlug);
     });
   });
 });

--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -16,10 +16,6 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { listSecrets } from "../../../../src/lib/secret/secret-service";
-import {
-  getOrgData,
-  getOrgBySlug,
-} from "../../../../src/lib/org/org-cache-service";
 import { listVariables } from "../../../../src/lib/variable/variable-service";
 import { listConnectors } from "../../../../src/lib/connector/connector-service";
 import type { AgentComposeYaml } from "../../../../src/types/agent-compose";
@@ -95,15 +91,10 @@ export async function GET(request: Request) {
       id: agentComposes.id,
       name: agentComposes.name,
       headVersionId: agentComposes.headVersionId,
-      orgId: agentComposes.orgId,
     })
     .from(agentComposes)
     .where(eq(agentComposes.id, installation.defaultComposeId))
     .limit(1);
-
-  const composeOrgSlug = compose
-    ? (await getOrgData(compose.orgId)).slug
-    : null;
 
   // Extract required secrets/vars from agent compose
   let requiredSecrets: string[] = [];
@@ -171,9 +162,7 @@ export async function GET(request: Request) {
       targetType: installation.targetType,
       isAdmin,
     },
-    agent: compose
-      ? { id: compose.id, name: compose.name, orgSlug: composeOrgSlug }
-      : null,
+    agent: compose ? { id: compose.id, name: compose.name } : null,
     environment: {
       requiredSecrets,
       requiredVars,
@@ -343,37 +332,17 @@ export async function PATCH(request: Request) {
     );
   }
 
-  // Parse org/agentName format (org member agents use "orgSlug/agentName")
-  const slashIndex = body.agentName.indexOf("/");
-  const agentName =
-    slashIndex === -1 ? body.agentName : body.agentName.slice(slashIndex + 1);
-  const orgSlug =
-    slashIndex === -1 ? null : body.agentName.slice(0, slashIndex);
+  // Resolve org from authenticated user's context
+  const { org } = await resolveOrg(authCtx);
 
-  // Resolve target org
-  let targetOrgId: string;
-  if (orgSlug) {
-    const targetOrg = await getOrgBySlug(orgSlug);
-    if (!targetOrg) {
-      return NextResponse.json(
-        { error: { message: "Org not found", code: "BAD_REQUEST" } },
-        { status: 400 },
-      );
-    }
-    targetOrgId = targetOrg.orgId;
-  } else {
-    const { org } = await resolveOrg(authCtx);
-    targetOrgId = org.orgId;
-  }
-
-  // Find agent compose by name in target org
+  // Find agent compose by name in user's org
   const [compose] = await db
     .select({ id: agentComposes.id })
     .from(agentComposes)
     .where(
       and(
-        eq(agentComposes.orgId, targetOrgId),
-        eq(agentComposes.name, agentName),
+        eq(agentComposes.orgId, org.orgId),
+        eq(agentComposes.name, body.agentName),
       ),
     )
     .limit(1);

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -15,17 +15,12 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { listSecrets } from "../../../../src/lib/secret/secret-service";
-import {
-  getOrgData,
-  getOrgBySlug,
-} from "../../../../src/lib/org/org-cache-service";
 import { listVariables } from "../../../../src/lib/variable/variable-service";
 import { listConnectors } from "../../../../src/lib/connector/connector-service";
 import type { AgentComposeYaml } from "../../../../src/types/agent-compose";
 import { decryptSecretValue } from "../../../../src/lib/crypto/secrets-encryption";
 import { deleteWebhook } from "../../../../src/lib/telegram/client";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
-import { isNotFound } from "../../../../src/lib/errors";
 import { logger } from "../../../../src/lib/logger";
 import { checkTelegramDomain } from "../../../../src/lib/telegram/check-domain";
 
@@ -88,21 +83,16 @@ export async function GET(request: Request) {
     );
   }
 
-  // Get default agent with org info
+  // Get default agent
   const [compose] = await db
     .select({
       id: agentComposes.id,
       name: agentComposes.name,
       headVersionId: agentComposes.headVersionId,
-      orgId: agentComposes.orgId,
     })
     .from(agentComposes)
     .where(eq(agentComposes.id, installation.defaultComposeId))
     .limit(1);
-
-  const composeOrgSlug = compose
-    ? (await getOrgData(compose.orgId)).slug
-    : null;
 
   // Extract required secrets/vars from agent compose
   let requiredSecrets: string[] = [];
@@ -174,9 +164,7 @@ export async function GET(request: Request) {
       id: installation.telegramBotId,
       username: installation.botUsername,
     },
-    agent: compose
-      ? { id: compose.id, name: compose.name, orgSlug: composeOrgSlug }
-      : null,
+    agent: compose ? { id: compose.id, name: compose.name } : null,
     isAdmin,
     isConnected,
     domainConfigured,
@@ -263,37 +251,8 @@ export async function PATCH(request: Request) {
     );
   }
 
-  // Parse org/agentName format
-  const slashIndex = body.agentName.indexOf("/");
-  const agentName =
-    slashIndex === -1 ? body.agentName : body.agentName.slice(slashIndex + 1);
-  const orgSlug =
-    slashIndex === -1 ? null : body.agentName.slice(0, slashIndex);
-
-  // Resolve target org
-  let targetOrg: { orgId: string };
-  if (orgSlug) {
-    const resolved = await getOrgBySlug(orgSlug);
-    if (!resolved) {
-      return NextResponse.json(
-        { error: { message: "Org not found", code: "BAD_REQUEST" } },
-        { status: 400 },
-      );
-    }
-    targetOrg = resolved;
-  } else {
-    try {
-      ({ org: targetOrg } = await resolveOrg(authCtx));
-    } catch (error) {
-      if (isNotFound(error)) {
-        return NextResponse.json(
-          { error: { message: "No org configured", code: "BAD_REQUEST" } },
-          { status: 400 },
-        );
-      }
-      throw error;
-    }
-  }
+  // Resolve org from authenticated user's context
+  const { org: targetOrg } = await resolveOrg(authCtx);
 
   // Find agent
   const [compose] = await db
@@ -302,7 +261,7 @@ export async function PATCH(request: Request) {
     .where(
       and(
         eq(agentComposes.orgId, targetOrg.orgId),
-        eq(agentComposes.name, agentName),
+        eq(agentComposes.name, body.agentName),
       ),
     )
     .limit(1);

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -2329,26 +2329,6 @@ export async function findTestSlackOrgConnections(
 }
 
 /**
- * Find a compose record with its org details.
- *
- * Direct DB read is required because the compose API does not expose
- * org slug in its response — it only returns compose-level fields.
- */
-export async function findTestComposeWithOrg(composeId: string) {
-  const [row] = await globalThis.services.db
-    .select({
-      composeId: agentComposes.id,
-      composeName: agentComposes.name,
-      orgSlug: orgCache.slug,
-    })
-    .from(agentComposes)
-    .innerJoin(orgCache, eq(orgCache.orgId, agentComposes.orgId))
-    .where(eq(agentComposes.id, composeId))
-    .limit(1);
-  return row;
-}
-
-/**
  * Create a runner job queue entry with an associated agent run.
  *
  * @param userId - The user who owns the run


### PR DESCRIPTION
## Summary

- Remove deprecated `orgSlug/agentName` parsing from Telegram and GitHub PATCH handlers — integrations now always resolve agents within the authenticated user's own org via `resolveOrg(authCtx)`
- Remove `orgSlug` display field from GET responses and the unnecessary `getOrgData()` DB call that powered it
- Clean up `getOrgBySlug`, `getOrgData`, and `isNotFound` imports no longer needed
- Remove cross-org agent selection test case and unused `findTestComposeWithOrg` test helper
- Update frontend Telegram integration mock to remove `orgSlug` from agent type

Closes #7468

## Test plan

- [ ] Existing Telegram integration tests pass (auth, admin, PATCH, DELETE)
- [ ] Existing GitHub integration tests pass (auth, admin, PATCH, DELETE, agent update)
- [ ] Cross-org test case removed (no longer applicable)
- [ ] Knip reports no unused code
- [ ] CI pipeline passes (lint, types, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)