### PR TITLE
feat(docs): remove stale --check-env and --model-provider from cli docs

### DIFF
--- a/turbo/apps/docs/content/docs/model-selection/aws-bedrock.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/aws-bedrock.mdx
@@ -93,12 +93,6 @@ Once configured, run agents as usual:
 vm0 run my-agent "build a todo app"
 ```
 
-Or specify the provider explicitly:
-
-```bash
-vm0 run my-agent "build a todo app" --model-provider aws-bedrock
-```
-
 ## Resources
 
 - [Claude Code Bedrock Setup Guide](https://code.claude.com/docs/en/amazon-bedrock)

--- a/turbo/apps/docs/content/docs/model-selection/azure-foundry.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/azure-foundry.mdx
@@ -44,12 +44,6 @@ Once configured, run agents as usual:
 vm0 run my-agent "build a todo app"
 ```
 
-Or specify the provider explicitly:
-
-```bash
-vm0 run my-agent "build a todo app" --model-provider azure-foundry
-```
-
 ## Resources
 
 - [Claude Code Foundry Setup Guide](https://code.claude.com/docs/en/microsoft-foundry)

--- a/turbo/apps/docs/content/docs/model-selection/index.mdx
+++ b/turbo/apps/docs/content/docs/model-selection/index.mdx
@@ -82,16 +82,7 @@ zero org model-provider remove anthropic-api-key
 When you run an agent:
 1. If your `vm0.yaml` has explicit auth environment variables, those are used
 2. Otherwise, your default model provider credential is injected automatically
-3. You can override at runtime with: `vm0 run agent "prompt" --model-provider <type>`
 </Callout>
-
-## Runtime Override
-
-Override your default provider for a single run:
-
-```bash
-vm0 run my-agent "build a todo app" --model-provider openrouter-api-key
-```
 
 ## Advanced: Manual Configuration
 

--- a/turbo/apps/docs/content/docs/reference/cli/index.mdx
+++ b/turbo/apps/docs/content/docs/reference/cli/index.mdx
@@ -134,8 +134,8 @@ Organizations are namespaces for organizing agents.
 | ------- | ----------- | ------- |
 | `vm0 compose [agent-yaml]` | Create or update agent compose (default: vm0.yaml) | `-y, --yes`, `--json` |
 | `vm0 run <agent-name> <prompt>` | Run an agent | See options table below |
-| `vm0 run continue <session-id> <prompt>` | Continue from session (uses latest artifact) | `--env-file <path>`, `--vars`, `--secrets`, `--model-provider <type>`, `--verbose`, `--check-env` |
-| `vm0 run resume <checkpoint-id> <prompt>` | Resume from checkpoint (uses snapshot data) | `--env-file <path>`, `--vars`, `--secrets`, `--volume-version <name=version>`, `--model-provider <type>`, `--verbose`, `--check-env` |
+| `vm0 run continue <session-id> <prompt>` | Continue from session (uses latest artifact) | `--env-file <path>`, `--vars`, `--secrets`, `--verbose` |
+| `vm0 run resume <checkpoint-id> <prompt>` | Resume from checkpoint (uses snapshot data) | `--env-file <path>`, `--vars`, `--secrets`, `--volume-version <name=version>`, `--verbose` |
 | `vm0 run list` | List runs | Alias: `ls`. Options: `--status <status,...>`, `--all`, `--agent <name>`, `--since <date>`, `--until <date>`, `--limit <n>` |
 | `vm0 run queue` | Show org run queue status (concurrency slots and waiting runs) | - |
 | `vm0 run kill <run-id>` | Kill (cancel) a pending or running run | - |
@@ -160,9 +160,7 @@ Organizations are namespaces for organizing agents.
 | `--volume-version <name=version>` | Volume version override (repeatable) |
 | `--memory <name>` | Memory storage name |
 | `--conversation <id>` | Resume from conversation ID |
-| `--model-provider <type>` | Override model provider |
 | `--verbose` | Show full tool inputs and outputs |
-| `--check-env` | Validate secrets and vars before running |
 
 ### `vm0 run` Examples
 

--- a/turbo/apps/docs/content/docs/usage/run-agent.mdx
+++ b/turbo/apps/docs/content/docs/usage/run-agent.mdx
@@ -33,9 +33,7 @@ vm0 run my-agent:abc123 "build a todo app"
 | `--volume-version <name=version>` | Volume version override (repeatable, format: volumeName=version)     |
 | `--memory <name>`                | Memory storage name                                                  |
 | `--conversation <id>`            | Resume from conversation ID (for fine-grained control)               |
-| `--model-provider <type>`        | Override model provider (e.g., anthropic-api-key)                    |
 | `--verbose`                      | Show full tool inputs and outputs                                    |
-| `--check-env`                    | Validate secrets and vars before running                             |
 
 ### Passing Variables and Secrets
 


### PR DESCRIPTION
## Summary

- Remove all `--check-env` references from CLI documentation (removed in PR #7543)
- Remove `--model-provider` from `vm0 run` documentation (removed in PR #7543, still exists in `zero run`)
- Clean up model-selection docs that referenced `vm0 run --model-provider` examples

## Files Changed

- `turbo/apps/docs/content/docs/usage/run-agent.mdx` — removed 2 table rows
- `turbo/apps/docs/content/docs/reference/cli/index.mdx` — removed from options tables and command summaries
- `turbo/apps/docs/content/docs/model-selection/index.mdx` — removed runtime override section and callout bullet
- `turbo/apps/docs/content/docs/model-selection/aws-bedrock.mdx` — removed "specify explicitly" block
- `turbo/apps/docs/content/docs/model-selection/azure-foundry.mdx` — removed "specify explicitly" block

## Verification

```bash
grep -r "check-env" turbo/apps/docs/content/  # zero results ✓
grep -r "model-provider" turbo/apps/docs/content/ | grep "vm0 run"  # zero results ✓
```

## Test plan

- [x] `grep -r "check-env" turbo/apps/docs/content/` returns zero results
- [x] `grep -r "model-provider" turbo/apps/docs/content/ | grep "vm0 run"` returns zero results
- [x] `--model-provider` still documented in `zero run` and `zero org model-provider` contexts
- [ ] Lint/format pass in CI

Closes #7576

🤖 Generated with [Claude Code](https://claude.com/claude-code)