### PR TITLE
refactor(web): remove defensive try-catch in execute-schedules cron

### DIFF
--- a/turbo/apps/web/app/api/cron/execute-schedules/route.ts
+++ b/turbo/apps/web/app/api/cron/execute-schedules/route.ts
@@ -27,29 +27,15 @@ export async function GET(request: Request) {
 
   log.debug("Executing due schedules...");
 
-  try {
-    const result = await executeDueSchedules();
+  const result = await executeDueSchedules();
 
-    log.debug(
-      `Cron completed: ${result.executed} executed, ${result.skipped} skipped`,
-    );
+  log.debug(
+    `Cron completed: ${result.executed} executed, ${result.skipped} skipped`,
+  );
 
-    return NextResponse.json({
-      success: true,
-      executed: result.executed,
-      skipped: result.skipped,
-    });
-  } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : "Unknown error";
-    log.error(`Cron execution failed: ${errorMessage}`);
-
-    return NextResponse.json(
-      {
-        success: false,
-        error: errorMessage,
-      },
-      { status: 500 },
-    );
-  }
+  return NextResponse.json({
+    success: true,
+    executed: result.executed,
+    skipped: result.skipped,
+  });
 }


### PR DESCRIPTION
## Summary
- Remove defensive try-catch block in `execute-schedules/route.ts` that violated the project's "Avoid Defensive Programming" principle
- The catch block only logged the error and returned a generic 500 JSON response — identical behavior to what Next.js provides for uncaught errors
- Errors now propagate naturally to the framework error handler

## Cleanup Analysis

**Blocks identified:** Scanned all ~213 TypeScript files in `turbo/` containing try-catch

**Blocks removed:** 1

**Blocks skipped:** All others were kept for legitimate reasons:
- Error type discrimination (isNotFound, isBadRequest, isConcurrentRunLimit)
- Meaningful recovery logic (markRunFailed + drainOrgQueue)
- Per-item error handling in loops (continue processing other items)
- Fire-and-forget for non-critical operations (send thinking message)
- JWT/token parsing where failure returns undefined (expected behavior, not defensive)

| File | Lines | Pattern | Safe to Remove | Reason |
|------|-------|---------|----------------|--------|
| `apps/web/app/api/cron/execute-schedules/route.ts` | 30-54 | Log + Return Generic Error | Yes | Next.js handles uncaught errors with 500; no recovery logic |

## Test plan
- [ ] Verify lint passes: `cd turbo && pnpm turbo run lint`
- [ ] Verify type-check passes: `cd turbo && pnpm check-types`
- [ ] Verify cron endpoint still works correctly in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)