### PR TITLE
feat: support graphql operation-level firewall rules

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -3,6 +3,7 @@
 Pure functions with no module-level state or I/O.
 """
 
+import json
 from typing import NamedTuple
 
 
@@ -217,8 +218,91 @@ class FirewallBlock(NamedTuple):
     path: str
 
 
+def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None] | None:
+    """Parse a rule's path+suffix into (path, type_filter, op_filter).
+
+    If the rule contains the ``GraphQL`` keyword, returns the path portion
+    and optional ``type:`` / ``operationName:`` filters.  Returns None when
+    the ``GraphQL`` keyword is absent (plain REST rule).
+    """
+    gql_idx = rest.find(" GraphQL")
+    if gql_idx == -1:
+        return None
+
+    path = rest[:gql_idx] if gql_idx > 0 else "/"
+    suffix_parts = rest[gql_idx + 1 :].split()  # ["GraphQL", "type:query", ...]
+
+    type_filter: str | None = None
+    op_filter: str | None = None
+
+    for part in suffix_parts[1:]:  # skip "GraphQL" itself
+        if part.startswith("type:"):
+            type_filter = part[5:]
+        elif part.startswith("operationName:"):
+            op_filter = part[14:]
+
+    return path, type_filter, op_filter
+
+
+def match_graphql_body(
+    body: bytes | None,
+    type_filter: str | None,
+    op_filter: str | None,
+) -> bool:
+    """Match a GraphQL request body against type and operationName filters.
+
+    Fail-closed: returns False if the body cannot be parsed or required
+    fields are missing.
+    """
+    if not body:
+        return False
+
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
+
+    if not isinstance(data, dict):
+        return False
+
+    # Extract operation type from the query string.
+    # GraphQL allows compact forms like `mutation{`, `query($id: ID!)`,
+    # so we extract only leading alpha characters as the keyword.
+    if type_filter is not None:
+        query_str = data.get("query")
+        if not isinstance(query_str, str):
+            return False
+        stripped = query_str.lstrip()
+        if not stripped:
+            return False
+        # Extract leading alphabetic chars: "mutation(" → "mutation"
+        end = 0
+        while end < len(stripped) and stripped[end].isalpha():
+            end += 1
+        keyword = stripped[:end].lower() if end > 0 else "query"
+        if keyword != type_filter:
+            return False
+
+    # Match operationName
+    if op_filter is not None:
+        op_name = data.get("operationName")
+        if not isinstance(op_name, str) or not op_name:
+            return False
+        if op_filter.endswith("*"):
+            prefix = op_filter[:-1]
+            if not op_name.startswith(prefix):
+                return False
+        elif op_name != op_filter:
+            return False
+
+    return True
+
+
 def match_firewall_request(
-    url: str, method: str, vm_firewalls: list | None
+    url: str,
+    method: str,
+    vm_firewalls: list | None,
+    body: bytes | None = None,
 ) -> FirewallAllow | FirewallBlock | None:
     """Match request against firewall permissions.
 
