### PR TITLE
perf(web): defer dispatch pipeline in chat messages route via after()

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -209,6 +209,9 @@ describe("POST /api/zero/chat/messages", () => {
       expect(response.status).toBe(201);
       const data = await response.json();
 
+      // Flush deferred after() callbacks (callback registration is deferred)
+      await context.mocks.flushAfter();
+
       // Verify callback registration using test helper
       const callbacks = await findTestCallbacksByRunId(data.runId);
       expect(callbacks.length).toBeGreaterThan(0);

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm";
+import { after } from "next/server";
 import {
   createHandler,
   createSafeErrorHandler,
@@ -10,8 +11,10 @@ import {
   requireAuth,
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
-import { createZeroRun } from "../../../../../src/lib/zero/zero-run-service";
-import { isRunDispatchError } from "../../../../../src/lib/run";
+import {
+  createZeroRunRecord,
+  dispatchZeroRun,
+} from "../../../../../src/lib/zero/zero-run-service";
 import { isApiError } from "../../../../../src/lib/errors";
 import {
   createChatThread,
@@ -109,8 +112,9 @@ const router = tsr.router(chatMessagesContract, {
           ? body.modelProvider
           : undefined;
 
-      // Create the run
-      const result = await createZeroRun({
+      // Create the run record (pre-flight checks + advisory-locked INSERT).
+      // Does NOT dispatch — tokens, secrets, and runner dispatch are deferred.
+      const result = await createZeroRunRecord({
         userId: authCtx.userId,
         prompt: body.prompt,
         agentId: body.agentId,
@@ -123,6 +127,18 @@ const router = tsr.router(chatMessagesContract, {
       // Associate run to thread
       await addRunToThread(threadId, result.runId, authCtx.userId);
 
+      // Defer the heavy dispatch pipeline (token generation, secret resolution,
+      // OAuth refresh, storage manifest, runner dispatch) to after the response
+      // is flushed. Failures are recorded via markRunFailed() inside dispatchZeroRun().
+      after(() => {
+        return dispatchZeroRun(result).catch((err: unknown) => {
+          log.error("Deferred dispatch failed", {
+            runId: result.runId,
+            err,
+          });
+        });
+      });
+
       return {
         status: 201 as const,
         body: {
@@ -133,18 +149,6 @@ const router = tsr.router(chatMessagesContract, {
         },
       };
     } catch (error) {
-      // Dispatch errors with a runId: return partial result with threadId
-      if (isRunDispatchError(error) && error.runId && threadId) {
-        return {
-          status: 201 as const,
-          body: {
-            runId: error.runId,
-            threadId,
-            status: "failed" as const,
-          },
-        };
-      }
-
       if (isApiError(error)) {
         const status = error.code === "UNAUTHORIZED" ? 404 : error.statusCode;
         const code = error.code === "UNAUTHORIZED" ? "NOT_FOUND" : error.code;

--- a/turbo/apps/web/src/lib/run/index.ts
+++ b/turbo/apps/web/src/lib/run/index.ts
@@ -16,4 +16,5 @@ export {
   type RunDispatchError,
   type CreateRunParams,
   type CreateRunResult,
+  type CreateRunRecordResult,
 } from "./run-service";

--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -927,7 +927,7 @@ export async function startRun(
  * Result of createRunRecord — contains the run record and all metadata
  * needed by buildAndDispatchRun to complete the dispatch pipeline.
  */
-interface CreateRunRecordResult {
+export interface CreateRunRecordResult {
   run: { id: string; createdAt: Date };
   composeContent: AgentComposeYaml;
   orgId: string;

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -383,11 +383,11 @@ export async function createZeroRunRecord(
  */
 export async function dispatchZeroRun(
   result: ZeroRunRecordResult,
-): Promise<void> {
+): Promise<{ status: RunStatus; sandboxId?: string } | undefined> {
   const { record, runParams, orgId, zeroParams } = result;
 
   // Nothing to dispatch if run was enqueued (concurrency limit)
-  if (!record || !runParams || !orgId || !zeroParams) return;
+  if (!record || !runParams || !orgId || !zeroParams) return undefined;
 
   try {
     // 5. Register callbacks early so they persist even if context building fails
@@ -416,7 +416,7 @@ export async function dispatchZeroRun(
     });
 
     // 8. Dispatch with pre-built context (callbacks already registered above)
-    await buildAndDispatchRun({
+    const dispatchResult = await buildAndDispatchRun({
       runId: record.run.id,
       context: contextResult.context,
       timings: {
@@ -431,6 +431,8 @@ export async function dispatchZeroRun(
 
     // 9. Persist zero-layer metadata (triggerSource + schedule + trigger agent + model fields)
     await persistZeroRunMetadata(record.run.id, zeroParams, contextResult);
+
+    return dispatchResult;
   } catch (error) {
     await markRunFailed(record.run.id, error);
     await drainOrgQueue(orgId, dispatchQueuedZeroRun).catch((drainErr) => {
@@ -465,11 +467,12 @@ export async function createZeroRun(
     };
   }
 
-  await dispatchZeroRun(result);
+  const dispatchResult = await dispatchZeroRun(result);
 
   return {
     runId: result.runId,
-    status: "pending",
+    status: dispatchResult?.status ?? "pending",
+    sandboxId: dispatchResult?.sandboxId,
     createdAt: result.createdAt,
   };
 }

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -5,6 +5,7 @@ import {
   type TriggerSource,
   type FirewallPolicies,
   type ConnectorType,
+  type RunStatus,
   connectorTypeSchema,
 } from "@vm0/core";
 import {
@@ -16,6 +17,7 @@ import {
   registerCallbacks,
   type CreateRunResult,
   type CreateRunParams,
+  type CreateRunRecordResult,
 } from "../run";
 import {
   enqueueRun,
@@ -190,19 +192,32 @@ async function checkModelProviderConfigured(
 }
 
 /**
- * Create an agent run with zero-layer defaults.
- *
- * agentId is the composeId (single UUID). Fetches agent metadata from
- * zero_agents, then injects agent identity, memoryName, artifactName,
- * and disallowedTools so that every zero trigger path gets consistent
- * identity, memory persistence, artifact storage, and cron-tool restrictions.
- *
- * Pre-flight checks (credits, model provider) run before createRunRecord()
- * so they apply to both direct and queued paths.
+ * Result of createZeroRunRecord() — contains everything needed by dispatchZeroRun().
+ * When the run is enqueued (concurrency limit), dispatch fields are undefined.
  */
-export async function createZeroRun(
+export interface ZeroRunRecordResult {
+  runId: string;
+  status: RunStatus;
+  createdAt: Date;
+  /** Undefined when run was enqueued (concurrency limit) — dispatch already deferred via queue */
+  record?: CreateRunRecordResult;
+  runParams?: CreateRunParams;
+  orgId?: string;
+  zeroParams?: ZeroRunParams;
+}
+
+/**
+ * Create a zero run record with pre-flight checks but without dispatching.
+ *
+ * Handles agent metadata, compose resolution, org data, pre-flight checks
+ * (credits, model provider), and advisory-locked run record creation.
+ * Does NOT generate tokens, build execution context, or dispatch to runner.
+ *
+ * Use dispatchZeroRun() to complete the dispatch pipeline after this returns.
+ */
+export async function createZeroRunRecord(
   params: ZeroRunParams,
-): Promise<CreateRunResult> {
+): Promise<ZeroRunRecordResult> {
   const db = globalThis.services.db;
 
   // Fetch agent metadata (displayName, description, sound, firewallPolicies, orgId)
@@ -337,14 +352,43 @@ export async function createZeroRun(
       // Persist zero-layer metadata
       await persistZeroRunMetadata(queueResult.runId, params);
 
-      return queueResult;
+      return {
+        runId: queueResult.runId,
+        status: queueResult.status,
+        createdAt: queueResult.createdAt,
+      };
     }
     throw error;
   }
 
-  // Steps 5-8 run after createRunRecord — wrap in try-catch so that
-  // failures (e.g. session framework mismatch, provider resolution) are
-  // recorded against the run and the route handler can return 201 + failed.
+  return {
+    runId: record.run.id,
+    status: "pending",
+    createdAt: record.run.createdAt,
+    record,
+    runParams,
+    orgId: resolved.orgId,
+    zeroParams: params,
+  };
+}
+
+/**
+ * Dispatch a zero run after its record has been created.
+ *
+ * Handles callbacks, token generation, execution context building,
+ * runner dispatch, and zero-layer metadata persistence.
+ * On failure: marks run as failed and drains the org queue.
+ *
+ * Safe to call from after() — errors are handled internally.
+ */
+export async function dispatchZeroRun(
+  result: ZeroRunRecordResult,
+): Promise<void> {
+  const { record, runParams, orgId, zeroParams } = result;
+
+  // Nothing to dispatch if run was enqueued (concurrency limit)
+  if (!record || !runParams || !orgId || !zeroParams) return;
+
   try {
     // 5. Register callbacks early so they persist even if context building fails
     if (runParams.callbacks && runParams.callbacks.length > 0) {
@@ -353,8 +397,8 @@ export async function createZeroRun(
 
     // 6. Generate ZERO_TOKEN + sandbox token (now we have runId)
     const [zeroToken, sandboxToken] = await Promise.all([
-      generateZeroToken(params.userId, record.run.id, resolved.orgId),
-      generateSandboxToken(params.userId, record.run.id),
+      generateZeroToken(zeroParams.userId, record.run.id, orgId),
+      generateSandboxToken(zeroParams.userId, record.run.id),
     ]);
     const tokenTime = Date.now();
 
@@ -372,7 +416,7 @@ export async function createZeroRun(
     });
 
     // 8. Dispatch with pre-built context (callbacks already registered above)
-    const result = await buildAndDispatchRun({
+    await buildAndDispatchRun({
       runId: record.run.id,
       context: contextResult.context,
       timings: {
@@ -386,23 +430,48 @@ export async function createZeroRun(
     });
 
     // 9. Persist zero-layer metadata (triggerSource + schedule + trigger agent + model fields)
-    await persistZeroRunMetadata(record.run.id, params, contextResult);
-
-    return {
-      runId: record.run.id,
-      status: result.status,
-      sandboxId: result.sandboxId,
-      createdAt: record.run.createdAt,
-    };
+    await persistZeroRunMetadata(record.run.id, zeroParams, contextResult);
   } catch (error) {
     await markRunFailed(record.run.id, error);
-    await drainOrgQueue(resolved.orgId, dispatchQueuedZeroRun).catch(
-      (drainErr) => {
-        log.error("Failed to drain org queue after run failure", { drainErr });
-      },
-    );
+    await drainOrgQueue(orgId, dispatchQueuedZeroRun).catch((drainErr) => {
+      log.error("Failed to drain org queue after run failure", { drainErr });
+    });
     throw error;
   }
+}
+
+/**
+ * Create an agent run with zero-layer defaults.
+ *
+ * Composition of createZeroRunRecord() + dispatchZeroRun(). Performs the
+ * full synchronous pipeline: pre-flight checks, record creation, token
+ * generation, context building, and runner dispatch.
+ *
+ * All trigger paths except chat messages use this function directly.
+ * The chat messages route uses createZeroRunRecord() + after(dispatchZeroRun)
+ * to defer the dispatch pipeline and return a response faster.
+ */
+export async function createZeroRun(
+  params: ZeroRunParams,
+): Promise<CreateRunResult> {
+  const result = await createZeroRunRecord(params);
+
+  // Enqueued runs (concurrency limit) — no dispatch needed
+  if (!result.record) {
+    return {
+      runId: result.runId,
+      status: result.status,
+      createdAt: result.createdAt,
+    };
+  }
+
+  await dispatchZeroRun(result);
+
+  return {
+    runId: result.runId,
+    status: "pending",
+    createdAt: result.createdAt,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Split `createZeroRun()` into `createZeroRunRecord()` + `dispatchZeroRun()` to decouple the API response from the heavy dispatch pipeline
- Chat messages route now returns `201` after pre-flight checks and run record creation, deferring token generation, secret resolution, OAuth refresh, storage manifest, and runner dispatch to `after()`
- All 8 other trigger paths (slack, telegram, email, schedule, github, runs route, etc.) continue using the composed `createZeroRun()` unchanged
- Updated callback registration test to flush `after()` callbacks before assertion

## Changes

| File | Change |
|------|--------|
| `zero-run-service.ts` | Extract `createZeroRunRecord()` + `dispatchZeroRun()`, recompose `createZeroRun()` |
| `chat/messages/route.ts` | Use `createZeroRunRecord()` + `after(dispatchZeroRun)` |
| `run-service.ts` | Export `CreateRunRecordResult` interface |
| `run/index.ts` | Re-export `CreateRunRecordResult` |
| `route.test.ts` | Add `flushAfter()` before callback assertion |

## Test plan

- [x] All 31 existing tests pass (chat messages route + zero-run-service)
- [x] TypeScript type check passes
- [x] Lint clean (0 warnings, 0 errors)
- [x] Knip clean (no new unused exports)
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [ ] CI pipeline (lint, test, deploy, cli-e2e)

Closes #7554

🤖 Generated with [Claude Code](https://claude.com/claude-code)