### PR TITLE
fix(web): include feature-flagged connectors with api-token in compose

### DIFF
--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -122,15 +122,15 @@ async function devSeed() {
 
     // --- skills (seed skills + common connectors, batch insert) ---
     console.log("Seeding skills...");
-    const gaConnectorTypes = Object.entries(CONNECTOR_TYPES)
+    const eligibleConnectorTypes = Object.entries(CONNECTOR_TYPES)
       .filter(([, config]) => {
-        return !config.featureFlag;
+        return !config.featureFlag || "api-token" in config.authMethods;
       })
       .map(([type]) => {
         return type;
       });
     const skillValues = buildSeedSkillValues([
-      ...new Set([...SEED_SKILLS, ...gaConnectorTypes]),
+      ...new Set([...SEED_SKILLS, ...eligibleConnectorTypes]),
     ]);
     const inserted = await db
       .insert(skills)

--- a/turbo/apps/web/scripts/dev-seed.ts
+++ b/turbo/apps/web/scripts/dev-seed.ts
@@ -3,7 +3,7 @@
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { eq, sql } from "drizzle-orm";
-import { VM0_MODEL_TO_PROVIDER, CONNECTOR_TYPES } from "@vm0/core";
+import { VM0_MODEL_TO_PROVIDER, getEligibleConnectorTypes } from "@vm0/core";
 import { schema } from "../src/db/db";
 import { creditPricing } from "../src/db/schema/credit-pricing";
 import { vm0ApiKeys } from "../src/db/schema/vm0-api-key";
@@ -122,13 +122,7 @@ async function devSeed() {
 
     // --- skills (seed skills + common connectors, batch insert) ---
     console.log("Seeding skills...");
-    const eligibleConnectorTypes = Object.entries(CONNECTOR_TYPES)
-      .filter(([, config]) => {
-        return !config.featureFlag || "api-token" in config.authMethods;
-      })
-      .map(([type]) => {
-        return type;
-      });
+    const eligibleConnectorTypes = getEligibleConnectorTypes();
     const skillValues = buildSeedSkillValues([
       ...new Set([...SEED_SKILLS, ...eligibleConnectorTypes]),
     ]);

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -67,6 +67,7 @@ import { encryptSecretsMap } from "../lib/crypto/secrets-encryption";
 import {
   VOLUME_ORG_USER_ID,
   SYSTEM_ORG_ID,
+  getEligibleConnectorTypes,
   type StoredExecutionContext,
   type FirewallPolicies,
 } from "@vm0/core";
@@ -3562,16 +3563,10 @@ export async function seedTestSkill(
 export async function seedSeedSkills(): Promise<void> {
   const { SEED_SKILLS, buildSeedSkillValues } =
     await import("../lib/zero/seed-skills");
-  const { CONNECTOR_TYPES } = await import("@vm0/core");
   initServices();
-  const eligibleConnectorTypes = Object.entries(CONNECTOR_TYPES)
-    .filter(([, config]) => {
-      return !config.featureFlag || "api-token" in config.authMethods;
-    })
-    .map(([type]) => {
-      return type;
-    });
-  const allNames = [...new Set([...SEED_SKILLS, ...eligibleConnectorTypes])];
+  const allNames = [
+    ...new Set([...SEED_SKILLS, ...getEligibleConnectorTypes()]),
+  ];
   const values = buildSeedSkillValues(allNames);
   await globalThis.services.db
     .insert(skills)
@@ -3589,15 +3584,9 @@ export async function seedSeedSkills(): Promise<void> {
  */
 export async function seedSeedSkillStorages(): Promise<void> {
   const { SEED_SKILLS } = await import("../lib/zero/seed-skills");
-  const { CONNECTOR_TYPES } = await import("@vm0/core");
-  const eligibleConnectorTypes = Object.entries(CONNECTOR_TYPES)
-    .filter(([, config]) => {
-      return !config.featureFlag || "api-token" in config.authMethods;
-    })
-    .map(([type]) => {
-      return type;
-    });
-  const allNames = [...new Set([...SEED_SKILLS, ...eligibleConnectorTypes])];
+  const allNames = [
+    ...new Set([...SEED_SKILLS, ...getEligibleConnectorTypes()]),
+  ];
 
   initServices();
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -3557,21 +3557,21 @@ export async function seedTestSkill(
 /**
  * Seed all SEED_SKILLS plus GA connector type skills into the skills table so
  * that server-side compose succeeds when buildComposeContent injects them.
- * Feature-flagged connectors are excluded to match buildComposeContent behaviour.
+ * Feature-flagged OAuth-only connectors are excluded to match buildComposeContent behaviour.
  */
 export async function seedSeedSkills(): Promise<void> {
   const { SEED_SKILLS, buildSeedSkillValues } =
     await import("../lib/zero/seed-skills");
   const { CONNECTOR_TYPES } = await import("@vm0/core");
   initServices();
-  const gaConnectorTypes = Object.entries(CONNECTOR_TYPES)
+  const eligibleConnectorTypes = Object.entries(CONNECTOR_TYPES)
     .filter(([, config]) => {
-      return !config.featureFlag;
+      return !config.featureFlag || "api-token" in config.authMethods;
     })
     .map(([type]) => {
       return type;
     });
-  const allNames = [...new Set([...SEED_SKILLS, ...gaConnectorTypes])];
+  const allNames = [...new Set([...SEED_SKILLS, ...eligibleConnectorTypes])];
   const values = buildSeedSkillValues(allNames);
   await globalThis.services.db
     .insert(skills)
@@ -3590,14 +3590,14 @@ export async function seedSeedSkills(): Promise<void> {
 export async function seedSeedSkillStorages(): Promise<void> {
   const { SEED_SKILLS } = await import("../lib/zero/seed-skills");
   const { CONNECTOR_TYPES } = await import("@vm0/core");
-  const gaConnectorTypes = Object.entries(CONNECTOR_TYPES)
+  const eligibleConnectorTypes = Object.entries(CONNECTOR_TYPES)
     .filter(([, config]) => {
-      return !config.featureFlag;
+      return !config.featureFlag || "api-token" in config.authMethods;
     })
     .map(([type]) => {
       return type;
     });
-  const allNames = [...new Set([...SEED_SKILLS, ...gaConnectorTypes])];
+  const allNames = [...new Set([...SEED_SKILLS, ...eligibleConnectorTypes])];
 
   initServices();
 

--- a/turbo/apps/web/src/lib/zero/__tests__/build-compose-content.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-compose-content.test.ts
@@ -7,19 +7,28 @@ import {
   getInstructionsFilename,
 } from "@vm0/core";
 
-/** Connector types that are NOT behind a feature flag (generally available). */
-const gaConnectorTypes = Object.entries(CONNECTOR_TYPES)
+/** Connector types eligible for compose: GA or feature-flagged with api-token. */
+const eligibleConnectorTypes = Object.entries(CONNECTOR_TYPES)
   .filter(([, config]) => {
-    return !config.featureFlag;
+    return !config.featureFlag || "api-token" in config.authMethods;
   })
   .map(([type]) => {
     return type;
   });
 
-/** Connector types that ARE behind a feature flag. */
-const flaggedConnectorTypes = Object.entries(CONNECTOR_TYPES)
+/** Feature-flagged connectors that have api-token (eligible despite flag). */
+const flaggedWithApiToken = Object.entries(CONNECTOR_TYPES)
   .filter(([, config]) => {
-    return !!config.featureFlag;
+    return !!config.featureFlag && "api-token" in config.authMethods;
+  })
+  .map(([type]) => {
+    return type;
+  });
+
+/** Feature-flagged connectors that are OAuth-only (excluded from compose). */
+const flaggedOauthOnly = Object.entries(CONNECTOR_TYPES)
+  .filter(([, config]) => {
+    return !!config.featureFlag && !("api-token" in config.authMethods);
   })
   .map(([type]) => {
     return type;
@@ -56,22 +65,21 @@ describe("buildComposeContent", () => {
     }
   });
 
-  it("should include GA connector types as skills", () => {
+  it("should include eligible connector types as skills", () => {
     const result = buildComposeContent("agent");
     const agent = (result.agents as Record<string, Record<string, unknown>>)[
       "agent"
     ]!;
     const skills = agent.skills as string[];
 
-    for (const connectorType of gaConnectorTypes) {
+    for (const connectorType of eligibleConnectorTypes) {
       const url = resolveSkillRef(connectorType);
       expect(skills).toContain(url);
     }
   });
 
-  it("should exclude feature-flagged connector types from skills", () => {
-    // Sanity: there are flagged connectors to exclude
-    expect(flaggedConnectorTypes.length).toBeGreaterThan(0);
+  it("should include feature-flagged connectors that have api-token", () => {
+    expect(flaggedWithApiToken.length).toBeGreaterThan(0);
 
     const result = buildComposeContent("agent");
     const agent = (result.agents as Record<string, Record<string, unknown>>)[
@@ -79,7 +87,22 @@ describe("buildComposeContent", () => {
     ]!;
     const skills = agent.skills as string[];
 
-    for (const connectorType of flaggedConnectorTypes) {
+    for (const connectorType of flaggedWithApiToken) {
+      const url = resolveSkillRef(connectorType);
+      expect(skills).toContain(url);
+    }
+  });
+
+  it("should exclude feature-flagged OAuth-only connectors from skills", () => {
+    expect(flaggedOauthOnly.length).toBeGreaterThan(0);
+
+    const result = buildComposeContent("agent");
+    const agent = (result.agents as Record<string, Record<string, unknown>>)[
+      "agent"
+    ]!;
+    const skills = agent.skills as string[];
+
+    for (const connectorType of flaggedOauthOnly) {
       const url = resolveSkillRef(connectorType);
       expect(skills).not.toContain(url);
     }
@@ -122,15 +145,26 @@ describe("buildComposeContent", () => {
     expect(environment.JIRA_API_TOKEN).toBe("${{ secrets.JIRA_API_TOKEN }}");
   });
 
-  it("should not inject env var templates for feature-flagged connectors", () => {
+  it("should inject env var templates for feature-flagged connectors with api-token", () => {
     const result = buildComposeContent("agent");
     const agent = (result.agents as Record<string, Record<string, unknown>>)[
       "agent"
     ]!;
     const environment = agent.environment as Record<string, string>;
 
-    // Ahrefs is feature-flagged — its env var should NOT be present
-    expect(environment.AHREFS_TOKEN).toBeUndefined();
+    // Mercury is feature-flagged but has api-token — its env var SHOULD be present
+    expect(environment.MERCURY_TOKEN).toBe("${{ secrets.MERCURY_TOKEN }}");
+  });
+
+  it("should not inject env var templates for feature-flagged OAuth-only connectors", () => {
+    const result = buildComposeContent("agent");
+    const agent = (result.agents as Record<string, Record<string, unknown>>)[
+      "agent"
+    ]!;
+    const environment = agent.environment as Record<string, string>;
+
+    // Reddit is feature-flagged and OAuth-only — its env var should NOT be present
+    expect(environment.REDDIT_TOKEN).toBeUndefined();
   });
 
   it("should always include ZERO_AGENT_ID and ZERO_TOKEN", () => {

--- a/turbo/apps/web/src/lib/zero/__tests__/build-compose-content.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-compose-content.test.ts
@@ -7,28 +7,10 @@ import {
   getInstructionsFilename,
 } from "@vm0/core";
 
-/** Connector types eligible for compose: GA or feature-flagged with api-token. */
-const eligibleConnectorTypes = Object.entries(CONNECTOR_TYPES)
+/** GA connector types (no feature flag). */
+const gaConnectorTypes = Object.entries(CONNECTOR_TYPES)
   .filter(([, config]) => {
-    return !config.featureFlag || "api-token" in config.authMethods;
-  })
-  .map(([type]) => {
-    return type;
-  });
-
-/** Feature-flagged connectors that have api-token (eligible despite flag). */
-const flaggedWithApiToken = Object.entries(CONNECTOR_TYPES)
-  .filter(([, config]) => {
-    return !!config.featureFlag && "api-token" in config.authMethods;
-  })
-  .map(([type]) => {
-    return type;
-  });
-
-/** Feature-flagged connectors that are OAuth-only (excluded from compose). */
-const flaggedOauthOnly = Object.entries(CONNECTOR_TYPES)
-  .filter(([, config]) => {
-    return !!config.featureFlag && !("api-token" in config.authMethods);
+    return !config.featureFlag;
   })
   .map(([type]) => {
     return type;
@@ -65,47 +47,43 @@ describe("buildComposeContent", () => {
     }
   });
 
-  it("should include eligible connector types as skills", () => {
+  it("should include GA connector types as skills", () => {
     const result = buildComposeContent("agent");
     const agent = (result.agents as Record<string, Record<string, unknown>>)[
       "agent"
     ]!;
     const skills = agent.skills as string[];
 
-    for (const connectorType of eligibleConnectorTypes) {
+    for (const connectorType of gaConnectorTypes) {
       const url = resolveSkillRef(connectorType);
       expect(skills).toContain(url);
     }
   });
 
   it("should include feature-flagged connectors that have api-token", () => {
-    expect(flaggedWithApiToken.length).toBeGreaterThan(0);
-
     const result = buildComposeContent("agent");
     const agent = (result.agents as Record<string, Record<string, unknown>>)[
       "agent"
     ]!;
     const skills = agent.skills as string[];
 
-    for (const connectorType of flaggedWithApiToken) {
-      const url = resolveSkillRef(connectorType);
-      expect(skills).toContain(url);
-    }
+    // mercury: feature-flagged + has api-token → should be included
+    expect(skills).toContain(resolveSkillRef("mercury"));
+    // ahrefs: feature-flagged + has api-token → should be included
+    expect(skills).toContain(resolveSkillRef("ahrefs"));
   });
 
   it("should exclude feature-flagged OAuth-only connectors from skills", () => {
-    expect(flaggedOauthOnly.length).toBeGreaterThan(0);
-
     const result = buildComposeContent("agent");
     const agent = (result.agents as Record<string, Record<string, unknown>>)[
       "agent"
     ]!;
     const skills = agent.skills as string[];
 
-    for (const connectorType of flaggedOauthOnly) {
-      const url = resolveSkillRef(connectorType);
-      expect(skills).not.toContain(url);
-    }
+    // reddit: feature-flagged + OAuth-only → should be excluded
+    expect(skills).not.toContain(resolveSkillRef("reddit"));
+    // canva: feature-flagged + OAuth-only → should be excluded
+    expect(skills).not.toContain(resolveSkillRef("canva"));
   });
 
   it("should not produce duplicate skills", () => {

--- a/turbo/apps/web/src/lib/zero/__tests__/build-compose-content.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-compose-content.test.ts
@@ -1,20 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildComposeContent } from "../build-compose-content";
 import { SEED_SKILLS } from "../seed-skills";
-import {
-  CONNECTOR_TYPES,
-  resolveSkillRef,
-  getInstructionsFilename,
-} from "@vm0/core";
-
-/** GA connector types (no feature flag). */
-const gaConnectorTypes = Object.entries(CONNECTOR_TYPES)
-  .filter(([, config]) => {
-    return !config.featureFlag;
-  })
-  .map(([type]) => {
-    return type;
-  });
+import { resolveSkillRef, getInstructionsFilename } from "@vm0/core";
 
 describe("buildComposeContent", () => {
   it("should return valid compose structure", () => {
@@ -54,10 +41,9 @@ describe("buildComposeContent", () => {
     ]!;
     const skills = agent.skills as string[];
 
-    for (const connectorType of gaConnectorTypes) {
-      const url = resolveSkillRef(connectorType);
-      expect(skills).toContain(url);
-    }
+    // github and jira are GA connectors (no feature flag)
+    expect(skills).toContain(resolveSkillRef("github"));
+    expect(skills).toContain(resolveSkillRef("jira"));
   });
 
   it("should include feature-flagged connectors that have api-token", () => {

--- a/turbo/apps/web/src/lib/zero/build-compose-content.ts
+++ b/turbo/apps/web/src/lib/zero/build-compose-content.ts
@@ -11,8 +11,9 @@ import { SEED_SKILLS } from "./seed-skills";
 /**
  * Build compose content for a zero agent.
  *
- * Always includes all SEED_SKILLS plus connector type skill names that are
- * generally available (i.e. not gated behind a feature flag).
+ * Always includes all SEED_SKILLS plus eligible connector type skill names.
+ * Eligible = GA (no feature flag) or has api-token auth (feature flag only
+ * gates OAuth, not api-token).
  * Connector env var templates are baked into the compose so that
  * expandEnvironmentFromCompose can resolve firewall placeholders at runtime.
  */
@@ -30,15 +31,18 @@ export function buildComposeContent(
     }
   }
 
-  const gaConnectorTypes = Object.entries(CONNECTOR_TYPES)
+  const eligibleConnectorTypes = Object.entries(CONNECTOR_TYPES)
     .filter(([, config]) => {
-      return !config.featureFlag;
+      // Feature flag only gates OAuth; api-token is always available
+      return !config.featureFlag || "api-token" in config.authMethods;
     })
     .map(([type]) => {
       return type;
     });
 
-  const allSkillNames = [...new Set([...SEED_SKILLS, ...gaConnectorTypes])];
+  const allSkillNames = [
+    ...new Set([...SEED_SKILLS, ...eligibleConnectorTypes]),
+  ];
   const skills = allSkillNames.map((name) => {
     return resolveSkillRef(name);
   });
@@ -50,7 +54,7 @@ export function buildComposeContent(
 
   // Inject env var templates from connector environmentMappings so that
   // expandEnvironmentFromCompose can substitute firewall placeholders.
-  for (const connector of gaConnectorTypes) {
+  for (const connector of eligibleConnectorTypes) {
     const parsed = connectorTypeSchema.safeParse(connector);
     if (!parsed.success) continue;
     const mapping = getConnectorEnvironmentMapping(parsed.data);

--- a/turbo/apps/web/src/lib/zero/build-compose-content.ts
+++ b/turbo/apps/web/src/lib/zero/build-compose-content.ts
@@ -2,8 +2,8 @@ import {
   resolveSkillRef,
   getInstructionsFilename,
   getConnectorEnvironmentMapping,
+  getEligibleConnectorTypes,
   connectorTypeSchema,
-  CONNECTOR_TYPES,
   getCustomSkillStorageName,
 } from "@vm0/core";
 import { SEED_SKILLS } from "./seed-skills";
@@ -31,14 +31,7 @@ export function buildComposeContent(
     }
   }
 
-  const eligibleConnectorTypes = Object.entries(CONNECTOR_TYPES)
-    .filter(([, config]) => {
-      // Feature flag only gates OAuth; api-token is always available
-      return !config.featureFlag || "api-token" in config.authMethods;
-    })
-    .map(([type]) => {
-      return type;
-    });
+  const eligibleConnectorTypes = getEligibleConnectorTypes();
 
   const allSkillNames = [
     ...new Set([...SEED_SKILLS, ...eligibleConnectorTypes]),

--- a/turbo/packages/core/src/contracts/connectors.ts
+++ b/turbo/packages/core/src/contracts/connectors.ts
@@ -3672,6 +3672,21 @@ export function getConnectorEnvironmentMapping(
 }
 
 /**
+ * Connector types eligible for agent compose: GA (no feature flag) or
+ * feature-flagged with an api-token auth method.  Feature flags only gate
+ * OAuth; api-token is always available.
+ */
+export function getEligibleConnectorTypes(): string[] {
+  return Object.entries(CONNECTOR_TYPES)
+    .filter(([, config]) => {
+      return !config.featureFlag || "api-token" in config.authMethods;
+    })
+    .map(([type]) => {
+      return type;
+    });
+}
+
+/**
  * Get connector label and derived env var names for a connector secret.
  * Performs a reverse lookup from secret name to the connector type and
  * environment mapping that references it.

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -359,6 +359,7 @@ export {
   getConnectorSecretsForAuthMethod,
   getConnectorSecretNames,
   getConnectorEnvironmentMapping,
+  getEligibleConnectorTypes,
   getConnectorDerivedNames,
   getConnectorProvidedSecretNames,
   getConnectorManagedSecretNames,


### PR DESCRIPTION
## Summary
- Feature flags only gate OAuth, not api-token auth. `buildComposeContent` was blanket-excluding all feature-flagged connectors, preventing skills like Mercury from being injected even when api-token auth is available.
- Changed filter from `!config.featureFlag` to `!config.featureFlag || "api-token" in config.authMethods`, matching the semantic used by all other consumers (search API, platform UI, CLI).
- Fixes 11 affected connectors: mercury, ahrefs, deel, dropbox, figma, mailchimp, neon, posthog, resend, supabase, webflow.

Closes #7437

## Test plan
- [x] Updated `build-compose-content.test.ts` — split flagged connector test into api-token vs OAuth-only cases
- [x] Added test for env template injection of flagged connectors with api-token (MERCURY_TOKEN)
- [x] Added test for exclusion of flagged OAuth-only connectors (REDDIT_TOKEN)
- [x] All 11 tests pass
- [x] Lint, type check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)