### PR TITLE
fix(nbd-cow): address code review findings post-merge

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -975,6 +975,7 @@ jobs:
       - runner-exec
       - runner-balloon
       - runner-upgrade-local
+      - nbd-cow-test
     # Always run so the gate reports an explicit result (not "skipped").
     if: always()
     steps:
@@ -1019,6 +1020,7 @@ jobs:
           check_result "runner-exec" "${{ needs.runner-exec.result }}" "true"
           check_result "runner-balloon" "${{ needs.runner-balloon.result }}" "true"
           check_result "runner-upgrade-local" "${{ needs.runner-upgrade-local.result }}" "true"
+          check_result "nbd-cow-test" "${{ needs.nbd-cow-test.result }}" "true"
 
           echo "::endgroup::"
           exit $FAILED

--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -60,6 +60,7 @@ impl CowLayer {
         block_size: usize,
         flush_threshold: usize,
     ) -> Result<Self> {
+        assert!(block_size > 0, "block_size must be positive");
         let base_fd = File::open(base_path)?;
         let num_blocks = (size as usize).div_ceil(block_size);
 

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -159,6 +159,10 @@ pub fn find_and_connect(client_fds: &[OwnedFd], size: u64, block_size: u64) -> R
 /// kernel-memory backed and complete in microseconds, so they do not
 /// meaningfully block the tokio worker thread.
 pub async fn verify_device_size(device_index: u32, expected_size: u64) -> bool {
+    debug_assert!(
+        expected_size.is_multiple_of(512),
+        "expected_size must be 512-aligned"
+    );
     let expected_sectors = expected_size / 512;
     let size_path = format!("/sys/block/nbd{device_index}/size");
     for _ in 0..5 {
@@ -404,6 +408,7 @@ fn recv_genl_ack(sock: &GenlSocket) -> Result<()> {
         });
     }
 
+    tracing::debug!(msg_type, "recv_genl_ack: ignoring non-error message type");
     Ok(())
 }
 
