### PR TITLE
fix: update sidebar highlight early on pinned agent switch

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/talk-page-setup.ts
@@ -21,13 +21,19 @@ export const setupTalkPage$ = command(
     // Reset the talk draft on entrance
     set(get(talkDraft$).clear$);
 
+    // Read agent ID from URL immediately (synchronous) and update sidebar
+    // highlight early so the UI responds without waiting for async data.
+    const agentId = get(currentAgentId$);
+    if (agentId) {
+      set(setSidebarChatAgent$, agentId);
+    }
+
     await set(loadInitialData$, signal);
 
     if (await set(onboardGuard$, signal)) {
       return;
     }
 
-    const agentId = get(currentAgentId$);
     if (!agentId) {
       throw new Error("Talk page requires an active agent, but none found");
     }
@@ -41,8 +47,11 @@ export const setupTalkPage$ = command(
     const defaultId = await get(defaultAgentId$);
     signal.throwIfAborted();
 
-    // Sync sidebar: remember this agent so sidebar retains it on non-chat pages.
-    set(setSidebarChatAgent$, agentId === defaultId ? null : agentId);
+    // Correct sidebar to null when chatting with the default agent.
+    if (agentId === defaultId) {
+      set(setSidebarChatAgent$, null);
+    }
+
     let agentName: string;
     if (agentId === defaultId) {
       agentName = (await get(agentDisplayName$)) ?? "Agent";

--- a/turbo/apps/platform/src/views/zero-page/__tests__/pinned-agent-switch.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/pinned-agent-switch.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function mockPinnedAgents() {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: DEFAULT_AGENT_ID,
+          displayName: null,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "agent-alpha",
+          displayName: "Alpha Bot",
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_2",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "agent-beta",
+          displayName: "Beta Bot",
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_3",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+  setMockUserPreferences({ pinnedAgentIds: ["agent-alpha", "agent-beta"] });
+}
+
+/** Find the pinned agent link inside the sidebar nav (not the main page area). */
+function getPinnedLink(name: string): HTMLAnchorElement {
+  const sidebar = screen.getByRole("navigation");
+  const link = within(sidebar).getByText(name).closest("a");
+  if (!link) {
+    throw new Error(`Pinned link for "${name}" not found in sidebar`);
+  }
+  return link;
+}
+
+describe("pinned agent switch (#6897)", () => {
+  it("should highlight the switched-to pinned agent after clicking it", async () => {
+    const user = userEvent.setup();
+    mockPinnedAgents();
+
+    await setupPage({ context, path: "/agents/agent-alpha/chat" });
+
+    // Wait for pinned agents to render in the sidebar
+    await waitFor(() => {
+      expect(
+        within(screen.getByRole("navigation")).getByText("Alpha Bot"),
+      ).toBeInTheDocument();
+    });
+
+    // Alpha Bot should be highlighted in the sidebar
+    expect(getPinnedLink("Alpha Bot").className).toContain("bg-gray-200");
+
+    // Click Beta Bot pinned agent in sidebar
+    await user.click(getPinnedLink("Beta Bot"));
+
+    // URL should update to beta agent
+    await waitFor(() => {
+      expect(pathname()).toBe("/agents/agent-beta/chat");
+    });
+
+    // Beta Bot should now be highlighted, Alpha Bot should not
+    await waitFor(() => {
+      expect(getPinnedLink("Beta Bot").className).toContain("bg-gray-200");
+    });
+    expect(getPinnedLink("Alpha Bot").className).not.toContain("bg-gray-200");
+  });
+
+  it("should highlight the switched-to pinned agent when switching back", async () => {
+    const user = userEvent.setup();
+    mockPinnedAgents();
+
+    await setupPage({ context, path: "/agents/agent-alpha/chat" });
+
+    await waitFor(() => {
+      expect(
+        within(screen.getByRole("navigation")).getByText("Alpha Bot"),
+      ).toBeInTheDocument();
+    });
+
+    // Switch to Beta
+    await user.click(getPinnedLink("Beta Bot"));
+    await waitFor(() => {
+      expect(getPinnedLink("Beta Bot").className).toContain("bg-gray-200");
+    });
+
+    // Switch back to Alpha
+    await user.click(getPinnedLink("Alpha Bot"));
+    await waitFor(() => {
+      expect(getPinnedLink("Alpha Bot").className).toContain("bg-gray-200");
+    });
+    expect(getPinnedLink("Beta Bot").className).not.toContain("bg-gray-200");
+  });
+});


### PR DESCRIPTION
## Summary
- Read the agent ID synchronously from the URL and set the sidebar highlight before awaiting async data, so the UI responds immediately when switching between pinned agents
- Correct the sidebar state for the default agent after data loads instead of unconditionally overwriting it
- Add integration tests for pinned agent sidebar highlight switching

## Test plan
- [ ] Verify pinned agent highlight updates immediately on click without waiting for async load
- [ ] Verify switching back and forth between pinned agents correctly updates highlight
- [ ] Verify default agent chat does not leave stale sidebar highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)