### PR TITLE
feat(runner): increase default vm resources and add configurable disk size

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -10,6 +10,7 @@
 #     --output-dir /path/to/output \
 #     --work-dir /path/to/workdir \
 #     --ca-dir /path/to/ca \
+#     --disk-mb 16384 \
 #     --guest-agent /path/to/guest-agent \
 #     --guest-download /path/to/guest-download \
 #     --guest-init /path/to/guest-init \
@@ -25,6 +26,7 @@ OUTPUT_DIR=""
 WORK_DIR=""
 CA_DIR=""
 INPUT_HASH=""
+DISK_MB=""
 GUEST_AGENT=""
 GUEST_DOWNLOAD=""
 GUEST_INIT=""
@@ -36,6 +38,7 @@ while [[ $# -gt 0 ]]; do
     --work-dir)   WORK_DIR="$2";   shift 2 ;;
     --ca-dir)     CA_DIR="$2";     shift 2 ;;
     --hash)       INPUT_HASH="$2"; shift 2 ;;
+    --disk-mb)    DISK_MB="$2";    shift 2 ;;
     --guest-agent)      GUEST_AGENT="$2";      shift 2 ;;
     --guest-download)   GUEST_DOWNLOAD="$2";   shift 2 ;;
     --guest-init)       GUEST_INIT="$2";       shift 2 ;;
@@ -44,7 +47,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-for var in OUTPUT_DIR WORK_DIR CA_DIR INPUT_HASH GUEST_AGENT GUEST_DOWNLOAD GUEST_INIT GUEST_MOCK_CLAUDE; do
+for var in OUTPUT_DIR WORK_DIR CA_DIR INPUT_HASH DISK_MB GUEST_AGENT GUEST_DOWNLOAD GUEST_INIT GUEST_MOCK_CLAUDE; do
   if [[ -z "${!var}" ]]; then
     echo "error: --$(echo "$var" | tr '_' '-' | tr '[:upper:]' '[:lower:]') is required" >&2
     exit 1
@@ -216,15 +219,18 @@ extract_and_inject() {
 create_ext4() {
   echo "creating ext4 image..."
 
-  # Size the image to content + 2 GiB free space.
+  # Image size from profile disk_mb.
   # With dm-snapshot COW, the guest filesystem is limited to this image
-  # size — there is no separate writable layer.  The old overlayfs approach
-  # had a 2 GiB upper layer for writes; we match that by reserving 2 GiB
-  # of free space inside the rootfs itself.
+  # size — there is no separate writable layer.
   local content_bytes
   content_bytes=$(sudo du -sb "$EXTRACT_DIR" | cut -f1)
-  local free_space=2147483648  # 2 GiB
-  local image_bytes=$(( content_bytes + free_space ))
+  local image_bytes=$(( DISK_MB * 1024 * 1024 ))
+
+  if (( image_bytes < content_bytes )); then
+    local content_mb=$(( content_bytes / 1024 / 1024 ))
+    echo "error: disk_mb (${DISK_MB} MiB) is smaller than rootfs content (${content_mb} MiB)" >&2
+    exit 1
+  fi
 
   # Derive a deterministic UUID from the input hash.  ext4 uses the UUID
   # as the htree seed for directory hashing — a fixed UUID ensures

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -108,6 +108,7 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
                 snapshot_hash: Some(snapshot_hash.clone()),
                 vcpu: def.vcpu,
                 memory_mb: def.memory_mb,
+                disk_mb: def.disk_mb,
             },
         );
     }

--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -119,6 +119,7 @@ async fn resolve_guest(
 pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     let def = profile::get(&args.profile)?;
     let dockerfile = def.dockerfile;
+    let disk_mb = def.disk_mb;
     let dry_run = args.dry_run;
 
     // Create temp dir for any bundled guest binaries that need extracting.
@@ -145,9 +146,9 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
         ),
     ];
 
-    // Compute input hash: script + dockerfile + guest binaries.
+    // Compute input hash: script + dockerfile + guest binaries + disk size.
     // The build script content is included so any logic change invalidates cache.