@@ -422,7 +427,7 @@ fn build_sockets_nla(client_fds: &[OwnedFd]) -> Vec<u8> {
 /// Build a netlink attribute (NLA).
 fn build_nla(nla_type: u16, payload: &[u8]) -> Vec<u8> {
     let nla_len = 4 + payload.len();
-    debug_assert!(nla_len <= u16::MAX as usize, "NLA payload too large");
+    assert!(nla_len <= u16::MAX as usize, "NLA payload too large");
     let aligned_len = (nla_len + 3) & !3;
     let mut buf = vec![0u8; aligned_len];
     if let Some(header) = buf.get_mut(..4) {

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -308,8 +308,9 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
         detect_global_orphans(&reports, &discovered.firecrackers, &discovered.mitmdumps).await
     } else {
         // Scoped detection: orphan firecracker for the named runner.
-        // Orphan mitmproxy and namespace cannot be scoped (no runner-identifying
-        // info on orphaned processes / no persistent runner→pool_idx mapping).
+        // Orphan mitmproxy, namespace, and NBD devices cannot be scoped
+        // (no runner-identifying info on orphaned processes / no persistent
+        // runner→pool_idx mapping / NBD devices lack per-runner attribution).
         let mut warnings = Vec::new();
 
         // Orphan firecracker: scope by base_dir match.
@@ -806,20 +807,9 @@ async fn detect_orphan_namespaces() -> Vec<Warning> {
 
 /// Scan for NBD devices whose owning process has exited without disconnecting.
 async fn detect_nbd_orphans() -> Vec<Warning> {
-    let orphans = tokio::task::spawn_blocking(|| {
-        let max_devs = super::nbd::read_nbds_max();
-        let mut found: Vec<(u32, u32)> = Vec::new();
-        for i in 0..max_devs {
-            if let Some(pid) = super::nbd::read_nbd_pid(i)
-                && !Path::new(&format!("/proc/{pid}")).exists()
-            {
-                found.push((i, pid));
-            }
-        }
-        found
-    })
-    .await
-    .unwrap_or_default();
+    let (_, orphans) = tokio::task::spawn_blocking(super::nbd::find_nbd_orphans)
+        .await
+        .unwrap_or_default();
 
     orphans
         .into_iter()

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -468,67 +468,61 @@ async fn gc_versions(home: &HomePaths, dry_run: bool) -> RunnerResult<Vec<String
 }
 
 /// Scan for NBD devices whose owning process has exited (orphans) and
-/// optionally disconnect them. Returns the number of orphans found.
+/// optionally disconnect them. Returns the number of orphans cleaned.
 async fn gc_nbd_orphans(dry_run: bool) -> RunnerResult<u32> {
-    let (max_devs, orphans) = tokio::task::spawn_blocking(|| {
-        let max_devs = super::nbd::read_nbds_max();
-        let mut orphans: Vec<(u32, u32)> = Vec::new();
-
-        for i in 0..max_devs {
-            if let Some(pid) = super::nbd::read_nbd_pid(i)
-                && !Path::new(&format!("/proc/{pid}")).exists()
-            {
-                orphans.push((i, pid));
-            }
-        }
-        (max_devs, orphans)
-    })
-    .await
-    .map_err(|e| RunnerError::Internal(format!("nbd orphan scan task failed: {e}")))?;
+    let (max_devs, orphans) = tokio::task::spawn_blocking(super::nbd::find_nbd_orphans)
+        .await
+        .map_err(|e| RunnerError::Internal(format!("nbd orphan scan task failed: {e}")))?;
 
     if orphans.is_empty() {
         tracing::debug!("nbd: scanned {max_devs} devices, no orphans");
         return Ok(0);
     }
 
-    let mut count: u32 = 0;
+    let found = orphans.len() as u32;
+    let mut cleaned: u32 = 0;
     for (device_index, pid) in orphans {
         if dry_run {
             info!(
                 "[dry-run] would disconnect orphan NBD device /dev/nbd{device_index} (owner PID {pid} dead)"
             );
-            count += 1;
+            cleaned += 1;
         } else {
             // Re-check before disconnect: between the scan and now, the device
             // could have been freed and re-acquired by another runner. Only
             // disconnect if the PID is unchanged and still dead.
-            let result =
-                tokio::task::spawn_blocking(move || {
-                    match super::nbd::read_nbd_pid(device_index) {
-                        Some(current_pid) if current_pid == pid
-                            && !Path::new(&format!("/proc/{pid}")).exists() =>
-                        {
-                            Some(nbd_cow::netlink::disconnect(device_index))
-                        }
-                        _ => {
-                            tracing::debug!(
-                                "nbd{device_index}: skipping disconnect, device state changed since scan"
-                            );
-                            None
-                        }
+            let result = match tokio::task::spawn_blocking(move || {
+                match super::nbd::read_nbd_pid(device_index) {
+                    Some(current_pid) if current_pid == pid
+                        && !Path::new(&format!("/proc/{pid}")).exists() =>
+                    {
+                        Some(nbd_cow::netlink::disconnect(device_index))
                     }
-                })
-                    .await
-                    .map_err(|e| {
-                        RunnerError::Internal(format!("nbd disconnect task failed: {e}"))
-                    })?;
+                    _ => {
+                        tracing::debug!(
+                            "nbd{device_index}: skipping disconnect, device state changed since scan"
+                        );
+                        None
+                    }
+                }
+            })
+            .await
+            {
+                Ok(result) => result,
+                Err(e) => {
+                    tracing::warn!(
+                        "nbd disconnect task failed for /dev/nbd{device_index}: {e}"
+                    );
+                    continue;
+                }
+            };
 
             match result {
                 Some(Ok(())) => {
                     info!(
                         "disconnected orphan NBD device /dev/nbd{device_index} (owner PID {pid} dead)"
                     );
-                    count += 1;
+                    cleaned += 1;
                 }
                 Some(Err(e)) => {
                     info!("failed to disconnect orphan NBD device /dev/nbd{device_index}: {e}");
@@ -538,7 +532,11 @@ async fn gc_nbd_orphans(dry_run: bool) -> RunnerResult<u32> {
         }
     }
 
-    Ok(count)
+    if cleaned < found {
+        info!("nbd orphans: {found} found, {cleaned} cleaned");
+    }
+
+    Ok(cleaned)
 }
 
 fn human_bytes(bytes: u64) -> String {

--- a/crates/runner/src/cmd/nbd.rs
+++ b/crates/runner/src/cmd/nbd.rs
@@ -24,3 +24,19 @@ pub(crate) fn read_nbd_pid(device_index: u32) -> Option<u32> {
     }
     trimmed.parse::<u32>().ok()
 }
+
+/// Scan all NBD devices for orphans: devices whose owning PID has exited.
+///
+/// Returns `(max_devs_scanned, orphans)` where each orphan is `(device_index, pid)`.
+pub(crate) fn find_nbd_orphans() -> (u32, Vec<(u32, u32)>) {
+    let max_devs = read_nbds_max();
+    let mut orphans: Vec<(u32, u32)> = Vec::new();
+    for i in 0..max_devs {
+        if let Some(pid) = read_nbd_pid(i)
+            && !std::path::Path::new(&format!("/proc/{pid}")).exists()
+        {
+            orphans.push((i, pid));
+        }
+    }
+    (max_devs, orphans)
+}

--- a/crates/sandbox-fc/src/cow_pool.rs
+++ b/crates/sandbox-fc/src/cow_pool.rs
@@ -18,8 +18,9 @@ use tracing::{error, info, warn};
 /// Number of pre-warmed COW slots to maintain in the queue.
 const BUFFER_SIZE: usize = 4;
 
-/// Maximum slots a single pool can allocate (prevents runaway NBD device
-/// consumption). Matches [`NetnsPool`]'s `MAX_NAMESPACES`.
+/// Maximum slots in the pool pipeline at any time (queue + pending + creating).
+/// Prevents runaway NBD device consumption. In practice the pool stays near
+/// `BUFFER_SIZE`; this is a safety ceiling.
 const MAX_SLOTS: u32 = 256;
 
 // ---------------------------------------------------------------------------
@@ -161,6 +162,7 @@ impl CowPool {
 
         // Tier 1: pop from queue.
         if let Some(slot) = self.queue.pop_front() {
+            self.next_slot_idx = self.next_slot_idx.saturating_sub(1);
             info!(id = %slot.id, remaining = self.queue.len(), "acquired COW slot from pool");
             self.maybe_replenish();
             return Ok(slot);
@@ -170,6 +172,7 @@ impl CowPool {
         while let Some(result) = self.pending.join_next().await {
             match result {
                 Ok(Ok(slot)) => {
+                    self.next_slot_idx = self.next_slot_idx.saturating_sub(1);
                     info!(id = %slot.id, "acquired COW slot from pending");
                     self.maybe_replenish();
                     return Ok(slot);
@@ -194,6 +197,7 @@ impl CowPool {
         let config = self.config.clone();
         match tokio::task::spawn_blocking(move || create_slot(&config)).await {
             Ok(Ok(slot)) => {
+                self.next_slot_idx = self.next_slot_idx.saturating_sub(1);
                 self.maybe_replenish();
                 Ok(slot)
             }
@@ -237,6 +241,7 @@ impl CowPool {
         info!(count, "cleaning up COW pool");
 
         while let Some(slot) = self.queue.pop_front() {
+            self.next_slot_idx = self.next_slot_idx.saturating_sub(1);
             destroy_slot(slot);
         }
         info!("COW pool cleanup complete");
@@ -265,10 +270,7 @@ impl CowPool {
 
     /// Spawn one background replenishment task if the queue is below threshold.
     fn maybe_replenish(&mut self) {
-        if self.queue.len() + self.pending.len() >= BUFFER_SIZE
-            || !self.pending.is_empty()
-            || self.next_slot_idx >= MAX_SLOTS
-        {
+        if self.queue.len() + self.pending.len() >= BUFFER_SIZE || self.next_slot_idx >= MAX_SLOTS {
             return;
         }
         self.next_slot_idx += 1;

--- a/crates/sandbox-fc/src/prerequisites.rs
+++ b/crates/sandbox-fc/src/prerequisites.rs
@@ -78,6 +78,8 @@ fn check_required_commands(_config: &PrerequisiteConfig<'_>, errors: &mut Vec<St
         "pgrep",
         // Required by cow_pool (sparse copy for golden snapshots).
         "cp",
+        // Required by snapshot restore (unshare --mount).
+        "unshare",
     ];
     for cmd in &commands {
         if which::which(cmd).is_err() {


### PR DESCRIPTION
## Summary

Post-merge review fixes for #7406 (replace dm-snapshot with nbd-cow).

### P1 (must fix)
- **cow_pool slot counter exhaustion**: `next_slot_idx` now decrements when slots are consumed (pop from queue, take from pending, on-demand return), so the counter tracks in-pool slots instead of monotonically increasing. Fixes pool exhaustion after 256 total sandbox creates on long-running runners.
- **CI gate missing nbd-cow-test**: added `nbd-cow-test` to `ci-gate-crates` needs and `check_result` validation — tests were running but failures didn't block merges.
- **GC spawn_blocking abort**: replaced `?` with `match` + `warn` + `continue` so a single task panic doesn't abort the entire GC orphan cleanup.

### P2 (should fix)
- **cow_pool replenishment**: removed overly conservative `!self.pending.is_empty()` guard — pool can now spawn multiple concurrent replenishment tasks up to `BUFFER_SIZE`.
- **Orphan scan dedup**: extracted `nbd::find_nbd_orphans()` shared helper, used by both `gc.rs` and `doctor.rs`.
- **GC orphan stats**: track found vs cleaned counts separately; log discrepancy when `cleaned < found`.
- **doctor --name comment**: clarified that NBD orphans cannot be scoped by runner name.
- **netlink hardening**: promoted `build_nla` overflow check from `debug_assert` to `assert`; added size alignment `debug_assert`; added `tracing::debug` for unexpected `recv_genl_ack` message types.
- **CowLayer validation**: `assert!(block_size > 0)` in `CowLayer::new()`.
- **Prerequisites**: added `unshare` to required commands check.

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] `cargo test -p sandbox-fc -- cow_pool` — all 8 tests pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)