### PR TITLE
fix: clean up stale org slug references in docs and tests

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1408,7 +1408,7 @@ describe("GET /api/agent/runs - List Runs", () => {
     expect(prompts).not.toContain("Other org run");
   });
 
-  it("should filter by org when ?org= query param is provided", async () => {
+  it("should filter runs by org context", async () => {
     // Create a compose + run in a different org
     const otherOrg = await context.createAgentCompose(user.userId);
     await createTestRunInDb(user.userId, otherOrg.id, {

--- a/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
+++ b/turbo/apps/web/app/api/storages/__tests__/capability-enforcement.test.ts
@@ -232,11 +232,9 @@ describe("Storage capability enforcement", () => {
   describe("backward compatibility", () => {
     it("should accept CLI token without capabilities for list", async () => {
       const cliToken = await createTestCliToken(userId);
-      const orgSlug = `org-${userId.slice(-8)}`;
-
       const response = await listRoute(
         createTestRequest(
-          `http://localhost:3000/api/storages/list?type=artifact&org=${orgSlug}`,
+          `http://localhost:3000/api/storages/list?type=artifact`,
           { headers: { authorization: `Bearer ${cliToken}` } },
         ),
       );

--- a/turbo/apps/web/app/api/zero/org/members/credit-cap/route.ts
+++ b/turbo/apps/web/app/api/zero/org/members/credit-cap/route.ts
@@ -17,7 +17,7 @@ const updateBodySchema = z.object({
 });
 
 /**
- * GET /api/zero/org/members/credit-cap?org={slug}&userId={userId}
+ * GET /api/zero/org/members/credit-cap?userId={userId}
  *
  * Get a member's credit cap configuration.
  * Any org member can read.
@@ -53,7 +53,7 @@ export async function GET(request: Request) {
 }
 
 /**
- * PUT /api/zero/org/members/credit-cap?org={slug}
+ * PUT /api/zero/org/members/credit-cap
  *
  * Set or clear a member's credit cap.
  * Only org admins can update.

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -354,7 +354,7 @@ const composeListItemSchema = z.object({
  */
 export const composesListContract = c.router({
   /**
-   * GET /api/agent/composes/list?org={org}
+   * GET /api/agent/composes/list
    * List all agent composes for an org
    * Uses the authenticated user's active org.
    */


### PR DESCRIPTION
## Summary
- Remove outdated `?org={slug}` from JSDoc comments in credit-cap route (`GET` and `PUT`)
- Remove stale `?org={org}` from JSDoc in composes list contract
- Fix misleading test name in runs route test (was referencing `?org=` query param that isn't used)
- Remove dead `&org=` param from storages capability-enforcement test URL and unused `orgSlug` variable

## Test plan
- [x] Lint passes
- [x] Type check passes (pre-existing platform errors unrelated to this change)
- [x] Knip passes
- [x] No functional changes — JSDoc, test names, and test URLs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)