### PR TITLE
refactor: replace manual loading booleans with loadable hooks

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -8,14 +8,12 @@ import {
   zeroVariablesContract,
   type ConnectorType,
   type ConnectorResponse,
-  type ScopeDiff,
 } from "@vm0/core";
 import { featureSwitch$ } from "../../external/feature-switch.ts";
 import { connectors$, reloadConnectors$ } from "../../external/connectors.ts";
 import { apiBaseForNavigation$ } from "../../fetch.ts";
 import { zeroClient$ } from "../../api-client.ts";
 import { throwIfAbort } from "../../utils.ts";
-import { logger } from "../../log.ts";
 import { delay } from "signal-timers";
 import { localStorageSignals } from "../../external/local-storage.ts";
 
@@ -152,51 +150,28 @@ export const setSelectedConnectorType$ = command(
 // Scope review modal state
 // ---------------------------------------------------------------------------
 
-const L = logger("ScopeReviewModal");
-
 const internalScopeReviewType$ = state<ConnectorType | null>(null);
 export const scopeReviewType$ = computed((get) => {
   return get(internalScopeReviewType$);
 });
 
-const internalScopeDiff$ = state<ScopeDiff | null>(null);
-export const scopeDiff$ = computed((get) => {
-  return get(internalScopeDiff$);
+export const scopeDiff$ = computed(async (get) => {
+  const type = get(internalScopeReviewType$);
+  if (!type) {
+    return null;
+  }
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroConnectorScopeDiffContract);
+  const result = await client.getScopeDiff({ params: { type } });
+  if (result.status === 200) {
+    return result.body;
+  }
+  throw new Error(`Failed to fetch scope diff: ${result.status}`);
 });
-
-const internalScopeReviewLoading$ = state(false);
-export const scopeReviewLoading$ = computed((get) => {
-  return get(internalScopeReviewLoading$);
-});
-
-const loadScopeDiff$ = command(
-  async ({ get, set }, type: ConnectorType, _signal: AbortSignal) => {
-    const createClient = get(zeroClient$);
-    const client = createClient(zeroConnectorScopeDiffContract);
-    try {
-      const result = await client.getScopeDiff({ params: { type } });
-      if (result.status === 200) {
-        set(internalScopeDiff$, result.body);
-      } else {
-        L.error(`Failed to fetch scope diff: ${result.status}`, result.body);
-      }
-    } catch (error: unknown) {
-      throwIfAbort(error);
-      L.error("Failed to fetch scope diff:", error);
-    } finally {
-      set(internalScopeReviewLoading$, false);
-    }
-  },
-);
 
 export const setScopeReviewType$ = command(
-  async ({ set }, type: ConnectorType | null, signal: AbortSignal) => {
+  ({ set }, type: ConnectorType | null) => {
     set(internalScopeReviewType$, type);
-    if (type) {
-      set(internalScopeDiff$, null);
-      set(internalScopeReviewLoading$, true);
-      await set(loadScopeDiff$, type, signal);
-    }
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/preferences-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/preferences-page.ts
@@ -53,17 +53,3 @@ export const updateSendMode$ = command(
     }
   },
 );
-
-// ---------------------------------------------------------------------------
-// Timezone saving state
-// ---------------------------------------------------------------------------
-
-const internalTimezoneSaving$ = state(false);
-
-export const timezoneSaving$ = computed((get) => {
-  return get(internalTimezoneSaving$);
-});
-
-export const setTimezoneSaving$ = command(({ set }, value: boolean) => {
-  set(internalTimezoneSaving$, value);
-});

--- a/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
@@ -37,21 +37,12 @@ export const pinnedAgentIds$ = computed((get) => {
 });
 
 /**
- * Whether a pinned agents update is in flight.
- */
-const internalSavingPinned$ = state(false);
-export const savingPinnedAgents$ = computed((get) => {
-  return get(internalSavingPinned$);
-});
-
-/**
  * Update pinned agent IDs on the server with optimistic UI.
  */
 export const updatePinnedAgentIds$ = command(
   async ({ get, set }, ids: string[], _signal: AbortSignal) => {
     // Optimistic update — UI reflects the change immediately
     set(optimisticPinnedIds$, ids);
-    set(internalSavingPinned$, true);
     try {
       const createClient = get(zeroClient$);
       const client = createClient(zeroUserPreferencesContract);
@@ -71,7 +62,6 @@ export const updatePinnedAgentIds$ = command(
       });
     } finally {
       set(optimisticPinnedIds$, null);
-      set(internalSavingPinned$, false);
     }
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/scope-review-modal.tsx
@@ -1,4 +1,4 @@
-import { useGet } from "ccstate-react";
+import { useLoadable } from "ccstate-react";
 import {
   Dialog,
   DialogContent,
@@ -7,10 +7,7 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { ConnectorIcon } from "./connector-icons.tsx";
-import {
-  scopeDiff$,
-  scopeReviewLoading$,
-} from "../../../../signals/zero-page/settings/connectors.ts";
+import { scopeDiff$ } from "../../../../signals/zero-page/settings/connectors.ts";
 
 interface ScopeReviewModalProps {
   connectorType: ConnectorType | null;
@@ -23,8 +20,10 @@ export function ScopeReviewModal({
   onClose,
   onReconnect,
 }: ScopeReviewModalProps) {
-  const scopeDiff = useGet(scopeDiff$);
-  const loading = useGet(scopeReviewLoading$);
+  const scopeDiffLoadable = useLoadable(scopeDiff$);
+  const loading = scopeDiffLoadable.state === "loading";
+  const scopeDiff =
+    scopeDiffLoadable.state === "hasData" ? scopeDiffLoadable.data : null;
 
   if (!connectorType) {
     return null;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/timezone-settings.tsx
@@ -1,4 +1,5 @@
-import { useGet, useLastResolved, useSet } from "ccstate-react";
+import { useGet, useLastResolved } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
   Select,
@@ -15,31 +16,21 @@ import {
   updateUserPreference$,
 } from "../../../../signals/zero-page/settings/user-preferences.ts";
 import {
-  timezoneSaving$,
-  setTimezoneSaving$,
-} from "../../../../signals/zero-page/settings/preferences-page.ts";
-import {
   COMMON_TIMEZONES,
   getTimezoneLabel,
 } from "../../../../signals/zero-page/cron.ts";
 
 export function TimezoneSettings() {
   const preferences = useLastResolved(userPreferences$);
-  const updatePreference = useSet(updateUserPreference$);
+  const [tzLoadable, updatePreference] = useLoadableSet(updateUserPreference$);
   const pageSignal = useGet(pageSignal$);
 
-  const loading = useGet(timezoneSaving$);
-  const setLoading = useSet(setTimezoneSaving$);
+  const loading = tzLoadable.state === "loading";
 
   const handleChange = (value: string) => {
-    setLoading(true);
-    updatePreference({ timezone: value }, pageSignal)
-      .finally(() => {
-        setLoading(false);
-      })
-      .catch(() => {
-        toast.error("Failed to update timezone");
-      });
+    updatePreference({ timezone: value }, pageSignal).catch(() => {
+      toast.error("Failed to update timezone");
+    });
   };
 
   if (!preferences) {

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -310,7 +310,7 @@ export function ZeroConnectorsPage() {
           return disconnectHandler(c.type);
         }}
         onReviewScopes={() => {
-          return detach(setScopeReviewType(c.type, signal), Reason.DomCallback);
+          return setScopeReviewType(c.type);
         }}
       />
     );
@@ -434,10 +434,10 @@ export function ZeroConnectorsPage() {
         <ScopeReviewModal
           connectorType={scopeReviewType}
           onClose={() => {
-            return detach(setScopeReviewType(null, signal), Reason.DomCallback);
+            return setScopeReviewType(null);
           }}
           onReconnect={(type) => {
-            detach(setScopeReviewType(null, signal), Reason.DomCallback);
+            setScopeReviewType(null);
             detach(connect(type, signal), Reason.DomCallback);
           }}
         />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   useGet,
   useSet,
 } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   IconChartBar,
@@ -83,7 +84,6 @@ import {
 } from "../../signals/zero-page/zero-chat.ts";
 import {
   pinnedAgentIds$,
-  savingPinnedAgents$,
   updatePinnedAgentIds$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
 import {
@@ -1240,8 +1240,8 @@ export function ZeroSidebar() {
   const pinnedIdsLoadable = useLastLoadable(pinnedAgentIds$);
   const pinnedIds: string[] =
     pinnedIdsLoadable.state === "hasData" ? pinnedIdsLoadable.data : [];
-  const savingPinned = useGet(savingPinnedAgents$);
-  const savePinnedIds = useSet(updatePinnedAgentIds$);
+  const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
+  const savingPinned = pinLoadable.state === "loading";
   const setPinnedIds = (ids: string[]) => {
     detach(savePinnedIds(ids, pageSignal), Reason.DomCallback);
   };


### PR DESCRIPTION
## Summary

- **Pinned agents**: Remove `internalSavingPinned$`/`savingPinnedAgents$` from signals, use `useLoadableSet(updatePinnedAgentIds$)` in sidebar to derive loading state
- **Timezone**: Remove `internalTimezoneSaving$`/`timezoneSaving$`/`setTimezoneSaving$` from signals, use `useLoadableSet(updateUserPreference$)` in timezone view
- **Scope review**: Convert `scopeDiff$` to async computed depending on `scopeReviewType$`, use `useLoadable(scopeDiff$)` in modal, simplify `setScopeReviewType$` to synchronous setter, remove `loadScopeDiff$` command and manual loading state

Closes #7781

## Test plan

- [x] `pnpm check-types` passes
- [x] `pnpm turbo run lint` passes (no new warnings)
- [x] `pnpm knip` reports no unused exports
- [x] `pnpm format` produces no changes
- [x] `pnpm vitest` -- all test failures are pre-existing on main (unrelated web app tests)
- [ ] Manual: pinned agents save shows loading indicator, optimistic update still works
- [ ] Manual: timezone select shows spinner during save, error toast on failure
- [ ] Manual: scope review modal shows loading while fetching diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)