### PR TITLE
fix(runner): also write tz to /etc/environment for system-wide inheritance

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -580,8 +580,12 @@ pub(crate) async fn fix_guest_clock(sandbox: &dyn Sandbox) -> RunnerResult<()> {
 
 /// Set system timezone inside the guest to match the user's preference.
 ///
-/// Writes `/etc/timezone` and symlinks `/etc/localtime` so all processes
-/// — not just those inheriting the TZ env var — see the correct timezone.
+/// Configures timezone at two levels so every process sees the correct time:
+///
+/// - `/etc/timezone` + `/etc/localtime` — filesystem-level (read by libc)
+/// - `TZ` in `/etc/environment` — inherited by all login shells via PAM
+///
+/// The agent process also receives `TZ` via the env vars in step 6.
 /// Skipped when no user timezone is configured (falls back to image default UTC).
 async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) {
     let tz = match &context.user_timezone {
@@ -601,7 +605,9 @@ async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) 
     let cmd = format!(
         "test -f /usr/share/zoneinfo/{tz} && \
          echo '{tz}' > /etc/timezone && \
-         ln -sf /usr/share/zoneinfo/{tz} /etc/localtime"
+         ln -sf /usr/share/zoneinfo/{tz} /etc/localtime && \
+         sed -i '/^TZ=/d' /etc/environment && \
+         echo 'TZ={tz}' >> /etc/environment"
     );
     // Best-effort: don't fail the run if timezone setup fails.
     if let Err(e) = sandbox


### PR DESCRIPTION
## Summary
- Append `TZ=<timezone>` to `/etc/environment` in the guest VM so all login shells (via PAM) inherit the timezone, not just the agent process
- Previously only `/etc/timezone` + `/etc/localtime` were set (PR #7716), but processes spawned outside the agent tree didn't get the `TZ` env var

## Changes
- **`executor.rs`**: Extend `sync_guest_timezone` shell command to also `sed -i '/^TZ=/d' /etc/environment && echo 'TZ={tz}' >> /etc/environment`

## Test plan
- [ ] Existing E2E `t32-zero-timezone.bats` verifies TZ injection
- [ ] `cargo test -p runner` passes (256 tests)

Closes #7744

🤖 Generated with [Claude Code](https://claude.com/claude-code)