### PR TITLE
refactor: move org id into execution context and remove from dispatch opts

### DIFF
--- a/turbo/apps/web/src/lib/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/run/context/execution-preparer.ts
@@ -76,8 +76,8 @@ interface PrepareResult {
 
 export async function prepareForExecution(
   context: ExecutionContext,
-  orgId: string,
 ): Promise<PrepareResult> {
+  const orgId = context.orgId;
   log.debug(`Preparing execution context for run ${context.runId}...`);
 
   // Extract configuration from agent compose

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -591,14 +591,13 @@ export async function buildAndDispatchRun(opts: {
   // Pre-built execution context (caller resolves all secrets/providers/firewalls)
   context: ExecutionContext;
   timings: DispatchTimings;
-  orgId: string;
   queueDispatcher?: (
     runId: string,
     createdAt: Date,
     params: CreateRunParams,
   ) => Promise<void>;
 }): Promise<{ status: RunStatus; sandboxId?: string }> {
-  const { runId, createdAt, context, timings, orgId } = opts;
+  const { runId, createdAt, context, timings } = opts;
 
   try {
     const buildContextTime = Date.now();
@@ -619,7 +618,7 @@ export async function buildAndDispatchRun(opts: {
       );
 
     // Prepare execution context (storage manifest, working dir, etc.)
-    const prepareResult = await prepareForExecution(context, orgId);
+    const prepareResult = await prepareForExecution(context);
     const prepareTime = Date.now();
 
     // Dispatch to executor
@@ -676,16 +675,9 @@ export async function buildAndDispatchRun(opts: {
     return result;
   } catch (error) {
     const dispatcher = opts.queueDispatcher ?? dispatchQueuedRun;
-    await markRunFailed(
-      runId,
-      createdAt,
-      error,
-      orgId
-        ? () => {
-            return drainOrgQueue(orgId, dispatcher);
-          }
-        : undefined,
-    );
+    await markRunFailed(runId, createdAt, error, () => {
+      return drainOrgQueue(context.orgId, dispatcher);
+    });
     throw error;
   }
 }
@@ -1067,7 +1059,6 @@ export async function createRun(
         resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
         resolveSecretsDuration: contextResult.timings.resolveSecrets,
       },
-      orgId: record.orgId,
     });
 
     return {
@@ -1182,7 +1173,6 @@ export async function dispatchQueuedRun(
         resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
         resolveSecretsDuration: contextResult.timings.resolveSecrets,
       },
-      orgId: params.orgId,
       queueDispatcher,
     });
   } catch (error) {

--- a/turbo/apps/web/src/lib/run/types.ts
+++ b/turbo/apps/web/src/lib/run/types.ts
@@ -51,6 +51,7 @@ export interface ResumeSession {
 export interface ExecutionContext {
   runId: string;
   userId?: string;
+  orgId: string;
   agentComposeVersionId: string;
   agentCompose: unknown;
   prompt: string;

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -1158,6 +1158,7 @@ export async function buildZeroExecutionContext(
     context: {
       runId: params.runId,
       userId: params.userId,
+      orgId: params.orgId,
       agentComposeVersionId,
       agentCompose,
       prompt: params.prompt,

--- a/turbo/apps/web/src/lib/zero/zero-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-queue-service.ts
@@ -110,7 +110,6 @@ export async function dispatchQueuedZeroRun(
         resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
         resolveSecretsDuration: contextResult.timings.resolveSecrets,
       },
-      orgId: params.orgId,
       queueDispatcher: dispatchQueuedZeroRun,
     });
 

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -388,7 +388,6 @@ export async function createZeroRun(
         resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
         resolveSecretsDuration: contextResult.timings.resolveSecrets,
       },
-      orgId: record.orgId,
       queueDispatcher: dispatchQueuedZeroRun,
     });
 


### PR DESCRIPTION
## Summary

- Add `orgId: string` to `ExecutionContext` interface so org identity is part of the execution context where it logically belongs
- Update `buildZeroExecutionContext` to include `orgId` in the returned context
- Remove standalone `orgId` parameter from `buildAndDispatchRun` opts and `prepareForExecution` — both now read from `context.orgId`
- Remove `orgId` from all 4 callers of `buildAndDispatchRun` (`createRun`, `dispatchQueuedRun`, `createZeroRun`, `dispatchQueuedZeroRun`)

Closes #7487

## Test plan

- [x] All 133 existing integration tests in `run/` and `zero/` pass — no new tests needed (pure structural refactoring, no behavior change)
- [x] Type checking passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Format passes (`pnpm format`)
- [x] Knip passes (`pnpm knip`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)