### PR TITLE
fix: prevent schedule instructions panel from prompting save without changes

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/tiptap-instructions-editor.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/tiptap-instructions-editor.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { TiptapInstructionsEditor } from "../tiptap-instructions-editor.tsx";
+
+describe("tiptap instructions editor", () => {
+  it("should not call onChange when editor initialises with content", async () => {
+    const onChange = vi.fn();
+
+    render(
+      <TiptapInstructionsEditor
+        initialContent={"# Hello\n\nThis is a **test** with formatting."}
+        onChange={onChange}
+      />,
+    );
+
+    // Wait for the editor to mount (the footer hint is always rendered)
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Edit the instructions directly to customize your agent's behavior.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    // The baseline extension should suppress the spurious onChange that
+    // Tiptap fires when it parses the initial markdown content.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
@@ -160,6 +160,30 @@ const EDITOR_CLASSES =
   "[&_pre]:bg-muted [&_pre]:rounded-md [&_pre]:p-3 [&_pre]:my-2 [&_pre_code]:bg-transparent [&_pre_code]:p-0 " +
   "[&_hr]:border-border [&_hr]:my-4";
 
+/**
+ * Tiptap extension that captures the markdown the editor produces right after
+ * parsing the initial content.  This "baseline" lets onUpdate distinguish
+ * Tiptap's own round-trip normalisation from genuine user edits.
+ */
+function createBaselineExtension(onChange: (markdown: string) => void) {
+  return Extension.create<Record<string, never>, { baseline: string | null }>({
+    name: "baselineMarkdown",
+    addStorage() {
+      return { baseline: null };
+    },
+    onCreate() {
+      this.storage.baseline = this.editor.getMarkdown();
+    },
+    onUpdate() {
+      const md = this.editor.getMarkdown();
+      if (md === this.storage.baseline) {
+        return;
+      }
+      onChange(md);
+    },
+  });
+}
+
 export function TiptapInstructionsEditor({
   initialContent,
   onChange,
@@ -167,13 +191,15 @@ export function TiptapInstructionsEditor({
   footerHint = "Edit the instructions directly to customize your agent's behavior.",
 }: TiptapInstructionsEditorProps) {
   const editor = useEditor({
-    extensions: [StarterKit, createLowlightPlugin(), Markdown],
+    extensions: [
+      StarterKit,
+      createLowlightPlugin(),
+      Markdown,
+      createBaselineExtension(onChange),
+    ],
     content: initialContent,
     contentType: "markdown",
     editable: !disabled,
-    onUpdate: ({ editor: e }) => {
-      onChange(e.getMarkdown());
-    },
     editorProps: {
       attributes: {
         class: EDITOR_CLASSES,


### PR DESCRIPTION
## Summary

- Fix false-positive save prompt in the Schedules instructions panel that appeared immediately on opening the tab or clicking without editing
- Root cause: Tiptap v3 fires `onUpdate` when initial content is set, and the markdown round-trip (parse → serialise) can produce slightly different text, making dirty-detection trigger spuriously
- Introduce a `baselineMarkdown` Tiptap extension that captures the initial serialised markdown in `onCreate` and suppresses `onChange` calls in `onUpdate` when the content matches the baseline

Closes #7674

## Test plan

- [ ] Navigate to Schedules → open a schedule → click "Instructions" tab
- [ ] Click inside the editor without typing → verify no save bar appears
- [ ] Type some text → verify the save bar appears
- [ ] Discard changes → verify the save bar disappears
- [ ] Verify the agent profile instructions editor (non-schedule) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)