### PR TITLE
feat: add collapsible permission groups in firewall dialog

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/firewall-permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/firewall-permissions-dialog.test.tsx
@@ -9,8 +9,6 @@ import { setupPage } from "../../../__tests__/page-helper.ts";
 
 const context = testContext();
 
-const ALL_CONNECTOR_TYPES = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
-
 function mockAPIs({
   firewallPolicies = null,
 }: { firewallPolicies?: Record<string, Record<string, string>> | null } = {}) {
@@ -76,7 +74,7 @@ function mockAPIs({
             updatedAt: "2026-01-01T00:00:00Z",
           },
         ],
-        configuredTypes: ALL_CONNECTOR_TYPES,
+        configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
         connectorProvidedSecretNames: [],
       });
     }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/firewall-permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/firewall-permissions-dialog.test.tsx
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+const ALL_CONNECTOR_TYPES = Object.keys(CONNECTOR_TYPES) as ConnectorType[];
+
+function mockAPIs({
+  firewallPolicies = null,
+}: { firewallPolicies?: Record<string, Record<string, string>> | null } = {}) {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: "c0000000-0000-4000-a000-000000000001",
+          name: "zero",
+          displayName: null,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "agent-detail-id",
+          name: "my-agent",
+          displayName: "My Agent",
+          description: "A helpful agent",
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_2",
+          updatedAt: "2024-01-02T00:00:00Z",
+        },
+      ]);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    http.get("*/api/zero/agents/my-agent", () => {
+      return HttpResponse.json({
+        name: "my-agent",
+        agentId: "e0000000-0000-4000-a000-000000000010",
+        description: "A helpful agent",
+        displayName: "My Agent",
+        sound: null,
+        avatarUrl: null,
+        connectors: [],
+        firewallPolicies,
+      });
+    }),
+    http.get("*/api/zero/agents/:name/instructions", () => {
+      return HttpResponse.json({ content: null, filename: null });
+    }),
+    http.get("*/api/zero/schedules", () => {
+      return HttpResponse.json({ schedules: [] });
+    }),
+    http.get("*/api/zero/connectors", () => {
+      return HttpResponse.json({
+        connectors: [
+          {
+            id: "d0000001-0000-4000-a000-000000000001",
+            type: "github",
+            authMethod: "oauth",
+            externalId: null,
+            externalUsername: "testuser",
+            externalEmail: null,
+            oauthScopes: ["repo", "project"],
+            needsReconnect: false,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+        configuredTypes: ALL_CONNECTOR_TYPES,
+        connectorProvidedSecretNames: [],
+      });
+    }),
+    http.get("*/api/zero/agents/:id/user-connectors", () => {
+      return HttpResponse.json({ enabledTypes: ["github"] });
+    }),
+    http.put("*/api/zero/firewall-policies", async ({ request }) => {
+      const body = (await request.json()) as {
+        agentId: string;
+        policies: Record<string, Record<string, string>>;
+      };
+      return HttpResponse.json({ firewallPolicies: body.policies });
+    }),
+  );
+}
+
+async function openPermissionsDrawer() {
+  const user = userEvent.setup();
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole("heading", { name: "My Agent" }),
+    ).toBeInTheDocument();
+  });
+
+  // Wait for connectors to load
+  await waitFor(() => {
+    expect(
+      screen.getByRole("button", {
+        name: /Manage GitHub permissions/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  await user.click(
+    screen.getByRole("button", { name: /Manage GitHub permissions/i }),
+  );
+
+  // Wait for drawer to open
+  await waitFor(() => {
+    expect(
+      screen.getByRole("heading", { name: /GitHub permissions/i }),
+    ).toBeInTheDocument();
+  });
+
+  return user;
+}
+
+describe("firewall permissions dialog - grouped connector (GitHub)", () => {
+  it("should show category groups collapsed by default with no global select-all", async () => {
+    mockAPIs();
+    await setupPage({ context, path: "/team/my-agent" });
+    await openPermissionsDrawer();
+
+    // Category groups should be visible
+    expect(
+      screen.getByRole("button", { name: /Read \(\d+\)/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Write \(\d+\)/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Admin \(\d+\)/i }),
+    ).toBeInTheDocument();
+
+    // Global "Select all" should NOT be present (grouped connectors don't show it)
+    expect(screen.queryByText(/Select all/i)).not.toBeInTheDocument();
+
+    // Individual permissions should NOT be visible (collapsed by default)
+    expect(screen.queryByText("actions:read")).not.toBeInTheDocument();
+    expect(screen.queryByText("actions:write")).not.toBeInTheDocument();
+  });
+
+  it("should expand a group when its header is clicked and collapse when clicked again", async () => {
+    mockAPIs();
+    await setupPage({ context, path: "/team/my-agent" });
+    const user = await openPermissionsDrawer();
+
+    const readButton = screen.getByRole("button", { name: /Read \(\d+\)/i });
+
+    // Click to expand
+    await user.click(readButton);
+
+    // Individual read permissions should now be visible
+    await waitFor(() => {
+      expect(screen.getByText("actions:read")).toBeInTheDocument();
+    });
+
+    // Click again to collapse
+    await user.click(readButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText("actions:read")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should not highlight either Allow or Deny at group level when permissions are mixed", async () => {
+    // Provide mixed policies: some allow, some deny within Read group
+    mockAPIs({
+      firewallPolicies: {
+        github: {
+          "actions:read": "allow",
+          "contents:read": "deny",
+        },
+      },
+    });
+    await setupPage({ context, path: "/team/my-agent" });
+    await openPermissionsDrawer();
+
+    // Find the Read group row — it contains the group button and a PolicyPill
+    const readButton = screen.getByRole("button", { name: /Read \(\d+\)/i });
+    const readRow = readButton.closest(
+      ".flex.items-center.justify-between",
+    ) as HTMLElement;
+    expect(readRow).not.toBeNull();
+
+    // Within that row, find the Allow/Deny buttons (the PolicyPill)
+    const pillButtons = within(readRow).getAllByRole("button");
+    // Filter to just Allow and Deny buttons (exclude the chevron toggle button)
+    const allowBtn = pillButtons.find((b) => {
+      return b.textContent?.includes("Allow") ?? false;
+    });
+    const denyBtn = pillButtons.find((b) => {
+      return b.textContent?.includes("Deny") ?? false;
+    });
+
+    expect(allowBtn).toBeDefined();
+    expect(denyBtn).toBeDefined();
+
+    // Neither should have the active "bg-muted" class (mixed state)
+    expect(allowBtn!.className).not.toContain("bg-muted text-foreground");
+    expect(denyBtn!.className).not.toContain("bg-muted text-foreground");
+  });
+
+  it("should highlight Allow at group level when all permissions in group are allow", async () => {
+    // Default policies are all "allow" when not specified
+    mockAPIs();
+    await setupPage({ context, path: "/team/my-agent" });
+    await openPermissionsDrawer();
+
+    const readButton = screen.getByRole("button", { name: /Read \(\d+\)/i });
+    const readRow = readButton.closest(
+      ".flex.items-center.justify-between",
+    ) as HTMLElement;
+
+    const pillButtons = within(readRow).getAllByRole("button");
+    const allowBtn = pillButtons.find((b) => {
+      return b.textContent?.includes("Allow") ?? false;
+    });
+
+    // Should have active styling since all permissions default to "allow"
+    expect(allowBtn!.className).toContain("bg-muted");
+  });
+
+  it("should set all permissions in a group when group-level Allow/Deny is clicked", async () => {
+    mockAPIs();
+    await setupPage({ context, path: "/team/my-agent" });
+    const user = await openPermissionsDrawer();
+
+    // Click Deny on the Read group
+    const readButton = screen.getByRole("button", { name: /Read \(\d+\)/i });
+    const readRow = readButton.closest(
+      ".flex.items-center.justify-between",
+    ) as HTMLElement;
+
+    const pillButtons = within(readRow).getAllByRole("button");
+    const denyBtn = pillButtons.find((b) => {
+      return b.textContent?.includes("Deny") ?? false;
+    });
+    await user.click(denyBtn!);
+
+    // Expand the group to verify individual permissions
+    await user.click(readButton);
+
+    // All individual Read permissions should now show "Deny" as active
+    await waitFor(() => {
+      expect(screen.getByText("actions:read")).toBeInTheDocument();
+    });
+
+    // Find an individual permission's Deny button and verify it's active
+    const actionsReadRow = screen
+      .getByText("actions:read")
+      .closest(".flex.items-center") as HTMLElement;
+    const individualButtons = within(actionsReadRow).getAllByRole("button");
+    const individualDeny = individualButtons.find((b) => {
+      return b.textContent?.includes("Deny") ?? false;
+    });
+    expect(individualDeny!.className).toContain("bg-muted");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/settings/firewall-permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/firewall-permissions-dialog.tsx
@@ -19,7 +19,7 @@ import {
 } from "@vm0/core";
 import { ConnectorIcon } from "./connector-icons.tsx";
 import type { PermissionPolicy } from "../../../../signals/zero-page/settings/firewalls.ts";
-import { IconCheck, IconBan } from "@tabler/icons-react";
+import { IconCheck, IconBan, IconChevronRight } from "@tabler/icons-react";
 import { detach, Reason } from "../../../../signals/utils.ts";
 
 interface FirewallPermission {
@@ -88,11 +88,27 @@ const POLICY_OPTIONS = [
   { value: "deny" as const, label: "Deny" },
 ] as const;
 
+function getGroupPolicy(
+  perms: FirewallPermission[],
+  policies: Record<string, PermissionPolicy>,
+): PermissionPolicy | "mixed" {
+  if (perms.length === 0) {
+    return "allow";
+  }
+  const first = policies[perms[0].name] ?? "allow";
+  for (let i = 1; i < perms.length; i++) {
+    if ((policies[perms[i].name] ?? "allow") !== first) {
+      return "mixed";
+    }
+  }
+  return first;
+}
+
 function PolicyPill({
   policy,
   onChange,
 }: {
-  policy: PermissionPolicy;
+  policy: PermissionPolicy | "mixed";
   onChange: (p: PermissionPolicy) => void;
 }) {
   return (
@@ -162,6 +178,7 @@ export function FirewallPermissionsDrawer({
 
   const [scrolled, setScrolled] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const permissions = config ? sortPermissions(extractPermissions(config)) : [];
   const policies = allPolicies[ref] ?? {};
   const groups = config
@@ -174,6 +191,18 @@ export function FirewallPermissionsDrawer({
         },
       ) ?? null)
     : null;
+
+  const toggleGroup = (category: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  };
 
   const handlePolicyChange = (name: string, policy: PermissionPolicy) => {
     setAllPolicies({
@@ -245,43 +274,22 @@ export function FirewallPermissionsDrawer({
           </div>
         ) : (
           <div className="flex flex-1 flex-col min-h-0">
-            <div
-              className={`flex items-center justify-between pb-3 -mx-6 px-6 pr-9 transition-shadow ${scrolled ? "shadow-[0_4px_8px_-4px_rgba(0,0,0,0.08)]" : ""}`}
-            >
-              <span className="text-xs font-medium text-foreground">
-                Select all ({permissions.length})
-              </span>
-              <span className="inline-flex shrink-0 rounded-md overflow-hidden text-xs font-medium zero-border">
-                {POLICY_OPTIONS.map((opt, idx) => {
-                  return (
-                    <button
-                      key={opt.value}
-                      type="button"
-                      style={
-                        idx > 0
-                          ? { borderLeft: "0.7px solid hsl(var(--gray-400))" }
-                          : undefined
-                      }
-                      onClick={() => {
-                        return handleSetAll(opt.value);
-                      }}
-                      className="flex items-center gap-1 px-2.5 py-1.5 transition-colors text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                    >
-                      {opt.value === "allow" && (
-                        <IconCheck size={12} stroke={2.5} />
-                      )}
-                      {opt.value === "deny" && (
-                        <IconBan size={12} stroke={2.5} />
-                      )}
-                      {opt.label}
-                    </button>
-                  );
-                })}
-              </span>
-            </div>
+            {!groups && (
+              <div
+                className={`flex items-center justify-between pb-3 -mx-6 px-6 pr-9 transition-shadow ${scrolled ? "shadow-[0_4px_8px_-4px_rgba(0,0,0,0.08)]" : ""}`}
+              >
+                <span className="text-xs font-medium text-foreground">
+                  Select all ({permissions.length})
+                </span>
+                <PolicyPill
+                  policy={getGroupPolicy(permissions, policies)}
+                  onChange={handleSetAll}
+                />
+              </div>
+            )}
 
             <div
-              className="flex-1 overflow-y-auto -mx-6 px-3"
+              className={`flex-1 overflow-y-auto -mx-6 px-3 ${groups ? "pt-1" : ""}`}
               onScroll={(e) => {
                 const target = e.currentTarget;
                 setScrolled(target.scrollTop > 0);
@@ -289,77 +297,67 @@ export function FirewallPermissionsDrawer({
             >
               {groups
                 ? groups.map((group, groupIdx) => {
+                    const expanded = expandedGroups.has(group.category);
+                    const groupPolicy = getGroupPolicy(
+                      group.permissions,
+                      policies,
+                    );
                     return (
                       <div key={group.category}>
                         {groupIdx > 0 && (
                           <div className="mx-3 border-t border-border/40 my-1" />
                         )}
                         <div className="flex items-center justify-between px-3 py-2">
-                          <span className="text-xs font-medium text-foreground">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              return toggleGroup(group.category);
+                            }}
+                            className="flex items-center gap-1.5 text-xs font-medium text-foreground hover:text-foreground/80 transition-colors"
+                          >
+                            <IconChevronRight
+                              size={14}
+                              stroke={2}
+                              className={`transition-transform ${expanded ? "rotate-90" : ""}`}
+                            />
                             {group.category} ({group.permissions.length})
-                          </span>
-                          <span className="inline-flex shrink-0 rounded-md overflow-hidden text-xs font-medium zero-border">
-                            {POLICY_OPTIONS.map((opt, idx) => {
-                              return (
-                                <button
-                                  key={opt.value}
-                                  type="button"
-                                  style={
-                                    idx > 0
-                                      ? {
-                                          borderLeft:
-                                            "0.7px solid hsl(var(--gray-400))",
-                                        }
-                                      : undefined
-                                  }
-                                  onClick={() => {
-                                    return handleSetGroupAll(
-                                      group.permissions,
-                                      opt.value,
-                                    );
-                                  }}
-                                  className="flex items-center gap-1 px-2.5 py-1.5 transition-colors text-muted-foreground hover:text-foreground hover:bg-muted/50"
-                                >
-                                  {opt.value === "allow" && (
-                                    <IconCheck size={12} stroke={2.5} />
-                                  )}
-                                  {opt.value === "deny" && (
-                                    <IconBan size={12} stroke={2.5} />
-                                  )}
-                                  {opt.label}
-                                </button>
-                              );
-                            })}
-                          </span>
+                          </button>
+                          <PolicyPill
+                            policy={groupPolicy}
+                            onChange={(p) => {
+                              return handleSetGroupAll(group.permissions, p);
+                            }}
+                          />
                         </div>
-                        {group.permissions.map((perm, idx) => {
-                          const pol = policies[perm.name] ?? "allow";
-                          return (
-                            <div key={perm.name}>
-                              {idx > 0 && (
-                                <div className="mx-3 border-t border-border/40" />
-                              )}
-                              <div className="flex items-center gap-2.5 px-3 py-2.5 pl-6 rounded-md hover:bg-muted/50 transition-colors">
-                                <div className="min-w-0 flex-1">
-                                  <code className="text-xs font-medium text-foreground truncate block">
-                                    {perm.name}
-                                  </code>
-                                  {perm.description && (
-                                    <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-                                      {perm.description}
-                                    </p>
-                                  )}
+                        {expanded &&
+                          group.permissions.map((perm, idx) => {
+                            const pol = policies[perm.name] ?? "allow";
+                            return (
+                              <div key={perm.name}>
+                                {idx > 0 && (
+                                  <div className="mx-3 border-t border-border/40" />
+                                )}
+                                <div className="flex items-center gap-2.5 px-3 py-2.5 pl-8 rounded-md hover:bg-muted/50 transition-colors">
+                                  <div className="min-w-0 flex-1">
+                                    <code className="text-xs font-medium text-foreground truncate block">
+                                      {perm.name}
+                                    </code>
+                                    {perm.description && (
+                                      <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
+                                        {perm.description}
+                                      </p>
+                                    )}
+                                  </div>
+                                  <PolicyPill
+                                    policy={pol}
+                                    onChange={(p) => {
+                                      return handlePolicyChange(perm.name, p);
+                                    }}
+                                  />
                                 </div>
-                                <PolicyPill
-                                  policy={pol}
-                                  onChange={(p) => {
-                                    return handlePolicyChange(perm.name, p);
-                                  }}
-                                />
                               </div>
-                            </div>
-                          );
-                        })}
+                            );
+                          })}
                       </div>
                     );
                   })


### PR DESCRIPTION
Closes #7336

## Summary
- Replace inline policy option buttons with reusable `PolicyPill` component to reduce code duplication
- Add collapsible/expandable permission groups with chevron toggle icons (groups start collapsed)
- Add `getGroupPolicy` helper that returns "mixed" when permissions within a group have different policies
- Add tests for the `getGroupPolicy` helper function

## Test plan
- [ ] Verify permission groups are collapsed by default
- [ ] Click chevron to expand/collapse groups
- [ ] Verify PolicyPill shows correct state (allow/deny/mixed) for each group
- [ ] Verify "Select all" header still works for ungrouped permissions
- [ ] Run `pnpm vitest` to confirm tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)