### PR TITLE
fix: remove append-system-prompt option from zero run commands

### DIFF
--- a/turbo/apps/cli/src/commands/zero/run/__tests__/continue.test.ts
+++ b/turbo/apps/cli/src/commands/zero/run/__tests__/continue.test.ts
@@ -123,35 +123,6 @@ describe("zero run continue command", () => {
       expect(capturedBody).not.toHaveProperty("agentId");
     });
 
-    it("should pass append-system-prompt option to API", async () => {
-      let capturedBody: Record<string, unknown> | undefined;
-
-      server.use(
-        http.post(
-          "http://localhost:3000/api/zero/runs",
-          async ({ request }) => {
-            capturedBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json(defaultCreateRunResponse, { status: 201 });
-          },
-        ),
-      );
-
-      await continueCommand.parseAsync([
-        "node",
-        "cli",
-        testSessionId,
-        "test prompt",
-        "--append-system-prompt",
-        "Always respond in JSON",
-      ]);
-
-      expect(capturedBody).toEqual(
-        expect.objectContaining({
-          appendSystemPrompt: "Always respond in JSON",
-        }),
-      );
-    });
-
     it("should pass model-provider option to API", async () => {
       let capturedBody: Record<string, unknown> | undefined;
 

--- a/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
+++ b/turbo/apps/cli/src/commands/zero/run/__tests__/run.test.ts
@@ -121,35 +121,6 @@ describe("zero run command", () => {
       );
     });
 
-    it("should pass append-system-prompt option to API", async () => {
-      let capturedBody: Record<string, unknown> | undefined;
-
-      server.use(
-        http.post(
-          "http://localhost:3000/api/zero/runs",
-          async ({ request }) => {
-            capturedBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json(defaultCreateRunResponse, { status: 201 });
-          },
-        ),
-      );
-
-      await mainRunCommand.parseAsync([
-        "node",
-        "cli",
-        testAgentId,
-        "test prompt",
-        "--append-system-prompt",
-        "Always respond in JSON",
-      ]);
-
-      expect(capturedBody).toEqual(
-        expect.objectContaining({
-          appendSystemPrompt: "Always respond in JSON",
-        }),
-      );
-    });
-
     it("should pass model-provider option to API", async () => {
       let capturedBody: Record<string, unknown> | undefined;
 

--- a/turbo/apps/cli/src/commands/zero/run/continue.ts
+++ b/turbo/apps/cli/src/commands/zero/run/continue.ts
@@ -10,10 +10,6 @@ export const continueCommand = new Command()
   .argument("<session-id>", "Session ID from a previous run")
   .argument("<prompt>", "Follow-up prompt for the agent")
   .option(
-    "--append-system-prompt <text>",
-    "Append text to the agent's system prompt",
-  )
-  .option(
     "--model-provider <type>",
     "Override model provider (e.g., anthropic-api-key)",
   )
@@ -35,7 +31,6 @@ Notes:
         sessionId: string,
         prompt: string,
         options: {
-          appendSystemPrompt?: string;
           modelProvider?: string;
           verbose?: boolean;
         },
@@ -51,7 +46,6 @@ Notes:
         const response = await createZeroRun({
           sessionId,
           prompt,
-          appendSystemPrompt: options.appendSystemPrompt,
           modelProvider: options.modelProvider,
         });
 

--- a/turbo/apps/cli/src/commands/zero/run/run.ts
+++ b/turbo/apps/cli/src/commands/zero/run/run.ts
@@ -10,10 +10,6 @@ export const mainRunCommand = new Command()
   .argument("<agent-id>", "Agent UUID (from `zero agent list`)")
   .argument("<prompt>", "Task prompt for the agent")
   .option(
-    "--append-system-prompt <text>",
-    "Append text to the agent's system prompt",
-  )
-  .option(
     "--model-provider <type>",
     "Override model provider (e.g., anthropic-api-key)",
   )
@@ -36,7 +32,6 @@ Notes:
         agentId: string,
         prompt: string,
         options: {
-          appendSystemPrompt?: string;
           modelProvider?: string;
           verbose?: boolean;
         },
@@ -54,7 +49,6 @@ Notes:
         const response = await createZeroRun({
           agentId,
           prompt,
-          appendSystemPrompt: options.appendSystemPrompt,
           modelProvider: options.modelProvider,
         });
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-runs.ts
@@ -14,7 +14,6 @@ export async function createZeroRun(body: {
   sessionId?: string;
   checkpointId?: string;
   prompt: string;
-  appendSystemPrompt?: string;
   modelProvider?: string;
   tools?: string[];
   settings?: string;

--- a/turbo/apps/web/app/api/zero/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/route.ts
@@ -111,7 +111,6 @@ const router = tsr.router(zeroRunsMainContract, {
         prompt: body.prompt,
         agentId: agent.id,
         sessionId: body.sessionId,
-        appendSystemPrompt: body.appendSystemPrompt,
         modelProvider: body.modelProvider,
         triggerSource: authCtx.runId ? "agent" : "web",
         triggerAgentId,

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -29,6 +29,7 @@ const zeroRunRequestSchema = unifiedRunRequestSchema
     vars: true,
     secrets: true,
     agentComposeId: true,
+    appendSystemPrompt: true,
   })
   .extend({
     agentId: z.string().optional(),


### PR DESCRIPTION
## Summary

- Remove `--append-system-prompt` option from `zero run` and `zero run continue` CLI commands
- Omit `appendSystemPrompt` from `zeroRunRequestSchema` contract so the API no longer accepts it
- Internal callers (Slack, Telegram, email, GitHub, schedule) are unaffected — they pass `appendSystemPrompt` directly to `createZeroRun()` via `ZeroRunParams`

Closes #7530

## Test plan

- [x] TypeScript type check passes (core, cli packages)
- [x] All `zero run` and `zero run continue` tests pass (12/12)
- [x] `grep` confirms zero occurrences of `appendSystemPrompt` in zero run CLI code
- [x] `grep` confirms internal `zero-run-service.ts` still uses `appendSystemPrompt` (5 occurrences)
- [ ] CI pipeline passes (lint, test, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)