### PR TITLE
refactor: move runner group check from zero/org to infra/run

### DIFF
--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -16,7 +16,7 @@ import { getRunnerAuth } from "../../../../../../src/lib/auth/runner-auth";
 import { generateSandboxToken } from "../../../../../../src/lib/auth/sandbox-token";
 import { logger } from "../../../../../../src/lib/logger";
 import { decryptSecretsMap } from "../../../../../../src/lib/shared/crypto/secrets-encryption";
-import { isOfficialRunnerGroup } from "../../../../../../src/lib/zero/org/org-service";
+import { isOfficialRunnerGroup } from "../../../../../../src/lib/infra/run/runner-group";
 import { recordSandboxOperation } from "../../../../../../src/lib/shared/metrics";
 
 const log = logger("api:runners:jobs:claim");

--- a/turbo/apps/web/app/api/runners/poll/route.ts
+++ b/turbo/apps/web/app/api/runners/poll/route.ts
@@ -10,7 +10,7 @@ import { runnerJobQueue } from "../../../../src/db/schema/runner-job-queue";
 import { eq, and, isNull, inArray, type SQL } from "drizzle-orm";
 import { getRunnerAuth } from "../../../../src/lib/auth/runner-auth";
 import { logger } from "../../../../src/lib/logger";
-import { isOfficialRunnerGroup } from "../../../../src/lib/zero/org/org-service";
+import { isOfficialRunnerGroup } from "../../../../src/lib/infra/run/runner-group";
 
 const log = logger("api:runners:poll");
 

--- a/turbo/apps/web/app/api/runners/realtime/token/route.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/route.ts
@@ -3,7 +3,7 @@ import { runnerRealtimeTokenContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getRunnerAuth } from "../../../../../src/lib/auth/runner-auth";
 import { generateRunnerGroupToken } from "../../../../../src/lib/shared/realtime/client";
-import { isOfficialRunnerGroup } from "../../../../../src/lib/zero/org/org-service";
+import { isOfficialRunnerGroup } from "../../../../../src/lib/infra/run/runner-group";
 import { logger } from "../../../../../src/lib/logger";
 
 const log = logger("api:runners:realtime:token");

--- a/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
@@ -11,7 +11,7 @@ import {
   type RunContextSnapshot,
 } from "../../../shared/axiom/client";
 import { encryptSecretsMap } from "../../../shared/crypto/secrets-encryption";
-import { isOfficialRunnerGroup } from "../../../zero/org/org-service";
+import { isOfficialRunnerGroup } from "../runner-group";
 import { forbidden } from "../../../errors";
 import { publishJobNotification } from "../../../shared/realtime/client";
 import { logger } from "../../../logger";

--- a/turbo/apps/web/src/lib/infra/run/runner-group.ts
+++ b/turbo/apps/web/src/lib/infra/run/runner-group.ts
@@ -1,0 +1,11 @@
+/**
+ * Check if a runner group belongs to the official vm0 organization.
+ *
+ * @param group - Runner group in format "vm0/<name>"
+ * @returns true if the group is an official runner group (vm0/*)
+ */
+export function isOfficialRunnerGroup(group: string): boolean {
+  const orgSlug = group.split("/")[0];
+  // TODO: Runner group public access for vm0 is hardcoded. This should be configurable.
+  return orgSlug === "vm0";
+}

--- a/turbo/apps/web/src/lib/zero/org/org-service.ts
+++ b/turbo/apps/web/src/lib/zero/org/org-service.ts
@@ -105,19 +105,6 @@ export async function updateOrg(
 }
 
 /**
- * Check if a runner group belongs to the official vm0 org.
- * Official runner groups (vm0/production, vm0/development) can be used by any user.
- *
- * @param group - Runner group in format "vm0/<name>"
- * @returns true if the group is an official runner group (vm0/*)
- */
-export function isOfficialRunnerGroup(group: string): boolean {
-  const orgSlug = group.split("/")[0];
-  // TODO: Runner group public access for vm0 is hardcoded. This should be configurable.
-  return orgSlug === "vm0";
-}
-
-/**
  * Atomically deduct credits from an org's balance.
  *
  * Uses INSERT ON CONFLICT UPDATE so the row is created with `-amount`


### PR DESCRIPTION
## Summary

- Move `isOfficialRunnerGroup` from `zero/org/org-service.ts` to `infra/run/runner-group.ts`
- Update all 4 consumers: `runner-executor.ts` + 3 API routes (`poll`, `claim`, `realtime/token`)
- Eliminate the `infra→zero` reverse dependency

## Test plan

- [x] `grep -r "isOfficialRunnerGroup" src/lib/zero/` returns empty
- [x] `grep -r "import.*from.*zero" src/lib/infra/` returns empty
- [x] TypeScript type check passes (`web` package)
- [x] Lint passes (0 errors)
- [x] Knip passes (no unused exports)
- [x] No runner-related test failures
- [ ] CI pipeline passes

Closes #7789

🤖 Generated with [Claude Code](https://claude.com/claude-code)