### PR TITLE
feat: upgrade sandbox rootfs to ubuntu 24.04 with expanded runtime support

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -556,6 +556,26 @@ jobs:
           [ -n "$OUTPUT" ] || fail "prefix match returned empty output"
           echo "PASS: prefix matching"
 
+          # Test 4: verify pre-installed language runtimes and databases
+          echo "--- Test: runtime availability ---"
+          for cmd in \
+            "node --version" \
+            "python3 --version" \
+            "ruby --version" \
+            "php --version" \
+            "javac -version" \
+            "go version" \
+            "rustc --version" \
+            "gcc --version" \
+            "clang --version" \
+            "psql --version" \
+            "redis-server --version"; do
+            OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- $cmd 2>&1) \
+              || fail "command failed: $cmd"
+            echo "  $cmd -> $(echo "$OUTPUT" | head -1)"
+          done
+          echo "PASS: runtime availability"
+
           # Stop transient service (kills sandbox, submit terminates naturally)
           sudo "$BIN_DIR/runner" service stop --name "$SVC"
           trap - EXIT

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -560,14 +560,24 @@ jobs:
           echo "--- Test: runtime availability ---"
           for cmd in \
             "node --version" \
+            "npm --version" \
             "python3 --version" \
+            "pip3 --version" \
             "ruby --version" \
+            "bundler --version" \
             "php --version" \
+            "composer --version" \
             "javac -version" \
+            "mvn --version" \
+            "gradle --version" \
             "go version" \
             "rustc --version" \
+            "cargo --version" \
             "gcc --version" \
+            "g++ --version" \
             "clang --version" \
+            "make --version" \
+            "cmake --version" \
             "psql --version" \
             "redis-server --version"; do
             OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- $cmd 2>&1) \

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -203,7 +203,9 @@ RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
 # User account
 # ---------------------------------------------------------------------------
 # Create 'user' account (UID 1000) matching E2B sandbox default
-RUN useradd -m -u 1000 -s /bin/bash user \
+# Ubuntu 24.04 ships with an 'ubuntu' user at UID 1000, so remove it first.
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && useradd -m -u 1000 -s /bin/bash user \
     && usermod -aG sudo user \
     && echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
     && passwd -d user

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -1,5 +1,19 @@
 # Firecracker VM rootfs image
-# Based on Node.js 24 with Python 3.11+, guest-init, and agent CLIs
+# Based on Ubuntu 24.04 with pre-installed language runtimes and databases
+#
+# Language runtimes:
+# - Node.js 24 (npm, npx)
+# - Python 3.x (pip)
+# - Ruby 3.x (gem, bundler)
+# - PHP 8.x (composer)
+# - Java (OpenJDK + Maven + Gradle)
+# - Go (latest stable)
+# - Rust (stable toolchain + cargo)
+# - C++ (GCC + Clang + CMake)
+#
+# Databases:
+# - PostgreSQL 16
+# - Redis 7.0
 #
 # Included CLIs:
 # - Claude Code CLI (@anthropic-ai/claude-code)
@@ -11,17 +25,19 @@
 # Build: docker build -t vm0-rootfs .
 # Export: See build-rootfs.sh
 
-FROM node:24-bookworm-slim
+FROM ubuntu:24.04
 
 # Avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install required packages
+# ---------------------------------------------------------------------------
+# System packages
+# ---------------------------------------------------------------------------
 # Core:
-# - python3: Python 3.11+ for agent scripts
+# - python3, python3-pip: Python runtime
 # - procps: Process utilities (pgrep, free) needed by metrics and executor
-# Development tools (matching e2b template):
-# - curl: HTTP client
+# Development tools:
+# - curl, wget: HTTP clients
 # - git: Version control
 # - ripgrep: Fast code search (used by Claude Code)
 # - jq: JSON processing
@@ -30,11 +46,15 @@ ENV DEBIAN_FRONTEND=noninteractive
 # - iproute2: Network utilities (ip command)
 # - ca-certificates: SSL certificates for HTTPS
 # - sudo: For privileged operations