@@ -274,11 +358,25 @@ def match_firewall_request(
                     parts = rule_str.split(" ", 1)
                     if len(parts) != 2:
                         continue
-                    rule_method, rule_pattern = parts[0].upper(), parts[1]
+                    rule_method = parts[0].upper()
+                    rest = parts[1]
                     if rule_method != "ANY" and rule_method != upper_method:
                         continue
+
+                    # Check for GraphQL suffix
+                    gql = parse_graphql_rule(rest)
+                    if gql is not None:
+                        rule_pattern, type_filter, op_filter = gql
+                    else:
+                        rule_pattern = rest
+                        type_filter, op_filter = None, None
+
                     params = match_path(rel_path, rule_pattern)
                     if params is not None:
+                        # If GraphQL rule, also check body
+                        has_gql_filter = type_filter is not None or op_filter is not None
+                        if has_gql_filter and not match_graphql_body(body, type_filter, op_filter):
+                            continue
                         # Merge base params with rule params
                         all_params = {**base_params, **params}
                         return FirewallAllow(

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -181,7 +181,9 @@ async def request(flow: http.HTTPFlow) -> None:
     # Match base URL, then check permission rules before injecting auth headers.
     vm_firewalls = vm_info.get("firewalls")
     if vm_firewalls:
-        result = match_firewall_request(original_url, flow.request.method, vm_firewalls)
+        result = match_firewall_request(
+            original_url, flow.request.method, vm_firewalls, body=flow.request.content
+        )
         if isinstance(result, FirewallBlock):
             ctx.log.warn(
                 f"[{run_id}] Firewall {result.ref}: "

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1821,3 +1821,369 @@ class TestAuthBaseUrlRewriteEdgeCases:
             await auth.handle_firewall_request(flow, api_entry, vm_info, match_info)
         assert flow.request.url == original_url
         assert "auth_url_rewrite" not in flow.metadata
+
+
+# =========================================================================
+# GraphQL operation-level matching
+# =========================================================================
+
+
+def _gql_body(query: str, operation_name: str | None = None) -> bytes:
+    """Build a GraphQL JSON request body."""
+    body: dict = {"query": query}
+    if operation_name is not None:
+        body["operationName"] = operation_name
+    return json.dumps(body).encode()
+
+
+def _gql_firewalls(rules: list[str]) -> list:
+    """Wrap GraphQL permission rules into a firewall entry list."""
+    return _wrap_firewalls(
+        [
+            {
+                "base": "https://api.linear.app",
+                "auth": {"headers": {}},
+                "permissions": [{"name": "test-perm", "rules": rules}],
+            }
+        ]
+    )
+
+
+class TestGraphQLMatching:
+    """Tests for GraphQL operation-level firewall matching."""
+
+    def test_type_query_allows_query(self):
+        body = _gql_body("query { viewer { id } }", "GetViewer")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_type_query_blocks_mutation(self):
+        body = _gql_body("mutation { issueCreate(input: {}) { id } }", "CreateIssue")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_type_mutation_allows_mutation(self):
+        body = _gql_body("mutation { issueCreate(input: {}) { id } }", "CreateIssue")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_type_mutation_blocks_query(self):
+        body = _gql_body("query { viewer { id } }", "GetViewer")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_operation_name_exact_match(self):
+        body = _gql_body("mutation { issueCreate(input: {}) { id } }", "issueCreate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation operationName:issueCreate"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_operation_name_mismatch_blocks(self):
+        body = _gql_body('mutation { issueDelete(id: "1") { id } }', "issueDelete")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation operationName:issueCreate"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_operation_name_wildcard(self):
+        body = _gql_body("mutation { issueUpdate(input: {}) { id } }", "issueUpdate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation operationName:issue*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_operation_name_wildcard_no_match(self):
+        body = _gql_body("mutation { commentCreate(input: {}) { id } }", "commentCreate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation operationName:issue*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_missing_operation_name_blocks(self):
+        """Fail-closed: rule requires operationName but body has none."""
+        body = _gql_body("mutation { issueCreate(input: {}) { id } }")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation operationName:issueCreate"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_invalid_json_body_blocks(self):
+        """Fail-closed: unparseable body → blocked."""
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query"]),
+            body=b"not json",
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_empty_body_blocks(self):
+        """Fail-closed: empty body → blocked."""
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query"]),
+            body=b"",
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_none_body_blocks(self):
+        """Fail-closed: None body → blocked."""
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query"]),
+            body=None,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_no_query_field_blocks(self):
+        """Fail-closed: body has no 'query' field → blocked when type: filter used."""
+        body = json.dumps({"operationName": "issueCreate"}).encode()
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_rest_rules_unaffected_by_body(self):
+        """Non-GraphQL rules ignore body parameter completely."""
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql"]),
+            body=b"irrelevant",
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_path_must_match_before_body_check(self):
+        """GraphQL rule still requires path match before body check."""
+        body = _gql_body("query { viewer { id } }", "GetViewer")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/v2",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query"]),
+            body=body,
+        )
+        # /v2 doesn't match /graphql → base matched but permission didn't → block
+        assert isinstance(result, FirewallBlock)
+
+    def test_bare_query_defaults_to_query_type(self):
+        """Query without explicit 'query' keyword defaults to query type."""
+        body = _gql_body("{ viewer { id } }", "GetViewer")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_bare_query_not_mutation(self):
+        """Bare query (no keyword) should NOT match mutation type."""
+        body = _gql_body("{ viewer { id } }", "GetViewer")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_only_operation_name_no_type_filter(self):
+        """Rule with only operationName (no type filter) matches any type."""
+        body = _gql_body("mutation { issueCreate(input: {}) { id } }", "issueCreate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL operationName:issueCreate"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_multiple_rules_first_match_wins(self):
+        """Multiple GraphQL rules — first match wins."""
+        body = _gql_body("mutation { issueCreate(input: {}) { id } }", "issueCreate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _wrap_firewalls(
+                [
+                    {
+                        "base": "https://api.linear.app",
+                        "auth": {"headers": {}},
+                        "permissions": [
+                            {"name": "read", "rules": ["POST /graphql GraphQL type:query"]},
+                            {"name": "write", "rules": ["POST /graphql GraphQL type:mutation"]},
+                        ],
+                    }
+                ]
+            ),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["permission"] == "write"
+
+    def test_array_body_blocks(self):
+        """Batched operations (JSON array) are not supported — blocked."""
+        body = json.dumps(
+            [
+                {"query": "query { viewer { id } }", "operationName": "GetViewer"},
+            ]
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_mutation_without_space_before_brace(self):
+        """'mutation{' (no space) is correctly detected as mutation type."""
+        body = _gql_body("mutation{ issueCreate(input: {}) { id } }", "issueCreate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_mutation_no_space_not_query(self):
+        """'mutation{' should NOT match type:query."""
+        body = _gql_body("mutation{ issueCreate(input: {}) { id } }", "issueCreate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_mutation_with_variables(self):
+        """'mutation($input: IssueInput!)' is correctly detected as mutation."""
+        body = _gql_body(
+            "mutation($input: IssueInput!) { issueCreate(input: $input) { id } }",
+            "issueCreate",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_query_with_variables_not_mutation(self):
+        """'query($id: ID!)' should NOT match type:mutation."""
+        body = _gql_body("query($id: ID!) { node(id: $id) { id } }", "GetNode")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_operation_name_catch_all_wildcard(self):
+        """operationName:* matches any non-empty operationName."""
+        body = _gql_body("query { viewer { id } }", "AnyName")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL operationName:*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_operation_name_catch_all_blocks_missing(self):
+        """operationName:* blocks when operationName is absent."""
+        body = _gql_body("query { viewer { id } }")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL operationName:*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_operation_name_null_in_body(self):
+        """operationName is JSON null — should block."""
+        body = json.dumps({"query": "query { viewer { id } }", "operationName": None}).encode()
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL operationName:GetViewer"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_query_field_non_string(self):
+        """query field is a number — should block when type: filter used."""
+        body = json.dumps({"query": 123, "operationName": "GetViewer"}).encode()
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_type_subscription_allows_subscription(self):
+        body = _gql_body("subscription { issueUpdated { id title } }", "OnIssueUpdate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:subscription"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_type_subscription_blocks_query(self):
+        body = _gql_body("query { viewer { id } }", "GetViewer")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:subscription"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -382,6 +382,95 @@ describe("validateRule", () => {
       return validateRule("GET /repos/{*}", "p", "fw");
     }).toThrow("empty parameter name");
   });
+
+  // GraphQL rules
+  it("should accept GraphQL type:query rule", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL type:query", "p", "fw");
+    }).not.toThrow();
+  });
+
+  it("should accept GraphQL type:mutation rule", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL type:mutation", "p", "fw");
+    }).not.toThrow();
+  });
+
+  it("should accept GraphQL type + operationName rule", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL type:mutation operationName:issueCreate",
+        "p",
+        "fw",
+      );
+    }).not.toThrow();
+  });
+
+  it("should accept GraphQL operationName only rule", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL operationName:issueCreate",
+        "p",
+        "fw",
+      );
+    }).not.toThrow();
+  });
+
+  it("should accept GraphQL operationName wildcard rule", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL operationName:issue*",
+        "p",
+        "fw",
+      );
+    }).not.toThrow();
+  });
+
+  it("should accept GraphQL operationName catch-all wildcard", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL operationName:*", "p", "fw");
+    }).not.toThrow();
+  });
+
+  it("should accept GraphQL type:subscription rule", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL type:subscription", "p", "fw");
+    }).not.toThrow();
+  });
+
+  it("should reject invalid GraphQL type", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL type:fragment", "p", "fw");
+    }).toThrow('type must be "query", "mutation", or "subscription"');
+  });
+
+  it("should reject empty GraphQL operationName", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL operationName:", "p", "fw");
+    }).toThrow("empty GraphQL operationName");
+  });
+
+  it("should reject unknown GraphQL modifier", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL foo:bar", "p", "fw");
+    }).toThrow("unknown GraphQL modifier");
+  });
+
+  it("should reject invalid operationName pattern", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL operationName:issue-create",
+        "p",
+        "fw",
+      );
+    }).toThrow("invalid GraphQL operationName pattern");
+  });
+
+  it("should validate path in GraphQL rule", () => {
+    expect(() => {
+      return validateRule("POST noslash GraphQL type:query", "p", "fw");
+    }).toThrow("path must start with");
+  });
 });
 
 describe("validateBaseUrl", () => {

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -438,6 +438,12 @@ describe("validateRule", () => {
     }).not.toThrow();
   });
 
