### PR TITLE
refactor: move billing and credit to lib/zero/

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -18,7 +18,7 @@ import {
   dispatchQueuedZeroRun,
   drainOrgQueue,
 } from "../../../../../../src/lib/zero/zero-run-queue-service";
-import { processOrgCredits } from "../../../../../../src/lib/credit/credit-service";
+import { processOrgCredits } from "../../../../../../src/lib/zero/credit/credit-service";
 import { isNotFound, isBadRequest } from "../../../../../../src/lib/errors";
 import { logger } from "../../../../../../src/lib/logger";
 import { after } from "next/server";

--- a/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
+++ b/turbo/apps/web/app/api/cron/cleanup-sandboxes/route.ts
@@ -19,7 +19,7 @@ import {
   drainOrgQueue,
   dispatchQueuedZeroRun,
 } from "../../../../src/lib/zero/zero-run-queue-service";
-import { processOrgCredits } from "../../../../src/lib/credit/credit-service";
+import { processOrgCredits } from "../../../../src/lib/zero/credit/credit-service";
 import { logger } from "../../../../src/lib/logger";
 import { env } from "../../../../src/env";
 

--- a/turbo/apps/web/app/api/cron/process-credits/route.ts
+++ b/turbo/apps/web/app/api/cron/process-credits/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../src/lib/init-services";
-import { processStaleCredits } from "../../../../src/lib/credit/credit-service";
+import { processStaleCredits } from "../../../../src/lib/zero/credit/credit-service";
 import { logger } from "../../../../src/lib/logger";
 import { env } from "../../../../src/env";
 

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -24,7 +24,7 @@ import {
   drainOrgQueue,
   dispatchQueuedZeroRun,
 } from "../../../../../src/lib/zero/zero-run-queue-service";
-import { processOrgCredits } from "../../../../../src/lib/credit/credit-service";
+import { processOrgCredits } from "../../../../../src/lib/zero/credit/credit-service";
 import { after } from "next/server";
 
 const log = logger("webhook:complete");

--- a/turbo/apps/web/app/api/webhooks/agent/events/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/events/route.ts
@@ -15,7 +15,7 @@ import {
   getDatasetName,
   DATASETS,
 } from "../../../../../src/lib/shared/axiom";
