### PR TITLE
feat: enable zero token auth for logs endpoints and add search

### DIFF
--- a/turbo/apps/web/app/api/logs/search/route.ts
+++ b/turbo/apps/web/app/api/logs/search/route.ts
@@ -3,22 +3,11 @@ import {
   tsr,
   TsRestResponse,
 } from "../../../../src/lib/ts-rest-handler";
-import { logsSearchContract, type RunEvent } from "@vm0/core";
+import { logsSearchContract } from "@vm0/core";
 import { initServices } from "../../../../src/lib/init-services";
-import { agentRuns } from "../../../../src/db/schema/agent-run";
-import { and, eq } from "drizzle-orm";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
-import { getDatasetName, DATASETS } from "../../../../src/lib/axiom";
-import {
-  SEVEN_DAYS_MS,
-  getUserRunIds,
-  searchEventsInAxiom,
-  fetchContextEvents,
-  getAgentNames,
-  buildRunIdFilter,
-  toRunEvent,
-} from "../../../../src/lib/run/log-search-service";
+import { handleSearchLogs } from "../../../../src/lib/run/log-search-service";
 
 const router = tsr.router(logsSearchContract, {
   searchLogs: async ({ query, headers }) => {
@@ -37,117 +26,9 @@ const router = tsr.router(logsSearchContract, {
 
     const { org } = await resolveOrg(authCtx);
 
-    const { keyword, agent, runId, limit, before, after } = query;
-    const since = query.since ?? Date.now() - SEVEN_DAYS_MS;
-    const sinceDate = new Date(since);
-    const sinceISO = sinceDate.toISOString();
-    const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
+    const body = await handleSearchLogs(userId, org.orgId, query);
 
-    // Determine which run IDs to search (ownership verified via DB).
-    let targetRunIds: string[];
-    if (runId) {
-      const [run] = await globalThis.services.db
-        .select({ id: agentRuns.id })
-        .from(agentRuns)
-        .where(
-          and(
-            eq(agentRuns.id, runId),
-            eq(agentRuns.userId, userId),
-            eq(agentRuns.orgId, org.orgId),
-          ),
-        )
-        .limit(1);
-
-      if (!run) {
-        return {
-          status: 200 as const,
-          body: { results: [], hasMore: false },
-        };
-      }
-      targetRunIds = [runId];
-    } else {
-      targetRunIds = await getUserRunIds(userId, org.orgId, sinceDate, agent);
-      if (targetRunIds.length === 0) {
-        return {
-          status: 200 as const,
-          body: { results: [], hasMore: false },
-        };
-      }
-    }
-
-    const runIdFilter = buildRunIdFilter(targetRunIds);
-
-    const matchedEvents = await searchEventsInAxiom(
-      dataset,
-      sinceISO,
-      runIdFilter,
-      keyword,
-      limit,
-    );
-
-    if (matchedEvents.length === 0) {
-      return {
-        status: 200 as const,
-        body: { results: [], hasMore: false },
-      };
-    }
-
-    const hasMore = matchedEvents.length > limit;
-    const matches = hasMore ? matchedEvents.slice(0, limit) : matchedEvents;
-
-    // Fetch context events
-    const contextMap = await fetchContextEvents(
-      dataset,
-      matches,
-      before,
-      after,
-    );
-
-    // Assemble results
-    const matchedRunIds = [
-      ...new Set(
-        matches.map((e) => {
-          return e.runId;
-        }),
-      ),
-    ];
-    const agentNames = await getAgentNames(matchedRunIds, userId, org.orgId);
-
-    const results = matches.map((match) => {
-      const contextBefore: RunEvent[] = [];
-      const contextAfter: RunEvent[] = [];
-
-      for (
-        let i = match.sequenceNumber - before;
-        i < match.sequenceNumber;
-        i++
-      ) {
-        const event = contextMap.get(`${match.runId}:${i}`);
-        if (event) contextBefore.push(toRunEvent(event));
-      }
-
-      for (
-        let i = match.sequenceNumber + 1;
-        i <= match.sequenceNumber + after;
-        i++
-      ) {
-        const event = contextMap.get(`${match.runId}:${i}`);
-        if (event) contextAfter.push(toRunEvent(event));
-      }
-
-      return {
-        runId: match.runId,
-        agentName: agentNames.get(match.runId) || "unknown",
-        matchedEvent: toRunEvent(match),
-        contextBefore,
-        contextAfter,
-      };
-    });
-
-    return {
-      status: 200 as const,
-      body: { results, hasMore },
-    };
+    return { status: 200 as const, body };
   },
 });
 

--- a/turbo/apps/web/app/api/zero/logs/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/[id]/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
   completeTestRun,
   failTestRun,
   createOrphanTestRun,
+  insertOrgMembersCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -17,6 +18,10 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
+import {
+  generateZeroToken,
+  generateSandboxToken,
+} from "../../../../../../src/lib/auth/sandbox-token";
 
 vi.mock("@e2b/code-interpreter", () => {
   return {
@@ -265,5 +270,57 @@ describe("GET /api/zero/logs/[id]", () => {
     expect(data.prompt).toBe("Orphan run prompt");
     expect(data.agentId).toBeNull();
     expect(data.framework).toBeNull();
+  });
+
+  describe("zero token auth", () => {
+    it("should return 200 for zero token with agent-run:read capability", async () => {
+      const { runId } = await createTestRun(testComposeId, "Test prompt");
+      await completeTestRun(user.userId, runId);
+
+      await insertOrgMembersCacheEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+      });
+      mockClerk({ userId: null });
+      const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/logs/${runId}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.id).toBe(runId);
+    });
+
+    it("should return 403 for sandbox token without agent-run:read", async () => {
+      const { runId } = await createTestRun(testComposeId, "Test prompt");
+      const token = await generateSandboxToken(user.userId, runId);
+      mockClerk({ userId: null });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/logs/${runId}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error.message).toContain("agent-run:read");
+    });
+
+    it("should return 401 when no auth is provided", async () => {
+      const { runId } = await createTestRun(testComposeId, "Test prompt");
+      mockClerk({ userId: null });
+
+      const request = createTestRequest(
+        `http://localhost:3000/api/zero/logs/${runId}`,
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(401);
+    });
   });
 });