+# - gnupg: Key management for APT repos
+# NSS/Chromium:
+# - libnss3, p11-kit-modules: System CA trust for NSS-based apps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     procps \
     curl \
+    wget \
     git \
     ripgrep \
     jq \
@@ -42,8 +62,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     ca-certificates \
     sudo \
+    gnupg \
     libnss3 \
-    p11-kit-modules
+    p11-kit-modules \
+    && rm -rf /var/lib/apt/lists/*
 
 # Make NSS-based applications (Chromium, Firefox) trust the system CA store.
 # By default NSS uses a built-in trust module (libnssckbi.so) with Mozilla's
@@ -53,9 +75,94 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN find /usr/lib -name libnssckbi.so -exec sh -c \
     'p11=$(find /usr/lib -name p11-kit-trust.so | head -1) && ln -sf "$p11" "$1"' _ {} \;
 
-# Install Claude Code CLI as a standalone Bun-compiled binary.
-# The binary bundles Bun runtime (JSC) + application code into a single executable,
-# eliminating module resolution overhead and reducing CLI cold-start time.
+# ---------------------------------------------------------------------------
+# Node.js 24 (via NodeSource)
+# ---------------------------------------------------------------------------
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Ruby 3.x
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ruby-full \
+    bundler \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# PHP 8.x + Composer
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    php \
+    php-cli \
+    php-common \
+    php-curl \
+    php-mbstring \
+    php-xml \
+    php-zip \
+    unzip \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Java (OpenJDK + Maven + Gradle)
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    default-jdk \
+    maven \
+    gradle \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Go (latest stable via official tarball)
+# ---------------------------------------------------------------------------
+ARG GO_VERSION=1.24.2
+RUN ARCH=$(dpkg --print-architecture) \
+    && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && rm /tmp/go.tar.gz \
+    && echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/golang.sh
+
+# ---------------------------------------------------------------------------
+# Rust (stable toolchain via rustup, system-wide)
+# ---------------------------------------------------------------------------
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable --no-modify-path \
+    && chmod -R a+rX /usr/local/rustup /usr/local/cargo \
+    && echo 'export PATH=$PATH:/usr/local/cargo/bin' > /etc/profile.d/rust.sh
+
+# ---------------------------------------------------------------------------
+# C++ (GCC + Clang + CMake)
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    g++ \
+    clang \
+    make \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# PostgreSQL 16
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql-16 \
+    postgresql-contrib \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Redis 7
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    redis-server \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Claude Code CLI (standalone Bun-compiled binary)
+# ---------------------------------------------------------------------------
 ARG CLAUDE_CODE_VERSION=2.1.90
 RUN ARCH=$(dpkg --print-architecture) \
     && case "$ARCH" in amd64) PLATFORM="linux-x64" ;; arm64) PLATFORM="linux-arm64" ;; *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; esac \
@@ -66,31 +173,47 @@ RUN ARCH=$(dpkg --print-architecture) \
     && echo "${CHECKSUM}  /usr/local/bin/claude" | sha256sum -c - \
     && chmod +x /usr/local/bin/claude
 
-# Install GitHub CLI (included in base image)
-# See: turbo/scripts/e2b/vm0-claude-code/template.ts
-# https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+# ---------------------------------------------------------------------------
+# GitHub CLI
+# ---------------------------------------------------------------------------
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt-get update \
-    && apt-get install -y gh
+    && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install Google Workspace CLI for Google Workspace service access
+# ---------------------------------------------------------------------------
+# Google Workspace CLI
+# ---------------------------------------------------------------------------
 ARG GWS_CLI_VERSION=0.22.5
 RUN npm install -g @googleworkspace/cli@${GWS_CLI_VERSION}
 
-# Install xurl (X/Twitter official CLI) for X API access
+# ---------------------------------------------------------------------------
+# xurl (X/Twitter official CLI)
+# ---------------------------------------------------------------------------
 ARG XURL_VERSION=1.0.3
 RUN npm install -g @xdevplatform/xurl@${XURL_VERSION}
 
+# ---------------------------------------------------------------------------
+# Chromium + agent-browser
+# ---------------------------------------------------------------------------
+# Ubuntu 24.04 defaults to snap-packaged Chromium which doesn't work in Docker.
+# Try chromium-browser first, fall back to chromium package name.
+ARG AGENT_BROWSER_VERSION=0.23.4
+RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
+    && apt-get update \
+    && (apt-get install -y --no-install-recommends chromium-browser \
+        || apt-get install -y --no-install-recommends chromium) \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# User account
+# ---------------------------------------------------------------------------
 # Create 'user' account (UID 1000) matching E2B sandbox default
-# - Home directory at /home/user
-# - Add to sudo group for privileged operations
-# Note: node:24-bookworm-slim has 'node' user at UID 1000, so we delete it first
-RUN userdel -r node 2>/dev/null || true \
-    && useradd -m -u 1000 -s /bin/bash user \
+RUN useradd -m -u 1000 -s /bin/bash user \
     && usermod -aG sudo user \
     && echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
     && passwd -d user
@@ -100,15 +223,9 @@ RUN userdel -r node 2>/dev/null || true \
 
 ENV LANG=C.UTF-8
 
-# Install Chromium and agent-browser CLI for browser automation.
-# System Chromium is used on all architectures for version consistency.
-# Chromium binaries are loaded on demand, so they don't consume memory unless launched.
-ARG AGENT_BROWSER_VERSION=0.23.4
-RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends chromium
-
-# Clean up caches to reduce rootfs size.
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
 # Docker layers don't matter since the image is exported as a flat rootfs.
 RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
     && npm cache clean --force

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -180,13 +180,14 @@ RUN npm install -g @xdevplatform/xurl@${XURL_VERSION}
 # ---------------------------------------------------------------------------
 # Chromium + agent-browser
 # ---------------------------------------------------------------------------
-# Ubuntu 24.04 defaults to snap-packaged Chromium which doesn't work in Docker.
-# Try chromium-browser first, fall back to chromium package name.
+# Ubuntu 24.04's chromium-browser is a snap stub that doesn't work in Docker.
+# Install the real Chromium deb from Debian Bookworm's repository instead.
 ARG AGENT_BROWSER_VERSION=0.23.4
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
+    && echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/debian-bookworm.list \
     && apt-get update \
-    && (apt-get install -y chromium-browser \
-        || apt-get install -y chromium)
+    && apt-get install -y -t bookworm chromium \
+    && rm /etc/apt/sources.list.d/debian-bookworm.list
 
 # ---------------------------------------------------------------------------
 # User account

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -184,10 +184,11 @@ RUN npm install -g @xdevplatform/xurl@${XURL_VERSION}
 # Install the real Chromium deb from Debian Bookworm's repository instead.
 ARG AGENT_BROWSER_VERSION=0.23.4
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
-    && echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/debian-bookworm.list \
+    && curl -fsSL https://ftp-master.debian.org/keys/archive-key-12.asc | gpg --dearmor -o /usr/share/keyrings/debian-bookworm.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/debian-bookworm.gpg] http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/debian-bookworm.list \
     && apt-get update \
     && apt-get install -y -t bookworm chromium \
-    && rm /etc/apt/sources.list.d/debian-bookworm.list
+    && rm /etc/apt/sources.list.d/debian-bookworm.list /usr/share/keyrings/debian-bookworm.gpg
 
 # ---------------------------------------------------------------------------
 # User account

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -77,8 +77,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 # ---------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y \
     python3 \
-    python3-pip \
-    && rm -f /usr/lib/python*/EXTERNALLY-MANAGED
+    python3-pip
 
 # ---------------------------------------------------------------------------
 # Ruby 3.x

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -115,7 +115,7 @@ ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --no-modify-path \
-    && chmod -R a+rX /usr/local/rustup /usr/local/cargo \
+    && chmod -R a+rwX /usr/local/rustup /usr/local/cargo \
     && echo 'export PATH=$PATH:/usr/local/cargo/bin' > /etc/profile.d/rust.sh
 
 # ---------------------------------------------------------------------------

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -64,8 +64,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo \
     gnupg \
     libnss3 \