-import { upsertCreditUsage } from "../../../../../src/lib/credit/credit-usage-service";
+import { upsertCreditUsage } from "../../../../../src/lib/zero/credit/credit-usage-service";
 const log = logger("webhook:events");
 
 const router = tsr.router(webhookEventsContract, {

--- a/turbo/apps/web/app/api/webhooks/stripe/route.ts
+++ b/turbo/apps/web/app/api/webhooks/stripe/route.ts
@@ -7,7 +7,7 @@ import {
   handleInvoicePaid,
   handleSubscriptionUpdated,
   handleSubscriptionDeleted,
-} from "../../../../src/lib/billing/billing-service";
+} from "../../../../src/lib/zero/billing/billing-service";
 import { logger } from "../../../../src/lib/logger";
 import type Stripe from "stripe";
 

--- a/turbo/apps/web/app/api/zero/billing/auto-recharge/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/auto-recharge/route.ts
@@ -16,7 +16,7 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import {
   getAutoRechargeConfig,
   updateAutoRechargeConfig,
-} from "../../../../../src/lib/billing/billing-service";
+} from "../../../../../src/lib/zero/billing/billing-service";
 
 const router = tsr.router(zeroBillingAutoRechargeContract, {
   get: async ({ headers }) => {

--- a/turbo/apps/web/app/api/zero/billing/checkout/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/checkout/route.ts
@@ -14,7 +14,7 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import {
   createCheckoutSession,
   activePriceId,
-} from "../../../../../src/lib/billing/billing-service";
+} from "../../../../../src/lib/zero/billing/billing-service";
 
 const router = tsr.router(zeroBillingCheckoutContract, {
   create: async ({ body, headers }) => {

--- a/turbo/apps/web/app/api/zero/billing/downgrade/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/downgrade/route.ts
@@ -11,7 +11,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { downgradeSubscription } from "../../../../../src/lib/billing/billing-service";
+import { downgradeSubscription } from "../../../../../src/lib/zero/billing/billing-service";
 
 const router = tsr.router(zeroBillingDowngradeContract, {
   create: async ({ body, headers }) => {

--- a/turbo/apps/web/app/api/zero/billing/invoices/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/invoices/route.ts
@@ -10,7 +10,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { getOrgInvoices } from "../../../../../src/lib/billing/billing-service";
+import { getOrgInvoices } from "../../../../../src/lib/zero/billing/billing-service";
 
 const router = tsr.router(zeroBillingInvoicesContract, {
   get: async ({ headers }) => {

--- a/turbo/apps/web/app/api/zero/billing/portal/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/portal/route.ts
@@ -11,7 +11,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { createBillingPortalSession } from "../../../../../src/lib/billing/billing-service";
+import { createBillingPortalSession } from "../../../../../src/lib/zero/billing/billing-service";
 
 const router = tsr.router(zeroBillingPortalContract, {
   create: async ({ body, headers }) => {

--- a/turbo/apps/web/app/api/zero/billing/status/route.ts
+++ b/turbo/apps/web/app/api/zero/billing/status/route.ts
@@ -10,7 +10,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { getBillingStatus } from "../../../../../src/lib/billing/billing-service";
+import { getBillingStatus } from "../../../../../src/lib/zero/billing/billing-service";
 
 const router = tsr.router(zeroBillingStatusContract, {
   get: async ({ headers }) => {

--- a/turbo/apps/web/app/api/zero/org/members/credit-cap/route.ts
+++ b/turbo/apps/web/app/api/zero/org/members/credit-cap/route.ts
@@ -9,7 +9,7 @@ import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
 import {
   getMemberCreditCap,
   setMemberCreditCap,
-} from "../../../../../../src/lib/credit/member-credit-cap-service";
+} from "../../../../../../src/lib/zero/credit/member-credit-cap-service";
 
 const updateBodySchema = z.object({
   userId: z.string().min(1),

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
@@ -18,7 +18,7 @@ import {
   dispatchQueuedZeroRun,
   drainOrgQueue,
 } from "../../../../../../src/lib/zero/zero-run-queue-service";
-import { processOrgCredits } from "../../../../../../src/lib/credit/credit-service";
+import { processOrgCredits } from "../../../../../../src/lib/zero/credit/credit-service";
 import { isNotFound, isBadRequest } from "../../../../../../src/lib/errors";
 import { after } from "next/server";
 

--- a/turbo/apps/web/app/api/zero/usage/members/route.ts
+++ b/turbo/apps/web/app/api/zero/usage/members/route.ts
@@ -10,7 +10,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { getUsageMembers } from "../../../../../src/lib/billing/usage-service";
+import { getUsageMembers } from "../../../../../src/lib/zero/billing/usage-service";
 
 const router = tsr.router(zeroUsageMembersContract, {
   get: async ({ headers }) => {

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -48,7 +48,7 @@ import { creditExpiresRecord } from "../db/schema/credit-expires-record";
 import {
   deductFromExpiresRecords,
   expireCredits,
-} from "../lib/credit/credit-expires-service";
+} from "../lib/zero/credit/credit-expires-service";
 import { modelProviders } from "../db/schema/model-provider";
 import { ORG_SENTINEL_USER_ID } from "../lib/org/org-sentinel";
 import { orgCache } from "../db/schema/org-cache";

--- a/turbo/apps/web/src/lib/zero/billing/__tests__/auto-recharge-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/billing/__tests__/auto-recharge-service.test.ts
@@ -3,14 +3,14 @@ import {
   testContext,
   uniqueId,
   type UserContext,
-} from "../../../__tests__/test-helpers";
+} from "../../../../__tests__/test-helpers";
 import {
   getOrgCredits,
   updateOrgTier,
   updateOrgStripeFields,
   updateOrgAutoRecharge,
   getOrgAutoRechargeFields,
-} from "../../../__tests__/api-test-helpers";
+} from "../../../../__tests__/api-test-helpers";
 
 // Stripe mock — must be defined before importing the service
 const stripeMocks = vi.hoisted(() => {
@@ -47,7 +47,7 @@ vi.mock("stripe", () => {
   };
 });
 
-import { reloadEnv } from "../../../env";
+import { reloadEnv } from "../../../../env";
 import {
   triggerAutoRecharge,
   handleAutoRechargeInvoicePaid,

--- a/turbo/apps/web/src/lib/zero/billing/auto-recharge-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/auto-recharge-service.ts
@@ -1,9 +1,9 @@
 import { eq, sql } from "drizzle-orm";
 import type Stripe from "stripe";
-import { orgMetadata } from "../../db/schema/org-metadata";
-import { grantOrgCredits } from "../org/org-service";
-import { getStripe } from "../stripe";
-import { logger } from "../logger";
+import { orgMetadata } from "../../../db/schema/org-metadata";
+import { grantOrgCredits } from "../../org/org-service";
+import { getStripe } from "../../stripe";
+import { logger } from "../../logger";
 
 const log = logger("billing:auto-recharge");
 

--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -1,9 +1,9 @@
 import { eq } from "drizzle-orm";
 import type { OrgTier } from "@vm0/core";
-import { getStripe } from "../stripe";
-import { env } from "../../env";
-import { orgMetadata } from "../../db/schema/org-metadata";
-import { grantOrgCredits } from "../org/org-service";
+import { getStripe } from "../../stripe";
+import { env } from "../../../env";
+import { orgMetadata } from "../../../db/schema/org-metadata";
+import { grantOrgCredits } from "../../org/org-service";
 import { handleAutoRechargeInvoicePaid } from "./auto-recharge-service";
 import { resetMemberCreditFlags } from "../credit/member-credit-cap-service";
 import {
@@ -11,7 +11,7 @@ import {
   expireCredits,
   getExpiresRecordsSummary,
 } from "../credit/credit-expires-service";
-import { logger } from "../logger";
+import { logger } from "../../logger";
 
 const log = logger("billing");
 

--- a/turbo/apps/web/src/lib/zero/billing/usage-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-service.ts
@@ -1,9 +1,9 @@
 import { sql, and, eq, gte, lt, inArray } from "drizzle-orm";
 import { type MemberUsage, type UsageMembersResponse } from "@vm0/core";
-import { getOrgBillingPeriod } from "../org/org-cache-service";
-import { creditUsage } from "../../db/schema/credit-usage";
-import { userCache } from "../../db/schema/user-cache";
-import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
+import { getOrgBillingPeriod } from "../../org/org-cache-service";
+import { creditUsage } from "../../../db/schema/credit-usage";
+import { userCache } from "../../../db/schema/user-cache";
+import { orgMembersMetadata } from "../../../db/schema/org-members-metadata";
 import { clerkClient } from "@clerk/nextjs/server";
 
 /**

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/credit-expiry.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/credit-expiry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { testContext, uniqueId } from "../../../__tests__/test-helpers";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
 import {
   insertCreditExpiresRecord,
   findCreditExpiresRecords,
@@ -7,7 +7,7 @@ import {
   grantCreditsToOrg,
   testDeductFromExpiresRecords,
   testExpireCredits,
-} from "../../../__tests__/api-test-helpers";
+} from "../../../../__tests__/api-test-helpers";
 import { getExpiresRecordsSummary } from "../credit-expires-service";
 
 const context = testContext();

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/member-credit-cap-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/member-credit-cap-service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { testContext, uniqueId } from "../../../__tests__/test-helpers";
-import { mockClerk } from "../../../__tests__/clerk-mock";
-import type { StripeMockFns } from "../../../__tests__/stripe-mock";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { mockClerk } from "../../../../__tests__/clerk-mock";
+import type { StripeMockFns } from "../../../../__tests__/stripe-mock";
 import {
   createTestOrg,
   insertOrgMembersEntry,
@@ -9,8 +9,8 @@ import {
   insertTestCreditUsage,
   updateOrgStripeFields,
   setOrgCacheBillingPeriod,
-} from "../../../__tests__/api-test-helpers";
-import { reloadEnv } from "../../../env";
+} from "../../../../__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../env";
 import { evaluateMemberCaps } from "../member-credit-cap-service";
 
 // Mock stripe module (external dependency) — required because

--- a/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-expires-service.ts
@@ -1,7 +1,7 @@
 import { eq, and, gt, lte, asc, sql } from "drizzle-orm";
-import { creditExpiresRecord } from "../../db/schema/credit-expires-record";
-import { orgMetadata } from "../../db/schema/org-metadata";
-import { logger } from "../logger";
+import { creditExpiresRecord } from "../../../db/schema/credit-expires-record";
+import { orgMetadata } from "../../../db/schema/org-metadata";
+import { logger } from "../../logger";
 
 const log = logger("service:credit-expires");
 

--- a/turbo/apps/web/src/lib/zero/credit/credit-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-service.ts
@@ -1,11 +1,11 @@
 import { eq, and, sql } from "drizzle-orm";
-import { creditUsage } from "../../db/schema/credit-usage";
-import { creditPricing } from "../../db/schema/credit-pricing";
-import { deductOrgCredits } from "../org/org-service";
+import { creditUsage } from "../../../db/schema/credit-usage";
+import { creditPricing } from "../../../db/schema/credit-pricing";
+import { deductOrgCredits } from "../../org/org-service";
 import { deductFromExpiresRecords } from "./credit-expires-service";
 import { triggerAutoRecharge } from "../billing/auto-recharge-service";
 import { evaluateMemberCaps } from "./member-credit-cap-service";
-import { logger } from "../logger";
+import { logger } from "../../logger";
 
 const log = logger("service:credit");
 

--- a/turbo/apps/web/src/lib/zero/credit/credit-usage-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-usage-service.ts
@@ -1,5 +1,5 @@
-import { creditUsage } from "../../db/schema/credit-usage";
-import { logger } from "../logger";
+import { creditUsage } from "../../../db/schema/credit-usage";
+import { logger } from "../../logger";
 
 const log = logger("service:credit-usage");
 

--- a/turbo/apps/web/src/lib/zero/credit/member-credit-cap-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/member-credit-cap-service.ts
@@ -1,7 +1,7 @@
 import { eq, and, sql, gte, inArray } from "drizzle-orm";
-import { orgMembersMetadata } from "../../db/schema/org-members-metadata";
-import { creditUsage } from "../../db/schema/credit-usage";
-import { getOrgBillingPeriod } from "../org/org-cache-service";
+import { orgMembersMetadata } from "../../../db/schema/org-members-metadata";
+import { creditUsage } from "../../../db/schema/credit-usage";
+import { getOrgBillingPeriod } from "../../org/org-cache-service";
 
 /**
  * Get a member's credit cap state.


### PR DESCRIPTION
## Summary
- Move `billing` (3 source + 1 test) and `credit` (4 source + 2 test) modules from `src/lib/` to `src/lib/zero/`
- These modules manage Zero platform billing and credits, making them a natural fit for the zero/ layer
- Part of the `lib/` restructuring effort (#7697)

## Changes
- `git mv` both modules into `lib/zero/`
- Updated internal imports (db schema, logger, org, stripe, env paths)
- Updated 16 external route file imports
- billing↔credit cross-references unchanged (both moved together as siblings)

## Test plan
- [x] TypeScript type check passes
- [x] Lint passes (0 warnings, 0 errors)
- [x] Format passes (no changes)
- [x] Knip passes (no new unused exports)
- [x] All 3 test files (29 tests) pass
- [ ] CI pipeline passes

Closes #7730

🤖 Generated with [Claude Code](https://claude.com/claude-code)