### PR TITLE
fix(cli): display full run ids in zero logs list and search

### DIFF
--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -69,7 +69,7 @@ describe("zero logs list command", () => {
     await listCommand.parseAsync(["node", "cli"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("abc12345");
+    expect(logCalls).toContain("abc12345-1234-1234-1234-123456789abc");
     expect(logCalls).toContain("My Agent");
     expect(logCalls).toContain("completed");
     expect(logCalls).toContain("2026-04-01");

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -71,7 +71,7 @@ describe("zero logs search command", () => {
     await searchCommand.parseAsync(["node", "cli", "OOM"]);
 
     const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-    expect(logCalls).toContain("abc12345");
+    expect(logCalls).toContain("abc12345-1234-1234-1234-123456789abc");
     expect(logCalls).toContain("my-agent");
     expect(logCalls).toContain("OOM killed");
   });

--- a/turbo/apps/cli/src/commands/zero/logs/list.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/list.ts
@@ -73,7 +73,7 @@ Examples:
         );
 
         const header = [
-          "RUN ID".padEnd(10),
+          "RUN ID".padEnd(38),
           "AGENT".padEnd(nameCol),
           "STATUS".padEnd(statusCol),
           "CREATED",
@@ -81,10 +81,10 @@ Examples:
         console.log(chalk.dim(header));
 
         for (const entry of result.data) {
-          const shortId = entry.id.slice(0, 8);
+          const runId = entry.id;
           const name = entry.displayName || entry.agentId || "-";
           const row = [
-            shortId.padEnd(10),
+            runId.padEnd(38),
             name.padEnd(nameCol),
             formatStatus(entry.status).padEnd(statusCol),
             formatTime(entry.createdAt),

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -36,9 +36,8 @@ function formatRunHeader(
   agentName: string,
   timestamp: string,
 ): string {
-  const shortId = runId.slice(0, 8);
   const time = new Date(timestamp).toISOString().replace(/\.\d{3}Z$/, "Z");
-  return `── Run ${shortId} (${agentName}, ${time}) ──────────`;
+  return `── Run ${runId} (${agentName}, ${time}) ──────────`;
 }
 
 function parseContextOptions(options: SearchOptions): {


### PR DESCRIPTION
## Summary
- Display full UUIDs instead of truncated 8-character IDs in `zero logs list` table output
- Display full UUIDs in `zero logs search` run headers
- Update test assertions to verify full UUID output

Previously, `zero logs list` truncated run IDs to 8 characters, but `zero logs <runId>` requires full UUIDs, causing 500 errors when users copy-pasted IDs from the list output.

Closes #7680

## Test plan
- [x] All 21 existing tests pass (`pnpm vitest run apps/cli/src/commands/zero/logs/`)
- [x] Type checks pass (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)