### PR TITLE
refactor: delete queued-run infra dispatcher and remove zero imports

### DIFF
--- a/turbo/apps/web/src/lib/run/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/credit-check.test.ts
@@ -13,12 +13,9 @@ import {
   insertTestZeroRun,
 } from "../../../__tests__/api-test-helpers";
 import { reloadEnv } from "../../../env";
-import {
-  startRun,
-  dispatchQueuedRun,
-  type CreateRunParams,
-} from "../run-service";
+import { startRun, type CreateRunParams } from "../run-service";
 import { drainOrgQueue, enqueueRun } from "../run-queue-service";
+import { dispatchQueuedZeroRun } from "../../zero/zero-queue-service";
 
 const context = testContext();
 
@@ -70,7 +67,7 @@ describe("credit check (infra queue path)", () => {
       await markRunningRunsAsCompleted(user.userId);
 
       // Drain queue
-      await drainOrgQueue(user.orgId, dispatchQueuedRun);
+      await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
 
       // Queued run should be marked as failed
       const run = await findTestRunRecord(queued.runId);
@@ -104,7 +101,7 @@ describe("credit check (infra queue path)", () => {
       await markRunningRunsAsCompleted(user.userId);
 
       // Drain queue
-      await drainOrgQueue(user.orgId, dispatchQueuedRun);
+      await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
 
       // Non-VM0 run should be dequeued normally
       const run = await findTestRunRecord(queued.runId);
@@ -139,7 +136,7 @@ describe("credit check (infra queue path)", () => {
       await markRunningRunsAsCompleted(user.userId);
 
       // Drain queue
-      await drainOrgQueue(user.orgId, dispatchQueuedRun);
+      await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
 
       // VM0 run should be failed
       const vm0 = await findTestRunRecord(vm0Run.runId);

--- a/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/run/__tests__/run-queue-service.test.ts
@@ -14,17 +14,14 @@ import {
   updateOrgTier,
 } from "../../../__tests__/api-test-helpers";
 import { reloadEnv } from "../../../env";
-import {
-  startRun,
-  dispatchQueuedRun,
-  type CreateRunParams,
-} from "../run-service";
+import { startRun, type CreateRunParams } from "../run-service";
 import {
   enqueueRun,
   drainOrgQueue,
   drainStaleQueues,
   cleanupExpiredQueueEntries,
 } from "../run-queue-service";
+import { dispatchQueuedZeroRun } from "../../zero/zero-queue-service";
 
 const context = testContext();
 
@@ -90,7 +87,7 @@ describe("run-queue-service", () => {
   describe("drainOrgQueue", () => {
     it("should be a no-op when queue is empty", async () => {
       // Should not throw
-      await drainOrgQueue(user.orgId, dispatchQueuedRun);
+      await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
     });
 
     it("should dequeue and execute the oldest entry", async () => {
@@ -110,7 +107,7 @@ describe("run-queue-service", () => {
       await markRunningRunsAsCompleted(user.userId);
 
       // Drain queue by orgId
-      await drainOrgQueue(user.orgId, dispatchQueuedRun);
+      await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
 
       // Queued run should now be dispatched (pending)
       const run = await findTestRunRecord(queued.runId);
@@ -179,7 +176,7 @@ describe("run-queue-service", () => {
       expect(queued.status).toBe("queued");
 
       // Drain without completing the running run — concurrency limit blocks dequeue
-      await drainOrgQueue(user.orgId, dispatchQueuedRun);
+      await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
 
       // Queue entry should still exist (nothing was dequeued)
       const queueEntry = await findTestQueueEntry(queued.runId);
@@ -358,7 +355,7 @@ describe("run-queue-service", () => {
       expect(run2.status).toBe("queued");
 
       // drainStaleQueues should NOT drain user2's queue (org has an active run)
-      await drainStaleQueues(dispatchQueuedRun);
+      await drainStaleQueues(dispatchQueuedZeroRun);
 
       // Queue entry should still exist — org-level concurrency prevented drain
       const queueEntry = await findTestQueueEntry(run2.runId);
@@ -396,7 +393,7 @@ describe("run-queue-service", () => {
       await markRunningRunsAsCompleted(user.userId);
 
       // drainStaleQueues should drain user2's queue
-      const drained = await drainStaleQueues(dispatchQueuedRun);
+      const drained = await drainStaleQueues(dispatchQueuedZeroRun);
       expect(drained).toBeGreaterThanOrEqual(1);
 
       // Queue entry should be consumed

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -27,7 +27,6 @@ import type { ExecutorResult, PreparedContext } from "./executors/types";
 import { generateSandboxToken } from "../auth/sandbox-token";
 import type { ExecutionContext, DispatchTimings } from "./types";
 import { buildZeroExecutionContext } from "../zero/build-zero-context";
-import { zeroRuns } from "../../db/schema/zero-run";
 import { buildInfraExecutionContext } from "./context/build-context";
 import { recordSandboxOperation } from "../metrics";
 import { canAccessCompose } from "../agent/compose-access";
@@ -555,7 +554,7 @@ export async function markRunFailed(
 
 /**
  * Shared dispatch pipeline for steps 6-10 of the run creation flow.
- * Used by both createRun (new runs) and dispatchQueuedRun (dequeued runs).
+ * Used by startRun (new runs) and dispatchQueuedZeroRun (dequeued runs).
  */
 export async function buildAndDispatchRun(opts: {
   runId: string;
@@ -1064,100 +1063,6 @@ export async function createRunRecord(
 }
 
 /**
- * Dispatch a previously queued run that has already been dequeued and
- * transitioned to "pending" by drainOrgQueue().
- *
- * Loads compose content, authorizes, and dispatches. Does NOT acquire
- * advisory lock or check concurrency — that is handled atomically in
- * the drain transaction.
- *
- * Called from drainOrgQueue() after the atomic dequeue + status update.
- */
-export async function dispatchQueuedRun(
-  runId: string,
-  params: CreateRunParams,
-  queueDispatcher?: (runId: string, params: CreateRunParams) => Promise<void>,
-): Promise<void> {
-  const apiStartTime = Date.now();
-  const { userId, agentComposeVersionId } = params;
-  const transactionTime = apiStartTime; // No separate transaction step
-
-  log.debug(`Dispatching queued run ${runId} for user ${userId}`);
-
-  // Load compose and authorize
-  const { composeContent, compose: queuedCompose } = await loadCompose(
-    agentComposeVersionId,
-    params.composeId,
-  );
-  authorizeCompose(userId, params.orgId, queuedCompose);
-  const authorizeTime = Date.now();
-
-  // Validate template vars and image access (for new runs only)
-  if (!params.checkpointId && !params.sessionId) {
-    await validateComposeRequirements(composeContent);
-  }
-
-  const sandboxToken = await generateSandboxToken(params.userId, runId);
-  const tokenTime = Date.now();
-
-  try {
-    // Register callbacks early so they persist even if context building fails
-    if (params.callbacks && params.callbacks.length > 0) {
-      await registerCallbacks(runId, params.callbacks);
-    }
-
-    const contextResult = await buildZeroExecutionContext({
-      ...params,
-      sandboxToken,
-      runId,
-      agentCompose: composeContent,
-      continuedFromSessionId: params.sessionId,
-    });
-
-    // Upsert zero_runs with resolved model fields before dispatch so metadata
-    // is recorded even if dispatch succeeds but a later step fails.
-    // Uses UPSERT to handle both cases: row exists (zero queued path creates
-    // it at enqueue time) and row doesn't exist (non-zero queued path).
-    // (reverse dependency — cleanup in later issue)
-    await globalThis.services.db
-      .insert(zeroRuns)
-      .values({
-        id: runId,
-        triggerSource: "api",
-        modelProvider: contextResult.resolvedModelProvider ?? null,
-        selectedModel: contextResult.selectedModel ?? null,
-      })
-      .onConflictDoUpdate({
-        target: zeroRuns.id,
-        set: {
-          modelProvider: contextResult.resolvedModelProvider ?? null,
-          selectedModel: contextResult.selectedModel ?? null,
-        },
-      });
-
-    await buildAndDispatchRun({
-      runId,
-      context: contextResult.context,
-      timings: {
-        apiStart: apiStartTime,
-        authorize: authorizeTime,
-        transaction: transactionTime,
-        token: tokenTime,
-        resolveSourceDuration: contextResult.timings.resolveSourceAndOrg,
-        resolveSecretsDuration: contextResult.timings.resolveSecrets,
-      },
-    });
-  } catch (error) {
-    const dispatcher = queueDispatcher ?? dispatchQueuedRun;
-    await markRunFailed(runId, error);
-    await drainOrgQueue(params.orgId, dispatcher).catch((drainErr) => {
-      log.error("Failed to drain org queue after run failure", { drainErr });
-    });
-    throw error;
-  }
-}
-
-/**
  * Get a run by ID, scoped to user and org for security.
  * Returns the run response object or null if not found.
  */
@@ -1273,10 +1178,7 @@ export async function cancelRun(
  */
 export async function dispatchCancelSideEffects(
   result: CancelRunResult,
-  queueDispatcher: (
-    runId: string,
-    params: CreateRunParams,
-  ) => Promise<void> = dispatchQueuedRun,
+  queueDispatcher: (runId: string, params: CreateRunParams) => Promise<void>,
 ): Promise<void> {
   const log = logger("service:run:cancel");
 

--- a/turbo/apps/web/src/lib/zero/zero-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-queue-service.ts
@@ -21,15 +21,19 @@ import { getCachedUser } from "../auth/user-cache-service";
 import {
   PENDING_RUN_TTL_MS,
   getEffectiveConcurrencyLimit,
-  dispatchQueuedRun,
   buildAndDispatchRun,
   loadCompose,
   authorizeCompose,
   validateComposeRequirements,
+  registerCallbacks,
+  markRunFailed,
 } from "../run/run-service";
 import type { CreateRunParams } from "../run/run-service";
+import { drainOrgQueue } from "../run/run-queue-service";
 import { generateZeroToken, generateSandboxToken } from "../auth/sandbox-token";
 import { buildZeroExecutionContext } from "./build-zero-context";
+import { buildInfraExecutionContext } from "../run/context/build-context";
+import { logger } from "../logger";
 import type { OrgTier, QueueResponse, TriggerSource } from "@vm0/core";
 
 /**
@@ -107,8 +111,56 @@ export async function dispatchQueuedZeroRun(
     return;
   }
 
-  // Non-zero path — delegate to infra dispatcher
-  return dispatchQueuedRun(runId, params, dispatchQueuedZeroRun);
+  // Non-zero path — build infra context and dispatch directly
+  const log = logger("zero:queue-service:non-zero");
+  const apiStartTime = Date.now();
+
+  const { composeContent, compose } = await loadCompose(
+    params.agentComposeVersionId,
+    params.composeId,
+  );
+  authorizeCompose(params.userId, params.orgId, compose);
+  const authorizeTime = Date.now();
+
+  if (!params.checkpointId && !params.sessionId) {
+    await validateComposeRequirements(composeContent);
+  }
+
+  const sandboxToken = await generateSandboxToken(params.userId, runId);
+  const tokenTime = Date.now();
+
+  try {
+    if (params.callbacks && params.callbacks.length > 0) {
+      await registerCallbacks(runId, params.callbacks);
+    }
+
+    const { context } = buildInfraExecutionContext({
+      ...params,
+      sandboxToken,
+      runId,
+      agentCompose: composeContent,
+      continuedFromSessionId: params.sessionId,
+    });
+
+    await buildAndDispatchRun({
+      runId,
+      context,
+      timings: {
+        apiStart: apiStartTime,
+        authorize: authorizeTime,
+        transaction: apiStartTime,
+        token: tokenTime,
+      },
+    });
+  } catch (error) {
+    await markRunFailed(runId, error);
+    await drainOrgQueue(params.orgId, dispatchQueuedZeroRun).catch(
+      (drainErr) => {
+        log.error("Failed to drain org queue after run failure", { drainErr });
+      },
+    );
+    throw error;
+  }
 }
 
 const RECENT_RUNS_FOR_ETA = 20;


### PR DESCRIPTION
## Summary

- Delete `dispatchQueuedRun()` from `run-service.ts` — the only remaining caller (`dispatchQueuedZeroRun` non-zero fallback) is inlined
- Inline non-zero fallback in `dispatchQueuedZeroRun()` using `buildInfraExecutionContext` (fixes bug where non-zero runs incorrectly used `buildZeroExecutionContext` and wrote to `zeroRuns` table)
- Remove `zeroRuns` import from `run-service.ts` (no more consumers)
- Make `dispatchCancelSideEffects()` `queueDispatcher` param required (all callers already pass explicit value)
- Update tests to use `dispatchQueuedZeroRun` instead of deleted `dispatchQueuedRun`

**Note:** `buildZeroExecutionContext` import remains in `run-service.ts` (still used by `startRun()` via `useZeroContext` flag) — tracked by parent epic #7152.

## Test plan

- [x] All 17 queue/credit tests pass with `dispatchQueuedZeroRun` as dispatcher
- [x] All 136 run+zero tests pass
- [x] Type check passes (`pnpm check-types --filter=web`)
- [x] Lint passes (`pnpm turbo run lint --filter=web`)
- [x] Knip clean (no unused exports)
- [x] `grep dispatchQueuedRun run-service.ts` returns no matches
- [x] `grep zeroRuns run-service.ts` returns no matches

Closes #7590

🤖 Generated with [Claude Code](https://claude.com/claude-code)