### PR TITLE
refactor: move small zero modules to lib/zero/

### DIFF
--- a/turbo/apps/web/app/api/integrations/github/route.ts
+++ b/turbo/apps/web/app/api/integrations/github/route.ts
@@ -15,8 +15,8 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
-import { listSecrets } from "../../../../src/lib/secret/secret-service";
-import { listVariables } from "../../../../src/lib/variable/variable-service";
+import { listSecrets } from "../../../../src/lib/zero/secret/secret-service";
+import { listVariables } from "../../../../src/lib/zero/variable/variable-service";
 import { listConnectors } from "../../../../src/lib/connector/connector-service";
 import type { AgentComposeYaml } from "../../../../src/types/agent-compose";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";

--- a/turbo/apps/web/app/api/integrations/telegram/route.ts
+++ b/turbo/apps/web/app/api/integrations/telegram/route.ts
@@ -14,8 +14,8 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
-import { listSecrets } from "../../../../src/lib/secret/secret-service";
-import { listVariables } from "../../../../src/lib/variable/variable-service";
+import { listSecrets } from "../../../../src/lib/zero/secret/secret-service";
+import { listVariables } from "../../../../src/lib/zero/variable/variable-service";
 import { listConnectors } from "../../../../src/lib/connector/connector-service";
 import type { AgentComposeYaml } from "../../../../src/types/agent-compose";
 import { decryptSecretValue } from "../../../../src/lib/shared/crypto/secrets-encryption";

--- a/turbo/apps/web/app/api/user/export/route.ts
+++ b/turbo/apps/web/app/api/user/export/route.ts
@@ -4,7 +4,7 @@ import { initServices } from "../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import { exportJobs } from "../../../../src/db/schema/export-job";
-import { executeExportJob } from "../../../../src/lib/export/export-service";
+import { executeExportJob } from "../../../../src/lib/zero/export/export-service";
 import { generatePresignedUrl } from "../../../../src/lib/s3/s3-client";
 import { env } from "../../../../src/env";
 

--- a/turbo/apps/web/app/api/zero/connectors/computer/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/route.ts
@@ -14,7 +14,7 @@ import { getConnector } from "../../../../../src/lib/connector/connector-service
 import {
   createComputerConnector,
   deleteComputerConnector,
-} from "../../../../../src/lib/computer-connector/computer-connector-service";
+} from "../../../../../src/lib/zero/computer-connector/computer-connector-service";
 import {
   isBadRequest,
   isConflict,

--- a/turbo/apps/web/app/api/zero/integrations/slack/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/route.ts
@@ -18,8 +18,8 @@ import {
   agentComposes,
   agentComposeVersions,
 } from "../../../../../src/db/schema/agent-compose";
-import { listSecrets } from "../../../../../src/lib/secret/secret-service";
-import { listVariables } from "../../../../../src/lib/variable/variable-service";
+import { listSecrets } from "../../../../../src/lib/zero/secret/secret-service";
+import { listVariables } from "../../../../../src/lib/zero/variable/variable-service";
 import { listConnectors } from "../../../../../src/lib/connector/connector-service";
 import { getOrgData } from "../../../../../src/lib/org/org-cache-service";
 import { createSlackClient } from "../../../../../src/lib/slack";

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/default/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/default/route.ts
@@ -13,7 +13,7 @@ import {
   isAuthError,
 } from "../../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
-import { setOrgModelProviderDefault } from "../../../../../../src/lib/model-provider/model-provider-service";
+import { setOrgModelProviderDefault } from "../../../../../../src/lib/zero/model-provider/model-provider-service";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../../src/lib/errors";
 

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/model/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/model/route.ts
@@ -13,7 +13,7 @@ import {
   isAuthError,
 } from "../../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../../src/lib/org/resolve-org";
-import { updateOrgModelProviderModel } from "../../../../../../src/lib/model-provider/model-provider-service";
+import { updateOrgModelProviderModel } from "../../../../../../src/lib/zero/model-provider/model-provider-service";
 import { logger } from "../../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../../src/lib/errors";
 

--- a/turbo/apps/web/app/api/zero/model-providers/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/[type]/route.ts
@@ -13,7 +13,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { deleteOrgModelProvider } from "../../../../../src/lib/model-provider/model-provider-service";
+import { deleteOrgModelProvider } from "../../../../../src/lib/zero/model-provider/model-provider-service";
 import { logger } from "../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../src/lib/errors";
 

--- a/turbo/apps/web/app/api/zero/model-providers/route.ts
+++ b/turbo/apps/web/app/api/zero/model-providers/route.ts
@@ -19,7 +19,7 @@ import {
   upsertOrgModelProvider,
   upsertOrgMultiAuthModelProvider,
   upsertOrgNoSecretModelProvider,
-} from "../../../../src/lib/model-provider/model-provider-service";
+} from "../../../../src/lib/zero/model-provider/model-provider-service";
 import { logger } from "../../../../src/lib/logger";
 import { isBadRequest } from "../../../../src/lib/errors";
 