+  it("should reject bare GraphQL keyword with no modifiers", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL", "p", "fw");
+    }).toThrow("requires at least one modifier");
+  });
+
   it("should reject invalid GraphQL type", () => {
     expect(() => {
       return validateRule("POST /graphql GraphQL type:fragment", "p", "fw");

--- a/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   matchFirewallPath,
   findMatchingPermissions,
+  type GraphQLBody,
 } from "../firewall-rule-matcher";
 import type { FirewallConfig } from "../firewalls";
 
@@ -211,5 +212,156 @@ describe("findMatchingPermissions", () => {
     expect(findMatchingPermissions("GET", "/data", multiApi)).toEqual([
       "shared-perm",
     ]);
+  });
+});
+
+describe("findMatchingPermissions with GraphQL rules", () => {
+  const gqlConfig: FirewallConfig = {
+    name: "linear",
+    apis: [
+      {
+        base: "https://api.linear.app",
+        auth: { headers: {} },
+        permissions: [
+          {
+            name: "read",
+            rules: ["POST /graphql GraphQL type:query"],
+          },
+          {
+            name: "write",
+            rules: ["POST /graphql GraphQL type:mutation"],
+          },
+          {
+            name: "issues-create",
+            rules: [
+              "POST /graphql GraphQL type:mutation operationName:issueCreate",
+            ],
+          },
+          {
+            name: "wildcard",
+            rules: ["POST /graphql GraphQL operationName:issue*"],
+          },
+        ],
+      },
+    ],
+  };
+
+  const queryBody: GraphQLBody = { type: "query", operationName: "GetViewer" };
+  const mutationBody: GraphQLBody = {
+    type: "mutation",
+    operationName: "issueCreate",
+  };
+
+  it("type:query matches query body", () => {
+    expect(
+      findMatchingPermissions("POST", "/graphql", gqlConfig, queryBody),
+    ).toContain("read");
+  });
+
+  it("type:query does not match mutation body", () => {
+    expect(
+      findMatchingPermissions("POST", "/graphql", gqlConfig, mutationBody),
+    ).not.toContain("read");
+  });
+
+  it("type:mutation matches mutation body", () => {
+    expect(
+      findMatchingPermissions("POST", "/graphql", gqlConfig, mutationBody),
+    ).toContain("write");
+  });
+
+  it("type:mutation + operationName matches exact name", () => {
+    expect(
+      findMatchingPermissions("POST", "/graphql", gqlConfig, mutationBody),
+    ).toContain("issues-create");
+  });
+
+  it("operationName wildcard matches prefix", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      operationName: "issueUpdate",
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", gqlConfig, body),
+    ).toContain("wildcard");
+  });
+
+  it("operationName wildcard does not match different prefix", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      operationName: "commentCreate",
+    };
+    const perms = findMatchingPermissions("POST", "/graphql", gqlConfig, body);
+    expect(perms).not.toContain("wildcard");
+    expect(perms).not.toContain("issues-create");
+  });
+
+  it("returns empty when no body provided for graphql rules", () => {
+    expect(findMatchingPermissions("POST", "/graphql", gqlConfig)).toEqual([]);
+  });
+
+  it("returns empty when body has no operationName and rule requires it", () => {
+    const noOpBody: GraphQLBody = { type: "mutation" };
+    const perms = findMatchingPermissions(
+      "POST",
+      "/graphql",
+      gqlConfig,
+      noOpBody,
+    );
+    expect(perms).not.toContain("issues-create");
+    expect(perms).not.toContain("wildcard");
+  });
+
+  it("path must match before body check", () => {
+    expect(
+      findMatchingPermissions("POST", "/v2", gqlConfig, queryBody),
+    ).toEqual([]);
+  });
+
+  it("type:subscription matches subscription body", () => {
+    const subConfig: FirewallConfig = {
+      name: "sub-test",
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [
+            {
+              name: "subscribe",
+              rules: ["POST /graphql GraphQL type:subscription"],
+            },
+          ],
+        },
+      ],
+    };
+    const subBody: GraphQLBody = {
+      type: "subscription",
+      operationName: "OnUpdate",
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", subConfig, subBody),
+    ).toEqual(["subscribe"]);
+  });
+
+  it("non-graphql rules still work when body is provided", () => {
+    const mixedConfig: FirewallConfig = {
+      name: "mixed",
+      apis: [
+        {
+          base: "https://example.com",
+          auth: { headers: {} },
+          permissions: [
+            { name: "rest-perm", rules: ["GET /api/users"] },
+            {
+              name: "gql-perm",
+              rules: ["POST /graphql GraphQL type:query"],
+            },
+          ],
+        },
+      ],
+    };
+    expect(
+      findMatchingPermissions("GET", "/api/users", mixedConfig, queryBody),
+    ).toEqual(["rest-perm"]);
   });
 });

