### PR TITLE
refactor: add get-org-metadata and remove clerk api from run creation

### DIFF
--- a/turbo/apps/web/src/lib/org/__tests__/org-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/org/__tests__/org-cache-service.test.ts
@@ -15,6 +15,7 @@ import {
 import { reloadEnv } from "../../../env";
 import {
   getOrgData,
+  getOrgMetadata,
   getOrgBySlug,
   getOrgBillingPeriod,
 } from "../org-cache-service";
@@ -414,5 +415,63 @@ describe("getOrgBillingPeriod", () => {
     const result = await getOrgBillingPeriod(orgId);
 
     expect(result).toBeNull();
+  });
+});
+
+describe("getOrgMetadata", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("returns tier and credits from org_metadata when row exists", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    await updateOrgTier(orgId, "pro");
+
+    const result = await getOrgMetadata(orgId);
+
+    expect(result).toEqual({
+      orgId,
+      tier: "pro",
+      credits: 10_000,
+    });
+
+    // Clerk API should NOT have been called
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("returns free tier with zero credits when no row exists", async () => {
+    const orgId = uniqueId("org-nonexistent");
+
+    const result = await getOrgMetadata(orgId);
+
+    expect(result).toEqual({
+      orgId,
+      tier: "free",
+      credits: 0,
+    });
+
+    // Clerk API should NOT have been called
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("returns default credits for new org", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    const result = await getOrgMetadata(orgId);
+
+    expect(result).toEqual({
+      orgId,
+      tier: "free",
+      credits: 10_000,
+    });
   });
 });

--- a/turbo/apps/web/src/lib/org/org-cache-service.ts
+++ b/turbo/apps/web/src/lib/org/org-cache-service.ts
@@ -20,6 +20,12 @@ interface OrgData {
   tier: string;
 }
 
+interface OrgMetadata {
+  orgId: string;
+  tier: string;
+  credits: number;
+}
+
 /**
  * Read tier from the org table (source of truth).
  * Returns "free" if the org row does not exist.
@@ -35,10 +41,35 @@ async function readTier(orgId: string): Promise<string> {
 }
 
 /**
+ * Read org metadata from the platform-owned org_metadata table.
+ * Returns tier, credits, and other platform fields.
+ *
+ * Unlike getOrgData(), this function NEVER calls the Clerk API —
+ * it only reads from our own database.
+ */
+export async function getOrgMetadata(orgId: string): Promise<OrgMetadata> {
+  const db = globalThis.services.db;
+  const [row] = await db
+    .select({ tier: orgMetadata.tier, credits: orgMetadata.credits })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return {
+    orgId,
+    tier: row?.tier ?? "free",
+    credits: row?.credits ?? 0,
+  };
+}
+
+/**
  * Get org data from cache or Clerk API.
  *
- * - slug: cached from Clerk (org_cache, 1-min TTL)
- * - tier: read from org table (owned by platform, always fresh)
+ * **WARNING: This function may call the Clerk API on cache miss (1-min TTL),
+ * adding 500-700ms of latency. Prefer `getOrgMetadata()` unless you need
+ * slug or name from Clerk.**
+ *
+ * - slug, name: cached from Clerk (org_cache, 1-min TTL)
+ * - tier: read from org_metadata table (platform-owned, always fresh)
  */
 export async function getOrgData(orgId: string): Promise<OrgData> {
   const db = globalThis.services.db;

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -29,7 +29,7 @@ import {
   buildZeroExecutionContext,
   MODEL_PROVIDER_ENV_VARS,
 } from "./build-zero-context";
-import { getOrgData } from "../org/org-cache-service";
+import { getOrgMetadata } from "../org/org-cache-service";
 import {
   isConcurrentRunLimit,
   insufficientCredits,
@@ -302,8 +302,8 @@ export async function createZeroRunRecord(
     composeId: params.agentId,
     sessionId: params.sessionId,
   });
-  const orgData = await getOrgData(resolved.orgId);
-  const orgTier = orgTierSchema.parse(orgData.tier);
+  const orgMeta = await getOrgMetadata(resolved.orgId);
+  const orgTier = orgTierSchema.parse(orgMeta.tier);
 
   // 2. Construct CreateRunParams (infra knows nothing about ZERO_TOKEN)
   const runParams: CreateRunParams = {


### PR DESCRIPTION
## Summary

- Add `getOrgMetadata()` function in `org-cache-service.ts` that reads only from the `org_metadata` table — no Clerk API calls
- Migrate `zero-run-service.ts` to use `getOrgMetadata()` instead of `getOrgData()`, eliminating 500-700ms Clerk API cache miss penalty from the chat messages run creation path
- Add JSDoc warning to `getOrgData()` recommending `getOrgMetadata()` for tier-only usage

Closes #7698
Parent Epic: #7693

## Test plan

- [x] Integration tests for `getOrgMetadata()`: returns tier when row exists, returns "free" default when no row, does NOT call Clerk API
- [x] All 17 org-cache-service tests pass (14 existing + 3 new)
- [x] Type-check passes for web workspace
- [x] Lint passes
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)