### PR TITLE
fix(platform): preserve chronological order of cancelled chat messages

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -76,6 +76,7 @@ export interface UserChatMessage {
   role: "user";
   content: string;
   attachments?: ZeroChatMessageAttachment[];
+  createdAt?: string;
 }
 
 export interface AssistantChatMessage {
@@ -90,6 +91,7 @@ export interface AssistantChatMessage {
   runLoop?: ReturnType<typeof createRunLoop>;
   summaries$?: Computed<Promise<string[]>>;
   beginLoop$?: ReturnType<typeof createRunLoop>["beginLoop$"];
+  createdAt?: string;
 }
 
 export type ZeroChatMessage = UserChatMessage | AssistantChatMessage;
@@ -388,6 +390,7 @@ interface ChatThread {
     status: string;
     prompt: string;
     error: string | null;
+    createdAt: string;
   }[];
   isLegacySession: boolean;
 }
@@ -486,6 +489,7 @@ function unsavedRunsToMessages(unsavedRuns: ChatThread["unsavedRuns"]): {
         id: crypto.randomUUID(),
         role: "user",
         content: run.prompt,
+        createdAt: run.createdAt,
       });
       messages.push({
         id: crypto.randomUUID(),
@@ -499,6 +503,7 @@ function unsavedRunsToMessages(unsavedRuns: ChatThread["unsavedRuns"]): {
           ? "Run cancelled."
           : (run.error ??
             "Something went wrong. Check the activity logs for details."),
+        createdAt: run.createdAt,
       });
     } else {
       const { userMessage, assistantMessage } = createActiveRunMessage(
@@ -598,6 +603,7 @@ const currentChatMessages$ = computed(
           ...base,
           role: "user" as const,
           content: m.content,
+          createdAt: m.createdAt,
         };
       }
 
@@ -609,6 +615,7 @@ const currentChatMessages$ = computed(
         }),
         legacyRunId: m.runId,
         ...(m.error ? { status: "failed" as const, error: m.error } : {}),
+        createdAt: m.createdAt,
       };
     });
   },
@@ -627,8 +634,15 @@ const chatSessionSnapshot$ = computed(
       lastActiveRunId: legacyLastActiveRunId,
     } = unsavedRunsToMessages(thread.unsavedRuns);
 
+    const allMessages = [...(await get(currentChatMessages$)), ...runMessages];
+    allMessages.sort((a, b) => {
+      const aTime = a.createdAt ?? "";
+      const bTime = b.createdAt ?? "";
+      return aTime.localeCompare(bTime);
+    });
+
     return {
-      messages: [...(await get(currentChatMessages$)), ...runMessages],
+      messages: allMessages,
       activeRunMessages,
       agentId: thread.agentId,
       lastActiveRunId: legacyLastActiveRunId,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/cancelled-message-ordering.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/cancelled-message-ordering.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+describe("cancelled message ordering after page refresh", () => {
+  it("should render cancelled message before successful message when it was created first", async () => {
+    // Scenario: user sent message A (cancelled), then message B (completed).
+    // After page refresh, message A (from unsavedRuns) should appear before
+    // message B (from chatMessages) because A was created earlier.
+    server.use(
+      http.get("*/api/zero/chat-threads/:id", () => {
+        return HttpResponse.json({
+          id: "thread-ordering",
+          title: null,
+          agentId: "c0000000-0000-4000-a000-000000000001",
+          chatMessages: [
+            {
+              role: "user",
+              content: "Second message (completed)",
+              createdAt: "2026-03-10T00:01:00Z",
+            },
+            {
+              role: "assistant",
+              content: "Reply to second message",
+              createdAt: "2026-03-10T00:01:01Z",
+            },
+          ],
+          latestSessionId: null,
+          unsavedRuns: [
+            {
+              runId: "run-cancelled",
+              status: "cancelled",
+              prompt: "First message (cancelled)",
+              error: null,
+              createdAt: "2026-03-10T00:00:00Z",
+            },
+          ],
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:01:01Z",
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/chat/thread-ordering" });
+
+    await waitFor(() => {
+      expect(screen.getByText("First message (cancelled)")).toBeInTheDocument();
+      expect(
+        screen.getByText("Second message (completed)"),
+      ).toBeInTheDocument();
+    });
+
+    // Verify order: the cancelled message should appear before the completed message.
+    // compareDocumentPosition bit 4 (DOCUMENT_POSITION_FOLLOWING) means the
+    // second node follows the first in DOM order.
+    const cancelledEl = screen.getByText("First message (cancelled)");
+    const completedEl = screen.getByText("Second message (completed)");
+    const position = cancelledEl.compareDocumentPosition(completedEl);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-activity-line-visibility.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-activity-line-visibility.test.tsx
@@ -23,6 +23,7 @@ describe("activity line visibility while run is still running", () => {
           status: "running",
           prompt: "Do a complex multi-step task",
           error: null,
+          createdAt: "2026-03-10T00:00:01Z",
         },
       ],
     });
@@ -72,6 +73,7 @@ describe("activity line visibility while run is still running", () => {
           status: "running",
           prompt: "Hello",
           error: null,
+          createdAt: "2026-03-10T00:00:00Z",
         },
       ],
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-resume.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-resume.test.tsx
@@ -28,6 +28,7 @@ describe("chat resume", () => {
           status: "running",
           prompt: "Follow up question",
           error: null,
+          createdAt: "2026-03-10T00:00:02Z",
         },
       ],
     });
@@ -71,6 +72,7 @@ describe("chat resume", () => {
           status: "running",
           prompt: "Active task",
           error: null,
+          createdAt: "2026-03-10T00:00:01Z",
         },
       ],
     });
@@ -104,6 +106,7 @@ describe("chat resume", () => {
           status: "running",
           prompt: "Active task",
           error: null,
+          createdAt: "2026-03-10T00:00:01Z",
         },
       ],
     });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-session-switch.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-session-switch.test.tsx
@@ -55,6 +55,7 @@ describe("chat session switch", () => {
               status: "running",
               prompt: "Active task prompt",
               error: null,
+              createdAt: "2026-03-10T00:00:01Z",
             },
           ],
           createdAt: "2026-03-10T00:00:00Z",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-test-helpers.ts
@@ -64,6 +64,7 @@ export function mockChatLifecycle(options?: {
     status: string;
     prompt: string;
     error: string | null;
+    createdAt: string;
   }[];
   threadTitle?: string | null;
   onRunCreate?: () => void;
@@ -95,6 +96,7 @@ export function mockChatLifecycle(options?: {
                 status: runStatus,
                 prompt: runPrompt ?? "Hello",
                 error: runError,
+                createdAt: "2026-03-10T00:00:00Z",
               },
             ]
           : []);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-title-refresh.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-title-refresh.test.tsx
@@ -90,6 +90,7 @@ describe("chat title refresh", () => {
                     status: "running",
                     prompt: "Follow-up question",
                     error: null,
+                    createdAt: "2026-03-10T00:00:01Z",
                   },
                 ]
               : [],

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -103,6 +103,7 @@ describe("provider incompatibility error", () => {
               prompt: "hello",
               error:
                 "Cannot continue session: this session was created with Moonshot (Kimi) and cannot be continued with Anthropic API Key.",
+              createdAt: "2026-03-10T00:00:00Z",
             },
           ],
           createdAt: "2026-03-10T00:00:00Z",
@@ -137,6 +138,7 @@ describe("provider incompatibility error", () => {
               status: "failed",
               prompt: "hello",
               error: "Invalid signature in thinking block",
+              createdAt: "2026-03-10T00:00:00Z",
             },
           ],
           createdAt: "2026-03-10T00:00:00Z",
@@ -199,6 +201,7 @@ describe("chat message activity line", () => {
           status: "running",
           prompt: "Do something",
           error: null,
+          createdAt: "2026-03-10T00:00:00Z",
         },
       ],
     });
