### PR TITLE
refactor: remove org-slug parsing from default agent resolution

### DIFF
--- a/turbo/apps/web/src/env.ts
+++ b/turbo/apps/web/src/env.ts
@@ -54,7 +54,7 @@ function initEnv() {
       SLACK_CLIENT_ID: z.string().min(1).optional(),
       SLACK_CLIENT_SECRET: z.string().min(1).optional(),
       SLACK_SIGNING_SECRET: z.string().min(1).optional(),
-      VM0_DEFAULT_AGENT: z.string().min(1).optional(), // Default agent for new integrations (format: "org/name")
+      VM0_DEFAULT_AGENT: z.string().min(1).optional(), // Default agent compose/agent UUID for new integrations
       // Ahrefs OAuth (for connector)
       AHREFS_OAUTH_CLIENT_ID: z.string().min(1).optional(),
       AHREFS_OAUTH_CLIENT_SECRET: z.string().min(1).optional(),

--- a/turbo/apps/web/src/lib/agent-compose/resolve-default.ts
+++ b/turbo/apps/web/src/lib/agent-compose/resolve-default.ts
@@ -1,58 +1,14 @@
-import { eq, and } from "drizzle-orm";
 import { env } from "../../env";
-import { agentComposes } from "../../db/schema/agent-compose";
-import { getOrgBySlug } from "../org/org-cache-service";
-import { logger } from "../logger";
-
-const log = logger("agent-compose:resolve-default");
 
 /**
  * Resolve the default agent compose ID from VM0_DEFAULT_AGENT env var.
- * Format: "org-slug/agent-name" (e.g. "yuma/deep-dive")
  *
- * Returns the compose ID if found, or null.
+ * The env var should contain a direct agent/compose UUID.
+ * Since zero_agents.id = agentComposes.id (unified PK), the returned
+ * value can be used as both agentId and composeId.
+ *
+ * Returns the compose ID if set, or null.
  */
-export async function resolveDefaultAgentComposeId(): Promise<string | null> {
-  const { VM0_DEFAULT_AGENT } = env();
-  if (!VM0_DEFAULT_AGENT) {
-    log.warn("VM0_DEFAULT_AGENT env var is not set");
-    return null;
-  }
-
-  const [orgSlug, agentName] = VM0_DEFAULT_AGENT.split("/");
-  if (!orgSlug || !agentName) {
-    log.warn("VM0_DEFAULT_AGENT has invalid format, expected 'org/name'", {
-      value: VM0_DEFAULT_AGENT,
-    });
-    return null;
-  }
-
-  const orgData = await getOrgBySlug(orgSlug);
-
-  if (!orgData) {
-    log.warn("Org not found for VM0_DEFAULT_AGENT", { orgSlug });
-    return null;
-  }
-
-  const [compose] = await globalThis.services.db
-    .select({ id: agentComposes.id })
-    .from(agentComposes)
-    .where(
-      and(
-        eq(agentComposes.orgId, orgData.orgId),
-        eq(agentComposes.name, agentName),
-      ),
-    )
-    .limit(1);
-
-  if (!compose) {
-    log.warn("Agent compose not found for VM0_DEFAULT_AGENT", {
-      orgSlug,
-      agentName,
-      orgId: orgData.orgId,
-    });
-    return null;
-  }
-
-  return compose.id;
+export function resolveDefaultAgentComposeId(): string | null {
+  return env().VM0_DEFAULT_AGENT ?? null;
 }

--- a/turbo/apps/web/src/lib/zero/resolve-default-agent.ts
+++ b/turbo/apps/web/src/lib/zero/resolve-default-agent.ts
@@ -1,11 +1,6 @@
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { env } from "../../env";
 import { orgMetadata } from "../../db/schema/org-metadata";
-import { zeroAgents } from "../../db/schema/zero-agent";
-import { getOrgBySlug } from "../org/org-cache-service";
-import { logger } from "../logger";
-
-const log = logger("zero:resolve-default-agent");
 
 /**
  * Resolve the default zero-layer agent ID for an org.
@@ -14,8 +9,8 @@ const log = logger("zero:resolve-default-agent");
  * Since zero_agents.id = agentComposes.id (composeId), the returned
  * value can be used directly as both agentId and composeId.
  *
- * Fallback path: parses VM0_DEFAULT_AGENT env var ("org-slug/agent-name"),
- * resolves the org, then queries zero_agents directly by (orgId, name).
+ * Fallback path: returns VM0_DEFAULT_AGENT env var value directly
+ * (expected to be an agent/compose UUID).
  *
  * Returns the agent/compose ID or null if no default agent is configured.
  */
@@ -30,55 +25,16 @@ export async function resolveDefaultAgentId(
 
   if (orgRow?.defaultAgentId) return orgRow.defaultAgentId;
 
-  // Fallback: resolve via VM0_DEFAULT_AGENT env var → zero_agents directly
+  // Fallback: return VM0_DEFAULT_AGENT env var directly (agent/compose UUID)
   return resolveDefaultAgentIdFromEnv();
 }
 
 /**
  * Resolve the default agent ID from the VM0_DEFAULT_AGENT env var.
- * Format: "org-slug/agent-name" (e.g. "yuma/deep-dive")
- *
- * Queries zero_agents directly by (orgId, name).
+ * The env var should contain a direct agent/compose UUID.
  */
-async function resolveDefaultAgentIdFromEnv(): Promise<string | null> {
-  const { VM0_DEFAULT_AGENT } = env();
-  if (!VM0_DEFAULT_AGENT) {
-    log.warn("VM0_DEFAULT_AGENT env var is not set");
-    return null;
-  }
-
-  const [orgSlug, agentName] = VM0_DEFAULT_AGENT.split("/");
-  if (!orgSlug || !agentName) {
-    log.warn("VM0_DEFAULT_AGENT has invalid format, expected 'org/name'", {
-      value: VM0_DEFAULT_AGENT,
-    });
-    return null;
-  }
-
-  const orgData = await getOrgBySlug(orgSlug);
-  if (!orgData) {
-    log.warn("Org not found for VM0_DEFAULT_AGENT", { orgSlug });
-    return null;
-  }
-
-  const [agent] = await globalThis.services.db
-    .select({ id: zeroAgents.id })
-    .from(zeroAgents)
-    .where(
-      and(eq(zeroAgents.orgId, orgData.orgId), eq(zeroAgents.name, agentName)),
-    )
-    .limit(1);
-
-  if (!agent) {
-    log.warn("Zero agent not found for VM0_DEFAULT_AGENT", {
-      orgSlug,
-      agentName,
-      orgId: orgData.orgId,
-    });
-    return null;
-  }
-
-  return agent.id;
+function resolveDefaultAgentIdFromEnv(): string | null {
+  return env().VM0_DEFAULT_AGENT ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Simplify `VM0_DEFAULT_AGENT` env var from `"org-slug/agent-name"` format to direct agent/compose UUID
- Remove `getOrgBySlug()` calls and slug parsing from both `resolveDefaultAgentComposeId()` and `resolveDefaultAgentIdFromEnv()`
- Eliminate unnecessary Clerk API lookups and database queries from resolve-default functions

## Changes
- `agent-compose/resolve-default.ts`: Simplified from 58 lines (slug parsing + DB query) to simple env var read
- `zero/resolve-default-agent.ts`: Simplified `resolveDefaultAgentIdFromEnv()` to direct env var read; `resolveDefaultAgentId(orgId)` unchanged (still queries org_metadata first)
- `env.ts`: Updated comment to reflect new UUID format

## Operational Note
After merging, update the GitHub Actions variable `vars.VM0_DEFAULT_AGENT` from `"org-slug/agent-name"` to the actual agent/compose UUID.

## Test plan
- [x] All pre-commit hooks pass (format, lint, knip, commitlint)
- [x] Type checking passes (`pnpm check-types`)
- [x] Telegram register tests pass (exercises fallback path)
- [x] GitHub OAuth tests pass (exercises fallback path)
- [x] No caller changes needed — same interface (`string | null`)

Closes #7592

🤖 Generated with [Claude Code](https://claude.com/claude-code)