--- a/turbo/apps/web/app/api/zero/logs/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/[id]/route.ts
@@ -18,7 +18,10 @@ import {
 import { zeroAgents } from "../../../../../src/db/schema/zero-agent";
 import { zeroRuns } from "../../../../../src/db/schema/zero-run";
 import { alias } from "drizzle-orm/pg-core";
-import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 import { eq, and } from "drizzle-orm";
@@ -84,18 +87,6 @@ function extractArtifact(runResult: RunResult | null): {
   const name = Object.keys(runResult.artifact)[0] ?? null;
   const version = name ? (runResult.artifact[name] ?? null) : null;
   return { name, version };
-}
-
-/**
- * Create unauthorized response
- */
-function unauthorizedResponse() {
-  return {
-    status: 401 as const,
-    body: {
-      error: { message: "Not authenticated", code: "UNAUTHORIZED" },
-    },
-  };
 }
 
 /**
@@ -170,10 +161,10 @@ const router = tsr.router(logsByIdContract, {
   getById: async ({ params, headers }) => {
     initServices();
 
-    const authCtx = await getAuthContext(headers.authorization);
-    if (!authCtx) {
-      return unauthorizedResponse();
-    }
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
+    if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
     // Resolve active org from JWT / CLI token / default

--- a/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/__tests__/route.test.ts
@@ -9,12 +9,17 @@ import {
   createTestZeroAgent,
   createTestRun,
   completeTestRun,
+  insertOrgMembersCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import {
+  generateZeroToken,
+  generateSandboxToken,
+} from "../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -834,6 +839,53 @@ describe("GET /api/zero/logs", () => {
 
       expect(response.status).toBe(400);
       expect(data.error.code).toBe("BAD_REQUEST");
+    });
+  });
+
+  describe("zero token auth", () => {
+    it("should return 200 for zero token with agent-run:read capability", async () => {
+      await insertOrgMembersCacheEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+      });
+      mockClerk({ userId: null });
+      const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+
+      const request = createTestRequest("http://localhost:3000/api/zero/logs", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.data).toEqual([]);
+    });
+
+    it("should return 403 for sandbox token without agent-run:read", async () => {
+      const { composeId } = await createTestCompose(
+        `zero-auth-${randomUUID().slice(0, 8)}`,
+      );
+      const { runId } = await createTestRun(composeId, "test");
+      const token = await generateSandboxToken(user.userId, runId);
+      mockClerk({ userId: null });
+
+      const request = createTestRequest("http://localhost:3000/api/zero/logs", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const response = await GET(request);
+
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error.message).toContain("agent-run:read");
+    });
+
+    it("should return 401 when no auth is provided", async () => {
+      mockClerk({ userId: null });
+
+      const request = createTestRequest("http://localhost:3000/api/zero/logs");
+      const response = await GET(request);
+
+      expect(response.status).toBe(401);
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/logs/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/route.ts
@@ -25,7 +25,10 @@ import { zeroAgents } from "../../../../src/db/schema/zero-agent";
 import { zeroRuns } from "../../../../src/db/schema/zero-run";
 import { alias } from "drizzle-orm/pg-core";
 import { conversations } from "../../../../src/db/schema/conversation";
-import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { isNotFound, isForbidden } from "../../../../src/lib/errors";
 import {
@@ -222,18 +225,13 @@ async function getAvailableFilters(
 }
 
 const router = tsr.router(logsListContract, {
-  list: async ({ query }) => {
+  list: async ({ query, headers }) => {
     initServices();
 
-    const authCtx = await getAuthContext();
-    if (!authCtx) {
-      return {
-        status: 401 as const,
-        body: {
-          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
-        },
-      };
-    }
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
+    if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 
     const limit = query.limit ?? 20;

--- a/turbo/apps/web/app/api/zero/logs/search/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/logs/search/__tests__/route.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestRun,
+  createTestRunInDb,
+  insertOrgMembersCacheEntry,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import {
+  generateZeroToken,
+  generateSandboxToken,
+} from "../../../../../../src/lib/auth/sandbox-token";
+
+// Only mock external services
+vi.mock("@clerk/nextjs/server");
+vi.mock("@e2b/code-interpreter");
+vi.mock("@aws-sdk/client-s3");
+vi.mock("@aws-sdk/s3-request-presigner");
+vi.mock("@axiomhq/js");
+
+const context = testContext();
+
+function createAxiomAgentEvent(
+  runId: string,
+  sequenceNumber: number,
+  text: string,
+  timestamp = "2024-01-15T10:30:00Z",
+) {
+  return {
+    _time: timestamp,
+    runId,
+    userId: "test-user",
+    sequenceNumber,
+    eventType: "assistant",
+    eventData: {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text }],
+      },
+    },
+  };
+}
+
+describe("GET /api/zero/logs/search", () => {
+  let user: UserContext;
+  let testRunId: string;
+  let zeroToken: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+
+    const { composeId } = await createTestCompose(`test-search-${Date.now()}`);
+    const { runId } = await createTestRun(composeId, "Test prompt");
+    testRunId = runId;
+
+    // Pre-populate org_members_cache so zero token auth resolves org membership
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+    });
+
+    // Generate zero token and disable Clerk auth
+    zeroToken = await generateZeroToken(user.userId, "run-1", user.orgId);
+    mockClerk({ userId: null });
+  });
+
+  it("should return 401 when no auth is provided", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/logs/search?keyword=test",
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 403 for sandbox token without agent-run:read", async () => {
+    const token = await generateSandboxToken(user.userId, testRunId);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/logs/search?keyword=test",
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(403);
+    const data = await response.json();
+    expect(data.error.message).toContain("agent-run:read");
+  });
+
+  it("should return empty results when no matches", async () => {
+    context.mocks.axiom.queryAxiom.mockResolvedValue([]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/logs/search?keyword=nonexistent",
+      { headers: { Authorization: `Bearer ${zeroToken}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual([]);
+    expect(data.hasMore).toBe(false);
+  });
+
+  it("should return matched events without context", async () => {
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      createAxiomAgentEvent(testRunId, 3, "OOM killed"),
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/logs/search?keyword=OOM",
+      { headers: { Authorization: `Bearer ${zeroToken}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].runId).toBe(testRunId);
+    expect(data.results[0].matchedEvent.sequenceNumber).toBe(3);
+    expect(data.results[0].contextBefore).toEqual([]);
+    expect(data.results[0].contextAfter).toEqual([]);
+  });
+
+  it("should return matched events with context", async () => {
+    // First Axiom call: search returns matched event
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      createAxiomAgentEvent(
+        testRunId,
+        5,
+        "Error: OOM killed",
+        "2024-01-15T10:30:05Z",
+      ),
+    ]);
+
+    // Second Axiom call: context query returns surrounding events
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      createAxiomAgentEvent(
+        testRunId,
+        4,
+        "Building...",
+        "2024-01-15T10:30:04Z",
+      ),
+      createAxiomAgentEvent(
+        testRunId,
+        5,
+        "Error: OOM killed",
+        "2024-01-15T10:30:05Z",
+      ),
+      createAxiomAgentEvent(
+        testRunId,
+        6,
+        "Retrying...",
+        "2024-01-15T10:30:06Z",
+      ),
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/logs/search?keyword=OOM&before=1&after=1",
+      { headers: { Authorization: `Bearer ${zeroToken}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].matchedEvent.sequenceNumber).toBe(5);
+    expect(data.results[0].contextBefore).toHaveLength(1);
+    expect(data.results[0].contextBefore[0].sequenceNumber).toBe(4);
+    expect(data.results[0].contextAfter).toHaveLength(1);
+    expect(data.results[0].contextAfter[0].sequenceNumber).toBe(6);
+  });
+
+  it("should filter by runId when provided", async () => {
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      createAxiomAgentEvent(testRunId, 1, "Found it"),
+    ]);
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/zero/logs/search?keyword=Found&runId=${testRunId}`,
+      { headers: { Authorization: `Bearer ${zeroToken}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].runId).toBe(testRunId);
+
+    // Verify APL query includes runId filter
+    const aplQuery = context.mocks.axiom.queryAxiom.mock.calls[0]![0] as string;
+    expect(aplQuery).toContain(`runId == "${testRunId}"`);
+  });
+
+  it("should use search operator in axiom query for keyword search", async () => {
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      createAxiomAgentEvent(testRunId, 2, "deploy failed with error"),
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/logs/search?keyword=deploy+failed",
+      { headers: { Authorization: `Bearer ${zeroToken}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toHaveLength(1);
+
+    // Verify APL uses search operator
+    const aplQuery = context.mocks.axiom.queryAxiom.mock.calls[0]![0] as string;
+    expect(aplQuery).toContain('search "*deploy failed*"');
+  });
+
+  it("should filter by agent name via database lookup", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/logs/search?keyword=test&agent=nonexistent-agent",
+      { headers: { Authorization: `Bearer ${zeroToken}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual([]);
+    expect(context.mocks.axiom.queryAxiom).not.toHaveBeenCalled();
+  });
+
+  it("should set hasMore when results exceed limit", async () => {
+    const events = Array.from({ length: 5 }, (_, i) => {
+      return createAxiomAgentEvent(testRunId, i, `Match ${i}`);
+    });
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce(events);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/logs/search?keyword=Match&limit=2",
+      { headers: { Authorization: `Bearer ${zeroToken}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toHaveLength(2);
+    expect(data.hasMore).toBe(true);
+  });
+
+  it("should not return runs from a different org", async () => {
+    const currentUser = await context.setupUser();
+
+    // Create a compose + run in a different org
+    const otherOrg = await context.createAgentCompose(currentUser.userId);
+    const { runId: otherOrgRunId } = await createTestRunInDb(
+      currentUser.userId,
+      otherOrg.id,
+    );
+
+    // Generate token for current user's org
+    const token = await generateZeroToken(
+      currentUser.userId,
+      "run-1",
+      currentUser.orgId,
+    );
+    mockClerk({ userId: null });
+
+    // Mock Axiom to return events for the default org run only
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      createAxiomAgentEvent(testRunId, 1, "Default org event"),
+    ]);
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/logs/search?keyword=event",
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].runId).toBe(testRunId);
+
+    // Verify the Axiom APL query only contains the default org's run ID
+    const aplQuery = context.mocks.axiom.queryAxiom.mock.calls[0]![0] as string;
+    expect(aplQuery).toContain(testRunId);
+    expect(aplQuery).not.toContain(otherOrgRunId);
+  });
+
+  it("should return empty when searching by runId from a different org", async () => {
+    const currentUser = await context.setupUser();
+
+    // Create a run in a different org
+    const otherOrg = await context.createAgentCompose(currentUser.userId);
+    const { runId: otherOrgRunId } = await createTestRunInDb(
+      currentUser.userId,
+      otherOrg.id,
+    );
+
+    const token = await generateZeroToken(
+      currentUser.userId,
+      "run-1",
+      currentUser.orgId,
+    );
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/zero/logs/search?keyword=test&runId=${otherOrgRunId}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.results).toEqual([]);
+    expect(data.hasMore).toBe(false);
+    // Axiom should not be called since the run doesn't belong to the active org
+    expect(context.mocks.axiom.queryAxiom).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/web/app/api/zero/logs/search/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/search/route.ts
@@ -8,25 +8,14 @@ import {
   tsr,
   TsRestResponse,
 } from "../../../../../src/lib/ts-rest-handler";
-import { zeroLogsSearchContract, type RunEvent } from "@vm0/core";
+import { zeroLogsSearchContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
-import { agentRuns } from "../../../../../src/db/schema/agent-run";
-import { and, eq } from "drizzle-orm";
 import {
   requireAuth,
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { getDatasetName, DATASETS } from "../../../../../src/lib/axiom";
-import {
-  SEVEN_DAYS_MS,
-  getUserRunIds,
-  searchEventsInAxiom,
-  fetchContextEvents,
-  getAgentNames,
-  buildRunIdFilter,
-  toRunEvent,
-} from "../../../../../src/lib/run/log-search-service";
+import { handleSearchLogs } from "../../../../../src/lib/run/log-search-service";
 
 const router = tsr.router(zeroLogsSearchContract, {
   searchLogs: async ({ query, headers }) => {
@@ -40,117 +29,9 @@ const router = tsr.router(zeroLogsSearchContract, {
 
     const { org } = await resolveOrg(authCtx);
 
-    const { keyword, agent, runId, limit, before, after } = query;
-    const since = query.since ?? Date.now() - SEVEN_DAYS_MS;
-    const sinceDate = new Date(since);
-    const sinceISO = sinceDate.toISOString();
-    const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
+    const body = await handleSearchLogs(userId, org.orgId, query);
 
-    // Determine which run IDs to search (ownership verified via DB).
-    let targetRunIds: string[];
-    if (runId) {
-      const [run] = await globalThis.services.db
-        .select({ id: agentRuns.id })
-        .from(agentRuns)
-        .where(
-          and(
-            eq(agentRuns.id, runId),
-            eq(agentRuns.userId, userId),
-            eq(agentRuns.orgId, org.orgId),
-          ),
-        )
-        .limit(1);
-
-      if (!run) {
-        return {
-          status: 200 as const,
-          body: { results: [], hasMore: false },
-        };
-      }
-      targetRunIds = [runId];
-    } else {
-      targetRunIds = await getUserRunIds(userId, org.orgId, sinceDate, agent);
-      if (targetRunIds.length === 0) {
-        return {
-          status: 200 as const,
-          body: { results: [], hasMore: false },
-        };
-      }
-    }
-
-    const runIdFilter = buildRunIdFilter(targetRunIds);
-
-    const matchedEvents = await searchEventsInAxiom(
-      dataset,
-      sinceISO,
-      runIdFilter,
-      keyword,
-      limit,
-    );
-
-    if (matchedEvents.length === 0) {
-      return {
-        status: 200 as const,
-        body: { results: [], hasMore: false },
-      };
-    }
-
-    const hasMore = matchedEvents.length > limit;
-    const matches = hasMore ? matchedEvents.slice(0, limit) : matchedEvents;
-
-    // Fetch context events
-    const contextMap = await fetchContextEvents(
-      dataset,
-      matches,
-      before,
-      after,
-    );
-
-    // Assemble results
-    const matchedRunIds = [
-      ...new Set(
-        matches.map((e) => {
-          return e.runId;
-        }),
-      ),
-    ];
-    const agentNames = await getAgentNames(matchedRunIds, userId, org.orgId);
-
-    const results = matches.map((match) => {
-      const contextBefore: RunEvent[] = [];
-      const contextAfter: RunEvent[] = [];
-
-      for (
-        let i = match.sequenceNumber - before;
-        i < match.sequenceNumber;
-        i++
-      ) {
-        const event = contextMap.get(`${match.runId}:${i}`);
-        if (event) contextBefore.push(toRunEvent(event));
-      }
-
-      for (
-        let i = match.sequenceNumber + 1;
-        i <= match.sequenceNumber + after;
-        i++
-      ) {
-        const event = contextMap.get(`${match.runId}:${i}`);
-        if (event) contextAfter.push(toRunEvent(event));
-      }
-
-      return {
-        runId: match.runId,
-        agentName: agentNames.get(match.runId) || "unknown",
-        matchedEvent: toRunEvent(match),
-        contextBefore,
-        contextAfter,
-      };
-    });
-
-    return {
-      status: 200 as const,
-      body: { results, hasMore },
-    };
+    return { status: 200 as const, body };
   },
 });
 

--- a/turbo/apps/web/app/api/zero/logs/search/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/search/route.ts
@@ -1,0 +1,183 @@
+/**
+ * Zero API - Logs Search Endpoint
+ *
+ * GET /api/zero/logs/search - Search agent events across runs
+ */
+import {
+  createHandler,
+  tsr,
+  TsRestResponse,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroLogsSearchContract, type RunEvent } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { and, eq } from "drizzle-orm";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
+import { getDatasetName, DATASETS } from "../../../../../src/lib/axiom";
+import {
+  SEVEN_DAYS_MS,
+  getUserRunIds,
+  searchEventsInAxiom,
+  fetchContextEvents,
+  getAgentNames,
+  buildRunIdFilter,
+  toRunEvent,
+} from "../../../../../src/lib/run/log-search-service";
+
+const router = tsr.router(zeroLogsSearchContract, {
+  searchLogs: async ({ query, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "agent-run:read",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const { org } = await resolveOrg(authCtx);
+
+    const { keyword, agent, runId, limit, before, after } = query;
+    const since = query.since ?? Date.now() - SEVEN_DAYS_MS;
+    const sinceDate = new Date(since);
+    const sinceISO = sinceDate.toISOString();
+    const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
+
+    // Determine which run IDs to search (ownership verified via DB).
+    let targetRunIds: string[];
+    if (runId) {
+      const [run] = await globalThis.services.db
+        .select({ id: agentRuns.id })
+        .from(agentRuns)
+        .where(
+          and(
+            eq(agentRuns.id, runId),
+            eq(agentRuns.userId, userId),
+            eq(agentRuns.orgId, org.orgId),
+          ),
+        )
+        .limit(1);
+
+      if (!run) {
+        return {
+          status: 200 as const,
+          body: { results: [], hasMore: false },
+        };
+      }
+      targetRunIds = [runId];
+    } else {
+      targetRunIds = await getUserRunIds(userId, org.orgId, sinceDate, agent);
+      if (targetRunIds.length === 0) {
+        return {
+          status: 200 as const,
+          body: { results: [], hasMore: false },
+        };
+      }
+    }
+
+    const runIdFilter = buildRunIdFilter(targetRunIds);
+
+    const matchedEvents = await searchEventsInAxiom(
+      dataset,
+      sinceISO,
+      runIdFilter,
+      keyword,
+      limit,
+    );
+
+    if (matchedEvents.length === 0) {
+      return {
+        status: 200 as const,
+        body: { results: [], hasMore: false },
+      };
+    }
+
+    const hasMore = matchedEvents.length > limit;
+    const matches = hasMore ? matchedEvents.slice(0, limit) : matchedEvents;
+
+    // Fetch context events
+    const contextMap = await fetchContextEvents(
+      dataset,
+      matches,
+      before,
+      after,
+    );
+
+    // Assemble results
+    const matchedRunIds = [
+      ...new Set(
+        matches.map((e) => {
+          return e.runId;
+        }),
+      ),
+    ];
+    const agentNames = await getAgentNames(matchedRunIds, userId, org.orgId);
+
+    const results = matches.map((match) => {
+      const contextBefore: RunEvent[] = [];
+      const contextAfter: RunEvent[] = [];
+
+      for (
+        let i = match.sequenceNumber - before;
+        i < match.sequenceNumber;
+        i++
+      ) {
+        const event = contextMap.get(`${match.runId}:${i}`);
+        if (event) contextBefore.push(toRunEvent(event));
+      }
+
+      for (
+        let i = match.sequenceNumber + 1;
+        i <= match.sequenceNumber + after;
+        i++
+      ) {
+        const event = contextMap.get(`${match.runId}:${i}`);
+        if (event) contextAfter.push(toRunEvent(event));
+      }
+
+      return {
+        runId: match.runId,
+        agentName: agentNames.get(match.runId) || "unknown",
+        matchedEvent: toRunEvent(match),
+        contextBefore,
+        contextAfter,
+      };
+    });
+
+    return {
+      status: 200 as const,
+      body: { results, hasMore },
+    };
+  },
+});
+
+function errorHandler(err: unknown): TsRestResponse | void {
+  if (err && typeof err === "object" && "queryError" in err) {
+    const validationError = err as {
+      queryError: {
+        issues: Array<{ path: string[]; message: string }>;
+      } | null;
+    };
+
+    if (validationError.queryError?.issues[0]) {
+      const issue = validationError.queryError.issues[0];
+      const path = issue.path.join(".");
+      const message = path ? `${path}: ${issue.message}` : issue.message;
+      return TsRestResponse.fromJson(
+        { error: { message, code: "BAD_REQUEST" } },
+        { status: 400 },
+      );
+    }
+  }
+
+  return undefined;
+}
+
+const handler = createHandler(zeroLogsSearchContract, router, {
+  errorHandler,
+});
+
+export { handler as GET };

--- a/turbo/apps/web/src/lib/run/log-search-service.ts
+++ b/turbo/apps/web/src/lib/run/log-search-service.ts
@@ -5,9 +5,9 @@ import {
 } from "../../db/schema/agent-compose";
 import { agentRuns } from "../../db/schema/agent-run";
 import { and, eq, inArray, gte } from "drizzle-orm";
-import { queryAxiom } from "../axiom";
+import { queryAxiom, getDatasetName, DATASETS } from "../axiom";
 
-export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 interface AxiomAgentEvent {
   _time: string;
@@ -22,7 +22,7 @@ function escapeApl(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
-export async function getAgentNames(
+async function getAgentNames(
   runIds: string[],
   userId: string,
   orgId: string,
@@ -59,7 +59,7 @@ export async function getAgentNames(
   return result;
 }
 
-export async function getUserRunIds(
+async function getUserRunIds(
   userId: string,
   orgId: string,
   since: Date,
@@ -100,7 +100,7 @@ export async function getUserRunIds(
   });
 }
 
-export function buildRunIdFilter(runIds: string[]): string {
+function buildRunIdFilter(runIds: string[]): string {
   return runIds.length === 1
     ? `| where runId == "${escapeApl(runIds[0]!)}"`
     : `| where runId in (${runIds
@@ -114,7 +114,7 @@ export function buildRunIdFilter(runIds: string[]): string {
  * Search events using Axiom's search operator which supports maps and arrays.
  * See: https://axiom.co/docs/apl/tabular-operators/search-operator
  */
-export async function searchEventsInAxiom(
+async function searchEventsInAxiom(
   dataset: string,
   sinceISO: string,
   runIdFilter: string,
@@ -134,7 +134,7 @@ ${runIdFilter}
 /**
  * Fetch context events (surrounding events by sequenceNumber) for matched events.
  */
-export async function fetchContextEvents(
+async function fetchContextEvents(
   dataset: string,
   matches: AxiomAgentEvent[],
   before: number,
@@ -161,11 +161,132 @@ export async function fetchContextEvents(
   return contextMap;
 }
 
-export function toRunEvent(event: AxiomAgentEvent): RunEvent {
+function toRunEvent(event: AxiomAgentEvent): RunEvent {
   return {
     sequenceNumber: event.sequenceNumber,
     eventType: event.eventType,
     eventData: event.eventData,
     createdAt: event._time,
   };
+}
+
+/**
+ * Shared search handler logic used by both `/api/logs/search` and `/api/zero/logs/search`.
+ *
+ * Accepts a pre-authenticated userId + orgId and the parsed query parameters,
+ * then performs the full search flow: run-ID resolution, Axiom search,
+ * context fetching, and result assembly.
+ */
+export async function handleSearchLogs(
+  userId: string,
+  orgId: string,
+  query: {
+    keyword: string;
+    agent?: string;
+    runId?: string;
+    since?: number;
+    limit: number;
+    before: number;
+    after: number;
+  },
+): Promise<{
+  results: Array<{
+    runId: string;
+    agentName: string;
+    matchedEvent: RunEvent;
+    contextBefore: RunEvent[];
+    contextAfter: RunEvent[];
+  }>;
+  hasMore: boolean;
+}> {
+  const { keyword, agent, runId, limit, before, after } = query;
+  const since = query.since ?? Date.now() - SEVEN_DAYS_MS;
+  const sinceDate = new Date(since);
+  const sinceISO = sinceDate.toISOString();
+  const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
+
+  // Determine which run IDs to search (ownership verified via DB).
+  let targetRunIds: string[];
+  if (runId) {
+    const [run] = await globalThis.services.db
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        and(
+          eq(agentRuns.id, runId),
+          eq(agentRuns.userId, userId),
+          eq(agentRuns.orgId, orgId),
+        ),
+      )
+      .limit(1);
+
+    if (!run) {
+      return { results: [], hasMore: false };
+    }
+    targetRunIds = [runId];
+  } else {
+    targetRunIds = await getUserRunIds(userId, orgId, sinceDate, agent);
+    if (targetRunIds.length === 0) {
+      return { results: [], hasMore: false };
+    }
+  }
+
+  const runIdFilter = buildRunIdFilter(targetRunIds);
+
+  const matchedEvents = await searchEventsInAxiom(
+    dataset,
+    sinceISO,
+    runIdFilter,
+    keyword,
+    limit,
+  );
+
+  if (matchedEvents.length === 0) {
+    return { results: [], hasMore: false };
+  }
+
+  const hasMore = matchedEvents.length > limit;
+  const matches = hasMore ? matchedEvents.slice(0, limit) : matchedEvents;
+
+  // Fetch context events
+  const contextMap = await fetchContextEvents(dataset, matches, before, after);
+
+  // Assemble results
+  const matchedRunIds = [
+    ...new Set(
+      matches.map((e) => {
+        return e.runId;
+      }),
+    ),
+  ];
+  const agentNames = await getAgentNames(matchedRunIds, userId, orgId);
+
+  const results = matches.map((match) => {
+    const contextBefore: RunEvent[] = [];
+    const contextAfter: RunEvent[] = [];
+
+    for (let i = match.sequenceNumber - before; i < match.sequenceNumber; i++) {
+      const event = contextMap.get(`${match.runId}:${i}`);
+      if (event) contextBefore.push(toRunEvent(event));
+    }
+
+    for (
+      let i = match.sequenceNumber + 1;
+      i <= match.sequenceNumber + after;
+      i++
+    ) {
+      const event = contextMap.get(`${match.runId}:${i}`);
+      if (event) contextAfter.push(toRunEvent(event));
+    }
+
+    return {
+      runId: match.runId,
+      agentName: agentNames.get(match.runId) || "unknown",
+      matchedEvent: toRunEvent(match),
+      contextBefore,
+      contextAfter,
+    };
+  });
+
+  return { results, hasMore };
 }

--- a/turbo/packages/core/src/contracts/logs.ts
+++ b/turbo/packages/core/src/contracts/logs.ts
@@ -143,6 +143,7 @@ export const logsListContract = c.router({
     responses: {
       200: logsListResponseSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
     },
     summary: "List agent run logs with pagination",
   },
@@ -163,6 +164,7 @@ export const logsByIdContract = c.router({
     responses: {
       200: logDetailSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
       404: apiErrorSchema,
     },
     summary: "Get agent run log details by ID",

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -269,6 +269,7 @@ export const zeroLogsSearchContract = c.router({
     responses: {
       200: logsSearchResponseSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
     },
     summary: "Search agent events across runs (zero proxy)",
   },


### PR DESCRIPTION
## Summary

- Switch `/api/zero/logs` (list) and `/api/zero/logs/:id` (detail) from `getAuthContext` to `requireAuth` with `agent-run:read` capability, enabling sandbox agent zero tokens to access these endpoints
- Create new `/api/zero/logs/search` endpoint for searching agent events across runs via zero token auth, using the shared `log-search-service` from #7641
- Add `403` response to all three contracts for capability enforcement

## Test plan

- [x] Zero token with `agent-run:read` → 200 OK on all three endpoints
- [x] Sandbox token without `agent-run:read` → 403 FORBIDDEN
- [x] No auth → 401 UNAUTHORIZED
- [x] Existing Clerk session auth still works (no regression)
- [x] Search endpoint: keyword matching, context events, runId filter, agent filter, hasMore, org isolation
- [x] All 68 tests pass: `cd turbo && pnpm vitest run apps/web/app/api/zero/logs/`
- [x] Existing search tests pass: `cd turbo && pnpm vitest run apps/web/app/api/logs/search/`
- [x] `cd turbo && pnpm check-types` passes
- [x] `cd turbo && pnpm turbo run lint` passes
- [x] `cd turbo && pnpm knip` passes

Closes #7635

🤖 Generated with [Claude Code](https://claude.com/claude-code)