### PR TITLE
refactor: remove org slug from billing service stripe metadata

### DIFF
--- a/turbo/apps/web/app/api/zero/billing/checkout/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/checkout/route.ts
@@ -50,7 +50,6 @@ const router = tsr.router(zeroBillingCheckoutContract, {
 
     const url = await createCheckoutSession(
       org.orgId,
-      org.slug,
       priceId,
       body.successUrl,
       body.cancelUrl,

--- a/turbo/apps/web/src/lib/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/billing/billing-service.ts
@@ -78,10 +78,7 @@ export function activePriceId(tier: "pro" | "team"): string | undefined {
  * Get or create a Stripe customer for an org.
  * Returns the Stripe customer ID.
  */
-async function getOrCreateStripeCustomer(
-  orgId: string,
-  orgSlug: string,
-): Promise<string> {
+async function getOrCreateStripeCustomer(orgId: string): Promise<string> {
   const db = globalThis.services.db;
   const [row] = await db
     .select({ stripeCustomerId: orgMetadata.stripeCustomerId })
@@ -95,7 +92,7 @@ async function getOrCreateStripeCustomer(
 
   const stripe = getStripe();
   const customer = await stripe.customers.create({
-    metadata: { orgId, orgSlug },
+    metadata: { orgId },
   });
 
   await db
@@ -115,12 +112,11 @@ async function getOrCreateStripeCustomer(
  */
 export async function createCheckoutSession(
   orgId: string,
-  orgSlug: string,
   priceId: string,
   successUrl: string,
   cancelUrl: string,
 ): Promise<string> {
-  const customerId = await getOrCreateStripeCustomer(orgId, orgSlug);
+  const customerId = await getOrCreateStripeCustomer(orgId);
   const stripe = getStripe();
 
   const session = await stripe.checkout.sessions.create({


### PR DESCRIPTION
## Summary
- Remove `orgSlug` parameter from `getOrCreateStripeCustomer()` and `createCheckoutSession()` in billing service
- Update Stripe customer metadata to only include `{ orgId }` (slug was never read back by code)
- Update checkout route caller to match new function signature

Part of org slug cleanup (#7257).

Closes #7477

## Test plan
- [x] Existing checkout route integration tests pass (5/5)
- [x] Type check passes
- [x] Lint passes
- [x] Knip finds no issues
- [x] Formatting unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)