### PR TITLE
fix(cli): add token presence check to doctor missing-token command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
@@ -38,12 +38,39 @@ describe("zero doctor missing-token command", () => {
 
   beforeEach(() => {
     chalk.level = 0;
+    // Ensure the token is absent by default; individual tests can override.
+    vi.stubEnv("GH_TOKEN", "");
   });
 
   afterEach(() => {
     mockExit.mockClear();
     mockConsoleLog.mockClear();
     mockConsoleError.mockClear();
+  });
+
+  describe("token present in environment", () => {
+    it("should report token is present and still run connector checks", async () => {
+      vi.stubEnv("VM0_API_URL", "https://app.vm0.ai");
+      vi.stubEnv("VM0_TOKEN", "test-token");
+      vi.stubEnv("ZERO_AGENT_ID", "agent-abc-123");
+      vi.stubEnv("GH_TOKEN", "ghp_test123");
+      server.use(
+        http.get("https://app.vm0.ai/api/zero/connectors/github", () => {
+          return HttpResponse.json(connectedResponse);
+        }),
+        http.get(
+          "https://app.vm0.ai/api/zero/agents/agent-abc-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+      );
+
+      await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Sandbox env: present");
+    });
   });
 
   describe("connector not connected", () => {
@@ -69,9 +96,7 @@ describe("zero doctor missing-token command", () => {
       await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "GH_TOKEN is provided by the GitHub connector",
-      );
+      expect(logCalls).toContain("Sandbox env: not present");
       expect(logCalls).toContain("not connected");
       expect(logCalls).toContain(
         "[Connect GitHub](https://app.vm0.ai/connectors)",
@@ -99,9 +124,7 @@ describe("zero doctor missing-token command", () => {
       await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "GH_TOKEN is provided by the GitHub connector",
-      );
+      expect(logCalls).toContain("Sandbox env: not present");
       expect(logCalls).toContain("not authorized");
       expect(logCalls).toContain(
         "[Authorize GitHub](https://app.vm0.ai/team/agent-abc-123?tab=authorization)",
@@ -132,9 +155,7 @@ describe("zero doctor missing-token command", () => {
       await missingTokenCommand.parseAsync(["node", "cli", "GH_TOKEN"]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain(
-        "GH_TOKEN is provided by the GitHub connector",
-      );
+      expect(logCalls).toContain("Sandbox env: not present");
       expect(logCalls).toContain("expired");
       expect(logCalls).toContain("needs to be reconnected");
       expect(logCalls).toContain(
@@ -198,6 +219,7 @@ describe("zero doctor missing-token command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("connected and authorized");
       expect(logCalls).toContain("still missing");
+      expect(logCalls).toContain("Ask VM0 developer to resolve this issue");
       expect(logCalls).toContain(
         "[Check GitHub status](https://app.vm0.ai/connectors)",
       );

--- a/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
@@ -42,6 +42,12 @@ Notes:
       const platformUrl = toPlatformUrl(apiUrl);
       const agentId = process.env.ZERO_AGENT_ID;
 
+      // Check whether the token actually exists in the sandbox environment.
+      const tokenPresent = Boolean(process.env[tokenName]);
+      console.log(
+        `${tokenName} is provided by the ${label} connector. Sandbox env: ${tokenPresent ? "present" : "not present"}.`,
+      );
+
       // Check whether the user has connected this connector and whether the
       // agent has permission to use it. Run both checks in parallel.
       const [connector, enabledTypes] = await Promise.all([
@@ -58,8 +64,6 @@ Notes:
       const isConnected = connector !== null;
       const hasPermission =
         enabledTypes !== null && enabledTypes.includes(connectorType);
-
-      console.log(`${tokenName} is provided by the ${label} connector.`);
 
       if (!isConnected) {
         // Connector not connected at all — direct to connectors page
@@ -95,7 +99,7 @@ Notes:
         // Both connected and authorized — something else is wrong
         const url = `${platformUrl.origin}/connectors`;
         console.log(
-          `The ${label} connector is connected and authorized, but the token is still missing. Ask the user to check the connector status at: [Check ${label} status](${url})`,
+          `The ${label} connector is connected and authorized, but the token is still missing. Ask VM0 developer to resolve this issue. Connector status: [Check ${label} status](${url})`,
         );
       }
     }),


### PR DESCRIPTION
## Summary
- Add an early check in `zero doctor missing-token` that reports whether the token is actually present in the sandbox environment before running connector checks
- Add test coverage for the "token present" scenario
- Improve the error message when the connector is connected and authorized but the token is still missing, directing users to ask a VM0 developer for help

## Test plan
- [x] New test verifies the "token present" path reports `Sandbox env: present`
- [x] Existing tests updated to expect the new `Sandbox env: not present` output
- [x] Existing test for the "connected but still missing" case now asserts the improved error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)