### PR TITLE
feat(onboarding): hide preferences in account menu during onboarding

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-onboarding.tsx
@@ -757,7 +757,10 @@ function OnboardingPageLayout({ children }: { children: React.ReactNode }) {
         {/* Account dropdown — bottom-left of left panel */}
         <div className="absolute bottom-6 left-4 z-20">
           <VM0ClerkProvider>
-            <AccountDropdown onAccountAction={onAccountAction} />
+            <AccountDropdown
+              onAccountAction={onAccountAction}
+              hidePreferences
+            />
           </VM0ClerkProvider>
         </div>
       </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -274,9 +274,11 @@ function useAccountSessions() {
 export function AccountDropdown({
   onAccountAction,
   collapsed = false,
+  hidePreferences = false,
 }: {
   onAccountAction?: (action: ZeroAccountAction) => void;
   collapsed?: boolean;
+  hidePreferences?: boolean;
 }) {
   const { user, clerk, accounts } = useAccountSessions();
   const features = useLastResolved(featureSwitch$);
@@ -384,20 +386,24 @@ export function AccountDropdown({
         )}
 
         {/* Preferences (standalone) */}
-        <DropdownMenuItem
-          onClick={() => {
-            return handleAccountAction("preferences");
-          }}
-          className="gap-3 px-3 py-2.5 rounded-lg"
-        >
-          <IconAdjustmentsHorizontal
-            size={18}
-            stroke={1.5}
-            className="text-muted-foreground"
-          />
-          <span>Preferences</span>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
+        {!hidePreferences && (
+          <>
+            <DropdownMenuItem
+              onClick={() => {
+                return handleAccountAction("preferences");
+              }}
+              className="gap-3 px-3 py-2.5 rounded-lg"
+            >
+              <IconAdjustmentsHorizontal
+                size={18}
+                stroke={1.5}
+                className="text-muted-foreground"
+              />
+              <span>Preferences</span>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
 
         {/* Account management group */}
         {hasOthers ? (


### PR DESCRIPTION
## Summary
- Added `hidePreferences` prop to `AccountDropdown` component
- Onboarding page passes `hidePreferences` to hide the Preferences menu item during onboarding flow

## Test plan
- [ ] Open onboarding flow and verify Preferences is not shown in the account dropdown
- [ ] Verify Preferences still appears in the account dropdown on all other pages