### PR TITLE
fix(cli): bundle pure js deps to prevent intermittent ci module resolution failures

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1255,6 +1255,8 @@ jobs:
           path: /tmp/cli-deploy
       - name: Link CLI globally
         run: cd /tmp/cli-deploy && sudo npm link
+      - name: Smoke test CLI
+        run: vm0 --help
       - name: Download E2E test tokens
         uses: actions/download-artifact@v8
         with:
@@ -1699,6 +1701,8 @@ jobs:
           path: /tmp/cli-deploy
       - name: Link CLI globally
         run: cd /tmp/cli-deploy && sudo npm link
+      - name: Smoke test CLI
+        run: vm0 --help
       - name: Download E2E test tokens
         uses: actions/download-artifact@v8
         with:
@@ -1756,6 +1760,8 @@ jobs:
           path: /tmp/cli-deploy
       - name: Link CLI globally
         run: cd /tmp/cli-deploy && sudo npm link
+      - name: Smoke test CLI
+        run: vm0 --help
       - name: Install GNU parallel for bats
         run: sudo curl -sL https://raw.githubusercontent.com/martinda/gnu-parallel/master/src/parallel -o /usr/local/bin/parallel && sudo chmod +x /usr/local/bin/parallel
       - name: Download E2E test tokens

--- a/turbo/apps/cli/package.json
+++ b/turbo/apps/cli/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@vm0/cli\"; delete this.private; delete this.scripts; delete this.devDependencies; delete this.dependencies[\"@vm0/core\"]; this.bin[\"vm0\"]=\"index.js\"; this.bin[\"zero\"]=\"zero.js\"; this.files=[\"*.js\",\"*.js.map\"]'",
+    "postbuild": "cp package.json dist/ && pnpm json -I -f dist/package.json -e 'this.name=\"@vm0/cli\"; delete this.private; delete this.scripts; delete this.devDependencies; delete this.dependencies[\"@vm0/core\"]; delete this.dependencies[\"commander\"]; delete this.dependencies[\"chalk\"]; delete this.dependencies[\"prompts\"]; delete this.dependencies[\"yaml\"]; delete this.dependencies[\"zod\"]; delete this.dependencies[\"dotenv\"]; delete this.dependencies[\"tar\"]; delete this.dependencies[\"undici\"]; delete this.dependencies[\"@ts-rest/core\"]; this.bin[\"vm0\"]=\"index.js\"; this.bin[\"zero\"]=\"zero.js\"; this.files=[\"*.js\",\"*.js.map\"]'",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/turbo/apps/cli/tsup.config.ts
+++ b/turbo/apps/cli/tsup.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "tsup";
 import { readFileSync } from "fs";
 import { execSync } from "child_process";
+import { resolve } from "path";
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8")) as {
   version: string;
@@ -42,6 +43,13 @@ export default defineConfig({
     "undici",
     "@ts-rest/core",
   ],
+  esbuildOptions(options) {
+    // Add CLI's node_modules as a fallback resolution path so esbuild can
+    // find bundled deps (zod, yaml, @ts-rest/core) when they're imported
+    // from @vm0/core source files during bundling. In CI's filtered pnpm
+    // install, these deps may not be symlinked into core's node_modules.
+    options.nodePaths = [resolve("node_modules")];
+  },
   // Inject version and default Sentry DSN from package.json/env at build time
   define: {
     __CLI_VERSION__: JSON.stringify(pkg.version),

--- a/turbo/apps/cli/tsup.config.ts
+++ b/turbo/apps/cli/tsup.config.ts
@@ -18,10 +18,30 @@ export default defineConfig({
   clean: true,
   shims: true,
   banner: {
-    js: "#!/usr/bin/env node",
+    js: [
+      "#!/usr/bin/env node",
+      // Provide a real require() for CJS packages bundled into ESM output.
+      // esbuild's __require shim checks typeof require and uses it if available.
+      'import { createRequire as __bundled_createRequire } from "module";',
+      "var require = __bundled_createRequire(import.meta.url);",
+    ].join("\n"),
   },
-  // Bundle workspace packages
-  noExternal: [/@vm0\/.*/],
+  // Bundle workspace packages and pure JS dependencies to avoid
+  // intermittent "Cannot find module" failures in CI artifact transfer.
+  // Keep @sentry/node external (OpenTelemetry runtime hooks) and
+  // @ngrok/ngrok external (native NAPI bindings).
+  noExternal: [
+    /@vm0\/.*/,
+    "commander",
+    "chalk",
+    "prompts",
+    "yaml",
+    "zod",
+    "dotenv",
+    "tar",
+    "undici",
+    "@ts-rest/core",
+  ],
   // Inject version and default Sentry DSN from package.json/env at build time
   define: {
     __CLI_VERSION__: JSON.stringify(pkg.version),


### PR DESCRIPTION
## Summary

- Bundle 9 pure JS dependencies (commander, chalk, prompts, yaml, zod, dotenv, tar, undici, @ts-rest/core) into CLI output via tsup `noExternal`, eliminating intermittent "Cannot find module" errors in CI e2e tests
- Add `createRequire` banner shim so CJS packages (commander, prompts, tar) work correctly when bundled into ESM output
- Add post-download `vm0 --help` smoke test in all 3 e2e CI jobs to catch artifact corruption early
- Update postbuild script to remove bundled deps from dist/package.json (only @sentry/node and @ngrok/ngrok remain external)

## Test plan

- [x] CLI builds successfully with new bundling config
- [x] `node dist/index.js --help` works (commander bundled, no node_modules needed)
- [x] `node dist/zero.js --help` works
- [x] dist/package.json only lists @sentry/node and @ngrok/ngrok as dependencies
- [x] All 945 CLI tests pass (103 test files)
- [x] Lint, type check, knip all pass
- [ ] CI pipeline validates full artifact chain (build → upload → download → link → e2e)

Closes #7812

🤖 Generated with [Claude Code](https://claude.com/claude-code)