### PR TITLE
refactor: remove --model-provider and --check-env from vm0 run commands

### DIFF
--- a/e2e/tests/03-runner/t27-real-claude-smoke.bats
+++ b/e2e/tests/03-runner/t27-real-claude-smoke.bats
@@ -35,17 +35,16 @@ VOLEOF
     $VM0_CLI volume push >/dev/null
     cd - >/dev/null
 
-    # Set up model-provider once for all tests
-    $ZERO_CLI org model-provider setup \
-        --type "anthropic-api-key" --secret "$ANTHROPIC_API_KEY"
-
     # Compose agents separately (only one agent per compose is supported)
+    # ANTHROPIC_API_KEY is passed via --secrets at run time (not via model-provider)
     cat > "$TEST_DIR/vm0-basic.yaml" <<EOF
 version: "1.0"
 agents:
   ${AGENT_NAME}:
     description: "Real Claude smoke test"
     framework: claude-code
+    environment:
+      ANTHROPIC_API_KEY: "\${{ secrets.ANTHROPIC_API_KEY }}"
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace
@@ -61,6 +60,8 @@ agents:
   ${AGENT_NAME}-flags:
     description: "Real Claude flags test"
     framework: claude-code
+    environment:
+      ANTHROPIC_API_KEY: "\${{ secrets.ANTHROPIC_API_KEY }}"
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace
@@ -76,6 +77,8 @@ agents:
   ${AGENT_NAME}-settings:
     description: "Real Claude settings test"
     framework: claude-code
+    environment:
+      ANTHROPIC_API_KEY: "\${{ secrets.ANTHROPIC_API_KEY }}"
     volumes:
       - claude-files:/home/user/.claude
     working_dir: /home/user/workspace
@@ -91,8 +94,6 @@ EOF
 }
 
 teardown_file() {
-    # Clean up model provider (best-effort)
-    $ZERO_CLI org model-provider remove "anthropic-api-key" 2>/dev/null || true
     if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
         rm -rf "$TEST_DIR"
     fi
@@ -106,7 +107,7 @@ teardown_file() {
 
     # Run claude --version inside the sandbox to confirm which binary is installed
     run $VM0_CLI run "$AGENT_NAME" \
-        --model-provider "anthropic-api-key" \
+        --secrets "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
         --debug-no-mock-claude \
         "Run 'claude --version' with the Bash tool and include the exact output"
 
@@ -123,7 +124,7 @@ teardown_file() {
     fi
 
     run $VM0_CLI run "$AGENT_NAME" \
-        --model-provider "anthropic-api-key" \
+        --secrets "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
         --debug-no-mock-claude \
         "Compute 123+456 and reply with exactly: RESULT=<answer>"
 
@@ -145,7 +146,7 @@ teardown_file() {
     # "--" separates variadic --disallowed-tools from the prompt
     # (Commander.js <tools...> would otherwise swallow subsequent args)
     run $VM0_CLI run "${AGENT_NAME}-flags" \
-        --model-provider "anthropic-api-key" \
+        --secrets "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
         --debug-no-mock-claude \
         --append-system-prompt "Always end your final response with SIGNATURE=smoke-test" \
         --disallowed-tools CronCreate CronList CronDelete \
@@ -173,7 +174,7 @@ teardown_file() {
     local settings='{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo SETTINGS_HOOK_OK > /tmp/hook_sentinel.txt"}]}]}}'
 
     run $VM0_CLI run "${AGENT_NAME}-settings" \
-        --model-provider "anthropic-api-key" \
+        --secrets "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" \
         --debug-no-mock-claude \
         --settings "$settings" \
         -- "Step 1: run 'echo hello'. Step 2: run 'cat /tmp/hook_sentinel.txt'. Include the exact output of step 2 in your response."

--- a/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/continue.test.ts
@@ -287,35 +287,6 @@ describe("run continue command", () => {
         }),
       );
     });
-
-    it("should pass model provider option to API", async () => {
-      let capturedBody: Record<string, unknown> | undefined;
-
-      server.use(
-        http.post(
-          "http://localhost:3000/api/agent/runs",
-          async ({ request }) => {
-            capturedBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json(defaultRunResponse, { status: 201 });
-          },
-        ),
-      );
-
-      await continueCommand.parseAsync([
-        "node",
-        "cli",
-        testSessionId,
-        "test prompt",
-        "--model-provider",
-        "anthropic-api-key",
-      ]);
-
-      expect(capturedBody).toEqual(
-        expect.objectContaining({
-          modelProvider: "anthropic-api-key",
-        }),
-      );
-    });
   });
 
   describe("session ID validation", () => {

--- a/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
+++ b/turbo/apps/cli/src/commands/run/__tests__/resume.test.ts
@@ -294,35 +294,6 @@ describe("run resume command", () => {
         }),
       );
     });
