### PR TITLE
fix(platform): filter null values from firewall params in network logs

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-activity-network-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-network-page.tsx
@@ -138,6 +138,15 @@ function formatValue(value: unknown): string {
   return String(value);
 }
 
+function formatParams(params: Record<string, string> | undefined): string {
+  if (!params) return "—";
+  const filtered = Object.fromEntries(
+    Object.entries(params).filter(([, v]) => v != null),
+  );
+  if (Object.keys(filtered).length === 0) return "—";
+  return JSON.stringify(filtered);
+}
+
 function collectDetails(entry: NetworkLogEntry): [string, string][] {
   return [
     ["Timestamp", entry.timestamp],
@@ -156,7 +165,7 @@ function collectDetails(entry: NetworkLogEntry): [string, string][] {
     ["Firewall Permission", formatValue(entry.firewall_permission)],
     ["Firewall Rule Match", formatValue(entry.firewall_rule_match)],
     ["Firewall Base URL", formatValue(entry.firewall_base)],
-    ["Firewall Params", formatValue(entry.firewall_params)],
+    ["Firewall Params", formatParams(entry.firewall_params)],
     ["Firewall Error", formatValue(entry.firewall_error)],
     ["Resolved Secrets", formatValue(entry.token_resolved_secrets)],
     ["Refreshed Connectors", formatValue(entry.token_refreshed_connectors)],

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-network-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-network-page.tsx
@@ -139,11 +139,17 @@ function formatValue(value: unknown): string {
 }
 
 function formatParams(params: Record<string, string> | undefined): string {
-  if (!params) return "—";
+  if (!params) {
+    return "—";
+  }
   const filtered = Object.fromEntries(
-    Object.entries(params).filter(([, v]) => v != null),
+    Object.entries(params).filter(([, v]) => {
+      return v !== null && v !== undefined;
+    }),
   );
-  if (Object.keys(filtered).length === 0) return "—";
+  if (Object.keys(filtered).length === 0) {
+    return "—";
+  }
   return JSON.stringify(filtered);
 }
 


### PR DESCRIPTION
## Summary
- Filter out null values from `firewall_params` before displaying in network log detail view
- Axiom's columnar storage merges all seen keys across log entries, filling missing values with null — this caused params like `{"fileId":null,"id":null,"idOrUrl":null,"path":null,"userId":null}` to show up even when they weren't relevant to the request

## Test plan
- [ ] Open network activity page for a run with firewall-matched requests
- [ ] Verify params with actual values display correctly (e.g. `{"owner":"octocat","repo":"hello"}`)
- [ ] Verify entries with all-null params show "—" instead of the null JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)