### PR TITLE
chore: enable skill-manager plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,10 @@
 {
+  "enabledPlugins": {
+    "dev-server@team-skills": true,
+    "deep-dive@team-skills": true,
+    "github-workflow@team-skills": true,
+    "skill-manager@team-skills": true
+  },
   "extraKnownMarketplaces": {
     "team-skills": {
       "source": {
@@ -6,10 +12,5 @@
         "repo": "vm0-ai/team-skills"
       }
     }
-  },
-  "enabledPlugins": {
-    "dev-server@team-skills": true,
-    "deep-dive@team-skills": true,
-    "github-workflow@team-skills": true
   }
 }


### PR DESCRIPTION
## Summary
- Enable `skill-manager@team-skills` plugin in Claude Code settings
- Reorder `enabledPlugins` before `extraKnownMarketplaces` for consistency

## Test plan
- [x] Verify plugin loads correctly with `/reload-plugins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)