### PR TITLE
chore: update rootfs-default.Dockerfile package versions

### DIFF
--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -56,7 +56,7 @@ RUN find /usr/lib -name libnssckbi.so -exec sh -c \
 # Install Claude Code CLI as a standalone Bun-compiled binary.
 # The binary bundles Bun runtime (JSC) + application code into a single executable,
 # eliminating module resolution overhead and reducing CLI cold-start time.
-ARG CLAUDE_CODE_VERSION=2.1.81
+ARG CLAUDE_CODE_VERSION=2.1.90
 RUN ARCH=$(dpkg --print-architecture) \
     && case "$ARCH" in amd64) PLATFORM="linux-x64" ;; arm64) PLATFORM="linux-arm64" ;; *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; esac \
     && GCS_BUCKET="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases" \
@@ -78,7 +78,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get install -y gh
 
 # Install Google Workspace CLI for Google Workspace service access
-ARG GWS_CLI_VERSION=0.22.0
+ARG GWS_CLI_VERSION=0.22.5
 RUN npm install -g @googleworkspace/cli@${GWS_CLI_VERSION}
 
 # Install xurl (X/Twitter official CLI) for X API access
@@ -103,7 +103,7 @@ ENV LANG=C.UTF-8
 # Install Chromium and agent-browser CLI for browser automation.
 # System Chromium is used on all architectures for version consistency.
 # Chromium binaries are loaded on demand, so they don't consume memory unless launched.
-ARG AGENT_BROWSER_VERSION=0.21.0
+ARG AGENT_BROWSER_VERSION=0.23.4
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
     && apt-get update \
     && apt-get install -y --no-install-recommends chromium


### PR DESCRIPTION
## Summary

Bump pinned package versions in `crates/runner/scripts/rootfs-default.Dockerfile` to their latest releases.

| Package | Old Version | New Version |
|---|---|---|
| `CLAUDE_CODE_VERSION` (`@anthropic-ai/claude-code`) | 2.1.81 | 2.1.90 |
| `GWS_CLI_VERSION` (`@googleworkspace/cli`) | 0.22.0 | 0.22.5 |
| `AGENT_BROWSER_VERSION` (`agent-browser`) | 0.21.0 | 0.23.4 |

`@xdevplatform/xurl` (1.0.3) is already at the latest version — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)