### PR TITLE
refactor: split org-cache-service into auth and metadata modules

### DIFF
--- a/turbo/apps/web/src/lib/auth/__tests__/org-cache.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/org-cache.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clerkClient } from "@clerk/nextjs/server";
+import { testContext, uniqueId } from "../../../__tests__/test-helpers";
+import { mockClerk } from "../../../__tests__/clerk-mock";
+import {
+  createTestOrg,
+  insertOrgCacheEntry,
+  deleteOrgCacheEntry,
+  getOrgCacheEntry,
+  ensureOrgRow,
+} from "../../../__tests__/api-test-helpers";
+import { getOrgIdentity, getOrgIdentityBySlug } from "../org-cache";
+
+const context = testContext();
+
+describe("getOrgIdentity", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("fetches from Clerk and caches on miss", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
+    });
+    await createTestOrg(slug);
+    const orgId = `org_mock_${slug}`;
+
+    // Delete pre-populated orgCache to test cache-miss behavior
+    await deleteOrgCacheEntry(orgId);
+
+    const result = await getOrgIdentity(orgId);
+
+    expect(result).toEqual({
+      orgId,
+      slug,
+      name: slug,
+    });
+
+    // Verify cache row was created
+    const cached = await getOrgCacheEntry(orgId);
+    expect(cached).not.toBeNull();
+    expect(cached!.slug).toBe(slug);
+
+    // Verify Clerk API was called
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).toHaveBeenCalledWith({
+      organizationId: orgId,
+    });
+  });
+
+  it("returns cached data without Clerk call when fresh", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    await createTestOrg(slug);
+    const orgId = `org_mock_${slug}`;
+
+    // Pre-populate cache with fresh entry (different slug)
+    await insertOrgCacheEntry({
+      orgId,
+      slug: "cached-slug",
+    });
+
+    const result = await getOrgIdentity(orgId);
+
+    expect(result).toEqual({
+      orgId,
+      slug: "cached-slug",
+      name: "cached-slug",
+    });
+
+    // Clerk API should NOT have been called
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("refetches from Clerk when cache is stale", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
+    });
+    await createTestOrg(slug);
+    const orgId = `org_mock_${slug}`;
+
+    // Overwrite with a stale entry
+    const twoMinutesAgo = new Date(Date.now() - 120_000);
+    await insertOrgCacheEntry({
+      orgId,
+      slug: "old-slug",
+      cachedAt: twoMinutesAgo,
+    });
+
+    const result = await getOrgIdentity(orgId);
+
+    // Should have fresh data from Clerk mock
+    expect(result.slug).toBe(slug);
+    expect(result.orgId).toBe(orgId);
+
+    // Verify Clerk API was called
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).toHaveBeenCalledWith({
+      organizationId: orgId,
+    });
+
+    // Verify cache was updated
+    const cached = await getOrgCacheEntry(orgId);
+    expect(cached!.slug).toBe(slug);
+    expect(cached!.cachedAt.getTime()).toBeGreaterThan(twoMinutesAgo.getTime());
+  });
+
+  it("throws when Clerk org has no slug", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    await createTestOrg(slug);
+    const orgId = `org_mock_${slug}`;
+
+    // Delete cache to force Clerk fetch
+    await deleteOrgCacheEntry(orgId);
+
+    // Override getOrganization to return null slug
+    const client = await clerkClient();
+    vi.mocked(client.organizations.getOrganization).mockResolvedValueOnce({
+      id: orgId,
+      slug: null,
+      name: slug,
+      publicMetadata: {},
+    } as unknown as Awaited<
+      ReturnType<typeof client.organizations.getOrganization>
+    >);
+
+    await expect(getOrgIdentity(orgId)).rejects.toThrow(
+      `Clerk organization ${orgId} has no slug`,
+    );
+  });
+});
+
+describe("getOrgIdentityBySlug", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("fetches from Clerk by slug and caches on miss", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    const orgId = `org_mock_${slug}`;
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: orgId, slug, name: slug }],
+    });
+
+    const result = await getOrgIdentityBySlug(slug);
+
+    expect(result).toEqual({
+      orgId,
+      slug,
+      name: slug,
+    });
+
+    // Verify cache row was created
+    const cached = await getOrgCacheEntry(orgId);
+    expect(cached).not.toBeNull();
+    expect(cached!.slug).toBe(slug);
+
+    // Verify Clerk API was called with slug param
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).toHaveBeenCalledWith({
+      slug,
+    });
+  });
+
+  it("returns cached data without Clerk call when fresh", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    const orgId = `org_mock_${slug}`;
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: orgId, slug, name: slug }],
+    });
+
+    // Insert fresh cache entry and org row directly
+    await insertOrgCacheEntry({ orgId, slug });
+    await ensureOrgRow(orgId);
+
+    const result = await getOrgIdentityBySlug(slug);
+
+    expect(result).toEqual({ orgId, slug, name: slug });
+
+    // Clerk API should NOT have been called
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("returns null when slug not found in Clerk", async () => {
+    const userId = uniqueId("test-user");
+    mockClerk({ userId });
+
+    const result = await getOrgIdentityBySlug("nonexistent-slug");
+
+    expect(result).toBeNull();
+  });
+
+  it("refetches from Clerk when cache is stale", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    const orgId = `org_mock_${slug}`;
+    mockClerk({
+      userId,
+      clerkOrgs: [{ id: orgId, slug, name: slug }],
+    });
+
+    // Insert stale cache entry directly
+    const twoMinutesAgo = new Date(Date.now() - 120_000);
+    await insertOrgCacheEntry({
+      orgId,
+      slug,
+      cachedAt: twoMinutesAgo,
+    });
+
+    const result = await getOrgIdentityBySlug(slug);
+
+    expect(result).not.toBeNull();
+    expect(result!.orgId).toBe(orgId);
+
+    // Verify Clerk API was called with slug param
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).toHaveBeenCalledWith({
+      slug,
+    });
+  });
+});

