### PR TITLE
refactor: centralize /etc/environment in build-rootfs.sh

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -588,6 +588,34 @@ jobs:
           done
           echo "PASS: runtime availability"
 
+          # Test 5: verify /etc/environment is loaded for both user and root
+          # [sync:etc-environment] Keep in sync with: crates/runner/scripts/build-rootfs.sh
+          echo "--- Test: environment variables ---"
+          EXPECTED_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          declare -A EXPECTED_ENV=(
+            [LANG]="C.UTF-8"
+            [NPM_CONFIG_UPDATE_NOTIFIER]="false"
+            [NODE_EXTRA_CA_CERTS]="/usr/local/share/ca-certificates/vm0-proxy-ca.crt"
+          )
+          check_env() {
+            local label=$1 sudo_flag=$2
+            for var in "${!EXPECTED_ENV[@]}"; do
+              val=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" $sudo_flag -- printenv "$var") \
+                || fail "$label: $var not set"
+              [ "$val" = "${EXPECTED_ENV[$var]}" ] \
+                || fail "$label: $var='$val', expected '${EXPECTED_ENV[$var]}'"
+              echo "  $label $var=$val"
+            done
+            val=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" $sudo_flag -- printenv PATH) \
+              || fail "$label: PATH not set"
+            echo "$val" | grep -qF "$EXPECTED_PATH" \
+              || fail "$label: PATH missing '$EXPECTED_PATH' in: $val"
+            echo "  $label PATH=$val"
+          }
+          check_env "user" ""
+          check_env "root" "--sudo"
+          echo "PASS: environment variables"
+
           # Stop transient service (kills sandbox, submit terminates naturally)
           sudo "$BIN_DIR/runner" service stop --name "$SVC"
           trap - EXIT

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -59,32 +59,27 @@ pub fn init_filesystem() -> Result<(), InitError> {
     })?;
     eprintln!("[guest-init] Virtual filesystems mounted");
 
-    // 2. Set environment variables for the init process (root).
-    // User commands run via `su - user` which resets env from /etc/passwd,
-    // so these only affect root/sudo commands (e.g. clock fix).
+    // 2. Load environment variables.
+    //
+    // /etc/environment is baked into the rootfs by build-rootfs.sh and
+    // contains variables shared by ALL users (LANG, NODE_EXTRA_CA_CERTS, …).
+    // PAM reads it for login shells (`su - user`), but the init process
+    // (root) and its children (vsock-guest → `sh -c`) don't go through PAM,
+    // so we load it explicitly here.
+    //
     // SAFETY: We are the init process, no other threads are running yet
     unsafe {
+        load_etc_environment();
         std::env::set_var("PATH", DEFAULT_PATH);
         std::env::set_var("HOME", "/root");
         std::env::set_var("USER", "root");
         std::env::set_var("SHELL", "/bin/bash");
-        std::env::set_var("LANG", "C.UTF-8");
     }
 
-    // Write environment for `su - user` (login shell). Docker ENV is lost
-    // during `docker export`, and `std::env::set_var` only affects the
-    // current process — `su -` resets the environment.
-    //
-    // LANG goes in /etc/environment (read by PAM, not overridden later).
-    // PATH goes in /etc/profile.d/ because Debian's /etc/profile overrides
-    // PATH from /etc/environment, omitting sbin dirs for non-root users.
-    // Scripts in /etc/profile.d/ run after /etc/profile, so our PATH wins.
-    if let Err(e) = fs::write(
-        "/etc/environment",
-        "LANG=C.UTF-8\nNPM_CONFIG_UPDATE_NOTIFIER=false\n",
-    ) {
-        eprintln!("[guest-init] Warning: failed to write /etc/environment: {e}");
-    }
+    // Write PATH for `su - user` (login shell).
+    // /etc/environment is baked into the rootfs by build-rootfs.sh.
+    // PATH goes in /etc/profile.d/ because /etc/profile overrides PATH
+    // from /etc/environment, omitting sbin dirs for non-root users.
     if let Err(e) = fs::write(
         "/etc/profile.d/vm0-path.sh",
         format!("export PATH={DEFAULT_PATH}\n"),
@@ -117,3 +112,30 @@ impl std::fmt::Display for InitError {
 }
 
 impl std::error::Error for InitError {}
+
+/// Parse `/etc/environment` and set each `KEY=VALUE` pair via `set_var`.
+///
+/// Skips blank lines, comments, and lines without `=`.
+/// SAFETY: caller must ensure no other threads are running.
+unsafe fn load_etc_environment() {
+    let content = match fs::read_to_string("/etc/environment") {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[guest-init] Warning: failed to read /etc/environment: {e}");
+            return;
+        }
+    };
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=') {
+            let key = key.trim();
+            let value = value.trim().trim_matches('"');
+            if !key.is_empty() {
+                unsafe { std::env::set_var(key, value) };
+            }
+        }
+    }
+}

--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -10,8 +10,6 @@
 use nix::mount::{MsFlags, mount};
 use std::fs;
 
-const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-
 /// Initialize virtual filesystems and environment.
 ///
 /// The kernel has already mounted `/dev/vda` as root (`root=/dev/vda rw`)
