### PR TITLE
refactor: move model provider resolution from infra to zero layer

### DIFF
--- a/turbo/apps/web/src/lib/run/resolvers/resolve-session.ts
+++ b/turbo/apps/web/src/lib/run/resolvers/resolve-session.ts
@@ -4,7 +4,6 @@ import {
   agentComposeVersions,
 } from "../../../db/schema/agent-compose";
 import { agentRuns } from "../../../db/schema/agent-run";
-import { zeroRuns } from "../../../db/schema/zero-run";
 import { notFound, unauthorized, badRequest } from "../../errors";
 import { logger } from "../../logger";
 import { getAgentSessionWithConversation } from "../../agent-session";
@@ -107,14 +106,12 @@ export async function resolveSession(
       conversation.cliAgentSessionHistoryHash,
       conversation.cliAgentSessionHistory,
     ),
-    // Last run vars and model provider as fallback for continue operations
+    // Last run vars as fallback for continue operations
     globalThis.services.db
       .select({
         vars: agentRuns.vars,
-        modelProvider: zeroRuns.modelProvider,
       })
       .from(agentRuns)
-      .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
       .where(eq(agentRuns.id, conversation.runId))
       .limit(1),
   ]);
@@ -139,6 +136,6 @@ export async function resolveSession(
     vars: lastRunVars,
     volumeVersions: undefined,
     buildResumeArtifact: !!session.artifactName,
-    originalModelProvider: lastRun?.modelProvider ?? undefined,
+    previousRunId: conversation.runId,
   };
 }

--- a/turbo/apps/web/src/lib/run/resolvers/types.ts
+++ b/turbo/apps/web/src/lib/run/resolvers/types.ts
@@ -19,6 +19,6 @@ export interface ConversationResolution {
   vars?: Record<string, string>;
   volumeVersions?: Record<string, string>;
   buildResumeArtifact: boolean;
-  /** Model provider from the previous run (null for runs before provider tracking) */
-  originalModelProvider?: string;
+  /** Run ID from the previous conversation (used by zero layer for provider compatibility) */
+  previousRunId?: string;
 }

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -25,6 +25,7 @@ import {
   resolveFirewallBaseUrlVars,
 } from "@vm0/core";
 import { agentComposeVersions } from "../../db/schema/agent-compose";
+import { zeroRuns } from "../../db/schema/zero-run";
 import {
   badRequest,
   notFound,
@@ -1096,7 +1097,7 @@ export async function buildZeroExecutionContext(
 
   // Step 4: Resolve secrets, user preferences in parallel.
   const resolveSecretsStart = Date.now();
-  const [secretsResult, userPrefs] = await Promise.all([
+  const [secretsResult, userPrefs, originalModelProvider] = await Promise.all([
     resolveSecretsAndEnvironment(
       params.orgId,
       agentCompose,
@@ -1110,6 +1111,17 @@ export async function buildZeroExecutionContext(
     params.userId
       ? getUserPreferences(params.orgId, params.userId)
       : Promise.resolve(null),
+    // Zero-layer concern: fetch previous run's model provider for compatibility check
+    resolution?.previousRunId
+      ? globalThis.services.db
+          .select({ modelProvider: zeroRuns.modelProvider })
+          .from(zeroRuns)
+          .where(eq(zeroRuns.id, resolution.previousRunId))
+          .limit(1)
+          .then(([row]) => {
+            return row?.modelProvider ?? undefined;
+          })
+      : Promise.resolve(undefined),
   ]);
   const resolveSecretsEnd = Date.now();
 
@@ -1129,11 +1141,11 @@ export async function buildZeroExecutionContext(
   // When resuming a session, verify the new provider is compatible with the
   // original provider to avoid mid-conversation base URL mismatches.
   if (
-    resolution?.originalModelProvider &&
+    originalModelProvider &&
     resolvedModelProvider &&
-    resolution.originalModelProvider in MODEL_PROVIDER_TYPES
+    originalModelProvider in MODEL_PROVIDER_TYPES
   ) {
-    const originalType = resolution.originalModelProvider as ModelProviderType;
+    const originalType = originalModelProvider as ModelProviderType;
     const newType = resolvedModelProvider as ModelProviderType;
     if (!areProvidersCompatible(originalType, newType)) {
       const originalLabel = MODEL_PROVIDER_TYPES[originalType].label;


### PR DESCRIPTION
## Summary

- Remove `zeroRuns` LEFT JOIN from `resolve-session.ts` (infra layer), eliminating the reverse dependency on the zero layer
- Replace `originalModelProvider` with `previousRunId` on `ConversationResolution` type — infra provides a generic run ID, zero layer handles the zero-specific lookup
- Move model provider query to `build-zero-context.ts` (zero layer), running in parallel with secrets resolution

Closes #7591

## Test plan

- [x] TypeScript type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Format check passes (`pnpm format`)
- [x] `build-zero-context.test.ts` — all 7 tests pass
- [x] `src/lib/run/` tests — all 84 tests pass
- [x] Knip analysis — no new issues
- [x] Grep verification: no `zeroRuns` in `resolve-session.ts`, no `originalModelProvider` in `src/lib/run/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)