### PR TITLE
fix: read correct route param name in schedule detail page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-detail-page.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+const SCHEDULE_ID = "f0000001-0000-4000-a000-000000000001";
+
+function createMockSchedule() {
+  return {
+    id: SCHEDULE_ID,
+    agentId: "c0000000-0000-4000-a000-000000000001",
+    displayName: "Zero",
+    name: "morning-briefing",
+    triggerType: "cron",
+    cronExpression: "0 9 * * 1-5",
+    atTime: null,
+    intervalSeconds: null,
+    timezone: "UTC",
+    prompt: "Summarize yesterday's threads",
+    description: "Daily morning briefing",
+    enabled: true,
+    nextRunAt: null,
+    lastRunAt: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+    userId: "test-user-123",
+    appendSystemPrompt: null,
+    vars: null,
+    secretNames: null,
+    volumeVersions: null,
+    retryStartedAt: null,
+    consecutiveFailures: 0,
+  };
+}
+
+function mockAPIs(schedules = [createMockSchedule()]) {
+  server.use(
+    http.get("*/api/zero/schedules", () => {
+      return HttpResponse.json({ schedules });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("zero schedule detail page", () => {
+  it("should render schedule detail when navigating to /schedules/:id", async () => {
+    mockAPIs();
+    await setupPage({ context, path: `/schedules/${SCHEDULE_ID}` });
+
+    // The detail page shows the description as the page title (appears in
+    // breadcrumb, header, and sidebar, so use getAllByText).
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Daily morning briefing")[0],
+      ).toBeInTheDocument();
+    });
+
+    // Should NOT show the not-found screen
+    expect(screen.queryByText("Schedule not found")).not.toBeInTheDocument();
+  });
+
+  it("should show not-found when schedule id does not match any schedule", async () => {
+    mockAPIs();
+    await setupPage({
+      context,
+      path: "/schedules/f0000001-0000-4000-a000-999999999999",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Schedule not found")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -934,8 +934,8 @@ function ScheduleDetailView({
 export function ZeroScheduleDetailPage() {
   const params = useGet(pathParams$);
   const scheduleId =
-    params && typeof params === "object" && "scheduleId" in params
-      ? String(params.scheduleId)
+    params && typeof params === "object" && "id" in params
+      ? String(params.id)
       : null;
 
   const entriesLoadable = useLastLoadable(allOrgScheduleEntries$);


### PR DESCRIPTION
## Summary
- **Root cause**: PR #7601 renamed the route from `/schedule/:scheduleId` to `/schedules/:id` but `ZeroScheduleDetailPage` still read `params.scheduleId`, which was always `undefined`
- This caused the schedule detail page to **always** show "Schedule not found" even though the schedule appeared correctly in the list view
- Fix: changed param reading from `params.scheduleId` to `params.id` to match the route definition

Closes #7646

## Test plan
- [x] Added `zero-schedule-detail-page.test.tsx` with two tests:
  - Navigating to `/schedules/:id` renders schedule detail (finds entry by ID)
  - Navigating to `/schedules/:id` with non-existent ID shows "Schedule not found"
- [x] Lint, type-check, format, knip all pass
- [ ] Verify in staging: navigate to a schedule detail page and confirm content loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)