### PR TITLE
feat: add connector read capability and gate connector api endpoints

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -248,4 +248,29 @@ describe("registerZeroCommands", () => {
     expect(visibleCommandNames(prog)).toEqual(["schedule", "whoami"]);
     expect(hiddenCommandNames(prog)).toContain("agent");
   });
+
+  it("should show connector when connector:read capability is present", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["connector:read"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+
+    expect(visibleCommandNames(prog)).toContain("connector");
+    expect(visibleCommandNames(prog)).toContain("whoami");
+  });
+
+  it("should hide connector when connector:read capability is missing", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["agent:read"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+
+    expect(hiddenCommandNames(prog)).toContain("connector");
+  });
 });

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -30,6 +30,7 @@ import {
 const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   agent: "agent:read",
   skill: "agent:read",
+  connector: "connector:read",
   run: "agent-run:write",
   schedule: "schedule:read",
   doctor: null,

--- a/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/__tests__/route.test.ts
@@ -59,7 +59,7 @@ describe("GET /api/zero/connectors/:type", () => {
     expect(response.status).toBe(401);
   });
 
-  it("should allow access with ZERO_TOKEN (agent:read capability)", async () => {
+  it("should allow access with ZERO_TOKEN (connector:read capability)", async () => {
     const user = await context.setupUser();
 
     await context.createConnector(user.orgId, {

--- a/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/[type]/route.ts
@@ -21,7 +21,7 @@ const router = tsr.router(zeroConnectorsByTypeContract, {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
-      requiredCapability: "agent:read",
+      requiredCapability: "connector:read",
     });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;

--- a/turbo/apps/web/app/api/zero/connectors/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/route.ts
@@ -20,7 +20,9 @@ const router = tsr.router(zeroConnectorsMainContract, {
   list: async ({ headers }) => {
     initServices();
 
-    const authCtx = await requireAuth(headers.authorization);
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "connector:read",
+    });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;
 

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -245,6 +245,7 @@ describe("sandbox-token", () => {
         "schedule:read",
         "schedule:write",
         "slack:write",
+        "connector:read",
       ]);
     });
 

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -23,8 +23,8 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 7 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(7);
+  it("should have exactly 8 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(8);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -34,6 +34,7 @@ export const ZERO_CAPABILITIES = [
   "schedule:read",
   "schedule:write",
   "slack:write",
+  "connector:read",
 ] as const;
 
 /** Inferred union type of all zero capability strings. */
@@ -62,6 +63,7 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
       label: "Create & delete schedules",
     },
     "slack:write": { group: "Integrations", label: "Send Slack messages" },
+    "connector:read": { group: "Connectors", label: "View connected services" },
   };
 
 /**


### PR DESCRIPTION
## Summary

- Add `connector:read` to `ZERO_CAPABILITIES` with metadata in `ZERO_CAPABILITY_META`
- Register `connector` command in `COMMAND_CAPABILITY_MAP` mapped to `connector:read`
- Gate `GET /api/zero/connectors` (list) with `requiredCapability: "connector:read"`
- Change `GET /api/zero/connectors/[type]` (get) from `agent:read` to `connector:read`
- Add CLI capability visibility tests for connector command

## Test plan

- [x] `pnpm vitest run zero-capability-visibility` — all 19 tests pass (2 new)
- [x] `pnpm check-types` — core and cli packages type-check clean
- [x] `pnpm turbo run lint` — no warnings or errors
- [x] `pnpm format` — no formatting changes needed
- [x] `pnpm knip` — no unused exports or dependencies

Closes #7816

🤖 Generated with [Claude Code](https://claude.com/claude-code)