### PR TITLE
feat: add device pool for pre-validated nbd device index management

### DIFF
--- a/crates/nbd-cow/src/bin/bench.rs
+++ b/crates/nbd-cow/src/bin/bench.rs
@@ -214,14 +214,20 @@ async fn run_nbd_cow_bench(
 
     eprintln!("  NBD module loaded, setting up NBD COW device...");
 
+    let device_pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
+        nbd_cow::pool::DevicePoolConfig::default(),
+    ));
+    device_pool.lock().await.warmup().await;
+
     for wl in workloads {
         let cow_path = work_dir.join("nbd-cow.img");
 
-        let mut device = NbdCowDevice::create(base_path, &cow_path, base_size)
+        let mut device = NbdCowDevice::create(base_path, &cow_path, base_size, &device_pool)
             .await
             .map_err(|e| format!("failed to create NBD COW device: {e}"))?;
 
         let dev_path = device.device_path().to_string_lossy().to_string();
+        let device_index = device.device_index();
         eprintln!("  Running fio ({}) on {dev_path}...", wl.name);
 
         let result = run_fio_with_iostat(&dev_path, wl, host_disk)?;
@@ -231,9 +237,11 @@ async fn run_nbd_cow_bench(
             .destroy()
             .await
             .map_err(|e| format!("failed to destroy NBD device: {e}"))?;
+        device_pool.lock().await.release(device_index);
         let _ = std::fs::remove_file(&cow_path);
     }
 
+    device_pool.lock().await.cleanup().await;
     Ok(results)
 }
 

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -397,3 +397,50 @@ impl Drop for NbdCowDevice {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify is_our_thread correctly identifies the main thread (TID == TGID).
+    #[test]
+    fn is_our_thread_main_thread() {
+        assert!(is_our_thread(std::process::id()));
+    }
+
+    /// Verify is_our_thread identifies a spawned thread's TID as ours.
+    /// This exercises the /proc/self/task/{tid} path used by tokio workers.
+    #[test]
+    fn is_our_thread_worker_thread() {
+        // Use a running thread to ensure /proc/self/task/{tid} exists.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let tid = unsafe { libc::gettid() } as u32;
+            tx.send(tid).unwrap();
+            // Keep thread alive until main reads the TID and checks it.
+            std::thread::park();
+            tid
+        });
+        let worker_tid = rx.recv().unwrap();
+        assert_ne!(
+            worker_tid,
+            std::process::id(),
+            "worker TID should differ from TGID"
+        );
+        assert!(
+            is_our_thread(worker_tid),
+            "worker thread TID should be recognized as ours"
+        );
+        handle.thread().unpark();
+        handle.join().unwrap();
+    }
+
+    /// Verify is_our_thread rejects a TID that doesn't belong to our process.
+    #[test]
+    fn is_our_thread_foreign_tid() {
+        // PID 1 (init) is never one of our threads.
+        assert!(!is_our_thread(1));
+        // A very large TID that doesn't exist.
+        assert!(!is_our_thread(u32::MAX));
+    }
+}

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -331,18 +331,19 @@ impl NbdCowDevice {
 
     /// Check if we still own the NBD device by comparing the sysfs PID.
     ///
-    /// The kernel records the connecting process's PID in `/sys/block/nbdN/pid`.
-    /// If another process recycled the device index, the PID will differ and
-    /// we must skip disconnect to avoid tearing down the other process's device.
+    /// The kernel records the connecting **thread's** TID (via `task_pid_nr`)
+    /// in `/sys/block/nbdN/pid`, not the process TGID. In multi-threaded
+    /// programs (tokio worker threads), TID ≠ TGID. We check ownership by
+    /// verifying the recorded TID belongs to our process via `/proc/self/task/`.
     fn device_ownership(&self) -> DeviceOwnership {
         let pid_path = format!("/sys/block/nbd{}/pid", self.device_index);
         match std::fs::read_to_string(&pid_path) {
             Ok(contents) => {
-                let pid: u32 = contents.trim().parse().unwrap_or(0);
-                if pid == std::process::id() {
+                let tid: u32 = contents.trim().parse().unwrap_or(0);
+                if is_our_thread(tid) {
                     DeviceOwnership::Ours
                 } else {
-                    DeviceOwnership::Foreign(pid)
+                    DeviceOwnership::Foreign(tid)
                 }
             }
             Err(e) => DeviceOwnership::Unknown(e),
@@ -352,6 +353,17 @@ impl NbdCowDevice {
     fn bitmap_path(&self) -> PathBuf {
         cow::bitmap_path_for(&self.cow_file)
     }
+}
+
+/// Check if a TID belongs to our process by probing `/proc/self/task/{tid}`.
+///
+/// The kernel NBD driver records the connecting thread's TID (not TGID) in
+/// sysfs. In a multi-threaded tokio runtime the connecting worker thread has
+/// a TID different from the process TGID returned by `std::process::id()`.
+/// This function handles both cases: TID == TGID (main thread) and
+/// TID != TGID (worker threads).
+fn is_our_thread(tid: u32) -> bool {
+    tid == std::process::id() || std::path::Path::new(&format!("/proc/self/task/{tid}")).exists()
 }
 
 /// Best-effort cleanup on drop: cancel tasks and disconnect the NBD device.

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cow;
 pub mod error;
 pub mod netlink;
+pub mod pool;
 pub mod protocol;
 pub mod server;
 
@@ -8,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use error::Result;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -56,11 +57,24 @@ pub struct NbdCowDevice {
 impl NbdCowDevice {
     /// Create a new NBD COW device.
     ///
-    /// 1. Finds a free NBD device index
+    /// 1. Acquires a pre-validated device index from the pool
     /// 2. Creates socketpairs (NUM_CONNECTIONS connections)
     /// 3. Spawns dispatch tasks for each connection
-    /// 4. Connects via netlink
-    pub async fn create(base_image: &Path, cow_file: &Path, size: u64) -> Result<Self> {
+    /// 4. Connects via netlink to the specific device
+    ///
+    /// Two retry loops:
+    /// - **Inner (EBUSY):** If another process grabbed the device between pool
+    ///   validation and our connect, try a different device. This has its own
+    ///   budget (up to 16 retries) separate from the size-verification loop.
+    /// - **Outer (size-stuck-at-0):** If the kernel hasn't finished tearing down
+    ///   a previous connection, disconnect, release with cooldown, and retry
+    ///   with fresh sockets. Up to 5 retries with 200ms sleep between attempts.
+    pub async fn create(
+        base_image: &Path,
+        cow_file: &Path,
+        size: u64,
+        device_pool: &Mutex<pool::DevicePool>,
+    ) -> Result<Self> {
         // Create COW layer
         let cow_layer = cow::CowLayer::new(
             base_image,
@@ -71,58 +85,83 @@ impl NbdCowDevice {
         )?;
         let cow_layer = Arc::new(RwLock::new(cow_layer));
 
-        // Retry loop: if the kernel is still tearing down a previous connection
-        // on the assigned device, the netlink CONNECT succeeds but set_capacity
-        // may not take effect (device size = 0). When detected, disconnect,
-        // recreate socketpairs + tasks, and retry. The kernel auto-assigns a
-        // (likely different) free device on each attempt.
-        // Fresh sockets and tasks are needed because the kernel may have started
-        // the NBD protocol on the old sockets; after disconnect the dispatch
-        // tasks exit and drop their server-side fds, making reuse unsafe.
-        const MAX_CONNECT_RETRIES: u32 = 5;
+        // Outer retry loop: handles "size stuck at 0" (kernel teardown timing).
+        // Inner retry loop: handles EBUSY (device grabbed by another process).
+        const MAX_SIZE_RETRIES: u32 = 5;
+        const MAX_EBUSY_RETRIES: u32 = 16;
         let mut last_err_idx: u32 = 0;
 
-        for attempt in 0..=MAX_CONNECT_RETRIES {
-            // Fresh shutdown token and socketpairs for each attempt
-            let shutdown = CancellationToken::new();
-            let mut client_fds = Vec::with_capacity(NUM_CONNECTIONS);
-            let mut server_handles = Vec::with_capacity(NUM_CONNECTIONS);
+        for size_attempt in 0..=MAX_SIZE_RETRIES {
+            // Inner loop: acquire from pool and try to connect.
+            // EBUSY retries get a fresh device without consuming the outer budget.
+            let mut ebusy_count: u32 = 0;
+            let (device_index, shutdown, server_handles) = loop {
+                let device_index = device_pool.lock().await.acquire().await?;
 
-            let setup_err = (|| -> Result<()> {
-                for _ in 0..NUM_CONNECTIONS {
-                    let (client_fd, server_fd) = netlink::create_socketpair()?;
-                    client_fds.push(client_fd);
+                // Fresh shutdown token and socketpairs for each attempt
+                let shutdown = CancellationToken::new();
+                let mut client_fds = Vec::with_capacity(NUM_CONNECTIONS);
+                let mut server_handles = Vec::with_capacity(NUM_CONNECTIONS);
 
-                    let cow = cow_layer.clone();
-                    let token = shutdown.clone();
-                    let handle = tokio::spawn(async move {
-                        if let Err(e) = server::dispatch(server_fd, cow, token).await {
-                            tracing::error!("NBD dispatch error: {e}");
-                        }
-                    });
-                    server_handles.push(handle);
-                }
-                Ok(())
-            })();
-            if let Err(e) = setup_err {
-                shutdown.cancel();
-                for handle in server_handles {
-                    handle.abort();
-                }
-                return Err(e);
-            }
+                let setup_err = (|| -> Result<()> {
+                    for _ in 0..NUM_CONNECTIONS {
+                        let (client_fd, server_fd) = netlink::create_socketpair()?;
+                        client_fds.push(client_fd);
 
-            // Atomically find a free device and connect — retries on EBUSY so
-            // concurrent runners don't race for the same device index.
-            let device_index = match netlink::find_and_connect(&client_fds, size, BLOCK_SIZE as u64)
-            {
-                Ok(idx) => idx,
-                Err(e) => {
+                        let cow = cow_layer.clone();
+                        let token = shutdown.clone();
+                        let handle = tokio::spawn(async move {
+                            if let Err(e) = server::dispatch(server_fd, cow, token).await {
+                                tracing::error!("NBD dispatch error: {e}");
+                            }
+                        });
+                        server_handles.push(handle);
+                    }
+                    Ok(())
+                })();
+                if let Err(e) = setup_err {
                     shutdown.cancel();
                     for handle in server_handles {
                         handle.abort();
                     }
+                    // Release device back — connect was never attempted, device
+                    // is still free in kernel. No cooldown needed but release()
+                    // adds one defensively.
+                    device_pool.lock().await.release(device_index);
                     return Err(e);
+                }
+
+                match netlink::connect_device(device_index, &client_fds, size, BLOCK_SIZE as u64) {
+                    Ok(()) => break (device_index, shutdown, server_handles),
+                    Err(error::NbdCowError::NetlinkErrno { errno, .. }) if errno == libc::EBUSY => {
+                        ebusy_count += 1;
+                        tracing::debug!(
+                            device_index,
+                            ebusy_count,
+                            "EBUSY on connect, trying next device"
+                        );
+                        shutdown.cancel();
+                        for handle in server_handles {
+                            handle.abort();
+                        }
+                        if ebusy_count > MAX_EBUSY_RETRIES {
+                            return Err(error::NbdCowError::NoFreeDevice);
+                        }
+                        // Device is owned by another process — don't release
+                        // to pool. Background scan will rediscover if it frees.
+                        continue;
+                    }
+                    Err(e) => {
+                        shutdown.cancel();
+                        for handle in server_handles {
+                            handle.abort();
+                        }
+                        // Connect failed with non-EBUSY error. Device may be in
+                        // an unknown kernel state — release with cooldown so it
+                        // gets re-validated before reuse.
+                        device_pool.lock().await.release(device_index);
+                        return Err(e);
+                    }
                 }
             };
 
@@ -140,29 +179,35 @@ impl NbdCowDevice {
                 });
             }
 
-            // Size is wrong — disconnect, clean up tasks, and retry.
+            // Size is wrong — disconnect, release with cooldown, and retry.
             tracing::debug!(
                 device_index,
-                attempt = attempt + 1,
+                attempt = size_attempt + 1,
                 "device size 0 after connect, disconnecting and retrying"
             );
             let _ = netlink::disconnect(device_index);
+            device_pool.lock().await.release(device_index);
             shutdown.cancel();
             for handle in server_handles {
                 handle.abort();
             }
             last_err_idx = device_index;
 
-            if attempt < MAX_CONNECT_RETRIES {
+            if size_attempt < MAX_SIZE_RETRIES {
                 tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             }
         }
 
         Err(error::NbdCowError::Io(std::io::Error::other(format!(
-            "device size stuck at 0 after {MAX_CONNECT_RETRIES} connect retries \
+            "device size stuck at 0 after {MAX_SIZE_RETRIES} connect retries \
              on nbd{last_err_idx} — kernel may not have finished releasing \
              the previous connection",
         ))))
+    }
+
+    /// NBD device index (N in `/dev/nbdN`).
+    pub fn device_index(&self) -> u32 {
+        self.device_index
     }
 
     /// Path to the block device (e.g., `/dev/nbd0`).

--- a/crates/nbd-cow/src/netlink.rs
+++ b/crates/nbd-cow/src/netlink.rs
@@ -89,7 +89,7 @@ pub fn nbds_max() -> u32 {
 /// Generate a random offset in `0..max` for device scanning.
 ///
 /// Uses `RandomState` (OS-seeded) to avoid pulling in an external RNG crate.
-fn random_offset(max: u32) -> u32 {
+pub fn random_offset(max: u32) -> u32 {
     if max == 0 {
         return 0;
     }
@@ -98,7 +98,7 @@ fn random_offset(max: u32) -> u32 {
 }
 
 /// Check if a device index appears free by inspecting its pid file.
-fn device_appears_free(index: u32) -> bool {
+pub fn device_appears_free(index: u32) -> bool {
     let pid_path = format!("/sys/block/nbd{index}/pid");
     let path = Path::new(&pid_path);
 
@@ -116,69 +116,44 @@ fn device_appears_free(index: u32) -> bool {
     }
 }
 
-/// Atomically find a free NBD device and connect it.
+/// Connect to a specific NBD device by index.
 ///
-/// Starts from a random offset and wraps around, so concurrent runners don't
-/// all compete for the same low-numbered devices. This also avoids reconnecting
-/// to a device that was just disconnected (kernel may still be tearing it down).
-///
-/// If the kernel returns EBUSY (another process grabbed it first), tries the next
-/// device. This eliminates the TOCTOU race between find and connect.
-///
-/// Returns the device index on success.
-pub fn find_and_connect(client_fds: &[OwnedFd], size: u64, block_size: u64) -> Result<u32> {
-    let max = nbds_max();
-
+/// The caller provides the device index (typically from a `DevicePool`).
+/// Returns `Ok(())` on success, or an error. In
+/// particular, `NbdCowError::NetlinkErrno { errno: EBUSY }` means the device
+/// was grabbed by another process between validation and connect.
+pub fn connect_device(
+    device_index: u32,
+    client_fds: &[OwnedFd],
+    size: u64,
+    block_size: u64,
+) -> Result<()> {
     let sock = open_genl_socket()?;
     let family_id = resolve_nbd_family(&sock)?;
 
-    // Build socket attributes once (reused across attempts)
     let sockets_nla = build_sockets_nla(client_fds);
     let flags =
         NBD_FLAG_HAS_FLAGS | NBD_FLAG_SEND_FLUSH | NBD_FLAG_SEND_TRIM | NBD_FLAG_CAN_MULTI_CONN;
 
-    // Random start offset to distribute device usage and avoid retrying
-    // a device that was just disconnected (kernel may still be cleaning up).
-    let start = random_offset(max);
-    for n in 0..max {
-        let i = (start + n) % max;
-        if !device_appears_free(i) {
-            continue;
-        }
+    let mut attrs = Vec::new();
+    attrs.extend_from_slice(&build_nla(NBD_ATTR_INDEX, &device_index.to_ne_bytes()));
+    attrs.extend_from_slice(&build_nla(NBD_ATTR_SIZE_BYTES, &size.to_ne_bytes()));
+    attrs.extend_from_slice(&build_nla(
+        NBD_ATTR_BLOCK_SIZE_BYTES,
+        &block_size.to_ne_bytes(),
+    ));
+    attrs.extend_from_slice(&build_nla(NBD_ATTR_SERVER_FLAGS, &flags.to_ne_bytes()));
+    attrs.extend_from_slice(&build_nla(NBD_ATTR_TIMEOUT, &TIMEOUT_SECS.to_ne_bytes()));
+    attrs.extend_from_slice(&build_nla(
+        NBD_ATTR_DEAD_CONN_TIMEOUT,
+        &TIMEOUT_SECS.to_ne_bytes(),
+    ));
+    attrs.extend_from_slice(&sockets_nla);
 
-        // Build per-device attributes
-        let mut attrs = Vec::new();
-        attrs.extend_from_slice(&build_nla(NBD_ATTR_INDEX, &i.to_ne_bytes()));
-        attrs.extend_from_slice(&build_nla(NBD_ATTR_SIZE_BYTES, &size.to_ne_bytes()));
-        attrs.extend_from_slice(&build_nla(
-            NBD_ATTR_BLOCK_SIZE_BYTES,
-            &block_size.to_ne_bytes(),
-        ));
-        attrs.extend_from_slice(&build_nla(NBD_ATTR_SERVER_FLAGS, &flags.to_ne_bytes()));
-        // Per-request timeout: on expiry, kernel retries via another connection.
-        // Also arms the blk-mq timer that drives dead-connection detection.
-        attrs.extend_from_slice(&build_nla(NBD_ATTR_TIMEOUT, &TIMEOUT_SECS.to_ne_bytes()));
-        // Dead-connection timeout: if ALL connections are dead for this long
-        // AND a request times out, the kernel auto-disconnects the device.
-        // Handles orphan cleanup after SIGKILL (where Drop can't run).
-        attrs.extend_from_slice(&build_nla(
-            NBD_ATTR_DEAD_CONN_TIMEOUT,
-            &TIMEOUT_SECS.to_ne_bytes(),
-        ));
-        attrs.extend_from_slice(&sockets_nla);
+    send_genl_msg(&sock, family_id, NBD_CMD_CONNECT, &attrs)?;
+    recv_genl_ack(&sock)?;
 
-        send_genl_msg(&sock, family_id, NBD_CMD_CONNECT, &attrs)?;
-        match recv_genl_ack(&sock) {
-            Ok(()) => return Ok(i),
-            Err(NbdCowError::NetlinkErrno { errno, .. }) if errno == libc::EBUSY => {
-                // Device was grabbed by another process — try next
-                continue;
-            }
-            Err(e) => return Err(e),
-        }
-    }
-
-    Err(NbdCowError::NoFreeDevice)
+    Ok(())
 }
 
 /// Check whether the device has the expected size via sysfs.

--- a/crates/nbd-cow/src/pool.rs
+++ b/crates/nbd-cow/src/pool.rs
@@ -1,0 +1,279 @@
+//! Device pool for pre-validated NBD device indices.
+//!
+//! Instead of scanning sysfs on every `NbdCowDevice::create()`, this pool
+//! maintains a queue of pre-validated device indices ready for immediate use.
+//! Released devices enter a cooldown period before becoming available again,
+//! preventing the "size stuck at 0" flake caused by reusing a device before
+//! the kernel finishes cleanup.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use crate::error::{NbdCowError, Result};
+use crate::netlink;
+
+/// Number of pre-validated device indices to maintain in the ready queue.
+const BUFFER_SIZE: usize = 4;
+
+/// Maximum background validation tasks running concurrently.
+const MAX_PENDING: usize = 4;
+
+/// Default cooldown period (milliseconds) after disconnecting a device.
+const DEFAULT_COOLDOWN_MS: u64 = 500;
+
+/// A device index with a timestamp marking when it was released.
+struct CooldownSlot {
+    index: u32,
+    released_at: Instant,
+}
+
+/// Configuration for the device pool.
+pub struct DevicePoolConfig {
+    /// Cooldown period before a released device can be reused.
+    pub cooldown: Duration,
+}
+
+impl Default for DevicePoolConfig {
+    fn default() -> Self {
+        Self {
+            cooldown: Duration::from_millis(DEFAULT_COOLDOWN_MS),
+        }
+    }
+}
+
+/// Pre-validated NBD device index pool.
+///
+/// Manages device indices as a host-level resource shared across factories
+/// via `Arc<Mutex<DevicePool>>`, following the same pattern as `NetnsPool`.
+pub struct DevicePool {
+    active: bool,
+    /// Validated free device indices ready for immediate acquire.
+    ready: VecDeque<u32>,
+    /// Recently released devices waiting for cooldown to expire.
+    cooldown: VecDeque<CooldownSlot>,
+    /// Background sysfs validation tasks.
+    pending: tokio::task::JoinSet<Result<u32>>,
+    /// Total number of NBD devices (from sysfs nbds_max).
+    max_devices: u32,
+    /// Pool configuration.
+    config: DevicePoolConfig,
+}
+
+impl DevicePool {
+    /// Create a new device pool.
+    ///
+    /// Reads `nbds_max` from sysfs to determine the device range.
+    /// Call [`warmup()`](Self::warmup) before first use to pre-populate
+    /// the ready queue and avoid a synchronous sysfs scan on the first
+    /// [`acquire()`](Self::acquire).
+    pub fn new(config: DevicePoolConfig) -> Self {
+        let max_devices = netlink::nbds_max();
+        Self {
+            active: true,
+            ready: VecDeque::with_capacity(BUFFER_SIZE),
+            cooldown: VecDeque::new(),
+            pending: tokio::task::JoinSet::new(),
+            max_devices,
+            config,
+        }
+    }
+
+    /// Pre-warm the pool by scanning for free devices.
+    pub async fn warmup(&mut self) {
+        self.spawn_validations();
+
+        // Wait for initial batch to complete
+        while let Some(result) = self.pending.join_next().await {
+            match result {
+                Ok(Ok(index)) => {
+                    if !self.ready.contains(&index) {
+                        self.ready.push_back(index);
+                    }
+                }
+                Ok(Err(e)) => tracing::debug!("warmup validation failed: {e}"),
+                Err(e) => tracing::debug!("warmup task panicked: {e}"),
+            }
+            if self.ready.len() >= BUFFER_SIZE {
+                break;
+            }
+        }
+
+        tracing::info!(
+            ready = self.ready.len(),
+            max_devices = self.max_devices,
+            "device pool warmed up"
+        );
+    }
+
+    /// Acquire a pre-validated device index.
+    ///
+    /// Three-tier strategy:
+    /// 1. Pop from ready queue (instant)
+    /// 2. Await a pending background validation
+    /// 3. Synchronous on-demand scan (fallback)
+    pub async fn acquire(&mut self) -> Result<u32> {
+        if !self.active {
+            return Err(NbdCowError::NoFreeDevice);
+        }
+
+        // Promote expired cooldown slots to ready queue
+        self.promote_cooled_down();
+        // Drain completed background tasks into ready queue
+        self.drain_completed();
+
+        // Tier 1: instant pop from ready queue
+        if let Some(index) = self.ready.pop_front() {
+            self.maybe_replenish();
+            return Ok(index);
+        }
+
+        // Tier 2: await pending background validation
+        while let Some(result) = self.pending.join_next().await {
+            match result {
+                Ok(Ok(index)) => {
+                    self.maybe_replenish();
+                    return Ok(index);
+                }
+                Ok(Err(_)) | Err(_) => continue,
+            }
+        }
+
+        // Tier 3: synchronous on-demand scan
+        let max = self.max_devices;
+        let tracked_indices = self.tracked_indices();
+        let index = tokio::task::spawn_blocking(move || scan_free_device(max, &tracked_indices))
+            .await
+            .map_err(|e| {
+                NbdCowError::Io(std::io::Error::other(format!("scan task panicked: {e}")))
+            })??;
+
+        self.maybe_replenish();
+        Ok(index)
+    }
+
+    /// Release a device index back to the pool after disconnect.
+    ///
+    /// The device enters a cooldown period before it can be reused,
+    /// giving the kernel time to finish teardown.
+    pub fn release(&mut self, index: u32) {
+        if !self.active {
+            return;
+        }
+        self.cooldown.push_back(CooldownSlot {
+            index,
+            released_at: Instant::now(),
+        });
+        self.maybe_replenish();
+    }
+
+    /// Clean up the pool: cancel pending tasks and clear queues.
+    pub async fn cleanup(&mut self) {
+        self.active = false;
+        self.pending.abort_all();
+        while self.pending.join_next().await.is_some() {}
+        self.ready.clear();
+        self.cooldown.clear();
+        tracing::info!("device pool cleanup complete");
+    }
+
+    /// Move expired cooldown slots to the ready queue.
+    fn promote_cooled_down(&mut self) {
+        let now = Instant::now();
+        while let Some(front) = self.cooldown.front() {
+            if now.duration_since(front.released_at) >= self.config.cooldown {
+                let Some(slot) = self.cooldown.pop_front() else {
+                    break;
+                };
+                // Re-validate via sysfs before promoting
+                if netlink::device_appears_free(slot.index) {
+                    self.ready.push_back(slot.index);
+                }
+                // If not free (recycled by another process), just drop it
+            } else {
+                break; // Cooldown queue is ordered by time
+            }
+        }
+    }
+
+    /// Drain completed pending tasks into the ready queue.
+    ///
+    /// Deduplicates against the ready queue: concurrent `spawn_blocking`
+    /// tasks may discover the same free device index because each task
+    /// snapshots `tracked_indices` at spawn time.
+    fn drain_completed(&mut self) {
+        while let Some(Ok(result)) = self.pending.try_join_next() {
+            match result {
+                Ok(index) => {
+                    if !self.ready.contains(&index) {
+                        self.ready.push_back(index);
+                    }
+                }
+                Err(e) => tracing::debug!("background validation failed: {e}"),
+            }
+        }
+    }
+
+    /// Spawn background validation tasks if the ready queue needs replenishment.
+    fn maybe_replenish(&mut self) {
+        let total_available = self.ready.len() + self.pending.len();
+        if total_available >= BUFFER_SIZE {
+            return;
+        }
+
+        self.spawn_validations();
+    }
+
+    /// Spawn background tasks to scan for free devices.
+    fn spawn_validations(&mut self) {
+        while self.pending.len() < MAX_PENDING
+            && self.ready.len() + self.pending.len() < BUFFER_SIZE
+        {
+            let max = self.max_devices;
+            let exclude = self.tracked_indices();
+            self.pending
+                .spawn_blocking(move || scan_free_device(max, &exclude));
+        }
+    }
+
+    /// Collect all indices currently tracked by the pool (ready + cooldown)
+    /// to exclude from background scanning. Prevents duplicate indices in
+    /// the ready queue from concurrent scan tasks.
+    fn tracked_indices(&self) -> Vec<u32> {
+        self.ready
+            .iter()
+            .copied()
+            .chain(self.cooldown.iter().map(|s| s.index))
+            .collect()
+    }
+}
+
+impl Drop for DevicePool {
+    fn drop(&mut self) {
+        if self.active {
+            tracing::warn!("DevicePool dropped without cleanup — call cleanup() first");
+        }
+    }
+}
+
+/// Scan sysfs for a single free device, excluding given indices.
+///
+/// Starts from a random offset to distribute usage across runners.
+fn scan_free_device(max_devices: u32, exclude: &[u32]) -> Result<u32> {
+    if max_devices == 0 {
+        return Err(NbdCowError::NoFreeDevice);
+    }
+
+    let start = netlink::random_offset(max_devices);
+
+    for n in 0..max_devices {
+        let i = (start + n) % max_devices;
+        if exclude.contains(&i) {
+            continue;
+        }
+        if netlink::device_appears_free(i) {
+            return Ok(i);
+        }
+    }
+
+    Err(NbdCowError::NoFreeDevice)
+}

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -655,13 +655,20 @@ async fn drop_without_destroy_disconnects() {
     // Drop without calling destroy — Drop impl should disconnect
     drop(device);
 
-    // Give the kernel a moment to update sysfs
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-    // The device should appear free (pid = -1 or missing)
+    // Poll sysfs until the kernel marks the device as free.
+    // Drop's disconnect is synchronous but the kernel may take time
+    // to update the sysfs pid file, especially under load.
+    let mut freed = false;
+    for _ in 0..20 {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        if nbd_cow::netlink::device_appears_free(device_index) {
+            freed = true;
+            break;
+        }
+    }
     assert!(
-        nbd_cow::netlink::device_appears_free(device_index),
-        "device nbd{device_index} should be free after drop"
+        freed,
+        "device nbd{device_index} should be free after drop (waited 2s)"
     );
 
     pool.lock().await.cleanup().await;

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -652,24 +652,37 @@ async fn drop_without_destroy_disconnects() {
 
     let device_index = device.device_index();
 
-    // Drop without calling destroy — Drop impl should disconnect
+    // Drop without calling destroy — Drop impl should disconnect.
+    // Drop aborts dispatch tasks (which hold server-side socket fds)
+    // and then calls netlink::disconnect synchronously. However, the
+    // aborted tasks' fds are only closed when tokio processes the abort,
+    // and the kernel won't fully release the device until all fds close.
+    // Yield to let the runtime process the aborts before dropping.
     drop(device);
+    tokio::task::yield_now().await;
 
     // Poll sysfs until the kernel marks the device as free.
-    // Drop's disconnect is synchronous but the kernel may take time
-    // to update the sysfs pid file, especially under load.
     let mut freed = false;
-    for _ in 0..20 {
+    for i in 0..50 {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         if nbd_cow::netlink::device_appears_free(device_index) {
             freed = true;
+            eprintln!(
+                "device nbd{device_index} freed after {:.1}s",
+                (i + 1) as f64 * 0.1
+            );
             break;
         }
     }
-    assert!(
-        freed,
-        "device nbd{device_index} should be free after drop (waited 2s)"
-    );
+    if !freed {
+        // Diagnostic: print what the pid file shows
+        let pid_path = format!("/sys/block/nbd{device_index}/pid");
+        let pid_content =
+            std::fs::read_to_string(&pid_path).unwrap_or_else(|e| format!("err: {e}"));
+        panic!(
+            "device nbd{device_index} should be free after drop (waited 5s), pid file: {pid_content}"
+        );
+    }
 
     pool.lock().await.cleanup().await;
 }

--- a/crates/nbd-cow/tests/integration.rs
+++ b/crates/nbd-cow/tests/integration.rs
@@ -44,6 +44,12 @@ fn create_test_base_image(path: &Path) {
     f.set_len(64 * 1024 * 1024).expect("truncate base image");
 }
 
+fn test_device_pool() -> tokio::sync::Mutex<nbd_cow::pool::DevicePool> {
+    tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
+        nbd_cow::pool::DevicePoolConfig::default(),
+    ))
+}
+
 // ---------------------------------------------------------------------------
 // Full device lifecycle tests (require root + nbd module)
 // ---------------------------------------------------------------------------
@@ -60,7 +66,8 @@ async fn create_and_destroy() {
     let cow = tmp.path().join("cow.img");
     let size = 64 * 1024 * 1024;
 
-    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+    let pool = test_device_pool();
+    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
         .await
         .expect("create");
 
@@ -88,7 +95,8 @@ async fn destroy_keep_cow_preserves_file() {
     let cow = tmp.path().join("cow.img");
     let size = 64 * 1024 * 1024;
 
-    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+    let pool = test_device_pool();
+    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
         .await
         .expect("create");
 
@@ -127,7 +135,8 @@ async fn write_and_read_back_via_block_device() {
     let cow = tmp.path().join("cow.img");
     let size = 64 * 1024 * 1024;
 
-    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+    let pool = test_device_pool();
+    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
         .await
         .expect("create");
     let dev_path = device.device_path().to_owned();
@@ -191,7 +200,8 @@ async fn cow_file_is_sparse() {
     let cow = tmp.path().join("cow.img");
     let size = 64 * 1024 * 1024;
 
-    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+    let pool = test_device_pool();
+    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
         .await
         .expect("create");
 
@@ -239,7 +249,8 @@ async fn device_path_format() {
     let cow = tmp.path().join("cow.img");
     let size = 64 * 1024 * 1024;
 
-    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+    let pool = test_device_pool();
+    let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
         .await
         .expect("create");
 
@@ -266,10 +277,11 @@ async fn multiple_devices_from_same_base() {
     let cow1 = tmp.path().join("cow1.img");
     let cow2 = tmp.path().join("cow2.img");
 
-    let mut dev1 = nbd_cow::NbdCowDevice::create(&base, &cow1, size)
+    let pool = test_device_pool();
+    let mut dev1 = nbd_cow::NbdCowDevice::create(&base, &cow1, size, &pool)
         .await
         .expect("create 1");
-    let mut dev2 = nbd_cow::NbdCowDevice::create(&base, &cow2, size)
+    let mut dev2 = nbd_cow::NbdCowDevice::create(&base, &cow2, size, &pool)
         .await
         .expect("create 2");
 
@@ -295,9 +307,11 @@ async fn snapshot_restore_round_trip() {
 
     let marker = b"NBD_SNAPSHOT_RESTORE_TEST_1234";
 
+    let pool = test_device_pool();
+
     // Phase 1: create device, write data, destroy_keep_cow
     {
-        let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+        let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
             .await
             .expect("create");
 
@@ -359,7 +373,7 @@ async fn snapshot_restore_round_trip() {
 
     // Phase 2: create new device with same base + COW — data should persist
     {
-        let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size)
+        let mut device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
             .await
             .expect("restore create");
 
@@ -397,4 +411,258 @@ async fn snapshot_restore_round_trip() {
 
     // After destroy, COW and bitmap should be cleaned up
     assert!(!cow.exists(), "COW file should be removed after destroy");
+}
+
+// ---------------------------------------------------------------------------
+// DevicePool-specific tests (require root + nbd module)
+// ---------------------------------------------------------------------------
+
+/// Verify connect_device works with a specific device index.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn connect_device_specific_index() {
+    require_root!();
+    require_nbd!();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let cow = tmp.path().join("cow.img");
+    let size: u64 = 64 * 1024 * 1024;
+
+    // Find a free device via pool, then connect with connect_device directly
+    let pool = test_device_pool();
+    let device_index = pool.lock().await.acquire().await.expect("acquire");
+
+    let mut client_fds = Vec::new();
+    let mut server_handles = Vec::new();
+    let shutdown = tokio_util::sync::CancellationToken::new();
+
+    let cow_layer = nbd_cow::cow::CowLayer::new(
+        &base,
+        &cow,
+        size,
+        nbd_cow::BLOCK_SIZE,
+        nbd_cow::DEFAULT_FLUSH_THRESHOLD,
+    )
+    .expect("cow layer");
+    let cow_layer = std::sync::Arc::new(tokio::sync::RwLock::new(cow_layer));
+
+    for _ in 0..nbd_cow::NUM_CONNECTIONS {
+        let (client_fd, server_fd) = nbd_cow::netlink::create_socketpair().expect("socketpair");
+        client_fds.push(client_fd);
+        let cow = cow_layer.clone();
+        let token = shutdown.clone();
+        server_handles.push(tokio::spawn(async move {
+            let _ = nbd_cow::server::dispatch(server_fd, cow, token).await;
+        }));
+    }
+
+    nbd_cow::netlink::connect_device(device_index, &client_fds, size, nbd_cow::BLOCK_SIZE as u64)
+        .expect("connect_device");
+
+    assert!(
+        nbd_cow::netlink::verify_device_size(device_index, size).await,
+        "device should have correct size"
+    );
+
+    // Clean up
+    shutdown.cancel();
+    for h in server_handles {
+        h.abort();
+    }
+    drop(client_fds);
+    let _ = nbd_cow::netlink::disconnect(device_index);
+
+    pool.lock().await.release(device_index);
+    pool.lock().await.cleanup().await;
+}
+
+/// After destroy + release, the pool should not hand back the same device
+/// index immediately (cooldown must expire first).
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn pool_cooldown_prevents_immediate_reuse() {
+    require_root!();
+    require_nbd!();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let size = 64 * 1024 * 1024;
+
+    // Use a long cooldown so the released device can't be reused
+    let pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
+        nbd_cow::pool::DevicePoolConfig {
+            cooldown: std::time::Duration::from_secs(60),
+        },
+    ));
+
+    let cow1 = tmp.path().join("cow1.img");
+    let mut dev1 = nbd_cow::NbdCowDevice::create(&base, &cow1, size, &pool)
+        .await
+        .expect("create 1");
+    let idx1 = dev1.device_index();
+
+    dev1.destroy().await.expect("destroy 1");
+    pool.lock().await.release(idx1);
+
+    // Immediately create another device — should get a DIFFERENT index
+    // because idx1 is still in cooldown (60s)
+    let cow2 = tmp.path().join("cow2.img");
+    let mut dev2 = nbd_cow::NbdCowDevice::create(&base, &cow2, size, &pool)
+        .await
+        .expect("create 2");
+    let idx2 = dev2.device_index();
+
+    assert_ne!(
+        idx1, idx2,
+        "pool should not reuse device {idx1} during cooldown"
+    );
+
+    dev2.destroy().await.expect("destroy 2");
+    pool.lock().await.release(idx2);
+    pool.lock().await.cleanup().await;
+}
+
+/// After cooldown expires, a released device should become available again.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn pool_release_and_reacquire_after_cooldown() {
+    require_root!();
+    require_nbd!();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let size = 64 * 1024 * 1024;
+
+    // Very short cooldown so we can test re-acquisition
+    let pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
+        nbd_cow::pool::DevicePoolConfig {
+            cooldown: std::time::Duration::from_millis(50),
+        },
+    ));
+
+    let cow = tmp.path().join("cow.img");
+    let mut dev = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+        .await
+        .expect("create");
+    let idx = dev.device_index();
+
+    dev.destroy().await.expect("destroy");
+    pool.lock().await.release(idx);
+
+    // Wait for cooldown to expire
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // The released device should now be available via acquire
+    let reacquired = pool.lock().await.acquire().await.expect("reacquire");
+
+    // We can't guarantee it's the SAME index (background scan might find
+    // another free device first), but acquire should succeed without error.
+    // Release it back and clean up.
+    pool.lock().await.release(reacquired);
+    pool.lock().await.cleanup().await;
+}
+
+/// Pool warmup should populate the ready queue.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn pool_warmup_populates_ready_queue() {
+    require_root!();
+    require_nbd!();
+
+    let pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
+        nbd_cow::pool::DevicePoolConfig::default(),
+    ));
+    pool.lock().await.warmup().await;
+
+    // After warmup, acquire should be instant (Tier 1 — from ready queue)
+    let start = std::time::Instant::now();
+    let idx = pool
+        .lock()
+        .await
+        .acquire()
+        .await
+        .expect("acquire after warmup");
+    let elapsed = start.elapsed();
+
+    // Tier 1 acquire should be sub-millisecond (no sysfs scan needed)
+    assert!(
+        elapsed.as_millis() < 50,
+        "acquire after warmup took {elapsed:?}, expected < 50ms (Tier 1)"
+    );
+
+    pool.lock().await.release(idx);
+    pool.lock().await.cleanup().await;
+}
+
+/// After cleanup(), acquire must return NoFreeDevice immediately.
+/// This is a pure-logic test — no root or nbd module required.
+#[tokio::test(flavor = "multi_thread")]
+async fn pool_cleanup_rejects_acquire() {
+    let pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
+        nbd_cow::pool::DevicePoolConfig::default(),
+    ));
+    pool.lock().await.cleanup().await;
+
+    let result = pool.lock().await.acquire().await;
+    assert!(result.is_err(), "acquire after cleanup should fail");
+}
+
+/// Calling release() after cleanup() should be a no-op (not panic or corrupt state).
+/// This is a pure-logic test — no root or nbd module required.
+#[tokio::test(flavor = "multi_thread")]
+async fn pool_release_after_cleanup_is_noop() {
+    let pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
+        nbd_cow::pool::DevicePoolConfig::default(),
+    ));
+    pool.lock().await.cleanup().await;
+
+    // release after cleanup should silently do nothing
+    pool.lock().await.release(42);
+
+    // pool should still reject acquire
+    let result = pool.lock().await.acquire().await;
+    assert!(
+        result.is_err(),
+        "acquire should still fail after release on cleaned-up pool"
+    );
+}
+
+/// Dropping an NbdCowDevice without calling destroy() should still
+/// disconnect the kernel device (best-effort cleanup via Drop).
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn drop_without_destroy_disconnects() {
+    require_root!();
+    require_nbd!();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let base = tmp.path().join("base.img");
+    create_test_base_image(&base);
+    let cow = tmp.path().join("cow.img");
+    let size: u64 = 64 * 1024 * 1024;
+
+    let pool = test_device_pool();
+    let device = nbd_cow::NbdCowDevice::create(&base, &cow, size, &pool)
+        .await
+        .expect("create");
+
+    let device_index = device.device_index();
+
+    // Drop without calling destroy — Drop impl should disconnect
+    drop(device);
+
+    // Give the kernel a moment to update sysfs
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // The device should appear free (pid = -1 or missing)
+    assert!(
+        nbd_cow::netlink::device_appears_free(device_index),
+        "device nbd{device_index} should be free after drop"
+    );
+
+    pool.lock().await.cleanup().await;
 }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -119,6 +119,8 @@ pub struct FirecrackerFactory {
     factory_paths: FactoryPaths,
     runtime_paths: RuntimePaths,
     netns_pool: Option<std::sync::Arc<tokio::sync::Mutex<NetnsPool>>>,
+    /// Shared NBD device pool for pre-validated device indices.
+    device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
     /// Base image path and size (bytes), populated during startup.
     base_image_path: Option<std::path::PathBuf>,
     base_image_size: u64,
@@ -136,6 +138,7 @@ impl FirecrackerFactory {
     pub async fn new(
         config: FirecrackerConfig,
         netns_pool: Option<std::sync::Arc<tokio::sync::Mutex<NetnsPool>>>,
+        device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
     ) -> Result<Self, SandboxError> {
         let t = std::time::Instant::now();
         prerequisites::check_prerequisites(&prerequisites::PrerequisiteConfig {
@@ -158,6 +161,7 @@ impl FirecrackerFactory {
             factory_paths,
             runtime_paths,
             netns_pool,
+            device_pool,
             base_image_path: None,
             base_image_size: 0,
             cow_pool: None,
@@ -322,22 +326,28 @@ impl SandboxFactory for FirecrackerFactory {
             .base_image_path
             .as_ref()
             .ok_or_else(|| SandboxError::CreationFailed("factory not started".into()))?;
-        let cow_device =
-            match NbdCowDevice::create(base_image, &cow_file, self.base_image_size).await {
-                Ok(d) => d,
-                Err(e) => {
-                    // Roll back: return netns to pool and clean up directories.
-                    let mut netns_pool = self.netns_pool().lock().await;
-                    if let Err(rel_err) = netns_pool.release(network).await {
-                        warn!(error = %rel_err, "failed to release netns during rollback");
-                    }
-                    let _ = tokio::fs::remove_dir_all(sandbox_paths.workspace()).await;
-                    let _ = tokio::fs::remove_dir_all(sock_paths.dir()).await;
-                    return Err(SandboxError::CreationFailed(format!(
-                        "create NBD COW device: {e}"
-                    )));
+        let cow_device = match NbdCowDevice::create(
+            base_image,
+            &cow_file,
+            self.base_image_size,
+            &self.device_pool,
+        )
+        .await
+        {
+            Ok(d) => d,
+            Err(e) => {
+                // Roll back: return netns to pool and clean up directories.
+                let mut netns_pool = self.netns_pool().lock().await;
+                if let Err(rel_err) = netns_pool.release(network).await {
+                    warn!(error = %rel_err, "failed to release netns during rollback");
                 }
-            };
+                let _ = tokio::fs::remove_dir_all(sandbox_paths.workspace()).await;
+                let _ = tokio::fs::remove_dir_all(sock_paths.dir()).await;
+                return Err(SandboxError::CreationFailed(format!(
+                    "create NBD COW device: {e}"
+                )));
+            }
+        };
 
         info!(id = %id, device = %cow_device.device_path().display(), "sandbox created");
 
@@ -383,6 +393,7 @@ impl SandboxFactory for FirecrackerFactory {
         // After kill_process_group + child.wait(), the kernel may still be
         // releasing file descriptors (particularly the NBD device fd).
         // Retry a few times to let it finish.
+        let device_index = sandbox.cow_device.device_index();
         let mut cow_destroyed = false;
         for attempt in 0..DESTROY_RETRIES {
             match sandbox.cow_device.destroy().await {
@@ -403,6 +414,9 @@ impl SandboxFactory for FirecrackerFactory {
             }
         }
         drop(sandbox);
+
+        // Release device index back to pool with cooldown.
+        self.device_pool.lock().await.release(device_index);
 
         // Return the network namespace to the pool.
         let mut netns_pool = self.netns_pool().lock().await;

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -7,6 +7,8 @@ use sandbox::{
     FactoryConfig, RuntimeProvider, SandboxError, SandboxFactory, SandboxRuntime, SnapshotRef,
 };
 
+use nbd_cow::pool::{DevicePool, DevicePoolConfig};
+
 use crate::config::{FirecrackerConfig, SnapshotConfig};
 use crate::factory::FirecrackerFactory;
 use crate::network::{NetnsPool, NetnsPoolConfig};
@@ -14,10 +16,11 @@ use crate::paths::{RuntimePaths, SandboxPaths, SnapshotOutputPaths, SockPaths};
 
 /// Firecracker-backed sandbox runtime.
 ///
-/// Manages shared resources ([`NetnsPool`]) and creates
+/// Manages shared resources ([`NetnsPool`], [`DevicePool`]) and creates
 /// [`FirecrackerFactory`] instances that share them.
 pub struct FirecrackerRuntime {
     netns_pool: Arc<tokio::sync::Mutex<NetnsPool>>,
+    device_pool: Arc<tokio::sync::Mutex<DevicePool>>,
     proxy_port: Option<u16>,
 }
 
@@ -39,8 +42,17 @@ impl FirecrackerRuntime {
             "runtime netns pool created"
         );
 
+        let t = std::time::Instant::now();
+        let mut device_pool = DevicePool::new(DevicePoolConfig::default());
+        device_pool.warmup().await;
+        info!(
+            elapsed_ms = t.elapsed().as_millis() as u64,
+            "runtime device pool created"
+        );
+
         Ok(Self {
             netns_pool: Arc::new(tokio::sync::Mutex::new(netns_pool)),
+            device_pool: Arc::new(tokio::sync::Mutex::new(device_pool)),
             proxy_port: config.proxy_port,
         })
     }
@@ -80,8 +92,12 @@ impl SandboxRuntime for FirecrackerRuntime {
         config: FactoryConfig,
     ) -> sandbox::Result<Box<dyn SandboxFactory>> {
         let fc_config = self.to_firecracker_config(config);
-        let mut factory =
-            FirecrackerFactory::new(fc_config, Some(Arc::clone(&self.netns_pool))).await?;
+        let mut factory = FirecrackerFactory::new(
+            fc_config,
+            Some(Arc::clone(&self.netns_pool)),
+            Arc::clone(&self.device_pool),
+        )
+        .await?;
         factory.startup().await?;
         Ok(Box::new(factory))
     }
@@ -93,6 +109,9 @@ impl SandboxRuntime for FirecrackerRuntime {
             warn!(error = %e, "failed to cleanup shared netns pool");
         }
         drop(pool);
+
+        // Clean up shared device pool.
+        self.device_pool.lock().await.cleanup().await;
 
         info!("runtime shutdown complete");
     }

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -117,10 +117,15 @@ pub async fn create_snapshot(
             .map_err(|e| SnapshotError::Setup(format!("set COW file size: {e}")))?;
     }
 
-    let cow_device = NbdCowDevice::create(&config.rootfs_path, &cow_file, base_size)
+    let device_pool = tokio::sync::Mutex::new(nbd_cow::pool::DevicePool::new(
+        nbd_cow::pool::DevicePoolConfig::default(),
+    ));
+    device_pool.lock().await.warmup().await;
+    let cow_device = NbdCowDevice::create(&config.rootfs_path, &cow_file, base_size, &device_pool)
         .await
         .map_err(|e| SnapshotError::Setup(format!("create NBD COW device: {e}")))?;
 
+    let device_index = cow_device.device_index();
     info!(device = %cow_device.device_path().display(), "NBD COW device created");
 
     // 3. Create network namespace (pool of 1, index auto-allocated via flock).
@@ -139,7 +144,9 @@ pub async fn create_snapshot(
     )
     .await;
 
-    // Always cleanup netns.
+    // Release device index back to pool before cleanup.
+    device_pool.lock().await.release(device_index);
+    device_pool.lock().await.cleanup().await;
     if let Err(e) = netns_pool.cleanup().await {
         tracing::warn!(error = %e, "failed to cleanup netns pool");
     }


### PR DESCRIPTION
## Summary

- Add `DevicePool` (`pool.rs`) that pre-validates NBD device indices via sysfs and maintains a ready queue with cooldown-based recycling, eliminating synchronous sysfs scans on every `NbdCowDevice::create()`
- Replace `find_and_connect` with `connect_device` (single-index connect) and a dual retry loop: inner EBUSY retries (16) for multi-runner contention + outer size-stuck-at-0 retries (5) for kernel teardown timing
- Share pool via `Arc<Mutex<DevicePool>>` from Runtime to Factories; all callers (factory, snapshot, bench) release indices after destroy

## Test plan

- [x] `cargo check` and `cargo clippy -- -D warnings` pass with zero warnings
- [x] New pure-logic tests: `pool_cleanup_rejects_acquire`, `pool_release_after_cleanup_is_noop`
- [x] New integration tests (require root + nbd): `connect_device_specific_index`, `pool_cooldown_prevents_immediate_reuse`, `pool_release_and_reacquire_after_cooldown`, `pool_warmup_populates_ready_queue`, `drop_without_destroy_disconnects`
- [ ] CI passes (build + lint + tests)
- [ ] Manual validation on runner with `modprobe nbd nbds_max=4096`

🤖 Generated with [Claude Code](https://claude.com/claude-code)