### PR TITLE
fix(web): treat firewalls without permissions as unrestricted

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { ExpandedFirewallConfig } from "@vm0/core";
+import {
+  applyConnectorPolicies,
+  UNRESTRICTED_PERMISSION,
+} from "../build-zero-context";
+
+function makeFirewall(
+  overrides: Partial<ExpandedFirewallConfig> & { ref: string },
+): ExpandedFirewallConfig {
+  return {
+    name: overrides.name ?? overrides.ref,
+    ref: overrides.ref,
+    apis: overrides.apis ?? [
+      {
+        base: `https://api.example.com`,
+        auth: { headers: { Authorization: "Bearer ${{ secrets.TOKEN }}" } },
+      },
+    ],
+  };
+}
+
+describe("applyConnectorPolicies", () => {
+  it("returns unrestricted when no policies are provided", () => {
+    const fw = makeFirewall({
+      ref: "github",
+      apis: [
+        {
+          base: "https://api.github.com",
+          auth: { headers: { Authorization: "Bearer token" } },
+          permissions: [
+            { name: "repo-read", rules: ["GET /repos/{owner}/{repo}"] },
+          ],
+        },
+      ],
+    });
+
+    const result = applyConnectorPolicies([fw], undefined);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].apis[0].permissions).toEqual([UNRESTRICTED_PERMISSION]);
+  });
+
+  it("filters permissions by policy when permissions are defined", () => {
+    const fw = makeFirewall({
+      ref: "github",
+      apis: [
+        {
+          base: "https://api.github.com",
+          auth: { headers: { Authorization: "Bearer token" } },
+          permissions: [
+            { name: "repo-read", rules: ["GET /repos/{owner}/{repo}"] },
+            { name: "repo-write", rules: ["PUT /repos/{owner}/{repo}"] },
+            {
+              name: "issues-read",
+              rules: ["GET /repos/{owner}/{repo}/issues"],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = applyConnectorPolicies([fw], {
+      github: {
+        "repo-read": "allow",
+        "repo-write": "deny",
+        "issues-read": "allow",
+      },
+    });
+
+    expect(result[0].apis[0].permissions).toEqual([
+      { name: "repo-read", rules: ["GET /repos/{owner}/{repo}"] },
+      { name: "issues-read", rules: ["GET /repos/{owner}/{repo}/issues"] },
+    ]);
+  });
+
+  it("returns unrestricted when firewall has no permissions on any api", () => {
+    const fw = makeFirewall({
+      ref: "custom-api",
+      apis: [
+        {
+          base: "https://api.custom.com",
+          auth: { headers: { Authorization: "Bearer token" } },
+        },
+        {
+          base: "https://api2.custom.com",
+          auth: { headers: { "X-Api-Key": "key" } },
+        },
+      ],
+    });
+
+    const result = applyConnectorPolicies([fw], {
+      "custom-api": { "some-perm": "allow" },
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].apis[0].permissions).toEqual([UNRESTRICTED_PERMISSION]);
+    expect(result[0].apis[1].permissions).toEqual([UNRESTRICTED_PERMISSION]);
+  });
+
+  it("returns unrestricted when all api permissions are empty arrays", () => {
+    const fw = makeFirewall({
+      ref: "custom-api",
+      apis: [
+        {
+          base: "https://api.custom.com",
+          auth: { headers: {} },
+          permissions: [],
+        },
+      ],
+    });
+
+    const result = applyConnectorPolicies([fw], {
+      "custom-api": { x: "allow" },
+    });
+
+    expect(result[0].apis[0].permissions).toEqual([UNRESTRICTED_PERMISSION]);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
@@ -38,7 +38,9 @@ describe("applyConnectorPolicies", () => {
     const result = applyConnectorPolicies([fw], undefined);
 
     expect(result).toHaveLength(1);
-    expect(result[0].apis[0].permissions).toEqual([UNRESTRICTED_PERMISSION]);
+    const entry = result[0];
+    expect(entry).toBeDefined();
+    expect(entry?.apis[0]?.permissions).toEqual([UNRESTRICTED_PERMISSION]);
   });
 
   it("filters permissions by policy when permissions are defined", () => {
@@ -68,7 +70,7 @@ describe("applyConnectorPolicies", () => {
       },
     });
 
-    expect(result[0].apis[0].permissions).toEqual([
+    expect(result[0]?.apis[0]?.permissions).toEqual([
       { name: "repo-read", rules: ["GET /repos/{owner}/{repo}"] },
       { name: "issues-read", rules: ["GET /repos/{owner}/{repo}/issues"] },
     ]);
@@ -94,8 +96,8 @@ describe("applyConnectorPolicies", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0].apis[0].permissions).toEqual([UNRESTRICTED_PERMISSION]);
-    expect(result[0].apis[1].permissions).toEqual([UNRESTRICTED_PERMISSION]);
+    expect(result[0]?.apis[0]?.permissions).toEqual([UNRESTRICTED_PERMISSION]);
+    expect(result[0]?.apis[1]?.permissions).toEqual([UNRESTRICTED_PERMISSION]);
   });
 
   it("returns unrestricted when all api permissions are empty arrays", () => {
@@ -114,6 +116,6 @@ describe("applyConnectorPolicies", () => {
       "custom-api": { x: "allow" },
     });
 
-    expect(result[0].apis[0].permissions).toEqual([UNRESTRICTED_PERMISSION]);
+    expect(result[0]?.apis[0]?.permissions).toEqual([UNRESTRICTED_PERMISSION]);
   });
 });

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -959,7 +959,7 @@ function mergeFirewalls(
 }
 
 /** Unrestricted permission — allows all endpoints through the proxy. */
-const UNRESTRICTED_PERMISSION = {
+export const UNRESTRICTED_PERMISSION = {
   name: "unrestricted",
   description: "Allow all endpoints",
   rules: ["ANY /{path*}"],
@@ -974,7 +974,7 @@ const UNRESTRICTED_PERMISSION = {
  *   permission is added to allow all endpoints through the proxy.
  * - If all permissions are denied, the entry is excluded entirely.
  */
-function applyConnectorPolicies(
+export function applyConnectorPolicies(
   connectorFirewalls: ExpandedFirewallConfig[],
   policies?: FirewallPolicies,
 ): ExperimentalFirewalls {
@@ -983,9 +983,14 @@ function applyConnectorPolicies(
   for (const fw of connectorFirewalls) {
     const refPolicies = policies?.[fw.ref];
 
+    // If no policies or the firewall defines no permissions on any api,
+    // treat all apis as unrestricted (no granular permission control).
+    const hasPermissions = fw.apis.some((api) => {
+      return api.permissions && api.permissions.length > 0;
+    });
+
     const apis = fw.apis.map((api) => {
-      if (!refPolicies) {
-        // No policies configured → unrestricted access
+      if (!refPolicies || !hasPermissions) {
         return {
           base: api.base,
           auth: api.auth,


### PR DESCRIPTION
## Summary
- When a firewall defines no permissions on any of its apis, `applyConnectorPolicies` now returns `UNRESTRICTED_PERMISSION` for all apis regardless of policies
- Previously, if policies existed but the firewall had no permissions to filter, all apis would get empty permissions — causing mitmproxy to block all requests (fail-closed)
- Exported `applyConnectorPolicies` and `UNRESTRICTED_PERMISSION` for direct testing

## Test plan
- [x] Added `apply-connector-policies.test.ts` with 4 test cases:
  - Unrestricted when no policies provided
  - Filters permissions by policy when permissions are defined
  - Unrestricted when firewall has no permissions on any api (new behavior)
  - Unrestricted when all api permissions are empty arrays (new behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)