### PR TITLE
fix(platform): prevent volume columns from overflowing on context page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-activity-context-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-context-page.tsx
@@ -86,7 +86,7 @@ function StorageTable({
     return <p className="text-sm text-muted-foreground">None</p>;
   }
   return (
-    <Table>
+    <Table className="table-fixed">
       <TableHeader>
         <TableRow>
           {columns.map((col) => {
@@ -101,13 +101,13 @@ function StorageTable({
               {item.name !== undefined && (
                 <TableCell className="font-mono text-xs">{item.name}</TableCell>
               )}
-              <TableCell className="font-mono text-xs">
+              <TableCell className="font-mono text-xs break-all">
                 {item.mountPath}
               </TableCell>
-              <TableCell className="font-mono text-xs">
+              <TableCell className="font-mono text-xs break-all">
                 {item.vasStorageName}
               </TableCell>
-              <TableCell className="font-mono text-xs truncate max-w-[200px]">
+              <TableCell className="font-mono text-xs break-all">
                 {item.vasVersionId}
               </TableCell>
             </TableRow>


### PR DESCRIPTION
## Summary
- Use `table-fixed` layout on `StorageTable` so columns share width evenly
- Add `break-all` to mount path, storage name, and version cells so long values wrap instead of overlapping adjacent columns
- Remove `truncate max-w-[200px]` from version column — values should be fully visible

## Test plan
- [ ] Open activity context page for a run with volumes/artifact/memory
- [ ] Verify long mount paths wrap within their column
- [ ] Verify version IDs are fully visible (not truncated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)