--- a/turbo/apps/web/app/api/zero/secrets/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/secrets/[name]/route.ts
@@ -10,7 +10,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { deleteSecret } from "../../../../../src/lib/secret/secret-service";
+import { deleteSecret } from "../../../../../src/lib/zero/secret/secret-service";
 import { logger } from "../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../src/lib/errors";
 

--- a/turbo/apps/web/app/api/zero/secrets/route.ts
+++ b/turbo/apps/web/app/api/zero/secrets/route.ts
@@ -13,7 +13,7 @@ import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import {
   listSecrets,
   setSecret,
-} from "../../../../src/lib/secret/secret-service";
+} from "../../../../src/lib/zero/secret/secret-service";
 import { logger } from "../../../../src/lib/logger";
 import { isBadRequest } from "../../../../src/lib/errors";
 

--- a/turbo/apps/web/app/api/zero/variables/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/variables/[name]/route.ts
@@ -10,7 +10,7 @@ import {
   isAuthError,
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
-import { deleteVariable } from "../../../../../src/lib/variable/variable-service";
+import { deleteVariable } from "../../../../../src/lib/zero/variable/variable-service";
 import { logger } from "../../../../../src/lib/logger";
 import { isNotFound } from "../../../../../src/lib/errors";
 

--- a/turbo/apps/web/app/api/zero/variables/route.ts
+++ b/turbo/apps/web/app/api/zero/variables/route.ts
@@ -13,7 +13,7 @@ import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import {
   listVariables,
   setVariable,
-} from "../../../../src/lib/variable/variable-service";
+} from "../../../../src/lib/zero/variable/variable-service";
 import { logger } from "../../../../src/lib/logger";
 import { isBadRequest } from "../../../../src/lib/errors";
 

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -119,7 +119,7 @@ import {
 import { conversations } from "../db/schema/conversation";
 import { uniqueId, uniqueNumericId } from "./test-helpers";
 import { vm0ApiKeys } from "../db/schema/vm0-api-key";
-import { getVm0ApiKey } from "../lib/vm0-key/vm0-key-service";
+import { getVm0ApiKey } from "../lib/zero/vm0-key/vm0-key-service";
 
 /**
  * Helper to create a NextRequest for testing.

--- a/turbo/apps/web/src/lib/connector/connector-service.ts
+++ b/turbo/apps/web/src/lib/connector/connector-service.ts
@@ -13,7 +13,10 @@ import { secrets } from "../../db/schema/secret";
 import { variables } from "../../db/schema/variable";
 import { notFound, badRequest } from "../errors";
 import { logger } from "../logger";
-import { getSecretValue, upsertSecretByOrg } from "../secret/secret-service";
+import {
+  getSecretValue,
+  upsertSecretByOrg,
+} from "../zero/secret/secret-service";
 import { PROVIDER_HANDLERS } from "./provider-registry";
 
 const log = logger("service:connector");

--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -13,9 +13,9 @@ import {
   findTestRunnerJobEntry,
 } from "../../../__tests__/api-test-helpers";
 import { createZeroRun } from "../zero-run-service";
-import { upsertOrgModelProvider } from "../../model-provider/model-provider-service";
-import { upsertSecretByOrg } from "../../secret/secret-service";
-import { setVariable } from "../../variable/variable-service";
+import { upsertOrgModelProvider } from "../model-provider/model-provider-service";
+import { upsertSecretByOrg } from "../secret/secret-service";
+import { setVariable } from "../variable/variable-service";
 import { ORG_SENTINEL_USER_ID } from "../../org/org-sentinel";
 import { isNoModelProvider } from "../../errors";
 import { reloadEnv } from "../../../env";

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -50,10 +50,10 @@ import {
 } from "../run/resolvers";
 import { expandEnvironmentFromCompose } from "../run/environment";
 import { getUserPreferences } from "./user/user-preferences-service";
-import { getSecretValue, getSecretValues } from "../secret/secret-service";
-import { getVariableValues } from "../variable/variable-service";
-import { getOrgDefaultModelProvider } from "../model-provider/model-provider-service";
-import { getVm0ApiKey } from "../vm0-key/vm0-key-service";
+import { getSecretValue, getSecretValues } from "./secret/secret-service";
+import { getVariableValues } from "./variable/variable-service";
+import { getOrgDefaultModelProvider } from "./model-provider/model-provider-service";
+import { getVm0ApiKey } from "./vm0-key/vm0-key-service";
 import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
 import { connectors } from "../../db/schema/connector";
 import { PROVIDER_HANDLERS } from "../connector/provider-registry";

--- a/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
@@ -7,11 +7,11 @@
 import { randomUUID } from "crypto";
 import { eq, and } from "drizzle-orm";
 import type { ComputerConnectorCreateResponse } from "@vm0/core";
-import { connectors } from "../../db/schema/connector";
-import { secrets } from "../../db/schema/secret";
-import { decryptSecretValue } from "../shared/crypto";
-import { badRequest, conflict, notFound } from "../errors";
-import { logger } from "../logger";
+import { connectors } from "../../../db/schema/connector";
+import { secrets } from "../../../db/schema/secret";
+import { decryptSecretValue } from "../../shared/crypto";
+import { badRequest, conflict, notFound } from "../../errors";
+import { logger } from "../../logger";
 import { upsertSecretByOrg } from "../secret/secret-service";
 import {
   findOrCreateBotUser,

--- a/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
@@ -4,7 +4,7 @@
  * Handles Bot User and Credential lifecycle for authenticated tunnel access.
  * Uses plain fetch() — no external SDK dependency.
  */
-import { logger } from "../logger";
+import { logger } from "../../logger";
 
 const log = logger("ngrok-client");
 

--- a/turbo/apps/web/src/lib/zero/export/export-service.ts
+++ b/turbo/apps/web/src/lib/zero/export/export-service.ts
@@ -1,30 +1,30 @@
 import { eq, and, inArray } from "drizzle-orm";
 import archiver from "archiver";
-import { exportJobs } from "../../db/schema/export-job";
-import type { ExportArtifactUrl } from "../../db/schema/export-job";
+import { exportJobs } from "../../../db/schema/export-job";
+import type { ExportArtifactUrl } from "../../../db/schema/export-job";
 import {
   agentComposes,
   agentComposeVersions,
-} from "../../db/schema/agent-compose";
-import { conversations } from "../../db/schema/conversation";
-import { storages, storageVersions } from "../../db/schema/storage";
+} from "../../../db/schema/agent-compose";
+import { conversations } from "../../../db/schema/conversation";
+import { storages, storageVersions } from "../../../db/schema/storage";
 import {
   uploadS3Buffer,
   generatePresignedUrl,
   downloadS3Buffer,
-} from "../s3/s3-client";
-import { getAllSessionsWithMessages } from "../zero/zero-session-service";
-import { resolveSessionHistory } from "../session-history/session-history-service";
-import { enqueueEmail } from "../email/outbox-service";
+} from "../../s3/s3-client";
+import { getAllSessionsWithMessages } from "../zero-session-service";
+import { resolveSessionHistory } from "../../session-history/session-history-service";
+import { enqueueEmail } from "../../email/outbox-service";
 import {
   buildFromAddress,
   buildUnsubscribeUrl,
   buildUnsubscribeHeaders,
-} from "../email/handlers/shared";
-import { isUserUnsubscribed } from "../email/unsubscribe-service";
-import { getCachedUser } from "../auth/user-cache-service";
-import { env } from "../../env";
-import { logger } from "../logger";
+} from "../../email/handlers/shared";
+import { isUserUnsubscribed } from "../../email/unsubscribe-service";
+import { getCachedUser } from "../../auth/user-cache-service";
+import { env } from "../../../env";
+import { logger } from "../../logger";
 
 const log = logger("export");
 