-
-    it("should pass model provider option to API", async () => {
-      let capturedBody: Record<string, unknown> | undefined;
-
-      server.use(
-        http.post(
-          "http://localhost:3000/api/agent/runs",
-          async ({ request }) => {
-            capturedBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json(defaultRunResponse, { status: 201 });
-          },
-        ),
-      );
-
-      await resumeCommand.parseAsync([
-        "node",
-        "cli",
-        testCheckpointId,
-        "test prompt",
-        "--model-provider",
-        "anthropic-api-key",
-      ]);
-
-      expect(capturedBody).toEqual(
-        expect.objectContaining({
-          modelProvider: "anthropic-api-key",
-        }),
-      );
-    });
   });
 
   describe("checkpoint ID validation", () => {

--- a/turbo/apps/cli/src/commands/run/continue.ts
+++ b/turbo/apps/cli/src/commands/run/continue.ts
@@ -35,10 +35,6 @@ export const continueCommand = new Command()
     {},
   )
   .option(
-    "--model-provider <type>",
-    "Override model provider (e.g., anthropic-api-key)",
-  )
-  .option(
     "--append-system-prompt <text>",
     "Append text to the agent's system prompt",
   )
@@ -59,7 +55,6 @@ export const continueCommand = new Command()
     'Firewall policies JSON (e.g., \'{"github": {"actions:read": "allow"}}\')',
   )
   .option("--verbose", "Show full tool inputs and outputs")
-  .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(
     withErrorHandler(
@@ -70,14 +65,12 @@ export const continueCommand = new Command()
           envFile?: string;
           vars: Record<string, string>;
           secrets: Record<string, string>;
-          modelProvider?: string;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
           settings?: string;
           firewallPolicies?: string;
           verbose?: boolean;
-          checkEnv?: boolean;
           debugNoMockClaude?: boolean;
         },
         command: { optsWithGlobals: () => Record<string, unknown> },
@@ -88,14 +81,12 @@ export const continueCommand = new Command()
           envFile?: string;
           vars: Record<string, string>;
           secrets: Record<string, string>;
-          modelProvider?: string;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
           settings?: string;
           firewallPolicies?: string;
           verbose?: boolean;
-          checkEnv?: boolean;
           debugNoMockClaude?: boolean;
         };
 
@@ -127,7 +118,6 @@ export const continueCommand = new Command()
           prompt,
           vars: Object.keys(vars).length > 0 ? vars : undefined,
           secrets: loadedSecrets,
-          modelProvider: options.modelProvider || allOpts.modelProvider,
           appendSystemPrompt:
             options.appendSystemPrompt || allOpts.appendSystemPrompt,
           disallowedTools: options.disallowedTools || allOpts.disallowedTools,
@@ -136,7 +126,6 @@ export const continueCommand = new Command()
           firewallPolicies: parseFirewallPolicies(
             options.firewallPolicies || allOpts.firewallPolicies,
           ),
-          checkEnv: options.checkEnv || allOpts.checkEnv || undefined,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,
         });

--- a/turbo/apps/cli/src/commands/run/resume.ts
+++ b/turbo/apps/cli/src/commands/run/resume.ts
@@ -40,10 +40,6 @@ export const resumeCommand = new Command()
     {},
   )
   .option(
-    "--model-provider <type>",
-    "Override model provider (e.g., anthropic-api-key)",
-  )
-  .option(
     "--append-system-prompt <text>",
     "Append text to the agent's system prompt",
   )
@@ -64,7 +60,6 @@ export const resumeCommand = new Command()
     'Firewall policies JSON (e.g., \'{"github": {"actions:read": "allow"}}\')',
   )
   .option("--verbose", "Show full tool inputs and outputs")
-  .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .action(
     withErrorHandler(
@@ -75,14 +70,12 @@ export const resumeCommand = new Command()
           envFile?: string;
           vars: Record<string, string>;
           secrets: Record<string, string>;
-          modelProvider?: string;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
           settings?: string;
           firewallPolicies?: string;
           verbose?: boolean;
-          checkEnv?: boolean;
           debugNoMockClaude?: boolean;
         },
         command: { optsWithGlobals: () => Record<string, unknown> },
@@ -94,14 +87,12 @@ export const resumeCommand = new Command()
           vars: Record<string, string>;
           secrets: Record<string, string>;
           volumeVersion: Record<string, string>;
-          modelProvider?: string;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
           settings?: string;
           firewallPolicies?: string;
           verbose?: boolean;
-          checkEnv?: boolean;
           debugNoMockClaude?: boolean;
         };
 
