### PR TITLE
refactor: remove remaining org_slug references from dev-auth script and cli tests

### DIFF
--- a/scripts/dev-auth.sh
+++ b/scripts/dev-auth.sh
@@ -33,9 +33,8 @@ if [[ "$HTTP_CODE" != "200" ]]; then
   exit 1
 fi
 
-# Extract token and org_slug from response
+# Extract token from response
 TOKEN=$(echo "$BODY" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
-ORG_SLUG=$(echo "$BODY" | grep -o '"org_slug":"[^"]*"' | cut -d'"' -f4)
 
 if [[ -z "$TOKEN" ]]; then
   echo "❌ Error: Failed to extract token from response"
@@ -44,31 +43,19 @@ if [[ -z "$TOKEN" ]]; then
 fi
 
 # Create config directory and file
+# Note: activeOrg is derived from the JWT token at runtime, not from config
 CONFIG_DIR="$HOME/.vm0"
 CONFIG_FILE="$CONFIG_DIR/config.json"
 
 mkdir -p "$CONFIG_DIR"
 
-if [[ -n "$ORG_SLUG" ]]; then
-  cat > "$CONFIG_FILE" << EOF
-{
-  "token": "$TOKEN",
-  "apiUrl": "$VM0_API_URL",
-  "activeOrg": "$ORG_SLUG"
-}
-EOF
-else
-  cat > "$CONFIG_FILE" << EOF
+cat > "$CONFIG_FILE" << EOF
 {
   "token": "$TOKEN",
   "apiUrl": "$VM0_API_URL"
 }
 EOF
-fi
 
 echo ""
 echo "✅ Authenticated successfully!"
 echo "Config saved to: $CONFIG_FILE"
-if [[ -n "$ORG_SLUG" ]]; then
-  echo "Active org: $ORG_SLUG"
-fi

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/leave.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/leave.test.ts
@@ -72,7 +72,6 @@ describe("zero org leave command", () => {
           access_token: newJwt,
           token_type: "Bearer",
           expires_in: 7776000,
-          org_slug: "other-org",
         });
       }),
     );
@@ -169,7 +168,6 @@ describe("zero org leave command", () => {
           access_token: newJwt,
           token_type: "Bearer",
           expires_in: 7776000,
-          org_slug: "next-org",
         });
       }),
     );

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/set.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/set.test.ts
@@ -99,7 +99,6 @@ describe("zero org set command", () => {
           access_token: newJwt,
           token_type: "Bearer",
           expires_in: 7776000,
-          org_slug: "newslug",
         });
       }),
     );
@@ -184,7 +183,6 @@ describe("zero org set command", () => {
           access_token: newJwt,
           token_type: "Bearer",
           expires_in: 7776000,
-          org_slug: "newslug",
         });
       }),
     );

--- a/turbo/apps/cli/src/commands/zero/org/__tests__/use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/org/__tests__/use.test.ts
@@ -67,7 +67,6 @@ describe("zero org use command", () => {
           access_token: newJwt,
           token_type: "Bearer",
           expires_in: 7776000,
-          org_slug: "org-b",
         });
       }),
     );
@@ -139,7 +138,6 @@ describe("zero org use command", () => {
           access_token: newJwt,
           token_type: "Bearer",
           expires_in: 7776000,
-          org_slug: "org-b",
         });
       }),
     );


### PR DESCRIPTION
## Summary

- Remove stale `org_slug` extraction and conditional `activeOrg` config logic from `scripts/dev-auth.sh` (follows same fix pattern applied to `e2e/scripts/generate-test-token.sh` in PR #7559)
- Remove `org_slug` from mock HTTP response objects in CLI org command tests (`use`, `set`, `leave`) to match current contract which no longer includes this field

Closes #7582

## Test plan

- [x] All 81 org command tests pass (`pnpm vitest run apps/cli/src/commands/zero/org`)
- [x] Lint passes (`pnpm turbo run lint --filter=@vm0/cli`)
- [x] Type check passes (`pnpm turbo run check-types --filter=@vm0/cli`)
- [x] Knip passes (no unused exports/dependencies)
- [x] No remaining `org_slug` references in active code (only migration/snapshot files and negative assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)