### PR TITLE
feat(cli): add --since filter to zero logs list command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/list.test.ts
@@ -165,6 +165,27 @@ describe("zero logs list command", () => {
     expect(mockExit).toHaveBeenCalledWith(1);
   });
 
+  it("should pass since filter to API", async () => {
+    let capturedUrl: URL | undefined;
+    server.use(
+      http.get("http://localhost:3000/api/zero/logs", ({ request }) => {
+        capturedUrl = new URL(request.url);
+        return HttpResponse.json({
+          data: [],
+          pagination: { hasMore: false, nextCursor: null, totalPages: 0 },
+          filters: emptyFilters,
+        });
+      }),
+    );
+
+    await listCommand.parseAsync(["node", "cli", "--since", "1h"]);
+
+    expect(capturedUrl?.searchParams.get("since")).toBeDefined();
+    const sinceValue = Number(capturedUrl?.searchParams.get("since"));
+    expect(sinceValue).toBeGreaterThan(Date.now() - 2 * 60 * 60 * 1000);
+    expect(sinceValue).toBeLessThanOrEqual(Date.now());
+  });
+
   it("should fall back to agentId when displayName is null", async () => {
     server.use(
       http.get("http://localhost:3000/api/zero/logs", () => {

--- a/turbo/apps/cli/src/commands/zero/logs/list.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/list.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { listZeroLogs } from "../../../lib/api";
+import { parseTime } from "../../../lib/utils/time-parser";
 import { withErrorHandler } from "../../../lib/command";
 
 function formatStatus(status: string): string {
@@ -34,6 +35,10 @@ export const listCommand = new Command()
     "--status <status>",
     "Filter by status (queued|pending|running|completed|failed|timeout|cancelled)",
   )
+  .option(
+    "--since <time>",
+    "Filter runs created since (e.g., 5m, 2h, 1d, 2024-01-15T10:30:00Z)",
+  )
   .option("--limit <n>", "Maximum number of results (default: 20)")
   .addHelpText(
     "after",
@@ -41,16 +46,25 @@ export const listCommand = new Command()
 Examples:
   zero logs list
   zero logs list --agent my-agent
-  zero logs list --status completed --limit 10`,
+  zero logs list --status completed --limit 10
+  zero logs list --since 1h
+  zero logs list --since 1d --status completed`,
   )
   .action(
     withErrorHandler(
-      async (options: { agent?: string; status?: string; limit?: string }) => {
+      async (options: {
+        agent?: string;
+        status?: string;
+        since?: string;
+        limit?: string;
+      }) => {
         const limit = options.limit ? parseInt(options.limit, 10) : undefined;
+        const since = options.since ? parseTime(options.since) : undefined;
 
         const result = await listZeroLogs({
           agent: options.agent,
           status: options.status,
+          since,
           limit,
         });
 

--- a/turbo/apps/cli/src/lib/api/domains/zero-logs.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-logs.ts
@@ -11,6 +11,7 @@ import { getClientConfig, handleError } from "../core/client-factory";
 export async function listZeroLogs(options?: {
   agent?: string;
   status?: string;
+  since?: number;
   limit?: number;
   cursor?: string;
 }): Promise<LogsListResponse> {
@@ -20,6 +21,7 @@ export async function listZeroLogs(options?: {
     query: {
       agent: options?.agent,
       status: options?.status as LogStatus | undefined,
+      since: options?.since,
       limit: options?.limit,
       cursor: options?.cursor,
     },

--- a/turbo/apps/web/app/api/zero/logs/route.ts
+++ b/turbo/apps/web/app/api/zero/logs/route.ts
@@ -36,6 +36,7 @@ import {
   and,
   desc,
   lt,
+  gte,
   or,
   ilike,
   count,
@@ -56,6 +57,7 @@ interface LogsQuery {
   org?: string;
   agent?: string;
   search?: string;
+  since?: number;
   status?: LogStatus;
   triggerSource?: TriggerSource;
   scheduleId?: string;
@@ -112,6 +114,9 @@ async function getTotalCount(
     eq(agentRuns.orgId, orgId),
   ];
   conditions.push(...buildAgentFilterConditions(query));
+  if (query.since) {
+    conditions.push(gte(agentRuns.createdAt, new Date(query.since)));
+  }
   if (query.status) {
     conditions.push(eq(agentRuns.status, query.status));
   }
@@ -271,6 +276,9 @@ const router = tsr.router(logsListContract, {
 
     conditions.push(...buildAgentFilterConditions(query));
 
+    if (query.since) {
+      conditions.push(gte(agentRuns.createdAt, new Date(query.since)));
+    }
     if (query.status) {
       conditions.push(eq(agentRuns.status, query.status));
     }

--- a/turbo/packages/core/src/contracts/logs.ts
+++ b/turbo/packages/core/src/contracts/logs.ts
@@ -135,6 +135,7 @@ export const logsListContract = c.router({
       search: z.string().optional(),
       agent: z.string().optional(),
       name: z.string().optional(),
+      since: z.coerce.number().optional(),
 
       status: logStatusSchema.optional(),
       triggerSource: triggerSourceSchema.optional(),


### PR DESCRIPTION
## Summary

- Add `--since` time-based filtering to `zero logs list` command, allowing users to filter runs by creation time (e.g., `--since 1h`, `--since 1d`, `--since 2024-01-15T10:30:00Z`)
- Follows the exact same pattern already established by `zero logs search --since` and `zero logs <runId> --since`
- Changes span all layers: contract schema, route handler, API client, CLI command, and test

## Test plan

- [x] New integration test verifies `--since` parameter is passed to API correctly
- [x] All 8 existing list command tests pass
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Knip passes (`pnpm knip`)
- [x] Format check passes (`pnpm format`)

Closes #7707

🤖 Generated with [Claude Code](https://claude.com/claude-code)