--- a/turbo/apps/web/src/lib/auth/org-cache.ts
+++ b/turbo/apps/web/src/lib/auth/org-cache.ts
@@ -1,0 +1,132 @@
+import { eq } from "drizzle-orm";
+import { clerkClient } from "@clerk/nextjs/server";
+import { orgCache } from "../../db/schema/org-cache";
+import { logger } from "../logger";
+
+const log = logger("service:org-cache");
+
+/** Cache TTL aligned with Clerk JWT TTL */
+const CACHE_TTL_MS = 60_000; // 1 minute
+
+interface OrgIdentity {
+  orgId: string;
+  slug: string;
+  name: string;
+}
+
+/**
+ * Get org identity (slug, name) from cache or Clerk API.
+ *
+ * **WARNING: This function may call the Clerk API on cache miss (1-min TTL),
+ * adding 500-700ms of latency.**
+ *
+ * - slug, name: cached from Clerk (org_cache, 1-min TTL)
+ */
+export async function getOrgIdentity(orgId: string): Promise<OrgIdentity> {
+  const db = globalThis.services.db;
+
+  // Check slug cache
+  const [cached] = await db
+    .select()
+    .from(orgCache)
+    .where(eq(orgCache.orgId, orgId))
+    .limit(1);
+
+  if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
+    return { orgId, slug: cached.slug, name: cached.name };
+  }
+
+  // Cache miss — fetch from Clerk (source of truth for slug)
+  const client = await clerkClient();
+  const clerkOrg = await client.organizations.getOrganization({
+    organizationId: orgId,
+  });
+
+  if (!clerkOrg.slug) {
+    throw new Error(`Clerk organization ${orgId} has no slug — cannot cache`);
+  }
+  const slug = clerkOrg.slug;
+  const name = clerkOrg.name;
+
+  // Upsert slug cache
+  const now = new Date();
+  await db
+    .insert(orgCache)
+    .values({ orgId, slug, name, cachedAt: now })
+    .onConflictDoUpdate({
+      target: orgCache.orgId,
+      set: { slug, name, cachedAt: now },
+    });
+
+  log.debug("org cache refreshed", { orgId, slug });
+
+  return { orgId, slug, name };
+}
+
+/**
+ * Invalidate (delete) an org_cache entry so the next getOrgIdentity call
+ * re-fetches from Clerk. Used after mutations that change org data
+ * (e.g. slug updates) to avoid returning stale cached values.
+ */
+export async function invalidateOrgCache(orgId: string): Promise<void> {
+  const db = globalThis.services.db;
+  await db.delete(orgCache).where(eq(orgCache.orgId, orgId));
+}
+
+/**
+ * Get org identity by slug from cache or Clerk API (reverse lookup).
+ *
+ * Returns null when the slug does not exist in Clerk.
+ */
+export async function getOrgIdentityBySlug(
+  slug: string,
+): Promise<OrgIdentity | null> {
+  const db = globalThis.services.db;
+
+  // Check slug cache
+  const [cached] = await db
+    .select()
+    .from(orgCache)
+    .where(eq(orgCache.slug, slug))
+    .limit(1);
+
+  if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
+    return { orgId: cached.orgId, slug: cached.slug, name: cached.name };
+  }
+
+  // Fetch from Clerk by slug
+  const client = await clerkClient();
+  let clerkOrg;
+  try {
+    clerkOrg = await client.organizations.getOrganization({ slug });
+  } catch {
+    return null;
+  }
+
+  if (!clerkOrg.slug) {
+    log.warn(`Clerk organization looked up by slug '${slug}' has no slug`);
+    return null;
+  }
+
+  // Upsert slug cache
+  const now = new Date();
+  await db
+    .insert(orgCache)
+    .values({
+      orgId: clerkOrg.id,
+      slug: clerkOrg.slug,
+      name: clerkOrg.name,
+      cachedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: orgCache.orgId,
+      set: { slug: clerkOrg.slug, name: clerkOrg.name, cachedAt: now },
+    });
+
+  log.debug("org cache refreshed (by slug)", {
+    orgId: clerkOrg.id,
+    slug: clerkOrg.slug,
+  });
+
+  return { orgId: clerkOrg.id, slug: clerkOrg.slug, name: clerkOrg.name };
+}

--- a/turbo/apps/web/src/lib/zero/billing/usage-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-service.ts
@@ -1,6 +1,6 @@
 import { sql, and, eq, gte, lt, inArray } from "drizzle-orm";
 import { type MemberUsage, type UsageMembersResponse } from "@vm0/core";
-import { getOrgBillingPeriod } from "../org/org-cache-service";
+import { getOrgBillingPeriod } from "../org/org-metadata-service";
 import { creditUsage } from "../../../db/schema/credit-usage";
 import { userCache } from "../../../db/schema/user-cache";
 import { orgMembersMetadata } from "../../../db/schema/org-members-metadata";

--- a/turbo/apps/web/src/lib/zero/credit/member-credit-cap-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/member-credit-cap-service.ts
@@ -1,7 +1,7 @@
 import { eq, and, sql, gte, inArray } from "drizzle-orm";
 import { orgMembersMetadata } from "../../../db/schema/org-members-metadata";
 import { creditUsage } from "../../../db/schema/credit-usage";
