### PR TITLE
docs: improve agent tools prompt and skill help text

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -78,7 +78,8 @@ Notes:
   - At least one option is required
   - Unspecified fields are preserved (not cleared)
   - --skills replaces the entire skill list; --add-skill/--remove-skill modify incrementally
-  - --skills cannot be combined with --add-skill or --remove-skill`,
+  - --skills cannot be combined with --add-skill or --remove-skill
+  - To create or edit skill content, use: zero skill --help`,
   )
   .action(
     withErrorHandler(

--- a/turbo/apps/web/src/lib/integration-context.ts
+++ b/turbo/apps/web/src/lib/integration-context.ts
@@ -61,7 +61,7 @@ export function buildAgentToolsPrompt(): string {
     "- Your replies are automatically sent to the originating thread. Only use `zero slack message send` when you need to message a different channel or thread. Never use SLACK_TOKEN to send messages directly — it's a user OAuth token.",
     "- When you encounter a missing token or environment variable error, run `zero doctor missing-token <TOKEN_NAME>` to diagnose the issue and get remediation steps for the user.",
     '- When you encounter a 403 error with "firewall_permission_denied", run `zero doctor firewall-deny <FIREWALL_REF> --method <METHOD> --path <PATH>` using the "firewall", "method", and "path" fields from the JSON error response to get remediation steps for the user.',
-    "- When you need to update your own configuration (description, tone, or instructions), use `zero agent edit --help`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",
-    "- When you need to manage custom skills, use `zero skill --help`.",
+    "- When you need to update your own configuration (instructions, skills, tone, etc.), use `zero agent edit --help`. Use `zero agent view $ZERO_AGENT_ID --instructions` to review your current settings first.",
+    "- When you need to create or edit custom skill content, use `zero skill --help`.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Update agent tools prompt to list `instructions, skills, tone, etc.` as configurable fields
- Clarify second bullet: `create or edit custom skill content` instead of generic `manage custom skills`
- Add `zero skill --help` cross-reference to `zero agent edit --help` Notes section

## Test plan
- [ ] Verify `zero agent edit --help` shows the new note about `zero skill --help`
- [ ] Verify agent tools prompt renders correctly in sandbox runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)