### PR TITLE
fix(nbd-cow): address pr review findings

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1027,6 +1027,7 @@ jobs:
 
   runner-cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: [runner-build, runner-benchmark, runner-exec, runner-cancel, runner-balloon, runner-upgrade-local]
     if: ${{ always() && needs.runner-build.result != 'skipped' }}
     steps:

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -84,11 +84,17 @@
           if ! grep -q '^[0-9]' /sys/block/nbd*/pid 2>/dev/null; then
             modprobe -r nbd && modprobe nbd nbds_max=$WANT
           else
-            echo "WARNING: nbd module has wrong nbds_max but devices are in use, skipping reload" >&2
+            echo "nbd module has wrong nbds_max but devices are in use, skipping reload"
           fi
         fi
       become: true
       changed_when: false
+      register: nbd_load
+
+    - name: Warn if nbd module reload was skipped
+      debug:
+        msg: "{{ nbd_load.stdout }}"
+      when: nbd_load.stdout | default('') | length > 0
 
     # When groups change, the current SSH session still has the old group list.
     # Reset the connection so subsequent playbooks (deploy-runner) pick up the

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -61,13 +61,14 @@ impl NbdCowDevice {
         )?;
         let cow_layer = Arc::new(RwLock::new(cow_layer));
 
-        // Retry loop: on reconnect (same device index after a recent disconnect),
-        // the kernel may still be tearing down the old connection. The netlink
-        // CONNECT succeeds but set_capacity may not take effect (device size = 0).
-        // When detected, disconnect, recreate socketpairs + tasks, and retry.
-        // Fresh sockets and tasks are needed each attempt because the kernel may
-        // have started the NBD protocol on the old sockets; after disconnect the
-        // dispatch tasks exit and drop their server-side fds, making reuse unsafe.
+        // Retry loop: if the kernel is still tearing down a previous connection
+        // on the chosen device, the netlink CONNECT succeeds but set_capacity
+        // may not take effect (device size = 0). When detected, disconnect,
+        // recreate socketpairs + tasks, and retry. Each attempt picks a new
+        // random start offset so it will likely land on a different device.
+        // Fresh sockets and tasks are needed because the kernel may have started
+        // the NBD protocol on the old sockets; after disconnect the dispatch
+        // tasks exit and drop their server-side fds, making reuse unsafe.
         const MAX_CONNECT_RETRIES: u32 = 5;
         let mut last_err_idx: u32 = 0;
 
