### PR TITLE
feat(cli): show connector permission details in zero agent view

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -18,6 +18,7 @@ const mockAgent = {
   displayName: "My Agent",
   description: "A test agent",
   sound: "professional",
+  firewallPolicies: null,
 };
 
 describe("zero agent view command", () => {
@@ -61,7 +62,36 @@ describe("zero agent view command", () => {
       expect(logCalls).toContain("comp_abc123");
       expect(logCalls).toContain("A test agent");
       expect(logCalls).toContain("professional");
-      expect(logCalls).toContain("Connectors:   github");
+      expect(logCalls).toContain("github (full access)");
+    });
+
+    it("should show permission summary with firewall policies", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json({
+            ...mockAgent,
+            firewallPolicies: {
+              github: {
+                "actions:read": "allow",
+                "actions:write": "deny",
+                "contents:read": "allow",
+                "contents:write": "deny",
+              },
+            },
+          });
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+      );
+
+      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toMatch(/github \(\d+\/\d+ allowed\)/);
     });
 
     it("should show instructions content with --instructions flag", async () => {
@@ -125,6 +155,99 @@ describe("zero agent view command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("No instructions set");
+    });
+  });
+
+  describe("--permissions flag", () => {
+    it("should show detailed permissions with allow/deny icons", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json({
+            ...mockAgent,
+            firewallPolicies: {
+              github: {
+                "actions:read": "allow",
+                "actions:write": "deny",
+                "contents:read": "allow",
+                "contents:write": "ask",
+              },
+            },
+          });
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+      );
+
+      await viewCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--permissions",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toMatch(/github \(\d+\/\d+ allowed\)/);
+      expect(logCalls).toContain("✓");
+      expect(logCalls).toContain("✗");
+      expect(logCalls).toContain("?");
+    });
+
+    it("should show full access for connectors without policies", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+      );
+
+      await viewCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--permissions",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("full access");
+      expect(logCalls).toContain(
+        "No permission rules configured — all API calls allowed.",
+      );
+    });
+
+    it("should handle non-firewall connectors gracefully", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({
+              enabledTypes: ["custom-connector"],
+            });
+          },
+        ),
+      );
+
+      await viewCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--permissions",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("custom-connector");
+      expect(logCalls).toContain("No firewall configured.");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -6,23 +6,33 @@ import {
   getZeroAgentUserConnectors,
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
+import {
+  isFirewallConnectorType,
+  getConnectorFirewall,
+  resolveFirewallPolicies,
+} from "@vm0/core";
 
 export const viewCommand = new Command()
   .name("view")
   .description("View a zero agent")
   .argument("<agent-id>", "Agent ID")
   .option("--instructions", "Also show instructions content")
+  .option("--permissions", "Show full permission details for each connector")
   .addHelpText(
     "after",
     `
 Examples:
   View basic info:         zero agent view <agent-id>
   Include instructions:    zero agent view <agent-id> --instructions
+  Show permissions:        zero agent view <agent-id> --permissions
   View yourself:           zero agent view $ZERO_AGENT_ID --instructions`,
   )
   .action(
     withErrorHandler(
-      async (agentId: string, options: { instructions?: boolean }) => {
+      async (
+        agentId: string,
+        options: { instructions?: boolean; permissions?: boolean },
+      ) => {
         const agent = await getZeroAgent(agentId);
 
         console.log(chalk.bold(agent.agentId));
@@ -30,14 +40,87 @@ Examples:
         console.log();
         console.log(`Agent ID:     ${agent.agentId}`);
         const connectors = await getZeroAgentUserConnectors(agentId);
-        if (connectors.length > 0)
-          console.log(`Connectors:   ${connectors.join(", ")}`);
+
+        const resolvedPolicies = resolveFirewallPolicies(
+          agent.firewallPolicies,
+          connectors,
+        );
+
+        if (connectors.length > 0) {
+          const summaries = connectors.map((type) => {
+            if (!isFirewallConnectorType(type)) return type;
+            const policies = resolvedPolicies?.[type];
+            if (!policies) return `${type} (full access)`;
+            const config = getConnectorFirewall(type);
+            const allPerms = config.apis.flatMap((a) => {
+              return a.permissions ?? [];
+            });
+            const total = allPerms.length;
+            const allowed = allPerms.filter((p) => {
+              return policies[p.name] === "allow";
+            }).length;
+            return `${type} (${allowed}/${total} allowed)`;
+          });
+          console.log(`Connectors:   ${summaries.join(", ")}`);
+        }
+
         if (agent.customSkills?.length > 0) {
           console.log(`Skills:       ${agent.customSkills.join(", ")}`);
         }
         if (agent.description)
           console.log(`Description:  ${agent.description}`);
         if (agent.sound) console.log(`Sound:        ${agent.sound}`);
+
+        if (options.permissions && connectors.length > 0) {
+          console.log();
+          for (const type of connectors) {
+            if (!isFirewallConnectorType(type)) {
+              console.log(chalk.dim(`── ${type} ──`));
+              console.log("  No firewall configured.");
+              continue;
+            }
+
+            const policies = resolvedPolicies?.[type];
+            const config = getConnectorFirewall(type);
+            const allPerms = config.apis.flatMap((a) => {
+              return a.permissions ?? [];
+            });
+
+            if (!policies) {
+              console.log(chalk.dim(`── ${type} (full access) ──`));
+              console.log(
+                "  No permission rules configured — all API calls allowed.",
+              );
+              continue;
+            }
+
+            const total = allPerms.length;
+            const allowed = allPerms.filter((p) => {
+              return policies[p.name] === "allow";
+            }).length;
+            console.log(
+              chalk.dim(`── ${type} (${allowed}/${total} allowed) ──`),
+            );
+
+            const nameWidth = Math.max(
+              ...allPerms.map((p) => {
+                return p.name.length;
+              }),
+            );
+
+            for (const perm of allPerms) {
+              const policy = policies[perm.name] ?? "deny";
+              const icon =
+                policy === "allow"
+                  ? chalk.green("✓")
+                  : policy === "ask"
+                    ? chalk.yellow("?")
+                    : chalk.dim("✗");
+              const desc = perm.description ?? "";
+              console.log(`  ${icon} ${perm.name.padEnd(nameWidth)}  ${desc}`);
+            }
+          }
+        }
 
         if (options.instructions) {
           console.log();

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -10,7 +10,53 @@ import {
   isFirewallConnectorType,
   getConnectorFirewall,
   resolveFirewallPolicies,
+  type FirewallPolicyValue,
 } from "@vm0/core";
+
+interface ConnectorPermissionInfo {
+  type: string;
+  hasFirewall: boolean;
+  permissions: Array<{ name: string; description?: string }>;
+  policies: Record<string, FirewallPolicyValue> | null;
+  allowed: number;
+  total: number;
+}
+
+function getConnectorPermissionInfo(
+  type: string,
+  resolvedPolicies: Record<string, Record<string, FirewallPolicyValue>> | null,
+): ConnectorPermissionInfo {
+  if (!isFirewallConnectorType(type)) {
+    return {
+      type,
+      hasFirewall: false,
+      permissions: [],
+      policies: null,
+      allowed: 0,
+      total: 0,
+    };
+  }
+
+  const policies = resolvedPolicies?.[type] ?? null;
+  const config = getConnectorFirewall(type);
+  const permissions = config.apis.flatMap((a) => {
+    return a.permissions ?? [];
+  });
+  const total = permissions.length;
+  const allowed = policies
+    ? permissions.filter((p) => {
+        return policies[p.name] === "allow";
+      }).length
+    : 0;
+
+  return { type, hasFirewall: true, permissions, policies, allowed, total };
+}
+
+function formatConnectorSummary(info: ConnectorPermissionInfo): string {
+  if (!info.hasFirewall) return info.type;
+  if (!info.policies) return `${info.type} (full access)`;
+  return `${info.type} (${info.allowed}/${info.total} allowed)`;
+}
 
 export const viewCommand = new Command()
   .name("view")
@@ -46,21 +92,12 @@ Examples:
           connectors,
         );
 
-        if (connectors.length > 0) {
-          const summaries = connectors.map((type) => {
-            if (!isFirewallConnectorType(type)) return type;
-            const policies = resolvedPolicies?.[type];
-            if (!policies) return `${type} (full access)`;
-            const config = getConnectorFirewall(type);
-            const allPerms = config.apis.flatMap((a) => {
-              return a.permissions ?? [];
-            });
-            const total = allPerms.length;
-            const allowed = allPerms.filter((p) => {
-              return policies[p.name] === "allow";
-            }).length;
-            return `${type} (${allowed}/${total} allowed)`;
-          });
+        const connectorInfos = connectors.map((type) => {
+          return getConnectorPermissionInfo(type, resolvedPolicies);
+        });
+
+        if (connectorInfos.length > 0) {
+          const summaries = connectorInfos.map(formatConnectorSummary);
           console.log(`Connectors:   ${summaries.join(", ")}`);
         }
 
@@ -71,45 +108,37 @@ Examples:
           console.log(`Description:  ${agent.description}`);
         if (agent.sound) console.log(`Sound:        ${agent.sound}`);
 
-        if (options.permissions && connectors.length > 0) {
+        if (options.permissions && connectorInfos.length > 0) {
           console.log();
-          for (const type of connectors) {
-            if (!isFirewallConnectorType(type)) {
-              console.log(chalk.dim(`── ${type} ──`));
+          for (const info of connectorInfos) {
+            if (!info.hasFirewall) {
+              console.log(chalk.dim(`── ${info.type} ──`));
               console.log("  No firewall configured.");
               continue;
             }
 
-            const policies = resolvedPolicies?.[type];
-            const config = getConnectorFirewall(type);
-            const allPerms = config.apis.flatMap((a) => {
-              return a.permissions ?? [];
-            });
-
-            if (!policies) {
-              console.log(chalk.dim(`── ${type} (full access) ──`));
+            if (!info.policies) {
+              console.log(chalk.dim(`── ${info.type} (full access) ──`));
               console.log(
                 "  No permission rules configured — all API calls allowed.",
               );
               continue;
             }
 
-            const total = allPerms.length;
-            const allowed = allPerms.filter((p) => {
-              return policies[p.name] === "allow";
-            }).length;
             console.log(
-              chalk.dim(`── ${type} (${allowed}/${total} allowed) ──`),
+              chalk.dim(
+                `── ${info.type} (${info.allowed}/${info.total} allowed) ──`,
+              ),
             );
 
             const nameWidth = Math.max(
-              ...allPerms.map((p) => {
+              ...info.permissions.map((p) => {
                 return p.name.length;
               }),
             );
 
-            for (const perm of allPerms) {
-              const policy = policies[perm.name] ?? "deny";
+            for (const perm of info.permissions) {
+              const policy = info.policies[perm.name] ?? "deny";
               const icon =
                 policy === "allow"
                   ? chalk.green("✓")


### PR DESCRIPTION
## Summary

- Display permission summary per connector in default `zero agent view` (e.g. `github (4/6 allowed)`, `notion (full access)`)
- Add `--permissions` flag for full permission list with ✓ (allow), ✗ (deny), ? (ask) status icons, permission names, and descriptions
- Gracefully handle non-firewall connectors and connectors without policies

Closes #7822

## Test plan

- [x] Existing tests updated with `firewallPolicies` field
- [x] New test: permission summary with firewall policies shows `(N/M allowed)` pattern
- [x] New test: `--permissions` flag shows detailed icons (✓, ✗, ?)
- [x] New test: full access connectors show appropriate message
- [x] New test: non-firewall connectors handled gracefully
- [x] All 8 tests passing
- [x] Lint, type check, format, knip all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)