### PR TITLE
feat(cli): show connected service identity in zero whoami

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -4,6 +4,8 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import * as os from "os";
 import chalk from "chalk";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
 import { zeroWhoamiCommand } from "../whoami";
 
 // Mock os.homedir to use temp directory for config isolation
@@ -179,6 +181,277 @@ describe("zero whoami command", () => {
           return line.includes("unavailable");
         }),
       ).toBe(true);
+    });
+
+    it("should show connected service identities", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [
+              {
+                id: "1",
+                type: "github",
+                authMethod: "oauth",
+                externalId: "12345",
+                externalUsername: "octocat",
+                externalEmail: "octocat@github.com",
+                oauthScopes: ["repo"],
+                needsReconnect: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                id: "2",
+                type: "google",
+                authMethod: "oauth",
+                externalId: "67890",
+                externalUsername: null,
+                externalEmail: "user@gmail.com",
+                oauthScopes: ["email"],
+                needsReconnect: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            configuredTypes: ["github", "google"],
+            connectorProvidedSecretNames: [],
+          });
+        }),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return line.includes("Connected Services:");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return (
+            line.includes("@octocat") && line.includes("(octocat@github.com)")
+          );
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("google") && line.includes("user@gmail.com");
+        }),
+      ).toBe(true);
+    });
+
+    it("should show needs reconnect warning", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [
+              {
+                id: "1",
+                type: "slack",
+                authMethod: "oauth",
+                externalId: "S123",
+                externalUsername: "john.doe",
+                externalEmail: null,
+                oauthScopes: ["chat:write"],
+                needsReconnect: true,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            configuredTypes: ["slack"],
+            connectorProvidedSecretNames: [],
+          });
+        }),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return (
+            line.includes("@john.doe") && line.includes("(needs reconnect)")
+          );
+        }),
+      ).toBe(true);
+    });
+
+    it("should gracefully handle connector API error", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json(
+            { error: { message: "Forbidden", code: "FORBIDDEN" } },
+            { status: 403 },
+          );
+        }),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return line.includes("Agent ID:");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("run-abc");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("Connected Services:");
+        }),
+      ).toBe(false);
+    });
+
+    it("should skip connected services section when no connectors have identity", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [],
+            configuredTypes: [],
+            connectorProvidedSecretNames: [],
+          });
+        }),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return line.includes("Agent ID:");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("Connected Services:");
+        }),
+      ).toBe(false);
+    });
+
+    it("should skip connectors without identity info", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [
+              {
+                id: "1",
+                type: "github",
+                authMethod: "oauth",
+                externalId: "12345",
+                externalUsername: "octocat",
+                externalEmail: "octocat@github.com",
+                oauthScopes: ["repo"],
+                needsReconnect: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+              {
+                id: "2",
+                type: "axiom",
+                authMethod: "api-token",
+                externalId: null,
+                externalUsername: null,
+                externalEmail: null,
+                oauthScopes: null,
+                needsReconnect: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            configuredTypes: ["github", "axiom"],
+            connectorProvidedSecretNames: [],
+          });
+        }),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return line.includes("Connected Services:");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("@octocat");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("axiom");
+        }),
+      ).toBe(false);
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -49,8 +49,8 @@ async function showSandboxInfo(): Promise<void> {
           identity = `@${connector.externalUsername} (${connector.externalEmail})`;
         } else if (connector.externalUsername) {
           identity = `@${connector.externalUsername}`;
-        } else {
-          identity = connector.externalEmail!;
+        } else if (connector.externalEmail) {
+          identity = connector.externalEmail;
         }
         if (connector.needsReconnect) {
           identity += ` ${chalk.yellow("(needs reconnect)")}`;

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -6,6 +6,7 @@ import {
   getToken,
   decodeZeroTokenPayload,
 } from "../../lib/api/config";
+import { listZeroConnectors } from "../../lib/api";
 import { withErrorHandler } from "../../lib/command";
 
 /**
@@ -30,6 +31,35 @@ async function showSandboxInfo(): Promise<void> {
     console.log();
     console.log(chalk.bold("Capabilities:"));
     console.log(`  ${payload.capabilities.join(", ")}`);
+  }
+
+  // Connected Services section
+  try {
+    const result = await listZeroConnectors();
+    const identities = result.connectors.filter((c) => {
+      return c.externalUsername !== null || c.externalEmail !== null;
+    });
+
+    if (identities.length > 0) {
+      console.log();
+      console.log(chalk.bold("Connected Services:"));
+      for (const connector of identities) {
+        let identity = "";
+        if (connector.externalUsername && connector.externalEmail) {
+          identity = `@${connector.externalUsername} (${connector.externalEmail})`;
+        } else if (connector.externalUsername) {
+          identity = `@${connector.externalUsername}`;
+        } else {
+          identity = connector.externalEmail!;
+        }
+        if (connector.needsReconnect) {
+          identity += ` ${chalk.yellow("(needs reconnect)")}`;
+        }
+        console.log(`  ${connector.type.padEnd(14)}${identity}`);
+      }
+    }
+  } catch {
+    // Silently skip — connector info is supplementary
   }
 }
 


### PR DESCRIPTION
## Summary

- Display connected OAuth service identities (GitHub username, Google email, Slack handle, etc.) in `zero whoami` sandbox mode
- AI agents can now resolve "me"/"my"/"I" references by running `zero whoami` without extra API calls
- Gracefully handles API errors — basic whoami info (Agent ID, Run ID, Org ID) always works

Closes #7817

## Changes

- **`turbo/apps/cli/src/commands/zero/whoami.ts`** — Add `listZeroConnectors()` call in `showSandboxInfo()` to display connected service identities after capabilities section
- **`turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts`** — Add 5 integration tests: identity display, reconnect warning, API error handling, empty list, no-identity connectors

## Output Format

```
Agent ID:   agent-123
Run ID:     run-abc
Org ID:     org-xyz

Capabilities:
  agent:read, connector:read

Connected Services:
  github        @octocat (octocat@github.com)
  google        user@gmail.com
  slack         @john.doe (needs reconnect)
```

## Test plan

- [x] All existing whoami tests pass
- [x] New tests: identity display with username + email
- [x] New tests: email-only connector display
- [x] New tests: needsReconnect warning indicator
- [x] New tests: graceful API error handling (basic info still shows)
- [x] New tests: empty connector list skips section
- [x] New tests: connectors without identity info are filtered out
- [x] Lint, type-check, format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)