### PR TITLE
fix: reset sidebar thread skeleton when switching agents

### DIFF
--- a/.claude/skills/ccstate/SKILL.md
+++ b/.claude/skills/ccstate/SKILL.md
@@ -1039,3 +1039,54 @@ function Child() {
 ### Circular dependency caveat
 
 When extracting handler logic into a new command signal, watch for circular imports. If `moduleA.ts` and `moduleB.ts` already import from each other, adding a command that imports both will create a cycle. In that case, place the command in a separate file (e.g., `moduleA-actions.ts`) that imports from both without being imported by either.
+
+## Resetting `useLastLoadable` on Dependency Change
+
+### Problem
+
+`useLastLoadable` retains the last resolved value in a `useRef`. When an external dependency changes (e.g., switching `agentId`), the underlying signal recomputes and enters a loading state, but `useLastLoadable` keeps showing stale data instead of a loading/skeleton state.
+
+### Solution
+
+Move the `useLastLoadable` call into the child component that renders the loading UI, and use React's `key` prop to force a remount when the dependency changes. The remount resets the internal `useRef` back to `{state: 'loading'}`.
+
+### Pattern
+
+```typescript
+// ❌ Parent owns useLastLoadable — child never resets
+function Parent() {
+  const agentId = useGet(sidebarChatAgentId$);
+  const loadable = useLastLoadable(chatThreads$);
+  const threads = loadable.state === "hasData" ? loadable.data : [];
+  const loading = loadable.state === "loading";
+
+  return <ThreadList threads={threads} loading={loading} />;
+}
+
+// ✅ Child owns useLastLoadable — key forces remount on agentId change
+function Parent() {
+  const agentId = useGet(sidebarChatAgentId$);
+  // If parent still needs resolved data for other logic, use useLastResolved
+  const threads = useLastResolved(chatThreads$) ?? [];
+
+  return <ThreadList key={agentId} />;
+}
+
+function ThreadList() {
+  const loadable = useLastLoadable(chatThreads$);
+  const threads = loadable.state === "hasData" ? loadable.data : [];
+  const loading = loadable.state === "loading";
+
+  if (loading && threads.length === 0) {
+    return <Skeleton />;
+  }
+  return threads.map(t => <ThreadItem key={t.id} thread={t} />);
+}
+```
+
+### Key Points
+
+1. **`key` drives the reset** — when the key value changes, React unmounts and remounts the component, creating a fresh `useRef({state: 'loading'})` inside `useLastLoadable`
+2. **Same key preserves retention** — navigating within the same agent (e.g., clicking a thread) keeps the key stable, so `useLastLoadable` retains data as intended
+3. **Parent can still access data** — use `useLastResolved` in the parent if it needs the resolved value for non-loading-UI logic (e.g., finding a selected item's metadata)
+4. **Aligns with "read signals directly" pattern** — the child owns both the data subscription and its loading state, making it self-contained

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -606,6 +606,58 @@ function ChatThreadItem({
   );
 }
 
+function RecentChatList({
+  loading,
+  error,
+  sessions,
+  searchTerm,
+  selectedRecentId,
+  onRecentSelect,
+}: {
+  loading: boolean;
+  error: string | null;
+  sessions: ChatThreadListItem[];
+  searchTerm: string;
+  selectedRecentId: string | null;
+  onRecentSelect?: (id: string) => void;
+}) {
+  if (loading && sessions.length === 0) {
+    return (
+      <>
+        {["w-3/4", "w-1/2", "w-2/3"].map((w) => {
+          return (
+            <div key={w} className="flex h-8 items-center rounded-lg p-2">
+              <Skeleton className={`h-4 ${w}`} />
+            </div>
+          );
+        })}
+      </>
+    );
+  }
+  if (error) {
+    return <p className="px-2 py-2 text-xs text-destructive">{error}</p>;
+  }
+  if (sessions.length === 0) {
+    return (
+      <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
+        {searchTerm.trim()
+          ? "No chats match your search"
+          : "Start a conversation and it'll show up here"}
+      </p>
+    );
+  }
+  return sessions.map((session) => {
+    return (
+      <ChatThreadItem
+        key={session.id}
+        session={session}
+        isSelected={selectedRecentId === session.id}
+        onSelect={onRecentSelect}
+      />
+    );
+  });
+}
+
 function RecentChatSection({
   currentChatAgentId,
   displayName,
@@ -655,14 +707,11 @@ function RecentChatSection({
         return !subagentIds.has(s.agentId);
       });
 
+  const matchedAgent = subagents.find((a) => {
+    return a.id === currentChatAgentId;
+  });
   const agentLabel = currentChatAgentId
-    ? (subagents.find((a) => {
-        return a.id === currentChatAgentId;
-      })?.displayName ??
-      subagents.find((a) => {
-        return a.id === currentChatAgentId;
-      })?.id ??
-      displayName)
+    ? (matchedAgent?.displayName ?? matchedAgent?.id ?? displayName)
     : displayName;
 
   const trimmedTerm = searchTerm.trim().toLowerCase();
@@ -784,41 +833,14 @@ function RecentChatSection({
       {!collapsed && (
         <div className="mt-1">
           <div className="flex flex-col gap-1">
-            {recentSessionsLoading && recentSessions.length === 0 ? (
-              <>
-                {["w-3/4", "w-1/2", "w-2/3"].map((w) => {
-                  return (
-                    <div
-                      key={w}
-                      className="flex h-8 items-center rounded-lg p-2"
-                    >
-                      <Skeleton className={`h-4 ${w}`} />
-                    </div>
-                  );
-                })}
-              </>
-            ) : recentSessionsError ? (
-              <p className="px-2 py-2 text-xs text-destructive">
-                {recentSessionsError}
-              </p>
-            ) : filteredSessions.length === 0 ? (
-              <p className="px-2 py-2 text-xs text-muted-foreground/70 leading-relaxed">
-                {searchTerm.trim()
-                  ? "No chats match your search"
-                  : "Start a conversation and it'll show up here"}
-              </p>
-            ) : (
-              filteredSessions.map((session) => {
-                return (
-                  <ChatThreadItem
-                    key={session.id}
-                    session={session}
-                    isSelected={selectedRecentId === session.id}
-                    onSelect={onRecentSelect}
-                  />
-                );
-              })
-            )}
+            <RecentChatList
+              loading={recentSessionsLoading}
+              error={recentSessionsError}
+              sessions={filteredSessions}
+              searchTerm={searchTerm}
+              selectedRecentId={selectedRecentId}
+              onRecentSelect={onRecentSelect}
+            />
           </div>
         </div>
       )}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -610,9 +610,6 @@ function RecentChatSection({
   currentChatAgentId,
   displayName,
   subagents,
-  recentSessions,
-  recentSessionsLoading,
-  recentSessionsError,
   selectedRecentId,
   onRecentSelect,
   onNewChat,
@@ -621,14 +618,23 @@ function RecentChatSection({
   currentChatAgentId: string | null;
   displayName: string;
   subagents: SubagentInfo[];
-  recentSessions: ChatThreadListItem[];
-  recentSessionsLoading: boolean;
-  recentSessionsError: string | null;
   selectedRecentId: string | null;
   onRecentSelect?: (id: string) => void;
   onNewChat?: (agentId: string | null) => void;
   newChatDisabled?: boolean;
 }) {
+  const recentSessionsLoadable = useLastLoadable(chatThreads$);
+  const recentSessions =
+    recentSessionsLoadable.state === "hasData"
+      ? recentSessionsLoadable.data
+      : [];
+  const recentSessionsLoading = recentSessionsLoadable.state === "loading";
+  const recentSessionsError =
+    recentSessionsLoadable.state === "hasError"
+      ? recentSessionsLoadable.error instanceof Error
+        ? recentSessionsLoadable.error.message
+        : "Failed to load chats"
+      : null;
   const searchOpen = useGet(sidebarSearchOpen$);
   const setSearchOpen = useSet(setSidebarSearchOpen$);
   const searchTerm = useGet(sidebarSearchTerm$);
@@ -1181,18 +1187,7 @@ export function ZeroSidebar() {
   };
   const selectedRecentId = useGet(chatThreadId$);
   const onAccountAction = useSet(handleZeroAccountAction$);
-  const recentSessionsLoadable = useLastLoadable(chatThreads$);
-  const recentSessions =
-    recentSessionsLoadable.state === "hasData"
-      ? recentSessionsLoadable.data
-      : [];
-  const recentSessionsLoading = recentSessionsLoadable.state === "loading";
-  const recentSessionsError =
-    recentSessionsLoadable.state === "hasError"
-      ? recentSessionsLoadable.error instanceof Error
-        ? recentSessionsLoadable.error.message
-        : "Failed to load chats"
-      : null;
+  const recentSessions = useLastResolved(chatThreads$) ?? [];
   const createNewChat = useSet(createNewChatThread$);
   const creatingNewSessionLoadable = useLoadable(creatingNewSession$);
   const creatingNewSession = creatingNewSessionLoadable.state === "loading";
@@ -1476,12 +1471,10 @@ export function ZeroSidebar() {
 
             {/* Recent chat sessions */}
             <RecentChatSection
+              key={currentChatAgentId}
               currentChatAgentId={currentChatAgentId}
               displayName={displayName}
               subagents={subagents}
-              recentSessions={recentSessions}
-              recentSessionsLoading={recentSessionsLoading}
-              recentSessionsError={recentSessionsError}
               selectedRecentId={selectedRecentId}
               onRecentSelect={onRecentSelect}
               onNewChat={onNewChat}


### PR DESCRIPTION
## Summary
- Move `useLastLoadable(chatThreads$)` from `ZeroSidebar` into `RecentChatSection` so the component owns its own loading state
- Key `RecentChatSection` by `currentChatAgentId` to force remount on agent switch, resetting the `useLastLoadable` ref back to loading
- Parent uses `useLastResolved(chatThreads$)` for the `selectedAgentIdFromChat` lookup logic
- Update ccstate skill with the `useLastLoadable` reset pattern

## Test plan
- [x] Existing `recent-thread-skeleton.test.tsx` passes — same-agent navigation still retains threads
- [ ] Manual: switch between agents in sidebar → skeleton should appear briefly while new threads load
- [ ] Manual: click a thread within the same agent → no skeleton flash, threads retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)