### PR TITLE
fix: use is_our_thread in bench cleanup and merge snapshot pool locks

### DIFF
--- a/crates/nbd-cow/src/bin/bench.rs
+++ b/crates/nbd-cow/src/bin/bench.rs
@@ -463,7 +463,6 @@ fn tool_exists(name: &str) -> bool {
 /// size (stale from a previous bench run that didn't clean up).
 fn cleanup_stale_nbd_devices() {
     let max = nbd_cow::netlink::nbds_max();
-    let my_pid = std::process::id();
     for i in 0..max {
         let size_path = format!("/sys/block/nbd{i}/size");
         let pid_path = format!("/sys/block/nbd{i}/pid");
@@ -479,7 +478,7 @@ fn cleanup_stale_nbd_devices() {
             .ok()
             .and_then(|s| s.trim().parse().ok())
             .unwrap_or(0);
-        if pid == my_pid || !std::path::Path::new(&format!("/proc/{pid}")).exists() {
+        if nbd_cow::is_our_thread(pid) || !std::path::Path::new(&format!("/proc/{pid}")).exists() {
             eprintln!("  Cleaning up stale /dev/nbd{i} (size={size}, pid={pid})...");
             let _ = nbd_cow::netlink::disconnect(i);
             std::thread::sleep(std::time::Duration::from_millis(200));

--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -362,7 +362,7 @@ impl NbdCowDevice {
 /// a TID different from the process TGID returned by `std::process::id()`.
 /// This function handles both cases: TID == TGID (main thread) and
 /// TID != TGID (worker threads).
-fn is_our_thread(tid: u32) -> bool {
+pub fn is_our_thread(tid: u32) -> bool {
     tid == std::process::id() || std::path::Path::new(&format!("/proc/self/task/{tid}")).exists()
 }
 

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -145,8 +145,10 @@ pub async fn create_snapshot(
     .await;
 
     // Release device index back to pool before cleanup.
-    device_pool.lock().await.release(device_index);
-    device_pool.lock().await.cleanup().await;
+    let mut pool = device_pool.lock().await;
+    pool.release(device_index);
+    pool.cleanup().await;
+    drop(pool);
     if let Err(e) = netns_pool.cleanup().await {
         tracing::warn!(error = %e, "failed to cleanup netns pool");
     }


### PR DESCRIPTION
## Summary
- Make `is_our_thread()` public so `bench.rs` can reuse it for correct TID-based ownership checks — same TID vs TGID bug fixed in #7695 but missed in the bench binary
- Replace `pid == my_pid` (TGID comparison) with `nbd_cow::is_our_thread(pid)` in `cleanup_stale_nbd_devices` to correctly identify worker-thread-connected devices in multi-threaded tokio runtime
- Merge two consecutive `device_pool.lock().await` calls in `snapshot.rs` into a single lock acquisition

## Test plan
- [x] `cargo check -p nbd-cow -p sandbox-fc` passes
- [x] `cargo test -p nbd-cow` passes
- [x] Pre-commit hooks (clippy, fmt, commitlint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)