### PR TITLE
refactor: extract log search service and update logs contracts

### DIFF
--- a/turbo/apps/web/app/api/logs/search/route.ts
+++ b/turbo/apps/web/app/api/logs/search/route.ts
@@ -5,182 +5,20 @@ import {
 } from "../../../../src/lib/ts-rest-handler";
 import { logsSearchContract, type RunEvent } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
-import { and, eq, inArray, gte } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
+import { getDatasetName, DATASETS } from "../../../../src/lib/axiom";
 import {
-  queryAxiom,
-  getDatasetName,
-  DATASETS,
-} from "../../../../src/lib/axiom";
-
-const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
-
-interface AxiomAgentEvent {
-  _time: string;
-  runId: string;
-  userId: string;
-  sequenceNumber: number;
-  eventType: string;
-  eventData: unknown;
-}
-
-function escapeApl(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
-async function getAgentNames(
-  runIds: string[],
-  userId: string,
-  orgId: string,
-): Promise<Map<string, string>> {
-  const result = new Map<string, string>();
-  if (runIds.length === 0) return result;
-
-  const rows = await globalThis.services.db
-    .select({
-      runId: agentRuns.id,
-      composeName: agentComposes.name,
-    })
-    .from(agentRuns)
-    .leftJoin(
-      agentComposeVersions,
-      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-    )
-    .leftJoin(
-      agentComposes,
-      eq(agentComposeVersions.composeId, agentComposes.id),
-    )
-    .where(
-      and(
-        inArray(agentRuns.id, runIds),
-        eq(agentRuns.userId, userId),
-        eq(agentRuns.orgId, orgId),
-      ),
-    );
-
-  for (const row of rows) {
-    result.set(row.runId, row.composeName || "unknown");
-  }
-
-  return result;
-}
-
-async function getUserRunIds(
-  userId: string,
-  orgId: string,
-  since: Date,
-  agentName?: string,
-): Promise<string[]> {
-  const conditions = [
-    eq(agentRuns.userId, userId),
-    eq(agentRuns.orgId, orgId),
-    gte(agentRuns.createdAt, since),
-  ];
-
-  if (agentName) {
-    const rows = await globalThis.services.db
-      .select({ runId: agentRuns.id })
-      .from(agentRuns)
-      .leftJoin(
-        agentComposeVersions,
-        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
-      )
-      .leftJoin(
-        agentComposes,
-        eq(agentComposeVersions.composeId, agentComposes.id),
-      )
-      .where(and(...conditions, eq(agentComposes.name, agentName)));
-
-    return rows.map((r) => {
-      return r.runId;
-    });
-  }
-
-  const rows = await globalThis.services.db
-    .select({ runId: agentRuns.id })
-    .from(agentRuns)
-    .where(and(...conditions));
-
-  return rows.map((r) => {
-    return r.runId;
-  });
-}
-
-function buildRunIdFilter(runIds: string[]): string {
-  return runIds.length === 1
-    ? `| where runId == "${escapeApl(runIds[0]!)}"`
-    : `| where runId in (${runIds
-        .map((id) => {
-          return `"${escapeApl(id)}"`;
-        })
-        .join(", ")})`;
-}
-
-/**
- * Search events using Axiom's search operator which supports maps and arrays.
- * See: https://axiom.co/docs/apl/tabular-operators/search-operator
- */
-async function searchEventsInAxiom(
-  dataset: string,
-  sinceISO: string,
-  runIdFilter: string,
-  keyword: string,
-  limit: number,
-): Promise<AxiomAgentEvent[]> {
-  const apl = `['${dataset}']
-| where _time > datetime("${sinceISO}")
-${runIdFilter}
-| search "*${escapeApl(keyword)}*"
-| order by _time desc
-| limit ${limit + 1}`;
-
-  return queryAxiom<AxiomAgentEvent>(apl);
-}
-
-/**
- * Fetch context events (surrounding events by sequenceNumber) for matched events.
- */
-async function fetchContextEvents(
-  dataset: string,
-  matches: AxiomAgentEvent[],
-  before: number,
-  after: number,
-): Promise<Map<string, AxiomAgentEvent>> {
-  const contextMap = new Map<string, AxiomAgentEvent>();
-  if (before === 0 && after === 0) return contextMap;
-
-  const contextConditions = matches.map((match) => {
-    const seqMin = Math.max(0, match.sequenceNumber - before);
-    const seqMax = match.sequenceNumber + after;
-    return `(runId == "${escapeApl(match.runId)}" and sequenceNumber >= ${seqMin} and sequenceNumber <= ${seqMax})`;
-  });
-
-  const apl = `['${dataset}']
-| where ${contextConditions.join("\n  or ")}
-| order by runId asc, sequenceNumber asc`;
-
-  const contextEvents = await queryAxiom<AxiomAgentEvent>(apl);
-  for (const event of contextEvents) {
-    contextMap.set(`${event.runId}:${event.sequenceNumber}`, event);
-  }
-
-  return contextMap;
-}
-
-function toRunEvent(event: AxiomAgentEvent): RunEvent {
-  return {
-    sequenceNumber: event.sequenceNumber,
-    eventType: event.eventType,
-    eventData: event.eventData,
-    createdAt: event._time,
-  };
-}
+  SEVEN_DAYS_MS,
+  getUserRunIds,
+  searchEventsInAxiom,
+  fetchContextEvents,
+  getAgentNames,
+  buildRunIdFilter,
+  toRunEvent,
+} from "../../../../src/lib/run/log-search-service";
 
 const router = tsr.router(logsSearchContract, {
   searchLogs: async ({ query, headers }) => {

--- a/turbo/apps/web/src/lib/run/log-search-service.ts
+++ b/turbo/apps/web/src/lib/run/log-search-service.ts
@@ -1,0 +1,171 @@
+import type { RunEvent } from "@vm0/core";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../db/schema/agent-compose";
+import { agentRuns } from "../../db/schema/agent-run";
+import { and, eq, inArray, gte } from "drizzle-orm";
+import { queryAxiom } from "../axiom";
+
+export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface AxiomAgentEvent {
+  _time: string;
+  runId: string;
+  userId: string;
+  sequenceNumber: number;
+  eventType: string;
+  eventData: unknown;
+}
+
+function escapeApl(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export async function getAgentNames(
+  runIds: string[],
+  userId: string,
+  orgId: string,
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  if (runIds.length === 0) return result;
+
+  const rows = await globalThis.services.db
+    .select({
+      runId: agentRuns.id,
+      composeName: agentComposes.name,
+    })
+    .from(agentRuns)
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .leftJoin(
+      agentComposes,
+      eq(agentComposeVersions.composeId, agentComposes.id),
+    )
+    .where(
+      and(
+        inArray(agentRuns.id, runIds),
+        eq(agentRuns.userId, userId),
+        eq(agentRuns.orgId, orgId),
+      ),
+    );
+
+  for (const row of rows) {
+    result.set(row.runId, row.composeName || "unknown");
+  }
+
+  return result;
+}
+
+export async function getUserRunIds(
+  userId: string,
+  orgId: string,
+  since: Date,
+  agentName?: string,
+): Promise<string[]> {
+  const conditions = [
+    eq(agentRuns.userId, userId),
+    eq(agentRuns.orgId, orgId),
+    gte(agentRuns.createdAt, since),
+  ];
+
+  if (agentName) {
+    const rows = await globalThis.services.db
+      .select({ runId: agentRuns.id })
+      .from(agentRuns)
+      .leftJoin(
+        agentComposeVersions,
+        eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+      )
+      .leftJoin(
+        agentComposes,
+        eq(agentComposeVersions.composeId, agentComposes.id),
+      )
+      .where(and(...conditions, eq(agentComposes.name, agentName)));
+
+    return rows.map((r) => {
+      return r.runId;
+    });
+  }
+
+  const rows = await globalThis.services.db
+    .select({ runId: agentRuns.id })
+    .from(agentRuns)
+    .where(and(...conditions));
+
+  return rows.map((r) => {
+    return r.runId;
+  });
+}
+
+export function buildRunIdFilter(runIds: string[]): string {
+  return runIds.length === 1
+    ? `| where runId == "${escapeApl(runIds[0]!)}"`
+    : `| where runId in (${runIds
+        .map((id) => {
+          return `"${escapeApl(id)}"`;
+        })
+        .join(", ")})`;
+}
+
+/**
+ * Search events using Axiom's search operator which supports maps and arrays.
+ * See: https://axiom.co/docs/apl/tabular-operators/search-operator
+ */
+export async function searchEventsInAxiom(
+  dataset: string,
+  sinceISO: string,
+  runIdFilter: string,
+  keyword: string,
+  limit: number,
+): Promise<AxiomAgentEvent[]> {
+  const apl = `['${dataset}']
+| where _time > datetime("${sinceISO}")
+${runIdFilter}
+| search "*${escapeApl(keyword)}*"
+| order by _time desc
+| limit ${limit + 1}`;
+
+  return queryAxiom<AxiomAgentEvent>(apl);
+}
+
+/**
+ * Fetch context events (surrounding events by sequenceNumber) for matched events.
+ */
+export async function fetchContextEvents(
+  dataset: string,
+  matches: AxiomAgentEvent[],
+  before: number,
+  after: number,
+): Promise<Map<string, AxiomAgentEvent>> {
+  const contextMap = new Map<string, AxiomAgentEvent>();
+  if (before === 0 && after === 0) return contextMap;
+
+  const contextConditions = matches.map((match) => {
+    const seqMin = Math.max(0, match.sequenceNumber - before);
+    const seqMax = match.sequenceNumber + after;
+    return `(runId == "${escapeApl(match.runId)}" and sequenceNumber >= ${seqMin} and sequenceNumber <= ${seqMax})`;
+  });
+
+  const apl = `['${dataset}']
+| where ${contextConditions.join("\n  or ")}
+| order by runId asc, sequenceNumber asc`;
+
+  const contextEvents = await queryAxiom<AxiomAgentEvent>(apl);
+  for (const event of contextEvents) {
+    contextMap.set(`${event.runId}:${event.sequenceNumber}`, event);
+  }
+
+  return contextMap;
+}
+
+export function toRunEvent(event: AxiomAgentEvent): RunEvent {
+  return {
+    sequenceNumber: event.sequenceNumber,
+    eventType: event.eventType,
+    eventData: event.eventData,
+    createdAt: event._time,
+  };
+}

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -595,6 +595,7 @@ export {
   zeroRunAgentEventsContract,
   zeroRunContextContract,
   zeroRunNetworkLogsContract,
+  zeroLogsSearchContract,
   type ZeroRunsMainContract,
   type ZeroRunsByIdContract,
   type ZeroRunsCancelContract,
@@ -602,6 +603,7 @@ export {
   type ZeroRunAgentEventsContract,
   type ZeroRunContextContract,
   type ZeroRunNetworkLogsContract,
+  type ZeroLogsSearchContract,
   type RunContextResponse,
 } from "./zero-runs";
 export {

--- a/turbo/packages/core/src/contracts/logs.ts
+++ b/turbo/packages/core/src/contracts/logs.ts
@@ -130,6 +130,7 @@ export const logsListContract = c.router({
   list: {
     method: "GET",
     path: "/api/zero/logs",
+    headers: authHeadersSchema,
     query: listQuerySchema.extend({
       search: z.string().optional(),
       agent: z.string().optional(),

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -9,6 +9,7 @@ import {
   queueResponseSchema,
   unifiedRunRequestSchema,
   networkLogsResponseSchema,
+  logsSearchResponseSchema,
 } from "./runs";
 
 /**
@@ -246,10 +247,37 @@ export const zeroRunNetworkLogsContract = c.router({
   },
 });
 
+/**
+ * Zero logs search contract (GET /api/zero/logs/search)
+ * Search agent events across runs via zero token auth
+ */
+export const zeroLogsSearchContract = c.router({
+  searchLogs: {
+    method: "GET",
+    path: "/api/zero/logs/search",
+    headers: authHeadersSchema,
+    query: z.object({
+      keyword: z.string().min(1),
+      agent: z.string().optional(),
+      runId: z.string().optional(),
+      since: z.coerce.number().optional(),
+      limit: z.coerce.number().min(1).max(50).default(20),
+      before: z.coerce.number().min(0).max(10).default(0),
+      after: z.coerce.number().min(0).max(10).default(0),
+    }),
+    responses: {
+      200: logsSearchResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Search agent events across runs (zero proxy)",
+  },
+});
+
 // Inferred types from Zod schemas
 export type RunContextResponse = z.infer<typeof runContextResponseSchema>;
 
 // Type exports
+export type ZeroLogsSearchContract = typeof zeroLogsSearchContract;
 export type ZeroRunsMainContract = typeof zeroRunsMainContract;
 export type ZeroRunsByIdContract = typeof zeroRunsByIdContract;
 export type ZeroRunsCancelContract = typeof zeroRunsCancelContract;


### PR DESCRIPTION
## Summary

- Add `headers: authHeadersSchema` to `logsListContract` to enable CLI token auth
- Define `zeroLogsSearchContract` for `/api/zero/logs/search` endpoint
- Export new contract from `@vm0/core`
- Extract search helpers into shared `log-search-service.ts`
- Refactor existing `/api/logs/search` route to use shared service

Closes #7634

## Test plan

- [x] Existing 11 tests in `apps/web/app/api/logs/search/__tests__/route.test.ts` pass without modification
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Knip passes (`pnpm knip`)
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)