### PR TITLE
fix: preserve text content in slack messages with agent footer

### DIFF
--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -213,8 +213,13 @@ describe("POST /api/zero/integrations/slack/message", () => {
       blocks: Array<{ type: string; elements?: Array<{ text: string }> }>;
     };
 
-    // Last two blocks should be divider + context with "Sent via My Assistant"
+    // Text-only message should be wrapped in a section block + footer
     const blocks = call.blocks;
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0]!.type).toBe("section");
+    expect((blocks[0] as unknown as { text: { text: string } }).text.text).toBe(
+      "Hello",
+    );
     expect(blocks[blocks.length - 2]!.type).toBe("divider");
     const footerCtx = blocks[blocks.length - 1]!;
     expect(footerCtx.type).toBe("context");

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
@@ -126,7 +126,18 @@ const router = tsr.router(integrationsSlackMessageContract, {
     let finalBlocks = body.blocks as (Block | KnownBlock)[] | undefined;
     if (agentLabel) {
       const footerBlocks = buildFooterBlocks(`Sent via ${agentLabel}`);
-      finalBlocks = [...(finalBlocks ?? []), ...footerBlocks];
+      if (finalBlocks && finalBlocks.length > 0) {
+        finalBlocks = [...finalBlocks, ...footerBlocks];
+      } else if (body.text) {
+        // Text-only message — wrap text in a section block so Slack renders it
+        // (when blocks are present, Slack ignores the text field for display)
+        finalBlocks = [
+          { type: "section", text: { type: "mrkdwn", text: body.text } },
+          ...footerBlocks,
+        ];
+      } else {
+        finalBlocks = footerBlocks;
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary
- Fix text-only Slack messages (`zero slack message send -t "msg"`) being invisible when "Sent via" agent footer is appended
- When `blocks` is present, Slack ignores the `text` field for display — now wraps text in a section block before appending footer

## Root Cause
When `body.blocks` is undefined (text-only message) and an agent label exists, `buildFooterBlocks()` created a `blocks` array containing only the footer (divider + context). Slack then ignored the `text` field entirely, rendering just the footer.

## Fix
Added conditional logic to wrap `body.text` in a `section` block when no user-provided blocks exist, before appending footer blocks.

## Test plan
- [x] Enhanced existing "Sent via footer" test to verify text content is preserved as section block
- [x] All 6 existing tests pass
- [x] Lint, type check, format all pass

Closes #7479

🤖 Generated with [Claude Code](https://claude.com/claude-code)