### PR TITLE
fix(platform): show activity line above content during streaming

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-activity-line-visibility.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-activity-line-visibility.test.tsx
@@ -54,12 +54,17 @@ describe("activity line visibility while run is still running", () => {
       ).toBeInTheDocument();
     });
 
-    // BUG: The activity line (shimmer text or summary steps) should still be
-    // visible because run status is still "running". Currently, the
-    // StaticAssistantMessage decision tree hides the activity line as soon as
-    // message.content becomes non-empty, regardless of run status.
+    // The activity line (shimmer text or summary steps) should still be
+    // visible because run status is still "running".
     const shimmer = document.querySelector(".zero-shimmer-text");
     expect(shimmer).toBeInTheDocument();
+
+    // The activity line should appear ABOVE the result content in the DOM,
+    // so the user sees the ongoing CoT before the result text.
+    const resultEl = screen.getByText("Here is the first part of the answer.");
+    expect(shimmer!.compareDocumentPosition(resultEl)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
   });
 
   it("should hide activity line only after run reaches terminal status", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -909,15 +909,15 @@ function StaticAssistantMessage({
                 messageId={message.id}
               />
             )}
+            {renderActivityLine && (
+              <div className="mb-3 pb-3 border-b">{renderActivityLine}</div>
+            )}
             <Markdown source={content} />
             {message.cancelled && (
               <div className="mt-3 pt-3 border-t flex items-center gap-1.5 text-xs text-muted-foreground">
                 <IconPlayerStop size={12} />
                 <span>Cancelled</span>
               </div>
-            )}
-            {renderActivityLine && (
-              <div className="mt-3 pt-3 border-t">{renderActivityLine}</div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Move the activity line (shimmer/CoT indicator) above the markdown content in `StaticAssistantMessage` so users see the ongoing chain-of-thought before the result text while the run is still active
- Add a bottom border separator between activity line and content for visual clarity
- Update tests to verify the correct DOM ordering and remove the now-resolved BUG comment

## Test plan
- [ ] Verify shimmer/CoT activity line renders above result content while a run is streaming
- [ ] Verify activity line disappears once run reaches terminal status
- [ ] Run `pnpm vitest` to confirm updated tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)