@@ -137,7 +128,6 @@ export const resumeCommand = new Command()
             Object.keys(allOpts.volumeVersion).length > 0
               ? allOpts.volumeVersion
               : undefined,
-          modelProvider: options.modelProvider || allOpts.modelProvider,
           appendSystemPrompt:
             options.appendSystemPrompt || allOpts.appendSystemPrompt,
           disallowedTools: options.disallowedTools || allOpts.disallowedTools,
@@ -146,7 +136,6 @@ export const resumeCommand = new Command()
           firewallPolicies: parseFirewallPolicies(
             options.firewallPolicies || allOpts.firewallPolicies,
           ),
-          checkEnv: options.checkEnv || allOpts.checkEnv || undefined,
           debugNoMockClaude:
             options.debugNoMockClaude || allOpts.debugNoMockClaude || undefined,
         });

--- a/turbo/apps/cli/src/commands/run/run.ts
+++ b/turbo/apps/cli/src/commands/run/run.ts
@@ -67,10 +67,6 @@ export const mainRunCommand = new Command()
     "Resume from conversation ID (for fine-grained control)",
   )
   .option(
-    "--model-provider <type>",
-    "Override model provider (e.g., anthropic-api-key)",
-  )
-  .option(
     "--append-system-prompt <text>",
     "Append text to the agent's system prompt",
   )
@@ -91,7 +87,6 @@ export const mainRunCommand = new Command()
     'Firewall policies JSON (e.g., \'{"github": {"actions:read": "allow"}}\')',
   )
   .option("--verbose", "Show full tool inputs and outputs")
-  .option("--check-env", "Validate secrets and vars before running")
   .addOption(new Option("--debug-no-mock-claude").hideHelp())
   .addOption(new Option("--no-auto-update").hideHelp())
   .action(
@@ -108,14 +103,12 @@ export const mainRunCommand = new Command()
           memory?: string;
           volumeVersion: Record<string, string>;
           conversation?: string;
-          modelProvider?: string;
           appendSystemPrompt?: string;
           disallowedTools?: string[];
           tools?: string[];
           settings?: string;
           firewallPolicies?: string;
           verbose?: boolean;
-          checkEnv?: boolean;
           debugNoMockClaude?: boolean;
           autoUpdate?: boolean;
         },
@@ -196,13 +189,11 @@ export const mainRunCommand = new Command()
               ? options.volumeVersion
               : undefined,
           conversationId: options.conversation,
-          modelProvider: options.modelProvider,
           appendSystemPrompt: options.appendSystemPrompt,
           disallowedTools: options.disallowedTools,
           tools: options.tools,
           settings: options.settings,
           firewallPolicies: parseFirewallPolicies(options.firewallPolicies),
-          checkEnv: options.checkEnv || undefined,
           debugNoMockClaude: options.debugNoMockClaude || undefined,
         });
 