-    p11-kit-modules \
-    && rm -rf /var/lib/apt/lists/*
+    p11-kit-modules
 
 # Make NSS-based applications (Chromium, Firefox) trust the system CA store.
 # By default NSS uses a built-in trust module (libnssckbi.so) with Mozilla's
@@ -79,16 +78,14 @@ RUN find /usr/lib -name libnssckbi.so -exec sh -c \
 # Node.js 24 (via NodeSource)
 # ---------------------------------------------------------------------------
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
-    && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y nodejs
 
 # ---------------------------------------------------------------------------
 # Ruby 3.x
 # ---------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ruby-full \
-    bundler \
-    && rm -rf /var/lib/apt/lists/*
+    bundler
 
 # ---------------------------------------------------------------------------
 # PHP 8.x + Composer
@@ -102,8 +99,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     php-xml \
     php-zip \
     unzip \
-    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && rm -rf /var/lib/apt/lists/*
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # ---------------------------------------------------------------------------
 # Java (OpenJDK + Maven + Gradle)
@@ -111,8 +107,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     default-jdk \
     maven \
-    gradle \
-    && rm -rf /var/lib/apt/lists/*
+    gradle
 
 # ---------------------------------------------------------------------------
 # Go (latest stable via official tarball)
@@ -142,23 +137,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     g++ \
     clang \
     make \
-    cmake \
-    && rm -rf /var/lib/apt/lists/*
+    cmake
 
 # ---------------------------------------------------------------------------
 # PostgreSQL 16
 # ---------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
     postgresql-16 \
-    postgresql-contrib \
-    && rm -rf /var/lib/apt/lists/*
+    postgresql-contrib
 
 # ---------------------------------------------------------------------------
 # Redis 7
 # ---------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    redis-server \
-    && rm -rf /var/lib/apt/lists/*
+    redis-server
 
 # ---------------------------------------------------------------------------
 # Claude Code CLI (standalone Bun-compiled binary)
@@ -182,8 +174,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt-get update \
-    && apt-get install -y gh \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y gh
 
 # ---------------------------------------------------------------------------
 # Google Workspace CLI
@@ -206,8 +197,7 @@ ARG AGENT_BROWSER_VERSION=0.23.4
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
     && apt-get update \
     && (apt-get install -y --no-install-recommends chromium-browser \
-        || apt-get install -y --no-install-recommends chromium) \
-    && rm -rf /var/lib/apt/lists/*
+        || apt-get install -y --no-install-recommends chromium)
 
 # ---------------------------------------------------------------------------
 # User account

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -57,6 +57,16 @@ RUN find /usr/lib -name libnssckbi.so -exec sh -c \
     'p11=$(find /usr/lib -name p11-kit-trust.so | head -1) && ln -sf "$p11" "$1"' _ {} \;
 
 # ---------------------------------------------------------------------------
+# User account
+# ---------------------------------------------------------------------------
+# Ubuntu 24.04 ships with an 'ubuntu' user at UID 1000, so remove it first.
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && useradd -m -u 1000 -s /bin/bash user \
+    && usermod -aG sudo user \
+    && echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && passwd -d user
+
+# ---------------------------------------------------------------------------
 # Node.js 24 (via NodeSource)
 # ---------------------------------------------------------------------------
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
@@ -108,16 +118,6 @@ RUN ARCH=$(dpkg --print-architecture) \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz \
     && echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/golang.sh
-
-# ---------------------------------------------------------------------------
-# User account (created early so Rust can be installed as user)
-# ---------------------------------------------------------------------------
-# Ubuntu 24.04 ships with an 'ubuntu' user at UID 1000, so remove it first.
-RUN userdel -r ubuntu 2>/dev/null || true \
-    && useradd -m -u 1000 -s /bin/bash user \
-    && usermod -aG sudo user \
-    && echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
-    && passwd -d user
 
 # ---------------------------------------------------------------------------
 # Rust (stable toolchain via rustup, installed as user)

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -116,7 +116,7 @@ RUN ARCH=$(dpkg --print-architecture) \
     && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz \
-    && echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/golang.sh
+    && echo 'export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin' > /etc/profile.d/golang.sh
 
 # ---------------------------------------------------------------------------
 # Rust (stable toolchain via rustup)

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -116,7 +116,9 @@ RUN ARCH=$(dpkg --print-architecture) \
     && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && rm /tmp/go.tar.gz \
-    && echo 'export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin' > /etc/profile.d/golang.sh
+    && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+    && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt \
+    && echo 'export PATH=$PATH:$HOME/go/bin' > /etc/profile.d/golang.sh
 
 # ---------------------------------------------------------------------------
 # Rust (stable toolchain via rustup)
@@ -125,7 +127,8 @@ ENV RUSTUP_HOME=/usr/local/rustup
 ENV CARGO_HOME=/usr/local/cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --no-modify-path \
-    && printf 'export RUSTUP_HOME=/usr/local/rustup\nexport CARGO_HOME=$HOME/.cargo\nexport PATH=$PATH:/usr/local/cargo/bin:$HOME/.cargo/bin\n' \
+    && for bin in /usr/local/cargo/bin/*; do ln -s "$bin" /usr/local/bin/; done \
+    && printf 'export RUSTUP_HOME=/usr/local/rustup\nexport CARGO_HOME=$HOME/.cargo\nexport PATH=$PATH:$HOME/.cargo/bin\n' \
        > /etc/profile.d/rust.sh
 
 # ---------------------------------------------------------------------------

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -110,14 +110,24 @@ RUN ARCH=$(dpkg --print-architecture) \
     && echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/golang.sh
 
 # ---------------------------------------------------------------------------
-# Rust (stable toolchain via rustup, system-wide)
+# User account (created early so Rust can be installed as user)
 # ---------------------------------------------------------------------------
-ENV RUSTUP_HOME=/usr/local/rustup
-ENV CARGO_HOME=/usr/local/cargo
+# Ubuntu 24.04 ships with an 'ubuntu' user at UID 1000, so remove it first.
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && useradd -m -u 1000 -s /bin/bash user \
+    && usermod -aG sudo user \
+    && echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && passwd -d user
+
+# ---------------------------------------------------------------------------
+# Rust (stable toolchain via rustup, installed as user)
+# ---------------------------------------------------------------------------
+USER user
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --no-modify-path \
-    && chmod -R a+rwX /usr/local/rustup /usr/local/cargo \
-    && printf 'export RUSTUP_HOME=/usr/local/rustup\nexport CARGO_HOME=/usr/local/cargo\nexport PATH=$PATH:/usr/local/cargo/bin\n' > /etc/profile.d/rust.sh
+    && echo 'export PATH=$PATH:$HOME/.cargo/bin' > /tmp/rust-profile.sh
+USER root
+RUN mv /tmp/rust-profile.sh /etc/profile.d/rust.sh
 
 # ---------------------------------------------------------------------------
 # C++ (GCC + Clang + CMake)
@@ -190,17 +200,6 @@ RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
     && apt-get update \
     && apt-get install -y -t bookworm chromium \
     && rm /etc/apt/sources.list.d/debian-bookworm.list /usr/share/keyrings/debian-bookworm.gpg
-
-# ---------------------------------------------------------------------------
-# User account
-# ---------------------------------------------------------------------------
-# Create 'user' account (UID 1000) matching E2B sandbox default
-# Ubuntu 24.04 ships with an 'ubuntu' user at UID 1000, so remove it first.
-RUN userdel -r ubuntu 2>/dev/null || true \
-    && useradd -m -u 1000 -s /bin/bash user \
-    && usermod -aG sudo user \
-    && echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
-    && passwd -d user
 
 # NOTE: DNS configuration is handled in build-rootfs.sh after export
 # /etc/resolv.conf is read-only during Docker build

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -67,7 +67,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 # ---------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y \
     python3 \
-    python3-pip
+    python3-pip \
+    && rm -f /usr/lib/python*/EXTERNALLY-MANAGED
 
 # ---------------------------------------------------------------------------
 # Ruby 3.x
