### PR TITLE
refactor: remove queue-dispatcher param from build-and-dispatch pipeline

### DIFF
--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -543,16 +543,15 @@ export async function registerCallbacks(
 }
 
 /**
- * Mark a run as failed, dispatch terminal side effects, and attach run
- * metadata to the error for callers.
+ * Mark a run as failed, dispatch terminal side effects (callbacks), and
+ * attach run metadata to the error for callers.
  *
- * @param drain - Optional queue drain function. Injected by callers to release
- *   concurrency slots when a run that occupied one fails during dispatch.
+ * Queue draining is NOT done here — callers are responsible for calling
+ * drainOrgQueue() separately after this function returns.
  */
 export async function markRunFailed(
   runId: string,
   error: unknown,
-  drain?: () => Promise<void>,
 ): Promise<void> {
   const errorMessage = error instanceof Error ? error.message : "Unknown error";
   log.error(`Run ${runId} failed: ${errorMessage}`);
@@ -567,9 +566,9 @@ export async function markRunFailed(
     ["queued", "pending", "running"],
   );
 
-  // Dispatch callbacks (e.g., loop schedule advancement) and drain queue if transition succeeded
+  // Dispatch callbacks (e.g., loop schedule advancement) if transition succeeded
   if (transitioned) {
-    await dispatchTerminalSideEffects(runId, "failed", errorMessage, drain);
+    await dispatchTerminalSideEffects(runId, "failed", errorMessage);
   }
 
   // Attach run metadata so callers can return partial results
@@ -587,7 +586,6 @@ export async function buildAndDispatchRun(opts: {
   // Pre-built execution context (caller resolves all secrets/providers/firewalls)
   context: ExecutionContext;
   timings: DispatchTimings;
-  queueDispatcher?: (runId: string, params: CreateRunParams) => Promise<void>;
 }): Promise<{ status: RunStatus; sandboxId?: string }> {
   const { runId, context, timings } = opts;
 
@@ -666,10 +664,7 @@ export async function buildAndDispatchRun(opts: {
     log.debug(`Run ${runId} dispatched with status: ${result.status}`);
     return result;
   } catch (error) {
-    const dispatcher = opts.queueDispatcher ?? dispatchQueuedRun;
-    await markRunFailed(runId, error, () => {
-      return drainOrgQueue(context.orgId, dispatcher);
-    });
+    await markRunFailed(runId, error);
     throw error;
   }
 }
@@ -1062,8 +1057,9 @@ export async function createRun(
     // Mark run as failed when context building or dispatch fails.
     // buildAndDispatchRun may have already called markRunFailed — the
     // second call is a safe no-op (transitionRunStatus guards on status).
-    await markRunFailed(record.run.id, error, () => {
-      return drainOrgQueue(record.orgId, dispatchQueuedRun);
+    await markRunFailed(record.run.id, error);
+    await drainOrgQueue(record.orgId, dispatchQueuedRun).catch((drainErr) => {
+      log.error("Failed to drain org queue after run failure", { drainErr });
     });
     throw error;
   }
@@ -1158,12 +1154,12 @@ export async function dispatchQueuedRun(
         resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
         resolveSecretsDuration: contextResult.timings.resolveSecrets,
       },
-      queueDispatcher,
     });
   } catch (error) {
     const dispatcher = queueDispatcher ?? dispatchQueuedRun;
-    await markRunFailed(runId, error, () => {
-      return drainOrgQueue(params.orgId, dispatcher);
+    await markRunFailed(runId, error);
+    await drainOrgQueue(params.orgId, dispatcher).catch((drainErr) => {
+      log.error("Failed to drain org queue after run failure", { drainErr });
     });
     throw error;
   }

--- a/turbo/apps/web/src/lib/zero/zero-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-queue-service.ts
@@ -108,7 +108,6 @@ export async function dispatchQueuedZeroRun(
         resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
         resolveSecretsDuration: contextResult.timings.resolveSecrets,
       },
-      queueDispatcher: dispatchQueuedZeroRun,
     });
 
     return;

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -44,6 +44,9 @@ import { zeroAgents } from "../../db/schema/zero-agent";
 import { zeroRuns } from "../../db/schema/zero-run";
 import { dispatchQueuedZeroRun } from "./zero-queue-service";
 import { userConnectors } from "../../db/schema/user-connector";
+import { logger } from "../logger";
+
+const log = logger("service:zero-run");
 
 /**
  * Parameters accepted by createZeroRun().
@@ -387,7 +390,6 @@ export async function createZeroRun(
         resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
         resolveSecretsDuration: contextResult.timings.resolveSecrets,
       },
-      queueDispatcher: dispatchQueuedZeroRun,
     });
 
     // 9. Persist zero-layer metadata (triggerSource + schedule + trigger agent + model fields)
@@ -400,9 +402,12 @@ export async function createZeroRun(
       createdAt: record.run.createdAt,
     };
   } catch (error) {
-    await markRunFailed(record.run.id, error, () => {
-      return drainOrgQueue(resolved.orgId, dispatchQueuedZeroRun);
-    });
+    await markRunFailed(record.run.id, error);
+    await drainOrgQueue(resolved.orgId, dispatchQueuedZeroRun).catch(
+      (drainErr) => {
+        log.error("Failed to drain org queue after run failure", { drainErr });
+      },
+    );
     throw error;
   }
 }


### PR DESCRIPTION
## Summary

- Remove `queueDispatcher` parameter from `buildAndDispatchRun` opts — infra layer should only mark runs as failed, not drain queues
- Remove `drain` callback from `markRunFailed` signature — callers handle queue drain independently
- Each caller (`createRun`, `dispatchQueuedRun`, `createZeroRun`) now calls `drainOrgQueue()` separately in its own catch block with `.catch()` error resilience

## Motivation

Part of #7152 (Extract Zero Platform Layer from Generic Run Infrastructure). `buildAndDispatchRun` mixed infra concerns (marking runs failed) with zero-layer concerns (draining org queues). This refactor enforces the separation principle: infra owns the run record lifecycle, zero/callers own queue management.

## Test plan

- [x] All 50 relevant integration tests pass (run-queue-service, credit-check, cancel route, complete webhook)
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [x] Type check passes for changed files
- [ ] CI pipeline validates full test suite

Closes #7490

🤖 Generated with [Claude Code](https://claude.com/claude-code)