--- a/turbo/apps/cli/src/lib/api/domains/runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/runs.ts
@@ -31,12 +31,8 @@ export async function createRun(body: {
   vars?: Record<string, string>;
   secrets?: Record<string, string>;
   volumeVersions?: Record<string, string>;
-  // Model provider for automatic secret injection
-  modelProvider?: string;
   // Debug flag (internal use only)
   debugNoMockClaude?: boolean;
-  // Environment validation flag - when true, validates secrets/vars before running
-  checkEnv?: boolean;
   // Append text to the agent's system prompt
   appendSystemPrompt?: string;
   // Tools to disable in Claude CLI (passed as --disallowed-tools)

--- a/turbo/apps/cli/src/lib/api/domains/zero-runs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-runs.ts
@@ -18,7 +18,6 @@ export async function createZeroRun(body: {
   modelProvider?: string;
   tools?: string[];
   settings?: string;
-  checkEnv?: boolean;
 }): Promise<CreateRunResponse> {
   const config = await getClientConfig();
   const client = initClient(zeroRunsMainContract, config);

--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -194,41 +194,6 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(data.error.message).toContain("both checkpointId and sessionId");
     });
 
-    it("should fail run when only some secrets are provided", async () => {
-      // Create compose that requires multiple secrets
-      const { composeId: multiSecretComposeId } = await createTestCompose(
-        `multi-secret-${Date.now()}`,
-        {
-          overrides: {
-            environment: {
-              ANTHROPIC_API_KEY: "test-key",
-              SECRET_A: "${{ secrets.SECRET_A }}",
-              SECRET_B: "${{ secrets.SECRET_B }}",
-            },
-          },
-        },
-      );
-
-      // Try to create run with only one secret
-      // Pass checkEnv: true to enable server-side validation
-      const data = await createTestRun(
-        multiSecretComposeId,
-        "Test with partial secrets",
-        { secrets: { SECRET_A: "value-a" }, checkEnv: true }, // Missing SECRET_B
-      );
-
-      // Route creates run first, then fails during preparation
-      expect(data.status).toBe("failed");
-
-      // Verify error via API
-      const run = await getTestRun(data.runId);
-
-      expect(run.error).toMatch(/Missing required secrets/i);
-      expect(run.error).toContain("SECRET_B");
-      // SECRET_A should NOT be in the error (it was provided)
-      expect(run.error).not.toContain("SECRET_A");
-    });
-
     it("should succeed when all required secrets are provided", async () => {
       // Create compose that requires secrets
       const { composeId: secretComposeId } = await createTestCompose(
@@ -324,45 +289,6 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
 
       // Should succeed
       expect(data.status).toBe("pending");
-    });
-
-    it("should reject run when only some vars are provided with checkEnv", async () => {
-      // Create compose that requires multiple vars
-      const { composeId: multiVarsComposeId } = await createTestCompose(
-        `multi-vars-${Date.now()}`,
-        {
-          overrides: {
-            environment: {
-              ANTHROPIC_API_KEY: "test-key",
-              VAR_A: "${{ vars.VAR_A }}",
-              VAR_B: "${{ vars.VAR_B }}",
-            },
-          },
-        },
-      );
-
-      // Try to create run with only one var AND checkEnv: true
-      // Vars validation only happens when checkEnv is enabled
-      const request = createTestRequest(
-        "http://localhost:3000/api/agent/runs",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentComposeId: multiVarsComposeId,
-            prompt: "Test with partial vars",
-            vars: { VAR_A: "value-a" }, // Missing VAR_B
-            checkEnv: true,
-          }),
-        },
-      );
-
-      const response = await POST(request);
-      const data = await response.json();
-
-      // API validates template variables when checkEnv is true
-      expect(response.status).toBe(400);
-      expect(data.error.code).toBe("BAD_REQUEST");
     });
 
     it("should succeed when all required vars are provided", async () => {
@@ -1294,59 +1220,6 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       expect(run.error).toContain("not found");
     });
 
