### PR TITLE
fix: chat thread delete dialog opens for all threads due to shared global state

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -411,6 +411,9 @@ export const chatThreads$ = computed(async (get) => {
 
 export const deleteChatThread$ = command(
   async ({ get, set }, threadId: string, signal: AbortSignal) => {
+    const threadSnapshot = await get(chatThreads$);
+    signal.throwIfAborted();
+
     const client = get(zeroClient$)(chatThreadByIdContract);
     const result = await client.delete({
       params: { id: threadId },
@@ -428,7 +431,18 @@ export const deleteChatThread$ = command(
     toast.success("Chat deleted");
 
     if (get(chatThreadId$) === threadId) {
-      set(detachedNavigateTo$, "/");
+      const idx = threadSnapshot.findIndex((t) => {
+        return t.id === threadId;
+      });
+      const remaining = threadSnapshot.filter((t) => {
+        return t.id !== threadId;
+      });
+      if (remaining.length === 0) {
+        set(detachedNavigateTo$, "/");
+      } else {
+        const nextThread = remaining[idx] ?? remaining[remaining.length - 1];
+        set(navigateToChat$, nextThread.id);
+      }
     }
 
     set(internalReloadChatThreads$, (n) => {

--- a/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-sidebar-state.ts
@@ -58,15 +58,17 @@ export const setChatListQuery$ = command(({ set }, query: string) => {
 });
 
 // ---------------------------------------------------------------------------
-// Delete confirmation dialog state (ChatThreadItem)
+// Delete confirmation dialog state (RecentChatList)
 // ---------------------------------------------------------------------------
-const internalConfirmOpen$ = state(false);
-export const confirmOpen$ = computed((get) => {
-  return get(internalConfirmOpen$);
+const internalPendingDeleteThreadId$ = state<string | null>(null);
+export const pendingDeleteThreadId$ = computed((get) => {
+  return get(internalPendingDeleteThreadId$);
 });
-export const setConfirmOpen$ = command(({ set }, open: boolean) => {
-  set(internalConfirmOpen$, open);
-});
+export const setPendingDeleteThreadId$ = command(
+  ({ set }, id: string | null) => {
+    set(internalPendingDeleteThreadId$, id);
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Session list collapse state (RecentChatSection)

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function makeThread(
+  id: string,
+  title: string,
+  createdAt: string,
+): {
+  id: string;
+  title: string;
+  agentId: string;
+  createdAt: string;
+  updatedAt: string;
+} {
+  return { id, title, agentId: AGENT_ID, createdAt, updatedAt: createdAt };
+}
+
+function mockAPIs() {
+  let threads = [
+    makeThread("thread-1", "First chat", "2026-03-10T00:00:00Z"),
+    makeThread("thread-2", "Second chat", "2026-03-09T00:00:00Z"),
+    makeThread("thread-3", "Third chat", "2026-03-08T00:00:00Z"),
+  ];
+
+  let lastDeletedId: string | null = null;
+
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: AGENT_ID,
+          displayName: null,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads });
+    }),
+    http.get("*/api/zero/chat-threads/:id", ({ params }) => {
+      const thread = threads.find((t) => {
+        return t.id === params.id;
+      });
+      return HttpResponse.json({
+        id: params.id,
+        title: thread?.title ?? null,
+        agentId: AGENT_ID,
+        chatMessages: [],
+        latestSessionId: null,
+        unsavedRuns: [],
+        createdAt: "2026-03-10T00:00:00Z",
+        updatedAt: "2026-03-10T00:00:00Z",
+      });
+    }),
+    http.delete("*/api/zero/chat-threads/:id", ({ params }) => {
+      const id = params.id as string;
+      lastDeletedId = id;
+      threads = threads.filter((t) => {
+        return t.id !== id;
+      });
+      return new HttpResponse(null, { status: 204 });
+    }),
+  );
+
+  return {
+    getLastDeletedId: () => {
+      return lastDeletedId;
+    },
+    getThreads: () => {
+      return threads;
+    },
+  };
+}
+
+async function deleteThread(
+  user: ReturnType<typeof userEvent.setup>,
+  nthButton: number,
+) {
+  const deleteButtons = await waitFor(() => {
+    const btns = screen.getAllByLabelText("Delete chat");
+    expect(btns.length).toBeGreaterThanOrEqual(nthButton);
+    return btns;
+  });
+
+  await user.click(deleteButtons[nthButton - 1]);
+
+  const dialog = await waitFor(() => {
+    return screen.getByRole("dialog");
+  });
+
+  const confirmBtn = within(dialog).getByRole("button", { name: "Delete" });
+  await user.click(confirmBtn);
+}
+
+describe("sidebar chat delete", () => {
+  it("should send the correct thread ID when deleting the first thread", async () => {
+    const user = userEvent.setup();
+    const { getLastDeletedId } = mockAPIs();
+
+    await setupPage({ context, path: "/chats/thread-1" });
+
+    await waitFor(() => {
+      expect(screen.getByText("First chat")).toBeInTheDocument();
+    });
+
+    await deleteThread(user, 1);
+
+    await waitFor(() => {
+      expect(getLastDeletedId()).toBe("thread-1");
+    });
+  });
+
+  it("should send the correct thread ID when deleting a middle thread", async () => {
+    const user = userEvent.setup();
+    const { getLastDeletedId } = mockAPIs();
+
+    await setupPage({ context, path: "/chats/thread-1" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Second chat")).toBeInTheDocument();
+    });
+
+    await deleteThread(user, 2);
+
+    await waitFor(() => {
+      expect(getLastDeletedId()).toBe("thread-2");
+    });
+  });
+
+  it("should remove the deleted thread from the sidebar list", async () => {
+    const user = userEvent.setup();
+    mockAPIs();
+
+    await setupPage({ context, path: "/chats/thread-2" });
+
+    await waitFor(() => {
+      expect(screen.getByText("First chat")).toBeInTheDocument();
+    });
+
+    await deleteThread(user, 1);
+
+    await waitFor(() => {
+      expect(screen.queryByText("First chat")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Second chat")).toBeInTheDocument();
+    expect(screen.getByText("Third chat")).toBeInTheDocument();
+  });
+
+  it("should navigate to the next thread after deleting the current one", async () => {
+    const user = userEvent.setup();
+    mockAPIs();
+
+    await setupPage({ context, path: "/chats/thread-1" });
+
+    await waitFor(() => {
+      expect(screen.getByText("First chat")).toBeInTheDocument();
+    });
+
+    await deleteThread(user, 1);
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-2");
+    });
+  });
+
+  it("should navigate to the previous thread when deleting the last one in the list", async () => {
+    const user = userEvent.setup();
+    mockAPIs();
+
+    await setupPage({ context, path: "/chats/thread-3" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Third chat")).toBeInTheDocument();
+    });
+
+    await deleteThread(user, 3);
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-2");
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-chat-delete.test.tsx
@@ -194,4 +194,64 @@ describe("sidebar chat delete", () => {
       expect(pathname()).toBe("/chats/thread-2");
     });
   });
+
+  it("should navigate away from the chat page when deleting the only remaining thread", async () => {
+    const user = userEvent.setup();
+
+    let threads = [
+      makeThread("thread-only", "Only chat", "2026-03-10T00:00:00Z"),
+    ];
+
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: AGENT_ID,
+            displayName: null,
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        ]);
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads });
+      }),
+      http.get("*/api/zero/chat-threads/:id", ({ params }) => {
+        const thread = threads.find((t) => {
+          return t.id === params.id;
+        });
+        return HttpResponse.json({
+          id: params.id,
+          title: thread?.title ?? null,
+          agentId: AGENT_ID,
+          chatMessages: [],
+          latestSessionId: null,
+          unsavedRuns: [],
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        });
+      }),
+      http.delete("*/api/zero/chat-threads/:id", ({ params }) => {
+        threads = threads.filter((t) => {
+          return t.id !== params.id;
+        });
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await setupPage({ context, path: "/chats/thread-only" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Only chat")).toBeInTheDocument();
+    });
+
+    await deleteThread(user, 1);
+
+    await waitFor(() => {
+      expect(pathname()).not.toBe("/chats/thread-only");
+    });
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -93,8 +93,8 @@ import {
   setSidebarSearchTerm$,
   managePinnedDialogOpen$,
   setManagePinnedDialogOpen$,
-  confirmOpen$,
-  setConfirmOpen$,
+  pendingDeleteThreadId$,
+  setPendingDeleteThreadId$,
   sessionListCollapsed$,
   setSessionListCollapsed$,
   chatListOpen$,
@@ -527,101 +527,60 @@ function ChatThreadItem({
   isSelected: boolean;
   onSelect?: (id: string) => void;
 }) {
-  const setDelete = useSet(deleteChatThread$);
-  const pageSignal = useGet(pageSignal$);
-  const confirmOpen = useGet(confirmOpen$);
-  const setConfirmOpen = useSet(setConfirmOpen$);
+  const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
 
   function handleDeleteClick(e: React.MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
-    setConfirmOpen(true);
-  }
-
-  function confirmDelete() {
-    setConfirmOpen(false);
-    detach(setDelete(session.id, pageSignal), Reason.DomCallback);
+    setPendingDeleteThreadId(session.id);
   }
 
   return (
-    <>
-      <div className="group relative">
-        <Link
-          pathname="/chats/:id"
-          options={{ pathParams: { id: session.id } }}
-          onClick={(e) => {
-            if (e.metaKey || e.ctrlKey || e.shiftKey) {
-              return;
-            }
-            e.preventDefault();
-            onSelect?.(session.id);
-          }}
-          className={`flex h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors ${
-            isSelected
-              ? "bg-gray-200 text-gray-900 font-medium"
-              : "text-sidebar-foreground hover:bg-sidebar-accent"
-          }`}
-        >
-          <span className="truncate min-w-0 flex-1">
-            {session.title ?? "New chat"}
-          </span>
-        </Link>
-        <div className="absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
-          <TooltipProvider delayDuration={200}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={handleDeleteClick}
-                  className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 ${
-                    isSelected
-                      ? "text-slate-500 hover:text-slate-900 hover:bg-slate-300"
-                      : "text-sidebar-foreground/80 hover:text-foreground hover:bg-sidebar-foreground/10"
-                  }`}
-                  aria-label="Delete chat"
-                >
-                  <IconTrash size={12} stroke={2} />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                <p className="text-xs">Delete chat</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
-      </div>
-      <Dialog
-        open={confirmOpen}
-        onOpenChange={(open) => {
-          if (!open) {
-            setConfirmOpen(false);
+    <div className="group relative">
+      <Link
+        pathname="/chats/:id"
+        options={{ pathParams: { id: session.id } }}
+        onClick={(e) => {
+          if (e.metaKey || e.ctrlKey || e.shiftKey) {
+            return;
           }
+          e.preventDefault();
+          onSelect?.(session.id);
         }}
+        className={`flex h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors ${
+          isSelected
+            ? "bg-gray-200 text-gray-900 font-medium"
+            : "text-sidebar-foreground hover:bg-sidebar-accent"
+        }`}
       >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete chat?</DialogTitle>
-            <DialogDescription>
-              This will permanently delete this chat. This action cannot be
-              undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setConfirmOpen(false);
-              }}
-            >
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={confirmDelete}>
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+        <span className="truncate min-w-0 flex-1">
+          {session.title ?? "New chat"}
+        </span>
+      </Link>
+      <div className="absolute right-0 top-0 flex h-8 w-8 items-center justify-center">
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleDeleteClick}
+                className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 ${
+                  isSelected
+                    ? "text-slate-500 hover:text-slate-900 hover:bg-slate-300"
+                    : "text-sidebar-foreground/80 hover:text-foreground hover:bg-sidebar-foreground/10"
+                }`}
+                aria-label="Delete chat"
+              >
+                <IconTrash size={12} stroke={2} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">Delete chat</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    </div>
   );
 }
 
@@ -640,6 +599,20 @@ function RecentChatList({
   selectedRecentId: string | null;
   onRecentSelect?: (id: string) => void;
 }) {
+  const pendingDeleteThreadId = useGet(pendingDeleteThreadId$);
+  const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
+  const setDelete = useSet(deleteChatThread$);
+  const pageSignal = useGet(pageSignal$);
+
+  function confirmDelete() {
+    if (!pendingDeleteThreadId) {
+      return;
+    }
+    const threadId = pendingDeleteThreadId;
+    setPendingDeleteThreadId(null);
+    detach(setDelete(threadId, pageSignal), Reason.DomCallback);
+  }
+
   if (loading && sessions.length === 0) {
     return (
       <>
@@ -665,16 +638,51 @@ function RecentChatList({
       </p>
     );
   }
-  return sessions.map((session) => {
-    return (
-      <ChatThreadItem
-        key={session.id}
-        session={session}
-        isSelected={selectedRecentId === session.id}
-        onSelect={onRecentSelect}
-      />
-    );
-  });
+  return (
+    <>
+      {sessions.map((session) => {
+        return (
+          <ChatThreadItem
+            key={session.id}
+            session={session}
+            isSelected={selectedRecentId === session.id}
+            onSelect={onRecentSelect}
+          />
+        );
+      })}
+      <Dialog
+        open={pendingDeleteThreadId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingDeleteThreadId(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete chat?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete this chat. This action cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setPendingDeleteThreadId(null);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
 }
 
 function RecentChatSection({


### PR DESCRIPTION
## Summary

- Replace global `confirmOpen$` boolean with `pendingDeleteThreadId$` (`string | null`) to track which specific thread is pending deletion, fixing the shared state bug where all threads' dialogs opened simultaneously
- Move the single `<Dialog>` from `ChatThreadItem` (rendered once per thread) into `RecentChatList` (rendered once), so only one dialog exists regardless of thread count
- Update `deleteChatThread$` to navigate to the next thread (or previous if deleting the last) instead of always navigating to root `/`

Closes #7829

## Test plan

- [x] All 5 new tests in `sidebar-chat-delete.test.tsx` pass
- [x] All existing sidebar tests pass (no regressions)
- [x] Type check passes (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Knip finds no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)