--- a/turbo/apps/web/src/lib/zero/model-provider/__tests__/org-model-provider.test.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/__tests__/org-model-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { testContext } from "../../../__tests__/test-helpers";
+import { testContext } from "../../../../__tests__/test-helpers";
 import {
   listOrgModelProviders,
   upsertOrgModelProvider,

--- a/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
+++ b/turbo/apps/web/src/lib/zero/model-provider/model-provider-service.ts
@@ -10,12 +10,12 @@ import {
   type ModelProviderType,
   type ModelProviderFramework,
 } from "@vm0/core";
-import { modelProviders } from "../../db/schema/model-provider";
-import { secrets } from "../../db/schema/secret";
-import { encryptSecretValue } from "../shared/crypto";
-import { badRequest, notFound } from "../errors";
-import { logger } from "../logger";
-import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
+import { modelProviders } from "../../../db/schema/model-provider";
+import { secrets } from "../../../db/schema/secret";
+import { encryptSecretValue } from "../../shared/crypto";
+import { badRequest, notFound } from "../../errors";
+import { logger } from "../../logger";
+import { ORG_SENTINEL_USER_ID } from "../../org/org-sentinel";
 
 const log = logger("service:model-provider");
 

--- a/turbo/apps/web/src/lib/zero/secret/__tests__/org-secret-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/secret/__tests__/org-secret-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { testContext } from "../../../__tests__/test-helpers";
+import { testContext } from "../../../../__tests__/test-helpers";
 import {
   listOrgSecrets,
   setOrgSecret,

--- a/turbo/apps/web/src/lib/zero/secret/secret-service.ts
+++ b/turbo/apps/web/src/lib/zero/secret/secret-service.ts
@@ -1,10 +1,10 @@
 import { eq, and } from "drizzle-orm";
 import { type SecretType } from "@vm0/core";
-import { secrets } from "../../db/schema/secret";
-import { encryptSecretValue, decryptSecretValue } from "../shared/crypto";
-import { badRequest, notFound } from "../errors";
-import { logger } from "../logger";
-import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
+import { secrets } from "../../../db/schema/secret";
+import { encryptSecretValue, decryptSecretValue } from "../../shared/crypto";
+import { badRequest, notFound } from "../../errors";
+import { logger } from "../../logger";
+import { ORG_SENTINEL_USER_ID } from "../../org/org-sentinel";
 
 const log = logger("service:secret");
 

--- a/turbo/apps/web/src/lib/zero/variable/__tests__/org-variable-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/variable/__tests__/org-variable-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { testContext } from "../../../__tests__/test-helpers";
+import { testContext } from "../../../../__tests__/test-helpers";
 import {
   listOrgVariables,
   setOrgVariable,

--- a/turbo/apps/web/src/lib/zero/variable/variable-service.ts
+++ b/turbo/apps/web/src/lib/zero/variable/variable-service.ts
@@ -1,8 +1,8 @@
 import { eq, and } from "drizzle-orm";
-import { variables } from "../../db/schema/variable";
-import { badRequest, notFound } from "../errors";
-import { logger } from "../logger";
-import { ORG_SENTINEL_USER_ID } from "../org/org-sentinel";
+import { variables } from "../../../db/schema/variable";
+import { badRequest, notFound } from "../../errors";
+import { logger } from "../../logger";
+import { ORG_SENTINEL_USER_ID } from "../../org/org-sentinel";
 
 const log = logger("service:variable");
 

--- a/turbo/apps/web/src/lib/zero/vm0-key/vm0-key-service.ts
+++ b/turbo/apps/web/src/lib/zero/vm0-key/vm0-key-service.ts
@@ -1,5 +1,5 @@
 import { eq, sql } from "drizzle-orm";
-import { vm0ApiKeys } from "../../db/schema/vm0-api-key";
+import { vm0ApiKeys } from "../../../db/schema/vm0-api-key";
 
 /**
  * Get a random API key from the VM0 key pool for the given vendor.


### PR DESCRIPTION
## Summary
- Move 6 small zero-related modules (`model-provider`, `secret`, `variable`, `vm0-key`, `export`, `computer-connector`) from `lib/` to `lib/zero/`
- Update all internal and external import paths (13 API routes, test helpers, connector service, build-zero-context)
- Part of Epic #7697 — restructure `src/lib/` into layered architecture (`infra/`, `zero/`, `auth/`, `shared/`)

Closes #7728

## Test plan
- [x] Type-check passes (`pnpm check-types --filter=web`)
- [x] Lint passes (`pnpm turbo run lint --filter=web`)
- [x] All 33 tests pass (`pnpm vitest --run`)
- [x] Knip passes (no unused exports/files)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)