### PR TITLE
feat(claude): add pr-review-merge skill for sequential pr lifecycle

### DIFF
--- a/.claude/skills/pr-review-merge/SKILL.md
+++ b/.claude/skills/pr-review-merge/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: pr-review-merge
+description: Review PR, fix CI issues, and merge to main — runs pr-review-loop, pr-check-loop, and pr-merge-loop sequentially
+context: fork
+---
+
+# PR Review → Check → Merge
+
+You are a PR lifecycle specialist. Your role is to shepherd a pull request from review through CI to merge by running three skills in sequence.
+
+## Arguments
+
+Your args are: `$ARGUMENTS`
+
+Extract the PR number using these rules:
+1. **Args is a URL** containing `/pull/<number>` → extract `<number>`
+2. **Args is a plain number** → use it directly
+3. **Args is empty** → detect from current branch using `gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'`
+
+---
+
+## Workflow
+
+Run these three skills **sequentially**. Each skill must complete before starting the next. Pass the PR number as args to each skill.
+
+### Step 1: Review Loop
+
+```
+invoke skill /pr-review-loop <PR_NUMBER>
+```
+
+Iteratively review the PR, post findings, fix P0/P1 issues, and repeat until LGTM or max iterations.
+
+**If review ends with "Changes Requested (max iterations)"**: Stop here. Report that manual intervention is needed. Do NOT proceed to Step 2.
+
+### Step 2: Check Loop
+
+```
+invoke skill /pr-check-loop <PR_NUMBER>
+```
+
+Monitor CI pipeline, auto-fix lint/format issues, and loop until all checks pass.
+
+**If checks end with "Manual Fix Required" or "Timeout"**: Stop here. Report the failure. Do NOT proceed to Step 3.
+
+### Step 3: Merge Loop
+
+```
+invoke skill /pr-merge-loop <PR_NUMBER>
+```
+
+Add PR to merge queue, monitor progress, auto-recover from ejections and conflicts, and loop until merged.
+
+---
+
+## Summary
+
+After the workflow completes (or stops early), display:
+
+```
+PR Review-Merge Complete
+
+PR: #<number> - <title>
+Review:  <LGTM / Changes Requested>
+CI:      <All Passed / Failed / Skipped>
+Merge:   <Merged / Failed / Skipped>
+```
+
+If any step was skipped due to a prior failure, show "Skipped" for that step.


### PR DESCRIPTION
## Summary
- Add a new Claude Code skill (`pr-review-merge`) that orchestrates the full PR lifecycle by running `pr-review-loop`, `pr-check-loop`, and `pr-merge-loop` sequentially
- The skill accepts a PR number (or auto-detects from the current branch), shepherds the PR from review through CI to merge, and stops early if any step fails

## Test plan
- [ ] Verify the skill is discoverable via `/pr-review-merge`
- [ ] Test with a PR number argument to confirm it invokes the three sub-skills in order
- [ ] Confirm early termination when review or CI steps fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)