@@ -116,7 +117,7 @@ ENV CARGO_HOME=/usr/local/cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --no-modify-path \
     && chmod -R a+rwX /usr/local/rustup /usr/local/cargo \
-    && echo 'export PATH=$PATH:/usr/local/cargo/bin' > /etc/profile.d/rust.sh
+    && printf 'export RUSTUP_HOME=/usr/local/rustup\nexport CARGO_HOME=/usr/local/cargo\nexport PATH=$PATH:/usr/local/cargo/bin\n' > /etc/profile.d/rust.sh
 
 # ---------------------------------------------------------------------------
 # C++ (GCC + Clang + CMake)

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -33,25 +33,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # ---------------------------------------------------------------------------
 # System packages
 # ---------------------------------------------------------------------------
-# Core:
-# - python3, python3-pip: Python runtime
-# - procps: Process utilities (pgrep, free) needed by metrics and executor
-# Development tools:
-# - curl, wget: HTTP clients
-# - git: Version control
-# - ripgrep: Fast code search (used by Claude Code)
-# - jq: JSON processing
-# - file: File type detection
-# System utilities:
-# - iproute2: Network utilities (ip command)
-# - ca-certificates: SSL certificates for HTTPS
-# - sudo: For privileged operations
-# - gnupg: Key management for APT repos
-# NSS/Chromium:
-# - libnss3, p11-kit-modules: System CA trust for NSS-based apps
 RUN apt-get update && apt-get install -y \
