### PR TITLE
fix(ci): add pipefail to runner-build to catch build failures

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -367,6 +367,7 @@ jobs:
           HOST: ${{ needs.detect.outputs.metal-host }}
           JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
         run: |
+          set -o pipefail
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
           BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -362,12 +362,13 @@ jobs:
 
       - name: Deploy and build on metal host
         id: build
+        shell: bash
         env:
           METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
           HOST: ${{ needs.detect.outputs.metal-host }}
           JOB_REF: ${{ needs.detect.outputs.metal-job-ref }}
         run: |
-          set -o pipefail
+          set -euo pipefail
           REMOTE="${METAL_USER}@${HOST}"
           # shellcheck disable=SC2088
           BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"


### PR DESCRIPTION
## Summary
- Add `set -o pipefail` to the "Deploy and build on metal host" step in `runner-build`
- Without this, `ssh ... runner build | tee` silently swallows the ssh exit code because bash defaults to the last command's exit code (`tee`, which always succeeds)
- This means a failed rootfs/snapshot build would not fail the CI job

## Test plan
- [x] Verified this is the only `| tee` pipeline in `crates.yml`
- [x] `set -o pipefail` is the standard bash fix — no behavior change when build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)