### PR TITLE
fix(platform): hide empty fields in network log detail view

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-activity-network-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-network-page.tsx
@@ -182,7 +182,9 @@ function collectDetails(entry: NetworkLogEntry): [string, string][] {
 }
 
 function NetworkLogRowDetail({ entry }: { entry: NetworkLogEntry }) {
-  const details = collectDetails(entry);
+  const details = collectDetails(entry).filter(([, value]) => {
+    return value !== "—";
+  });
 
   if (details.length === 0) {
     return null;


### PR DESCRIPTION
## Summary

- Filter out fields with "—" placeholder in network log detail view instead of displaying them
- Only shows fields that have actual data

## Test plan

- [x] Open network logs page, click a log entry, verify only fields with data are shown
- [x] Verify entries with all fields populated still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)