-import { getOrgBillingPeriod } from "../org/org-cache-service";
+import { getOrgBillingPeriod } from "../org/org-metadata-service";
 
 /**
  * Get a member's credit cap state.

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-cache-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-cache-service.test.ts
@@ -1,63 +1,15 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { clerkClient } from "@clerk/nextjs/server";
 import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
 import { mockClerk } from "../../../../__tests__/clerk-mock";
-import type { StripeMockFns } from "../../../../__tests__/stripe-mock";
 import {
   createTestOrg,
   insertOrgCacheEntry,
   deleteOrgCacheEntry,
-  getOrgCacheEntry,
   updateOrgTier,
-  updateOrgStripeFields,
   ensureOrgRow,
 } from "../../../../__tests__/api-test-helpers";
-import { reloadEnv } from "../../../../env";
-import {
-  getOrgData,
-  getOrgMetadata,
-  getOrgBySlug,
-  getOrgBillingPeriod,
-} from "../org-cache-service";
-
-// Mock stripe module (external dependency)
-const stripeMocks = vi.hoisted<StripeMockFns>(() => {
-  return {
-    subscriptionsRetrieve: vi.fn(),
-    subscriptionsUpdate: vi.fn(),
-    subscriptionsCancel: vi.fn(),
-    invoicesRetrieve: vi.fn(),
-    invoicesList: vi.fn(),
-    customersCreate: vi.fn(),
-    checkoutSessionsCreate: vi.fn(),
-    billingPortalSessionsCreate: vi.fn(),
-    constructEvent: vi.fn(),
-  };
-});
-
-vi.mock("stripe", () => {
-  return {
-    default: function MockStripe() {
-      return {
-        subscriptions: {
-          retrieve: stripeMocks.subscriptionsRetrieve,
-          update: stripeMocks.subscriptionsUpdate,
-          cancel: stripeMocks.subscriptionsCancel,
-        },
-        invoices: {
-          retrieve: stripeMocks.invoicesRetrieve,
-          list: stripeMocks.invoicesList,
-        },
-        customers: { create: stripeMocks.customersCreate },
-        checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
-        billingPortal: {
-          sessions: { create: stripeMocks.billingPortalSessionsCreate },
-        },
-        webhooks: { constructEvent: stripeMocks.constructEvent },
-      };
-    },
-  };
-});
+import { getOrgData, getOrgBySlug } from "../org-cache-service";
 
 const context = testContext();
 
@@ -66,10 +18,24 @@ describe("getOrgData", () => {
     context.setupMocks();
   });
 
-  it("fetches from Clerk and caches on miss", async () => {
+  it("combines Clerk identity with tier from org_metadata", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");
-    // Set up Clerk org with slug-based ID BEFORE creating org
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    await updateOrgTier(orgId, "pro");
+
+    const result = await getOrgData(orgId);
+
+    expect(result.tier).toBe("pro");
+    expect(result.slug).toBe(slug);
+    expect(result.orgId).toBe(orgId);
+  });
+
+  it("fetches from Clerk on cache miss and returns composed data", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
     mockClerk({
       userId,
       clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
@@ -77,7 +43,6 @@ describe("getOrgData", () => {
     await createTestOrg(slug);
     const orgId = `org_mock_${slug}`;
 
-    // Delete pre-populated orgCache to test cache-miss behavior
     await deleteOrgCacheEntry(orgId);
 
     const result = await getOrgData(orgId);
@@ -89,26 +54,19 @@ describe("getOrgData", () => {
       tier: "free",
     });
 
-    // Verify cache row was created
-    const cached = await getOrgCacheEntry(orgId);
-    expect(cached).not.toBeNull();
-    expect(cached!.slug).toBe(slug);
-
-    // Verify Clerk API was called
     const client = await clerkClient();
     expect(client.organizations.getOrganization).toHaveBeenCalledWith({
       organizationId: orgId,
     });
   });
 
-  it("returns cached data without Clerk call when fresh", async () => {
+  it("returns cached identity without Clerk call when fresh", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");
     mockClerk({ userId });
     await createTestOrg(slug);
     const orgId = `org_mock_${slug}`;
 
-    // Pre-populate cache with fresh entry (different slug)
     await insertOrgCacheEntry({
       orgId,
       slug: "cached-slug",
@@ -123,116 +81,8 @@ describe("getOrgData", () => {
       tier: "free",
     });
 
-    // Clerk API should NOT have been called
     const client = await clerkClient();
     expect(client.organizations.getOrganization).not.toHaveBeenCalled();
-  });
-
-  it("refetches from Clerk when cache is stale", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    // Set up Clerk org with slug-based ID BEFORE creating org
-    mockClerk({
-      userId,
-      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
-    });
-    await createTestOrg(slug);
-    const orgId = `org_mock_${slug}`;
-
-    // Overwrite the fresh orgCache entry from createTestOrg with a stale one
-    const twoMinutesAgo = new Date(Date.now() - 120_000);
-    await insertOrgCacheEntry({
-      orgId,
-      slug: "old-slug",
-      cachedAt: twoMinutesAgo,
-    });
-
-    const result = await getOrgData(orgId);
-
-    // Should have fresh data from Clerk mock (slug = org name from createOrganization)
-    expect(result.slug).toBe(slug);
-    expect(result.orgId).toBe(orgId);
-
-    // Verify Clerk API was called
-    const client = await clerkClient();
-    expect(client.organizations.getOrganization).toHaveBeenCalledWith({
-      organizationId: orgId,
-    });
-
-    // Verify cache was updated
-    const cached = await getOrgCacheEntry(orgId);
-    expect(cached!.slug).toBe(slug);
-    expect(cached!.cachedAt.getTime()).toBeGreaterThan(twoMinutesAgo.getTime());
-  });
-
-  it("reads tier from org table", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    mockClerk({ userId });
-    const { id: orgId } = await createTestOrg(slug);
-
-    // Update tier in org table
-    await updateOrgTier(orgId, "pro");
-
-    const result = await getOrgData(orgId);
-
-    expect(result.tier).toBe("pro");
-  });
-
-  it("returns DB tier directly when DB has non-free on cache miss", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    mockClerk({
-      userId,
-      clerkOrgs: [{ id: `org_mock_${slug}`, slug, name: slug }],
-    });
-    const { id: orgId } = await createTestOrg(slug);
-
-    await updateOrgTier(orgId, "pro");
-
-    const result = await getOrgData(orgId);
-    expect(result.tier).toBe("pro");
-  });
-
-  it("returns free on cache hit when DB has free (no Clerk fallback)", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    mockClerk({ userId });
-    const { id: orgId } = await createTestOrg(slug);
-
-    // Cache is fresh (from createTestOrg), DB tier is "free"
-    // No Clerk call happens, so no fallback possible
-    const result = await getOrgData(orgId);
-    expect(result.tier).toBe("free");
-
-    const client = await clerkClient();
-    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
-  });
-
-  it("throws when Clerk org has no slug", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    mockClerk({ userId });
-    await createTestOrg(slug);
-    const orgId = `org_mock_${slug}`;
-
-    // Delete cache to force Clerk fetch
-    await deleteOrgCacheEntry(orgId);
-
-    // Override getOrganization to return null slug
-    const client = await clerkClient();
-    vi.mocked(client.organizations.getOrganization).mockResolvedValueOnce({
-      id: orgId,
-      slug: null,
-      name: slug,
-      publicMetadata: {},
-    } as unknown as Awaited<
-      ReturnType<typeof client.organizations.getOrganization>
-    >);
-
-    await expect(getOrgData(orgId)).rejects.toThrow(
-      `Clerk organization ${orgId} has no slug`,
-    );
   });
 });
 
@@ -241,7 +91,7 @@ describe("getOrgBySlug", () => {
     context.setupMocks();
   });
 
-  it("fetches from Clerk by slug and caches on miss", async () => {
+  it("combines Clerk identity with tier from org_metadata", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");
     const orgId = `org_mock_${slug}`;
@@ -250,39 +100,6 @@ describe("getOrgBySlug", () => {
       clerkOrgs: [{ id: orgId, slug, name: slug }],
     });
 
-    // No org_cache entry — this is a cache-miss scenario
-    const result = await getOrgBySlug(slug);
-
-    expect(result).toEqual({
-      orgId,
-      slug,
-      name: slug,
-      tier: "free",
-    });
-
-    // Verify cache row was created
-    const cached = await getOrgCacheEntry(orgId);
-    expect(cached).not.toBeNull();
-    expect(cached!.slug).toBe(slug);
-
-    // Verify Clerk API was called with slug param
-    const client = await clerkClient();
-    expect(client.organizations.getOrganization).toHaveBeenCalledWith({
-      slug,
-    });
-  });
-
-  it("returns cached data without Clerk call when fresh", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    const orgId = `org_mock_${slug}`;
-    mockClerk({
-      userId,
-      clerkOrgs: [{ id: orgId, slug, name: slug }],
-    });
-
-    // Insert fresh cache entry and org row directly (bypass createTestOrg
-    // which uses org_mock_${userId} as orgId, not org_mock_${slug})
     await insertOrgCacheEntry({ orgId, slug });
     await ensureOrgRow(orgId);
     await updateOrgTier(orgId, "pro");
@@ -291,7 +108,6 @@ describe("getOrgBySlug", () => {
 
     expect(result).toEqual({ orgId, slug, name: slug, tier: "pro" });
 
-    // Clerk API should NOT have been called
     const client = await clerkClient();
     expect(client.organizations.getOrganization).not.toHaveBeenCalled();
   });
@@ -303,175 +119,5 @@ describe("getOrgBySlug", () => {
     const result = await getOrgBySlug("nonexistent-slug");
 
     expect(result).toBeNull();
-  });
-
-  it("refetches from Clerk when cache is stale", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    const orgId = `org_mock_${slug}`;
-    mockClerk({
-      userId,
-      clerkOrgs: [{ id: orgId, slug, name: slug }],
-    });
-
-    // Insert stale cache entry directly
-    const twoMinutesAgo = new Date(Date.now() - 120_000);
-    await insertOrgCacheEntry({
-      orgId,
-      slug,
-      cachedAt: twoMinutesAgo,
-    });
-
-    const result = await getOrgBySlug(slug);
-
-    expect(result).not.toBeNull();
-    expect(result!.orgId).toBe(orgId);
-
-    // Verify Clerk API was called with slug param
-    const client = await clerkClient();
-    expect(client.organizations.getOrganization).toHaveBeenCalledWith({
-      slug,
-    });
-  });
-});
-
-describe("getOrgBillingPeriod", () => {
-  beforeEach(() => {
-    context.setupMocks();
-    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
-    reloadEnv();
-  });
-
-  it("returns billing period from Stripe invoice when currentPeriodEnd is not cached", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    mockClerk({ userId });
-    const { id: orgId } = await createTestOrg(slug);
-
-    const subId = uniqueId("sub");
-
-    // Set subscription ID but no currentPeriodEnd — triggers Stripe fallback
-    await updateOrgStripeFields(orgId, {
-      stripeSubscriptionId: subId,
-      stripeCustomerId: uniqueId("cus"),
-      subscriptionStatus: "active",
-      currentPeriodEnd: null,
-    });
-
-    const periodEndUnix = Math.floor(
-      new Date("2026-05-01T00:00:00Z").getTime() / 1000,
-    );
-
-    stripeMocks.subscriptionsRetrieve.mockResolvedValueOnce({
-      latest_invoice: "inv_abc123",
-    });
-    stripeMocks.invoicesRetrieve.mockResolvedValueOnce({
-      period_end: periodEndUnix,
-    });
-
-    const result = await getOrgBillingPeriod(orgId);
-
-    expect(result).not.toBeNull();
-    expect(result!.end).toEqual(new Date("2026-05-01T00:00:00Z"));
-
-    // Start should be 1 month before end
-    const expectedStart = new Date("2026-04-01T00:00:00Z");
-    expect(result!.start).toEqual(expectedStart);
-
-    // Verify Stripe was called with the correct subscription ID
-    expect(stripeMocks.subscriptionsRetrieve).toHaveBeenCalledWith(subId);
-    expect(stripeMocks.invoicesRetrieve).toHaveBeenCalledWith("inv_abc123");
-  });
-
-  it("returns null for free tier org without subscription", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    mockClerk({ userId });
-    const { id: orgId } = await createTestOrg(slug);
-
-    const result = await getOrgBillingPeriod(orgId);
-
-    expect(result).toBeNull();
-    expect(stripeMocks.subscriptionsRetrieve).not.toHaveBeenCalled();
-  });
-
-  it("returns null when subscription has no latest_invoice", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    mockClerk({ userId });
-    const { id: orgId } = await createTestOrg(slug);
-
-    await updateOrgStripeFields(orgId, {
-      stripeSubscriptionId: uniqueId("sub"),
-      stripeCustomerId: uniqueId("cus"),
-      subscriptionStatus: "active",
-      currentPeriodEnd: null,
-    });
-
-    stripeMocks.subscriptionsRetrieve.mockResolvedValueOnce({
-      latest_invoice: null,
-    });
-
-    const result = await getOrgBillingPeriod(orgId);
-
-    expect(result).toBeNull();
-  });
-});
-
-describe("getOrgMetadata", () => {
-  beforeEach(() => {
-    context.setupMocks();
-  });
-
-  it("returns tier and credits from org_metadata when row exists", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    mockClerk({ userId });
-    const { id: orgId } = await createTestOrg(slug);
-
-    await updateOrgTier(orgId, "pro");
-
-    const result = await getOrgMetadata(orgId);
-
-    expect(result).toEqual({
-      orgId,
-      tier: "pro",
-      credits: 10_000,
-    });
-
-    // Clerk API should NOT have been called
-    const client = await clerkClient();
-    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
-  });
-
-  it("returns free tier with zero credits when no row exists", async () => {
-    const orgId = uniqueId("org-nonexistent");
-
-    const result = await getOrgMetadata(orgId);
-
-    expect(result).toEqual({
-      orgId,
-      tier: "free",
-      credits: 0,
-    });
-
-    // Clerk API should NOT have been called
-    const client = await clerkClient();
-    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
-  });
-
-  it("returns default credits for new org", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-    mockClerk({ userId });
-    const { id: orgId } = await createTestOrg(slug);
-
-    const result = await getOrgMetadata(orgId);
-
-    expect(result).toEqual({
-      orgId,
-      tier: "free",
-      credits: 10_000,
-    });
   });
 });

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-metadata-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-metadata-service.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { clerkClient } from "@clerk/nextjs/server";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { mockClerk } from "../../../../__tests__/clerk-mock";
+import type { StripeMockFns } from "../../../../__tests__/stripe-mock";
+import {
+  createTestOrg,
+  updateOrgTier,
+  updateOrgStripeFields,
+} from "../../../../__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../env";
+import { getOrgMetadata, getOrgBillingPeriod } from "../org-metadata-service";
+
+// Mock stripe module (external dependency)
+const stripeMocks = vi.hoisted<StripeMockFns>(() => {
+  return {
+    subscriptionsRetrieve: vi.fn(),
+    subscriptionsUpdate: vi.fn(),
+    subscriptionsCancel: vi.fn(),
+    invoicesRetrieve: vi.fn(),
+    invoicesList: vi.fn(),
+    customersCreate: vi.fn(),
+    checkoutSessionsCreate: vi.fn(),
+    billingPortalSessionsCreate: vi.fn(),
+    constructEvent: vi.fn(),
+  };
+});
+
+vi.mock("stripe", () => {
+  return {
+    default: function MockStripe() {
+      return {
+        subscriptions: {
+          retrieve: stripeMocks.subscriptionsRetrieve,
+          update: stripeMocks.subscriptionsUpdate,
+          cancel: stripeMocks.subscriptionsCancel,
+        },
+        invoices: {
+          retrieve: stripeMocks.invoicesRetrieve,
+          list: stripeMocks.invoicesList,
+        },
+        customers: { create: stripeMocks.customersCreate },
+        checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+        billingPortal: {
+          sessions: { create: stripeMocks.billingPortalSessionsCreate },
+        },
+        webhooks: { constructEvent: stripeMocks.constructEvent },
+      };
+    },
+  };
+});
+
+const context = testContext();
+
+describe("getOrgMetadata", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("returns tier and credits from org_metadata when row exists", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    await updateOrgTier(orgId, "pro");
+
+    const result = await getOrgMetadata(orgId);
+
+    expect(result).toEqual({
+      orgId,
+      tier: "pro",
+      credits: 10_000,
+    });
+
+    // Clerk API should NOT have been called
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("returns free tier with zero credits when no row exists", async () => {
+    const orgId = uniqueId("org-nonexistent");
+
+    const result = await getOrgMetadata(orgId);
+
+    expect(result).toEqual({
+      orgId,
+      tier: "free",
+      credits: 0,
+    });
+
+    // Clerk API should NOT have been called
+    const client = await clerkClient();
+    expect(client.organizations.getOrganization).not.toHaveBeenCalled();
+  });
+
+  it("returns default credits for new org", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    const result = await getOrgMetadata(orgId);
+
+    expect(result).toEqual({
+      orgId,
+      tier: "free",
+      credits: 10_000,
+    });
+  });
+});
+
+describe("getOrgBillingPeriod", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_fake");
+    reloadEnv();
+  });
+
+  it("returns billing period from Stripe invoice when currentPeriodEnd is not cached", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    const subId = uniqueId("sub");
+
+    // Set subscription ID but no currentPeriodEnd — triggers Stripe fallback
+    await updateOrgStripeFields(orgId, {
+      stripeSubscriptionId: subId,
+      stripeCustomerId: uniqueId("cus"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: null,
+    });
+
+    const periodEndUnix = Math.floor(
+      new Date("2026-05-01T00:00:00Z").getTime() / 1000,
+    );
+
+    stripeMocks.subscriptionsRetrieve.mockResolvedValueOnce({
+      latest_invoice: "inv_abc123",
+    });
+    stripeMocks.invoicesRetrieve.mockResolvedValueOnce({
+      period_end: periodEndUnix,
+    });
+
+    const result = await getOrgBillingPeriod(orgId);
+
+    expect(result).not.toBeNull();
+    expect(result!.end).toEqual(new Date("2026-05-01T00:00:00Z"));
+
+    // Start should be 1 month before end
+    const expectedStart = new Date("2026-04-01T00:00:00Z");
+    expect(result!.start).toEqual(expectedStart);
+
+    // Verify Stripe was called with the correct subscription ID
+    expect(stripeMocks.subscriptionsRetrieve).toHaveBeenCalledWith(subId);
+    expect(stripeMocks.invoicesRetrieve).toHaveBeenCalledWith("inv_abc123");
+  });
+
+  it("returns null for free tier org without subscription", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    const result = await getOrgBillingPeriod(orgId);
+
+    expect(result).toBeNull();
+    expect(stripeMocks.subscriptionsRetrieve).not.toHaveBeenCalled();
+  });
+
+  it("returns null when subscription has no latest_invoice", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    await updateOrgStripeFields(orgId, {
+      stripeSubscriptionId: uniqueId("sub"),
+      stripeCustomerId: uniqueId("cus"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: null,
+    });
+
+    stripeMocks.subscriptionsRetrieve.mockResolvedValueOnce({
+      latest_invoice: null,
+    });
+
+    const result = await getOrgBillingPeriod(orgId);
+
+    expect(result).toBeNull();
+  });
+});

--- a/turbo/apps/web/src/lib/zero/org/org-cache-service.ts
+++ b/turbo/apps/web/src/lib/zero/org/org-cache-service.ts
@@ -1,64 +1,13 @@
-import { eq } from "drizzle-orm";
-import { clerkClient } from "@clerk/nextjs/server";
-import { orgCache } from "../../../db/schema/org-cache";
-import { orgMetadata } from "../../../db/schema/org-metadata";
-import { logger } from "../../logger";
-import { getStripe } from "../../stripe";
+import { getOrgIdentity, getOrgIdentityBySlug } from "../../auth/org-cache";
+import { readTier } from "./org-metadata-service";
 
-const log = logger("service:org-cache");
-
-/** Cache TTL aligned with Clerk JWT TTL */
-const CACHE_TTL_MS = 60_000; // 1 minute
-
-/** Billing period cache TTL — period changes monthly, no need for frequent refresh */
-const BILLING_CACHE_TTL_MS = 300_000; // 5 minutes
+export { invalidateOrgCache } from "../../auth/org-cache";
 
 export interface OrgData {
   orgId: string;
   slug: string;
   name: string;
   tier: string;
-}
-
-interface OrgMetadata {
-  orgId: string;
-  tier: string;
-  credits: number;
-}
-
-/**
- * Read tier from the org table (source of truth).
- * Returns "free" if the org row does not exist.
- */
-async function readTier(orgId: string): Promise<string> {
-  const db = globalThis.services.db;
-  const [orgRow] = await db
-    .select({ tier: orgMetadata.tier })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
-  return orgRow?.tier ?? "free";
-}
-
-/**
- * Read org metadata from the platform-owned org_metadata table.
- * Returns tier, credits, and other platform fields.
- *
- * Unlike getOrgData(), this function NEVER calls the Clerk API —
- * it only reads from our own database.
- */
-export async function getOrgMetadata(orgId: string): Promise<OrgMetadata> {
-  const db = globalThis.services.db;
-  const [row] = await db
-    .select({ tier: orgMetadata.tier, credits: orgMetadata.credits })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
-  return {
-    orgId,
-    tier: row?.tier ?? "free",
-    credits: row?.credits ?? 0,
-  };
 }
 
 /**
@@ -72,219 +21,22 @@ export async function getOrgMetadata(orgId: string): Promise<OrgMetadata> {
  * - tier: read from org_metadata table (platform-owned, always fresh)
  */
 export async function getOrgData(orgId: string): Promise<OrgData> {
-  const db = globalThis.services.db;
-
-  // Check slug cache
-  const [cached] = await db
-    .select()
-    .from(orgCache)
-    .where(eq(orgCache.orgId, orgId))
-    .limit(1);
-
-  if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
-    const tier = await readTier(orgId);
-    return { orgId, slug: cached.slug, name: cached.name, tier };
-  }
-
-  // Cache miss — fetch from Clerk (source of truth for slug)
-  const client = await clerkClient();
-  const clerkOrg = await client.organizations.getOrganization({
-    organizationId: orgId,
-  });
-
-  if (!clerkOrg.slug) {
-    throw new Error(`Clerk organization ${orgId} has no slug — cannot cache`);
-  }
-  const slug = clerkOrg.slug;
-  const name = clerkOrg.name;
-
+  const identity = await getOrgIdentity(orgId);
   const tier = await readTier(orgId);
