### PR TITLE
feat(cli): add firewall-permissions-change doctor command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
@@ -3,12 +3,19 @@
  *
  * Tests command-level behavior via parseAsync() following CLI testing principles:
  * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW (org endpoint for role detection)
  * - Real (internal): All CLI code, firewall configs from @vm0/core
- * - No external API calls — this command only reads local firewall config
  */
 
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
 import { firewallDenyCommand } from "../firewall-deny";
+
+/** Minimal org response for MSW handlers */
+function orgResponse(role: "admin" | "member") {
+  return { id: "org-1", slug: "test-org", name: "Test Org", role };
+}
 
 describe("zero doctor firewall-deny command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
@@ -203,6 +210,89 @@ describe("zero doctor firewall-deny command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain(
         "https://tunnel-yuma-vm0-app.vm7.ai/firewall-allow/agent-1?",
+      );
+    });
+  });
+
+  describe("role-aware messaging", () => {
+    it("should output direct allow message for admin", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/org", () => {
+          return HttpResponse.json(orgResponse("admin"));
+        }),
+      );
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/owner/repo/pulls",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "You can allow this permission directly: [Manage GitHub firewall]",
+      );
+    });
+
+    it("should output request access message for member", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/org", () => {
+          return HttpResponse.json(orgResponse("member"));
+        }),
+      );
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/owner/repo/pulls",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "This change requires admin approval. Request access at: [Request GitHub access]",
+      );
+    });
+
+    it("should output fallback message when org API fails", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/org", () => {
+          return HttpResponse.json(
+            { error: { message: "Internal error", code: "INTERNAL" } },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--method",
+        "GET",
+        "--path",
+        "/repos/owner/repo/pulls",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        "Ask the user to allow it at: [Allow GitHub access]",
       );
     });
   });