@@ -70,21 +68,9 @@ pub fn init_filesystem() -> Result<(), InitError> {
     // SAFETY: We are the init process, no other threads are running yet
     unsafe {
         load_etc_environment();
-        std::env::set_var("PATH", DEFAULT_PATH);
         std::env::set_var("HOME", "/root");
         std::env::set_var("USER", "root");
         std::env::set_var("SHELL", "/bin/bash");
-    }
-
-    // Write PATH for `su - user` (login shell).
-    // /etc/environment is baked into the rootfs by build-rootfs.sh.
-    // PATH goes in /etc/profile.d/ because /etc/profile overrides PATH
-    // from /etc/environment, omitting sbin dirs for non-root users.
-    if let Err(e) = fs::write(
-        "/etc/profile.d/vm0-path.sh",
-        format!("export PATH={DEFAULT_PATH}\n"),
-    ) {
-        eprintln!("[guest-init] Warning: failed to write /etc/profile.d/vm0-path.sh: {e}");
     }
 
     // 3. Change to root home directory (init runs as root;

--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -210,10 +210,12 @@ extract_and_inject() {
   sudo chroot "$EXTRACT_DIR" update-ca-certificates
 
   # Write /etc/environment (read by PAM for all login sessions).
+  # [sync:etc-environment] Keep in sync with: .github/workflows/crates.yml (runner-exec Test 5)
   # - LANG: locale (Docker ENV is lost after export)
   # - NPM_CONFIG_UPDATE_NOTIFIER: suppress npm update nags
   # - NODE_EXTRA_CA_CERTS: Node.js uses its own root CAs, not the system bundle
   printf '%s\n' \
+    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
     "LANG=C.UTF-8" \
     "NPM_CONFIG_UPDATE_NOTIFIER=false" \
     "NODE_EXTRA_CA_CERTS=/${CA_ROOTFS_DEST}" \

--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -209,6 +209,16 @@ extract_and_inject() {
   # Update system CA bundle
   sudo chroot "$EXTRACT_DIR" update-ca-certificates
 
+  # Write /etc/environment (read by PAM for all login sessions).
+  # - LANG: locale (Docker ENV is lost after export)
+  # - NPM_CONFIG_UPDATE_NOTIFIER: suppress npm update nags
+  # - NODE_EXTRA_CA_CERTS: Node.js uses its own root CAs, not the system bundle
+  printf '%s\n' \
+    "LANG=C.UTF-8" \
+    "NPM_CONFIG_UPDATE_NOTIFIER=false" \
+    "NODE_EXTRA_CA_CERTS=/${CA_ROOTFS_DEST}" \
+    | sudo tee "${EXTRACT_DIR}/etc/environment" > /dev/null
+
   echo "[OK] proxy CA installed and system bundle updated"
 }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -703,9 +703,6 @@ async fn restore_session(
     Ok(())
 }
 
-/// Proxy CA certificate path inside the guest rootfs (pre-baked at build time).
-const VM_PROXY_CA_PATH: &str = "/usr/local/share/ca-certificates/vm0-proxy-ca.crt";
-
 /// Returns true if the session ID contains only safe characters (alphanumeric, dash, underscore).
 fn is_valid_session_id(id: &str) -> bool {
     !id.is_empty()
@@ -783,11 +780,6 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
     {
         env.insert("USE_MOCK_CLAUDE".into(), val);
     }
-
-    // Tell Node.js/Bun to trust the proxy CA. All VMs route through
-    // mitmproxy, so the CA cert is always needed.
-    // The certificate is pre-baked into the rootfs at build time.
-    env.insert("NODE_EXTRA_CA_CERTS".into(), VM_PROXY_CA_PATH.into());
 
     // Artifact config
     if let Some(manifest) = &context.storage_manifest
@@ -872,10 +864,7 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{
-        ArtifactEntry, Firewall, FirewallApi, FirewallAuth, ResumeSession, StorageEntry,
-        StorageManifest,
-    };
+    use crate::types::{ArtifactEntry, ResumeSession, StorageEntry, StorageManifest};
     use uuid::Uuid;
 
     fn minimal_context() -> ExecutionContext {
@@ -1155,37 +1144,6 @@ mod tests {
             Some(v) => unsafe { std::env::set_var("USE_MOCK_CLAUDE", v) },
             None => unsafe { std::env::remove_var("USE_MOCK_CLAUDE") },
         }
-    }
-
-    #[test]
-    fn build_env_json_firewall_enable_ca_certs() {
-        let mut ctx = minimal_context();
-        ctx.firewalls = Some(vec![Firewall {
-            name: "gmail".into(),
-            ref_key: "gmail".into(),
-            apis: vec![FirewallApi {
-                id: String::new(),
-                base: "https://gmail.googleapis.com/gmail/v1/users/me".into(),
-                auth: FirewallAuth {
-                    headers: std::collections::HashMap::from([(
-                        "Authorization".into(),
-                        "Bearer ${{ secrets.GMAIL_TOKEN }}".into(),
-                    )]),
-                    base: None,
-                },
-                permissions: None,
-            }],
-        }]);
-        let env = build_env_json(&ctx, "http://localhost");
-        assert_eq!(env.get("NODE_EXTRA_CA_CERTS").unwrap(), VM_PROXY_CA_PATH);
-    }
-
-    #[test]
-    fn build_env_json_empty_firewall_still_has_ca_certs() {
-        let mut ctx = minimal_context();
-        ctx.firewalls = Some(vec![]);
-        let env = build_env_json(&ctx, "http://localhost");
-        assert_eq!(env.get("NODE_EXTRA_CA_CERTS").unwrap(), VM_PROXY_CA_PATH);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Move static env vars (LANG, NPM_CONFIG_UPDATE_NOTIFIER, NODE_EXTRA_CA_CERTS) from guest-init into build-rootfs.sh, baked into rootfs at build time
- guest-init now loads /etc/environment at boot so root processes also inherit these vars
- Remove redundant NODE_EXTRA_CA_CERTS injection from executor (now system-wide)

## Test plan
- [ ] `cargo clippy` / `cargo test` pass (254 tests)
- [ ] CI runner-build passes
- [ ] CI runner-exec passes (sandbox commands still work with proxy CA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)