### PR TITLE
refactor: move agent-compose to lib/infra/

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/route.ts
@@ -15,7 +15,7 @@ import {
   getComposeById,
   getComposeOrgId,
   deleteCompose,
-} from "../../../../../src/lib/agent-compose/compose-service";
+} from "../../../../../src/lib/infra/agent-compose/compose-service";
 import { isNotFound, isConflict } from "../../../../../src/lib/errors";
 
 const router = tsr.router(composesByIdContract, {

--- a/turbo/apps/web/app/api/agent/composes/route.ts
+++ b/turbo/apps/web/app/api/agent/composes/route.ts
@@ -19,8 +19,8 @@ import {
   isAuthError,
 } from "../../../../src/lib/auth/require-auth";
 import { eq, and } from "drizzle-orm";
-import { computeComposeVersionId } from "../../../../src/lib/agent-compose/content-hash";
-import { getComposeByName } from "../../../../src/lib/agent-compose/compose-service";
+import { computeComposeVersionId } from "../../../../src/lib/infra/agent-compose/content-hash";
+import { getComposeByName } from "../../../../src/lib/infra/agent-compose/compose-service";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
 import {
   isNotFound,

--- a/turbo/apps/web/app/api/github/oauth/callback/route.ts
+++ b/turbo/apps/web/app/api/github/oauth/callback/route.ts
@@ -12,7 +12,7 @@ import {
   getInstallationInfo,
 } from "../../../../../src/lib/github/github-app";
 import { getAppUrl } from "../../../../../src/lib/url";
-import { resolveDefaultAgentComposeId } from "../../../../../src/lib/agent-compose/resolve-default";
+import { resolveDefaultAgentComposeId } from "../../../../../src/lib/infra/agent-compose/resolve-default";
 
 /**
  * GitHub App OAuth Callback Endpoint

--- a/turbo/apps/web/app/api/github/oauth/install/route.ts
+++ b/turbo/apps/web/app/api/github/oauth/install/route.ts
@@ -11,7 +11,7 @@ import {
   listAppInstallations,
   getInstallationAccessToken,
 } from "../../../../../src/lib/github/github-app";
-import { resolveDefaultAgentComposeId } from "../../../../../src/lib/agent-compose/resolve-default";
+import { resolveDefaultAgentComposeId } from "../../../../../src/lib/infra/agent-compose/resolve-default";
 import { linkVm0User } from "../callback/route";
 import { logger } from "../../../../../src/lib/logger";
 

--- a/turbo/apps/web/app/api/telegram/register/route.ts
+++ b/turbo/apps/web/app/api/telegram/register/route.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../../src/lib/telegram/client";
 import { encryptSecretValue } from "../../../../src/lib/shared/crypto/secrets-encryption";
 import { generateCallbackSecret } from "../../../../src/lib/callback/hmac";
-import { resolveDefaultAgentComposeId } from "../../../../src/lib/agent-compose/resolve-default";
+import { resolveDefaultAgentComposeId } from "../../../../src/lib/infra/agent-compose/resolve-default";
 import { logger } from "../../../../src/lib/logger";
 import { checkTelegramDomain } from "../../../../src/lib/telegram/check-domain";
 

--- a/turbo/apps/web/app/api/zero/agents/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/agents/[id]/route.ts
@@ -19,7 +19,7 @@ import {
   requireAgentPermission,
   requireAdminPermission,
 } from "../../../../../src/lib/zero/require-agent-permission";
-import { deleteComposeById } from "../../../../../src/lib/agent-compose/compose-service";
+import { deleteComposeById } from "../../../../../src/lib/infra/agent-compose/compose-service";
 import { isConflict } from "../../../../../src/lib/errors";
 import { logger } from "../../../../../src/lib/logger";
 

--- a/turbo/apps/web/app/api/zero/composes/[id]/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/[id]/route.ts
@@ -13,7 +13,7 @@ import { resolveOrg } from "../../../../../src/lib/org/resolve-org";
 import {
   getComposeById,
   deleteCompose,
-} from "../../../../../src/lib/agent-compose/compose-service";
+} from "../../../../../src/lib/infra/agent-compose/compose-service";
 import { isNotFound, isConflict } from "../../../../../src/lib/errors";
 
 const router = tsr.router(zeroComposesByIdContract, {

--- a/turbo/apps/web/app/api/zero/composes/route.ts
+++ b/turbo/apps/web/app/api/zero/composes/route.ts
@@ -10,7 +10,7 @@ import {
   isAuthError,
 } from "../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../src/lib/org/resolve-org";
-import { getComposeByName } from "../../../../src/lib/agent-compose/compose-service";
+import { getComposeByName } from "../../../../src/lib/infra/agent-compose/compose-service";
 import {
   isNotFound,
   isForbidden,

--- a/turbo/apps/web/src/lib/compose/server-side-compose.ts
+++ b/turbo/apps/web/src/lib/compose/server-side-compose.ts
@@ -7,7 +7,7 @@ import {
 } from "@vm0/core";
 import type { AgentComposeYaml } from "../../types/agent-compose";
 import { uploadInstructionsServerSide } from "../infra/storage/instruction-upload";
-import { computeComposeVersionId } from "../agent-compose/content-hash";
+import { computeComposeVersionId } from "../infra/agent-compose/content-hash";
 import {
   agentComposes,
   agentComposeVersions,

--- a/turbo/apps/web/src/lib/infra/agent-compose/__tests__/content-hash.test.ts
+++ b/turbo/apps/web/src/lib/infra/agent-compose/__tests__/content-hash.test.ts
@@ -9,7 +9,7 @@ import {
   DEFAULT_VERSION_DISPLAY_LENGTH,
   MIN_VERSION_PREFIX_LENGTH,
 } from "../content-hash";
-import type { AgentComposeYaml } from "../../../types/agent-compose";
+import type { AgentComposeYaml } from "../../../../types/agent-compose";
 
 describe("content-hash", () => {
   describe("computeComposeVersionId", () => {

--- a/turbo/apps/web/src/lib/infra/agent-compose/compose-service.ts
+++ b/turbo/apps/web/src/lib/infra/agent-compose/compose-service.ts
@@ -2,14 +2,14 @@ import { eq, and, inArray } from "drizzle-orm";
 import {
   agentComposes,
   agentComposeVersions,
-} from "../../db/schema/agent-compose";
-import { storages } from "../../db/schema/storage";
-import { agentRuns } from "../../db/schema/agent-run";
+} from "../../../db/schema/agent-compose";
+import { storages } from "../../../db/schema/storage";
+import { agentRuns } from "../../../db/schema/agent-run";
 import { getInstructionsStorageName } from "@vm0/core";
-import { notFound, conflict } from "../errors";
-import { canAccessCompose } from "../agent/compose-access";
-import { listS3Objects, deleteS3Objects } from "../s3/s3-client";
-import type { AgentComposeYaml } from "../../types/agent-compose";
+import { notFound, conflict } from "../../errors";
+import { canAccessCompose } from "../../agent/compose-access";
+import { listS3Objects, deleteS3Objects } from "../../s3/s3-client";
+import type { AgentComposeYaml } from "../../../types/agent-compose";
 import type { ComposeResponse } from "@vm0/core";
 
 /**

--- a/turbo/apps/web/src/lib/infra/agent-compose/content-hash.ts
+++ b/turbo/apps/web/src/lib/infra/agent-compose/content-hash.ts
@@ -4,7 +4,7 @@
  */
 
 import { createHash } from "crypto";
-import type { AgentComposeYaml } from "../../types/agent-compose";
+import type { AgentComposeYaml } from "../../../types/agent-compose";
 
 /**
  * Minimum length for short version ID prefix

--- a/turbo/apps/web/src/lib/infra/agent-compose/resolve-default.ts
+++ b/turbo/apps/web/src/lib/infra/agent-compose/resolve-default.ts
@@ -1,4 +1,4 @@
-import { env } from "../../env";
+import { env } from "../../../env";
 
 /**
  * Resolve the default agent compose ID from VM0_DEFAULT_AGENT env var.

--- a/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/slack-org/handlers/shared.ts
@@ -5,7 +5,7 @@ import { slackOrgThreadSessions } from "../../../db/schema/slack-org-thread-sess
 import { zeroAgents } from "../../../db/schema/zero-agent";
 import { orgMetadata as orgTable } from "../../../db/schema/org-metadata";
 import { getAppUrl } from "../../url";
-import { resolveDefaultAgentComposeId } from "../../agent-compose/resolve-default";
+import { resolveDefaultAgentComposeId } from "../../infra/agent-compose/resolve-default";
 import { ensureStorageExists } from "../../infra/storage/storage-service";
 import {
   createSlackClient,


### PR DESCRIPTION
## Summary
- Move `lib/agent-compose/` to `lib/infra/agent-compose/` (3 source files + 1 test file)
- Update 14 import paths (4 internal + 10 external consumers)
- Part of Epic #7697 — restructure src/lib/ into layered architecture

## Verification
- [x] `pnpm check-types` passes (web package)
- [x] `pnpm turbo run lint` passes
- [x] `pnpm vitest` — all 23 content-hash tests pass
- [x] `pnpm format` — no changes needed
- [x] `pnpm knip` — no issues found
- [x] No stale import references remain

Closes #7721

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>