--- a/turbo/packages/core/src/contracts/firewall-expander.ts
+++ b/turbo/packages/core/src/contracts/firewall-expander.ts
@@ -20,23 +20,50 @@ const VALID_RULE_METHODS = new Set([
   "ANY",
 ]);
 
-export function validateRule(
+const VALID_GRAPHQL_TYPES = new Set(["query", "mutation", "subscription"]);
+
+const GRAPHQL_OP_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]*\*?$/;
+
+function validateGraphQLModifiers(
+  modifiers: string[],
   rule: string,
   permName: string,
   serviceName: string,
 ): void {
-  const parts = rule.split(" ", 2);
-  if (parts.length !== 2 || !parts[1]) {
-    throw new Error(
-      `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": must be "METHOD /path"`,
-    );
+  for (const part of modifiers) {
+    if (part.startsWith("type:")) {
+      const val = part.slice(5);
+      if (!VALID_GRAPHQL_TYPES.has(val)) {
+        throw new Error(
+          `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": GraphQL type must be "query", "mutation", or "subscription", got "${val}"`,
+        );
+      }
+    } else if (part.startsWith("operationName:")) {
+      const val = part.slice(14);
+      if (!val) {
+        throw new Error(
+          `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": empty GraphQL operationName`,
+        );
+      }
+      if (val !== "*" && !GRAPHQL_OP_NAME_RE.test(val)) {
+        throw new Error(
+          `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": invalid GraphQL operationName pattern "${val}"`,
+        );
+      }
+    } else {
+      throw new Error(
+        `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": unknown GraphQL modifier "${part}"`,
+      );
+    }
   }
-  const [method, path] = parts as [string, string];
-  if (!VALID_RULE_METHODS.has(method)) {
-    throw new Error(
-      `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": unknown method "${method}" (must be uppercase)`,
-    );
-  }
+}
+
+function validatePathSegments(
+  path: string,
+  rule: string,
+  permName: string,
+  serviceName: string,
+): void {
   if (!path.startsWith("/")) {
     throw new Error(
       `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": path must start with "/"`,
@@ -72,6 +99,44 @@ export function validateRule(
         );
       }
     }
+  }
+}
+
+export function validateRule(
+  rule: string,
+  permName: string,
+  serviceName: string,
+): void {
+  const spaceIdx = rule.indexOf(" ");
+  if (spaceIdx === -1) {
+    throw new Error(
+      `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": must be "METHOD /path"`,
+    );
+  }
+  const method = rule.slice(0, spaceIdx);
+  const rest = rule.slice(spaceIdx + 1);
+  if (!method || !rest) {
+    throw new Error(
+      `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": must be "METHOD /path"`,
+    );
+  }
+  if (!VALID_RULE_METHODS.has(method)) {
+    throw new Error(
+      `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": unknown method "${method}" (must be uppercase)`,
+    );
+  }
+
+  // Check for GraphQL suffix: "POST /graphql GraphQL type:query operationName:foo"
+  const gqlIdx = rest.indexOf(" GraphQL");
+  if (gqlIdx !== -1) {
+    const path = rest.slice(0, gqlIdx);
+    const suffixStr = rest.slice(gqlIdx + 1); // "GraphQL type:query ..."
+    const suffixParts = suffixStr.split(/\s+/);
+    // suffixParts[0] is "GraphQL", rest are modifiers
+    validatePathSegments(path, rule, permName, serviceName);
+    validateGraphQLModifiers(suffixParts.slice(1), rule, permName, serviceName);
+  } else {
+    validatePathSegments(rest, rule, permName, serviceName);
   }
 }
 

