### PR TITLE
fix: include .source/ in turbo build outputs to fix flaky lint-types

### DIFF
--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -180,7 +180,13 @@
         "!**/vitest.config.ts",
         "!**/src/test/**"
       ],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**", "src/dist/**", ".source/**"]
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "dist/**",
+        "src/dist/**",
+        ".source/**"
+      ]
     },
     "lint": {
       "dependsOn": ["^lint"]

--- a/turbo/turbo.json
+++ b/turbo/turbo.json
@@ -180,7 +180,7 @@
         "!**/vitest.config.ts",
         "!**/src/test/**"
       ],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**", "src/dist/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**", "src/dist/**", ".source/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
## Summary

- Add `.source/**` to Turbo's `build` task outputs so fumadocs-generated files are cached and restored on cache hit
- Fixes intermittent `TS2306: File '.source/server.ts' is not a module` errors in the `lint-types` CI job

Closes #7694

## Test plan

- [x] Verify `turbo.json` change is valid JSON
- [ ] CI `lint-types` job should pass consistently (no more flaky failures on cache miss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)