### PR TITLE
refactor: replace manual loading booleans with loadable set hook in zero-jobs-page

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-jobs-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-jobs-page.ts
@@ -1,7 +1,5 @@
 import { command, computed, state } from "ccstate";
 import { randomPresetAvatar } from "../../views/zero-page/avatar-utils.ts";
-import { throwIfAbort } from "../utils.ts";
-import { toast } from "@vm0/ui/components/ui/sonner";
 
 // ---------------------------------------------------------------------------
 // Create-teammate dialog state
@@ -57,22 +55,17 @@ export const uploadJobsAvatar$ = command(
     ) => Promise<Response>,
     _signal: AbortSignal,
   ): Promise<void> => {
-    try {
-      const formData = new FormData();
-      formData.append("file", file);
-      const res = await fetchFn("/api/zero/uploads", {
-        method: "POST",
-        body: formData,
-      });
-      if (!res.ok) {
-        throw new Error(`Upload failed (${res.status})`);
-      }
-      const data: { url: string } = await res.json();
-      set(internalAvatarUrl$, data.url);
-    } catch (error) {
-      throwIfAbort(error);
-      toast.error("Failed to upload avatar");
+    const formData = new FormData();
+    formData.append("file", file);
+    const res = await fetchFn("/api/zero/uploads", {
+      method: "POST",
+      body: formData,
+    });
+    if (!res.ok) {
+      throw new Error(`Upload failed (${res.status})`);
     }
+    const data: { url: string } = await res.json();
+    set(internalAvatarUrl$, data.url);
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-jobs-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-jobs-page.ts
@@ -1,5 +1,7 @@
 import { command, computed, state } from "ccstate";
 import { randomPresetAvatar } from "../../views/zero-page/avatar-utils.ts";
+import { throwIfAbort } from "../utils.ts";
+import { toast } from "@vm0/ui/components/ui/sonner";
 
 // ---------------------------------------------------------------------------
 // Create-teammate dialog state
@@ -27,9 +29,6 @@ const internalAvatarUrl$ = state(randomPresetAvatar());
 export const jobsAvatarUrl$ = computed((get) => {
   return get(internalAvatarUrl$);
 });
-export const setJobsAvatarUrl$ = command(({ set }, url: string) => {
-  set(internalAvatarUrl$, url);
-});
 export const resetJobsAvatarUrl$ = command(({ set }) => {
   set(internalAvatarUrl$, randomPresetAvatar());
 });
@@ -46,25 +45,36 @@ export const setJobsFileInputEl$ = command(
   },
 );
 
-// -- Avatar upload loading --------------------------------------------------
+// -- Upload avatar command --------------------------------------------------
 
-const internalUploading$ = state(false);
-export const jobsUploading$ = computed((get) => {
-  return get(internalUploading$);
-});
-export const setJobsUploading$ = command(({ set }, uploading: boolean) => {
-  set(internalUploading$, uploading);
-});
-
-// -- Create loading ---------------------------------------------------------
-
-const internalCreating$ = state(false);
-export const jobsCreating$ = computed((get) => {
-  return get(internalCreating$);
-});
-export const setJobsCreating$ = command(({ set }, creating: boolean) => {
-  set(internalCreating$, creating);
-});
+export const uploadJobsAvatar$ = command(
+  async (
+    { set },
+    file: File,
+    fetchFn: (
+      url: string | URL | Request,
+      options?: RequestInit,
+    ) => Promise<Response>,
+    _signal: AbortSignal,
+  ): Promise<void> => {
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await fetchFn("/api/zero/uploads", {
+        method: "POST",
+        body: formData,
+      });
+      if (!res.ok) {
+        throw new Error(`Upload failed (${res.status})`);
+      }
+      const data: { url: string } = await res.json();
+      set(internalAvatarUrl$, data.url);
+    } catch (error) {
+      throwIfAbort(error);
+      toast.error("Failed to upload avatar");
+    }
+  },
+);
 
 // -- Reset dialog state on close --------------------------------------------
 

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -353,9 +353,10 @@ function CreateTeammateDialogContent({
   const fileInputEl = useGet(jobsFileInputEl$);
   const setFileInputEl = useSet(setJobsFileInputEl$);
   const fetchFn = useGet(fetch$);
+  const pageSignal = useGet(pageSignal$);
 
   const handleUpload = (file: File) => {
-    detach(uploadAvatarFn(file, fetchFn), Reason.DomCallback);
+    detach(uploadAvatarFn(file, fetchFn, pageSignal), Reason.DomCallback);
   };
 
   const isCustom = !avatarUrl.startsWith(AVATAR_PRESET_PREFIX);

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -1,4 +1,5 @@
 import { useGet, useLastResolved, useLoadable, useSet } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   IconCrown,
@@ -27,7 +28,7 @@ import {
   defaultAgentId$,
 } from "../../signals/zero-page/zero-agent-name.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
-import { detach, Reason, throwIfAbort } from "../../signals/utils.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { Link } from "../router/link.tsx";
 import { useAgentAvatar } from "./zero-sidebar.tsx";
 import { ZERO_AVATARS } from "./zero-avatars.ts";
@@ -38,13 +39,9 @@ import {
   setJobsDialogOpen$,
   jobsNewName$,
   setJobsNewName$,
-  jobsCreating$,
-  setJobsCreating$,
   jobsAvatarUrl$,
-  setJobsAvatarUrl$,
   resetJobsAvatarUrl$,
-  jobsUploading$,
-  setJobsUploading$,
+  uploadJobsAvatar$,
   jobsFileInputEl$,
   setJobsFileInputEl$,
   resetJobsDialog$,
@@ -71,10 +68,9 @@ export function ZeroJobsPage() {
   const setDialogOpen = useSet(setJobsDialogOpen$);
   const newName = useGet(jobsNewName$);
   const setNewName = useSet(setJobsNewName$);
-  const creating = useGet(jobsCreating$);
-  const setCreating = useSet(setJobsCreating$);
+  const [createLoadable, createSubagentFn] = useLoadableSet(createSubagent$);
+  const creating = createLoadable.state === "loading";
   const resetDialog = useSet(resetJobsDialog$);
-  const createSubagent = useSet(createSubagent$);
   const pageSignal = useGet(pageSignal$);
 
   const handleCreateTeammate = (avatarUrl: string) => {
@@ -82,17 +78,14 @@ export function ZeroJobsPage() {
     if (!trimmed || creating) {
       return;
     }
-    setCreating(true);
     detach(
-      createSubagent(trimmed, avatarUrl, pageSignal).then(
+      createSubagentFn(trimmed, avatarUrl, pageSignal).then(
         () => {
           setDialogOpen(false);
           resetDialog();
-          setCreating(false);
           toast.success(`${trimmed} created successfully`);
         },
         (error: unknown) => {
-          setCreating(false);
           toast.error(
             error instanceof Error
               ? error.message
@@ -354,34 +347,15 @@ function CreateTeammateDialogContent({
   creating: boolean;
 }) {
   const avatarUrl = useGet(jobsAvatarUrl$);
-  const setAvatarUrl = useSet(setJobsAvatarUrl$);
   const resetAvatarUrl = useSet(resetJobsAvatarUrl$);
-  const uploading = useGet(jobsUploading$);
-  const setUploading = useSet(setJobsUploading$);
+  const [uploadLoadable, uploadAvatarFn] = useLoadableSet(uploadJobsAvatar$);
+  const uploading = uploadLoadable.state === "loading";
   const fileInputEl = useGet(jobsFileInputEl$);
   const setFileInputEl = useSet(setJobsFileInputEl$);
   const fetchFn = useGet(fetch$);
 
-  const handleUpload = async (file: File) => {
-    setUploading(true);
-    try {
-      const formData = new FormData();
-      formData.append("file", file);
-      const res = await fetchFn("/api/zero/uploads", {
-        method: "POST",
-        body: formData,
-      });
-      if (!res.ok) {
-        throw new Error(`Upload failed (${res.status})`);
-      }
-      const data: { url: string } = await res.json();
-      setAvatarUrl(data.url);
-    } catch (error) {
-      throwIfAbort(error);
-      toast.error("Failed to upload avatar");
-    } finally {
-      setUploading(false);
-    }
+  const handleUpload = (file: File) => {
+    detach(uploadAvatarFn(file, fetchFn), Reason.DomCallback);
   };
 
   const isCustom = !avatarUrl.startsWith(AVATAR_PRESET_PREFIX);
@@ -422,7 +396,7 @@ function CreateTeammateDialogContent({
               onChange={(e) => {
                 const file = e.target.files?.[0];
                 if (file) {
-                  detach(handleUpload(file), Reason.DomCallback);
+                  handleUpload(file);
                 }
                 e.target.value = "";
               }}

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -356,7 +356,17 @@ function CreateTeammateDialogContent({
   const pageSignal = useGet(pageSignal$);
 
   const handleUpload = (file: File) => {
-    detach(uploadAvatarFn(file, fetchFn, pageSignal), Reason.DomCallback);
+    detach(
+      uploadAvatarFn(file, fetchFn, pageSignal).then(
+        undefined,
+        (error: unknown) => {
+          toast.error(
+            error instanceof Error ? error.message : "Failed to upload avatar",
+          );
+        },
+      ),
+      Reason.DomCallback,
+    );
   };
 
   const isCustom = !avatarUrl.startsWith(AVATAR_PRESET_PREFIX);


### PR DESCRIPTION
## Summary

- Migrates `creating` state in `ZeroJobsPage` from manual `jobsCreating$`/`setJobsCreating$` boolean signals to `useLoadableSet(createSubagent$)`
- Migrates `uploading` state in `CreateTeammateDialogContent` from manual `jobsUploading$`/`setJobsUploading$` signals to `useLoadableSet(uploadJobsAvatar$)`
- Adds new `uploadJobsAvatar$` command to `signals/zero-page/zero-jobs-page.ts` that wraps the avatar fetch call (Option A from the issue), mirroring the pattern from `settings-tab.ts`
- Removes now-unused signals: `jobsCreating$`, `setJobsCreating$`, `jobsUploading$`, `setJobsUploading$`, `setJobsAvatarUrl$`

Closes #7782

## Test plan

- [ ] Create agent button shows loading spinner during agent creation
- [ ] Dialog closes on success and toast fires
- [ ] Double-click prevention naturally works (loading state blocks re-entry)
- [ ] Avatar upload button shows spinner during upload
- [ ] Failed upload shows error toast
- [ ] `pnpm turbo run lint` passes
- [ ] `pnpm knip` passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)