### PR TITLE
fix(web): replace 'join the beta' CTA with 'get started'

### DIFF
--- a/turbo/apps/web/app/components/LandingPage.tsx
+++ b/turbo/apps/web/app/components/LandingPage.tsx
@@ -77,7 +77,7 @@ export default function LandingPage() {
   const { lineIndex, charIndex, done } = useTypewriterLines(lines);
   const { isSignedIn } = useUser();
 
-  const ctaText = isSignedIn ? "Open app" : "Join the beta";
+  const ctaText = isSignedIn ? "Open app" : "Get started";
   const ctaHref = isSignedIn ? getAppUrl() : "/sign-up";
 
   return (


### PR DESCRIPTION
## Summary
- Removes the "Join the beta" label from the landing page CTA button
- Replaces with "Get started" since the product is no longer in beta

## Test plan
- [ ] Visit landing page while signed out — button should show "Get started"
- [ ] Visit landing page while signed in — button should show "Open app" (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)