-    python3 \
-    python3-pip \
     procps \
     curl \
     wget \
@@ -65,6 +47,13 @@ RUN apt-get update && apt-get install -y \
     gnupg \
     libnss3 \
     p11-kit-modules
+
+# ---------------------------------------------------------------------------
+# Python 3.x
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip
 
 # Make NSS-based applications (Chromium, Firefox) trust the system CA store.
 # By default NSS uses a built-in trust module (libnssckbi.so) with Mozilla's

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -120,14 +120,14 @@ RUN ARCH=$(dpkg --print-architecture) \
     && echo 'export PATH=$PATH:/usr/local/go/bin' > /etc/profile.d/golang.sh
 
 # ---------------------------------------------------------------------------
-# Rust (stable toolchain via rustup, installed as user)
+# Rust (stable toolchain via rustup)
 # ---------------------------------------------------------------------------
-USER user
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --no-modify-path \
-    && echo 'export PATH=$PATH:$HOME/.cargo/bin' > /tmp/rust-profile.sh
-USER root
-RUN mv /tmp/rust-profile.sh /etc/profile.d/rust.sh
+    && printf 'export RUSTUP_HOME=/usr/local/rustup\nexport CARGO_HOME=$HOME/.cargo\nexport PATH=$PATH:/usr/local/cargo/bin:$HOME/.cargo/bin\n' \
+       > /etc/profile.d/rust.sh
 
 # ---------------------------------------------------------------------------
 # C++ (GCC + Clang + CMake)

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -48,13 +48,6 @@ RUN apt-get update && apt-get install -y \
     libnss3 \
     p11-kit-modules
 
