### PR TITLE
fix: upload images in channel context prefix on first thread @mention

### DIFF
--- a/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import type { WebClient } from "@slack/web-api";
+import { HttpResponse } from "msw";
 import {
   buildOrgConnectUrl,
   buildLogsUrl,
@@ -7,6 +8,9 @@ import {
   enrichMessageContent,
   fetchConversationContexts,
 } from "../shared";
+import { testContext } from "../../../../__tests__/test-helpers";
+import { server } from "../../../../mocks/server";
+import { http } from "../../../../__tests__/msw";
 
 describe("buildOrgConnectUrl", () => {
   it("should point to platform slack connect page", () => {
@@ -343,5 +347,68 @@ describe("fetchConversationContexts", () => {
     expect(executionContext).toContain("Msg 1");
     // conversations.history called once (for channel context), not twice
     expect(client.conversations.history).toHaveBeenCalledTimes(1);
+  });
+
+  describe("image upload in channel context prefix", () => {
+    const context = testContext();
+
+    it("should upload images in channel messages to S3 on first thread session", async () => {
+      context.setupMocks();
+
+      const downloadHandler = http.get(
+        "https://files.slack.com/files-pri/T123-F999/download/screenshot.png",
+        () => {
+          return new HttpResponse(Buffer.from("fake-png-data"), {
+            headers: { "content-type": "image/png" },
+          });
+        },
+      );
+      server.use(downloadHandler.handler);
+
+      context.mocks.s3.generatePresignedUrl.mockResolvedValue(
+        "https://mock-presigned-url/screenshot.png",
+      );
+
+      const client = createMockConversationClient({
+        threadMessages: [{ user: "U100", text: "Thread parent", ts: "100.0" }],
+        channelMessages: [
+          {
+            user: "U200",
+            text: "Look at this",
+            ts: "99.0",
+            files: [
+              {
+                id: "F999",
+                name: "screenshot.png",
+                mimetype: "image/png",
+                filetype: "png",
+                url_private_download:
+                  "https://files.slack.com/files-pri/T123-F999/download/screenshot.png",
+              },
+            ],
+          },
+        ],
+      });
+
+      const { executionContext } = await fetchConversationContexts(
+        client,
+        "C-chan",
+        "100.0",
+        "BBOT",
+        "xoxb-token",
+        undefined,
+        undefined,
+        undefined, // first session
+      );
+
+      // S3 upload should have been triggered for the channel message image
+      expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalled();
+      expect(context.mocks.s3.generatePresignedUrl).toHaveBeenCalled();
+
+      // executionContext should contain the presigned URL, not a raw Slack permalink
+      expect(executionContext).toContain("https://mock-presigned-url");
+      expect(executionContext).not.toContain("permalink_public");
+      expect(executionContext).toContain("# Recent Channel Messages");
+    });
   });
 });

--- a/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/__tests__/shared.test.ts
@@ -219,17 +219,16 @@ describe("fetchConversationContexts", () => {
       ],
     });
 
-    const { executionContext, routingContext } =
-      await fetchConversationContexts(
-        client,
-        "C-chan",
-        "100.0", // threadTs
-        "BBOT",
-        "xoxb-token",
-        undefined, // lastProcessedMessageTs
-        "100.1", // currentMessageTs excluded from context
-        undefined, // no existingSessionId → first session
-      );
+    const { executionContext } = await fetchConversationContexts(
+      client,
+      "C-chan",
+      "100.0", // threadTs
+      "BBOT",
+      "xoxb-token",
+      undefined, // lastProcessedMessageTs
+      "100.1", // currentMessageTs excluded from context
+      undefined, // no existingSessionId → first session
+    );
 
     // Should contain both channel and thread sections
     expect(executionContext).toContain("# Recent Channel Messages");
@@ -239,9 +238,6 @@ describe("fetchConversationContexts", () => {
     expect(executionContext).toContain("Thread parent");
     // Current message excluded
     expect(executionContext).not.toContain("Reply");
-
-    expect(routingContext).toContain("# Recent Channel Messages");
-    expect(routingContext).toContain("# Slack Thread Context");
   });
 
   it("should fetch channel messages with latest=threadTs", async () => {

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -185,6 +185,7 @@ export async function handleOrgDirectMessage(
     botUserId,
     channelId: context.channelId,
     channelType: "dm",
+    threadTs,
     callbackContext,
   });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -185,7 +185,7 @@ export async function handleOrgDirectMessage(
     botUserId,
     channelId: context.channelId,
     channelType: "dm",
-    threadTs: context.threadTs,
+    threadTs,
     callbackContext,
   });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/direct-message.ts
@@ -185,7 +185,7 @@ export async function handleOrgDirectMessage(
     botUserId,
     channelId: context.channelId,
     channelType: "dm",
-    threadTs,
+    threadTs: context.threadTs,
     callbackContext,
   });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -189,6 +189,7 @@ export async function handleOrgMention(
         : context.channelType === "mpim"
           ? "group_dm"
           : "channel",
+    threadTs,
     callbackContext,
   });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -189,7 +189,7 @@ export async function handleOrgMention(
         : context.channelType === "mpim"
           ? "group_dm"
           : "channel",
-    threadTs: context.threadTs,
+    threadTs,
     callbackContext,
   });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/mention.ts
