### PR TITLE
fix(slack): append schedule context to cli message footer

### DIFF
--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -8,6 +8,7 @@ import {
   createTestZeroAgent,
   createTestSlackOrgInstallation,
   insertOrgMembersCacheEntry,
+  createTestSchedule,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -224,5 +225,59 @@ describe("POST /api/zero/integrations/slack/message", () => {
     const footerCtx = blocks[blocks.length - 1]!;
     expect(footerCtx.type).toBe("context");
     expect(footerCtx.elements![0]!.text).toBe("Sent via My Assistant");
+  });
+
+  it("appends schedule context in footer when run is triggered by a schedule", async () => {
+    const agentName = uniqueId("agent");
+    const { composeId } = await createTestCompose(agentName);
+    await createTestZeroAgent(user.orgId, agentName, {
+      displayName: "My Assistant",
+    });
+
+    // Create a schedule with a description
+    const schedule = await createTestSchedule(composeId, "daily-standup", {
+      description: "Daily standup summary",
+    });
+
+    // Create run linked to the schedule
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      scheduleId: schedule.id,
+      triggerSource: "schedule",
+    });
+
+    mockClerk({ userId: null });
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
+    const token = await generateZeroToken(user.userId, runId, user.orgId);
+    await createTestSlackOrgInstallation({ orgId: user.orgId });
+
+    const request = createTestRequest(URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ channel: "C123456", text: "Standup results" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const mockClient = vi.mocked(new WebClient(""));
+    const call = vi.mocked(mockClient.chat.postMessage).mock.calls[0]![0] as {
+      blocks: Array<{ type: string; elements?: Array<{ text: string }> }>;
+    };
+
+    const blocks = call.blocks;
+    expect(blocks).toHaveLength(3); // section + divider + context
+
+    const footerCtx = blocks[blocks.length - 1]!;
+    expect(footerCtx.type).toBe("context");
+    expect(footerCtx.elements![0]!.text).toBe(
+      'Sent via My Assistant · Triggered by schedule "Daily standup summary"',
+    );
   });
 });

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
@@ -4,6 +4,8 @@ import { initServices } from "../../../../../../src/lib/init-services";
 import { agentComposeVersions } from "../../../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { zeroAgents } from "../../../../../../src/db/schema/zero-agent";
+import { zeroRuns } from "../../../../../../src/db/schema/zero-run";
+import { zeroAgentSchedules } from "../../../../../../src/db/schema/zero-agent-schedule";
 import {
   isSlackPlatformError,
   postMessage,
@@ -34,6 +36,22 @@ async function resolveAgentLabel(runId: string): Promise<string | undefined> {
   return row?.displayName ?? row?.name;
 }
 
+/** Best-effort schedule description resolution from a run ID. */
+async function resolveScheduleLabel(
+  runId: string,
+): Promise<string | undefined> {
+  const [row] = await globalThis.services.db
+    .select({ description: zeroAgentSchedules.description })
+    .from(zeroRuns)
+    .innerJoin(
+      zeroAgentSchedules,
+      eq(zeroRuns.scheduleId, zeroAgentSchedules.id),
+    )
+    .where(eq(zeroRuns.id, runId))
+    .limit(1);
+  return row?.description ?? undefined;
+}
+
 const router = tsr.router(integrationsSlackMessageContract, {
   sendMessage: async ({ body, headers }) => {
     initServices();
@@ -44,17 +62,27 @@ const router = tsr.router(integrationsSlackMessageContract, {
     );
     if (isSlackClientError(slackCtx)) return slackCtx;
 
-    // Resolve agent name for "Sent via" footer (best-effort)
+    // Resolve agent name and schedule context for footer (best-effort)
     const agentLabel = slackCtx.authRunId
       ? await resolveAgentLabel(slackCtx.authRunId).catch(() => {
           return undefined;
         })
       : undefined;
+    const scheduleLabel = slackCtx.authRunId
+      ? await resolveScheduleLabel(slackCtx.authRunId).catch(() => {
+          return undefined;
+        })
+      : undefined;
 
-    // Append "Sent via <agent>" footer blocks when agent is known
+    // Build combined footer text from available context
+    const footerParts: string[] = [];
+    if (agentLabel) footerParts.push(`Sent via ${agentLabel}`);
+    if (scheduleLabel)
+      footerParts.push(`Triggered by schedule "${scheduleLabel}"`);
+
     let finalBlocks = body.blocks as (Block | KnownBlock)[] | undefined;
-    if (agentLabel) {
-      const footerBlocks = buildFooterBlocks(`Sent via ${agentLabel}`);
+    if (footerParts.length > 0) {
+      const footerBlocks = buildFooterBlocks(footerParts.join(" · "));
       if (finalBlocks && finalBlocks.length > 0) {
         finalBlocks = [...finalBlocks, ...footerBlocks];
       } else if (body.text) {


### PR DESCRIPTION
## Summary

- Add `resolveScheduleLabel(runId)` to the CLI Slack message route that traverses `zeroRuns → zeroAgentSchedules` to get the schedule description
- Combine agent and schedule context in the footer: `Sent via <agent> · Triggered by schedule "<description>"`
- Gracefully degrades when schedule context is unavailable (non-scheduled runs unchanged)

Resolves #7513

## Test plan

- [x] New integration test: verifies combined footer when run is linked to a schedule
- [x] Existing test: verifies agent-only footer still works for non-scheduled runs
- [x] All 7 tests pass locally
- [x] Prettier formatting verified
- [x] Knip passes (no unused code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)