-# ---------------------------------------------------------------------------
-# Python 3.x
-# ---------------------------------------------------------------------------
-RUN apt-get update && apt-get install -y \
-    python3 \
-    python3-pip
-
 # Make NSS-based applications (Chromium, Firefox) trust the system CA store.
 # By default NSS uses a built-in trust module (libnssckbi.so) with Mozilla's
 # root CAs. Replacing it with p11-kit's module makes NSS read from the same
@@ -68,6 +61,13 @@ RUN find /usr/lib -name libnssckbi.so -exec sh -c \
 # ---------------------------------------------------------------------------
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs
+
+# ---------------------------------------------------------------------------
+# Python 3.x
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip
 
 # ---------------------------------------------------------------------------
 # Ruby 3.x

--- a/crates/runner/scripts/rootfs-default.Dockerfile
+++ b/crates/runner/scripts/rootfs-default.Dockerfile
@@ -49,7 +49,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # - gnupg: Key management for APT repos
 # NSS/Chromium:
 # - libnss3, p11-kit-modules: System CA trust for NSS-based apps
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     python3 \
     python3-pip \
     procps \
@@ -83,14 +83,14 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 # ---------------------------------------------------------------------------
 # Ruby 3.x
 # ---------------------------------------------------------------------------
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     ruby-full \
     bundler
 
 # ---------------------------------------------------------------------------
 # PHP 8.x + Composer
 # ---------------------------------------------------------------------------
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     php \
     php-cli \
     php-common \