@@ -238,6 +241,7 @@ describe("chat message activity line", () => {
           status: "running",
           prompt: "Do something else",
           error: null,
+          createdAt: "2026-03-10T00:00:00Z",
         },
       ],
     });

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -250,6 +250,48 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     expect(listData.threads).toHaveLength(1);
     expect(listData.threads[0].title).toBe("After AI update");
   });
+
+  it("should return createdAt on unsaved (cancelled) runs", async () => {
+    // Create a thread
+    const createRes = await POST(
+      createTestRequest("http://localhost:3000/api/zero/chat-threads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: testComposeId,
+          title: "Cancelled run thread",
+        }),
+      }),
+    );
+    const { id: threadId } = await createRes.json();
+
+    // Create a cancelled run (no agentSessionId in result)
+    const { runId } = await createTestRunInDb(testUserId, testComposeId, {
+      status: "cancelled",
+      prompt: "This was cancelled",
+    });
+
+    // Link run to thread
+    await addRunToThread(threadId, runId, testUserId);
+
+    // GET thread detail
+    const response = await GET(
+      createTestRequest(
+        `http://localhost:3000/api/zero/chat-threads/${threadId}`,
+      ),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.unsavedRuns).toHaveLength(1);
+    expect(data.unsavedRuns[0].runId).toBe(runId);
+    expect(data.unsavedRuns[0].status).toBe("cancelled");
+    expect(data.unsavedRuns[0].createdAt).toBeDefined();
+    // Verify it's a valid ISO 8601 date string
+    expect(new Date(data.unsavedRuns[0].createdAt).toISOString()).toBe(
+      data.unsavedRuns[0].createdAt,
+    );
+  });
 });
 
 describe("DELETE /api/zero/chat-threads/:id - Delete Thread", () => {

--- a/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
@@ -184,6 +184,7 @@ interface UnsavedRun {
   status: string;
   prompt: string;
   error: string | null;
+  createdAt: string;
 }
 
 export async function getChatThreadMessages(
@@ -297,6 +298,7 @@ export async function getChatThreadMessages(
         status: r.status,
         prompt: r.prompt,
         error: r.error,
+        createdAt: r.createdAt.toISOString(),
       };
     });
 

--- a/turbo/packages/core/src/contracts/chat-threads.ts
+++ b/turbo/packages/core/src/contracts/chat-threads.ts
@@ -44,6 +44,7 @@ const unsavedRunSchema = z.object({
   status: z.string(),
   prompt: z.string(),
   error: z.string().nullable(),
+  createdAt: z.string(),
 });
 
 const chatThreadDetailSchema = z.object({


### PR DESCRIPTION
## Summary

Fixes #7478

- Added `createdAt` to `unsavedRunSchema` in `@vm0/core` and projected it from the server query into unsaved runs response
- Propagated `createdAt` through frontend `ZeroChatMessage` types and message construction (`unsavedRunsToMessages`, `currentChatMessages$`)
- Replaced naive concatenation in `chatSessionSnapshot$` with sort-merge by `createdAt`, so cancelled/failed messages from `unsavedRuns` appear in correct chronological position relative to `chatMessages`
- Active run messages remain appended at the bottom (unchanged behavior)

## Test plan

- [x] New regression test `cancelled-message-ordering.test.tsx` verifies cancelled message renders before completed message when created first
- [x] New web route test verifies server returns `createdAt` on unsaved (cancelled) runs
- [x] All 258 existing platform tests pass
- [x] All 13 web route tests pass
- [x] Type checks pass (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)