-
-  // Upsert slug cache
-  const now = new Date();
-  await db
-    .insert(orgCache)
-    .values({ orgId, slug, name, cachedAt: now })
-    .onConflictDoUpdate({
-      target: orgCache.orgId,
-      set: { slug, name, cachedAt: now },
-    });
-
-  log.debug("org cache refreshed", { orgId, slug, tier });
-
-  return { orgId, slug, name, tier };
-}
-
-/**
- * Invalidate (delete) an org_cache entry so the next getOrgData call
- * re-fetches from Clerk. Used after mutations that change org data
- * (e.g. slug updates) to avoid returning stale cached values.
- */
-export async function invalidateOrgCache(orgId: string): Promise<void> {
-  const db = globalThis.services.db;
-  await db.delete(orgCache).where(eq(orgCache.orgId, orgId));
+  return { ...identity, tier };
 }
 
 /**
  * Get org data by slug from cache or Clerk API (reverse lookup).
  *
  * - slug: cached from Clerk (org_cache, 1-min TTL)
- * - tier: read from org table (owned by platform, always fresh)
+ * - tier: read from org_metadata table (platform-owned, always fresh)
  *
  * Returns null when the slug does not exist in Clerk.
  */
 export async function getOrgBySlug(slug: string): Promise<OrgData | null> {
-  const db = globalThis.services.db;
-
-  // Check slug cache
-  const [cached] = await db
-    .select()
-    .from(orgCache)
-    .where(eq(orgCache.slug, slug))
-    .limit(1);
-
-  if (cached && Date.now() - cached.cachedAt.getTime() < CACHE_TTL_MS) {
-    const tier = await readTier(cached.orgId);
-    return { orgId: cached.orgId, slug: cached.slug, name: cached.name, tier };
-  }
-
-  // Fetch from Clerk by slug
-  const client = await clerkClient();
-  let clerkOrg;
-  try {
-    clerkOrg = await client.organizations.getOrganization({ slug });
-  } catch {
-    return null;
-  }
-
-  if (!clerkOrg.slug) {
-    log.warn(`Clerk organization looked up by slug '${slug}' has no slug`);
-    return null;
-  }
-
-  const tier = await readTier(clerkOrg.id);
-
-  // Upsert slug cache
-  const now = new Date();
-  await db
-    .insert(orgCache)
-    .values({
-      orgId: clerkOrg.id,
-      slug: clerkOrg.slug,
-      name: clerkOrg.name,
-      cachedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: orgCache.orgId,
-      set: { slug: clerkOrg.slug, name: clerkOrg.name, cachedAt: now },
-    });
-
-  log.debug("org cache refreshed (by slug)", {
-    orgId: clerkOrg.id,
-    slug: clerkOrg.slug,
-    tier,
-  });
-
-  return { orgId: clerkOrg.id, slug: clerkOrg.slug, name: clerkOrg.name, tier };
-}
-
-/**
- * Get the current billing period for an org, using org_cache as a read-through
- * cache with independent 5-min TTL.
- *
- * Returns `{ start, end }` for paying orgs, or `null` for free tier (no billing period).
- * Free-tier null results are cached to avoid repeated DB/Stripe lookups.
- */
-export async function getOrgBillingPeriod(
-  orgId: string,
-): Promise<{ start: Date; end: Date } | null> {
-  const db = globalThis.services.db;
-
-  // 1. Check cache
-  const [cached] = await db
-    .select({
-      currentPeriodStart: orgCache.currentPeriodStart,
-      currentPeriodEnd: orgCache.currentPeriodEnd,
-      billingCachedAt: orgCache.billingCachedAt,
-    })
-    .from(orgCache)
-    .where(eq(orgCache.orgId, orgId))
-    .limit(1);
-
-  if (
-    cached?.billingCachedAt &&
-    Date.now() - cached.billingCachedAt.getTime() < BILLING_CACHE_TTL_MS
-  ) {
-    // Cache hit — return cached values or null (negative cache for free tier)
-    if (cached.currentPeriodEnd && cached.currentPeriodStart) {
-      return { start: cached.currentPeriodStart, end: cached.currentPeriodEnd };
-    }
-    return null;
-  }
-
-  // 2. Cache miss/stale — read from org_metadata
-  const [orgRow] = await db
-    .select({
-      currentPeriodEnd: orgMetadata.currentPeriodEnd,
-      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
-    })
-    .from(orgMetadata)
-    .where(eq(orgMetadata.orgId, orgId))
-    .limit(1);
-
-  let periodEnd = orgRow?.currentPeriodEnd ?? null;
-
-  if (!periodEnd && orgRow?.stripeSubscriptionId) {
-    // Has subscription but no period cached in metadata — fetch from Stripe.
-    // In Stripe v2025 API, current_period_end was removed from Subscription.
-    // Use the latest_invoice.period_end instead.
-    const stripe = getStripe();
-    const subscription = await stripe.subscriptions.retrieve(
-      orgRow.stripeSubscriptionId,
-    );
-    if (subscription.latest_invoice) {
-      const invoiceId =
-        typeof subscription.latest_invoice === "string"
-          ? subscription.latest_invoice
-          : subscription.latest_invoice.id;
-      const latestInvoice = await stripe.invoices.retrieve(invoiceId);
-      periodEnd = new Date(latestInvoice.period_end * 1000);
-
-      // Update org_metadata so future lookups skip Stripe
-      await db
-        .update(orgMetadata)
-        .set({ currentPeriodEnd: periodEnd, updatedAt: new Date() })
-        .where(eq(orgMetadata.orgId, orgId));
-    }
-  }
-
-  const now = new Date();
-
-  if (periodEnd) {
-    // Compute start = end - 1 month
-    const periodStart = new Date(periodEnd);
-    periodStart.setMonth(periodStart.getMonth() - 1);
-
-    // Cache the result
-    await db
-      .update(orgCache)
-      .set({
-        currentPeriodStart: periodStart,
-        currentPeriodEnd: periodEnd,
-        billingCachedAt: now,
-      })
-      .where(eq(orgCache.orgId, orgId));
-
-    log.debug("billing period cached", { orgId, periodStart, periodEnd });
-    return { start: periodStart, end: periodEnd };
-  }
-
-  // Free tier — cache negative result
-  await db
-    .update(orgCache)
-    .set({ billingCachedAt: now })
-    .where(eq(orgCache.orgId, orgId));
-
-  log.debug("billing period cached (free tier)", { orgId });
-  return null;
+  const identity = await getOrgIdentityBySlug(slug);
+  if (!identity) return null;
+  const tier = await readTier(identity.orgId);
+  return { ...identity, tier };
 }