-    let hash = compute_input_hash(dockerfile, &bins).await?;
+    let hash = compute_input_hash(dockerfile, &bins, disk_mb).await?;
     tracing::info!("rootfs input hash: {hash}");
     // Machine-readable output — do not change format without updating consumers
     println!("rootfs_hash={hash}");
@@ -209,6 +210,7 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
     let guest_init_str = guest_init.to_string_lossy();
     let guest_mock_claude_str = guest_mock_claude.to_string_lossy();
     let ca_dir_str = paths.ca_dir().to_string_lossy().to_string();
+    let disk_mb_str = disk_mb.to_string();
 
     let status = tokio::process::Command::new("bash")
         .arg(&script_path)
@@ -221,6 +223,8 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
             &ca_dir_str,
             "--hash",
             &hash,
+            "--disk-mb",
+            &disk_mb_str,
             "--guest-agent",
             &guest_agent_str,
             "--guest-download",
@@ -282,6 +286,7 @@ async fn is_build_complete(rootfs: &RootfsPaths) -> RunnerResult<bool> {
 async fn compute_input_hash(
     dockerfile: &str,
     guest_bins: &[(&Path, &str)],
+    disk_mb: u32,
 ) -> RunnerResult<String> {
     let mut hasher = Sha256::new();
 
@@ -296,6 +301,10 @@ async fn compute_input_hash(
     // Hash Dockerfile content
     hasher.update(b"dockerfile:");
     hasher.update(dockerfile.as_bytes());
+
+    // Hash disk size
+    hasher.update(b"disk_mb:");
+    hasher.update(disk_mb.to_le_bytes());
 
     // Hash guest binaries (already sorted by name via guest_bins())
     for (src, dest) in guest_bins {

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -37,14 +37,7 @@ pub struct ProfileConfig {
     pub snapshot_hash: Option<String>,
     pub vcpu: u32,
     pub memory_mb: u32,
-    /// Disk size in MiB. Defaults to 16384 (16 GiB) for backward compatibility
-    /// with runner.yaml files generated before this field existed.
-    #[serde(default = "default_disk_mb")]
     pub disk_mb: u32,
-}
-
-fn default_disk_mb() -> u32 {
-    16384
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -481,6 +474,45 @@ profiles:
     vcpu: 0
     memory_mb: 4096
     disk_mb: 16384
+"#,
+            base_dir = dir.path().display(),
+            ca_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let err = load_with_home(&config_path, &home).await.unwrap_err();
+        assert!(err.to_string().contains("non-zero"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn load_rejects_zero_disk_mb_in_profile() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        for f in [&fc, &kernel] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+        let home = test_home_with_artifacts(dir.path(), &[]).await;
+
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+profiles:
+  vm0/default:
+    rootfs_hash: abc
+    vcpu: 2
+    memory_mb: 4096
+    disk_mb: 0
 "#,
             base_dir = dir.path().display(),
             ca_dir = dir.path().display(),

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -37,6 +37,14 @@ pub struct ProfileConfig {
     pub snapshot_hash: Option<String>,
     pub vcpu: u32,
     pub memory_mb: u32,
+    /// Disk size in MiB. Defaults to 16384 (16 GiB) for backward compatibility
+    /// with runner.yaml files generated before this field existed.
+    #[serde(default = "default_disk_mb")]
+    pub disk_mb: u32,
+}
+
+fn default_disk_mb() -> u32 {
+    16384
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -127,9 +135,9 @@ async fn validate(config: &RunnerConfig, home: &HomePaths) -> RunnerResult<()> {
                 "invalid profile name: {name} (must be org/name format, lowercase alphanumeric + hyphens)"
             )));
         }
-        if profile.vcpu == 0 || profile.memory_mb == 0 {
+        if profile.vcpu == 0 || profile.memory_mb == 0 || profile.disk_mb == 0 {
             return Err(RunnerError::Config(format!(
-                "profile {name}: vcpu and memory_mb must be non-zero"
+                "profile {name}: vcpu, memory_mb, and disk_mb must be non-zero"
             )));
         }
         // Validate rootfs exists on disk.
@@ -263,7 +271,8 @@ mod tests {
                 rootfs_hash: "abc123".into(),
                 snapshot_hash: Some("def456".into()),
                 vcpu: 2,
-                memory_mb: 2048,
+                memory_mb: 4096,
+                disk_mb: 16384,
             },
         );
         profiles
@@ -292,7 +301,8 @@ profiles:
     rootfs_hash: abc123
     snapshot_hash: def456
     vcpu: 2
-    memory_mb: 2048
+    memory_mb: 4096
+    disk_mb: 16384
 sandbox:
   max_concurrent: 8
   concurrency_factor: 2.0
@@ -347,7 +357,8 @@ profiles:
   vm0/default:
     rootfs_hash: abc
     vcpu: 2
-    memory_mb: 2048
+    memory_mb: 4096
+    disk_mb: 16384
 "#,
             base_dir = dir.path().display(),
             ca_dir = dir.path().display(),
@@ -426,7 +437,8 @@ profiles:
   bad-name:
     rootfs_hash: abc
     vcpu: 2
-    memory_mb: 2048
+    memory_mb: 4096
+    disk_mb: 16384
 "#,
             base_dir = dir.path().display(),
             ca_dir = dir.path().display(),
@@ -467,7 +479,8 @@ profiles:
   vm0/default:
     rootfs_hash: abc
     vcpu: 0
-    memory_mb: 2048
+    memory_mb: 4096
+    disk_mb: 16384
 "#,
             base_dir = dir.path().display(),
             ca_dir = dir.path().display(),
@@ -507,7 +520,8 @@ profiles:
   vm0/default:
     rootfs_hash: abc
     vcpu: 2
-    memory_mb: 2048
+    memory_mb: 4096
+    disk_mb: 16384
 sandbox:
   concurrency_factor: {bad_value}
 "#,
@@ -587,7 +601,8 @@ profiles:
   vm0/default:
     rootfs_hash: abc
     vcpu: 2
-    memory_mb: 2048
+    memory_mb: 4096
+    disk_mb: 16384
 "#;
 
         let config_path = dir.path().join("runner.yaml");

--- a/crates/runner/src/profile.rs
+++ b/crates/runner/src/profile.rs
@@ -10,6 +10,8 @@ pub struct ProfileDef {
     pub vcpu: u32,
     /// Memory in MiB for VMs using this profile.
     pub memory_mb: u32,
+    /// Disk size in MiB for VMs using this profile.
+    pub disk_mb: u32,
 }
 
 pub const DEFAULT_PROFILE: &str = "vm0/default";
@@ -19,7 +21,8 @@ pub fn get(name: &str) -> RunnerResult<&'static ProfileDef> {
     static DEFAULT: ProfileDef = ProfileDef {
         dockerfile: EMBEDDED_DOCKERFILE_DEFAULT,
         vcpu: 2,
-        memory_mb: 2048,
+        memory_mb: 4096,
+        disk_mb: 16384,
     };
 
     match name {
@@ -60,7 +63,8 @@ mod tests {
     fn get_default_profile() {
         let def = get("vm0/default").unwrap();
         assert_eq!(def.vcpu, 2);
-        assert_eq!(def.memory_mb, 2048);
+        assert_eq!(def.memory_mb, 4096);
+        assert_eq!(def.disk_mb, 16384);
         assert!(!def.dockerfile.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- Bump default VM profile: 2 vCPU / 2G RAM → 2 vCPU / **4G RAM** / **16G disk**
- Add `disk_mb` field to `ProfileDef` and `ProfileConfig`, passed to `build-rootfs.sh` via `--disk-mb`
- Content size validation in build script — fails early if content exceeds disk size
- `disk_mb` is a required field in `ProfileConfig` (no backward compat needed — rootfs/snapshot hashes change, so runner.yaml is always regenerated)

Closes #6785

## Test plan
- [x] All 256 runner tests pass (including new `disk_mb: 0` validation test)
- [x] Pre-commit hooks (cargo-fmt, cargo-clippy, commitlint) pass
- [ ] Full CI pipeline (build, lint, test)
- [ ] Deploy and rebuild rootfs/snapshot on a dev host to verify 16G image + 4G memory.bin

🤖 Generated with [Claude Code](https://claude.com/claude-code)