### PR TITLE
fix: prevent layout shift when invite button appears on chat page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -478,10 +478,7 @@ describe("zero chat page - invite button", () => {
       return screen.getByRole("button", { name: /Ideas & use cases/ });
     });
 
-    const button = screen.getByRole("button", {
-      name: /invite people/i,
-      hidden: true,
-    });
+    const button = screen.getByTestId("invite-button");
     expect(button).toBeInTheDocument();
     expect(button).toHaveAttribute("aria-hidden", "true");
   });
@@ -496,10 +493,7 @@ describe("zero chat page - invite button", () => {
 
     // Button is always in DOM; wait for aria-hidden to be removed once admin state resolves
     await waitFor(() => {
-      const button = screen.getByRole("button", {
-        name: /invite people/i,
-        hidden: true,
-      });
+      const button = screen.getByTestId("invite-button");
       expect(button).not.toHaveAttribute("aria-hidden", "true");
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -486,11 +486,17 @@ describe("zero chat page - invite button", () => {
   it("renders invite button as visible and accessible when user is admin", async () => {
     await renderChatPage();
 
+    // Button is always in DOM; wait for aria-hidden to be removed once admin state resolves
     const button = await waitFor(() => {
-      return screen.getByRole("button", { name: /invite people/i });
+      return screen.getByRole("button", {
+        name: /invite people/i,
+        hidden: true,
+      });
+    });
+    await waitFor(() => {
+      expect(button).not.toHaveAttribute("aria-hidden", "true");
     });
     expect(button).toBeInTheDocument();
-    expect(button).not.toHaveAttribute("aria-hidden", "true");
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -473,11 +473,14 @@ describe("zero chat page - invite button", () => {
 
     await renderChatPage();
 
-    const button = await waitFor(() => {
-      return screen.getByRole("button", {
-        name: /invite people/i,
-        hidden: true,
-      });
+    // Wait for the page to fully load before checking the invite button
+    await waitFor(() => {
+      return screen.getByRole("button", { name: /Ideas & use cases/ });
+    });
+
+    const button = screen.getByRole("button", {
+      name: /invite people/i,
+      hidden: true,
     });
     expect(button).toBeInTheDocument();
     expect(button).toHaveAttribute("aria-hidden", "true");
@@ -486,17 +489,19 @@ describe("zero chat page - invite button", () => {
   it("renders invite button as visible and accessible when user is admin", async () => {
     await renderChatPage();
 
+    // Wait for the page to fully load before checking the invite button
+    await waitFor(() => {
+      return screen.getByRole("button", { name: /Ideas & use cases/ });
+    });
+
     // Button is always in DOM; wait for aria-hidden to be removed once admin state resolves
-    const button = await waitFor(() => {
-      return screen.getByRole("button", {
+    await waitFor(() => {
+      const button = screen.getByRole("button", {
         name: /invite people/i,
         hidden: true,
       });
-    });
-    await waitFor(() => {
       expect(button).not.toHaveAttribute("aria-hidden", "true");
     });
-    expect(button).toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -458,6 +458,42 @@ describe("zero chat page - connector label casing", () => {
   });
 });
 
+describe("zero chat page - invite button", () => {
+  it("renders invite button in DOM even when user is not admin", async () => {
+    server.use(
+      http.get("*/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "org_1",
+          slug: "user-12345678",
+          name: "User 12345678",
+          role: "member",
+        });
+      }),
+    );
+
+    await renderChatPage();
+
+    const button = await waitFor(() => {
+      return screen.getByRole("button", {
+        name: /invite people/i,
+        hidden: true,
+      });
+    });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("renders invite button as visible and accessible when user is admin", async () => {
+    await renderChatPage();
+
+    const button = await waitFor(() => {
+      return screen.getByRole("button", { name: /invite people/i });
+    });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toHaveAttribute("aria-hidden", "true");
+  });
+});
+
 describe("zero chat page - agent avatar and greeting", () => {
   it("should render agent avatar link on the landing page", async () => {
     await renderChatPage();

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -146,6 +146,33 @@ function useUserFirstName(): string | undefined {
   return loadable.data?.firstName ?? undefined;
 }
 
+function InviteButton({ pageSignal }: { pageSignal: AbortSignal }) {
+  const isAdminLoadable = useLoadable(isOrgAdmin$);
+  const isAdmin =
+    isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
+  const setTab = useSet(setActiveTab$);
+  const setSubPage = useSet(setBillingSubPage$);
+  const openManage = useSet(setOrgManageDialogOpen$);
+  const handleInvite = () => {
+    setTab("members");
+    setSubPage(false);
+    detach(openManage(true, pageSignal), Reason.DomCallback);
+  };
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={handleInvite}
+      className={`zero-btn-morandi gap-1.5${isAdmin ? "" : " invisible"}`}
+      aria-hidden={isAdmin ? undefined : "true"}
+      tabIndex={isAdmin ? undefined : -1}
+    >
+      <IconUserPlus size={14} stroke={1.5} />
+      Invite people
+    </Button>
+  );
+}
+
 export function ZeroChatPage() {
   // Agent resolution (moved from ZeroTalkPage)
   const chatAgentLoadable = useLastLoadable(zeroChatAgentId$);
@@ -207,19 +234,6 @@ export function ZeroChatPage() {
   // Agent ID from URL for ideas navigation
   const talkAgentId = useGet(currentAgentId$);
 
-  // Admin invite
-  const isAdminLoadable = useLoadable(isOrgAdmin$);
-  const isAdmin =
-    isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
-  const setTab = useSet(setActiveTab$);
-  const setSubPage = useSet(setBillingSubPage$);
-  const openManage = useSet(setOrgManageDialogOpen$);
-  const handleInvite = () => {
-    setTab("members");
-    setSubPage(false);
-    detach(openManage(true, pageSignal), Reason.DomCallback);
-  };
-
   // Pin pill (currentChatAgentId is resolved above)
   const pinnedLoadable = useLastLoadable(pinnedAgentIds$);
   const pinnedIds =
@@ -249,17 +263,7 @@ export function ZeroChatPage() {
     <div className="relative flex flex-1 flex-col min-h-0">
       <header className="hidden md:block shrink-0 bg-transparent px-4 sm:px-6 pt-4 pb-2">
         <div className="flex justify-end">
-          {isAdmin && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleInvite}
-              className="zero-btn-morandi gap-1.5"
-            >
-              <IconUserPlus size={14} stroke={1.5} />
-              Invite people
-            </Button>
-          )}
+          <InviteButton pageSignal={pageSignal} />
         </div>
       </header>
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -166,6 +166,7 @@ function InviteButton({ pageSignal }: { pageSignal: AbortSignal }) {
       className={`zero-btn-morandi gap-1.5${isAdmin ? "" : " invisible"}`}
       aria-hidden={isAdmin ? undefined : "true"}
       tabIndex={isAdmin ? undefined : -1}
+      data-testid="invite-button"
     >
       <IconUserPlus size={14} stroke={1.5} />
       Invite people


### PR DESCRIPTION
## Summary

- Fixes layout shift (CLS) caused by the "Invite people" button conditionally appearing in the header after async admin state resolves
- Always renders the button in the DOM; uses CSS `invisible` class to hide it visually when user is not admin
- Adds `aria-hidden="true"` and `tabIndex={-1}` when hidden for accessibility
- Extracts invite button logic into a separate `InviteButton` component to keep `ZeroChatPage` complexity within lint limits

Closes #7770

## Test plan

- [ ] New tests added: "zero chat page - invite button" describe block in `zero-chat-page.test.tsx`
  - Verifies button is in DOM with `aria-hidden="true"` when user is non-admin (member role)
  - Verifies button is visible and accessible when user is admin (default mock)
- [ ] Lint passes: `pnpm turbo run lint`
- [ ] Format passes: `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)