@@ -104,7 +104,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ---------------------------------------------------------------------------
 # Java (OpenJDK + Maven + Gradle)
 # ---------------------------------------------------------------------------
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     default-jdk \
     maven \
     gradle
@@ -132,7 +132,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 # ---------------------------------------------------------------------------
 # C++ (GCC + Clang + CMake)
 # ---------------------------------------------------------------------------
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     clang \
@@ -142,14 +142,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ---------------------------------------------------------------------------
 # PostgreSQL 16
 # ---------------------------------------------------------------------------
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     postgresql-16 \
     postgresql-contrib
 
 # ---------------------------------------------------------------------------
 # Redis 7
 # ---------------------------------------------------------------------------
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
     redis-server
 
 # ---------------------------------------------------------------------------
@@ -196,8 +196,8 @@ RUN npm install -g @xdevplatform/xurl@${XURL_VERSION}
 ARG AGENT_BROWSER_VERSION=0.23.4
 RUN npm install -g agent-browser@${AGENT_BROWSER_VERSION} \
     && apt-get update \
-    && (apt-get install -y --no-install-recommends chromium-browser \
-        || apt-get install -y --no-install-recommends chromium)
+    && (apt-get install -y chromium-browser \
+        || apt-get install -y chromium)
 
 # ---------------------------------------------------------------------------
 # User account

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -139,7 +139,7 @@ check_bin "/usr/bin/ruby"                      "ruby"
 check_bin "/usr/bin/php*"                      "php"
 check_bin "/usr/lib/jvm/java-*/bin/javac"      "javac"
 check_bin "/usr/local/go/bin/go"               "go"
-check_bin "/home/user/.cargo/bin/rustc"        "rustc"
+check_bin "/usr/local/cargo/bin/rustc"         "rustc"
 check_bin "/usr/bin/gcc"                       "gcc"
 check_bin "/usr/bin/clang"                     "clang"
 

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -121,6 +121,37 @@ else
   errors+=("gh CLI not found at /usr/bin/gh")
 fi
 
+# Check language runtimes
+for bin_check in \
+  "/usr/bin/ruby:ruby" \
+  "/usr/bin/php:php" \
+  "/usr/bin/javac:javac" \
+  "/usr/local/go/bin/go:go" \
+  "/usr/local/cargo/bin/rustc:rustc" \
+  "/usr/bin/gcc:gcc" \
+  "/usr/bin/clang:clang"; do
+  bin_path="${bin_check%%:*}"
+  bin_name="${bin_check#*:}"
+  if [[ -f "${MOUNT_DIR}${bin_path}" ]]; then
+    echo "  ${bin_name}: found"
+  else
+    errors+=("${bin_name} not found at ${bin_path}")
+  fi
+done
+
+# Check databases
+if [[ -f "${MOUNT_DIR}/usr/bin/psql" ]]; then
+  echo "  psql: found"
+else
+  errors+=("psql not found at /usr/bin/psql")
+fi
+
+if [[ -f "${MOUNT_DIR}/usr/bin/redis-server" ]]; then
+  echo "  redis-server: found"
+else
+  errors+=("redis-server not found at /usr/bin/redis-server")
+fi
+
 # Check proxy CA certificate file
 ca_path="${MOUNT_DIR}/${CA_ROOTFS_DEST}"
 if [[ -f "$ca_path" ]]; then

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -122,22 +122,26 @@ else
 fi
 
 # Check language runtimes