-    it("should reject request when volume has missing template variable with checkEnv", async () => {
-      // Create compose with volume that uses a template variable
-      const composeRequest = createTestRequest(
-        "http://localhost:3000/api/agent/composes",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            content: {
-              version: "1.0",
-              agents: {
-                "test-agent": {
-                  framework: "claude-code",
-                  environment: { ANTHROPIC_API_KEY: "test-key" },
-                  volumes: ["data:/mnt/data"],
-                },
-              },
-              volumes: {
-                data: {
-                  name: "user-${{ vars.userId }}-storage",
-                  version: "latest",
-                },
-              },
-            },
-          }),
-        },
-      );
-      const composeResponse = await createComposeRoute(composeRequest);
-      const compose = await composeResponse.json();
-
-      // Create run WITHOUT providing required vars but WITH checkEnv: true
-      // Vars validation only happens when checkEnv is enabled
-      const runRequest = createTestRequest(
-        "http://localhost:3000/api/agent/runs",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentComposeId: compose.composeId,
-            prompt: "Test missing var",
-            checkEnv: true,
-          }),
-        },
-      );
-
-      const response = await POST(runRequest);
-      const data = await response.json();
-
-      // API validates template variables when checkEnv is true
-      expect(response.status).toBe(400);
-      expect(data.error.code).toBe("BAD_REQUEST");
-    });
-
     it("should fail run when volume definition is missing", async () => {
       // Create compose with volume that references an undefined volume
       // Use unique agent name to avoid content-addressed version collision
@@ -1453,126 +1326,6 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const data = await createTestRun(composeId, "Test CLI override", {
         vars: { MY_VAR: "cli-value" },
       });
-
-      expect(data.status).toBe("pending");
-    });
-
-    it("should still fail when required var is neither on server nor CLI with checkEnv", async () => {
-      // Create compose that requires a variable that doesn't exist
-      const { composeId } = await createTestCompose(uniqueId("missing-var"), {
-        overrides: {
-          environment: {
-            ANTHROPIC_API_KEY: "test-key",
-            MISSING_VAR: "${{ vars.MISSING_VAR }}",
-          },
-        },
-      });
-
-      // Try to create run without providing the variable but WITH checkEnv: true
-      // Vars validation only happens when checkEnv is enabled
-      const request = createTestRequest(
-        "http://localhost:3000/api/agent/runs",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentComposeId: composeId,
-            prompt: "Test without var",
-            checkEnv: true,
-          }),
-        },
-      );
-
-      const response = await POST(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(400);
-      expect(data.error.code).toBe("BAD_REQUEST");
-    });
-  });
-
-  describe("checkEnv flag behavior for vars", () => {
-    it("should allow run with missing vars when checkEnv is not set (default)", async () => {
-      // Create compose that requires vars
-      const { composeId } = await createTestCompose(
-        `vars-no-check-${Date.now()}`,
-        {
-          overrides: {
-            environment: {
-              ANTHROPIC_API_KEY: "test-key",
-              MY_VAR: "${{ vars.MY_VAR }}",
-            },
-          },
-        },
-      );
-
-      // Create run WITHOUT providing vars and WITHOUT checkEnv
-      // This should succeed because validation is opt-in
-      const data = await createTestRun(composeId, "Test without vars");
-
-      // Should succeed (pending, not failed) - validation is skipped
-      expect(data.status).toBe("pending");
-    });
-
-    it("should reject run with missing vars when checkEnv is true", async () => {
-      // Create compose that requires vars
-      const { composeId } = await createTestCompose(
-        `vars-check-${Date.now()}`,
-        {
-          overrides: {
-            environment: {
-              ANTHROPIC_API_KEY: "test-key",
-              MY_VAR: "${{ vars.MY_VAR }}",
-            },
-          },
-        },
-      );
-
-      // Create run WITHOUT providing vars but WITH checkEnv: true
-      const request = createTestRequest(
-        "http://localhost:3000/api/agent/runs",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            agentComposeId: composeId,
-            prompt: "Test with checkEnv",
-            checkEnv: true,
-          }),
-        },
-      );
-
-      const response = await POST(request);
-      const data = await response.json();
-
-      // API validates template variables when checkEnv is true
-      expect(response.status).toBe(400);
-      expect(data.error.code).toBe("BAD_REQUEST");
-    });
-
-    it("should succeed with checkEnv when all vars are provided", async () => {
-      // Create compose that requires vars
-      const { composeId } = await createTestCompose(
-        `vars-check-ok-${Date.now()}`,
-        {
-          overrides: {
-            environment: {
-              ANTHROPIC_API_KEY: "test-key",
-              MY_VAR: "${{ vars.MY_VAR }}",
-            },
-          },
-        },
-      );
-
-      // Create run WITH vars AND checkEnv: true
-      const data = await createTestRun(
-        composeId,
-        "Test with vars and checkEnv",
-        {
-          vars: { MY_VAR: "value" },
-          checkEnv: true,
-        },
-      );
 
       expect(data.status).toBe("pending");
     });

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -233,7 +233,6 @@ const router = tsr.router(runsMainContract, {
         volumeVersions: body.volumeVersions,
         debugNoMockClaude: body.debugNoMockClaude,
         modelProvider: body.modelProvider,
-        checkEnv: body.checkEnv,
         firewallPolicies: body.firewallPolicies,
         callerOrgId: org.orgId,
       });

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -853,7 +853,6 @@ export async function createTestRun(
     sessionId?: string;
     checkpointId?: string;
     modelProvider?: string;
-    checkEnv?: boolean;
     memoryName?: string;
     appendSystemPrompt?: string;
     firewallPolicies?: Record<string, Record<string, string>>;

--- a/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/create-run.test.ts
@@ -271,29 +271,6 @@ describe("createRun()", () => {
         ),
       ).rejects.toSatisfy(isBadRequest);
     });
