### PR TITLE
refactor: remove redundant ?org= query param from firewall-access-requests and skills routes

### DIFF
--- a/turbo/apps/web/app/api/zero/firewall-access-requests/route.ts
+++ b/turbo/apps/web/app/api/zero/firewall-access-requests/route.ts
@@ -67,7 +67,7 @@ async function resolveUserNames(
 
 // --- POST: Create Request ---
 const createRouter = tsr.router(firewallAccessRequestsCreateContract, {
-  create: async ({ body, headers }, { request }) => {
+  create: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -75,8 +75,7 @@ const createRouter = tsr.router(firewallAccessRequestsCreateContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     // Validate firewall ref
     if (!isFirewallConnectorType(body.firewallRef)) {
@@ -173,7 +172,7 @@ const createRouter = tsr.router(firewallAccessRequestsCreateContract, {
 
 // --- GET: List Requests ---
 const listRouter = tsr.router(firewallAccessRequestsListContract, {
-  list: async ({ headers, query }, { request }) => {
+  list: async ({ headers, query }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -181,8 +180,7 @@ const listRouter = tsr.router(firewallAccessRequestsListContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     const { agentId, status } = query;
 
@@ -234,7 +232,7 @@ const listRouter = tsr.router(firewallAccessRequestsListContract, {
 
 // --- PUT: Resolve Request ---
 const resolveRouter = tsr.router(firewallAccessRequestsResolveContract, {
-  resolve: async ({ body, headers }, { request }) => {
+  resolve: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -242,8 +240,7 @@ const resolveRouter = tsr.router(firewallAccessRequestsResolveContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org, member } = await resolveOrg(authCtx, orgSlug);
+    const { org, member } = await resolveOrg(authCtx);
 
     // Find the request and agent owner in a single query
     const [row] = await globalThis.services.db

--- a/turbo/apps/web/app/api/zero/skills/route.ts
+++ b/turbo/apps/web/app/api/zero/skills/route.ts
@@ -19,7 +19,7 @@ import { logger } from "../../../../src/lib/logger";
 const log = logger("api:zero-skills");
 
 const router = tsr.router(zeroSkillsCollectionContract, {
-  list: async ({ headers }, { request }) => {
+  list: async ({ headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -27,8 +27,7 @@ const router = tsr.router(zeroSkillsCollectionContract, {
     });
     if (isAuthError(authCtx)) return authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     const rows = await globalThis.services.db
       .select({
@@ -51,7 +50,7 @@ const router = tsr.router(zeroSkillsCollectionContract, {
     };
   },
 
-  create: async ({ body, headers }, { request }) => {
+  create: async ({ body, headers }) => {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
@@ -60,8 +59,7 @@ const router = tsr.router(zeroSkillsCollectionContract, {
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
-    const orgSlug = new URL(request.url).searchParams.get("org");
-    const { org } = await resolveOrg(authCtx, orgSlug);
+    const { org } = await resolveOrg(authCtx);
 
     // Validate name not in seed skills
     const seedSet = new Set<string>(SEED_SKILLS);


### PR DESCRIPTION
## Summary

- Remove `searchParams.get("org")` extraction from all handlers in `firewall-access-requests/route.ts` (3 handlers) and `skills/route.ts` (2 handlers)
- Change `resolveOrg(authCtx, orgSlug)` to `resolveOrg(authCtx)` — the second param is redundant since `authCtx.orgId` is always present
- Remove unused `{ request }` destructuring from handler parameters

Closes #7585

## Test plan

- [x] Existing integration tests pass (34/34) for both routes
- [x] TypeScript type-check passes
- [x] Lint passes
- [x] Knip passes
- [x] Verified no remaining `searchParams.get("org")` in `turbo/apps/web/app/api/zero/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)