### PR TITLE
fix: respect redirect_url query parameter after sign-in and sign-up

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -86,11 +86,18 @@ export const mockedClerk = {
   },
   get session() {
     return {
+      id: "test-session-id",
       getToken: () => {
         return Promise.resolve(internalMockedSession?.token ?? "");
       },
     };
   },
+  signOut: vi.fn(() => {
+    return Promise.resolve();
+  }),
+  openUserProfile: vi.fn(() => {
+    return Promise.resolve();
+  }),
   load: () => {
     return Promise.resolve();
   },

--- a/turbo/apps/platform/src/signals/__tests__/auth.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/auth.test.ts
@@ -1,10 +1,45 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { testContext } from "./test-helpers";
 import { setupPage } from "../../__tests__/page-helper";
 import { fireClerkListeners, mockUser } from "../../__tests__/mock-auth";
-import { setupClerk$, user$ } from "../auth";
+import { setupClerk$, user$, resolveWebOrigin } from "../auth";
 
 const context = testContext();
+
+describe("resolveWebOrigin", () => {
+  it("should replace platform subdomain with www", () => {
+    vi.stubGlobal("location", new URL("https://platform.vm0.ai/agents"));
+    expect(resolveWebOrigin()).toBe("https://www.vm0.ai");
+    vi.unstubAllGlobals();
+  });
+
+  it("should replace app subdomain with www", () => {
+    vi.stubGlobal("location", new URL("https://app.vm0.ai/connectors"));
+    expect(resolveWebOrigin()).toBe("https://www.vm0.ai");
+    vi.unstubAllGlobals();
+  });
+
+  it("should handle hyphenated subdomains like staging-platform", () => {
+    vi.stubGlobal(
+      "location",
+      new URL("https://staging-platform.vm0.ai/agents"),
+    );
+    expect(resolveWebOrigin()).toBe("https://staging-www.vm0.ai");
+    vi.unstubAllGlobals();
+  });
+
+  it("should return origin unchanged when no platform/app subdomain", () => {
+    vi.stubGlobal("location", new URL("https://www.vm0.ai/"));
+    expect(resolveWebOrigin()).toBe("https://www.vm0.ai");
+    vi.unstubAllGlobals();
+  });
+
+  it("should return empty string when origin is missing", () => {
+    vi.stubGlobal("location", { origin: "" });
+    expect(resolveWebOrigin()).toBe("");
+    vi.unstubAllGlobals();
+  });
+});
 
 describe("setupClerk$ auth reload filtering", () => {
   it("should not trigger user$ recomputation on token refresh (same user)", async () => {

--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -8,7 +8,7 @@ const reload$ = state(0);
  * Replaces "platform" or "app" with "www" in the hostname so sign-in/sign-out
  * redirects land on the web app where auth pages live.
  */
-function resolveWebOrigin(): string {
+export function resolveWebOrigin(): string {
   const origin = location.origin;
   if (!origin || origin === "null") {
     return "";

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -53,7 +53,7 @@ import {
 } from "@vm0/ui/components/ui/dialog";
 import { Skeleton } from "@vm0/ui/components/ui/skeleton";
 import slackIcon from "./components/settings/icons/slack.svg";
-import { clerk$, user$ } from "../../signals/auth.ts";
+import { clerk$, user$, resolveWebOrigin } from "../../signals/auth.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   activeRoute$,
@@ -286,7 +286,11 @@ export function AccountDropdown({
   const handleAccountAction = (action: ZeroAccountAction) => {
     if (action === "signout") {
       const sessionId = clerk?.session?.id;
-      detach(clerk?.signOut({ sessionId }), Reason.DomCallback);
+      const signInUrl = `${resolveWebOrigin()}/sign-in?redirect_url=${encodeURIComponent(location.href)}`;
+      detach(
+        clerk?.signOut({ sessionId, redirectUrl: signInUrl }),
+        Reason.DomCallback,
+      );
       return;
     }
     if (action === "manage") {

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -136,8 +136,8 @@ export default function RootLayout({
       publishableKey={getClerkPublishableKey()}
       signInUrl="/sign-in"
       signUpUrl="/sign-up"
-      signInForceRedirectUrl={getAppUrl()}
-      signUpForceRedirectUrl={getAppUrl()}
+      signInFallbackRedirectUrl={getAppUrl()}
+      signUpFallbackRedirectUrl={getAppUrl()}
       allowedRedirectOrigins={[getAppUrl()]}
     >
       <html lang="en" data-theme="dark" suppressHydrationWarning>


### PR DESCRIPTION
## Summary
- Switch ClerkProvider from `forceRedirectUrl` to `fallbackRedirectUrl` so that `?redirect_url` query parameters are respected after sign-in/sign-up
- When no `redirect_url` is present, behavior is unchanged — users still redirect to `NEXT_PUBLIC_APP_URL` (platform app)
- This fixes broken flows in connector OAuth (`/api/connectors/[type]/authorize`) and Slack connect (`/api/zero/slack/connect`) where unauthenticated users were redirected to sign-in with a `redirect_url` param that was silently ignored

## Context
Clerk's `forceRedirectUrl` always overrides any `redirect_url` query parameter. Two API routes already set `redirect_url` when redirecting unauthenticated users to sign-in, but the parameter had no effect. Switching to `fallbackRedirectUrl` makes Clerk respect the param when present, and fall back to the default URL otherwise.

## Test plan
- [ ] Sign in without `redirect_url` → redirects to platform app (unchanged behavior)
- [ ] Sign up without `redirect_url` → redirects to platform app (unchanged behavior)
- [ ] Visit `/api/connectors/{type}/authorize` unauthenticated → sign in → returns to connector authorize flow
- [ ] Visit `/api/zero/slack/connect` unauthenticated → sign in → returns to Slack connect flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)