### PR TITLE
refactor: replace manual loading booleans with useLoadableSet in billing signals

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -46,12 +46,8 @@ function getErrorMessage(body: unknown): string | undefined {
 // ---------------------------------------------------------------------------
 
 const internalDialogOpen$ = state(false);
-const internalCheckoutLoading$ = state(false);
-const internalPortalLoading$ = state(false);
 const billingReload$ = state(0);
 const internalDowngradeDialogOpen$ = state(false);
-const internalDowngradeLoading$ = state(false);
-const internalDowngradeError$ = state<string | null>(null);
 const internalPendingEnabled$ = state<boolean | null>(null);
 
 // ---------------------------------------------------------------------------
@@ -61,21 +57,8 @@ const internalPendingEnabled$ = state<boolean | null>(null);
 export const billingDialogOpen$ = computed((get) => {
   return get(internalDialogOpen$);
 });
-export const billingDialogLoading$ = computed((get) => {
-  return (
-    get(internalCheckoutLoading$) ||
-    get(internalPortalLoading$) ||
-    get(internalDowngradeLoading$)
-  );
-});
 export const downgradeDialogOpen$ = computed((get) => {
   return get(internalDowngradeDialogOpen$);
-});
-export const downgradeLoading$ = computed((get) => {
-  return get(internalDowngradeLoading$);
-});
-export const downgradeError$ = computed((get) => {
-  return get(internalDowngradeError$);
 });
 export const pendingEnabled$ = computed((get) => {
   return get(internalPendingEnabled$);
@@ -116,9 +99,7 @@ export const closeBillingDialog$ = command(({ set }) => {
 });
 
 export const startCheckout$ = command(
-  async ({ get, set }, tier: "pro" | "team", _signal: AbortSignal) => {
-    set(internalCheckoutLoading$, true);
-
+  async ({ get }, tier: "pro" | "team", _signal: AbortSignal) => {
     const currentUrl = window.location.href;
     const successUrl = new URL(currentUrl);
     successUrl.searchParams.set("billing", "success");
@@ -140,15 +121,13 @@ export const startCheckout$ = command(
       // Don't reset loading — page is navigating away
     } else {
       log.error("Checkout failed", getErrorMessage(result.body));
-      set(internalCheckoutLoading$, false);
+      throw new Error(getErrorMessage(result.body) ?? "Checkout failed");
     }
   },
 );
 
 export const startDowngrade$ = command(
-  async ({ get, set }, _signal: AbortSignal) => {
-    set(internalPortalLoading$, true);
-
+  async ({ get }, _signal: AbortSignal) => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingPortalContract);
     const result = await client.create({
@@ -159,7 +138,7 @@ export const startDowngrade$ = command(
       window.location.href = result.body.url;
     } else {
       log.error("Portal redirect failed", getErrorMessage(result.body));
-      set(internalPortalLoading$, false);
+      throw new Error(getErrorMessage(result.body) ?? "Portal redirect failed");
     }
   },
 );
@@ -169,7 +148,6 @@ export const startDowngrade$ = command(
 // ---------------------------------------------------------------------------
 
 export const openDowngradeDialog$ = command(({ set }) => {
-  set(internalDowngradeError$, null);
   set(internalDowngradeDialogOpen$, true);
 });
 
@@ -179,16 +157,11 @@ export const closeDowngradeDialog$ = command(({ set }) => {
 
 export const confirmDowngrade$ = command(
   async ({ get, set }, targetTier: "free" | "pro", _signal: AbortSignal) => {
-    set(internalDowngradeLoading$, true);
-    set(internalDowngradeError$, null);
-
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingDowngradeContract);
     const result = await client.create({
       body: { targetTier },
     });
-
-    set(internalDowngradeLoading$, false);
 
     if (result.status === 200) {
       set(internalDowngradeDialogOpen$, false);
@@ -200,7 +173,7 @@ export const confirmDowngrade$ = command(
       const message =
         getErrorMessage(result.body) ?? "Failed to downgrade plan";
       log.error("Downgrade failed", message);
-      set(internalDowngradeError$, message);
+      throw new Error(message);
     }
   },
 );
@@ -234,26 +207,20 @@ export const saveAutoRecharge$ = command(
     config: { enabled: boolean; threshold?: number; amount?: number },
     _signal: AbortSignal,
   ) => {
-    set(internalCheckoutLoading$, true);
-
     const createClient = get(zeroClient$);
     const client = createClient(zeroBillingAutoRechargeContract);
     const result = await client.update({ body: config });
 
-    set(internalCheckoutLoading$, false);
-
     if (result.status !== 200) {
       const message = getErrorMessage(result.body);
       log.error("Auto-recharge save failed", message);
-      return { ok: false, error: message };
+      throw new Error(message ?? "Auto-recharge save failed");
     }
 
     // Reload billing status — autoRechargeConfig$ re-derives automatically
     set(billingReload$, (x) => {
       return x + 1;
     });
-
-    return { ok: true };
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -1,4 +1,5 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -14,7 +15,6 @@ import {
   type BillingTier,
   apiTierToBillingTier,
   billingDialogOpen$,
-  billingDialogLoading$,
   billingStatusAsync$,
   closeBillingDialog$,
   startCheckout$,
@@ -121,7 +121,7 @@ const settingsCardBorder = {
 
 export function AutoRechargeSection({
   currentTier,
-  loading,
+  loading: externalLoading,
   variant = "dialog",
 }: {
   currentTier: BillingTier;
@@ -130,7 +130,8 @@ export function AutoRechargeSection({
   variant?: "dialog" | "settings";
 }) {
   const pageSignal = useGet(pageSignal$);
-  const save = useSet(saveAutoRecharge$);
+  const [autoRechargeLoadable, save] = useLoadableSet(saveAutoRecharge$);
+  const loading = externalLoading || autoRechargeLoadable.state === "loading";
   const configLoadable = useLastLoadable(autoRechargeConfig$);
   const config =
     configLoadable.state === "hasData"
@@ -387,15 +388,16 @@ export function AutoRechargeSection({
 export function BillingDialog() {
   const pageSignal = useGet(pageSignal$);
   const open = useGet(billingDialogOpen$);
-  const loading = useGet(billingDialogLoading$);
   const statusLoadable = useLastLoadable(billingStatusAsync$);
   const status =
     statusLoadable.state === "hasData" ? statusLoadable.data : null;
   const close = useSet(closeBillingDialog$);
-  const checkout = useSet(startCheckout$);
+  const [checkoutLoadable, checkout] = useLoadableSet(startCheckout$);
   const openDowngrade = useSet(openDowngradeDialog$);
   const selectedTier = useGet(selectedPlanTier$);
   const setSelectedTier = useSet(setSelectedPlanTier$);
+
+  const loading = checkoutLoadable.state === "loading";
 
   const currentTier: BillingTier = apiTierToBillingTier(status?.tier);
 

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -1,4 +1,5 @@
 import { useGet, useSet, useLoadable } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconExternalLink,
   IconCrown,
@@ -12,14 +13,11 @@ import {
   reloadBillingStatus$,
   startCheckout$,
   startDowngrade$,
-  billingDialogLoading$,
   apiTierToBillingTier,
   openDowngradeDialog$,
   closeDowngradeDialog$,
   confirmDowngrade$,
   downgradeDialogOpen$,
-  downgradeLoading$,
-  downgradeError$,
   type BillingTier,
 } from "../../../../signals/zero-page/billing.ts";
 import {
@@ -245,8 +243,8 @@ function PricingPage({
   onBack: () => void;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const loading = useGet(billingDialogLoading$);
-  const checkout = useSet(startCheckout$);
+  const [checkoutLoadable, checkout] = useLoadableSet(startCheckout$);
+  const loading = checkoutLoadable.state === "loading";
   const openDowngrade = useSet(openDowngradeDialog$);
 
   const handlePlanAction = (planTier: BillingTier) => {
@@ -315,10 +313,13 @@ function formatTierLabel(tier: BillingTier): string {
 function DowngradeConfirmDialog({ currentTier }: { currentTier: BillingTier }) {
   const pageSignal = useGet(pageSignal$);
   const open = useGet(downgradeDialogOpen$);
-  const loading = useGet(downgradeLoading$);
-  const error = useGet(downgradeError$);
+  const [downgradeLoadable, confirm] = useLoadableSet(confirmDowngrade$);
+  const loading = downgradeLoadable.state === "loading";
+  const error =
+    downgradeLoadable.state === "hasError"
+      ? String(downgradeLoadable.error)
+      : null;
   const close = useSet(closeDowngradeDialog$);
-  const confirm = useSet(confirmDowngrade$);
   const selectedTarget = useGet(selectedTarget$);
   const setSelectedTarget = useSet(setSelectedTarget$);
 
@@ -472,9 +473,9 @@ export function OrgBillingTab() {
   const pageSignal = useGet(pageSignal$);
   const reloadBilling = useSet(reloadBillingStatus$);
   const openDowngrade = useSet(openDowngradeDialog$);
-  const portal = useSet(startDowngrade$);
+  const [portalLoadable, portal] = useLoadableSet(startDowngrade$);
   const statusLoadable = useLoadable(billingStatusAsync$);
-  const loading = useGet(billingDialogLoading$);
+  const loading = portalLoadable.state === "loading";
 
   const status =
     statusLoadable.state === "hasData" ? statusLoadable.data : null;


### PR DESCRIPTION
## Summary

- Delete manual loading/error states (`internalCheckoutLoading$`, `internalPortalLoading$`, `internalDowngradeLoading$`, `internalDowngradeError$`) and their derived exports (`billingDialogLoading$`, `downgradeLoading$`, `downgradeError$`) from `billing.ts`
- Simplify commands to throw errors instead of storing in state, letting `useLoadableSet` handle loading/error tracking automatically
- Fix shared-flag bug where `saveAutoRecharge$` incorrectly used `internalCheckoutLoading$` (each operation now has independent loading state)

## Test plan

- [x] All 36 existing tests pass (org-billing-tab, org-usage-tab)
- [ ] Checkout flow: button shows loading, navigates to Stripe
- [ ] Portal redirect: button shows loading, navigates away
- [ ] Downgrade flow: dialog shows loading during API call, shows error on failure, closes on success
- [ ] Auto-recharge save: shows loading independently from checkout

Closes #7780

🤖 Generated with [Claude Code](https://claude.com/claude-code)