### PR TITLE
refactor: move org-membership-cache to auth layer

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/org/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/org/route.ts
@@ -8,7 +8,7 @@ import crypto from "crypto";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { getOrgBySlug } from "../../../../../src/lib/zero/org/org-cache-service";
-import { verifyMembershipCached } from "../../../../../src/lib/zero/org/org-membership-cache";
+import { verifyMembershipCached } from "../../../../../src/lib/auth/org-membership-cache";
 import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 

--- a/turbo/apps/web/src/lib/auth/__tests__/org-membership-cache.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/org-membership-cache.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { testContext } from "../../../../__tests__/test-helpers";
+import { testContext } from "../../../__tests__/test-helpers";
 import {
   insertOrgCacheEntry,
   insertOrgMembersCacheEntry,
   findOrgMembersCacheEntry,
-} from "../../../../__tests__/api-test-helpers";
-import { mockClerk } from "../../../../__tests__/clerk-mock";
+} from "../../../__tests__/api-test-helpers";
+import { mockClerk } from "../../../__tests__/clerk-mock";
 import { verifyMembershipCached } from "../org-membership-cache";
 
 const context = testContext();

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -9,7 +9,7 @@ import {
   verifyZeroToken,
   verifyCliToken,
 } from "./sandbox-token";
-import { verifyMembershipCached } from "../zero/org/org-membership-cache";
+import { verifyMembershipCached } from "./org-membership-cache";
 import { logger } from "../logger";
 
 const log = logger("auth:user");

--- a/turbo/apps/web/src/lib/auth/org-membership-cache.ts
+++ b/turbo/apps/web/src/lib/auth/org-membership-cache.ts
@@ -1,7 +1,7 @@
 import { eq, and } from "drizzle-orm";
 import { clerkClient } from "@clerk/nextjs/server";
-import { orgMembersCache } from "../../../db/schema/org-members-cache";
-import { logger } from "../../logger";
+import { orgMembersCache } from "../../db/schema/org-members-cache";
+import { logger } from "../logger";
 import { orgRoleSchema, type OrgRole } from "@vm0/core";
 
 const log = logger("org:membership-cache");

--- a/turbo/apps/web/src/lib/zero/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/email/handlers/inbound-trigger.ts
@@ -15,7 +15,7 @@ import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
 import { getUserIdByEmail } from "../../../auth/get-user-id-by-email";
 import { getOrgBySlug } from "../../../zero/org/org-cache-service";
-import { verifyMembershipCached } from "../../../zero/org/org-membership-cache";
+import { verifyMembershipCached } from "../../../auth/org-membership-cache";
 import { logger } from "../../../logger";
 
 const log = logger("email:inbound-trigger");

--- a/turbo/apps/web/src/lib/zero/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/zero/org/resolve-org.ts
@@ -9,7 +9,7 @@ import {
 import { getOrgMetadata, getOrgData } from "./org-cache-service";
 import { orgMetadata } from "../../../db/schema/org-metadata";
 import { orgCache } from "../../../db/schema/org-cache";
-import { verifyMembershipCached } from "./org-membership-cache";
+import { verifyMembershipCached } from "../../auth/org-membership-cache";
 import type { AuthContext } from "../../auth/get-auth-context";
 
 import type { OrgRole } from "@vm0/core";


### PR DESCRIPTION
## Summary

- Move `org-membership-cache.ts` and its test from `zero/org/` to `auth/`, eliminating the auth→zero reverse dependency
- Update all 4 consumer import paths (`get-auth-context.ts`, `resolve-org.ts`, `inbound-trigger.ts`, `route.ts`)
- No logic changes — pure file move with import path adjustments

Closes #7790
Part of Epic #7788

## Test plan

- [x] All 5 existing tests pass at new location
- [x] Type check passes (`pnpm check-types --filter=web`)
- [x] Lint passes (`pnpm turbo run lint --filter=web`)
- [x] Knip passes — no unused exports/imports
- [x] No `from.*zero` imports remain in `auth/` directory
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)