### PR TITLE
fix: use page signal instead of standalone abort controller in onboarding

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -117,7 +117,6 @@ export default [
       "src/signals/__tests__/test-helpers.ts",
       "src/signals/__tests__/utils.test.ts",
       "src/signals/zero-page/__tests__/poll-slack-connection.test.ts",
-      "src/views/zero-page/zero-onboarding.tsx",
     ],
     rules: {
       "ccstate/no-new-abort-controller": "off",

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -637,6 +637,7 @@ function OnboardingPageLayout({ children }: { children: React.ReactNode }) {
   const nextDisabled = useLastResolved(onboardingNextDisabled$) ?? false;
   const stepBack = useSet(onboardingStepBack$);
   const stepNext = useSet(onboardingStepNext$);
+  const pageSignal = useGet(pageSignal$);
   const effectiveConnectors =
     useLastResolved(onboardingEffectiveConnectors$) ?? [];
 
@@ -781,10 +782,7 @@ function OnboardingPageLayout({ children }: { children: React.ReactNode }) {
                   variant="ghost"
                   className="rounded-lg text-muted-foreground"
                   onClick={() => {
-                    detach(
-                      stepBack(new AbortController().signal),
-                      Reason.DomCallback,
-                    );
+                    detach(stepBack(pageSignal), Reason.DomCallback);
                   }}
                 >
                   Back
@@ -795,10 +793,7 @@ function OnboardingPageLayout({ children }: { children: React.ReactNode }) {
               {showNext && (
                 <Button
                   onClick={() => {
-                    detach(
-                      stepNext(new AbortController().signal),
-                      Reason.DomCallback,
-                    );
+                    detach(stepNext(pageSignal), Reason.DomCallback);
                   }}
                   className="rounded-lg min-w-[100px]"
                   disabled={nextDisabled}
@@ -822,6 +817,7 @@ function WorkspaceStepContent() {
   const workspaceName = useGet(zeroWorkspaceName$);
   const setWorkspaceName = useSet(setZeroWorkspaceName$);
   const stepNext = useSet(onboardingStepNext$);
+  const pageSignal = useGet(pageSignal$);
 
   return (
     <>
@@ -848,10 +844,7 @@ function WorkspaceStepContent() {
           }}
           onKeyDown={(e) => {
             if (e.key === "Enter" && workspaceName.trim()) {
-              detach(
-                stepNext(new AbortController().signal),
-                Reason.DomCallback,
-              );
+              detach(stepNext(pageSignal), Reason.DomCallback);
             }
           }}
           className="h-10 rounded-lg"

--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -330,6 +330,7 @@ function WhereToWorkContent() {
   const error = useLastResolved(onboardingError$) ?? null;
   const addToSlack = useSet(onboardingAddToSlack$);
   const continueWeb = useSet(onboardingContinueWeb$);
+  const pageSignal = useGet(pageSignal$);
 
   return (
     <>
@@ -350,10 +351,7 @@ function WhereToWorkContent() {
         <button
           type="button"
           onClick={() => {
-            return detach(
-              addToSlack(new AbortController().signal),
-              Reason.DomCallback,
-            );
+            detach(addToSlack(pageSignal), Reason.DomCallback);
           }}
           disabled={saving}
           className="flex items-center gap-4 rounded-xl bg-card px-6 py-6 text-left transition-colors hover:bg-muted/30 disabled:opacity-50 zero-border"
@@ -374,10 +372,7 @@ function WhereToWorkContent() {
         <button
           type="button"
           onClick={() => {
-            return detach(
-              continueWeb(new AbortController().signal),
-              Reason.DomCallback,
-            );
+            detach(continueWeb(pageSignal), Reason.DomCallback);
           }}
           disabled={saving}
           className="flex items-center gap-4 rounded-xl bg-card px-6 py-6 text-left transition-colors hover:bg-muted/30 disabled:opacity-50 zero-border"


### PR DESCRIPTION
## Summary
- Replace `new AbortController().signal` with `pageSignal` in onboarding button handlers so abort signals are properly tied to page lifecycle
- Remove eslint ignore for `zero-onboarding.tsx` since the file now follows all lint rules

## Test plan
- [ ] Verify onboarding "Add to Slack" and "Continue on web" buttons work correctly
- [ ] Confirm no eslint violations in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)