### PR TITLE
refactor: make cf-ssh compatible with standard ssh argument format

### DIFF
--- a/scripts/cf-ssh.sh
+++ b/scripts/cf-ssh.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # SSH to metal machines via Cloudflare Tunnel.
 #
-# For dev-* hosts: reads CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET
+# Compatible with standard ssh argument format, so it can be used as a
+# drop-in replacement (e.g., ansible_ssh_executable).
+#
+# For dev-* / local-* hosts: reads CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET
 # from scripts/.env.local (same pattern as other project scripts).
 #
 # For prod-* hosts: uses CF_ACCESS_CLIENT_ID_PROD and CF_ACCESS_CLIENT_SECRET_PROD
@@ -10,19 +13,17 @@
 # Hostname conversion must match parse_host() in scripts/cloudflared-ssh.sh:
 #   dev-1.aws.vm3.ai -> dev-1-aws-ssh.vm3.ai
 #
-# Usage:
+# Usage (direct):
 #   scripts/cf-ssh.sh <host> [ssh-args...]
-#
-# Examples:
-#   scripts/cf-ssh.sh dev-1.aws.vm3.ai
-#   scripts/cf-ssh.sh dev-1.aws.vm3.ai -L 8080:localhost:8080
 #   scripts/cf-ssh.sh dev-1.aws.vm3.ai -- ls -la
-#   scripts/cf-ssh.sh prod-1.aws.vm3.ai -- uptime
+#
+# Usage (as ssh replacement):
+#   scripts/cf-ssh.sh -o Option=Value dev-1.aws.vm3.ai command
+#   ansible-playbook -i "host," playbook.yml -e "ansible_ssh_executable=scripts/cf-ssh.sh"
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DOMAIN="vm3.ai"
 
 # --- Load .env.local ---
@@ -39,18 +40,57 @@ if [[ -f "$ENV_FILE" ]]; then
   done < "$ENV_FILE"
 fi
 
-# --- Args ---
-if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <host> [ssh-args...]" >&2
+# --- Parse ssh-style arguments to extract hostname ---
+# SSH options that consume the next argument as a value.
+# e.g., -o Key=Value, -i /path/to/key, -l user
+OPTS_WITH_VALUE="bcDEeFIiJLlmOopQRSWw"
+
+HOST=""
+args=()
+skip_next=false
+
+for arg in "$@"; do
+  if $skip_next; then
+    args+=("$arg")
+    skip_next=false
+    continue
+  fi
+
+  case "$arg" in
+    # Long-form: -oKey=Value, -luser, -p22 (option letter + value joined)
+    -[$OPTS_WITH_VALUE]?*)
+      args+=("$arg")
+      ;;
+    # Short-form: -o Key=Value (next arg is the value)
+    -[$OPTS_WITH_VALUE])
+      args+=("$arg")
+      skip_next=true
+      ;;
+    # Flags without values: -v, -A, -N, -tt, -46, etc.
+    -*)
+      args+=("$arg")
+      ;;
+    # First non-option argument is the hostname
+    *)
+      if [[ -z "$HOST" ]]; then
+        HOST="$arg"
+      fi
+      args+=("$arg")
+      ;;
+  esac
+done
+
+if [[ -z "$HOST" ]]; then
+  echo "Usage: $0 [ssh-options...] <host> [command...]" >&2
   echo "Example: $0 dev-1.aws.vm3.ai" >&2
   exit 1
 fi
 
-HOST="$1"
-shift
+# Strip user@ prefix if present (user@host)
+BARE_HOST="${HOST#*@}"
 
 # --- Select credentials based on host prefix ---
-if [[ "$HOST" == prod-* ]]; then
+if [[ "$BARE_HOST" == prod-* ]]; then
   CF_ID="${CF_ACCESS_CLIENT_ID_PROD:-}"
   CF_SECRET="${CF_ACCESS_CLIENT_SECRET_PROD:-}"
   if [[ -z "$CF_ID" || -z "$CF_SECRET" ]]; then
@@ -69,11 +109,11 @@ fi
 
 # --- Convert hostname to tunnel hostname ---
 # Must match parse_host() in scripts/cloudflared-ssh.sh
-SUB="${HOST%.${DOMAIN}}"
+SUB="${BARE_HOST%.${DOMAIN}}"
 TUNNEL_HOST="${SUB//./-}-ssh.${DOMAIN}"
 
 exec ssh \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \
-  -o ProxyCommand="cloudflared access ssh --hostname $TUNNEL_HOST --id $CF_ID --secret $CF_SECRET" \
-  "$HOST" "$@"
+  -o "ProxyCommand=cloudflared access ssh --hostname $TUNNEL_HOST --id $CF_ID --secret $CF_SECRET" \
+  "${args[@]}"


### PR DESCRIPTION
## Summary
- Parse ssh-style arguments (`-o Key=Value`, `-i path`, `-l user`, etc.) to extract hostname from any position
- Enables use as `ansible_ssh_executable` and other tools that pass ssh-style options before the hostname
- Handles `user@host` format
- Backward compatible — `cf-ssh.sh <host> -- command` still works

## Test plan
- [x] Direct usage: `cf-ssh.sh local-1.aws.vm3.ai -- hostname`
- [x] SSH-style args: `cf-ssh.sh -o ConnectTimeout=10 local-1.aws.vm3.ai hostname`
- [x] Ansible: `ansible-playbook -i "local-1.aws.vm3.ai," playbook.yml -e "ansible_ssh_executable=scripts/cf-ssh.sh"`
- [x] dev-runner.sh `ssh_cmd()` — host as first arg, compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)