### PR TITLE
docs: add ci failure rerun limit and fix e2e timeout values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,9 +221,13 @@ If tests timeout, investigate why:
 2. Are there network issues or external service dependencies?
 3. Is the test itself poorly designed and needs optimization?
 
+### CI Failure Rerun Limit
+
+**If a CI job fails 3 times, stop rerunning and investigate your own code.** Assume your changes caused the failure until proven otherwise — do not default to "infrastructure issue". Read the failure logs and search the entire repo (including `e2e/`, `.github/`, shell scripts) for references to anything you changed.
+
 ### CLI E2E Timeout
 
-The `cli-e2e` jobs have a **maximum timeout** (5 minutes for serial/parallel tests, 8 minutes for runner tests). If tests exceed this limit, GitHub Actions will **cancel** the job (not fail). **Cancelled status is NOT acceptable for merge** - treat it as a failure and investigate the cause.
+The `cli-e2e` jobs have a **maximum timeout** (5 minutes for serial, 8 minutes for browser and runner tests). If tests exceed this limit, GitHub Actions will **cancel** the job (not fail). **Cancelled status is NOT acceptable for merge** - treat it as a failure and investigate the cause.
 
 ### Merge Requirements
 


### PR DESCRIPTION
## Summary

- Add "CI Failure Rerun Limit" rule: if a CI job fails 3 times, stop rerunning and investigate your own code
- Fix E2E timeout values: `serial/parallel` → `serial`, browser timeout corrected from 5min to 8min to match actual workflow

## Test plan

- [x] Documentation-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)