### PR TITLE
fix(ci): retry browser benchmark on transient network change

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -456,11 +456,13 @@ jobs:
             'curl -sf --max-time 10 https://httpbin.org/get'"
 
           echo "=== Running benchmark (browser automation) ==="
+          # Retry once — snapshot restore can trigger transient Chromium
+          # ERR_NETWORK_CHANGED due to stale netlink messages.
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo ${BIN_DIR}/runner benchmark \
             --config ${RUNNER_DIR}/runner.yaml \
             --profile vm0/default \
-            'agent-browser open https://github.com/ && agent-browser get title && agent-browser close'"
+            '(agent-browser open https://github.com/ && agent-browser get title && agent-browser close) || (sleep 2 && agent-browser open https://github.com/ && agent-browser get title && agent-browser close)'"
 
   runner-exec:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Snapshot restore can trigger Chromium `ERR_NETWORK_CHANGED` due to stale netlink messages in the guest kernel
- Add in-VM retry with 2s delay to let the netlink buffer drain before second attempt
- Fixes intermittent `runner-benchmark` CI failures ([example](https://github.com/vm0-ai/vm0/actions/runs/23911085733/job/69733410929))

## Test plan
- [ ] Verify `runner-benchmark` job passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)