### PR TITLE
fix: filter api-token connector secrets by user_connector permissions

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -8,6 +8,7 @@ import {
   createTestCompose,
   createTestSecret,
   createTestVariable,
+  createTestUserConnector,
   getTestZeroAgentId,
   findTestRunnerJobEntry,
 } from "../../../__tests__/api-test-helpers";
@@ -243,6 +244,89 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
       // createZeroRun doesn't accept CLI vars directly, so user value wins
       expect(job!.executionContext.environment).toMatchObject({
         MY_VAR: "user-value",
+      });
+    });
+  });
+
+  describe("Connector Secret Filtering", () => {
+    it("should not inject api-token connector secret when connector is not in allowedConnectorTypes", async () => {
+      const agentName = uniqueId("conn-agent");
+      await createTestCompose(agentName, {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            AXIOM_TOKEN: "${{ secrets.AXIOM_TOKEN }}",
+          },
+        },
+      });
+      const connAgentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      // User has the AXIOM_TOKEN secret stored, but no user_connector permission for axiom
+      await createTestSecret("AXIOM_TOKEN", "my-axiom-token");
+
+      const result = await createZeroRun(baseParams({ agentId: connAgentId }));
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      // Real secret value must not leak — the template stays unresolved
+      expect(job!.executionContext.environment?.["AXIOM_TOKEN"]).not.toBe(
+        "my-axiom-token",
+      );
+    });
+
+    it("should inject api-token connector secret when connector is in allowedConnectorTypes", async () => {
+      const agentName = uniqueId("conn-agent");
+      await createTestCompose(agentName, {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            AXIOM_TOKEN: "${{ secrets.AXIOM_TOKEN }}",
+          },
+        },
+      });
+      const connAgentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      // User has the secret AND the connector permission for this agent
+      await createTestSecret("AXIOM_TOKEN", "my-axiom-token");
+      await createTestUserConnector(
+        user.orgId,
+        user.userId,
+        connAgentId,
+        "axiom",
+      );
+
+      const result = await createZeroRun(baseParams({ agentId: connAgentId }));
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      // AXIOM_TOKEN should be resolved (firewall gateway replaces with placeholder)
+      expect(job!.executionContext.environment?.["AXIOM_TOKEN"]).not.toBe(
+        "${{ secrets.AXIOM_TOKEN }}",
+      );
+    });
+
+    it("should not filter custom user secrets that do not belong to any connector", async () => {
+      const agentName = uniqueId("conn-agent");
+      await createTestCompose(agentName, {
+        overrides: {
+          environment: {
+            ANTHROPIC_API_KEY: "test-api-key",
+            MY_CUSTOM_SECRET: "${{ secrets.MY_CUSTOM_SECRET }}",
+          },
+        },
+      });
+      const connAgentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      // Custom secret that doesn't belong to any connector type
+      await createTestSecret("MY_CUSTOM_SECRET", "custom-value");
+
+      const result = await createZeroRun(baseParams({ agentId: connAgentId }));
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      // Custom secrets should always pass through regardless of connector permissions
+      expect(job!.executionContext.environment).toMatchObject({
+        MY_CUSTOM_SECRET: "custom-value",
       });
     });
   });

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -23,6 +23,7 @@ import {
   getConnectorFirewall,
   isFirewallConnectorType,
   resolveFirewallBaseUrlVars,
+  getConnectorProvidedSecretNames,
 } from "@vm0/core";
 import { agentComposeVersions } from "../../db/schema/agent-compose";
 import {
@@ -587,6 +588,47 @@ async function fetchReferencedSecrets(
 }
 
 /**
+ * Filter dbSecrets to remove env vars that belong to connectors not in allowedConnectorTypes.
+ * Custom user secrets (not owned by any connector) pass through unfiltered.
+ * When allowedConnectorTypes is undefined (e.g. CLI runs), no filtering is applied.
+ */
+function filterDbSecretsByConnectorPermissions(
+  dbSecrets: Record<string, string> | undefined,
+  allApiTokenTypes: ConnectorType[],
+  allowedConnectorTypes: ConnectorType[] | undefined,
+): Record<string, string> | undefined {
+  if (!dbSecrets || !allowedConnectorTypes) {
+    return dbSecrets;
+  }
+
+  // Compute the set of env var names belonging to ALL api-token connectors the user has.
+  const allConnectorEnvVars = getConnectorProvidedSecretNames(allApiTokenTypes);
+  // Compute the set of env var names belonging to ALLOWED connectors only.
+  const allowedApiTokenTypes = allApiTokenTypes.filter((t) => {
+    return allowedConnectorTypes.includes(t);
+  });
+  const allowedEnvVars = getConnectorProvidedSecretNames(allowedApiTokenTypes);
+  // Disallowed = belongs to a connector but not an allowed one.
+  const disallowed = new Set(
+    [...allConnectorEnvVars].filter((name) => {
+      return !allowedEnvVars.has(name);
+    }),
+  );
+
+  if (disallowed.size === 0) {
+    return dbSecrets;
+  }
+
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(dbSecrets)) {
+    if (!disallowed.has(key)) {
+      filtered[key] = value;
+    }
+  }
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
+/**
  * Fetch server-stored variables and merge with CLI-provided vars
  * Priority: CLI vars > server-stored vars
  *
@@ -777,19 +819,29 @@ async function resolveSecretsAndEnvironment(
     ...new Set([...oauthResult.connectorTypes, ...rawApiTokenTypes]),
   ];
 
+  // Filter dbSecrets: strip env vars that belong to disallowed connectors.
+  // Without this, api-token connector secrets (e.g. AXIOM_TOKEN) would leak
+  // into the run context even when the agent doesn't have that connector enabled.
+  // Custom user secrets (not owned by any connector) are never filtered.
+  const filteredDbSecrets = filterDbSecretsByConnectorPermissions(
+    dbSecrets,
+    apiTokenTypes,
+    allowedConnectorTypes,
+  );
+
   // Single secrets map with explicit priority (later overrides earlier).
   // Only mapped env vars from connectors are included — raw connector secrets
   // (including refresh tokens) are kept server-side and never sent to the runner.
   const hasSecrets =
     oauthResult.resolvedSecrets ||
     modelProviderResult.secrets ||
-    dbSecrets ||
+    filteredDbSecrets ||
     cliSecrets;
   const secrets: Record<string, string> | undefined = hasSecrets
     ? {
         ...oauthResult.resolvedSecrets, // connector env mappings (e.g. GITHUB_TOKEN)
         ...modelProviderResult.secrets, // model provider
-        ...dbSecrets, // DB user secrets
+        ...filteredDbSecrets, // DB user secrets (connector secrets filtered)
         ...cliSecrets, // highest: CLI --secrets
       }
     : undefined;


### PR DESCRIPTION
## Summary

- Api-token connector secrets (e.g. `AXIOM_TOKEN`) were injected into the run context even when the agent didn't have that connector enabled via `user_connectors`
- Root cause: `fetchReferencedSecrets()` fetches ALL user secrets without filtering by `allowedConnectorTypes`, unlike `resolveOauthConnectorSecrets()` which already respects this
- Added `filterDbSecretsByConnectorPermissions()` to strip env vars belonging to disallowed connectors before merging into the final secrets map
- Custom user secrets (not owned by any connector) pass through unfiltered

## Test plan

- [x] Integration test: disallowed connector secret is NOT injected (real value does not leak)
- [x] Integration test: allowed connector secret IS injected (resolved through firewall gateway)
- [x] Integration test: custom user secrets unrelated to connectors pass through unfiltered
- [x] All existing build-zero-context tests continue to pass (10/10)
- [x] Type check, lint, format, knip all pass

Closes #7583

🤖 Generated with [Claude Code](https://claude.com/claude-code)