### PR TITLE
fix(monitoring): exclude nbd devices from alloy diskstats collection

### DIFF
--- a/ansible/playbooks/provision-monitoring.yml
+++ b/ansible/playbooks/provision-monitoring.yml
@@ -67,6 +67,9 @@
               "netdev", "os", "pressure", "processes",
               "uname", "vmstat",
             ]
+            disk {
+              device_exclude = `^(nbd|ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$`
+            }
             netdev {
               device_include = "^(en|eth|bond).*"
             }


### PR DESCRIPTION
## Summary

- Exclude `nbd*` devices from Alloy's `diskstats` collector via `disk.device_exclude`
- With `nbds_max=4096`, each nbd device generates ~20 disk metrics → ~80K series from nbd alone
- This exceeds Grafana Cloud Free tier's 10K series limit, causing persistent 429 rate limiting on all hosts
- Preserves default exclusions (ram, loop, fd, partitions) by extending the regex

## Test plan

- [ ] Deploy to dev-1 with `ansible-playbook` and verify Alloy restarts without errors
- [ ] Confirm `curl localhost:12345/metrics | grep -c nbd` returns 0
- [ ] Monitor Grafana Cloud series count drops from ~92K to <10K

🤖 Generated with [Claude Code](https://claude.com/claude-code)