--- a/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
+++ b/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
@@ -1,0 +1,106 @@
+import { eq } from "drizzle-orm";
+import { orgMetadata } from "../../../db/schema/org-metadata";
+import { logger } from "../../logger";
+import { getStripe } from "../../stripe";
+
+const log = logger("service:org-metadata");
+
+interface OrgMetadata {
+  orgId: string;
+  tier: string;
+  credits: number;
+}
+
+/**
+ * Read tier from the org_metadata table (source of truth).
+ * Returns "free" if the org row does not exist.
+ */
+export async function readTier(orgId: string): Promise<string> {
+  const db = globalThis.services.db;
+  const [orgRow] = await db
+    .select({ tier: orgMetadata.tier })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return orgRow?.tier ?? "free";
+}
+
+/**
+ * Read org metadata from the platform-owned org_metadata table.
+ * Returns tier, credits, and other platform fields.
+ *
+ * Unlike getOrgData(), this function NEVER calls the Clerk API —
+ * it only reads from our own database.
+ */
+export async function getOrgMetadata(orgId: string): Promise<OrgMetadata> {
+  const db = globalThis.services.db;
+  const [row] = await db
+    .select({ tier: orgMetadata.tier, credits: orgMetadata.credits })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+  return {
+    orgId,
+    tier: row?.tier ?? "free",
+    credits: row?.credits ?? 0,
+  };
+}
+
+/**
+ * Get the current billing period for an org by reading org_metadata directly.
+ *
+ * Returns `{ start, end }` for paying orgs, or `null` for free tier (no billing period).
+ * Falls back to Stripe when currentPeriodEnd is not cached in org_metadata.
+ */
+export async function getOrgBillingPeriod(
+  orgId: string,
+): Promise<{ start: Date; end: Date } | null> {
+  const db = globalThis.services.db;
+
+  // Read from org_metadata directly
+  const [orgRow] = await db
+    .select({
+      currentPeriodEnd: orgMetadata.currentPeriodEnd,
+      stripeSubscriptionId: orgMetadata.stripeSubscriptionId,
+    })
+    .from(orgMetadata)
+    .where(eq(orgMetadata.orgId, orgId))
+    .limit(1);
+
+  let periodEnd = orgRow?.currentPeriodEnd ?? null;
+
+  if (!periodEnd && orgRow?.stripeSubscriptionId) {
+    // Has subscription but no period cached in metadata — fetch from Stripe.
+    // In Stripe v2025 API, current_period_end was removed from Subscription.
+    // Use the latest_invoice.period_end instead.
+    const stripe = getStripe();
+    const subscription = await stripe.subscriptions.retrieve(
+      orgRow.stripeSubscriptionId,
+    );
+    if (subscription.latest_invoice) {
+      const invoiceId =
+        typeof subscription.latest_invoice === "string"
+          ? subscription.latest_invoice
+          : subscription.latest_invoice.id;
+      const latestInvoice = await stripe.invoices.retrieve(invoiceId);
+      periodEnd = new Date(latestInvoice.period_end * 1000);
+
+      // Update org_metadata so future lookups skip Stripe
+      await db
+        .update(orgMetadata)
+        .set({ currentPeriodEnd: periodEnd, updatedAt: new Date() })
+        .where(eq(orgMetadata.orgId, orgId));
+    }
+  }
+
+  if (periodEnd) {
+    // Compute start = end - 1 month
+    const periodStart = new Date(periodEnd);
+    periodStart.setMonth(periodStart.getMonth() - 1);
+
+    log.debug("billing period resolved", { orgId, periodStart, periodEnd });
+    return { start: periodStart, end: periodEnd };
+  }
+
+  return null;
+}

