### PR TITLE
feat(cli): handle expired connector reconnect in doctor missing-token

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
@@ -109,6 +109,73 @@ describe("zero doctor missing-token command", () => {
     });
   });
 
+  describe("connector connected but expired", () => {
+    it("should direct to connectors page to reconnect when needsReconnect is true", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json({
+            ...connectedResponse,
+            needsReconnect: true,
+          });
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+      );
+
+      await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "GH_TOKEN is provided by the GitHub connector",
+      );
+      expect(logCalls).toContain("expired");
+      expect(logCalls).toContain("needs to be reconnected");
+      expect(logCalls).toContain(
+        "[Reconnect GitHub](https://app.vm0.ai/connectors)",
+      );
+      expect(logCalls).not.toContain("not authorized");
+    });
+
+    it("should show both expired and not authorized when both issues exist", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json({
+            ...connectedResponse,
+            needsReconnect: true,
+          });
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["slack"] });
+          },
+        ),
+      );
+
+      await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("expired");
+      expect(logCalls).toContain(
+        "[Reconnect GitHub](https://app.vm0.ai/connectors)",
+      );
+      expect(logCalls).toContain("not authorized");
+      expect(logCalls).toContain(
+        "[Authorize GitHub](https://app.vm0.ai/team/agent-abc-123?tab=authorization)",
+      );
+    });
+  });
+
   describe("connector connected and authorized", () => {
     it("should report unexpected state when both are fine", async () => {
       vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");

--- a/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
@@ -67,13 +67,30 @@ Notes:
         console.log(
           `The ${label} connector is not connected. Ask the user to connect it at: [Connect ${label}](${url})`,
         );
-      } else if (!hasPermission) {
-        // Connected but not authorized for this agent — direct to authorization tab
+        return;
+      }
+
+      const issues: string[] = [];
+
+      if (connector.needsReconnect) {
+        const url = `${platformUrl.origin}/connectors`;
+        issues.push(
+          `The ${label} connector has expired and needs to be reconnected. Ask the user to reconnect it at: [Reconnect ${label}](${url})`,
+        );
+      }
+
+      if (!hasPermission) {
         const path = agentId ? `/team/${agentId}` : "/team";
         const url = `${platformUrl.origin}${path}?tab=authorization`;
-        console.log(
-          `The ${label} connector is connected but not authorized for this agent. Ask the user to enable it at: [Authorize ${label}](${url})`,
+        issues.push(
+          `The ${label} connector is not authorized for this agent. Ask the user to enable it at: [Authorize ${label}](${url})`,
         );
+      }
+
+      if (issues.length > 0) {
+        for (const issue of issues) {
+          console.log(issue);
+        }
       } else {
         // Both connected and authorized — something else is wrong
         const url = `${platformUrl.origin}/connectors`;


### PR DESCRIPTION
## Summary
- Add detection for connectors with `needsReconnect` flag in the `missing-token` doctor command
- When a connector has expired, direct users to the connectors page to reconnect it
- Support reporting multiple issues simultaneously (e.g., both expired and unauthorized)
- Include integration tests for expired connector scenarios

## Test plan
- [x] New tests for `needsReconnect: true` scenario directing to connectors page
- [x] New test for combined expired + unauthorized state showing both messages
- [ ] Existing tests continue to pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)