### PR TITLE
feat: enable zero token auth for org endpoint

### DIFF
--- a/turbo/apps/web/app/api/zero/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/__tests__/route.test.ts
@@ -3,12 +3,14 @@ import { GET, PUT } from "../route";
 import {
   createTestRequest,
   createTestOrg,
+  insertOrgMembersCacheEntry,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   uniqueId,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { generateZeroToken } from "../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -62,6 +64,25 @@ describe("GET /api/zero/org", () => {
       createTestRequest("http://localhost:3000/api/zero/org"),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("should return org info with zero token", async () => {
+    mockClerk({ userId: null });
+    const userId = uniqueId("zorg-zero");
+    const { slug, orgId } = await setupOrg(userId);
+    await insertOrgMembersCacheEntry({ orgId, userId, role: "admin" });
+
+    const token = await generateZeroToken(userId, "run-123", orgId);
+    const response = await GET(
+      createTestRequest(orgUrl(), {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.slug).toBe(slug);
+    expect(data.role).toBe("admin");
   });
 });
 
@@ -133,5 +154,25 @@ describe("PUT /api/zero/org", () => {
       }),
     );
     expect(response.status).toBe(404);
+  });
+
+  it("should reject zero token for PUT", async () => {
+    mockClerk({ userId: null });
+    const userId = uniqueId("zorg-put-zero");
+    const { orgId } = await setupOrg(userId);
+    await insertOrgMembersCacheEntry({ orgId, userId, role: "admin" });
+
+    const token = await generateZeroToken(userId, "run-123", orgId);
+    const response = await PUT(
+      createTestRequest(orgUrl(), {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "Hacked" }),
+      }),
+    );
+    expect(response.status).toBe(403);
   });
 });

--- a/turbo/apps/web/app/api/zero/org/route.ts
+++ b/turbo/apps/web/app/api/zero/org/route.ts
@@ -21,7 +21,9 @@ const router = tsr.router(zeroOrgContract, {
   get: async ({ headers }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      acceptAnySandboxCapability: true,
+    });
     if (isAuthError(authCtx)) return authCtx;
 
     try {

--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -73,7 +73,7 @@ function buildAgentToolsPrompt(): string {
     "- Schedule recurring tasks: `zero schedule --help`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "- Ask the user a question: `zero ask-user question --help`.",
     "- Slack messaging and file uploads: `zero slack --help`. Your replies are automatically sent to the originating thread — only use these commands for different channels/threads. Never use SLACK_TOKEN directly — it's a user OAuth token.",
-    "- Troubleshoot errors (missing tokens, firewall denials): `zero doctor --help`.",
+    "- Troubleshoot errors (missing tokens, firewall denials, permission changes): `zero doctor --help`.",
     "- Update your own configuration: `zero agent edit --help`. Review current settings with `zero agent view $ZERO_AGENT_ID --instructions` first.",
     "- Manage custom skills: `zero skill --help`.",
   ].join("\n");

--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -73,7 +73,8 @@ function buildAgentToolsPrompt(): string {
     "- Schedule recurring tasks: `zero schedule --help`. Do NOT use /loop or cron tools (CronCreate, CronList, CronDelete) — they are not available.",
     "- Ask the user a question: `zero ask-user question --help`.",
     "- Slack messaging and file uploads: `zero slack --help`. Your replies are automatically sent to the originating thread — only use these commands for different channels/threads. Never use SLACK_TOKEN directly — it's a user OAuth token.",
-    "- Troubleshoot errors (missing tokens, firewall denials, permission changes): `zero doctor --help`.",
+    "- Diagnose missing tokens or expired connectors: `zero doctor missing-token --help`.",
+    "- Troubleshoot firewall denials and permission changes: `zero doctor firewall-deny --help` and `zero doctor firewall-permissions-change --help`.",
     "- Update your own configuration: `zero agent edit --help`. Review current settings with `zero agent view $ZERO_AGENT_ID --instructions` first.",
     "- Manage custom skills: `zero skill --help`.",
   ].join("\n");


### PR DESCRIPTION
## Summary
- Allow sandbox/zero tokens to authenticate against `GET /api/zero/org` so that `zero doctor` commands can resolve the user's org role in sandbox environments instead of always falling back to "unknown"
- PUT remains restricted to non-sandbox tokens
- Add "permission changes" to the agent tools doctor prompt

## Test plan
- [x] Existing org route tests pass
- [x] New test: zero token returns org info with correct role on GET
- [x] New test: zero token is rejected (403) on PUT
- [x] zero-run-service tests pass (agent prompt change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)