### PR TITLE
fix: reset chat thread page on thread switch to show skeleton

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-skeleton-switch.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-skeleton-switch.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse, delay } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { detachedNavigateTo$ } from "../../../signals/route.ts";
+
+const context = testContext();
+
+describe("chat skeleton on switch", () => {
+  it("should show skeleton when switching between chats", async () => {
+    server.use(
+      http.get("*/api/zero/chat-threads/:id", async ({ params }) => {
+        const id = params.id as string;
+        if (id === "thread-b") {
+          // Delay thread-B so loading state is observable
+          await delay(200);
+        }
+        return HttpResponse.json({
+          id,
+          title: null,
+          agentId: "c0000000-0000-4000-a000-000000000001",
+          chatMessages: [
+            {
+              role: "user" as const,
+              content: `Question for ${id}`,
+              createdAt: "2026-03-10T00:00:00Z",
+            },
+            {
+              role: "assistant" as const,
+              content: `Answer for ${id}`,
+              createdAt: "2026-03-10T00:00:01Z",
+            },
+          ],
+          latestSessionId: null,
+          unsavedRuns: [],
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    // Start on thread-A — messages load immediately
+    await setupPage({ context, path: "/chat/thread-a" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Answer for thread-a")).toBeInTheDocument();
+    });
+
+    // Switch to thread-B — API is delayed, skeleton should appear
+    context.store.set(detachedNavigateTo$, "/chat/:chatThreadId", {
+      pathParams: { chatThreadId: "thread-b" },
+    });
+
+    // Skeleton should be visible while thread-B loads
+    await waitFor(() => {
+      const skeletons = document.querySelectorAll(".animate-pulse");
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+
+    // Eventually thread-B content should load
+    await waitFor(() => {
+      expect(screen.getByText("Answer for thread-b")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-session-page-wrapper.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-session-page-wrapper.tsx
@@ -1,10 +1,16 @@
+import { useGet } from "ccstate-react";
+import { chatThreadId$ } from "../../signals/zero-page/zero-nav.ts";
 import { SidebarLayout } from "./sidebar-layout.tsx";
 import { ZeroChatThreadPage } from "./zero-chat-thread-page.tsx";
 
 export function ZeroChatSessionPageWrapper() {
+  const chatThreadId = useGet(chatThreadId$);
+  if (!chatThreadId) {
+    return null;
+  }
   return (
     <SidebarLayout>
-      <ZeroChatThreadPage />
+      <ZeroChatThreadPage key={chatThreadId} />
     </SidebarLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Add `key={chatThreadId}` to `ZeroChatThreadPage` so the component fully remounts when switching chat threads, displaying the loading skeleton instead of stale content
- Return `null` from `ZeroChatSessionPageWrapper` when no thread is selected
- Add integration test verifying skeleton appears during thread switch

## Test plan
- [ ] Verify skeleton loading state appears when switching between chat threads
- [ ] Verify no crash when chatThreadId is null
- [ ] CI passes (lint, type-check, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)