### PR TITLE
perf: skip redundant db query in zero run creation path

### DIFF
--- a/turbo/apps/web/src/lib/run/run-service.ts
+++ b/turbo/apps/web/src/lib/run/run-service.ts
@@ -325,6 +325,11 @@ export interface CreateRunParams {
   // Per-permission firewall policies from zero agent configuration.
   firewallPolicies?: FirewallPolicies;
   allowedConnectorTypes?: ConnectorType[];
+  // Pre-loaded compose data. When provided, skips the internal loadCompose() call.
+  preloadedCompose?: {
+    composeContent: AgentComposeYaml;
+    compose: { id: string; userId: string; orgId: string };
+  };
 }
 
 /**
@@ -962,10 +967,9 @@ export async function createRunRecord(
   const { userId, agentComposeVersionId, prompt } = params;
 
   // Steps 1-2: Load compose and authorize
-  const { composeContent, compose } = await loadCompose(
-    agentComposeVersionId,
-    params.composeId,
-  );
+  const { composeContent, compose } =
+    params.preloadedCompose ??
+    (await loadCompose(agentComposeVersionId, params.composeId));
   authorizeCompose(userId, params.orgId, compose);
   const authorizeTime = Date.now();
 

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -326,7 +326,7 @@ export async function createZeroRunRecord(
   };
 
   // 3. Pre-flight checks: credits + model provider (before createRunRecord)
-  const { composeContent: preflightCompose } = await loadCompose(
+  const preloadedCompose = await loadCompose(
     resolved.agentComposeVersionId,
     resolved.composeId,
   );
@@ -335,14 +335,14 @@ export async function createZeroRunRecord(
     checkModelProviderConfigured(
       resolved.orgId,
       params.modelProvider,
-      preflightCompose,
+      preloadedCompose.composeContent,
     ),
   ]);
 
   // 4. Create run record (may throw ConcurrentRunLimitError)
   let record;
   try {
-    record = await createRunRecord(runParams);
+    record = await createRunRecord({ ...runParams, preloadedCompose });
   } catch (error) {
     if (isConcurrentRunLimit(error)) {
       // Enqueue without token — dispatchQueuedZeroRun generates a fresh


### PR DESCRIPTION
## Summary

- Add optional `preloadedCompose` parameter to `CreateRunParams` so callers can pass already-loaded compose data
- Update `createZeroRunRecord()` to pass its pre-loaded compose through to `createRunRecord()`, eliminating a duplicate `loadCompose()` DB round-trip (~15-25ms per zero run creation)
- `startRun()` path (CLI/API) is unchanged — continues to load compose internally

Closes #7699

## Test plan

- [x] All 49 tests in `zero-run-service.test.ts`, `credit-check.test.ts`, `build-zero-context.test.ts` pass
- [x] All 54 tests in `agent/runs/route.test.ts` pass (startRun path)
- [x] Type check, lint, format, knip all pass
- [x] Pre-commit hooks (prettier, knip, commitlint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)