### PR TITLE
fix: use instant scroll behavior for chat auto-scroll

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -139,7 +139,7 @@ export function ZeroChatThreadPage({
   // Auto-scroll when messages change — ref callback runs at commit time
   const scrollAnchorRef = (el: HTMLDivElement | null) => {
     if (el && messages.length > 0) {
-      el.scrollIntoView({ behavior: "smooth" });
+      el.scrollIntoView({ behavior: "instant" });
     }
   };
 


### PR DESCRIPTION
## Summary
- Change chat thread auto-scroll behavior from `smooth` to `instant` to eliminate visual jitter during rapid message updates

## Test plan
- [ ] Open a chat thread and verify auto-scroll works without visual lag
- [ ] Confirm new messages scroll into view immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)