### PR TITLE
fix: reject non-uuid run ids in zero logs before api call

### DIFF
--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/search.test.ts
@@ -145,11 +145,13 @@ describe("zero logs search command", () => {
       "--agent",
       "zero",
       "--run",
-      "run-123",
+      "abc12345-1234-1234-1234-123456789abc",
     ]);
 
     expect(capturedUrl?.searchParams.get("agent")).toBe("zero");
-    expect(capturedUrl?.searchParams.get("runId")).toBe("run-123");
+    expect(capturedUrl?.searchParams.get("runId")).toBe(
+      "abc12345-1234-1234-1234-123456789abc",
+    );
   });
 
   it("should show hasMore hint when truncated", async () => {
@@ -212,6 +214,16 @@ describe("zero logs search command", () => {
     expect(logCalls).toContain("Connecting to database");
     expect(logCalls).toContain("connection refused");
     expect(logCalls).toContain("Retrying connection");
+  });
+
+  it("should reject non-UUID --run value", async () => {
+    await expect(
+      searchCommand.parseAsync(["node", "cli", "error", "--run", "6af7eece"]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid run ID");
+    expect(errorCalls).toContain("zero logs list");
   });
 
   it("should handle authentication error", async () => {

--- a/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/__tests__/view.test.ts
@@ -161,6 +161,16 @@ describe("zero logs view command", () => {
     expect(errorCalls).toContain("mutually exclusive");
   });
 
+  it("should reject non-UUID run ID", async () => {
+    await expect(
+      zeroLogsCommand.parseAsync(["node", "cli", "6af7eece"]),
+    ).rejects.toThrow("process.exit called");
+
+    const errorCalls = mockConsoleError.mock.calls.flat().join("\n");
+    expect(errorCalls).toContain("Invalid run ID");
+    expect(errorCalls).toContain("zero logs list");
+  });
+
   it("should handle authentication error", async () => {
     server.use(
       http.get(

--- a/turbo/apps/cli/src/commands/zero/logs/index.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/index.ts
@@ -6,6 +6,7 @@ import { ClaudeEventParser } from "../../../lib/events/claude-event-parser";
 import { EventRenderer } from "../../../lib/events/event-renderer";
 import { paginate } from "../../../lib/utils/paginate";
 import { withErrorHandler } from "../../../lib/command";
+import { isUUID } from "../../run/shared";
 import { listCommand } from "./list";
 import { searchCommand } from "./search";
 
@@ -135,6 +136,14 @@ Examples:
         if (!runId) {
           zeroLogsCommand.help();
           return;
+        }
+
+        if (!isUUID(runId)) {
+          console.error(
+            chalk.red(`✗ Invalid run ID "${runId}" — expected a UUID`),
+          );
+          console.error(chalk.dim("  Run: zero logs list    to find run IDs"));
+          process.exit(1);
         }
 
         const countModes = [

--- a/turbo/apps/cli/src/commands/zero/logs/search.ts
+++ b/turbo/apps/cli/src/commands/zero/logs/search.ts
@@ -9,6 +9,7 @@ import { parseTime } from "../../../lib/utils/time-parser";
 import { ClaudeEventParser } from "../../../lib/events/claude-event-parser";
 import { EventRenderer } from "../../../lib/events/event-renderer";
 import { withErrorHandler } from "../../../lib/command";
+import { isUUID } from "../../run/shared";
 
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -149,6 +150,15 @@ Examples:
   .action(
     withErrorHandler(async (keyword: string, options: SearchOptions) => {
       const { before, after } = parseContextOptions(options);
+
+      if (options.run && !isUUID(options.run)) {
+        console.error(
+          chalk.red(`✗ Invalid run ID "${options.run}" — expected a UUID`),
+        );
+        console.error(chalk.dim("  Run: zero logs list    to find run IDs"));
+        process.exit(1);
+      }
+
       const since = options.since
         ? parseTime(options.since)
         : Date.now() - SEVEN_DAYS_MS;


### PR DESCRIPTION
## Summary

- Add UUID format validation to `zero logs <runId>` and `zero logs search --run <id>` before making API calls
- Reuse existing `isUUID()` utility from `run/shared.ts`, following the same pattern used in 5 other CLI commands
- Display clear error message with hint to use `zero logs list` when invalid ID is provided

Closes #7709

## Test plan

- [x] `zero logs <short-hex>` rejects with clear error message
- [x] `zero logs search --run <short-hex>` rejects with clear error message
- [x] Existing tests for valid UUIDs still pass (23/23)
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)