### PR TITLE
feat(org): add role selection to member invite flow

### DIFF
--- a/turbo/apps/cli/src/commands/zero/org/__tests__/invite.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/invite.test.ts
@@ -19,7 +19,7 @@ describe("zero org invite command", () => {
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
-  it("should invite member and show success", async () => {
+  it("should invite member with default role and show success", async () => {
     server.use(
       http.post("http://localhost:3000/api/zero/org/invite", () => {
         return HttpResponse.json({
@@ -37,7 +37,48 @@ describe("zero org invite command", () => {
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
     expect(logCalls).toContain("member@example.com");
-    expect(logCalls).toContain("Invitation sent");
+    expect(logCalls).toContain("as member");
+  });
+
+  it("should invite member with --role admin", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/org/invite", () => {
+        return HttpResponse.json({
+          message: "Invitation sent to admin@example.com",
+        });
+      }),
+    );
+
+    await inviteCommand.parseAsync([
+      "node",
+      "cli",
+      "--email",
+      "admin@example.com",
+      "--role",
+      "admin",
+    ]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("admin@example.com");
+    expect(logCalls).toContain("as admin");
+  });
+
+  it("should reject invalid role value", async () => {
+    await expect(async () => {
+      await inviteCommand.parseAsync([
+        "node",
+        "cli",
+        "--email",
+        "user@example.com",
+        "--role",
+        "superadmin",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid role "superadmin"'),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
   });
 
   it("should handle forbidden error (non-admin)", async () => {

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/invite.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/invite.test.ts
@@ -81,6 +81,47 @@ describe("zero org invite command", () => {
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 
+  it("should invite member with admin role", async () => {
+    server.use(
+      http.post("http://localhost:3000/api/zero/org/invite", () => {
+        return HttpResponse.json({
+          message: "Invitation sent to admin@example.com",
+        });
+      }),
+    );
+
+    await inviteCommand.parseAsync([
+      "node",
+      "cli",
+      "--email",
+      "admin@example.com",
+      "--role",
+      "admin",
+    ]);
+
+    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+    expect(logCalls).toContain("admin@example.com");
+    expect(logCalls).toContain("as admin");
+  });
+
+  it("should reject invalid role value", async () => {
+    await expect(async () => {
+      await inviteCommand.parseAsync([
+        "node",
+        "cli",
+        "--email",
+        "user@example.com",
+        "--role",
+        "superadmin",
+      ]);
+    }).rejects.toThrow("process.exit called");
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid role "superadmin"'),
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
   it("should handle forbidden error (non-admin)", async () => {
     server.use(
       http.post("http://localhost:3000/api/zero/org/invite", () => {

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/invite.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/invite.test.ts
@@ -81,47 +81,6 @@ describe("zero org invite command", () => {
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 
-  it("should invite member with admin role", async () => {
-    server.use(
-      http.post("http://localhost:3000/api/zero/org/invite", () => {
-        return HttpResponse.json({
-          message: "Invitation sent to admin@example.com",
-        });
-      }),
-    );
-
-    await inviteCommand.parseAsync([
-      "node",
-      "cli",
-      "--email",
-      "admin@example.com",
-      "--role",
-      "admin",
-    ]);
-
-    const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("admin@example.com");
-    expect(logCalls).toContain("as admin");
-  });
-
-  it("should reject invalid role value", async () => {
-    await expect(async () => {
-      await inviteCommand.parseAsync([
-        "node",
-        "cli",
-        "--email",
-        "user@example.com",
-        "--role",
-        "superadmin",
-      ]);
-    }).rejects.toThrow("process.exit called");
-
-    expect(mockConsoleError).toHaveBeenCalledWith(
-      expect.stringContaining('Invalid role "superadmin"'),
-    );
-    expect(mockExit).toHaveBeenCalledWith(1);
-  });
-
   it("should handle forbidden error (non-admin)", async () => {
     server.use(
       http.post("http://localhost:3000/api/zero/org/invite", () => {

--- a/turbo/apps/cli/src/commands/zero/org/invite.ts
+++ b/turbo/apps/cli/src/commands/zero/org/invite.ts
@@ -7,9 +7,21 @@ export const inviteCommand = new Command()
   .name("invite")
   .description("Invite a member to the current organization")
   .requiredOption("--email <email>", "Email address of the member to invite")
+  .option(
+    "--role <role>",
+    "Role for the invited member (member or admin)",
+    "member",
+  )
   .action(
-    withErrorHandler(async (options: { email: string }) => {
-      await inviteZeroOrgMember(options.email);
-      console.log(chalk.green(`✓ Invitation sent to ${options.email}`));
+    withErrorHandler(async (options: { email: string; role: string }) => {
+      if (options.role !== "member" && options.role !== "admin") {
+        throw new Error(
+          `Invalid role "${options.role}". Must be "member" or "admin".`,
+        );
+      }
+      await inviteZeroOrgMember(options.email, options.role);
+      console.log(
+        chalk.green(`✓ Invitation sent to ${options.email} as ${options.role}`),
+      );
     }),
   );

--- a/turbo/apps/cli/src/lib/api/domains/zero-orgs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-orgs.ts
@@ -113,12 +113,15 @@ export async function getZeroOrgMembers(): Promise<OrgMembersResponse> {
 /**
  * Invite a member to the org via zero API
  */
-export async function inviteZeroOrgMember(email: string): Promise<void> {
+export async function inviteZeroOrgMember(
+  email: string,
+  role: "member" | "admin" = "member",
+): Promise<void> {
   const config = await getClientConfig();
   const client = initClient(zeroOrgInviteContract, config);
 
   const result = await client.invite({
-    body: { email },
+    body: { email, role },
   });
 
   if (result.status === 200) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/org-members-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/org-members-dialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
@@ -213,6 +213,93 @@ describe("org members - invite dialog loading state", () => {
       expect(
         screen.queryByRole("heading", { name: "Invite member" }),
       ).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("org members - invite dialog role selector", () => {
+  it("should show role selector defaulting to Member", async () => {
+    const user = userEvent.setup();
+    mockMembersAPI();
+    server.use(
+      http.post("*/api/zero/org/invite", () => {
+        return HttpResponse.json({ message: "ok" }, { status: 200 });
+      }),
+    );
+
+    await renderMembersTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("admin@example.com")).toBeInTheDocument();
+    });
+
+    // Open invite dialog
+    await user.click(screen.getByRole("button", { name: /Add member/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Invite member" }),
+      ).toBeInTheDocument();
+    });
+
+    // Role label and selector should be present within the dialog
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Role")).toBeInTheDocument();
+    // The select trigger should show the default "Member" value
+    expect(within(dialog).getByRole("combobox")).toHaveTextContent("Member");
+  });
+
+  it("should send invite with selected admin role", async () => {
+    const user = userEvent.setup();
+    let capturedBody: Record<string, unknown> | null = null;
+
+    mockMembersAPI();
+    server.use(
+      http.post("*/api/zero/org/invite", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ message: "ok" }, { status: 200 });
+      }),
+    );
+
+    await renderMembersTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("admin@example.com")).toBeInTheDocument();
+    });
+
+    // Open invite dialog
+    await user.click(screen.getByRole("button", { name: /Add member/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Invite member" }),
+      ).toBeInTheDocument();
+    });
+
+    // Fill email
+    const emailInput = screen.getByPlaceholderText("email@example.com");
+    await user.clear(emailInput);
+    await user.type(emailInput, "new-admin@example.com");
+
+    // Change role to Admin
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "Admin" })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("option", { name: "Admin" }));
+
+    // Submit
+    await user.click(screen.getByRole("button", { name: /Send invitation/i }));
+
+    // Wait for dialog to close (invite succeeded)
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Invite member" }),
+      ).not.toBeInTheDocument();
+    });
+
+    // Verify the request body included role: "admin"
+    expect(capturedBody).toMatchObject({
+      email: "new-admin@example.com",
+      role: "admin",
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -37,6 +37,7 @@ import {
   zeroOrgInviteContract,
   zeroOrgMembershipRequestsContract,
   type OrgRole,
+  orgRoleSchema,
 } from "@vm0/core";
 import {
   orgMembers$,
@@ -410,7 +411,7 @@ function InviteDialog({
             <Select
               value={role}
               onValueChange={(v) => {
-                return setRole(v as OrgRole);
+                return setRole(orgRoleSchema.parse(v));
               }}
               disabled={sending}
             >

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-members-tab.tsx
@@ -25,6 +25,11 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import {
@@ -121,9 +126,9 @@ export function OrgMembersTab() {
     });
   })();
 
-  const handleInvite = async (email: string) => {
+  const handleInvite = async (email: string, role: OrgRole) => {
     const client = createClient(zeroOrgInviteContract);
-    const result = await client.invite({ body: { email } });
+    const result = await client.invite({ body: { email, role } });
     if (result.status === 200) {
       toast.success(`Invitation sent to ${email}`);
       refreshMembers();
@@ -317,12 +322,13 @@ export function OrgMembersTab() {
 function InviteDialog({
   onInvite,
 }: {
-  onInvite: (email: string) => Promise<void>;
+  onInvite: (email: string, role: OrgRole) => Promise<void>;
 }) {
   const email = useGet(inviteEmail$);
   const setEmail = useSet(setInviteEmail$);
   const [open, setOpen] = useState(false);
   const [sending, setSending] = useState(false);
+  const [role, setRole] = useState<OrgRole>("member");
 
   const trimmed = email.trim();
   const isValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed);
@@ -333,10 +339,11 @@ function InviteDialog({
   const handleSend = () => {
     setSending(true);
     detach(
-      onInvite(trimmed).then(
+      onInvite(trimmed, role).then(
         () => {
           setOpen(false);
           setEmail("");
+          setRole("member");
           setSending(false);
         },
         (error: unknown) => {
@@ -358,6 +365,9 @@ function InviteDialog({
       onOpenChange={(v) => {
         if (!sending) {
           setOpen(v);
+          if (!v) {
+            setRole("member");
+          }
         }
       }}
     >
@@ -374,25 +384,45 @@ function InviteDialog({
             Send an invitation to join this workspace.
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-1.5">
-          <Input
-            placeholder="email@example.com"
-            type="email"
-            value={email}
-            disabled={sending}
-            onChange={(e) => {
-              setEmail(e.target.value);
-              setTouched(false);
-            }}
-            onBlur={() => {
-              return setTouched(true);
-            }}
-          />
-          {touched && trimmed && !isValid && (
-            <p className="text-[13px] text-destructive">
-              Please enter a valid email address
-            </p>
-          )}
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Input
+              placeholder="email@example.com"
+              type="email"
+              value={email}
+              disabled={sending}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                setTouched(false);
+              }}
+              onBlur={() => {
+                return setTouched(true);
+              }}
+            />
+            {touched && trimmed && !isValid && (
+              <p className="text-[13px] text-destructive">
+                Please enter a valid email address
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Role</label>
+            <Select
+              value={role}
+              onValueChange={(v) => {
+                return setRole(v as OrgRole);
+              }}
+              disabled={sending}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="member">Member</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
         </div>
         <DialogFooter>
           <Button

--- a/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { clerkClient } from "@clerk/nextjs/server";
 import { POST, DELETE } from "../route";
 import {
   createTestRequest,
@@ -29,7 +30,7 @@ describe("POST /api/zero/org/invite (invite)", () => {
     context.setupMocks();
   });
 
-  it("should invite a member for an admin", async () => {
+  it("should invite a member with default role", async () => {
     const userId = uniqueId("inv-ok");
     await setupOrg(userId);
 
@@ -44,6 +45,33 @@ describe("POST /api/zero/org/invite (invite)", () => {
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.message).toContain("newuser@example.com");
+
+    const client = await clerkClient();
+    expect(
+      client.organizations.createOrganizationInvitation,
+    ).toHaveBeenCalledWith(expect.objectContaining({ role: "org:member" }));
+  });
+
+  it("should invite a member with admin role", async () => {
+    const userId = uniqueId("inv-admin");
+    await setupOrg(userId);
+
+    const response = await POST(
+      createTestRequest(inviteUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "admin@example.com", role: "admin" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toContain("admin@example.com");
+
+    const client = await clerkClient();
+    expect(
+      client.organizations.createOrganizationInvitation,
+    ).toHaveBeenCalledWith(expect.objectContaining({ role: "org:admin" }));
   });
 
   it("should return 403 when caller is not an admin", async () => {

--- a/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
@@ -74,26 +74,6 @@ describe("POST /api/zero/org/invite (invite)", () => {
     ).toHaveBeenCalledWith(expect.objectContaining({ role: "org:admin" }));
   });
 
-  it("should invite a member with admin role", async () => {
-    const userId = uniqueId("inv-role");
-    await setupOrg(userId);
-
-    const response = await POST(
-      createTestRequest(inviteUrl(), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          email: "admin-invite@example.com",
-          role: "admin",
-        }),
-      }),
-    );
-
-    expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data.message).toContain("admin-invite@example.com");
-  });
-
   it("should return 403 when caller is not an admin", async () => {
     const userId = uniqueId("inv-403");
     const slug = uniqueId("inv-member");

--- a/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
@@ -74,6 +74,26 @@ describe("POST /api/zero/org/invite (invite)", () => {
     ).toHaveBeenCalledWith(expect.objectContaining({ role: "org:admin" }));
   });
 
+  it("should invite a member with admin role", async () => {
+    const userId = uniqueId("inv-role");
+    await setupOrg(userId);
+
+    const response = await POST(
+      createTestRequest(inviteUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: "admin-invite@example.com",
+          role: "admin",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.message).toContain("admin-invite@example.com");
+  });
+
   it("should return 403 when caller is not an admin", async () => {
     const userId = uniqueId("inv-403");
     const slug = uniqueId("inv-member");

--- a/turbo/apps/web/app/api/zero/org/invite/route.ts
+++ b/turbo/apps/web/app/api/zero/org/invite/route.ts
@@ -29,7 +29,13 @@ const router = tsr.router(zeroOrgInviteContract, {
 
     try {
       const { org, member } = await resolveOrg(authCtx);
-      await inviteMember(authCtx.userId, org.orgId, member.role, body.email);
+      await inviteMember(
+        authCtx.userId,
+        org.orgId,
+        member.role,
+        body.email,
+        body.role,
+      );
       return {
         status: 200 as const,
         body: { message: `Invitation sent to ${body.email}` },

--- a/turbo/apps/web/src/lib/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/org/org-member-service.ts
@@ -293,10 +293,11 @@ export async function getOrgMembers(
 export async function inviteMember(
   callerUserId: string,
   orgId: string,
-  role: OrgRole,
+  callerRole: OrgRole,
   email: string,
+  inviteRole: OrgRole = "member",
 ) {
-  if (role !== "admin") {
+  if (callerRole !== "admin") {
     throw forbidden("Only admins can invite members");
   }
 
@@ -305,10 +306,10 @@ export async function inviteMember(
     organizationId: orgId,
     emailAddress: email,
     inviterUserId: callerUserId,
-    role: "org:member",
+    role: inviteRole === "admin" ? "org:admin" : "org:member",
   });
 
-  log.debug("Invitation sent", { orgId, email });
+  log.debug("Invitation sent", { orgId, email, inviteRole });
 }
 
 /**

--- a/turbo/packages/core/src/contracts/org-members.ts
+++ b/turbo/packages/core/src/contracts/org-members.ts
@@ -83,6 +83,7 @@ export type OrgMembersResponse = z.infer<typeof orgMembersResponseSchema>;
  */
 export const inviteOrgMemberRequestSchema = z.object({
   email: z.string().email(),
+  role: orgRoleSchema.optional().default("member"),
 });
 export type InviteOrgMemberRequest = z.infer<
   typeof inviteOrgMemberRequestSchema


### PR DESCRIPTION
## Summary
- Add `--role` option to CLI `org invite` command (member or admin, defaults to member)
- Add role selector dropdown to the platform invite dialog UI
- Pass the selected role through the API contract and org member service to Clerk

## Test plan
- [ ] CLI: Run `vm0 zero org invite --email test@example.com --role admin` and verify invitation is sent with admin role
- [ ] CLI: Verify `--role` defaults to member when omitted
- [ ] CLI: Verify invalid role values are rejected
- [ ] Platform: Open invite dialog and verify role selector appears with Member/Admin options
- [ ] Platform: Invite a member as admin and verify the role is applied
- [ ] API: Verify the invite endpoint accepts and passes the role field correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)