### PR TITLE
refactor: remove createdAt from run dispatch error chain

### DIFF
--- a/turbo/apps/cli/src/lib/api/core/types.ts
+++ b/turbo/apps/cli/src/lib/api/core/types.ts
@@ -41,7 +41,7 @@ export interface CreateRunResponse {
   output?: string;
   error?: string;
   executionTimeMs?: number;
-  createdAt: string;
+  createdAt?: string;
 }
 
 export interface GetComposeVersionResponse {

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -41,7 +41,6 @@ function handleCreateRunError(error: unknown) {
           runId: dispatchError.runId,
           status: "failed" as const,
           error: error.message,
-          createdAt: dispatchError.createdAt?.toISOString() ?? "",
         },
       };
     }
@@ -67,7 +66,6 @@ function handleCreateRunError(error: unknown) {
         runId: dispatchError.runId,
         status: "failed" as const,
         error: "Run failed",
-        createdAt: dispatchError.createdAt?.toISOString() ?? "",
       },
     };
   }

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -141,7 +141,6 @@ const router = tsr.router(chatMessagesContract, {
             runId: error.runId,
             threadId,
             status: "failed" as const,
-            createdAt: error.createdAt?.toISOString() ?? "",
           },
         };
       }

--- a/turbo/apps/web/src/lib/run/run-queue-service.ts
+++ b/turbo/apps/web/src/lib/run/run-queue-service.ts
@@ -28,7 +28,6 @@ const QUEUE_TTL_MS = 2 * 60 * 60 * 1000;
  */
 type QueuedRunDispatcher = (
   runId: string,
-  createdAt: Date,
   params: CreateRunParams,
 ) => Promise<void>;
 
