### PR TITLE
refactor: simplify zero onboarding with shared completion command

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
@@ -271,9 +271,9 @@ describe("onboardingContinueWeb$", () => {
 
     await context.store.set(onboardingContinueWeb$, context.signal);
 
-    expect(pathname()).toBe("/");
+    expect(pathname()).toBe("/chats/thread-1");
     expect(context.store.get(zeroSaving$)).toBeFalsy();
-    // Step is set to "done" by dismissZeroOnboarding$
+    // Step is set to "done" by completeOnboarding$
     await expect(context.store.get(zeroOnboardingStep$)).resolves.toBe("done");
   });
 
@@ -299,6 +299,6 @@ describe("onboardingContinueWeb$", () => {
 
     await context.store.set(onboardingContinueWeb$, context.signal);
 
-    expect(pathname()).toBe("/");
+    expect(pathname()).toBe("/chats/thread-1");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
@@ -337,7 +337,7 @@ describe("completeZeroOnboarding$", () => {
 
     await context.store.set(completeZeroOnboarding$, context.signal);
 
-    // Step no longer auto-set to "done"; callers use dismissZeroOnboarding$
+    // Step no longer auto-set to "done"; callers handle dismissal
     expect(context.store.get(zeroSaving$)).toBeFalsy();
   });
 
@@ -494,7 +494,7 @@ describe("completeZeroOnboarding$", () => {
 
     expect(context.store.get(zeroOnboardingError$)).toBeNull();
     // Step is no longer auto-set to "done" by completeZeroOnboarding$;
-    // callers use dismissZeroOnboarding$ to dismiss the dialog.
+    // callers handle dismissal separately.
     await expect(context.store.get(zeroOnboardingStep$)).resolves.toBe("4");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -12,16 +12,14 @@ import {
   setZeroStep$,
   completeZeroOnboarding$,
   completeMemberOnboarding$,
-  dismissZeroOnboarding$,
   clearZeroOnboardingError$,
 } from "./zero-onboarding.ts";
 import { agentDisplayName$ } from "./zero-agent-name.ts";
-import { sendNewThreadMessage$, startNewZeroSession$ } from "./zero-chat.ts";
+import { sendNewThreadMessage$ } from "./zero-chat.ts";
 import { allConnectorTypes$ } from "./settings/connectors.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
 import { reloadBillingStatus$ } from "./billing.ts";
-import { detach, Reason } from "../utils.ts";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 
 // ---------------------------------------------------------------------------
@@ -254,91 +252,54 @@ export const onboardingError$ = computed(async (get) => {
   return get(zeroOnboardingError$);
 });
 
-// ---------------------------------------------------------------------------
-// Action commands for WhereToWorkContent
-// ---------------------------------------------------------------------------
-
-/**
- * Complete onboarding and navigate to Slack setup.
- * Admin: create agent → reload billing → open Slack install URL → /works
- * Member: mark complete → /works
- */
-export const onboardingAddToSlack$ = command(
+const completeOnboarding$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     set(clearZeroOnboardingError$);
+    set(reloadBillingStatus$);
+
     const isAdmin = await get(zeroNeedsOnboarding$);
     signal.throwIfAborted();
+    return isAdmin
+      ? await set(completeZeroOnboarding$, signal)
+      : await set(completeMemberOnboarding$, signal);
+  },
+);
 
+export const onboardingAddToSlack$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const result = await set(completeOnboarding$, signal);
+    if (!result) {
+      return;
+    }
+
+    const isAdmin = await get(zeroNeedsOnboarding$);
+    signal.throwIfAborted();
     if (isAdmin) {
-      const result = await set(completeZeroOnboarding$, signal);
-      if (!result) {
-        return;
-      }
-      set(reloadBillingStatus$);
-      set(dismissZeroOnboarding$);
-
       const slackData = get(slackOrgData$);
       if (slackData?.isAdmin && slackData.installUrl) {
         const url = new URL(slackData.installUrl, window.location.origin);
         url.searchParams.set("_t", String(Date.now()));
         window.open(url.toString(), "_blank");
       }
-
-      set(detachedNavigateTo$, "/works");
-    } else {
-      await set(completeMemberOnboarding$, signal);
-      set(detachedNavigateTo$, "/works");
     }
+    set(detachedNavigateTo$, "/works");
   },
 );
 
-/**
- * Complete onboarding and start a web chat session.
- * Admin: create agent → reload billing → navigate home → send intro message
- * Member: mark complete → navigate home → send intro message
- */
 export const onboardingContinueWeb$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    set(clearZeroOnboardingError$);
-    const isAdmin = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
+  async ({ set }, signal: AbortSignal) => {
+    const agentId = await set(completeOnboarding$, signal);
 
-    if (isAdmin) {
-      const agentId = await set(completeZeroOnboarding$, signal);
-      if (!agentId) {
-        return;
-      }
-      set(reloadBillingStatus$);
-      set(detachedNavigateTo$, "/");
-      set(startNewZeroSession$);
-      detach(
-        set(
-          sendNewThreadMessage$,
-          agentId,
-          "Who are you and what can you do?",
-          undefined,
-          signal,
-        ),
-        Reason.DomCallback,
-      );
-      set(dismissZeroOnboarding$);
-    } else {
-      const agentId = await set(completeMemberOnboarding$, signal);
-      if (!agentId) {
-        return;
-      }
-      set(detachedNavigateTo$, "/");
-      set(startNewZeroSession$);
-      detach(
-        set(
-          sendNewThreadMessage$,
-          agentId,
-          "Who are you and what can you do?",
-          undefined,
-          signal,
-        ),
-        Reason.DomCallback,
-      );
+    if (!agentId) {
+      return;
     }
+
+    await set(
+      sendNewThreadMessage$,
+      agentId,
+      "Who are you and what can you do?",
+      undefined,
+      signal,
+    );
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -298,7 +298,6 @@ export const completeZeroOnboarding$ = command(
       await clerk.organization?.reload();
       signal.throwIfAborted();
 
-      // Reload status (caller dismisses via dismissZeroOnboarding$)
       set(internalReload$, (x) => {
         return x + 1;
       });
@@ -316,15 +315,6 @@ export const completeZeroOnboarding$ = command(
     }
   },
 );
-
-/**
- * Dismiss the admin onboarding dialog.
- * Separated from completeZeroOnboarding$ so callers can control when the
- * dialog disappears (e.g. after a chat thread is initiated).
- */
-export const dismissZeroOnboarding$ = command(({ set }) => {
-  set(userStep$, "done");
-});
 
 /**
  * Initialize onboarding status by eagerly loading it.


### PR DESCRIPTION
## Summary
- Extract shared admin/member completion logic into a `completeOnboarding$` command to deduplicate code across `onboardingAddToSlack$` and `onboardingContinueWeb$`
- Simplify `onboardingContinueWeb$` to navigate directly to the chat thread instead of navigating to "/" and starting a separate session
- Remove unused `dismissZeroOnboarding$` export and clean up stale comment references

## Test plan
- [ ] Verify zero onboarding "add to Slack" flow works for admin and member
- [ ] Verify zero onboarding "continue on web" flow navigates to chat thread
- [ ] Run existing onboarding action tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)