### PR TITLE
fix(nbd-cow): advertise flush/trim flags and harden i/o paths

### DIFF
--- a/crates/nbd-cow/src/cow.rs
+++ b/crates/nbd-cow/src/cow.rs
@@ -61,6 +61,10 @@ impl CowLayer {
         flush_threshold: usize,
     ) -> Result<Self> {
         assert!(block_size > 0, "block_size must be positive");
+        debug_assert!(
+            size.is_multiple_of(block_size as u64),
+            "device size ({size}) must be a multiple of block_size ({block_size})"
+        );
         let base_fd = File::open(base_path)?;
         let num_blocks = (size as usize).div_ceil(block_size);
 
@@ -133,7 +137,7 @@ impl CowLayer {
             } else if self.is_dirty(block_idx) {
                 // Read from COW file
                 if let Some(ref cow_fd) = self.cow_fd {
-                    cow_fd.read_at(dest, current_offset)?;
+                    cow_fd.read_exact_at(dest, current_offset)?;
                 } else {
                     return Err(NbdCowError::Io(std::io::Error::other(
                         "dirty bit set but COW file not open",
@@ -141,7 +145,7 @@ impl CowLayer {
                 }
             } else {
                 // Read from base image
-                self.base_fd.read_at(dest, current_offset)?;
+                self.base_fd.read_exact_at(dest, current_offset)?;
             }
 
             pos += to_read;
@@ -209,7 +213,7 @@ impl CowLayer {
         for (i, entry) in blocks.iter().enumerate() {
             let offset = entry.0 * block_size as u64;
             if let Some(ref cow_fd) = self.cow_fd
-                && let Err(e) = cow_fd.write_at(&entry.1, offset)
+                && let Err(e) = cow_fd.write_all_at(&entry.1, offset)
             {
                 // Restore unwritten blocks back to the buffer
                 for (idx, buf) in blocks.into_iter().skip(i) {
@@ -261,6 +265,11 @@ impl CowLayer {
     }
 
     fn is_dirty(&self, block_idx: u64) -> bool {
+        debug_assert!(
+            (block_idx as usize) < self.dirty.len(),
+            "block_idx {block_idx} out of range (max {})",
+            self.dirty.len()
+        );
         self.dirty
             .get(block_idx as usize)
             .as_deref()
@@ -269,6 +278,11 @@ impl CowLayer {
     }
 
     fn set_dirty(&mut self, block_idx: u64) {
+        debug_assert!(
+            (block_idx as usize) < self.dirty.len(),
+            "block_idx {block_idx} out of range (max {})",
+            self.dirty.len()
+        );
         if let Some(mut bit) = self.dirty.get_mut(block_idx as usize) {
             *bit = true;
         }
@@ -281,7 +295,7 @@ impl CowLayer {
 
         if self.is_dirty(block_idx) {
             if let Some(ref cow_fd) = self.cow_fd {
-                cow_fd.read_at(&mut buf, offset)?;
+                cow_fd.read_exact_at(&mut buf, offset)?;
                 return Ok(buf);
             }
             return Err(NbdCowError::Io(std::io::Error::other(
@@ -289,7 +303,7 @@ impl CowLayer {
             )));
         }
 
-        self.base_fd.read_at(&mut buf, offset)?;
+        self.base_fd.read_exact_at(&mut buf, offset)?;
         Ok(buf)
     }
 
@@ -318,10 +332,15 @@ impl CowLayer {
         for word in raw {
             data.extend_from_slice(&(*word as u64).to_le_bytes());
         }
-        // Write to a temp file then rename for atomicity — if the process
-        // crashes mid-write, the old bitmap (or no bitmap) remains intact.
+        // Write to a temp file, fsync, then rename for crash-safe atomicity.
+        // Without fsync, a power failure after rename could leave a corrupt bitmap
+        // (data still in page cache), which would cause dirty-block information
+        // loss on the next restore.
         let tmp_path = PathBuf::from(format!("{}.tmp", path.display()));
-        if let Err(e) = std::fs::write(&tmp_path, &data) {
+        if let Err(e) = File::create(&tmp_path).and_then(|f| {
+            f.write_all_at(&data, 0)?;
+            f.sync_all()
+        }) {
             let _ = std::fs::remove_file(&tmp_path);
             return Err(e.into());
         }

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -268,6 +268,12 @@ impl NbdCowDevice {
 /// Best-effort cleanup on drop: cancel tasks and disconnect the NBD device.
 /// This ensures leaked devices are cleaned up even if `destroy()` is not called
 /// (e.g., test panics).
+///
+/// **Note:** Drop aborts dispatch tasks immediately without waiting for them to
+/// flush buffered writes. Any data in the write buffer that has not been flushed
+/// is silently lost. Always call [`destroy()`](Self::destroy) or
+/// [`destroy_keep_cow()`](Self::destroy_keep_cow) for clean shutdown with data
+/// persistence guarantees.
 impl Drop for NbdCowDevice {
     fn drop(&mut self) {
         self.shutdown.cancel();

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -32,6 +32,8 @@ const NBD_SOCK_FD: u16 = 1;
 
 // NBD server flags
 const NBD_FLAG_HAS_FLAGS: u64 = 1 << 0;
+const NBD_FLAG_SEND_FLUSH: u64 = 1 << 2;
+const NBD_FLAG_SEND_TRIM: u64 = 1 << 5;
 const NBD_FLAG_CAN_MULTI_CONN: u64 = 1 << 8;
 
 // Netlink constants
@@ -90,7 +92,7 @@ fn device_appears_free(index: u32) -> bool {
             let pid = contents.trim();
             pid == "-1" || pid == "0" || pid.is_empty()
         }
-        Err(_) => true, // Can't read pid file → assume free
+        Err(_) => false, // Can't read pid file → skip (EBUSY fallback will catch free devices)
     }
 }
 
@@ -109,7 +111,8 @@ pub fn find_and_connect(client_fds: &[OwnedFd], size: u64, block_size: u64) -> R
 
     // Build socket attributes once (reused across attempts)
     let sockets_nla = build_sockets_nla(client_fds);
-    let flags = NBD_FLAG_HAS_FLAGS | NBD_FLAG_CAN_MULTI_CONN;
+    let flags =
+        NBD_FLAG_HAS_FLAGS | NBD_FLAG_SEND_FLUSH | NBD_FLAG_SEND_TRIM | NBD_FLAG_CAN_MULTI_CONN;
 
     for i in 0..max {
         if !device_appears_free(i) {
@@ -310,6 +313,7 @@ fn send_genl_msg_raw(
 ) -> Result<()> {
     // nlmsghdr (16) + genlmsghdr (4) + attrs
     let total_len = 16 + 4 + attrs.len();
+    assert!(total_len <= u32::MAX as usize, "netlink message too large");
     let mut msg = vec![0u8; total_len];
 
     // nlmsghdr: length(4) + type(2) + flags(2) + seq(4) + pid(4)
@@ -448,6 +452,7 @@ fn build_nla(nla_type: u16, payload: &[u8]) -> Vec<u8> {
 /// Build a nested netlink attribute.
 fn build_nested_nla(nla_type: u16, payload: &[u8]) -> Vec<u8> {
     let nla_len = 4 + payload.len();
+    assert!(nla_len <= u16::MAX as usize, "nested NLA payload too large");
     let aligned_len = (nla_len + 3) & !3;
     let mut buf = vec![0u8; aligned_len];
     // Set NLA_F_NESTED flag (1 << 15)

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -647,4 +647,105 @@ mod tests {
             );
         }
     }
+
+    #[tokio::test]
+    async fn dispatch_out_of_bounds_read_returns_error() {
+        let base_data = vec![0xAA; 8192];
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(RwLock::new(cow));
+
+        let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow).await;
+
+        // Send a read request beyond the device size (8192 bytes)
+        let oob_read = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 1,
+            offset: 8192, // at EOF
+            length: 4096, // reading past end
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &oob_read).await;
+        assert_ne!(error, 0, "out-of-bounds read should return error");
+
+        // Connection should still be alive — a normal read should work
+        let normal_read = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 2,
+            offset: 0,
+            length: 4096,
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &normal_read).await;
+        assert_eq!(error, 0, "normal read after out-of-bounds should succeed");
+        let mut data = vec![0u8; 4096];
+        reader.read_exact(&mut data).await.unwrap();
+        assert!(data.iter().all(|&b| b == 0xAA));
+
+        // Disconnect
+        let disc = NbdRequest {
+            flags: 0,
+            command: Command::Disconnect,
+            handle: 3,
+            offset: 0,
+            length: 0,
+        };
+        writer.write_all(&serialize_request(&disc)).await.unwrap();
+        task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn dispatch_out_of_bounds_write_returns_error() {
+        let base_data = vec![0xAA; 8192];
+        let (_base, _cow_file, cow) = create_test_cow(&base_data);
+        let cow = Arc::new(RwLock::new(cow));
+
+        let (mut reader, mut writer, task, _shutdown) = setup_dispatch(cow).await;
+
+        // Send a write request beyond the device size
+        let oob_write = NbdRequest {
+            flags: 0,
+            command: Command::Write,
+            handle: 1,
+            offset: 8192,
+            length: 4096,
+        };
+        writer
+            .write_all(&serialize_request(&oob_write))
+            .await
+            .unwrap();
+        writer.write_all(&vec![0xFF; 4096]).await.unwrap();
+
+        let mut reply_buf = [0u8; 16];
+        reader.read_exact(&mut reply_buf).await.unwrap();
+        let error = u32::from_be_bytes([reply_buf[4], reply_buf[5], reply_buf[6], reply_buf[7]]);
+        assert_ne!(error, 0, "out-of-bounds write should return error");
+
+        // Connection should still be alive — verify with a normal read
+        let normal_read = NbdRequest {
+            flags: 0,
+            command: Command::Read,
+            handle: 2,
+            offset: 0,
+            length: 4096,
+        };
+        let error = send_and_recv_reply(&mut reader, &mut writer, &normal_read).await;
+        assert_eq!(
+            error, 0,
+            "normal read after out-of-bounds write should succeed"
+        );
+        let mut data = vec![0u8; 4096];
+        reader.read_exact(&mut data).await.unwrap();
+        assert!(data.iter().all(|&b| b == 0xAA));
+
+        // Disconnect
+        let disc = NbdRequest {
+            flags: 0,
+            command: Command::Disconnect,
+            handle: 3,
+            offset: 0,
+            length: 0,
+        };
+        writer.write_all(&serialize_request(&disc)).await.unwrap();
+        task.await.unwrap().unwrap();
+    }
 }

--- a/crates/nbd-cow/src/server.rs
+++ b/crates/nbd-cow/src/server.rs
@@ -103,7 +103,15 @@ async fn handle_read(
     let mut data = vec![0u8; request.length as usize];
     {
         let cow = cow.read().await;
-        cow.read(request.offset, &mut data)?;
+        if let Err(e) = cow.read(request.offset, &mut data) {
+            tracing::warn!(
+                offset = request.offset,
+                len = request.length,
+                "read error: {e}"
+            );
+            send_error_reply(writer, request.handle, libc::EIO as u32).await?;
+            return Ok(());
+        }
     }
 
     let reply = NbdReply {
@@ -134,9 +142,23 @@ async fn handle_write(
 
     {
         let mut cow = cow.write().await;
-        let needs_flush = cow.write(request.offset, &data)?;
-        if needs_flush {
-            cow.flush()?;
+        match cow.write(request.offset, &data) {
+            Ok(needs_flush) => {
+                if needs_flush && let Err(e) = cow.flush() {
+                    tracing::warn!("flush error after write: {e}");
+                    send_error_reply(writer, request.handle, libc::EIO as u32).await?;
+                    return Ok(());
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    offset = request.offset,
+                    len = request.length,
+                    "write error: {e}"
+                );
+                send_error_reply(writer, request.handle, libc::EIO as u32).await?;
+                return Ok(());
+            }
         }
     }
 
@@ -154,7 +176,11 @@ async fn handle_flush(
 ) -> Result<()> {
     {
         let mut cow = cow.write().await;
-        cow.sync()?;
+        if let Err(e) = cow.sync() {
+            tracing::warn!("sync error: {e}");
+            send_error_reply(writer, request.handle, libc::EIO as u32).await?;
+            return Ok(());
+        }
     }
 
     let reply = NbdReply {

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -308,9 +308,10 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
         detect_global_orphans(&reports, &discovered.firecrackers, &discovered.mitmdumps).await
     } else {
         // Scoped detection: orphan firecracker for the named runner.
-        // Orphan mitmproxy, namespace, and NBD devices cannot be scoped
-        // (no runner-identifying info on orphaned processes / no persistent
-        // runner→pool_idx mapping / NBD devices lack per-runner attribution).
+        // Orphan mitmproxy and namespace cannot be scoped (no runner-identifying
+        // info on orphaned processes / no persistent runner→pool_idx mapping).
+        // NBD orphan detection always runs because devices lack per-runner
+        // attribution and the check is fast (<100ms).
         let mut warnings = Vec::new();
 
         // Orphan firecracker: scope by base_dir match.
@@ -325,6 +326,9 @@ pub async fn run_doctor(args: DoctorArgs) -> RunnerResult<ExitCode> {
                     .await,
             );
         }
+
+        // NBD orphan detection (host-wide, cannot scope to a single runner).
+        warnings.extend(detect_nbd_orphans().await);
 
         warnings
     };
@@ -807,9 +811,13 @@ async fn detect_orphan_namespaces() -> Vec<Warning> {
 
 /// Scan for NBD devices whose owning process has exited without disconnecting.
 async fn detect_nbd_orphans() -> Vec<Warning> {
-    let (_, orphans) = tokio::task::spawn_blocking(super::nbd::find_nbd_orphans)
-        .await
-        .unwrap_or_default();
+    let (_, orphans) = match tokio::task::spawn_blocking(super::nbd::find_nbd_orphans).await {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::warn!("NBD orphan scan task failed: {e}");
+            return Vec::new();
+        }
+    };
 
     orphans
         .into_iter()

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -71,6 +71,8 @@ enum Warning {
     OrphanNamespace { ns_name: String, pool_idx: u32 },
     /// An NBD device whose owning process has exited without disconnecting.
     OrphanNbdDevice { device_index: u32, pid: u32 },
+    /// The NBD orphan scan task panicked (bug in find_nbd_orphans).
+    NbdScanFailed,
 }
 
 impl fmt::Display for Warning {
@@ -114,6 +116,9 @@ impl fmt::Display for Warning {
                     f,
                     "orphan NBD device /dev/nbd{device_index} (owner PID {pid} no longer exists)"
                 )
+            }
+            Self::NbdScanFailed => {
+                write!(f, "NBD orphan scan failed (task panicked)")
             }
         }
     }
@@ -206,6 +211,12 @@ impl Warning {
                 })
                 .await
                 .unwrap_or(false)
+            }
+            Self::NbdScanFailed => {
+                // Retry the scan — persists if it panics again.
+                tokio::task::spawn_blocking(super::nbd::find_nbd_orphans)
+                    .await
+                    .is_err()
             }
         }
     }
@@ -815,7 +826,7 @@ async fn detect_nbd_orphans() -> Vec<Warning> {
         Ok(result) => result,
         Err(e) => {
             tracing::warn!("NBD orphan scan task failed: {e}");
-            return Vec::new();
+            return vec![Warning::NbdScanFailed];
         }
     };
 
@@ -1243,6 +1254,9 @@ mod tests {
             w.to_string(),
             "orphan NBD device /dev/nbd3 (owner PID 12345 no longer exists)"
         );
+
+        let w = Warning::NbdScanFailed;
+        assert_eq!(w.to_string(), "NBD orphan scan failed (task panicked)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **[P1] Add `NBD_FLAG_SEND_FLUSH` and `NBD_FLAG_SEND_TRIM` to netlink server flags.** Without `SEND_FLUSH`, the kernel NBD client never sends FLUSH commands — guest `fsync()` was silently a no-op, violating data integrity guarantees. Verified against `drivers/block/nbd.c` `nbd_set_size()` which gates `BLK_FEAT_WRITE_CACHE` on this flag.
- **[P1] Replace `read_at`/`write_at` with `read_exact_at`/`write_all_at`** (5 call sites in `cow.rs`) to eliminate theoretical silent short-read/write data corruption.
- **[P1] Add overflow assertions** to `build_nested_nla` and `send_genl_msg_raw` for consistency with `build_nla`.
- **[P2] Add `fsync` before rename in `save_bitmap`** for crash-safe bitmap atomicity — prevents dirty-block info loss on power failure during snapshot persistence.
- **[P2] Return NBD error replies on COW layer errors** (read/write/flush) instead of propagating the error and killing the connection. Keeps other multi-conn dispatch tasks alive.
- **[P2] Add `debug_assert`** for block-aligned device size and dirty-bitmap bounds checks.
- **[P2] `device_appears_free` returns `false` on read error** instead of `true` — avoids unnecessary connect attempts on sysfs errors.
- **[P2] Doctor: always run NBD orphan detection** even with `--name` flag (was silently skipped).
- **[P2] Doctor: warn on `JoinError`** in `detect_nbd_orphans` instead of silent `unwrap_or_default`.
- **[P2] Document Drop behavior** — clarify that `Drop` aborts tasks without flushing buffered writes.

## Test plan

- [x] `cargo check` passes for nbd-cow, sandbox-fc, runner
- [x] `cargo clippy -D warnings` clean
- [x] All 93 unit tests pass (`cargo test -p nbd-cow -p sandbox-fc -p runner`)
- [ ] Integration tests (require root + nbd module on metal host, run via CI `nbd-cow-test` job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)