@@ -189,7 +189,7 @@ export async function handleOrgMention(
         : context.channelType === "mpim"
           ? "group_dm"
           : "channel",
-    threadTs,
+    threadTs: context.threadTs,
     callbackContext,
   });
 

--- a/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/run-agent.ts
@@ -21,6 +21,7 @@ interface RunAgentParams {
   botUserId: string;
   channelId?: string;
   channelType?: "channel" | "dm" | "group_dm";
+  threadTs?: string;
   callbackContext: SlackOrgCallbackPayload;
 }
 
@@ -56,13 +57,19 @@ export async function runAgentForSlackOrg(
     botUserId,
     channelId,
     channelType,
+    threadTs,
     callbackContext,
   } = params;
 
   try {
     // Build system prompt from context parts (agent identity is prepended by startRun)
     const contextParts = [
-      buildIntegrationContext("Slack", { botUserId, channelId, channelType }),
+      buildIntegrationContext("Slack", {
+        botUserId,
+        channelId,
+        channelType,
+        threadId: threadTs,
+      }),
       threadContext,
       userContext,
     ].filter(Boolean);

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -276,11 +276,13 @@ export async function fetchConversationContexts(
   const userIds = [...senderIds, ...mentionedIds];
   const userInfoMap = await fetchSlackUserInfoMap(client, userIds);
 
-  // Format channel context prefix (for first thread mention only, text-only)
+  // Format channel context prefix (for first thread mention only, with image upload)
   const channelContextPrefix =
     channelMessages.length > 0
-      ? formatContextForAgent(
+      ? await formatContextForAgentWithImages(
           channelMessages,
+          botToken,
+          imageSessionId,
           botUserId,
           "channel",
           userInfoMap,

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -15,7 +15,6 @@ import {
 import {
   fetchThreadContext,
   fetchChannelContext,
-  formatContextForAgent,
   formatContextForAgentWithImages,
   formatCurrentMessageFiles,
   extractMentionedUserIds,
@@ -228,8 +227,7 @@ type SlackClient = ReturnType<typeof createSlackClient>;
 
 /**
  * Fetch conversation context with deduplication support.
- * Returns separate contexts for routing (text-only, full history) and
- * execution (with images, only new messages since lastProcessedMessageTs).
+ * Returns execution context (with images, only new messages since lastProcessedMessageTs).
  *
  * Single Slack API call — messages are fetched once and filtered in-memory.
  */
@@ -242,7 +240,7 @@ export async function fetchConversationContexts(
   lastProcessedMessageTs?: string,
   currentMessageTs?: string,
   existingSessionId?: string,
-): Promise<{ routingContext: string; executionContext: string }> {
+): Promise<{ executionContext: string }> {
   const imageSessionId = `${channelId}-${threadTs ?? "channel"}`;
   const contextType = threadTs ? "thread" : "channel";
 
@@ -289,17 +287,6 @@ export async function fetchConversationContexts(
         )
       : "";
 
-  // Text-only full context for routing (no image uploads needed)
-  const threadRoutingContext = formatContextForAgent(
-    contextMessages,
-    botUserId,
-    contextType,
-    userInfoMap,
-  );
-  const routingContext = channelContextPrefix
-    ? `${channelContextPrefix}\n\n${threadRoutingContext}`
-    : threadRoutingContext;
-
   // Filter to only new messages for execution context
   const executionMessages = lastProcessedMessageTs
     ? contextMessages.filter((m) => {
@@ -323,7 +310,7 @@ export async function fetchConversationContexts(
     ? `${channelContextPrefix}\n\n${threadExecContext}`
     : threadExecContext;
 
-  return { routingContext, executionContext };
+  return { executionContext };
 }
 
 /**

--- a/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/slack/__tests__/context.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { HttpResponse } from "msw";
 import {
-  formatContextForAgent,
   formatContextForAgentWithImages,
   formatCurrentMessageFiles,
   extractMessageContent,
@@ -15,378 +14,6 @@ import { http } from "../../../__tests__/msw";
 // Mock external dependencies required by testContext().setupMocks()
 
 const context = testContext();
-
-describe("Feature: Format Context For Agent", () => {
-  describe("Scenario: Format thread messages into context string", () => {
-    it("should include all messages with structured metadata", () => {
-      const messages = [
-        { user: "U123", text: "Hello, can you help me?", ts: "1234567890.001" },
-        { user: "U456", text: "Sure, what do you need?", ts: "1234567890.002" },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("# Slack Thread Context");
-      expect(result).toContain("- RELATIVE_INDEX: -2");
-      expect(result).toContain("- SENDER: {id: U123}");
-      expect(result).toContain("Hello, can you help me?");
-      expect(result).toContain("- RELATIVE_INDEX: -1");
-      expect(result).toContain("- SENDER: {id: U456}");
-      expect(result).toContain("Sure, what do you need?");
-    });
-
-    it("should use --- separators between messages", () => {
-      const messages = [
-        { user: "U123", text: "First", ts: "1234567890.001" },
-        { user: "U456", text: "Second", ts: "1234567890.002" },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      // Each message starts with --- and the output ends with ---
-      expect(result).toMatch(/---\n\n- RELATIVE_INDEX: -2/);
-      expect(result).toMatch(/---\n\n- RELATIVE_INDEX: -1/);
-      expect(result).toMatch(/\n\n---$/);
-    });
-  });
-
-  describe("Scenario: Include bot messages in context", () => {
-    it("should include bot messages with SENDER ID: BOT", () => {
-      const messages = [
-        { user: "U123", text: "Hello", ts: "1234567890.001" },
-        { bot_id: "BBOT123", text: "Bot response", ts: "1234567890.002" },
-        { user: "U456", text: "Thanks", ts: "1234567890.003" },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("- SENDER: {id: U123}");
-      expect(result).toContain("- SENDER: {id: BOT}");
-      expect(result).toContain("Bot response");
-      expect(result).toContain("- SENDER: {id: U456}");
-    });
-
-    it("should not filter out any messages even when botUserId is provided", () => {
-      const botUserId = "BBOT123";
-      const messages = [
-        { user: "U123", text: "User message 1", ts: "1234567890.001" },
-        { user: "BBOT123", text: "Bot message", ts: "1234567890.002" },
-        { user: "U456", text: "User message 2", ts: "1234567890.003" },
-      ];
-
-      const result = formatContextForAgent(messages, botUserId);
-
-      // All messages should be included
-      expect(result).toContain("User message 1");
-      expect(result).toContain("- SENDER: {id: BBOT123}");
-      expect(result).toContain("Bot message");
-      expect(result).toContain("User message 2");
-    });
-  });
-
-  describe("Scenario: Handle edge cases", () => {
-    it("should return empty string for empty messages array", () => {
-      const result = formatContextForAgent([]);
-
-      expect(result).toBe("");
-    });
-
-    it("should handle messages with missing user or text", () => {
-      const messages = [{ text: "No user" }, { user: "U123" }];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("- SENDER: {id: unknown}");
-      expect(result).toContain("No user");
-      expect(result).toContain("- SENDER: {id: U123}");
-    });
-  });
-
-  describe("Scenario: Format channel messages", () => {
-    it("should use channel context header", () => {
-      const messages = [
-        { user: "U123", text: "Recent message", ts: "1234567890.001" },
-      ];
-
-      const result = formatContextForAgent(messages, undefined, "channel");
-
-      expect(result).toContain("# Recent Channel Messages");
-      expect(result).toContain("- SENDER: {id: U123}");
-      expect(result).toContain("Recent message");
-    });
-  });
-
-  describe("Scenario: Include files in context", () => {
-    it("should format message with single image file", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "Check out this screenshot",
-          ts: "1234567890.001",
-          files: [
-            {
-              name: "screenshot.png",
-              pretty_type: "PNG Image",
-              original_w: "1920",
-              original_h: "1080",
-              permalink_public: "https://files.slack.com/public/screenshot.png",
-            },
-          ],
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("Check out this screenshot");
-      expect(result).toContain("[file]: screenshot.png (PNG Image)");
-      expect(result).toContain("Dimensions: 1920x1080");
-      expect(result).toContain(
-        "URL: https://files.slack.com/public/screenshot.png",
-      );
-    });
-
-    it("should format message with multiple files", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "Here are the files",
-          ts: "1234567890.001",
-          files: [
-            {
-              name: "image1.png",
-              pretty_type: "PNG Image",
-              permalink: "https://slack.com/files/image1.png",
-            },
-            {
-              name: "document.pdf",
-              pretty_type: "PDF",
-              permalink: "https://slack.com/files/document.pdf",
-            },
-          ],
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("[file]: image1.png (PNG Image)");
-      expect(result).toContain("[file]: document.pdf (PDF)");
-    });
-
-    it("should use thumbnail URL when public URL is not available", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "Private image",
-          ts: "1234567890.001",
-          files: [
-            {
-              name: "private.png",
-              mimetype: "image/png",
-              thumb_480: "https://files.slack.com/thumb_480/private.png",
-            },
-          ],
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("[file]: private.png (image/png)");
-      expect(result).toContain(
-        "URL: https://files.slack.com/thumb_480/private.png",
-      );
-    });
-
-    it("should handle files without dimensions", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "A document",
-          ts: "1234567890.001",
-          files: [
-            {
-              name: "report.docx",
-              pretty_type: "Word Document",
-              permalink: "https://slack.com/files/report.docx",
-            },
-          ],
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("[file]: report.docx (Word Document)");
-      expect(result).not.toContain("Dimensions:");
-    });
-  });
-
-  describe("Scenario: Include attachments with images in context", () => {
-    it("should format attachment with image URL", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "Check this article",
-          ts: "1234567890.001",
-          attachments: [
-            {
-              title: "Article Preview",
-              image_url: "https://example.com/preview.jpg",
-              image_width: 800,
-              image_height: 600,
-            },
-          ],
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("Check this article");
-      expect(result).toContain("[image]: Article Preview");
-      expect(result).toContain("Dimensions: 800x600");
-      expect(result).toContain(
-        'View: curl -sS -o /tmp/attachment_image.jpg "https://example.com/preview.jpg"',
-      );
-    });
-
-    it("should use fallback for attachment title", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "Link",
-          ts: "1234567890.001",
-          attachments: [
-            {
-              fallback: "Preview image",
-              thumb_url: "https://example.com/thumb.jpg",
-            },
-          ],
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("[image]: Preview image");
-      expect(result).toContain(
-        'View: curl -sS -o /tmp/attachment_image.jpg "https://example.com/thumb.jpg"',
-      );
-    });
-
-    it("should skip attachments without images", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "Text only attachment",
-          ts: "1234567890.001",
-          attachments: [
-            {
-              title: "No image here",
-              fallback: "Just text",
-            },
-          ],
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("Text only attachment");
-      expect(result).not.toContain("[image]:");
-    });
-  });
-
-  describe("Scenario: Mixed content in thread", () => {
-    it("should format thread with text, files, and attachments", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "Here is the error screenshot",
-          ts: "1234567890.001",
-        },
-        {
-          user: "U456",
-          text: "I see the issue",
-          ts: "1234567890.002",
-          files: [
-            {
-              name: "fix.png",
-              pretty_type: "PNG Image",
-              original_w: "640",
-              original_h: "480",
-              permalink_public: "https://files.slack.com/fix.png",
-            },
-          ],
-        },
-        {
-          user: "U123",
-          text: "Related article",
-          ts: "1234567890.003",
-          attachments: [
-            {
-              title: "Bug Report",
-              image_url: "https://example.com/bug.jpg",
-            },
-          ],
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("- RELATIVE_INDEX: -3");
-      expect(result).toContain("Here is the error screenshot");
-      expect(result).toContain("- RELATIVE_INDEX: -2");
-      expect(result).toContain("I see the issue");
-      expect(result).toContain("[file]: fix.png (PNG Image)");
-      expect(result).toContain("Dimensions: 640x480");
-      expect(result).toContain("- RELATIVE_INDEX: -1");
-      expect(result).toContain("Related article");
-      expect(result).toContain("[image]: Bug Report");
-    });
-  });
-
-  describe("Scenario: Include context preamble with interpretation guidelines", () => {
-    it("should include preamble between header and messages for thread context", () => {
-      const messages = [{ user: "U123", text: "Hello", ts: "1234567890.001" }];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("Match the tone of the conversation");
-      expect(result).toContain(
-        "Only provide technical analysis when explicitly asked",
-      );
-      expect(result).toContain(
-        "Keep responses proportional to the message length",
-      );
-    });
-
-    it("should include preamble for channel context", () => {
-      const messages = [{ user: "U123", text: "Hello", ts: "1234567890.001" }];
-
-      const result = formatContextForAgent(messages, undefined, "channel");
-
-      expect(result).toContain("Match the tone of the conversation");
-    });
-
-    it("should not include preamble for empty messages", () => {
-      const result = formatContextForAgent([]);
-
-      expect(result).toBe("");
-    });
-  });
-
-  describe("Scenario: Relative index calculation", () => {
-    it("should calculate relative index from the end of messages", () => {
-      const messages = [
-        { user: "U1", text: "First", ts: "1.0" },
-        { user: "U2", text: "Second", ts: "2.0" },
-        { user: "U3", text: "Third", ts: "3.0" },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("- RELATIVE_INDEX: -3");
-      expect(result).toContain("- RELATIVE_INDEX: -2");
-      expect(result).toContain("- RELATIVE_INDEX: -1");
-    });
-  });
-});
 
 describe("Feature: Extract Message Content", () => {
   describe("Scenario: Remove bot mention from message", () => {
@@ -1391,70 +1018,6 @@ describe("Feature: Extract Text From Rich Text Blocks", () => {
       );
     });
   });
-
-  describe("Scenario: Integration with formatContextForAgent", () => {
-    it("should prefer blocks content over text fallback", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "Short fallback",
-          ts: "1234567890.001",
-          blocks: [
-            {
-              type: "rich_text",
-              elements: [
-                {
-                  type: "rich_text_section",
-                  elements: [
-                    {
-                      type: "text",
-                      text: "Full rich text content with all details preserved",
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain(
-        "Full rich text content with all details preserved",
-      );
-      expect(result).not.toContain("Short fallback");
-    });
-
-    it("should fall back to text when no rich_text blocks", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "Plain text message",
-          ts: "1234567890.001",
-          blocks: [{ type: "section" }],
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("Plain text message");
-    });
-
-    it("should fall back to text when blocks is undefined", () => {
-      const messages = [
-        {
-          user: "U123",
-          text: "Plain text message",
-          ts: "1234567890.001",
-        },
-      ];
-
-      const result = formatContextForAgent(messages);
-
-      expect(result).toContain("Plain text message");
-    });
-  });
 });
 
 describe("Feature: Format Current Message Files", () => {
@@ -1629,7 +1192,11 @@ describe("Feature: Format Current Message Files", () => {
 });
 
 describe("Feature: Resolve User Mentions In Context", () => {
-  it("should resolve user mention to name when user info available", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("should resolve user mention to name when user info available", async () => {
     const messages = [
       { user: "U100", text: "Hey <@U200>, can you help?", ts: "1.0" },
     ];
@@ -1638,8 +1205,10 @@ describe("Feature: Resolve User Mentions In Context", () => {
       ["U200", { id: "U200", name: "Bob", email: "bob@example.com" }],
     ]);
 
-    const result = formatContextForAgent(
+    const result = await formatContextForAgentWithImages(
       messages,
+      "xoxb-token",
+      "session-1",
       undefined,
       "thread",
       userInfoMap,
@@ -1649,12 +1218,14 @@ describe("Feature: Resolve User Mentions In Context", () => {
     expect(result).not.toContain("<@U200>");
   });
 
-  it("should keep raw mention when user info not available", () => {
+  it("should keep raw mention when user info not available", async () => {
     const messages = [{ user: "U100", text: "Hey <@U999>", ts: "1.0" }];
     const userInfoMap = new Map([["U100", { id: "U100", name: "Alice" }]]);
 
-    const result = formatContextForAgent(
+    const result = await formatContextForAgentWithImages(
       messages,
+      "xoxb-token",
+      "session-1",
       undefined,
       "thread",
       userInfoMap,
@@ -1663,7 +1234,7 @@ describe("Feature: Resolve User Mentions In Context", () => {
     expect(result).toContain("<@U999>");
   });
 
-  it("should resolve multiple mentions in one message", () => {
+  it("should resolve multiple mentions in one message", async () => {
     const messages = [
       {
         user: "U100",
@@ -1677,8 +1248,10 @@ describe("Feature: Resolve User Mentions In Context", () => {
       ["U300", { id: "U300", name: "Charlie" }],
     ]);
 
-    const result = formatContextForAgent(
+    const result = await formatContextForAgentWithImages(
       messages,
+      "xoxb-token",
+      "session-1",
       undefined,
       "thread",
       userInfoMap,
@@ -1688,7 +1261,7 @@ describe("Feature: Resolve User Mentions In Context", () => {
     expect(result).toContain("@Charlie (U300)");
   });
 
-  it("should resolve mentions from rich_text blocks", () => {
+  it("should resolve mentions from rich_text blocks", async () => {
     const messages = [
       {
         user: "U100",
@@ -1715,8 +1288,10 @@ describe("Feature: Resolve User Mentions In Context", () => {
       ["U200", { id: "U200", name: "Bob" }],
     ]);
 
-    const result = formatContextForAgent(
+    const result = await formatContextForAgentWithImages(
       messages,
+      "xoxb-token",
+      "session-1",
       undefined,
       "thread",
       userInfoMap,

--- a/turbo/apps/web/src/lib/slack/context.ts
+++ b/turbo/apps/web/src/lib/slack/context.ts
@@ -357,29 +357,6 @@ async function downloadAndUploadSlackFile(
 }
 
 /**
- * Format file information for context (sync version, metadata only)
- */
-function formatFileInfo(file: SlackFile): string {
-  const parts: string[] = [];
-
-  const name = file.name || file.title || "Untitled";
-  const type = file.pretty_type || file.mimetype || "file";
-  parts.push(`[file]: ${name} (${type})`);
-
-  if (file.original_w && file.original_h) {
-    parts.push(`   Dimensions: ${file.original_w}x${file.original_h}`);
-  }
-
-  const url =
-    file.permalink_public || file.thumb_480 || file.thumb_360 || file.permalink;
-  if (url) {
-    parts.push(`   URL: ${url}`);
-  }
-
-  return parts.join("\n");
-}
-
-/**
  * Format file information for context with file upload to R2
  * Uploads files to R2 and provides presigned URLs for agent access
  */
@@ -532,72 +509,6 @@ const CONTEXT_PREAMBLE = [
   "- Only provide technical analysis when explicitly asked a technical question.",
   "- Keep responses proportional to the message length and complexity.",
 ].join("\n");
-
-/**
- * Format messages into context for agent prompt (sync version, metadata only)
- *
- * @param messages - Array of Slack messages
- * @param botUserId - Bot user ID (kept for API compatibility, no longer used for filtering)
- * @param contextType - Type of context: "thread" or "channel"
- * @param userInfoMap - Pre-resolved map of Slack user ID → user info
- * @returns Formatted context string
- */
-export function formatContextForAgent(
-  messages: SlackMessage[],
-  botUserId?: string,
-  contextType: "thread" | "channel" = "thread",
-  userInfoMap?: Map<string, SlackUserInfo>,
-): string {
-  if (messages.length === 0) {
-    return "";
-  }
-
-  const totalMessages = messages.length;
-
-  // Include all messages (don't filter bot messages)
-  const formattedMessages = messages.map((msg, index) => {
-    const relativeIndex = index - totalMessages;
-
-    const fileParts: string[] = [];
-
-    // Format files (uploaded images, documents, etc.)
-    if (msg.files && msg.files.length > 0) {
-      for (const file of msg.files) {
-        fileParts.push(formatFileInfo(file));
-      }
-    }
-
-    // Format attachments with images (URL unfurls, etc.)
-    if (msg.attachments && msg.attachments.length > 0) {
-      for (const attachment of msg.attachments) {
-        const attachmentInfo = formatAttachmentImage(attachment);
-        if (attachmentInfo) {
-          fileParts.push(attachmentInfo);
-        }
-      }
-    }
-
-    return formatMessageWithMetadata(
-      msg,
-      relativeIndex,
-      fileParts,
-      userInfoMap,
-    );
-  });
-
-  const header =
-    contextType === "thread"
-      ? "# Slack Thread Context"
-      : "# Recent Channel Messages";
-
-  const result = `${header}\n\n${CONTEXT_PREAMBLE}\n\n${formattedMessages.join("\n\n")}\n\n---`;
-  log.debug("Formatted messages for context", {
-    messageCount: formattedMessages.length,
-    contextType,
-    resultLength: result.length,
-  });
-  return result;
-}
 
 /**
  * Format messages into context for agent prompt with file upload

--- a/turbo/apps/web/src/lib/telegram/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/telegram/__tests__/context.test.ts
@@ -1,155 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { formatContextForAgent, fetchTelegramContext } from "../context";
+import { fetchTelegramContext } from "../context";
 import { uniqueId } from "../../../__tests__/test-helpers";
 import { createTelegramInstallation, insertTelegramMessage } from "./helpers";
-
-describe("formatContextForAgent", () => {
-  it("should return empty string for empty messages", () => {
-    expect(formatContextForAgent([])).toBe("");
-  });
-
-  it("should format messages with username", () => {
-    const messages = [
-      {
-        fromUsername: "alice",
-        fromUserId: "111",
-        text: "Hello",
-        isBot: false,
-        messageId: "1",
-        fileId: null,
-      },
-    ];
-
-    const result = formatContextForAgent(messages);
-
-    expect(result).toContain("# Telegram Chat Context");
-    expect(result).toContain("SENDER_ID: alice");
-    expect(result).toContain("Hello");
-  });
-
-  it("should fall back to user ID when username is null", () => {
-    const messages = [
-      {
-        fromUsername: null,
-        fromUserId: "222",
-        text: "Hi there",
-        isBot: false,
-        messageId: "2",
-        fileId: null,
-      },
-    ];
-
-    const result = formatContextForAgent(messages);
-
-    expect(result).toContain("SENDER_ID: user:222");
-    expect(result).toContain("Hi there");
-  });
-
-  it("should label bot messages as BOT", () => {
-    const messages = [
-      {
-        fromUsername: "my_bot",
-        fromUserId: "333",
-        text: "I am a bot",
-        isBot: true,
-        messageId: "3",
-        fileId: null,
-      },
-    ];
-
-    const result = formatContextForAgent(messages);
-
-    expect(result).toContain("SENDER_ID: BOT");
-    expect(result).toContain("I am a bot");
-  });
-
-  it("should filter out messages with null text and no file", () => {
-    const messages = [
-      {
-        fromUsername: "alice",
-        fromUserId: "111",
-        text: null,
-        isBot: false,
-        messageId: "1",
-        fileId: null,
-      },
-      {
-        fromUsername: "bob",
-        fromUserId: "222",
-        text: "Visible",
-        isBot: false,
-        messageId: "2",
-        fileId: null,
-      },
-    ];
-
-    const result = formatContextForAgent(messages);
-
-    expect(result).not.toContain("alice");
-    expect(result).toContain("Visible");
-  });
-
-  it("should include context preamble", () => {
-    const messages = [
-      {
-        fromUsername: "alice",
-        fromUserId: "111",
-        text: "Hello",
-        isBot: false,
-        messageId: "1",
-        fileId: null,
-      },
-    ];
-
-    const result = formatContextForAgent(messages);
-
-    expect(result).toContain("Match the tone of the conversation");
-    expect(result).toContain(
-      "Only provide technical analysis when explicitly asked",
-    );
-    expect(result).toContain(
-      "Keep responses proportional to the message length",
-    );
-  });
-
-  it("should format multiple messages in order", () => {
-    const messages = [
-      {
-        fromUsername: "alice",
-        fromUserId: "111",
-        text: "First",
-        isBot: false,
-        messageId: "1",
-        fileId: null,
-      },
-      {
-        fromUsername: null,
-        fromUserId: "222",
-        text: "Second",
-        isBot: false,
-        messageId: "2",
-        fileId: null,
-      },
-      {
-        fromUsername: "bot",
-        fromUserId: "333",
-        text: "Third",
-        isBot: true,
-        messageId: "3",
-        fileId: null,
-      },
-    ];
-
-    const result = formatContextForAgent(messages);
-
-    const aliceIdx = result.indexOf("First");
-    const userIdx = result.indexOf("Second");
-    const botIdx = result.indexOf("Third");
-
-    expect(aliceIdx).toBeLessThan(userIdx);
-    expect(userIdx).toBeLessThan(botIdx);
-  });
-});
 
 describe("fetchTelegramContext", () => {
   let installationId: string;
@@ -161,7 +13,6 @@ describe("fetchTelegramContext", () => {
   it("should return empty context when no messages exist", async () => {
     const result = await fetchTelegramContext(installationId, "chat-1");
 
-    expect(result.routingContext).toBe("");
     expect(result.executionContext).toBe("");
   });
 
@@ -189,17 +40,17 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatId);
 
-    expect(result.routingContext).toContain("First message");
-    expect(result.routingContext).toContain("SENDER_ID: alice");
-    expect(result.routingContext).toContain("Second message");
-    expect(result.routingContext).toContain("SENDER_ID: bob");
+    expect(result.executionContext).toContain("First message");
+    expect(result.executionContext).toContain("SENDER_ID: alice");
+    expect(result.executionContext).toContain("Second message");
+    expect(result.executionContext).toContain("SENDER_ID: bob");
 
-    const firstIdx = result.routingContext.indexOf("First message");
-    const secondIdx = result.routingContext.indexOf("Second message");
+    const firstIdx = result.executionContext.indexOf("First message");
+    const secondIdx = result.executionContext.indexOf("Second message");
     expect(firstIdx).toBeLessThan(secondIdx);
   });
 
-  it("should split routing and execution context by lastProcessedMessageId", async () => {
+  it("should filter execution context by lastProcessedMessageId", async () => {
     const chatId = uniqueId("chat");
 
     await insertTelegramMessage({
@@ -223,10 +74,6 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatId, "10");
 
-    // Routing context includes all messages
-    expect(result.routingContext).toContain("Old message");
-    expect(result.routingContext).toContain("New message");
-
     // Execution context only includes messages after ID 10
     expect(result.executionContext).not.toContain("Old message");
     expect(result.executionContext).toContain("New message");
@@ -247,7 +94,6 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatId, "5");
 
-    expect(result.routingContext).toContain("Only message");
     expect(result.executionContext).toBe("");
   });
 
@@ -274,8 +120,8 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatA);
 
-    expect(result.routingContext).toContain("Chat A message");
-    expect(result.routingContext).not.toContain("Chat B message");
+    expect(result.executionContext).toContain("Chat A message");
+    expect(result.executionContext).not.toContain("Chat B message");
   });
 
   it("should include bot messages in context", async () => {
@@ -303,8 +149,8 @@ describe("fetchTelegramContext", () => {
 
     const result = await fetchTelegramContext(installationId, chatId);
 
-    expect(result.routingContext).toContain("User message");
-    expect(result.routingContext).toContain("SENDER_ID: BOT");
-    expect(result.routingContext).toContain("Bot reply");
+    expect(result.executionContext).toContain("User message");
+    expect(result.executionContext).toContain("SENDER_ID: BOT");
+    expect(result.executionContext).toContain("Bot reply");
   });
 });

--- a/turbo/apps/web/src/lib/telegram/context.ts
+++ b/turbo/apps/web/src/lib/telegram/context.ts
@@ -29,14 +29,14 @@ interface TelegramContextMessage {
 }
 
 /**
- * Fetch recent Telegram messages for a chat and build context strings.
+ * Fetch recent Telegram messages for a chat and build execution context.
  *
  * @param installationId - Telegram installation ID
  * @param chatId - Telegram chat ID
  * @param lastProcessedMessageId - Only include messages after this ID for execution context
  * @param client - Telegram client (needed to download images for execution context)
  * @param currentMessageId - The message being processed; excluded from context to avoid duplication with prompt
- * @returns routingContext (all recent text) and executionContext (only new messages, with images)
+ * @returns executionContext (only new messages, with images)
  */
 export async function fetchTelegramContext(
   installationId: string,
@@ -44,7 +44,7 @@ export async function fetchTelegramContext(
   lastProcessedMessageId?: string,
   client?: TelegramClient,
   currentMessageId?: string,
-): Promise<{ routingContext: string; executionContext: string }> {
+): Promise<{ executionContext: string }> {
   const messages = await globalThis.services.db
     .select({
       fromUsername: telegramMessages.fromUsername,
@@ -75,9 +75,6 @@ export async function fetchTelegramContext(
     count: chronological.length,
   });
 
-  // Routing context: text only, no image downloads
-  const routingContext = formatContextForAgent(chronological);
-
   // For execution context, only include messages after lastProcessedMessageId
   const executionMessages = lastProcessedMessageId
     ? chronological.filter((m) => {
@@ -95,7 +92,7 @@ export async function fetchTelegramContext(
         )
       : "";
 
-  return { routingContext, executionContext };
+  return { executionContext };
 }
 
 /**
@@ -136,39 +133,6 @@ function formatMessageWithMetadata(
   }
 
   return parts.join("\n");
-}
-
-/**
- * Format message array into agent-readable text (text only, no image downloads)
- */
-export function formatContextForAgent(
-  messages: TelegramContextMessage[],
-): string {
-  if (messages.length === 0) {
-    return "";
-  }
-
-  const totalMessages = messages.length;
-
-  const formattedMessages = messages
-    .filter((m) => {
-      return m.text || m.fileId;
-    })
-    .map((msg, index) => {
-      const relativeIndex = index - totalMessages;
-      const imageParts: string[] = [];
-      if (msg.fileId) {
-        imageParts.push("[image]: photo (not downloaded for routing context)");
-      }
-      return formatMessageWithMetadata(msg, relativeIndex, imageParts);
-    });
-
-  const result = `# Telegram Chat Context\n\n${CONTEXT_PREAMBLE}\n\n${formattedMessages.join("\n\n")}\n\n---`;
-  log.debug("Formatted messages for context", {
-    messageCount: formattedMessages.length,
-    resultLength: result.length,
-  });
-  return result;
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/__tests__/integration-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/integration-context.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { buildIntegrationContext } from "../integration-context";
+
+describe("buildIntegrationContext", () => {
+  it("should include platform name", () => {
+    const result = buildIntegrationContext("Slack");
+
+    expect(result).toContain("# Current Integration");
+    expect(result).toContain("You are currently running inside: Slack");
+  });
+
+  it("should include all slack options", () => {
+    const result = buildIntegrationContext("Slack", {
+      botUserId: "BBOT",
+      channelId: "C123",
+      channelType: "channel",
+      threadId: "1234567890.001",
+    });
+
+    expect(result).toContain("Your bot user ID: BBOT");
+    expect(result).toContain("Channel ID: C123");
+    expect(result).toContain("Channel type: Channel");
+    expect(result).toContain("Thread ID: 1234567890.001");
+  });
+
+  it("should map channel type labels", () => {
+    expect(buildIntegrationContext("Slack", { channelType: "dm" })).toContain(
+      "Channel type: Direct message",
+    );
+    expect(
+      buildIntegrationContext("Slack", { channelType: "group_dm" }),
+    ).toContain("Channel type: Group direct message");
+    expect(
+      buildIntegrationContext("Slack", { channelType: "channel" }),
+    ).toContain("Channel type: Channel");
+  });
+
+  it("should omit fields when options are not provided", () => {
+    const result = buildIntegrationContext("Telegram");
+
+    expect(result).not.toContain("bot user ID");
+    expect(result).not.toContain("Channel ID");
+    expect(result).not.toContain("Channel type");
+    expect(result).not.toContain("Thread ID");
+  });
+
+  it("should omit thread id when undefined", () => {
+    const result = buildIntegrationContext("Slack", {
+      channelId: "C123",
+      threadId: undefined,
+    });
+
+    expect(result).toContain("Channel ID: C123");
+    expect(result).not.toContain("Thread ID");
+  });
+});

--- a/turbo/apps/web/src/lib/zero/integration-context.ts
+++ b/turbo/apps/web/src/lib/zero/integration-context.ts
@@ -13,6 +13,7 @@ export function buildIntegrationContext(
     botUserId?: string;
     channelId?: string;
     channelType?: "channel" | "dm" | "group_dm";
+    threadId?: string;
   },
 ): string {
   let context = `# Current Integration\nYou are currently running inside: ${platform}`;
@@ -30,6 +31,9 @@ export function buildIntegrationContext(
           ? "Group direct message"
           : "Channel";
     context += `\nChannel type: ${typeLabel}`;
+  }
+  if (options?.threadId) {
+    context += `\nThread ID: ${options.threadId}`;
   }
   return context;
 }


### PR DESCRIPTION
## Summary

When a user @mentions Zero for the first time in a thread, the handler fetches up to 10 recent channel messages as background context (`channelContextPrefix`). These were formatted with the sync `formatContextForAgent()`, which only outputs raw Slack metadata URLs (`permalink_public` / `thumb_480`) — no S3 upload happens.

This means if a channel message contained an image, the agent received an unauthenticated `slack-files.com` URL it couldn't access.

**Root cause** (`shared.ts:280`):
```typescript
// Before: sync version, no upload
const channelContextPrefix = formatContextForAgent(channelMessages, ...)

// After: async version, uploads to R2
const channelContextPrefix = await formatContextForAgentWithImages(channelMessages, botToken, imageSessionId, ...)
```

**Trigger condition**: `isFirstThreadSession = true` (first @mention in a thread, no existing session).

## Changes

- `shared.ts`: Switch `channelContextPrefix` to `formatContextForAgentWithImages`
- `shared.test.ts`: Add test verifying S3 upload is triggered and presigned URL appears in `executionContext` when channel messages contain images

## Test plan

- [ ] Existing `fetchConversationContexts` tests pass
- [ ] New test: channel message with `url_private_download` → `uploadS3Buffer` called → presigned URL in `executionContext`
- [ ] Manual: @mention Zero in a thread where the recent channel history has images → images accessible to agent