--- a/turbo/packages/core/src/contracts/firewall-expander.ts
+++ b/turbo/packages/core/src/contracts/firewall-expander.ts
@@ -30,6 +30,11 @@ function validateGraphQLModifiers(
   permName: string,
   serviceName: string,
 ): void {
+  if (modifiers.length === 0) {
+    throw new Error(
+      `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": GraphQL keyword requires at least one modifier (type: or operationName:)`,
+    );
+  }
   for (const part of modifiers) {
     if (part.startsWith("type:")) {
       const val = part.slice(5);

--- a/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
+++ b/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
@@ -59,17 +59,93 @@ export function matchFirewallPath(
   return params;
 }
 
+interface GraphQLRule {
+  path: string;
+  typeFilter: string | null;
+  opFilter: string | null;
+}
+
+/**
+ * Parse the path+suffix portion of a rule for an optional GraphQL qualifier.
+ *
+ * Returns null when the `GraphQL` keyword is absent (plain REST rule).
+ */
+function parseGraphQLRule(rest: string): GraphQLRule | null {
+  const gqlIdx = rest.indexOf(" GraphQL");
+  if (gqlIdx === -1) return null;
+
+  const path = gqlIdx > 0 ? rest.slice(0, gqlIdx) : "/";
+  const suffixParts = rest.slice(gqlIdx + 1).split(/\s+/); // ["GraphQL", ...]
+
+  let typeFilter: string | null = null;
+  let opFilter: string | null = null;
+
+  for (let i = 1; i < suffixParts.length; i++) {
+    const part = suffixParts[i]!;
+    if (part.startsWith("type:")) {
+      typeFilter = part.slice(5);
+    } else if (part.startsWith("operationName:")) {
+      opFilter = part.slice(14);
+    }
+  }
+
+  return { path, typeFilter, opFilter };
+}
+
+/**
+ * Parsed GraphQL request body fields used for matching.
+ */
+export interface GraphQLBody {
+  /** The operation type keyword: `"query"` or `"mutation"`. */
+  type: string;
+  /** The named operation, if present. */
+  operationName?: string;
+}
+
+/**
+ * Match a parsed GraphQL body against type and operationName filters.
+ *
+ * Fail-closed: returns false if required fields are missing.
+ */
+function matchGraphQLBody(
+  body: GraphQLBody | undefined,
+  typeFilter: string | null,
+  opFilter: string | null,
+): boolean {
+  if (!body) return false;
+
+  if (typeFilter !== null && body.type !== typeFilter) {
+    return false;
+  }
+
+  if (opFilter !== null) {
+    const opName = body.operationName;
+    if (!opName) return false;
+    if (opFilter.endsWith("*")) {
+      if (!opName.startsWith(opFilter.slice(0, -1))) return false;
+    } else if (opName !== opFilter) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 /**
  * Find all permission names from a firewall config whose rules match
  * the given HTTP method and relative path.
  *
  * Method matching is case-insensitive. The special method `ANY` matches
  * any HTTP method.
+ *
+ * When `graphqlBody` is provided, rules containing the `GraphQL` keyword
+ * will also match against the parsed body's type and operationName.
  */
 export function findMatchingPermissions(
   method: string,
   path: string,
   config: FirewallConfig,
+  graphqlBody?: GraphQLBody,
 ): string[] {
   const upperMethod = method.toUpperCase();
   const matched = new Set<string>();
@@ -82,9 +158,20 @@ export function findMatchingPermissions(
         const spaceIdx = rule.indexOf(" ");
         if (spaceIdx === -1) continue;
         const ruleMethod = rule.slice(0, spaceIdx).toUpperCase();
-        const rulePath = rule.slice(spaceIdx + 1);
+        const rest = rule.slice(spaceIdx + 1);
         if (ruleMethod !== "ANY" && ruleMethod !== upperMethod) continue;
+
+        const gql = parseGraphQLRule(rest);
+        const rulePath = gql ? gql.path : rest;
+
         if (matchFirewallPath(path, rulePath) !== null) {
+          if (
+            gql &&
+            (gql.typeFilter !== null || gql.opFilter !== null) &&
+            !matchGraphQLBody(graphqlBody, gql.typeFilter, gql.opFilter)
+          ) {
+            continue;
+          }
           matched.add(perm.name);
           break;
         }

--- a/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
+++ b/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
@@ -96,8 +96,8 @@ function parseGraphQLRule(rest: string): GraphQLRule | null {
  * Parsed GraphQL request body fields used for matching.
  */
 export interface GraphQLBody {
-  /** The operation type keyword: `"query"` or `"mutation"`. */
-  type: string;
+  /** The operation type keyword: `"query"`, `"mutation"`, or `"subscription"`. */
+  type: "query" | "mutation" | "subscription";
   /** The named operation, if present. */
   operationName?: string;
 }

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -421,6 +421,7 @@ export {
 export {
   matchFirewallPath,
   findMatchingPermissions,
+  type GraphQLBody,
 } from "./firewall-rule-matcher";
 
 export {


### PR DESCRIPTION
## Summary

- Extend firewall rule format with optional `GraphQL type:<type> operationName:<pattern>` suffix for operation-level matching
- Proxy parses request body JSON only when `GraphQL` keyword is present — zero overhead for REST rules
- Fail-closed: unparseable body, missing fields, or no match → block
- Changes across all three matching layers (Python proxy, TS validation, TS matcher)

## Rule Format

```
POST /graphql GraphQL type:query                              # all queries
POST /graphql GraphQL type:mutation                           # all mutations
POST /graphql GraphQL type:mutation operationName:issueCreate # specific mutation
POST /graphql GraphQL operationName:issue*                    # wildcard prefix
POST /graphql GraphQL type:subscription                       # subscriptions
```

## Changed Files

| Layer | File | Change |
|---|---|---|
| Python proxy | `matching.py` | `parse_graphql_rule()`, `match_graphql_body()`, `body` param on `match_firewall_request()` |
| Python proxy | `mitm_addon.py` | Pass `flow.request.content` to matching |
| TS validation | `firewall-expander.ts` | `validateRule()` accepts GraphQL modifiers |
| TS matcher | `firewall-rule-matcher.ts` | `findMatchingPermissions()` accepts optional `GraphQLBody` |
| TS exports | `index.ts` | Export `GraphQLBody` type |

## Test plan

- [x] Python: 30 integration tests via `match_firewall_request()` (type matching, operationName exact/wildcard, fail-closed for invalid JSON/missing fields/null/array body, bare query default, compact syntax `mutation{`/`query($var)`, subscription, REST backward compat)
- [x] TS matcher: 32 tests including GraphQL body matching
- [x] TS validation: 78 tests including GraphQL modifier acceptance/rejection
- [x] All existing tests pass (143 Python, 280 TS)
- [x] Type check, lint, knip, format all pass

Closes #7573

🤖 Generated with [Claude Code](https://claude.com/claude-code)