### PR TITLE
fix: add merge conflict detection to pr-check and pr-check-loop skills

### DIFF
--- a/.claude/skills/pr-check-loop/SKILL.md
+++ b/.claude/skills/pr-check-loop/SKILL.md
@@ -188,23 +188,28 @@ Follow the returned ACTION.
 
 ### On `ACTION: CHECK`
 
-Poll CI status:
+Poll CI status and merge status in parallel:
 
 ```bash
 gh pr checks "$pr_id"
 ```
 
+```bash
+gh pr view "$pr_id" --json mergeable,mergeStateStatus --jq '{mergeable, mergeStateStatus}'
+```
+
 Classify the result:
 
-1. **All checks `pass` or `skipping`** → status is `pass`
-2. **Any check `fail`** → analyze failure type:
+1. **Merge conflict detected** (`mergeable: CONFLICTING` or `mergeStateStatus: DIRTY`) → status is `fail-manual`. This takes priority over CI status — there is no point fixing lint if the branch has conflicts.
+2. **All checks `pass` or `skipping`** → status is `pass`
+3. **Any check `fail`** → analyze failure type:
    - Lint/format failures only → status is `fail-fixable`
    - Type/test failures (with or without lint/format) → status is `fail-manual`
-3. **No failures, some `pending`** → status is `pending`
+4. **No failures, some `pending`** → status is `pending`
 
 **Fail-fast**: If ANY check has `fail` status, classify immediately without waiting for pending checks.
 
-When failures are detected, get failure details:
+When failures are detected (not merge conflicts), get failure details:
 
 ```bash
 # Get the PR branch
@@ -215,6 +220,17 @@ gh run list --branch "$branch" --status failure -L 1
 
 # Get failure logs
 gh run view {run-id} --log-failed
+```
+
+When merge conflicts are detected, include rebase guidance in the manual report:
+
+```
+Merge conflict detected. The branch has conflicts with the base branch.
+Rebase onto main to resolve:
+  git fetch origin main
+  git rebase origin/main
+  # resolve conflicts
+  git push --force-with-lease
 ```
 
 Report to driver:

--- a/.claude/skills/pr-check/SKILL.md
+++ b/.claude/skills/pr-check/SKILL.md
@@ -55,13 +55,28 @@ gh pr checks "$pr_id"
 - `pending`: Still running
 - `skipping`: Skipped (acceptable)
 
+### Check Merge Status
+
+```bash
+gh pr view "$pr_id" --json mergeable,mergeStateStatus --jq '{mergeable, mergeStateStatus}'
+```
+
+**Merge Status Values:**
+- `mergeable: MERGEABLE` — No conflicts
+- `mergeable: CONFLICTING` — Merge conflicts exist
+- `mergeable: UNKNOWN` — GitHub is still computing (treat as pending)
+- `mergeStateStatus: DIRTY` — Merge conflicts or other issues
+- `mergeStateStatus: BEHIND` — Branch is behind base branch (may need rebase)
+- `mergeStateStatus: CLEAN` — Ready to merge
+
 ### Classify Results
 
 After polling, classify the overall status:
 
-1. **All checks `pass` or `skipping`** → Report success, go to Step 4
-2. **Any check `fail`** → Proceed to Step 3 (analyze and fix), even if other checks are still `pending`
-3. **No failures but some `pending`** → Report pending status, go to Step 4
+1. **Merge conflict detected** (`mergeable: CONFLICTING` or `mergeStateStatus: DIRTY`) → Report conflict, go to Step 4. This takes priority over CI status.
+2. **All checks `pass` or `skipping`** → Report success, go to Step 4
+3. **Any check `fail`** → Proceed to Step 3 (analyze and fix), even if other checks are still `pending`
+4. **No failures but some `pending`** → Report pending status, go to Step 4
 
 ---
 
@@ -140,11 +155,21 @@ PR Check Result
 
 PR: #<number> - <title>
 Branch: <branch>
-Status: <All Passed / Pending / Auto-Fixed / Manual Fix Required>
+Status: <All Passed / Pending / Auto-Fixed / Manual Fix Required / Merge Conflict>
 
 Checks:
   <check-name>: <status>
   ...
+
+Merge Status: <mergeable> / <mergeStateStatus>
+
+[If merge conflict]
+Merge conflict detected. The branch has conflicts with the base branch.
+Rebase onto main to resolve:
+  git fetch origin main
+  git rebase origin/main
+  # resolve conflicts
+  git push --force-with-lease
 
 [If all passed]
 All CI checks passed. No action needed.


### PR DESCRIPTION
## Summary
- Add `gh pr view --json mergeable,mergeStateStatus` check to both `/pr-check` and `/pr-check-loop` skills
- Merge conflict detection takes priority over CI status — no point auto-fixing lint when the branch has conflicts
- Conflicts are classified as `fail-manual` with rebase guidance, consistent with the separation of concerns (rebase is `pr-merge-loop`'s job)

## Test plan
- [ ] Run `/pr-check` on a PR with merge conflicts — should report conflict with rebase instructions
- [ ] Run `/pr-check` on a clean PR — should behave as before
- [ ] Run `/pr-check-loop` on a PR with merge conflicts — should exit immediately as `fail-manual`

🤖 Generated with [Claude Code](https://claude.com/claude-code)