### PR TITLE
fix(ci): disable gather_facts and reduce control persist in ansible.cfg

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -3,7 +3,7 @@ inventory = inventory/
 roles_path = roles/
 host_key_checking = False
 timeout = 30
-gather_facts = True
+gathering = explicit
 
 # Reduce SSH connection overhead
 pipelining = True
@@ -15,4 +15,4 @@ callback_whitelist = profile_tasks
 
 [ssh_connection]
 # Keep SSH connection alive during long operations (drain can take hours)
-ssh_args = -o ControlMaster=auto -o ControlPersist=3600s -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10


### PR DESCRIPTION
## Summary

- Disable `gather_facts` globally — no playbook uses `ansible_facts`, and it was causing `ansible-playbook` to hang on GitHub Actions runners with cloudflared ProxyCommand
- Reduce `ControlPersist` from 3600s (1h) to 600s (10min) — stale control sockets from dead tunnel connections block SSH for up to an hour

## Root cause

The `runner-cleanup` CI job has been hanging at `Gathering Facts` indefinitely. Diagnostic testing confirmed:
- Raw SSH: works
- `ansible` ad-hoc commands (ping, setup, become): all work
- `ansible-playbook` with `gather_facts: true` (default): hangs

Disabling `gather_facts` eliminates the hang since cleanup/deploy playbooks only run shell commands and don't need host facts.

## Test plan

- [ ] `runner-cleanup` job completes without hanging
- [ ] `provision-runner`, `deploy-runner`, `provision-monitoring` playbooks still work
- [ ] No playbook relies on `ansible_facts` variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)