@@ -277,8 +278,8 @@ impl NbdCowDevice {
     /// The kernel records the connecting process's PID in `/sys/block/nbdN/pid`.
     /// If another process recycled the device index, the PID will differ and
     /// we must skip disconnect to avoid tearing down the other process's device.
-    /// Returns `Ok(true)` if we own the device, `Ok(false)` if not (with the
-    /// foreign PID), or `Err` if the pid file is unreadable.
+    /// Returns `Ok(true)` if we own the device, `Ok(false)` if another process
+    /// owns it, or `Err` if the pid file is unreadable.
     fn device_owned_by_us(&self) -> std::result::Result<bool, ()> {
         let pid_path = format!("/sys/block/nbd{}/pid", self.device_index);
         match std::fs::read_to_string(&pid_path) {

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -236,13 +236,21 @@ impl NbdCowDevice {
         // disconnect(device_index) would tear down the new owner's device.
         if !self.disconnected {
             self.disconnected = true;
-            if self.device_owned_by_us() {
-                netlink::disconnect(self.device_index)?;
-            } else {
-                tracing::warn!(
-                    device_index = self.device_index,
-                    "skipping disconnect: device recycled by another process"
-                );
+            match self.device_owned_by_us() {
+                Ok(true) => netlink::disconnect(self.device_index)?,
+                Ok(false) => {
+                    tracing::warn!(
+                        device_index = self.device_index,
+                        foreign_pid = self.device_foreign_pid(),
+                        "skipping disconnect: device recycled by another process"
+                    );
+                }
+                Err(()) => {
+                    tracing::warn!(
+                        device_index = self.device_index,
+                        "skipping disconnect: cannot read device pid"
+                    );
+                }
             }
         }
 
@@ -269,15 +277,25 @@ impl NbdCowDevice {
     /// The kernel records the connecting process's PID in `/sys/block/nbdN/pid`.
     /// If another process recycled the device index, the PID will differ and
     /// we must skip disconnect to avoid tearing down the other process's device.
-    fn device_owned_by_us(&self) -> bool {
+    /// Returns `Ok(true)` if we own the device, `Ok(false)` if not (with the
+    /// foreign PID), or `Err` if the pid file is unreadable.
+    fn device_owned_by_us(&self) -> std::result::Result<bool, ()> {
         let pid_path = format!("/sys/block/nbd{}/pid", self.device_index);
         match std::fs::read_to_string(&pid_path) {
             Ok(contents) => {
                 let pid: u32 = contents.trim().parse().unwrap_or(0);
-                pid == std::process::id()
+                Ok(pid == std::process::id())
             }
-            Err(_) => false,
+            Err(_) => Err(()),
         }
+    }
+
+    /// Read the foreign PID from sysfs for logging purposes.
+    fn device_foreign_pid(&self) -> Option<u32> {
+        let pid_path = format!("/sys/block/nbd{}/pid", self.device_index);
+        std::fs::read_to_string(&pid_path)
+            .ok()
+            .and_then(|s| s.trim().parse().ok())
     }
 
     fn bitmap_path(&self) -> PathBuf {
@@ -305,7 +323,7 @@ impl Drop for NbdCowDevice {
         // still own the device. Another runner's cleanup may have already
         // disconnected our index and a third runner may have recycled it.
         if !self.disconnected
-            && self.device_owned_by_us()
+            && self.device_owned_by_us() == Ok(true)
             && let Err(e) = netlink::disconnect(self.device_index)
         {
             tracing::warn!(

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -86,6 +86,17 @@ pub fn nbds_max() -> u32 {
         .unwrap_or(256)
 }
 
+/// Generate a random offset in `0..max` for device scanning.
+///
+/// Uses `RandomState` (OS-seeded) to avoid pulling in an external RNG crate.
+fn random_offset(max: u32) -> u32 {
+    if max == 0 {
+        return 0;
+    }
+    use std::hash::{BuildHasher, Hasher, RandomState};
+    (RandomState::new().build_hasher().finish() % max as u64) as u32
+}
+
 /// Check if a device index appears free by inspecting its pid file.
 fn device_appears_free(index: u32) -> bool {
     let pid_path = format!("/sys/block/nbd{index}/pid");
@@ -107,7 +118,10 @@ fn device_appears_free(index: u32) -> bool {
 
 /// Atomically find a free NBD device and connect it.
 ///
-/// Iterates candidate devices, attempts `connect` on each one that appears free.
+/// Starts from a random offset and wraps around, so concurrent runners don't
+/// all compete for the same low-numbered devices. This also avoids reconnecting
+/// to a device that was just disconnected (kernel may still be tearing it down).
+///
 /// If the kernel returns EBUSY (another process grabbed it first), tries the next
 /// device. This eliminates the TOCTOU race between find and connect.
 ///
@@ -123,7 +137,11 @@ pub fn find_and_connect(client_fds: &[OwnedFd], size: u64, block_size: u64) -> R
     let flags =
         NBD_FLAG_HAS_FLAGS | NBD_FLAG_SEND_FLUSH | NBD_FLAG_SEND_TRIM | NBD_FLAG_CAN_MULTI_CONN;
 
-    for i in 0..max {
+    // Random start offset to distribute device usage and avoid retrying
+    // a device that was just disconnected (kernel may still be cleaning up).
+    let start = random_offset(max);
+    for n in 0..max {
+        let i = (start + n) % max;
         if !device_appears_free(i) {
             continue;
         }

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -52,6 +52,9 @@ const CTRL_ATTR_FAMILY_ID: u16 = 1;
 const NLM_F_REQUEST: u16 = 1;
 const NLM_F_ACK: u16 = 4;
 
+/// Timeout (seconds) used for both `NBD_ATTR_TIMEOUT` and `NBD_ATTR_DEAD_CONN_TIMEOUT`.
+const TIMEOUT_SECS: u64 = 30;
+
 const NLMSG_ERROR: u16 = 2;
 
 /// Create a Unix socketpair for NBD communication.
@@ -136,15 +139,13 @@ pub fn find_and_connect(client_fds: &[OwnedFd], size: u64, block_size: u64) -> R
         attrs.extend_from_slice(&build_nla(NBD_ATTR_SERVER_FLAGS, &flags.to_ne_bytes()));
         // Per-request timeout: on expiry, kernel retries via another connection.
         // Also arms the blk-mq timer that drives dead-connection detection.
-        let request_timeout: u64 = 30;
-        attrs.extend_from_slice(&build_nla(NBD_ATTR_TIMEOUT, &request_timeout.to_ne_bytes()));
+        attrs.extend_from_slice(&build_nla(NBD_ATTR_TIMEOUT, &TIMEOUT_SECS.to_ne_bytes()));
         // Dead-connection timeout: if ALL connections are dead for this long
         // AND a request times out, the kernel auto-disconnects the device.
         // Handles orphan cleanup after SIGKILL (where Drop can't run).
-        let dead_conn_timeout: u64 = 30;
         attrs.extend_from_slice(&build_nla(
             NBD_ATTR_DEAD_CONN_TIMEOUT,
-            &dead_conn_timeout.to_ne_bytes(),
+            &TIMEOUT_SECS.to_ne_bytes(),
         ));
         attrs.extend_from_slice(&sockets_nla);
 


### PR DESCRIPTION
## Summary
- Log foreign PID in "skipping disconnect" warning for shared-host debugging
- Extract `TIMEOUT_SECS` constant to deduplicate `NBD_ATTR_TIMEOUT` and `NBD_ATTR_DEAD_CONN_TIMEOUT` values
- Surface ansible nbd module reload warning via `register` + `debug` instead of silent stderr
- Distinguish unreadable pid file (`Err`) from foreign ownership (`Ok(false)`) in `device_owned_by_us`

Addresses P1 and P2 findings from #7581 code review.

## Test plan
- [ ] `cargo clippy -p nbd-cow` passes
- [ ] Ansible playbook renders correctly with `--check` mode
- [ ] Verify warning log includes `foreign_pid` field when device is recycled

🤖 Generated with [Claude Code](https://claude.com/claude-code)