### PR TITLE
refactor: create zero-session-service and extract zero session ops from agent-session-service

### DIFF
--- a/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/[id]/route.ts
@@ -6,7 +6,7 @@ import {
 import { sessionsByIdContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
-import { getSessionResponse } from "../../../../../src/lib/agent-session/agent-session-service";
+import { getSessionResponse } from "../../../../../src/lib/zero/zero-session-service";
 import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(sessionsByIdContract, {

--- a/turbo/apps/web/app/api/agent/sessions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/sessions/__tests__/route.test.ts
@@ -13,7 +13,7 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { appendChatMessages } from "../../../../../src/lib/agent-session";
+import { appendChatMessages } from "../../../../../src/lib/zero/zero-session-service";
 
 const context = testContext();
 

--- a/turbo/apps/web/app/api/agent/sessions/route.ts
+++ b/turbo/apps/web/app/api/agent/sessions/route.ts
@@ -3,7 +3,7 @@ import { sessionsContract } from "@vm0/core";
 import { eq } from "drizzle-orm";
 import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
-import { listAgentSessions } from "../../../../src/lib/agent-session";
+import { listSessionsWithMessages } from "../../../../src/lib/zero/zero-session-service";
 import { agentComposes } from "../../../../src/db/schema/agent-compose";
 
 const router = tsr.router(sessionsContract, {
@@ -47,7 +47,10 @@ const router = tsr.router(sessionsContract, {
       };
     }
 
-    const sessions = await listAgentSessions(userId, query.agentComposeId);
+    const sessions = await listSessionsWithMessages(
+      userId,
+      query.agentComposeId,
+    );
 
     return {
       status: 200 as const,

--- a/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/__tests__/route.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { computeHmacSignature } from "../../../../../../src/lib/callback/hmac";
 import { reloadEnv } from "../../../../../../src/env";
-import { getSessionChatMessages } from "../../../../../../src/lib/agent-session";
+import { getSessionChatMessages } from "../../../../../../src/lib/zero/zero-session-service";
 import { POST as createThreadHandler } from "../../../../zero/chat-threads/route";
 import { POST } from "../route";
 import { http } from "../../../../../../src/__tests__/msw";

--- a/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/chat/route.ts
@@ -7,7 +7,7 @@ import { chatThreads } from "../../../../../src/db/schema/chat-thread";
 import { agentRuns } from "../../../../../src/db/schema/agent-run";
 import { findNewSessionId } from "../../../../../src/lib/session/find-new-session";
 import { queryRunEventsForChat } from "../../../../../src/lib/run/extract-chat-events";
-import { appendChatMessages } from "../../../../../src/lib/agent-session/agent-session-service";
+import { appendChatMessages } from "../../../../../src/lib/zero/zero-session-service";
 import {
   generateChatTitle,
   type TitleContextMessage,

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -12,7 +12,7 @@ import {
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
-import { appendChatMessages } from "../../../../../../src/lib/agent-session/agent-session-service";
+import { appendChatMessages } from "../../../../../../src/lib/zero/zero-session-service";
 import {
   addRunToThread,
   updateChatThreadTitle,

--- a/turbo/apps/web/app/api/zero/sessions/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/sessions/[id]/route.ts
@@ -10,7 +10,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { getSessionResponse } from "../../../../../src/lib/agent-session/agent-session-service";
+import { getSessionResponse } from "../../../../../src/lib/zero/zero-session-service";
 import { isNotFound, isForbidden } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroSessionsByIdContract, {

--- a/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
+++ b/turbo/apps/web/src/lib/agent-session/agent-session-service.ts
@@ -1,27 +1,20 @@
-import { eq, and, isNull, desc, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { agentSessions } from "../../db/schema/agent-session";
-import {
-  zeroAgentSessions,
-  type StoredChatMessage,
-} from "../../db/schema/zero-agent-session";
-import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../db/schema/agent-compose";
 import { conversations } from "../../db/schema/conversation";
-import { extractAndGroupVariables, type SummaryEntry } from "@vm0/core";
-import { notFound, forbidden } from "../errors";
+import { notFound } from "../errors";
 import type {
   AgentSessionData,
   AgentSessionWithConversation,
   CreateAgentSessionInput,
 } from "./types";
-import type { SessionResponse } from "@vm0/core";
 
 /**
- * Agent Session Service - Pure Functions
- * Manages VM0 agent sessions - lightweight compose ↔ conversation associations
- * Sessions always use HEAD compose version at runtime — no snapshotting
+ * Agent Session Service - Pure Infra Functions
+ * Manages VM0 agent sessions - lightweight compose <-> conversation associations
+ * Sessions always use HEAD compose version at runtime -- no snapshotting
+ *
+ * Note: zeroAgentSessions operations (chat messages, session listing with messages,
+ * session response) have been moved to zero-session-service.ts
  */
 
 /**
@@ -109,129 +102,6 @@ export async function updateAgentSession(
   return mapToAgentSessionData(session);
 }
 
-/**
- * List chat sessions for a user + agent compose (no artifact).
- * Only returns sessions that have at least one chat message.
- */
-export async function listAgentSessions(
-  userId: string,
-  agentComposeId: string,
-): Promise<
-  Array<{
-    id: string;
-    createdAt: Date;
-    updatedAt: Date;
-    messageCount: number;
-    preview: string | null;
-  }>
-> {
-  const rows = await globalThis.services.db
-    .select({
-      id: agentSessions.id,
-      createdAt: agentSessions.createdAt,
-      updatedAt: agentSessions.updatedAt,
-      chatMessages: zeroAgentSessions.chatMessages,
-    })
-    .from(agentSessions)
-    .leftJoin(zeroAgentSessions, eq(agentSessions.id, zeroAgentSessions.id))
-    .where(
-      and(
-        eq(agentSessions.userId, userId),
-        eq(agentSessions.agentComposeId, agentComposeId),
-        isNull(agentSessions.artifactName),
-      ),
-    )
-    .orderBy(desc(agentSessions.updatedAt));
-
-  return rows.map((row) => {
-    const messages = (row.chatMessages ?? []) as StoredChatMessage[];
-    const firstUserMsg = messages.find((m) => {
-      return m.role === "user";
-    });
-    return {
-      id: row.id,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
-      messageCount: messages.length,
-      preview: firstUserMsg ? firstUserMsg.content.slice(0, 100) : null,
-    };
-  });
-}
-
-/**
- * Get chat messages for a session by ID.
- */
-export async function getSessionChatMessages(
-  sessionId: string,
-): Promise<StoredChatMessage[]> {
-  const [row] = await globalThis.services.db
-    .select({ chatMessages: zeroAgentSessions.chatMessages })
-    .from(zeroAgentSessions)
-    .where(eq(zeroAgentSessions.id, sessionId))
-    .limit(1);
-
-  if (!row) {
-    return [];
-  }
-
-  return (row.chatMessages ?? []) as StoredChatMessage[];
-}
-
-/**
- * Append chat messages to a session's chatMessages JSONB array.
- * Adds server-side createdAt timestamp to each message.
- */
-export async function appendChatMessages(
-  sessionId: string,
-  userId: string,
-  messages: Array<{
-    role: "user" | "assistant";
-    content: string;
-    runId?: string;
-    summaries?: SummaryEntry[];
-  }>,
-): Promise<void> {
-  const now = new Date().toISOString();
-  const withTimestamps = messages.map((m) => {
-    return { ...m, createdAt: now };
-  });
-
-  await globalThis.services.db.transaction(async (tx) => {
-    // Verify session ownership
-    const [session] = await tx
-      .select({ id: agentSessions.id })
-      .from(agentSessions)
-      .where(
-        and(eq(agentSessions.id, sessionId), eq(agentSessions.userId, userId)),
-      )
-      .limit(1);
-
-    if (!session) {
-      throw notFound("Session not found or not owned by user");
-    }
-
-    // Upsert messages into extension table
-    await tx
-      .insert(zeroAgentSessions)
-      .values({
-        id: sessionId,
-        chatMessages: sql`${JSON.stringify(withTimestamps)}::jsonb`,
-      })
-      .onConflictDoUpdate({
-        target: zeroAgentSessions.id,
-        set: {
-          chatMessages: sql`COALESCE(${zeroAgentSessions.chatMessages}, '[]'::jsonb) || ${JSON.stringify(withTimestamps)}::jsonb`,
-        },
-      });
-
-    // Update session timestamp
-    await tx
-      .update(agentSessions)
-      .set({ updatedAt: new Date() })
-      .where(eq(agentSessions.id, sessionId));
-  });
-}
-
 function mapToAgentSessionData(
   session: typeof agentSessions.$inferSelect,
 ): AgentSessionData {
@@ -245,79 +115,5 @@ function mapToAgentSessionData(
     memoryName: session.memoryName,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
-  };
-}
-
-/**
- * Get a session by ID with ownership + org verification,
- * returning the full API response shape including secret names.
- *
- * Throws notFound if session doesn't exist or belongs to different org.
- * Throws forbidden if session belongs to a different user.
- */
-export async function getSessionResponse(
-  sessionId: string,
-  userId: string,
-  orgId: string,
-): Promise<SessionResponse> {
-  const db = globalThis.services.db;
-
-  const [result] = await db
-    .select({
-      session: agentSessions,
-      chatMessages: zeroAgentSessions.chatMessages,
-    })
-    .from(agentSessions)
-    .leftJoin(zeroAgentSessions, eq(agentSessions.id, zeroAgentSessions.id))
-    .where(eq(agentSessions.id, sessionId))
-    .limit(1);
-
-  if (!result) {
-    throw notFound("Session not found");
-  }
-
-  const session = result.session;
-
-  if (session.userId !== userId) {
-    throw forbidden("You do not have permission to access this session");
-  }
-
-  if (orgId !== session.orgId) {
-    throw notFound("Session not found");
-  }
-
-  // Extract secret names from HEAD compose content
-  let secretNames: string[] | null = null;
-  const [compose] = await db
-    .select()
-    .from(agentComposes)
-    .where(eq(agentComposes.id, session.agentComposeId))
-    .limit(1);
-
-  if (compose?.headVersionId) {
-    const [version] = await db
-      .select()
-      .from(agentComposeVersions)
-      .where(eq(agentComposeVersions.id, compose.headVersionId))
-      .limit(1);
-
-    if (version?.content) {
-      const grouped = extractAndGroupVariables(version.content);
-      const names = grouped.secrets.map((ref) => {
-        return ref.name;
-      });
-      secretNames = names.length > 0 ? names : null;
-    }
-  }
-
-  return {
-    id: session.id,
-    agentComposeId: session.agentComposeId,
-    conversationId: session.conversationId,
-    artifactName: session.artifactName,
-    secretNames,
-    chatMessages: result.chatMessages ?? [],
-    createdAt: session.createdAt.toISOString(),
-    updatedAt: session.updatedAt.toISOString(),
   };
 }

--- a/turbo/apps/web/src/lib/agent-session/index.ts
+++ b/turbo/apps/web/src/lib/agent-session/index.ts
@@ -2,7 +2,4 @@ export {
   getAgentSessionWithConversation,
   createAgentSession,
   updateAgentSession,
-  listAgentSessions,
-  appendChatMessages,
-  getSessionChatMessages,
 } from "./agent-session-service";

--- a/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
+++ b/turbo/apps/web/src/lib/chat-thread/chat-thread-service.ts
@@ -1,12 +1,11 @@
 import { eq, and, desc } from "drizzle-orm";
 import { chatThreads, chatThreadRuns } from "../../db/schema/chat-thread";
 import { agentRuns } from "../../db/schema/agent-run";
-import { agentSessions } from "../../db/schema/agent-session";
-import {
-  zeroAgentSessions,
-  type StoredChatMessage,
-} from "../../db/schema/zero-agent-session";
 import { notFound } from "../errors";
+import {
+  getChatMessagesForSession,
+  type StoredChatMessage,
+} from "../zero/zero-session-service";
 import type { SummaryEntry } from "@vm0/core";
 import type { TitleContextMessage } from "../ai/lightweight-model";
 
@@ -253,15 +252,7 @@ export async function getChatThreadMessages(
   let messages: StoredChatMessage[] = [];
 
   if (sessionId) {
-    const [session] = await globalThis.services.db
-      .select({ chatMessages: zeroAgentSessions.chatMessages })
-      .from(agentSessions)
-      .leftJoin(zeroAgentSessions, eq(agentSessions.id, zeroAgentSessions.id))
-      .where(
-        and(eq(agentSessions.id, sessionId), eq(agentSessions.userId, userId)),
-      )
-      .limit(1);
-    messages = session?.chatMessages ?? [];
+    messages = await getChatMessagesForSession(sessionId, userId);
 
     // Mark runs that have messages in the session
     for (const msg of messages) {
@@ -327,19 +318,7 @@ export async function getChatThreadContext(
     return [];
   }
 
-  const [session] = await globalThis.services.db
-    .select({ chatMessages: zeroAgentSessions.chatMessages })
-    .from(agentSessions)
-    .leftJoin(zeroAgentSessions, eq(agentSessions.id, zeroAgentSessions.id))
-    .where(
-      and(
-        eq(agentSessions.id, threadRow.sessionId),
-        eq(agentSessions.userId, userId),
-      ),
-    )
-    .limit(1);
-
-  const messages = session?.chatMessages ?? [];
+  const messages = await getChatMessagesForSession(threadRow.sessionId, userId);
   return messages.slice(-10).map((m) => {
     return {
       role: m.role,

--- a/turbo/apps/web/src/lib/export/export-service.ts
+++ b/turbo/apps/web/src/lib/export/export-service.ts
@@ -6,8 +6,6 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../db/schema/agent-compose";
-import { agentSessions } from "../../db/schema/agent-session";
-import { zeroAgentSessions } from "../../db/schema/zero-agent-session";
 import { conversations } from "../../db/schema/conversation";
 import { storages, storageVersions } from "../../db/schema/storage";
 import {
@@ -15,6 +13,7 @@ import {
   generatePresignedUrl,
   downloadS3Buffer,
 } from "../s3/s3-client";
+import { getAllSessionsWithMessages } from "../zero/zero-session-service";
 import { resolveSessionHistory } from "../session-history/session-history-service";
 import { enqueueEmail } from "../email/outbox-service";
 import {
@@ -130,19 +129,10 @@ async function collectConversations(
   const entries: ZipEntry[] = [];
   let count = 0;
 
-  const sessions = await db
-    .select({
-      id: agentSessions.id,
-      chatMessages: zeroAgentSessions.chatMessages,
-      conversationId: agentSessions.conversationId,
-      agentComposeId: agentSessions.agentComposeId,
-    })
-    .from(agentSessions)
-    .leftJoin(zeroAgentSessions, eq(agentSessions.id, zeroAgentSessions.id))
-    .where(eq(agentSessions.userId, userId));
+  const sessions = await getAllSessionsWithMessages(userId);
 
   for (const session of sessions) {
-    if (session.chatMessages && session.chatMessages.length > 0) {
+    if (session.chatMessages.length > 0) {
       entries.push({
         path: `conversations/${session.id}.json`,
         content: JSON.stringify(session.chatMessages, null, 2),

--- a/turbo/apps/web/src/lib/zero/zero-session-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-session-service.ts
@@ -1,0 +1,273 @@
+import { eq, and, isNull, desc, sql } from "drizzle-orm";
+import { agentSessions } from "../../db/schema/agent-session";
+import {
+  zeroAgentSessions,
+  type StoredChatMessage,
+} from "../../db/schema/zero-agent-session";
+
+export type { StoredChatMessage };
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../db/schema/agent-compose";
+import { extractAndGroupVariables, type SummaryEntry } from "@vm0/core";
+import { notFound, forbidden } from "../errors";
+import type { SessionResponse } from "@vm0/core";
+
+/**
+ * Zero Session Service
+ * Owns all zeroAgentSessions table operations — chat message persistence,
+ * session listing with messages, and session response building.
+ */
+
+/**
+ * List chat sessions for a user + agent compose (no artifact).
+ * Only returns sessions that have at least one chat message.
+ */
+export async function listSessionsWithMessages(
+  userId: string,
+  agentComposeId: string,
+): Promise<
+  Array<{
+    id: string;
+    createdAt: Date;
+    updatedAt: Date;
+    messageCount: number;
+    preview: string | null;
+  }>
+> {
+  const rows = await globalThis.services.db
+    .select({
+      id: agentSessions.id,
+      createdAt: agentSessions.createdAt,
+      updatedAt: agentSessions.updatedAt,
+      chatMessages: zeroAgentSessions.chatMessages,
+    })
+    .from(agentSessions)
+    .leftJoin(zeroAgentSessions, eq(agentSessions.id, zeroAgentSessions.id))
+    .where(
+      and(
+        eq(agentSessions.userId, userId),
+        eq(agentSessions.agentComposeId, agentComposeId),
+        isNull(agentSessions.artifactName),
+      ),
+    )
+    .orderBy(desc(agentSessions.updatedAt));
+
+  return rows.map((row) => {
+    const messages = (row.chatMessages ?? []) as StoredChatMessage[];
+    const firstUserMsg = messages.find((m) => {
+      return m.role === "user";
+    });
+    return {
+      id: row.id,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      messageCount: messages.length,
+      preview: firstUserMsg ? firstUserMsg.content.slice(0, 100) : null,
+    };
+  });
+}
+
+/**
+ * Get chat messages for a session by ID.
+ */
+export async function getSessionChatMessages(
+  sessionId: string,
+): Promise<StoredChatMessage[]> {
+  const [row] = await globalThis.services.db
+    .select({ chatMessages: zeroAgentSessions.chatMessages })
+    .from(zeroAgentSessions)
+    .where(eq(zeroAgentSessions.id, sessionId))
+    .limit(1);
+
+  if (!row) {
+    return [];
+  }
+
+  return (row.chatMessages ?? []) as StoredChatMessage[];
+}
+
+/**
+ * Append chat messages to a session's chatMessages JSONB array.
+ * Adds server-side createdAt timestamp to each message.
+ * CRITICAL: preserves the transaction that writes to both agentSessions
+ * (updatedAt) and zeroAgentSessions (chatMessages JSONB append).
+ */
+export async function appendChatMessages(
+  sessionId: string,
+  userId: string,
+  messages: Array<{
+    role: "user" | "assistant";
+    content: string;
+    runId?: string;
+    summaries?: SummaryEntry[];
+  }>,
+): Promise<void> {
+  const now = new Date().toISOString();
+  const withTimestamps = messages.map((m) => {
+    return { ...m, createdAt: now };
+  });
+
+  await globalThis.services.db.transaction(async (tx) => {
+    // Verify session ownership
+    const [session] = await tx
+      .select({ id: agentSessions.id })
+      .from(agentSessions)
+      .where(
+        and(eq(agentSessions.id, sessionId), eq(agentSessions.userId, userId)),
+      )
+      .limit(1);
+
+    if (!session) {
+      throw notFound("Session not found or not owned by user");
+    }
+
+    // Upsert messages into extension table
+    await tx
+      .insert(zeroAgentSessions)
+      .values({
+        id: sessionId,
+        chatMessages: sql`${JSON.stringify(withTimestamps)}::jsonb`,
+      })
+      .onConflictDoUpdate({
+        target: zeroAgentSessions.id,
+        set: {
+          chatMessages: sql`COALESCE(${zeroAgentSessions.chatMessages}, '[]'::jsonb) || ${JSON.stringify(withTimestamps)}::jsonb`,
+        },
+      });
+
+    // Update session timestamp
+    await tx
+      .update(agentSessions)
+      .set({ updatedAt: new Date() })
+      .where(eq(agentSessions.id, sessionId));
+  });
+}
+
+/**
+ * Get a session by ID with ownership + org verification,
+ * returning the full API response shape including secret names.
+ *
+ * Throws notFound if session doesn't exist or belongs to different org.
+ * Throws forbidden if session belongs to a different user.
+ */
+export async function getSessionResponse(
+  sessionId: string,
+  userId: string,
+  orgId: string,
+): Promise<SessionResponse> {
+  const db = globalThis.services.db;
+
+  const [result] = await db
+    .select({
+      session: agentSessions,
+      chatMessages: zeroAgentSessions.chatMessages,
+    })
+    .from(agentSessions)
+    .leftJoin(zeroAgentSessions, eq(agentSessions.id, zeroAgentSessions.id))
+    .where(eq(agentSessions.id, sessionId))
+    .limit(1);
+
+  if (!result) {
+    throw notFound("Session not found");
+  }
+
+  const session = result.session;
+
+  if (session.userId !== userId) {
+    throw forbidden("You do not have permission to access this session");
+  }
+
+  if (orgId !== session.orgId) {
+    throw notFound("Session not found");
+  }
+
+  // Extract secret names from HEAD compose content
+  let secretNames: string[] | null = null;
+  const [compose] = await db
+    .select()
+    .from(agentComposes)
+    .where(eq(agentComposes.id, session.agentComposeId))
+    .limit(1);
+
+  if (compose?.headVersionId) {
+    const [version] = await db
+      .select()
+      .from(agentComposeVersions)
+      .where(eq(agentComposeVersions.id, compose.headVersionId))
+      .limit(1);
+
+    if (version?.content) {
+      const grouped = extractAndGroupVariables(version.content);
+      const names = grouped.secrets.map((ref) => {
+        return ref.name;
+      });
+      secretNames = names.length > 0 ? names : null;
+    }
+  }
+
+  return {
+    id: session.id,
+    agentComposeId: session.agentComposeId,
+    conversationId: session.conversationId,
+    artifactName: session.artifactName,
+    secretNames,
+    chatMessages: result.chatMessages ?? [],
+    createdAt: session.createdAt.toISOString(),
+    updatedAt: session.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Get chat messages for a session with ownership check.
+ * Used by chat-thread-service to avoid direct zeroAgentSessions access.
+ */
+export async function getChatMessagesForSession(
+  sessionId: string,
+  userId: string,
+): Promise<StoredChatMessage[]> {
+  const [session] = await globalThis.services.db
+    .select({ chatMessages: zeroAgentSessions.chatMessages })
+    .from(agentSessions)
+    .leftJoin(zeroAgentSessions, eq(agentSessions.id, zeroAgentSessions.id))
+    .where(
+      and(eq(agentSessions.id, sessionId), eq(agentSessions.userId, userId)),
+    )
+    .limit(1);
+
+  return (session?.chatMessages ?? []) as StoredChatMessage[];
+}
+
+/**
+ * Get all sessions with their chat messages for a user.
+ * Used by export-service to avoid direct zeroAgentSessions access.
+ */
+export async function getAllSessionsWithMessages(userId: string): Promise<
+  Array<{
+    id: string;
+    chatMessages: StoredChatMessage[];
+    conversationId: string | null;
+    agentComposeId: string;
+  }>
+> {
+  const sessions = await globalThis.services.db
+    .select({
+      id: agentSessions.id,
+      chatMessages: zeroAgentSessions.chatMessages,
+      conversationId: agentSessions.conversationId,
+      agentComposeId: agentSessions.agentComposeId,
+    })
+    .from(agentSessions)
+    .leftJoin(zeroAgentSessions, eq(agentSessions.id, zeroAgentSessions.id))
+    .where(eq(agentSessions.userId, userId));
+
+  return sessions.map((s) => {
+    return {
+      id: s.id,
+      chatMessages: (s.chatMessages ?? []) as StoredChatMessage[],
+      conversationId: s.conversationId,
+      agentComposeId: s.agentComposeId,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

- Create `zero-session-service.ts` in the zero layer with all `zeroAgentSessions` table operations (6 functions)
- Remove 4 coupled functions and `zeroAgentSessions` import from `agent-session-service.ts`, leaving only pure infra functions
- Fix secondary layering violations in `chat-thread-service.ts` and `export-service.ts` by replacing direct schema access with service calls

## Details

Moves the following functions to `zero-session-service.ts`:
- `listSessionsWithMessages` (renamed from `listAgentSessions`)
- `getSessionChatMessages`
- `appendChatMessages` (preserves transaction atomicity)
- `getSessionResponse`
- `getChatMessagesForSession` (new helper for chat-thread-service)
- `getAllSessionsWithMessages` (new helper for export-service)

After this change:
- `agent-session-service.ts` has zero `zeroAgentSessions` imports
- `chat-thread-service.ts` has zero `zeroAgentSessions` imports
- `export-service.ts` has zero `zeroAgentSessions` imports

Pure structural move — no behavioral changes, no migrations.

Closes #7679

## Test plan

- [x] All 50 tests across 6 affected test files pass
- [x] TypeScript type-check passes (web)
- [x] Lint passes (web)
- [x] Knip finds no issues
- [x] Verified zero `zeroAgentSessions` references in agent-session, chat-thread, and export service dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)