--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-permissions-change.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-permissions-change.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for zero doctor firewall-permissions-change command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW (org endpoint for role detection)
+ * - Real (internal): All CLI code, firewall configs from @vm0/core
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { firewallPermissionsChangeCommand } from "../firewall-permissions-change";
+
+/** Minimal org response for MSW handlers */
+function orgResponse(role: "admin" | "member") {
+  return { id: "org-1", slug: "test-org", name: "Test Org", role };
+}
+
+describe("zero doctor firewall-permissions-change command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("admin role", () => {
+    it("should output direct enable message for admin", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/org", () => {
+          return HttpResponse.json(orgResponse("admin"));
+        }),
+      );
+
+      await firewallPermissionsChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--permission",
+        "contents:read",
+        "--enable",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        'You can enable the "contents:read" permission directly',
+      );
+      expect(logCalls).toContain("[Manage GitHub firewall]");
+      expect(logCalls).toContain("/firewall-allow/agent-abc-123?");
+      expect(logCalls).toContain("ref=github");
+      expect(logCalls).toContain("permission=contents%3Aread");
+    });
+
+    it("should output direct disable message for admin", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/org", () => {
+          return HttpResponse.json(orgResponse("admin"));
+        }),
+      );
+
+      await firewallPermissionsChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--permission",
+        "contents:read",
+        "--disable",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain(
+        'You can disable the "contents:read" permission directly',
+      );
+      expect(logCalls).toContain("[Manage GitHub firewall]");
+    });
+  });
+
+  describe("member role", () => {
+    it("should output request access message for member enable", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/org", () => {
+          return HttpResponse.json(orgResponse("member"));
+        }),
+      );
+
+      await firewallPermissionsChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--permission",
+        "contents:read",
+        "--enable",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Permission changes require admin approval");
+      expect(logCalls).toContain("[Request GitHub access]");
+    });
+
+    it("should output contact admin message for member disable", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/org", () => {
+          return HttpResponse.json(orgResponse("member"));
+        }),
+      );
+
+      await firewallPermissionsChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--permission",
+        "contents:read",
+        "--disable",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Permission changes require admin approval");
+      expect(logCalls).toContain("Contact an org admin to disable");
+      expect(logCalls).toContain("[View GitHub firewall]");
+    });
+  });
+
+  describe("unknown role (no ZERO_AGENT_ID)", () => {
+    it("should output fallback message when ZERO_AGENT_ID is not set", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "");
+
+      await firewallPermissionsChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--permission",
+        "contents:read",
+        "--enable",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('To enable the "contents:read" permission');
+      expect(logCalls).toContain("[Manage GitHub firewall]");
+      expect(logCalls).toContain("/firewall-allow?");
+      expect(logCalls).not.toContain("/firewall-allow/");
+    });
+  });
+
+  describe("unknown role (API failure)", () => {
+    it("should output fallback message when org API fails", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/org", () => {
+          return HttpResponse.json(
+            { error: { message: "Internal error", code: "INTERNAL" } },
+            { status: 500 },
+          );
+        }),
+      );
+
+      await firewallPermissionsChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--permission",
+        "contents:read",
+        "--enable",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('To enable the "contents:read" permission');
+      expect(logCalls).toContain("[Manage GitHub firewall]");
+    });
+  });
+
+  describe("validation errors", () => {
+    it("should exit with error for unknown firewall ref", async () => {
+      await expect(async () => {
+        await firewallPermissionsChangeCommand.parseAsync([
+          "node",
+          "cli",
+          "unknown_service",
+          "--permission",
+          "foo",
+          "--enable",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Unknown firewall connector type: unknown_service",
+        ),
+      );
+    });
+
+    it("should exit with error for invalid permission name", async () => {
+      await expect(async () => {
+        await firewallPermissionsChangeCommand.parseAsync([
+          "node",
+          "cli",
+          "github",
+          "--permission",
+          "nonexistent:perm",
+          "--enable",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Unknown permission "nonexistent:perm" for github firewall',
+        ),
+      );
+    });
+
+    it("should exit with error when neither --enable nor --disable is provided", async () => {
+      await expect(async () => {
+        await firewallPermissionsChangeCommand.parseAsync([
+          "node",
+          "cli",
+          "github",
+          "--permission",
+          "contents:read",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Either --enable or --disable is required"),
+      );
+    });
+  });
+
+  describe("URL construction", () => {
+    it("should transform www.vm0.ai to app.vm0.ai", async () => {
+      vi.stubEnv("VM0_API_URL", "https://www.vm0.ai");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-1");
+
+      await firewallPermissionsChangeCommand.parseAsync([
+        "node",
+        "cli",
+        "github",
+        "--permission",
+        "contents:read",
+        "--enable",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("https://app.vm0.ai/firewall-allow/agent-1?");
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/doctor/firewall-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/firewall-deny.ts
@@ -7,6 +7,7 @@ import {
 } from "@vm0/core";
 import { withErrorHandler } from "../../../lib/command";
 import { getPlatformOrigin } from "./platform-url";
+import { resolveRole } from "./resolve-role";
 
 export const firewallDenyCommand = new Command()
   .name("firewall-deny")
@@ -92,9 +93,21 @@ Notes:
           console.log("");
         }
 
-        console.log(
-          `Ask the user to allow it at: [Allow ${label} access](${url})`,
-        );
+        const role = agentId ? await resolveRole() : "unknown";
+
+        if (role === "admin") {
+          console.log(
+            `You can allow this permission directly: [Manage ${label} firewall](${url})`,
+          );
+        } else if (role === "member") {
+          console.log(
+            `This change requires admin approval. Request access at: [Request ${label} access](${url})`,
+          );
+        } else {
+          console.log(
+            `Ask the user to allow it at: [Allow ${label} access](${url})`,
+          );
+        }
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/doctor/firewall-permissions-change.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/firewall-permissions-change.ts
@@ -1,0 +1,113 @@
+import { Command, Option } from "commander";
+import {
+  isFirewallConnectorType,
+  getConnectorFirewall,
+  CONNECTOR_TYPES,
+} from "@vm0/core";
+import { withErrorHandler } from "../../../lib/command";
+import { getPlatformOrigin } from "./platform-url";
+import { resolveRole } from "./resolve-role";
+
+function findPermissionInConfig(ref: string, permissionName: string): boolean {
+  if (!isFirewallConnectorType(ref)) return false;
+  const config = getConnectorFirewall(ref);
+  for (const api of config.apis) {
+    if (!api.permissions) continue;
+    for (const p of api.permissions) {
+      if (p.name === permissionName) return true;
+    }
+  }
+  return false;
+}
+
+export const firewallPermissionsChangeCommand = new Command()
+  .name("firewall-permissions-change")
+  .description("Request a firewall permission change (enable or disable)")
+  .argument("<firewall-ref>", "The firewall connector type (e.g. github)")
+  .addOption(
+    new Option(
+      "--permission <name>",
+      "The permission name to change",
+    ).makeOptionMandatory(),
+  )
+  .addOption(
+    new Option("--enable", "Request to enable the permission").conflicts(
+      "disable",
+    ),
+  )
+  .addOption(
+    new Option("--disable", "Request to disable the permission").conflicts(
+      "enable",
+    ),
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  zero doctor firewall-permissions-change github --permission contents:read --enable
+  zero doctor firewall-permissions-change slack --permission chat:write --disable
+
+Notes:
+  - Outputs a platform URL for the user to adjust the permission
+  - Admins can change permissions directly; members must request approval`,
+  )
+  .action(
+    withErrorHandler(
+      async (
+        firewallRef: string,
+        opts: { permission: string; enable?: boolean; disable?: boolean },
+      ) => {
+        if (!opts.enable && !opts.disable) {
+          throw new Error("Either --enable or --disable is required");
+        }
+
+        if (!isFirewallConnectorType(firewallRef)) {
+          throw new Error(`Unknown firewall connector type: ${firewallRef}`);
+        }
+
+        if (!findPermissionInConfig(firewallRef, opts.permission)) {
+          throw new Error(
+            `Unknown permission "${opts.permission}" for ${firewallRef} firewall`,
+          );
+        }
+
+        const { label } = CONNECTOR_TYPES[firewallRef];
+        const action = opts.enable ? "enable" : "disable";
+
+        const platformOrigin = await getPlatformOrigin();
+        const agentId = process.env.ZERO_AGENT_ID;
+
+        const urlParams = new URLSearchParams({
+          ref: firewallRef,
+          permission: opts.permission,
+        });
+
+        const pagePath = agentId
+          ? `/firewall-allow/${agentId}`
+          : "/firewall-allow";
+        const url = `${platformOrigin}${pagePath}?${urlParams.toString()}`;
+
+        const role = agentId ? await resolveRole() : "unknown";
+
+        if (role === "admin") {
+          console.log(
+            `You can ${action} the "${opts.permission}" permission directly: [Manage ${label} firewall](${url})`,
+          );
+        } else if (role === "member") {
+          if (action === "enable") {
+            console.log(
+              `Permission changes require admin approval. Request access at: [Request ${label} access](${url})`,
+            );
+          } else {
+            console.log(
+              `Permission changes require admin approval. Contact an org admin to disable this permission: [View ${label} firewall](${url})`,
+            );
+          }
+        } else {
+          console.log(
+            `To ${action} the "${opts.permission}" permission on the ${label} firewall: [Manage ${label} firewall](${url})`,
+          );
+        }
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/doctor/index.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/index.ts
@@ -1,18 +1,21 @@
 import { Command } from "commander";
 import { missingTokenCommand } from "./missing-token";
 import { firewallDenyCommand } from "./firewall-deny";
+import { firewallPermissionsChangeCommand } from "./firewall-permissions-change";
 
 export const zeroDoctorCommand = new Command()
   .name("doctor")
   .description("Diagnose runtime issues (missing tokens, firewall denials)")
   .addCommand(missingTokenCommand)
   .addCommand(firewallDenyCommand)
+  .addCommand(firewallPermissionsChangeCommand)
   .addHelpText(
     "after",
     `
 Examples:
   Missing an API key?    zero doctor missing-token GITHUB_TOKEN
   Firewall blocked?      zero doctor firewall-deny github --method GET --path /repos/owner/repo
+  Change a permission?   zero doctor firewall-permissions-change github --permission contents:read --enable
 
 Notes:
   - Use this when your task fails due to a missing environment variable or firewall denial

--- a/turbo/apps/cli/src/commands/zero/doctor/resolve-role.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/resolve-role.ts
@@ -1,0 +1,22 @@
+import { getZeroOrg } from "../../../lib/api/domains/zero-orgs";
+
+type UserRole = "admin" | "member" | "unknown";
+
+/**
+ * Best-effort role detection for the current user.
+ *
+ * Calls the org API to retrieve the caller's role.
+ * Returns "unknown" when the API call fails (no auth, network error, etc.)
+ * so callers can fall back to generic messaging.
+ */
+export async function resolveRole(): Promise<UserRole> {
+  try {
+    const org = await getZeroOrg();
+    if (org.role === "admin" || org.role === "member") {
+      return org.role;
+    }
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}

--- a/turbo/apps/cli/src/commands/zero/doctor/resolve-role.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/resolve-role.ts
@@ -10,6 +10,9 @@ type UserRole = "admin" | "member" | "unknown";
  * so callers can fall back to generic messaging.
  */
 export async function resolveRole(): Promise<UserRole> {
+  // Intentional: doctor commands must work even without API access (no token,
+  // network error, etc.). Catching all errors and falling back to "unknown"
+  // lets callers degrade to generic messaging instead of crashing the CLI.
   try {
     const org = await getZeroOrg();
     if (org.role === "admin" || org.role === "member") {

--- a/turbo/apps/cli/src/commands/zero/doctor/resolve-role.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/resolve-role.ts
@@ -16,7 +16,8 @@ export async function resolveRole(): Promise<UserRole> {
       return org.role;
     }
     return "unknown";
-  } catch {
+  } catch (error: unknown) {
+    console.debug("resolveRole failed, falling back to unknown:", error);
     return "unknown";
   }
 }


### PR DESCRIPTION
## Summary
- Add `zero doctor firewall-permissions-change` command for proactive firewall permission enable/disable
- Enhance `firewall-deny` with role-aware messaging (admin gets direct manage link, member gets request access link)
- Add shared `resolveRole()` utility that detects user role via org API with graceful fallback

## Test plan
- [x] 10 tests for `firewall-permissions-change` (admin, member, unknown, validation, URL)
- [x] 3 new tests for `firewall-deny` role-aware messaging (admin, member, API failure)
- [x] All 34 doctor tests passing
- [x] Existing `firewall-deny` tests remain backward compatible
- [x] Lint, type-check, format, knip all passing

Closes #7511

🤖 Generated with [Claude Code](https://claude.com/claude-code)