@@ -150,7 +149,7 @@ export async function drainOrgQueue(
 
     // Dispatch the run (compose loading, authorization, execution)
     try {
-      await dispatch(dequeued.runId, dequeued.createdAt, params);
+      await dispatch(dequeued.runId, params);
       log.debug(`Queued run ${dequeued.runId} dispatched successfully`);
       return; // Successfully dispatched — done
     } catch (error) {
@@ -167,7 +166,6 @@ export async function drainOrgQueue(
 
 interface DequeuedEntry {
   runId: string;
-  createdAt: Date;
   encryptedParams: string | null;
 }
 
@@ -260,7 +258,7 @@ async function dequeueNextAtomic(
           .where(
             and(eq(agentRuns.id, row.run_id), eq(agentRuns.status, "queued")),
           )
-          .returning({ createdAt: agentRuns.createdAt });
+          .returning({ id: agentRuns.id });
 
         if (!updated) {
           // Run was cancelled/failed between enqueue and drain — skip it
@@ -271,7 +269,6 @@ async function dequeueNextAtomic(
         log.debug(`Dequeued run ${row.run_id} for org ${orgId}`);
         return {
           runId: row.run_id,
-          createdAt: updated.createdAt,
           encryptedParams: row.encrypted_params,
         };
       }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -282,12 +282,11 @@ async function dispatchRun(context: PreparedContext): Promise<ExecutorResult> {
 /**
  * Extended error type for dispatch failures that includes run metadata.
  * When createRun() fails after the run record is created (post-INSERT),
- * the error is augmented with runId and createdAt so callers can
- * return partial results if needed.
+ * the error is augmented with runId so callers can return partial
+ * results if needed.
  */
 export interface RunDispatchError extends Error {
   runId?: string;
-  createdAt?: Date;
 }
 
 export function isRunDispatchError(error: unknown): error is RunDispatchError {
@@ -552,7 +551,6 @@ export async function registerCallbacks(
  */
 export async function markRunFailed(
   runId: string,
-  createdAt: Date,
   error: unknown,
   drain?: () => Promise<void>,
 ): Promise<void> {
@@ -577,7 +575,6 @@ export async function markRunFailed(
   // Attach run metadata so callers can return partial results
   if (error instanceof Error) {
     (error as RunDispatchError).runId = runId;
-    (error as RunDispatchError).createdAt = createdAt;
   }
 }
 
@@ -587,17 +584,12 @@ export async function markRunFailed(
  */
 export async function buildAndDispatchRun(opts: {
   runId: string;
-  createdAt: Date;
   // Pre-built execution context (caller resolves all secrets/providers/firewalls)
   context: ExecutionContext;
   timings: DispatchTimings;
-  queueDispatcher?: (
-    runId: string,
-    createdAt: Date,
-    params: CreateRunParams,
-  ) => Promise<void>;
+  queueDispatcher?: (runId: string, params: CreateRunParams) => Promise<void>;
 }): Promise<{ status: RunStatus; sandboxId?: string }> {
-  const { runId, createdAt, context, timings } = opts;
+  const { runId, context, timings } = opts;
 
   try {
     const buildContextTime = Date.now();
@@ -675,7 +667,7 @@ export async function buildAndDispatchRun(opts: {
     return result;
   } catch (error) {
     const dispatcher = opts.queueDispatcher ?? dispatchQueuedRun;
-    await markRunFailed(runId, createdAt, error, () => {
+    await markRunFailed(runId, error, () => {
       return drainOrgQueue(context.orgId, dispatcher);
     });
     throw error;
@@ -1049,7 +1041,6 @@ export async function createRun(
 
     const result = await buildAndDispatchRun({
       runId: record.run.id,
-      createdAt: record.run.createdAt,
       context: contextResult.context,
       timings: {
         apiStart: record.apiStartTime,
@@ -1071,7 +1062,7 @@ export async function createRun(
     // Mark run as failed when context building or dispatch fails.
     // buildAndDispatchRun may have already called markRunFailed — the
     // second call is a safe no-op (transitionRunStatus guards on status).
-    await markRunFailed(record.run.id, record.run.createdAt, error, () => {
+    await markRunFailed(record.run.id, error, () => {
       return drainOrgQueue(record.orgId, dispatchQueuedRun);
     });
     throw error;
@@ -1090,13 +1081,8 @@ export async function createRun(
  */
 export async function dispatchQueuedRun(
   runId: string,
-  createdAt: Date,
   params: CreateRunParams,
-  queueDispatcher?: (
-    runId: string,
-    createdAt: Date,
-    params: CreateRunParams,
-  ) => Promise<void>,
+  queueDispatcher?: (runId: string, params: CreateRunParams) => Promise<void>,
 ): Promise<void> {
   const apiStartTime = Date.now();
   const { userId, agentComposeVersionId } = params;
@@ -1163,7 +1149,6 @@ export async function dispatchQueuedRun(
 
     await buildAndDispatchRun({
       runId,
-      createdAt,
       context: contextResult.context,
       timings: {
         apiStart: apiStartTime,
@@ -1177,7 +1162,7 @@ export async function dispatchQueuedRun(
     });
   } catch (error) {
     const dispatcher = queueDispatcher ?? dispatchQueuedRun;
-    await markRunFailed(runId, createdAt, error, () => {
+    await markRunFailed(runId, error, () => {
       return drainOrgQueue(params.orgId, dispatcher);
     });
     throw error;

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -1287,7 +1287,6 @@ export async function dispatchCancelSideEffects(
   result: CancelRunResult,
   queueDispatcher: (
     runId: string,
-    createdAt: Date,
     params: CreateRunParams,
   ) => Promise<void> = dispatchQueuedRun,
 ): Promise<void> {

--- a/turbo/apps/web/src/lib/zero/zero-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-queue-service.ts
@@ -40,7 +40,6 @@ import type { OrgTier, QueueResponse, TriggerSource } from "@vm0/core";
  */
 export async function dispatchQueuedZeroRun(
   runId: string,
-  createdAt: Date,
   params: CreateRunParams,
 ): Promise<void> {
   if (params.vars?.ZERO_AGENT_ID) {
@@ -100,7 +99,6 @@ export async function dispatchQueuedZeroRun(
 
     await buildAndDispatchRun({
       runId,
-      createdAt,
       context: contextResult.context,
       timings: {
         apiStart: apiStartTime,
@@ -117,7 +115,7 @@ export async function dispatchQueuedZeroRun(
   }
 
   // Non-zero path — delegate to infra dispatcher
-  return dispatchQueuedRun(runId, createdAt, params, dispatchQueuedZeroRun);
+  return dispatchQueuedRun(runId, params, dispatchQueuedZeroRun);
 }
 
 const RECENT_RUNS_FOR_ETA = 20;

--- a/turbo/apps/web/src/lib/zero/zero-run-errors.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-errors.ts
@@ -15,7 +15,6 @@ export function handleCreateRunError(error: unknown) {
         runId: error.runId,
         status: "failed" as const,
         error: error.message,
-        createdAt: error.createdAt?.toISOString() ?? "",
       },
     };
   }

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -378,7 +378,6 @@ export async function createZeroRun(
     // 8. Dispatch with pre-built context (callbacks already registered above)
     const result = await buildAndDispatchRun({
       runId: record.run.id,
-      createdAt: record.run.createdAt,
       context: contextResult.context,
       timings: {
         apiStart: record.apiStartTime,
@@ -401,7 +400,7 @@ export async function createZeroRun(
       createdAt: record.run.createdAt,
     };
   } catch (error) {
-    await markRunFailed(record.run.id, record.run.createdAt, error, () => {
+    await markRunFailed(record.run.id, error, () => {
       return drainOrgQueue(resolved.orgId, dispatchQueuedZeroRun);
     });
     throw error;

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -146,7 +146,7 @@ export const chatMessagesContract = c.router({
         runId: z.string(),
         threadId: z.string(),
         status: runStatusSchema,
-        createdAt: z.string(),
+        createdAt: z.string().optional(),
       }),
       400: apiErrorSchema,
       401: apiErrorSchema,

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -85,7 +85,7 @@ const createRunResponseSchema = z.object({
   output: z.string().optional(),
   error: z.string().optional(),
   executionTimeMs: z.number().optional(),
-  createdAt: z.string(),
+  createdAt: z.string().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

Closes #7486

- Remove `createdAt` from `RunDispatchError` interface, `markRunFailed` signature, `buildAndDispatchRun` opts, `dispatchQueuedRun`/`dispatchQueuedZeroRun` signatures, `QueuedRunDispatcher` type, and `DequeuedEntry`
- Remove `createdAt` from all error response bodies in route handlers (`agent/runs`, `zero/runs`, `zero/chat/messages`)
- Make `createdAt` optional in `createRunResponseSchema` and chat messages create response contract (backward-compatible — success path still provides it)

No client reads `createdAt` from error responses. The CLI only uses `runId` and `status`.

## Test plan

- [x] TypeScript type-check passes (all packages except pre-existing @vm0/app issue)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Format passes
- [x] 353/354 tests pass (1 failure is pre-existing DB migration issue, unrelated)
- [x] Knip passes
- [x] `grep -rn "RunDispatchError.*createdAt\|dispatchError.createdAt" turbo/apps/web/` → zero results
- [x] `grep -rn "markRunFailed.*createdAt" turbo/apps/web/` → zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)