--- a/turbo/apps/web/src/lib/zero/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/zero/org/resolve-org.ts
@@ -6,7 +6,8 @@ import {
   isBadRequest,
   isNotFound,
 } from "../../errors";
-import { getOrgMetadata, getOrgData } from "./org-cache-service";
+import { getOrgData } from "./org-cache-service";
+import { getOrgMetadata } from "./org-metadata-service";
 import { orgMetadata } from "../../../db/schema/org-metadata";
 import { orgCache } from "../../../db/schema/org-cache";
 import { verifyMembershipCached } from "./org-membership-cache";

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -29,7 +29,7 @@ import {
   buildZeroExecutionContext,
   MODEL_PROVIDER_ENV_VARS,
 } from "./build-zero-context";
-import { getOrgMetadata } from "./org/org-cache-service";
+import { getOrgMetadata } from "./org/org-metadata-service";
 import {
   isConcurrentRunLimit,
   insufficientCredits,


### PR DESCRIPTION
## Summary

- Extract Clerk identity caching (`getOrgIdentity`, `getOrgIdentityBySlug`, `invalidateOrgCache`) into `auth/org-cache.ts`
- Extract business data functions (`getOrgMetadata`, `getOrgBillingPeriod`, `readTier`) into `zero/org/org-metadata-service.ts`
- Simplify `org-cache-service.ts` to a thin composition layer that delegates to the above modules
- Remove `org_cache` caching layer from `getOrgBillingPeriod` — it now reads `org_metadata` directly

## Test plan

- [x] All 19 tests pass across 3 test files (auth/org-cache, org-metadata-service, org-cache-service)
- [x] `grep -r "from.*zero" src/lib/auth/org-cache.ts` returns empty (auth doesn't import zero)
- [x] Lint, type-check, format, knip all pass
- [x] Existing `getOrgData`/`getOrgBySlug` behavior preserved via composition

Closes #7791

🤖 Generated with [Claude Code](https://claude.com/claude-code)