-
-    it("should reject missing required template variables with checkEnv", async () => {
-      // Create a compose with template variables
-      const compose = await createTestCompose(uniqueId("var-agent"), {
-        overrides: {
-          environment: {
-            MY_KEY: "${{ vars.REQUIRED_VAR }}",
-            ANTHROPIC_API_KEY: "test-key",
-          },
-        },
-      });
-
-      // Vars validation only happens when checkEnv is enabled
-      await expect(
-        createRun(
-          baseParams({
-            agentComposeVersionId: compose.versionId,
-            checkEnv: true, // Enable vars validation
-            // No vars provided — should fail
-          }),
-        ),
-      ).rejects.toSatisfy(isBadRequest);
-    });
   });
 
   describe("Callback Registration", () => {

--- a/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
+++ b/turbo/apps/web/src/lib/run/environment/__tests__/expand-environment.test.ts
@@ -65,7 +65,6 @@ describe("expandEnvironmentFromCompose — firewall env vars", () => {
       compose,
       undefined,
       undefined,
-      false,
       undefined,
       [githubService],
     );
@@ -82,12 +81,9 @@ describe("expandEnvironmentFromCompose — firewall env vars", () => {
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
     });
 
-    const { environment } = expandEnvironmentFromCompose(
-      compose,
-      undefined,
-      { GITHUB_TOKEN: "user-provided" },
-      false,
-    );
+    const { environment } = expandEnvironmentFromCompose(compose, undefined, {
+      GITHUB_TOKEN: "user-provided",
+    });
 
     expect(environment).toBeDefined();
     expect(environment!.GH_TOKEN).toBe("user-provided");
@@ -103,7 +99,6 @@ describe("expandEnvironmentFromCompose — firewall env vars", () => {
       compose,
       undefined,
       undefined,
-      false,
       undefined,
       [githubService, slackService],
     );
@@ -126,7 +121,6 @@ describe("expandEnvironmentFromCompose — firewall env vars", () => {
       compose,
       undefined,
       { GITHUB_TOKEN: "user-provided-token" },
-      false,
       undefined,
       [githubService],
     );
@@ -146,7 +140,6 @@ describe("expandEnvironmentFromCompose — firewall env vars", () => {
       compose,
       undefined,
       undefined,
-      false,
       undefined,
       [airtableService],
     );
@@ -168,7 +161,6 @@ describe("expandEnvironmentFromCompose — additionalEnvironment", () => {
       compose,
       undefined,
       { ANTHROPIC_API_KEY: "sk-xxx" },
-      false,
       { ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}" },
     );
 
@@ -186,7 +178,6 @@ describe("expandEnvironmentFromCompose — additionalEnvironment", () => {
       compose,
       undefined,
       undefined,
-      false,
       { API_KEY: "additional-value" },
     );
 
@@ -203,7 +194,6 @@ describe("expandEnvironmentFromCompose — additionalEnvironment", () => {
       compose,
       undefined,
       { GITHUB_TOKEN: "real-token" },
-      false,
       { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" },
       [githubService],
     );
@@ -221,7 +211,6 @@ describe("expandEnvironmentFromCompose — additionalEnvironment", () => {
       undefined,
       undefined,
       { ANTHROPIC_API_KEY: "sk-xxx" },
-      false,
       { ANTHROPIC_API_KEY: "${{ secrets.ANTHROPIC_API_KEY }}" },
     );
 
@@ -233,8 +222,6 @@ describe("expandEnvironmentFromCompose — additionalEnvironment", () => {
     const { environment } = expandEnvironmentFromCompose(
       undefined,
       undefined,
-      undefined,
-      false,
       undefined,
     );
 
@@ -248,7 +235,6 @@ describe("expandEnvironmentFromCompose — additionalEnvironment", () => {
       compose,
       undefined,
       undefined,
-      false,
       {
         OPENAI_BASE_URL: "https://api.moonshot.cn/v1",
         ANTHROPIC_MODEL: "claude-sonnet-4-20250514",

--- a/turbo/apps/web/src/lib/run/environment/expand-environment.ts
+++ b/turbo/apps/web/src/lib/run/environment/expand-environment.ts
@@ -4,7 +4,6 @@ import {
   extractSecretNamesFromApis,
   type ExpandedFirewallConfig,
 } from "@vm0/core";
-import { badRequest } from "../../errors";
 import { logger } from "../../logger";
 import type { AgentComposeYaml } from "../../../types/agent-compose";
 
@@ -18,26 +17,14 @@ interface ExpandedEnvironmentResult {
 }
 
 /**
- * Process secret values: validate and resolve from passed secrets or firewall placeholders.
+ * Process secret values: resolve from passed secrets or firewall placeholders.
  */
 function processSecretValues(
   secretNames: string[],
   passedSecrets: Record<string, string> | undefined,
-  checkEnv: boolean | undefined,
   firewallPlaceholders?: Record<string, string>,
 ): Record<string, string> | undefined {
   if (secretNames.length === 0) return undefined;
-
-  if (checkEnv) {
-    const missingSecrets = secretNames.filter((name) => {
-      return !passedSecrets || !passedSecrets[name];
-    });
-    if (missingSecrets.length > 0) {
-      throw badRequest(
-        `Missing required secrets: ${missingSecrets.join(", ")}. Use '--secrets ${missingSecrets[0]}=<value>' or '--env-file <path>' to provide them.`,
-      );
-    }
-  }
 
   const secrets: Record<string, string> = {};
   for (const name of secretNames) {
@@ -92,7 +79,6 @@ function buildFirewallPlaceholders(
  * @param agentCompose Agent compose configuration
  * @param vars Variables for expansion (from --vars CLI param)
  * @param passedSecrets Secrets for expansion (from --secrets CLI param, already decrypted)
- * @param checkEnv When true, validates that all required secrets/vars are provided
  * @param additionalEnvironment Extra env entries (e.g. model provider) to merge before expansion.
  *   Compose-declared entries take precedence. Secret-derived values should use
  *   $\{{ secrets.X }} templates so firewallPlaceholders logic applies.
@@ -103,7 +89,6 @@ export function expandEnvironmentFromCompose(
   agentCompose: unknown,
   vars: Record<string, string> | undefined,
   passedSecrets: Record<string, string> | undefined,
-  checkEnv?: boolean,
   additionalEnvironment?: Record<string, string>,
   firewalls?: ExpandedFirewallConfig[],
 ): ExpandedEnvironmentResult {
@@ -149,7 +134,6 @@ export function expandEnvironmentFromCompose(
   const secrets = processSecretValues(
     secretNames,
     passedSecrets,
-    checkEnv,
     firewallPlaceholders,
   );
 
@@ -179,23 +163,7 @@ export function expandEnvironmentFromCompose(
   }
 
   // Expand all variables
-  const { result, missingVars } = expandVariables(environment, sources);
-
-  // Check for missing vars (only when checkEnv is enabled)
-  if (checkEnv) {
-    const missingVarNames = missingVars
-      .filter((v) => {
-        return v.source === "vars";
-      })
-      .map((v) => {
-        return v.name;
-      });
-    if (missingVarNames.length > 0) {
-      throw badRequest(
-        `Missing required variables: ${missingVarNames.join(", ")}. Use '--vars ${missingVarNames[0]}=<value>' or '--env-file <path>' to provide them.`,
-      );
-    }
-  }
+  const { result } = expandVariables(environment, sources);
 
   return { environment: result };
 }

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -17,7 +17,6 @@ import {
   isConcurrentRunLimit,
 } from "../errors";
 import { enqueueRun, drainOrgQueue } from "./run-queue-service";
-import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { logger } from "../logger";
 import type { Database } from "../../types/global";
 import type { AgentComposeSnapshot } from "../checkpoint/types";
@@ -31,10 +30,8 @@ import type { ExecutionContext, DispatchTimings } from "./types";
 import { buildZeroExecutionContext } from "../zero/build-zero-context";
 import { zeroRuns } from "../../db/schema/zero-run";
 import { recordSandboxOperation } from "../metrics";
-import { extractTemplateVars } from "../config-validator";
 import { canAccessCompose } from "../agent/compose-access";
 
-import { getVariableValues } from "../variable/variable-service";
 import { encryptSecretValue } from "../crypto/secrets-encryption";
 import {
   type OrgTier,
@@ -324,7 +321,6 @@ export interface CreateRunParams {
   agentName?: string;
   modelProvider?: string;
   debugNoMockClaude?: boolean;
-  checkEnv?: boolean;
   // Caller-resolved org context for variable/storage resolution.
   orgId: string;
   // Caller-resolved org tier for concurrency limit derivation.
@@ -375,7 +371,6 @@ interface StartRunParams {
   callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
   modelProvider?: string;
   debugNoMockClaude?: boolean;
-  checkEnv?: boolean;
   firewallPolicies?: FirewallPolicies;
   allowedConnectorTypes?: ConnectorType[];
 }
@@ -479,42 +474,15 @@ export function authorizeCompose(
 }
 
 /**
- * Validate template vars availability and image access for new runs.
+ * Validate image access for new runs.
  *
  * Skipped when resuming from checkpoint or continuing a session.
- * Vars validation only runs when checkEnv is enabled (matching expand-environment.ts behavior).
- *
- * @throws BadRequestError - missing required template variables (only when checkEnv is true)
  */
 export async function validateComposeRequirements(
-  userId: string,
   composeContent: AgentComposeYaml,
-  orgId: string,
-  vars?: Record<string, string>,
-  checkEnv?: boolean,
 ): Promise<void> {
   if (!composeContent?.agents) {
     return;
-  }
-
-  // Only validate vars when checkEnv is enabled (matching expand-environment.ts behavior)
-  if (checkEnv) {
-    const requiredVars = extractTemplateVars(composeContent);
-    if (requiredVars.length > 0) {
-      const [orgVars, userVars] = await Promise.all([
-        getVariableValues(orgId, ORG_SENTINEL_USER_ID),
-        getVariableValues(orgId, userId),
-      ]);
-      const allVars = { ...orgVars, ...userVars, ...vars };
-      const missingVars = requiredVars.filter((varName) => {
-        return allVars[varName] === undefined;
-      });
-      if (missingVars.length > 0) {
-        throw badRequest(
-          `Missing required template variables: ${missingVars.join(", ")}`,
-        );
-      }
-    }
   }
 }
 
@@ -857,7 +825,6 @@ export async function startRun(
     agentName: resolved.agentName,
     modelProvider: params.modelProvider,
     debugNoMockClaude: params.debugNoMockClaude,
-    checkEnv: params.checkEnv,
     firewallPolicies: params.firewallPolicies,
     allowedConnectorTypes: params.allowedConnectorTypes,
     orgId: authOrgId,
@@ -913,13 +880,7 @@ export async function createRunRecord(
 
   // Step 3: Validate template vars and image access (for new runs only)
   if (!params.checkpointId && !params.sessionId) {
-    await validateComposeRequirements(
-      userId,
-      composeContent,
-      params.orgId,
-      params.vars,
-      params.checkEnv,
-    );
+    await validateComposeRequirements(composeContent);
   }
 
   // Step 4: Validate mutual exclusivity
@@ -1096,13 +1057,7 @@ export async function dispatchQueuedRun(
 
   // Validate template vars and image access (for new runs only)
   if (!params.checkpointId && !params.sessionId) {
-    await validateComposeRequirements(
-      userId,
-      composeContent,
-      params.orgId,
-      params.vars,
-      params.checkEnv,
-    );
+    await validateComposeRequirements(composeContent);
   }
 
   const sandboxToken = await generateSandboxToken(params.userId, runId);

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -656,8 +656,6 @@ interface BuildZeroContextParams {
   debugNoMockClaude?: boolean;
   // Model provider for automatic secret injection
   modelProvider?: string;
-  // Environment validation flag - when true, validates secrets/vars before running
-  checkEnv?: boolean;
   // API start time for E2E timing metrics
   apiStartTime?: number;
   // Per-permission firewall policies from zero agent configuration.
@@ -729,7 +727,6 @@ async function resolveSecretsAndEnvironment(
   vars: Record<string, string> | undefined,
   cliSecrets: Record<string, string> | undefined,
   modelProvider: string | undefined,
-  checkEnv: boolean | undefined,
   userId: string,
   allowedConnectorTypes?: ConnectorType[],
 ): Promise<{
@@ -831,7 +828,6 @@ async function resolveSecretsAndEnvironment(
     agentCompose,
     mergedVars,
     secrets,
-    checkEnv,
     modelProviderResult.injectedEnvironment,
     [
       ...(modelProviderFirewall ? [modelProviderFirewall] : []),
@@ -1108,7 +1104,6 @@ export async function buildZeroExecutionContext(
       vars,
       params.secrets,
       params.modelProvider,
-      params.checkEnv,
       params.userId,
       params.allowedConnectorTypes,
     ),

--- a/turbo/apps/web/src/lib/zero/zero-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-queue-service.ts
@@ -66,13 +66,7 @@ export async function dispatchQueuedZeroRun(
 
     // Validate compose requirements for new runs only
     if (!params.checkpointId && !params.sessionId) {
-      await validateComposeRequirements(
-        params.userId,
-        composeContent,
-        params.orgId,
-        params.vars,
-        params.checkEnv,
-      );
+      await validateComposeRequirements(composeContent);
     }
 
     // Generate sandbox token + build zero context

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -50,9 +50,6 @@ const unifiedRunRequestSchema = z.object({
   // Model provider for automatic secret injection
   modelProvider: z.string().optional(),
 
-  // Environment validation flag - when true, validates secrets/vars before running
-  checkEnv: z.boolean().optional(),
-
   // Required
   prompt: z.string().min(1, "Missing prompt"),
 


### PR DESCRIPTION
## Summary

Part of epic #7152 (Extract Zero Platform Layer from Generic Run Infrastructure).

- Remove `--model-provider` and `--check-env` CLI options from `vm0 run`, `vm0 run continue`, and `vm0 run resume` commands — these trigger zero platform business logic that doesn't belong in the infra run path
- Remove `checkEnv` from server-side API contract (`unifiedRunRequestSchema`), API route, run-service, expand-environment, and build-zero-context
- Simplify `validateComposeRequirements` by removing checkEnv-dependent validation logic
- Update E2E smoke tests to use `--secrets` pattern instead of `--model-provider`
- Remove all checkEnv-related test cases from route, create-run, and expand-environment tests

Closes #7537

## Test plan

- [x] All 110 server-side tests pass (60 route, 39 create-run, 11 expand-environment)
- [x] CLI tests pass with model-provider tests removed
- [x] E2E smoke tests updated to use --secrets for ANTHROPIC_API_KEY
- [x] Type checks pass
- [x] Lint passes with 0 warnings
- [x] Knip finds no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)