### PR TITLE
feat(cli): add slack upload-file command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/slack/__tests__/upload-file.test.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/__tests__/upload-file.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for zero slack upload-file command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW, Slack pre-signed URL via MSW
+ * - Real (internal): All CLI code, file reading, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { uploadFileCommand } from "../upload-file";
+import chalk from "chalk";
+
+const UPLOAD_INIT_URL =
+  "http://localhost:3000/api/zero/integrations/slack/upload-file/init";
+const UPLOAD_COMPLETE_URL =
+  "http://localhost:3000/api/zero/integrations/slack/upload-file/complete";
+const SLACK_PRESIGNED_URL = "https://files.slack.com/upload/v1/test-presigned";
+
+describe("zero slack upload-file command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  let tmpDir: string;
+  let testFilePath: string;
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+
+    // Create temp file for tests
+    tmpDir = join(tmpdir(), `upload-file-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    testFilePath = join(tmpDir, "test-report.pdf");
+    writeFileSync(testFilePath, "fake pdf content for testing");
+  });
+
+  afterEach(() => {
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("successful upload", () => {
+    it("should upload a file and return file_id and permalink", async () => {
+      server.use(
+        http.post(UPLOAD_INIT_URL, () => {
+          return HttpResponse.json(
+            { uploadUrl: SLACK_PRESIGNED_URL, fileId: "F0123ABC" },
+            { status: 200 },
+          );
+        }),
+        http.post(SLACK_PRESIGNED_URL, () => {
+          return new HttpResponse(null, { status: 200 });
+        }),
+        http.post(UPLOAD_COMPLETE_URL, () => {
+          return HttpResponse.json(
+            {
+              fileId: "F0123ABC",
+              permalink: "https://workspace.slack.com/files/F0123ABC",
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await uploadFileCommand.parseAsync([
+        "node",
+        "cli",
+        "--file",
+        testFilePath,
+        "--channel",
+        "C1234567",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("File uploaded");
+      expect(logCalls).toContain("F0123ABC");
+      expect(logCalls).toContain("https://workspace.slack.com/files/F0123ABC");
+    });
+
+    it("should pass thread, title, and comment to complete", async () => {
+      let capturedCompleteBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(UPLOAD_INIT_URL, () => {
+          return HttpResponse.json(
+            { uploadUrl: SLACK_PRESIGNED_URL, fileId: "F0456DEF" },
+            { status: 200 },
+          );
+        }),
+        http.post(SLACK_PRESIGNED_URL, () => {
+          return new HttpResponse(null, { status: 200 });
+        }),
+        http.post(UPLOAD_COMPLETE_URL, async ({ request }) => {
+          capturedCompleteBody = (await request.json()) as Record<
+            string,
+            unknown
+          >;
+          return HttpResponse.json(
+            {
+              fileId: "F0456DEF",
+              permalink: "https://slack.com/files/F0456DEF",
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await uploadFileCommand.parseAsync([
+        "node",
+        "cli",
+        "--file",
+        testFilePath,
+        "--channel",
+        "C1234567",
+        "--thread",
+        "1234567890.000000",
+        "--title",
+        "Daily Report",
+        "--comment",
+        "Here is the report",
+      ]);
+
+      expect(capturedCompleteBody).toMatchObject({
+        fileId: "F0456DEF",
+        channel: "C1234567",
+        threadTs: "1234567890.000000",
+        title: "Daily Report",
+        initialComment: "Here is the report",
+      });
+    });
+
+    it("should send correct filename and length in init", async () => {
+      let capturedInitBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(UPLOAD_INIT_URL, async ({ request }) => {
+          capturedInitBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            { uploadUrl: SLACK_PRESIGNED_URL, fileId: "F0789GHI" },
+            { status: 200 },
+          );
+        }),
+        http.post(SLACK_PRESIGNED_URL, () => {
+          return new HttpResponse(null, { status: 200 });
+        }),
+        http.post(UPLOAD_COMPLETE_URL, () => {
+          return HttpResponse.json(
+            {
+              fileId: "F0789GHI",
+              permalink: "https://slack.com/files/F0789GHI",
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await uploadFileCommand.parseAsync([
+        "node",
+        "cli",
+        "--file",
+        testFilePath,
+        "--channel",
+        "C1234567",
+      ]);
+
+      expect(capturedInitBody).toMatchObject({
+        filename: "test-report.pdf",
+        length: 28, // "fake pdf content for testing".length
+      });
+    });
+  });
+
+  describe("validation errors", () => {
+    it("should error when file does not exist", async () => {
+      await expect(async () => {
+        await uploadFileCommand.parseAsync([
+          "node",
+          "cli",
+          "--file",
+          "/tmp/nonexistent-file.pdf",
+          "--channel",
+          "C1234567",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("File not found"),
+      );
+    });
+
+    it("should error when file is empty", async () => {
+      const emptyFile = join(tmpDir, "empty.txt");
+      writeFileSync(emptyFile, "");
+
+      await expect(async () => {
+        await uploadFileCommand.parseAsync([
+          "node",
+          "cli",
+          "--file",
+          emptyFile,
+          "--channel",
+          "C1234567",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("File is empty"),
+      );
+    });
+  });
+
+  describe("API errors", () => {
+    it("should handle init 401 unauthorized", async () => {
+      server.use(
+        http.post(UPLOAD_INIT_URL, () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await uploadFileCommand.parseAsync([
+          "node",
+          "cli",
+          "--file",
+          testFilePath,
+          "--channel",
+          "C1234567",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+    });
+
+    it("should handle init 404 no Slack installation", async () => {
+      server.use(
+        http.post(UPLOAD_INIT_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "No Slack installation found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await uploadFileCommand.parseAsync([
+          "node",
+          "cli",
+          "--file",
+          testFilePath,
+          "--channel",
+          "C1234567",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("No Slack installation found"),
+      );
+    });
+
+    it("should handle direct upload failure", async () => {
+      server.use(
+        http.post(UPLOAD_INIT_URL, () => {
+          return HttpResponse.json(
+            { uploadUrl: SLACK_PRESIGNED_URL, fileId: "F0123ABC" },
+            { status: 200 },
+          );
+        }),
+        http.post(SLACK_PRESIGNED_URL, () => {
+          return new HttpResponse(null, {
+            status: 500,
+            statusText: "Internal Server Error",
+          });
+        }),
+      );
+
+      await expect(async () => {
+        await uploadFileCommand.parseAsync([
+          "node",
+          "cli",
+          "--file",
+          testFilePath,
+          "--channel",
+          "C1234567",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("File upload failed"),
+      );
+    });
+
+    it("should handle complete API failure", async () => {
+      server.use(
+        http.post(UPLOAD_INIT_URL, () => {
+          return HttpResponse.json(
+            { uploadUrl: SLACK_PRESIGNED_URL, fileId: "F0123ABC" },
+            { status: 200 },
+          );
+        }),
+        http.post(SLACK_PRESIGNED_URL, () => {
+          return new HttpResponse(null, { status: 200 });
+        }),
+        http.post(UPLOAD_COMPLETE_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Slack API error: channel_not_found",
+                code: "SLACK_ERROR",
+              },
+            },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await uploadFileCommand.parseAsync([
+          "node",
+          "cli",
+          "--file",
+          testFilePath,
+          "--channel",
+          "C1234567",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Slack API error: channel_not_found"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/slack/index.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/index.ts
@@ -1,14 +1,17 @@
 import { Command } from "commander";
 import { zeroSlackMessageCommand } from "./message";
+import { uploadFileCommand } from "./upload-file";
 
 export const zeroSlackCommand = new Command()
   .name("slack")
-  .description("Send messages to Slack channels as the bot")
+  .description("Send messages and upload files to Slack channels as the bot")
   .addCommand(zeroSlackMessageCommand)
+  .addCommand(uploadFileCommand)
   .addHelpText(
     "after",
     `
 Examples:
   Send a message:        zero slack message send -c <channel-id> -t "Hello!"
-  Reply in a thread:     zero slack message send -c <channel-id> --thread <ts> -t "reply"`,
+  Reply in a thread:     zero slack message send -c <channel-id> --thread <ts> -t "reply"
+  Upload a file:         zero slack upload-file -f /tmp/report.pdf -c <channel-id>`,
   );

--- a/turbo/apps/cli/src/commands/zero/slack/upload-file.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/upload-file.ts
@@ -1,0 +1,84 @@
+import { statSync, readFileSync } from "fs";
+import { basename } from "path";
+import { Command } from "commander";
+import chalk from "chalk";
+import { initSlackFileUpload, completeSlackFileUpload } from "../../../lib/api";
+import { withErrorHandler } from "../../../lib/command";
+
+export const uploadFileCommand = new Command()
+  .name("upload-file")
+  .description("Upload a file to a Slack channel as the bot")
+  .requiredOption("-f, --file <path>", "Local file path to upload")
+  .requiredOption("-c, --channel <id>", "Slack channel ID")
+  .option("--thread <ts>", "Thread timestamp to post as a reply")
+  .option("--title <title>", "Display title for the file")
+  .option("--comment <text>", "Initial comment to accompany the file")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Upload a file:           zero slack upload-file -f /tmp/report.pdf -c C01234
+  Upload to thread:        zero slack upload-file -f /tmp/log.txt -c C01234 --thread 1234567890.123456
+  With title and comment:  zero slack upload-file -f /tmp/data.csv -c C01234 --title "Daily Report" --comment "Here's the report"
+
+Notes:
+  - Uses the bot token (not user SLACK_TOKEN), so no files:write firewall permission is needed
+  - Returns file_id and permalink for reference`,
+  )
+  .action(
+    withErrorHandler(
+      async (options: {
+        file: string;
+        channel: string;
+        thread?: string;
+        title?: string;
+        comment?: string;
+      }) => {
+        // Validate file exists and get size
+        let fileSize: number;
+        try {
+          const stat = statSync(options.file);
+          fileSize = stat.size;
+        } catch {
+          throw new Error(`File not found: ${options.file}`);
+        }
+
+        if (fileSize === 0) {
+          throw new Error("File is empty");
+        }
+
+        const filename = basename(options.file);
+
+        // Step 1: Get pre-signed upload URL from server
+        const { uploadUrl, fileId } = await initSlackFileUpload({
+          filename,
+          length: fileSize,
+        });
+
+        // Step 2: Upload file directly to Slack's pre-signed URL
+        const fileContent = readFileSync(options.file);
+        const uploadResponse = await fetch(uploadUrl, {
+          method: "POST",
+          body: fileContent,
+        });
+
+        if (!uploadResponse.ok) {
+          throw new Error(
+            `File upload failed: ${uploadResponse.status} ${uploadResponse.statusText}`,
+          );
+        }
+
+        // Step 3: Complete the upload and share to channel/thread
+        const result = await completeSlackFileUpload({
+          fileId,
+          channel: options.channel,
+          threadTs: options.thread,
+          title: options.title,
+          initialComment: options.comment,
+        });
+
+        console.log(chalk.green(`✓ File uploaded (file_id: ${result.fileId})`));
+        console.log(chalk.dim(`  permalink: ${result.permalink}`));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/integrations-slack.ts
+++ b/turbo/apps/cli/src/lib/api/domains/integrations-slack.ts
@@ -1,8 +1,14 @@
 import { initClient } from "@ts-rest/core";
 import {
   integrationsSlackMessageContract,
+  integrationsSlackUploadInitContract,
+  integrationsSlackUploadCompleteContract,
   type SendSlackMessageBody,
   type SendSlackMessageResponse,
+  type SlackUploadInitBody,
+  type SlackUploadInitResponse,
+  type SlackUploadCompleteBody,
+  type SlackUploadCompleteResponse,
 } from "@vm0/core";
 import { getClientConfig, handleError } from "../core/client-factory";
 
@@ -19,4 +25,34 @@ export async function sendSlackMessage(
   }
 
   handleError(result, "Failed to send Slack message");
+}
+
+export async function initSlackFileUpload(
+  body: SlackUploadInitBody,
+): Promise<SlackUploadInitResponse> {
+  const config = await getClientConfig();
+  const client = initClient(integrationsSlackUploadInitContract, config);
+
+  const result = await client.init({ body, headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to initialize Slack file upload");
+}
+
+export async function completeSlackFileUpload(
+  body: SlackUploadCompleteBody,
+): Promise<SlackUploadCompleteResponse> {
+  const config = await getClientConfig();
+  const client = initClient(integrationsSlackUploadCompleteContract, config);
+
+  const result = await client.complete({ body, headers: {} });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to complete Slack file upload");
 }

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -127,7 +127,11 @@ export {
 } from "./domains/zero-connectors";
 
 // Domain modules - Integrations Slack
-export { sendSlackMessage } from "./domains/integrations-slack";
+export {
+  sendSlackMessage,
+  initSlackFileUpload,
+  completeSlackFileUpload,
+} from "./domains/integrations-slack";
 
 // Domain modules - Zero Schedules
 export {

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
@@ -1,24 +1,20 @@
 import { createHandler, tsr } from "../../../../../../src/lib/ts-rest-handler";
 import { integrationsSlackMessageContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
-import {
-  requireAuth,
-  isAuthError,
-} from "../../../../../../src/lib/auth/require-auth";
-import { isSandboxAuth } from "../../../../../../src/lib/auth/capability-check";
-import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
-import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { agentComposeVersions } from "../../../../../../src/db/schema/agent-compose";
+import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { zeroAgents } from "../../../../../../src/db/schema/zero-agent";
-import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
-import { decryptSecretValue } from "../../../../../../src/lib/crypto/secrets-encryption";
 import {
-  createSlackClient,
+  isSlackPlatformError,
   postMessage,
 } from "../../../../../../src/lib/slack/client";
+import {
+  resolveSlackClient,
+  isSlackClientError,
+} from "../../../../../../src/lib/slack/resolve-slack-client";
 import { buildFooterBlocks } from "../../../../../../src/lib/slack/blocks";
 import type { Block, KnownBlock } from "@slack/web-api";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 
 /** Best-effort agent display name resolution from a run ID. */
 async function resolveAgentLabel(runId: string): Promise<string | undefined> {
@@ -38,86 +34,19 @@ async function resolveAgentLabel(runId: string): Promise<string | undefined> {
   return row?.displayName ?? row?.name;
 }
 
-/** Type guard for Slack API platform errors that carry a `data.error` string */
-function isSlackPlatformError(
-  err: unknown,
-): err is Error & { data: { error: string } } {
-  if (!(err instanceof Error) || !("data" in err)) return false;
-  const { data } = err as { data: unknown };
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "error" in data &&
-    typeof (data as { error: unknown }).error === "string"
-  );
-}
-
 const router = tsr.router(integrationsSlackMessageContract, {
   sendMessage: async ({ body, headers }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization, {
-      requiredCapability: "slack:write",
-    });
-    if (isAuthError(authCtx)) return authCtx;
-    const { userId } = authCtx;
-
-    // Resolve orgId — zero tokens carry orgId directly, sandbox tokens derive from runId
-    let orgId: string;
-    if (authCtx.orgId) {
-      orgId = authCtx.orgId;
-    } else if (isSandboxAuth(authCtx)) {
-      const [sandboxRun] = await globalThis.services.db
-        .select({ orgId: agentRuns.orgId })
-        .from(agentRuns)
-        .where(
-          and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)),
-        )
-        .limit(1);
-      if (!sandboxRun) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Agent run not found", code: "NOT_FOUND" },
-          },
-        };
-      }
-      orgId = sandboxRun.orgId;
-    } else {
-      const { org } = await resolveOrg(authCtx);
-      orgId = org.orgId;
-    }
-
-    // Look up Slack installation for the org
-    const [installation] = await globalThis.services.db
-      .select()
-      .from(slackOrgInstallations)
-      .where(eq(slackOrgInstallations.orgId, orgId))
-      .limit(1);
-
-    if (!installation) {
-      return {
-        status: 404 as const,
-        body: {
-          error: {
-            message: "No Slack installation found for this organization",
-            code: "NOT_FOUND",
-          },
-        },
-      };
-    }
-
-    // Decrypt bot token and send message
-    const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
-    const botToken = decryptSecretValue(
-      installation.encryptedBotToken,
-      SECRETS_ENCRYPTION_KEY,
+    const slackCtx = await resolveSlackClient(
+      headers.authorization,
+      "slack:write",
     );
-    const client = createSlackClient(botToken);
+    if (isSlackClientError(slackCtx)) return slackCtx;
 
     // Resolve agent name for "Sent via" footer (best-effort)
-    const agentLabel = authCtx.runId
-      ? await resolveAgentLabel(authCtx.runId).catch(() => {
+    const agentLabel = slackCtx.authRunId
+      ? await resolveAgentLabel(slackCtx.authRunId).catch(() => {
           return undefined;
         })
       : undefined;
@@ -141,10 +70,15 @@ const router = tsr.router(integrationsSlackMessageContract, {
     }
 
     try {
-      const result = await postMessage(client, body.channel, body.text ?? "", {
-        threadTs: body.threadTs,
-        blocks: finalBlocks,
-      });
+      const result = await postMessage(
+        slackCtx.client,
+        body.channel,
+        body.text ?? "",
+        {
+          threadTs: body.threadTs,
+          blocks: finalBlocks,
+        },
+      );
       return {
         status: 200 as const,
         body: {

--- a/turbo/apps/web/app/api/zero/integrations/slack/upload-file/complete/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/upload-file/complete/route.ts
@@ -1,0 +1,134 @@
+import {
+  createHandler,
+  tsr,
+} from "../../../../../../../src/lib/ts-rest-handler";
+import { integrationsSlackUploadCompleteContract } from "@vm0/core";
+import { initServices } from "../../../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../../src/lib/auth/require-auth";
+import { isSandboxAuth } from "../../../../../../../src/lib/auth/capability-check";
+import { resolveOrg } from "../../../../../../../src/lib/org/resolve-org";
+import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
+import { slackOrgInstallations } from "../../../../../../../src/db/schema/slack-org-installation";
+import { decryptSecretValue } from "../../../../../../../src/lib/crypto/secrets-encryption";
+import { createSlackClient } from "../../../../../../../src/lib/slack/client";
+import { eq, and } from "drizzle-orm";
+
+/** Type guard for Slack API platform errors that carry a `data.error` string */
+function isSlackPlatformError(
+  err: unknown,
+): err is Error & { data: { error: string } } {
+  if (!(err instanceof Error) || !("data" in err)) return false;
+  const { data } = err as { data: unknown };
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "error" in data &&
+    typeof (data as { error: unknown }).error === "string"
+  );
+}
+
+const router = tsr.router(integrationsSlackUploadCompleteContract, {
+  complete: async ({ body, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "slack:write",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    // Resolve orgId
+    let orgId: string;
+    if (authCtx.orgId) {
+      orgId = authCtx.orgId;
+    } else if (isSandboxAuth(authCtx)) {
+      const [sandboxRun] = await globalThis.services.db
+        .select({ orgId: agentRuns.orgId })
+        .from(agentRuns)
+        .where(
+          and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)),
+        )
+        .limit(1);
+      if (!sandboxRun) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent run not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      orgId = sandboxRun.orgId;
+    } else {
+      const { org } = await resolveOrg(authCtx);
+      orgId = org.orgId;
+    }
+
+    // Look up Slack installation for the org
+    const [installation] = await globalThis.services.db
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.orgId, orgId))
+      .limit(1);
+
+    if (!installation) {
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            message: "No Slack installation found for this organization",
+            code: "NOT_FOUND",
+          },
+        },
+      };
+    }
+
+    // Decrypt bot token and complete the file upload
+    const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+    const botToken = decryptSecretValue(
+      installation.encryptedBotToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    const client = createSlackClient(botToken);
+
+    try {
+      await client.files.completeUploadExternal({
+        files: [{ id: body.fileId, title: body.title }],
+        channel_id: body.channel,
+        thread_ts: body.threadTs,
+        initial_comment: body.initialComment,
+      });
+
+      // completeUploadExternal returns minimal data — fetch full file info for permalink
+      const fileInfo = await client.files.info({ file: body.fileId });
+      const permalink = fileInfo.file?.permalink ?? "";
+
+      return {
+        status: 200 as const,
+        body: {
+          fileId: body.fileId,
+          permalink,
+        },
+      };
+    } catch (error) {
+      if (isSlackPlatformError(error)) {
+        return {
+          status: 400 as const,
+          body: {
+            error: {
+              message: `Slack API error: ${error.data.error}`,
+              code: "SLACK_ERROR",
+            },
+          },
+        };
+      }
+      throw error;
+    }
+  },
+});
+
+const handler = createHandler(integrationsSlackUploadCompleteContract, router);
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/zero/integrations/slack/upload-file/complete/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/upload-file/complete/route.ts
@@ -4,97 +4,24 @@ import {
 } from "../../../../../../../src/lib/ts-rest-handler";
 import { integrationsSlackUploadCompleteContract } from "@vm0/core";
 import { initServices } from "../../../../../../../src/lib/init-services";
+import { isSlackPlatformError } from "../../../../../../../src/lib/slack/client";
 import {
-  requireAuth,
-  isAuthError,
-} from "../../../../../../../src/lib/auth/require-auth";
-import { isSandboxAuth } from "../../../../../../../src/lib/auth/capability-check";
-import { resolveOrg } from "../../../../../../../src/lib/org/resolve-org";
-import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
-import { slackOrgInstallations } from "../../../../../../../src/db/schema/slack-org-installation";
-import { decryptSecretValue } from "../../../../../../../src/lib/crypto/secrets-encryption";
-import { createSlackClient } from "../../../../../../../src/lib/slack/client";
-import { eq, and } from "drizzle-orm";
-
-/** Type guard for Slack API platform errors that carry a `data.error` string */
-function isSlackPlatformError(
-  err: unknown,
-): err is Error & { data: { error: string } } {
-  if (!(err instanceof Error) || !("data" in err)) return false;
-  const { data } = err as { data: unknown };
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "error" in data &&
-    typeof (data as { error: unknown }).error === "string"
-  );
-}
+  resolveSlackClient,
+  isSlackClientError,
+} from "../../../../../../../src/lib/slack/resolve-slack-client";
 
 const router = tsr.router(integrationsSlackUploadCompleteContract, {
   complete: async ({ body, headers }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization, {
-      requiredCapability: "slack:write",
-    });
-    if (isAuthError(authCtx)) return authCtx;
-    const { userId } = authCtx;
-
-    // Resolve orgId
-    let orgId: string;
-    if (authCtx.orgId) {
-      orgId = authCtx.orgId;
-    } else if (isSandboxAuth(authCtx)) {
-      const [sandboxRun] = await globalThis.services.db
-        .select({ orgId: agentRuns.orgId })
-        .from(agentRuns)
-        .where(
-          and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)),
-        )
-        .limit(1);
-      if (!sandboxRun) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Agent run not found", code: "NOT_FOUND" },
-          },
-        };
-      }
-      orgId = sandboxRun.orgId;
-    } else {
-      const { org } = await resolveOrg(authCtx);
-      orgId = org.orgId;
-    }
-
-    // Look up Slack installation for the org
-    const [installation] = await globalThis.services.db
-      .select()
-      .from(slackOrgInstallations)
-      .where(eq(slackOrgInstallations.orgId, orgId))
-      .limit(1);
-
-    if (!installation) {
-      return {
-        status: 404 as const,
-        body: {
-          error: {
-            message: "No Slack installation found for this organization",
-            code: "NOT_FOUND",
-          },
-        },
-      };
-    }
-
-    // Decrypt bot token and complete the file upload
-    const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
-    const botToken = decryptSecretValue(
-      installation.encryptedBotToken,
-      SECRETS_ENCRYPTION_KEY,
+    const slackCtx = await resolveSlackClient(
+      headers.authorization,
+      "slack:write",
     );
-    const client = createSlackClient(botToken);
+    if (isSlackClientError(slackCtx)) return slackCtx;
 
     try {
-      await client.files.completeUploadExternal({
+      await slackCtx.client.files.completeUploadExternal({
         files: [{ id: body.fileId, title: body.title }],
         channel_id: body.channel,
         thread_ts: body.threadTs,
@@ -102,7 +29,7 @@ const router = tsr.router(integrationsSlackUploadCompleteContract, {
       });
 
       // completeUploadExternal returns minimal data — fetch full file info for permalink
-      const fileInfo = await client.files.info({ file: body.fileId });
+      const fileInfo = await slackCtx.client.files.info({ file: body.fileId });
       const permalink = fileInfo.file?.permalink ?? "";
 
       return {

--- a/turbo/apps/web/app/api/zero/integrations/slack/upload-file/init/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/upload-file/init/route.ts
@@ -1,0 +1,140 @@
+import {
+  createHandler,
+  tsr,
+} from "../../../../../../../src/lib/ts-rest-handler";
+import { integrationsSlackUploadInitContract } from "@vm0/core";
+import { initServices } from "../../../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../../../src/lib/auth/require-auth";
+import { isSandboxAuth } from "../../../../../../../src/lib/auth/capability-check";
+import { resolveOrg } from "../../../../../../../src/lib/org/resolve-org";
+import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
+import { slackOrgInstallations } from "../../../../../../../src/db/schema/slack-org-installation";
+import { decryptSecretValue } from "../../../../../../../src/lib/crypto/secrets-encryption";
+import { createSlackClient } from "../../../../../../../src/lib/slack/client";
+import { eq, and } from "drizzle-orm";
+
+/** Type guard for Slack API platform errors that carry a `data.error` string */
+function isSlackPlatformError(
+  err: unknown,
+): err is Error & { data: { error: string } } {
+  if (!(err instanceof Error) || !("data" in err)) return false;
+  const { data } = err as { data: unknown };
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "error" in data &&
+    typeof (data as { error: unknown }).error === "string"
+  );
+}
+
+const router = tsr.router(integrationsSlackUploadInitContract, {
+  init: async ({ body, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "slack:write",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    // Resolve orgId
+    let orgId: string;
+    if (authCtx.orgId) {
+      orgId = authCtx.orgId;
+    } else if (isSandboxAuth(authCtx)) {
+      const [sandboxRun] = await globalThis.services.db
+        .select({ orgId: agentRuns.orgId })
+        .from(agentRuns)
+        .where(
+          and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)),
+        )
+        .limit(1);
+      if (!sandboxRun) {
+        return {
+          status: 404 as const,
+          body: {
+            error: { message: "Agent run not found", code: "NOT_FOUND" },
+          },
+        };
+      }
+      orgId = sandboxRun.orgId;
+    } else {
+      const { org } = await resolveOrg(authCtx);
+      orgId = org.orgId;
+    }
+
+    // Look up Slack installation for the org
+    const [installation] = await globalThis.services.db
+      .select()
+      .from(slackOrgInstallations)
+      .where(eq(slackOrgInstallations.orgId, orgId))
+      .limit(1);
+
+    if (!installation) {
+      return {
+        status: 404 as const,
+        body: {
+          error: {
+            message: "No Slack installation found for this organization",
+            code: "NOT_FOUND",
+          },
+        },
+      };
+    }
+
+    // Decrypt bot token and request upload URL from Slack
+    const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+    const botToken = decryptSecretValue(
+      installation.encryptedBotToken,
+      SECRETS_ENCRYPTION_KEY,
+    );
+    const client = createSlackClient(botToken);
+
+    try {
+      const result = await client.files.getUploadURLExternal({
+        filename: body.filename,
+        length: body.length,
+      });
+
+      if (!result.ok || !result.upload_url || !result.file_id) {
+        return {
+          status: 400 as const,
+          body: {
+            error: {
+              message: `Slack API error: ${result.error ?? "unknown error"}`,
+              code: "SLACK_ERROR",
+            },
+          },
+        };
+      }
+
+      return {
+        status: 200 as const,
+        body: {
+          uploadUrl: result.upload_url,
+          fileId: result.file_id,
+        },
+      };
+    } catch (error) {
+      if (isSlackPlatformError(error)) {
+        return {
+          status: 400 as const,
+          body: {
+            error: {
+              message: `Slack API error: ${error.data.error}`,
+              code: "SLACK_ERROR",
+            },
+          },
+        };
+      }
+      throw error;
+    }
+  },
+});
+
+const handler = createHandler(integrationsSlackUploadInitContract, router);
+
+export { handler as POST };

--- a/turbo/apps/web/app/api/zero/integrations/slack/upload-file/init/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/upload-file/init/route.ts
@@ -4,97 +4,24 @@ import {
 } from "../../../../../../../src/lib/ts-rest-handler";
 import { integrationsSlackUploadInitContract } from "@vm0/core";
 import { initServices } from "../../../../../../../src/lib/init-services";
+import { isSlackPlatformError } from "../../../../../../../src/lib/slack/client";
 import {
-  requireAuth,
-  isAuthError,
-} from "../../../../../../../src/lib/auth/require-auth";
-import { isSandboxAuth } from "../../../../../../../src/lib/auth/capability-check";
-import { resolveOrg } from "../../../../../../../src/lib/org/resolve-org";
-import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
-import { slackOrgInstallations } from "../../../../../../../src/db/schema/slack-org-installation";
-import { decryptSecretValue } from "../../../../../../../src/lib/crypto/secrets-encryption";
-import { createSlackClient } from "../../../../../../../src/lib/slack/client";
-import { eq, and } from "drizzle-orm";
-
-/** Type guard for Slack API platform errors that carry a `data.error` string */
-function isSlackPlatformError(
-  err: unknown,
-): err is Error & { data: { error: string } } {
-  if (!(err instanceof Error) || !("data" in err)) return false;
-  const { data } = err as { data: unknown };
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "error" in data &&
-    typeof (data as { error: unknown }).error === "string"
-  );
-}
+  resolveSlackClient,
+  isSlackClientError,
+} from "../../../../../../../src/lib/slack/resolve-slack-client";
 
 const router = tsr.router(integrationsSlackUploadInitContract, {
   init: async ({ body, headers }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization, {
-      requiredCapability: "slack:write",
-    });
-    if (isAuthError(authCtx)) return authCtx;
-    const { userId } = authCtx;
-
-    // Resolve orgId
-    let orgId: string;
-    if (authCtx.orgId) {
-      orgId = authCtx.orgId;
-    } else if (isSandboxAuth(authCtx)) {
-      const [sandboxRun] = await globalThis.services.db
-        .select({ orgId: agentRuns.orgId })
-        .from(agentRuns)
-        .where(
-          and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)),
-        )
-        .limit(1);
-      if (!sandboxRun) {
-        return {
-          status: 404 as const,
-          body: {
-            error: { message: "Agent run not found", code: "NOT_FOUND" },
-          },
-        };
-      }
-      orgId = sandboxRun.orgId;
-    } else {
-      const { org } = await resolveOrg(authCtx);
-      orgId = org.orgId;
-    }
-
-    // Look up Slack installation for the org
-    const [installation] = await globalThis.services.db
-      .select()
-      .from(slackOrgInstallations)
-      .where(eq(slackOrgInstallations.orgId, orgId))
-      .limit(1);
-
-    if (!installation) {
-      return {
-        status: 404 as const,
-        body: {
-          error: {
-            message: "No Slack installation found for this organization",
-            code: "NOT_FOUND",
-          },
-        },
-      };
-    }
-
-    // Decrypt bot token and request upload URL from Slack
-    const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
-    const botToken = decryptSecretValue(
-      installation.encryptedBotToken,
-      SECRETS_ENCRYPTION_KEY,
+    const slackCtx = await resolveSlackClient(
+      headers.authorization,
+      "slack:write",
     );
-    const client = createSlackClient(botToken);
+    if (isSlackClientError(slackCtx)) return slackCtx;
 
     try {
-      const result = await client.files.getUploadURLExternal({
+      const result = await slackCtx.client.files.getUploadURLExternal({
         filename: body.filename,
         length: body.length,
       });

--- a/turbo/apps/web/src/lib/slack/client.ts
+++ b/turbo/apps/web/src/lib/slack/client.ts
@@ -275,3 +275,17 @@ export async function setThreadStatus(
     status,
   });
 }
+
+/** Type guard for Slack API platform errors that carry a `data.error` string */
+export function isSlackPlatformError(
+  err: unknown,
+): err is Error & { data: { error: string } } {
+  if (!(err instanceof Error) || !("data" in err)) return false;
+  const { data } = err as { data: unknown };
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "error" in data &&
+    typeof (data as { error: unknown }).error === "string"
+  );
+}

--- a/turbo/apps/web/src/lib/slack/resolve-slack-client.ts
+++ b/turbo/apps/web/src/lib/slack/resolve-slack-client.ts
@@ -1,0 +1,99 @@
+import type { WebClient } from "@slack/web-api";
+import type { ZeroCapability } from "@vm0/core";
+import { requireAuth, isAuthError } from "../auth/require-auth";
+import { isSandboxAuth } from "../auth/capability-check";
+import { resolveOrg } from "../org/resolve-org";
+import { agentRuns } from "../../db/schema/agent-run";
+import { slackOrgInstallations } from "../../db/schema/slack-org-installation";
+import { decryptSecretValue } from "../crypto/secrets-encryption";
+import { createSlackClient } from "./client";
+import { eq, and } from "drizzle-orm";
+
+type ApiErrorResponse = {
+  status: 401 | 403 | 404;
+  body: { error: { message: string; code: string } };
+};
+
+type SlackClientResult = {
+  orgId: string;
+  client: WebClient;
+  authRunId: string | undefined;
+};
+
+/**
+ * Authenticate the request, resolve the org, look up the Slack installation,
+ * decrypt the bot token, and return a ready-to-use Slack WebClient.
+ *
+ * Returns either a `SlackClientResult` on success or an `ApiErrorResponse`
+ * that the caller can return directly from a ts-rest handler.
+ */
+export async function resolveSlackClient(
+  authHeader: string | undefined,
+  requiredCapability: ZeroCapability,
+): Promise<SlackClientResult | ApiErrorResponse> {
+  const authCtx = await requireAuth(authHeader, { requiredCapability });
+  if (isAuthError(authCtx)) return authCtx;
+  const { userId } = authCtx;
+
+  // Resolve orgId
+  let orgId: string;
+  if (authCtx.orgId) {
+    orgId = authCtx.orgId;
+  } else if (isSandboxAuth(authCtx)) {
+    const [sandboxRun] = await globalThis.services.db
+      .select({ orgId: agentRuns.orgId })
+      .from(agentRuns)
+      .where(and(eq(agentRuns.id, authCtx.runId), eq(agentRuns.userId, userId)))
+      .limit(1);
+    if (!sandboxRun) {
+      return {
+        status: 404 as const,
+        body: {
+          error: { message: "Agent run not found", code: "NOT_FOUND" },
+        },
+      };
+    }
+    orgId = sandboxRun.orgId;
+  } else {
+    const { org } = await resolveOrg(authCtx);
+    orgId = org.orgId;
+  }
+
+  // Look up Slack installation for the org
+  const [installation] = await globalThis.services.db
+    .select()
+    .from(slackOrgInstallations)
+    .where(eq(slackOrgInstallations.orgId, orgId))
+    .limit(1);
+
+  if (!installation) {
+    return {
+      status: 404 as const,
+      body: {
+        error: {
+          message: "No Slack installation found for this organization",
+          code: "NOT_FOUND",
+        },
+      },
+    };
+  }
+
+  // Decrypt bot token and create Slack client
+  const { SECRETS_ENCRYPTION_KEY } = globalThis.services.env;
+  const botToken = decryptSecretValue(
+    installation.encryptedBotToken,
+    SECRETS_ENCRYPTION_KEY,
+  );
+  const client = createSlackClient(botToken);
+
+  return { orgId, client, authRunId: authCtx.runId };
+}
+
+/**
+ * Type guard to check if the result of `resolveSlackClient` is an error response.
+ */
+export function isSlackClientError(
+  result: SlackClientResult | ApiErrorResponse,
+): result is ApiErrorResponse {
+  return "status" in result && "body" in result && !("client" in result);
+}

--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -68,14 +68,13 @@ function buildAgentToolsPrompt(): string {
   return [
     "# Agent Tools",
     "You have access to the Zero CLI. Run commands with: `npx -p @vm0/cli zero <command>`",
-    "- When you need to discover available commands, run `zero --help`.",
-    "- When you need to delegate a task to a teammate agent, use `zero agent list` and `zero run --help`.",
-    "- When you need to schedule or manage recurring tasks, use `zero schedule --help`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
-    "- When you need to ask the user a question, use `zero ask-user question --help`.",
-    "- Your replies are automatically sent to the originating thread. Only use `zero slack message send` when you need to message a different channel or thread. Never use SLACK_TOKEN to send messages directly — it's a user OAuth token.",
-    "- When you encounter a missing token or environment variable error, run `zero doctor missing-token <TOKEN_NAME>` to diagnose the issue and get remediation steps for the user.",
-    '- When you encounter a 403 error with "firewall_permission_denied", run `zero doctor firewall-deny <FIREWALL_REF> --method <METHOD> --path <PATH>` using the "firewall", "method", and "path" fields from the JSON error response to get remediation steps for the user.',
-    "- When you need to update your own configuration (instructions, skills, tone, etc.), use `zero agent edit --help`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",
-    "- When you need to create or edit custom skill content, use `zero skill --help`.",
+    "- Discover available commands: `zero --help`.",
+    "- Delegate tasks to teammates: `zero run --help` and `zero agent list`.",
+    "- Schedule recurring tasks: `zero schedule --help`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
+    "- Ask the user a question: `zero ask-user question --help`.",
+    "- Slack messaging and file uploads: `zero slack --help`. Your replies are automatically sent to the originating thread — only use these commands for different channels/threads. Never use SLACK_TOKEN directly — it's a user OAuth token.",
+    "- Troubleshoot errors (missing tokens, firewall denials): `zero doctor --help`.",
+    "- Update your own configuration: `zero agent edit --help`. Review current settings with `zero agent view $ZERO_AGENT_ID --instructions` first.",
+    "- Manage custom skills: `zero skill --help`.",
   ].join("\n");
 }

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -649,6 +649,12 @@ export {
   type IntegrationsSlackMessageContract,
   type SendSlackMessageBody,
   type SendSlackMessageResponse,
+  integrationsSlackUploadInitContract,
+  type SlackUploadInitBody,
+  type SlackUploadInitResponse,
+  integrationsSlackUploadCompleteContract,
+  type SlackUploadCompleteBody,
+  type SlackUploadCompleteResponse,
 } from "./integrations";
 export {
   zeroBillingStatusContract,

--- a/turbo/packages/core/src/contracts/integrations.ts
+++ b/turbo/packages/core/src/contracts/integrations.ts
@@ -49,3 +49,89 @@ export const integrationsSlackMessageContract = c.router({
 
 export type IntegrationsSlackMessageContract =
   typeof integrationsSlackMessageContract;
+
+/**
+ * Integration Slack file upload — init contract
+ * POST /api/zero/integrations/slack/upload-file/init
+ *
+ * Requests a pre-signed upload URL from Slack via the org's bot token.
+ * The CLI then uploads the file directly to that URL (no auth needed).
+ * Requires `slack:write` capability (via ZERO_TOKEN).
+ */
+const slackUploadInitBodySchema = z.object({
+  filename: z.string().min(1, "Filename is required"),
+  length: z.number().int().positive("File length must be a positive integer"),
+});
+
+export type SlackUploadInitBody = z.infer<typeof slackUploadInitBodySchema>;
+
+const slackUploadInitResponseSchema = z.object({
+  uploadUrl: z.string(),
+  fileId: z.string(),
+});
+
+export type SlackUploadInitResponse = z.infer<
+  typeof slackUploadInitResponseSchema
+>;
+
+export const integrationsSlackUploadInitContract = c.router({
+  init: {
+    method: "POST",
+    path: "/api/zero/integrations/slack/upload-file/init",
+    headers: authHeadersSchema,
+    body: slackUploadInitBodySchema,
+    responses: {
+      200: slackUploadInitResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get a pre-signed Slack upload URL via org bot token",
+  },
+});
+
+/**
+ * Integration Slack file upload — complete contract
+ * POST /api/zero/integrations/slack/upload-file/complete
+ *
+ * Finalizes a Slack file upload and shares it to a channel/thread.
+ * Requires `slack:write` capability (via ZERO_TOKEN).
+ */
+const slackUploadCompleteBodySchema = z.object({
+  fileId: z.string().min(1, "File ID is required"),
+  channel: z.string().min(1, "Channel ID is required"),
+  threadTs: z.string().optional(),
+  title: z.string().optional(),
+  initialComment: z.string().optional(),
+});
+
+export type SlackUploadCompleteBody = z.infer<
+  typeof slackUploadCompleteBodySchema
+>;
+
+const slackUploadCompleteResponseSchema = z.object({
+  fileId: z.string(),
+  permalink: z.string(),
+});
+
+export type SlackUploadCompleteResponse = z.infer<
+  typeof slackUploadCompleteResponseSchema
+>;
+
+export const integrationsSlackUploadCompleteContract = c.router({
+  complete: {
+    method: "POST",
+    path: "/api/zero/integrations/slack/upload-file/complete",
+    headers: authHeadersSchema,
+    body: slackUploadCompleteBodySchema,
+    responses: {
+      200: slackUploadCompleteResponseSchema,
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Finalize Slack file upload and share to channel",
+  },
+});


### PR DESCRIPTION
## Summary

- Add `zero slack upload-file` CLI command that uploads files to Slack channels/threads using the org's bot token
- Implement two-phase upload flow: init (get pre-signed URL) -> upload to Slack -> complete (share to channel)
- Add ts-rest contracts (`integrationsSlackUploadInitContract`, `integrationsSlackUploadCompleteContract`) and corresponding API routes
- Include agent tools prompt so agents know how to use the new command
- Add integration tests covering happy path, validation errors, and API error handling

## Test plan

- [ ] Verify `zero slack upload-file -f /tmp/test.txt -c <channel-id>` uploads a file successfully
- [ ] Verify `--thread`, `--title`, and `--comment` options are passed through correctly
- [ ] Verify proper error messages for missing file, empty file, auth failures, and Slack API errors
- [ ] Run `pnpm vitest apps/cli/src/commands/zero/slack/__tests__/upload-file.test.ts` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)