-for bin_check in \
-  "/usr/bin/ruby:ruby" \
-  "/usr/bin/php:php" \
-  "/usr/bin/javac:javac" \
-  "/usr/local/go/bin/go:go" \
-  "/usr/local/cargo/bin/rustc:rustc" \
-  "/usr/bin/gcc:gcc" \
-  "/usr/bin/clang:clang"; do
-  bin_path="${bin_check%%:*}"
-  bin_name="${bin_check#*:}"
-  if [[ -f "${MOUNT_DIR}${bin_path}" ]]; then
-    echo "  ${bin_name}: found"
+# Some binaries use update-alternatives symlinks or versioned names (e.g.
+# php8.3 instead of php, javac under /usr/lib/jvm/). Use glob patterns
+# and ls to handle both exact paths and wildcards.
+check_bin() {
+  local pattern="$1" name="$2"
+  # shellcheck disable=SC2086
+  if ls ${MOUNT_DIR}${pattern} &>/dev/null; then
+    echo "  ${name}: found"
   else
-    errors+=("${bin_name} not found at ${bin_path}")
+    errors+=("${name} not found (pattern: ${pattern})")
   fi
-done
+}
+
+check_bin "/usr/bin/ruby"                      "ruby"
+check_bin "/usr/bin/php*"                      "php"
+check_bin "/usr/lib/jvm/java-*/bin/javac"      "javac"
+check_bin "/usr/local/go/bin/go"               "go"
+check_bin "/usr/local/cargo/bin/rustc"         "rustc"
+check_bin "/usr/bin/gcc"                       "gcc"
+check_bin "/usr/bin/clang"                     "clang"
 
 # Check databases
 if [[ -f "${MOUNT_DIR}/usr/bin/psql" ]]; then

--- a/crates/runner/scripts/verify-rootfs.sh
+++ b/crates/runner/scripts/verify-rootfs.sh
@@ -139,7 +139,7 @@ check_bin "/usr/bin/ruby"                      "ruby"
 check_bin "/usr/bin/php*"                      "php"
 check_bin "/usr/lib/jvm/java-*/bin/javac"      "javac"
 check_bin "/usr/local/go/bin/go"               "go"
-check_bin "/usr/local/cargo/bin/rustc"         "rustc"
+check_bin "/home/user/.cargo/bin/rustc"        "rustc"
 check_bin "/usr/bin/gcc"                       "gcc"
 check_bin "/usr/bin/clang"                     "clang"
 


### PR DESCRIPTION
## Summary

- Migrate rootfs base image from `node:24-bookworm-slim` (Debian Bookworm) to `ubuntu:24.04`
- Add language runtimes: Ruby 3.x, PHP 8.x, Java (OpenJDK+Maven+Gradle), Go 1.24.2, Rust stable, C++ (GCC+Clang+CMake)
- Add databases: PostgreSQL 16, Redis 7.0
- Node.js 24 installed via NodeSource APT repo (previously from base image)
- All existing CLIs retained (Claude Code, gh, agent-browser, gws, xurl)
- Updated `verify-rootfs.sh` with checks for all new runtimes and databases

Closes #7599

## Test plan

- [ ] CI runner-build job builds rootfs successfully on metal hosts
- [ ] `verify-rootfs.sh` passes all new binary checks
- [ ] Runner exec tests pass (sandbox functionality unchanged)
- [ ] Chromium install works in Ubuntu 24.04 Docker (snap workaround)
- [ ] Go and Rust available via PATH (`/etc/profile.d/` scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)