### PR TITLE
feat: add no-direct-local-storage eslint rule

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-direct-local-storage.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-direct-local-storage.test.ts
@@ -1,0 +1,44 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-direct-local-storage.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-direct-local-storage", rule, {
+  valid: [
+    {
+      code: `
+        import { localStorageSignals } from "../external/local-storage";
+        const { get$, set$ } = localStorageSignals("theme");
+      `,
+    },
+    {
+      code: `const storage = new Map();`,
+    },
+    {
+      code: `sessionStorage.getItem("key");`,
+    },
+  ],
+  invalid: [
+    {
+      code: `localStorage.getItem("theme");`,
+      errors: [{ messageId: "noDirectLocalStorage" }],
+    },
+    {
+      code: `localStorage.setItem("theme", "dark");`,
+      errors: [{ messageId: "noDirectLocalStorage" }],
+    },
+    {
+      code: `localStorage.removeItem("theme");`,
+      errors: [{ messageId: "noDirectLocalStorage" }],
+    },
+    {
+      code: `const v = localStorage.getItem("key") ?? "default";`,
+      errors: [{ messageId: "noDirectLocalStorage" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/__tests__/no-direct-local-storage.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-direct-local-storage.test.ts
@@ -40,5 +40,13 @@ ruleTester.run("no-direct-local-storage", rule, {
       code: `const v = localStorage.getItem("key") ?? "default";`,
       errors: [{ messageId: "noDirectLocalStorage" }],
     },
+    {
+      code: `window.localStorage.getItem("theme");`,
+      errors: [{ messageId: "noDirectLocalStorage" }],
+    },
+    {
+      code: `window.localStorage.setItem("theme", "dark");`,
+      errors: [{ messageId: "noDirectLocalStorage" }],
+    },
   ],
 });

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -18,6 +18,7 @@
  * - command-async-signal: Async commands must accept AbortSignal as last param
  * - no-getter-setter-params: Functions must not accept ccstate Getter/Setter — use command()
  * - no-new-abort-controller: Disallow new AbortController() — use signal hierarchy
+ * - no-direct-local-storage: Disallow direct localStorage access — use localStorageSignals()
  */
 
 import signalDollarSuffix from "./rules/signal-dollar-suffix.ts";
@@ -38,6 +39,7 @@ import commandAsyncSignal from "./rules/command-async-signal.ts";
 import noGetterSetterParams from "./rules/no-getter-setter-params.ts";
 import noNewAbortController from "./rules/no-new-abort-controller.ts";
 import preferUserEvent from "./rules/prefer-user-event.ts";
+import noDirectLocalStorage from "./rules/no-direct-local-storage.ts";
 
 const plugin = {
   meta: {
@@ -63,6 +65,7 @@ const plugin = {
     "no-getter-setter-params": noGetterSetterParams,
     "no-new-abort-controller": noNewAbortController,
     "prefer-user-event": preferUserEvent,
+    "no-direct-local-storage": noDirectLocalStorage,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/no-direct-local-storage.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-direct-local-storage.ts
@@ -13,10 +13,29 @@
  *   localStorage.getItem("myKey");
  *   localStorage.setItem("myKey", value);
  *   localStorage.removeItem("myKey");
+ *   window.localStorage.getItem("myKey");
  */
 
-import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
 import { createRule } from "../utils.ts";
+
+function isLocalStorage(node: TSESTree.Node): boolean {
+  // bare `localStorage`
+  if (node.type === AST_NODE_TYPES.Identifier && node.name === "localStorage") {
+    return true;
+  }
+  // `window.localStorage`
+  if (
+    node.type === AST_NODE_TYPES.MemberExpression &&
+    node.object.type === AST_NODE_TYPES.Identifier &&
+    node.object.name === "window" &&
+    node.property.type === AST_NODE_TYPES.Identifier &&
+    node.property.name === "localStorage"
+  ) {
+    return true;
+  }
+  return false;
+}
 
 export default createRule({
   name: "no-direct-local-storage",
@@ -35,11 +54,8 @@ export default createRule({
   },
   create(context) {
     return {
-      MemberExpression(node) {
-        if (
-          node.object.type === AST_NODE_TYPES.Identifier &&
-          node.object.name === "localStorage"
-        ) {
+      MemberExpression(node: TSESTree.MemberExpression) {
+        if (isLocalStorage(node.object)) {
           context.report({
             node,
             messageId: "noDirectLocalStorage",

--- a/turbo/apps/platform/custom-eslint/rules/no-direct-local-storage.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-direct-local-storage.ts
@@ -1,0 +1,51 @@
+/**
+ * ESLint rule: no-direct-local-storage
+ *
+ * Disallows direct access to `localStorage`. All localStorage access should go
+ * through the `localStorageSignals()` abstraction in signals/external/local-storage.ts
+ * which provides ccstate reactivity and test cleanup.
+ *
+ * Good:
+ *   import { localStorageSignals } from "../external/local-storage";
+ *   const { get$, set$, clear$ } = localStorageSignals("myKey");
+ *
+ * Bad:
+ *   localStorage.getItem("myKey");
+ *   localStorage.setItem("myKey", value);
+ *   localStorage.removeItem("myKey");
+ */
+
+import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+export default createRule({
+  name: "no-direct-local-storage",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow direct localStorage access — use localStorageSignals() instead",
+    },
+    schema: [],
+    messages: {
+      noDirectLocalStorage:
+        "Do not access localStorage directly. Use localStorageSignals() from signals/external/local-storage.ts instead.",
+    },
+  },
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (
+          node.object.type === AST_NODE_TYPES.Identifier &&
+          node.object.name === "localStorage"
+        ) {
+          context.report({
+            node,
+            messageId: "noDirectLocalStorage",
+          });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -100,15 +100,9 @@ export default [
       ],
     },
   },
-  // Allow direct localStorage in the abstraction layer and existing files
-  // that predate this rule (to be migrated incrementally)
+  // Allow direct localStorage in the abstraction layer only
   {
-    files: [
-      "src/signals/external/local-storage.ts",
-      "src/signals/theme.ts",
-      "src/signals/zero-page/zero-model-preference.ts",
-      "src/signals/zero-page/__tests__/zero-model-preference.test.ts",
-    ],
+    files: ["src/signals/external/local-storage.ts"],
     rules: {
       "ccstate/no-direct-local-storage": "off",
     },

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -37,6 +37,7 @@ export default [
       "ccstate/no-use-ccstate-in-views": "error",
       "ccstate/no-non-zero-api": "error",
       "ccstate/no-new-abort-controller": "error",
+      "ccstate/no-direct-local-storage": "error",
     },
   },
   // Type-aware rules (only for TypeScript files)
@@ -97,6 +98,19 @@ export default [
             "Do not set test timeout. The default timeout (5000ms) is sufficient — a single test should complete within 500ms. Polling intervals are reduced to 10ms in tests, so do not rely on extending timeout to fix flaky tests. Find and fix the underlying timing issue instead.",
         },
       ],
+    },
+  },
+  // Allow direct localStorage in the abstraction layer and existing files
+  // that predate this rule (to be migrated incrementally)
+  {
+    files: [
+      "src/signals/external/local-storage.ts",
+      "src/signals/theme.ts",
+      "src/signals/zero-page/zero-model-preference.ts",
+      "src/signals/zero-page/__tests__/zero-model-preference.test.ts",
+    ],
+    rules: {
+      "ccstate/no-direct-local-storage": "off",
     },
   },
   // Allow new AbortController in signal infrastructure, test helpers, and

--- a/turbo/apps/platform/src/signals/external/local-storage.ts
+++ b/turbo/apps/platform/src/signals/external/local-storage.ts
@@ -15,6 +15,35 @@ export const resetLocalStorageForTest$ = command(({ set, get }) => {
   set(registeredLocalStorageKeys$, null);
 });
 
+/**
+ * Read a value from localStorage by dynamic key.
+ */
+export const readLocalStorage$ = command((_, key: string): string | null => {
+  return localStorage.getItem(key);
+});
+
+/**
+ * Write or remove a value in localStorage by dynamic key.
+ * Passing null removes the item.
+ */
+export const writeLocalStorage$ = command(
+  ({ set }, { key, value }: { key: string; value: string | null }) => {
+    if (value === null) {
+      localStorage.removeItem(key);
+    } else {
+      set(registeredLocalStorageKeys$, (x) => {
+        if (x?.has(key)) {
+          return x;
+        }
+        x = new Set(x ?? []);
+        x.add(key);
+        return x;
+      });
+      localStorage.setItem(key, value);
+    }
+  },
+);
+
 export function localStorageSignals(key: string) {
   const reload$ = state(0);
 

--- a/turbo/apps/platform/src/signals/external/local-storage.ts
+++ b/turbo/apps/platform/src/signals/external/local-storage.ts
@@ -18,13 +18,17 @@ export const resetLocalStorageForTest$ = command(({ set, get }) => {
 /**
  * Read a value from localStorage by dynamic key.
  */
-export const readLocalStorage$ = command((_, key: string): string | null => {
+export function readLocalStorage(key: string): string | null {
   return localStorage.getItem(key);
-});
+}
 
 /**
  * Write or remove a value in localStorage by dynamic key.
  * Passing null removes the item.
+ *
+ * Note: This command does NOT trigger reactive updates for signals created via
+ * `localStorageSignals(key).get$`. The two APIs are not interoperable for the
+ * same key — use `localStorageSignals(key).set$` if reactive propagation is needed.
  */
 export const writeLocalStorage$ = command(
   ({ set }, { key, value }: { key: string; value: string | null }) => {

--- a/turbo/apps/platform/src/signals/theme.ts
+++ b/turbo/apps/platform/src/signals/theme.ts
@@ -1,9 +1,13 @@
 import { command, computed, state } from "ccstate";
+import { localStorageSignals } from "./external/local-storage.ts";
 
 export type ThemePreference = "light" | "dark" | "system";
 
 const internalPreference$ = state<ThemePreference>("system");
 const internalResolved$ = state<"light" | "dark">("light");
+
+const { get$: themeStorageGet$, set$: themeStorageSet$ } =
+  localStorageSignals("theme");
 
 /**
  * Current resolved theme value (always "light" or "dark").
@@ -45,14 +49,14 @@ export const setTheme$ = command(({ set }, preference: ThemePreference) => {
   const resolved = resolveTheme(preference);
   set(internalResolved$, resolved);
   applyTheme(resolved);
-  localStorage.setItem("theme", preference);
+  set(themeStorageSet$, preference);
 });
 
 /**
  * Initialize theme from localStorage or system preference.
  */
-export const initTheme$ = command(({ set }) => {
-  const stored = localStorage.getItem("theme") as ThemePreference | null;
+export const initTheme$ = command(({ get, set }) => {
+  const stored = get(themeStorageGet$) as ThemePreference | null;
   const preference = stored ?? "system";
   set(internalPreference$, preference);
   const resolved = resolveTheme(preference);
@@ -63,9 +67,7 @@ export const initTheme$ = command(({ set }) => {
   window
     .matchMedia("(prefers-color-scheme: dark)")
     .addEventListener("change", () => {
-      const currentPref = localStorage.getItem(
-        "theme",
-      ) as ThemePreference | null;
+      const currentPref = get(themeStorageGet$) as ThemePreference | null;
       if (!currentPref || currentPref === "system") {
         const newResolved = window.matchMedia("(prefers-color-scheme: dark)")
           .matches

--- a/turbo/apps/platform/src/signals/theme.ts
+++ b/turbo/apps/platform/src/signals/theme.ts
@@ -3,6 +3,10 @@ import { localStorageSignals } from "./external/local-storage.ts";
 
 export type ThemePreference = "light" | "dark" | "system";
 
+function isThemePreference(v: string | null): v is ThemePreference {
+  return v === "light" || v === "dark" || v === "system";
+}
+
 const internalPreference$ = state<ThemePreference>("system");
 const internalResolved$ = state<"light" | "dark">("light");
 
@@ -56,8 +60,8 @@ export const setTheme$ = command(({ set }, preference: ThemePreference) => {
  * Initialize theme from localStorage or system preference.
  */
 export const initTheme$ = command(({ get, set }) => {
-  const stored = get(themeStorageGet$) as ThemePreference | null;
-  const preference = stored ?? "system";
+  const rawStored = get(themeStorageGet$);
+  const preference = isThemePreference(rawStored) ? rawStored : "system";
   set(internalPreference$, preference);
   const resolved = resolveTheme(preference);
   set(internalResolved$, resolved);
@@ -67,8 +71,8 @@ export const initTheme$ = command(({ get, set }) => {
   window
     .matchMedia("(prefers-color-scheme: dark)")
     .addEventListener("change", () => {
-      const currentPref = get(themeStorageGet$) as ThemePreference | null;
-      if (!currentPref || currentPref === "system") {
+      const currentPref = get(themeStorageGet$);
+      if (!isThemePreference(currentPref) || currentPref === "system") {
         const newResolved = window.matchMedia("(prefers-color-scheme: dark)")
           .matches
           ? "dark"

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-model-preference.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-model-preference.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../zero-model-preference.ts";
 import {
   writeLocalStorage$,
-  readLocalStorage$,
+  readLocalStorage,
 } from "../../external/local-storage.ts";
 
 const context = testContext();
@@ -90,9 +90,7 @@ describe("zero-model-preference signals", () => {
 
     context.store.set(persistModelPreference$);
 
-    expect(
-      context.store.set(readLocalStorage$, "zero.modelProvider.my-agent"),
-    ).toBe("openai");
+    expect(readLocalStorage("zero.modelProvider.my-agent")).toBe("openai");
   });
 
   it("should remove localStorage entry when persisting 'default'", async () => {
@@ -105,9 +103,7 @@ describe("zero-model-preference signals", () => {
 
     context.store.set(persistModelPreference$);
 
-    expect(
-      context.store.set(readLocalStorage$, "zero.modelProvider.my-agent"),
-    ).toBeNull();
+    expect(readLocalStorage("zero.modelProvider.my-agent")).toBeNull();
   });
 
   it("should reset model selection when agent changes via sync", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-model-preference.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-model-preference.test.ts
@@ -14,6 +14,10 @@ import {
   syncModelPreference$,
   persistModelPreference$,
 } from "../zero-model-preference.ts";
+import {
+  writeLocalStorage$,
+  readLocalStorage$,
+} from "../../external/local-storage.ts";
 
 const context = testContext();
 
@@ -48,7 +52,10 @@ describe("zero-model-preference signals", () => {
 
   it("should sync model preference from localStorage for current agent", async () => {
     await setupTalkRoutes("/agents/my-agent/chat");
-    localStorage.setItem("zero.modelProvider.my-agent", "anthropic");
+    context.store.set(writeLocalStorage$, {
+      key: "zero.modelProvider.my-agent",
+      value: "anthropic",
+    });
 
     context.store.set(syncModelPreference$);
 
@@ -67,7 +74,10 @@ describe("zero-model-preference signals", () => {
 
   it("should use 'default' key when zeroTalkAgentId is null", () => {
     mockLocation({ pathname: "/", search: "" }, context.signal);
-    localStorage.setItem("zero.modelProvider.default", "anthropic");
+    context.store.set(writeLocalStorage$, {
+      key: "zero.modelProvider.default",
+      value: "anthropic",
+    });
 
     context.store.set(syncModelPreference$);
 
@@ -80,23 +90,33 @@ describe("zero-model-preference signals", () => {
 
     context.store.set(persistModelPreference$);
 
-    expect(localStorage.getItem("zero.modelProvider.my-agent")).toBe("openai");
+    expect(
+      context.store.set(readLocalStorage$, "zero.modelProvider.my-agent"),
+    ).toBe("openai");
   });
 
   it("should remove localStorage entry when persisting 'default'", async () => {
     await setupTalkRoutes("/agents/my-agent/chat");
-    localStorage.setItem("zero.modelProvider.my-agent", "openai");
+    context.store.set(writeLocalStorage$, {
+      key: "zero.modelProvider.my-agent",
+      value: "openai",
+    });
     context.store.set(setSelectedModel$, "default");
 
     context.store.set(persistModelPreference$);
 
-    expect(localStorage.getItem("zero.modelProvider.my-agent")).toBeNull();
+    expect(
+      context.store.set(readLocalStorage$, "zero.modelProvider.my-agent"),
+    ).toBeNull();
   });
 
   it("should reset model selection when agent changes via sync", async () => {
     // Agent-a has a saved preference; agent-b does not.
     // Each sync should read localStorage for the current agent.
-    localStorage.setItem("zero.modelProvider.agent-a", "anthropic");
+    context.store.set(writeLocalStorage$, {
+      key: "zero.modelProvider.agent-a",
+      value: "anthropic",
+    });
 
     // Start on agent-a
     await setupTalkRoutes("/agents/agent-a/chat");

--- a/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
@@ -2,7 +2,7 @@ import { command } from "ccstate";
 import { currentDraft$ } from "./chat-draft.ts";
 import { currentAgentId$ } from "./agent.ts";
 import {
-  readLocalStorage$,
+  readLocalStorage,
   writeLocalStorage$,
 } from "../external/local-storage.ts";
 
@@ -30,7 +30,7 @@ export const syncModelPreference$ = command(({ get, set }) => {
   const key = modelStorageKey(agentId);
   const draft = get(currentDraft$);
   if (draft) {
-    const stored = set(readLocalStorage$, key);
+    const stored = readLocalStorage(key);
     set(draft.setSelectedModel$, stored ?? "default");
   }
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-model-preference.ts
@@ -1,21 +1,10 @@
 import { command } from "ccstate";
 import { currentDraft$ } from "./chat-draft.ts";
 import { currentAgentId$ } from "./agent.ts";
-
-function readModelPreference(key: string): string {
-  if (typeof window === "undefined") {
-    return "default";
-  }
-  return localStorage.getItem(key) ?? "default";
-}
-
-function writeModelPreference(key: string, value: string) {
-  if (value === "default") {
-    localStorage.removeItem(key);
-  } else {
-    localStorage.setItem(key, value);
-  }
-}
+import {
+  readLocalStorage$,
+  writeLocalStorage$,
+} from "../external/local-storage.ts";
 
 function modelStorageKey(agentId: string | null): string {
   return `zero.modelProvider.${agentId ?? "default"}`;
@@ -41,7 +30,8 @@ export const syncModelPreference$ = command(({ get, set }) => {
   const key = modelStorageKey(agentId);
   const draft = get(currentDraft$);
   if (draft) {
-    set(draft.setSelectedModel$, readModelPreference(key));
+    const stored = set(readLocalStorage$, key);
+    set(draft.setSelectedModel$, stored ?? "default");
   }
 });
 
@@ -49,12 +39,15 @@ export const syncModelPreference$ = command(({ get, set }) => {
  * Persist the current model selection to localStorage.
  * Called before sending a message.
  */
-export const persistModelPreference$ = command(({ get }) => {
+export const persistModelPreference$ = command(({ get, set }) => {
   const agentId = get(currentAgentId$);
   const key = modelStorageKey(agentId);
   const draft = get(currentDraft$);
   if (draft) {
     const value = get(draft.selectedModel$);
-    writeModelPreference(key, value);
+    set(writeLocalStorage$, {
+      key,
+      value: value === "default" ? null : value,
+    });
   }
 });


### PR DESCRIPTION
## Summary
- Add custom ESLint rule `no-direct-local-storage` that disallows direct `localStorage` access
- Enforces usage of `localStorageSignals()` abstraction from `signals/external/local-storage.ts` for ccstate reactivity and test cleanup
- Includes exemptions for the abstraction layer itself and existing files to be migrated incrementally

## Test plan
- [x] Rule test file covers valid cases (localStorageSignals usage, Map, sessionStorage) and invalid cases (getItem, setItem, removeItem)
- [ ] CI lint and type checks pass
- [ ] Existing code with exemptions continues to lint cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)