### PR TITLE
feat: add no-detach-in-signals eslint rule

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-detach-in-signals.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-detach-in-signals.test.ts
@@ -1,0 +1,51 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-detach-in-signals.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-detach-in-signals", rule, {
+  valid: [
+    // Views layer — detach is allowed
+    {
+      filename: "/app/src/views/zero-page/my-component.tsx",
+      code: `detach(commandFn(pageSignal), Reason.DomCallback);`,
+    },
+    // Test files — detach is allowed
+    {
+      filename: "/app/src/signals/__tests__/utils.test.ts",
+      code: `detach(Promise.resolve("value"), Reason.Entrance);`,
+    },
+    // Signals layer — non-detach calls are fine
+    {
+      filename: "/app/src/signals/route.ts",
+      code: `await set(loadRoute$, signal);`,
+    },
+    // Outside src/signals/ entirely
+    {
+      filename: "/app/src/lib/helpers.ts",
+      code: `detach(someWork(), Reason.Daemon);`,
+    },
+  ],
+  invalid: [
+    {
+      filename: "/app/src/signals/bootstrap.ts",
+      code: `detach(set(initApp$, signal), Reason.Entrance);`,
+      errors: [{ messageId: "noDetachInSignals" }],
+    },
+    {
+      filename: "/app/src/signals/route.ts",
+      code: `detach(set(loadRoute$, signal), Reason.Daemon);`,
+      errors: [{ messageId: "noDetachInSignals" }],
+    },
+    {
+      filename: "/app/src/signals/zero-page/zero-page.ts",
+      code: `detach(set(initSlackOrg$, signal), Reason.Entrance);`,
+      errors: [{ messageId: "noDetachInSignals" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -18,6 +18,7 @@
  * - no-getter-setter-params: Functions must not accept ccstate Getter/Setter — use command()
  * - no-new-abort-controller: Disallow new AbortController() — use signal hierarchy
  * - no-direct-local-storage: Disallow direct localStorage access — use localStorageSignals()
+ * - no-detach-in-signals: Disallow detach() in signals/ — use await or signal chain
  */
 
 import signalDollarSuffix from "./rules/signal-dollar-suffix.ts";
@@ -38,6 +39,7 @@ import noGetterSetterParams from "./rules/no-getter-setter-params.ts";
 import noNewAbortController from "./rules/no-new-abort-controller.ts";
 import preferUserEvent from "./rules/prefer-user-event.ts";
 import noDirectLocalStorage from "./rules/no-direct-local-storage.ts";
+import noDetachInSignals from "./rules/no-detach-in-signals.ts";
 
 const plugin = {
   meta: {
@@ -63,6 +65,7 @@ const plugin = {
     "no-new-abort-controller": noNewAbortController,
     "prefer-user-event": preferUserEvent,
     "no-direct-local-storage": noDirectLocalStorage,
+    "no-detach-in-signals": noDetachInSignals,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/no-detach-in-signals.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-detach-in-signals.ts
@@ -1,0 +1,66 @@
+/**
+ * ESLint rule: no-detach-in-signals
+ *
+ * Disallows calling `detach()` in files under `src/signals/`.
+ *
+ * `detach()` is designed for the views layer where DOM event callbacks cannot
+ * return promises.  In the signals layer, commands should manage async work
+ * through `await` and the signal chain — using `detach` there is a misuse
+ * that hides lifecycle issues.
+ *
+ * Good (views layer):
+ *   const handleClick = () => {
+ *     detach(commandFn(pageSignal), Reason.DomCallback);
+ *   };
+ *
+ * Bad (signals layer):
+ *   export const setupPage$ = command(({ set }, signal) => {
+ *     detach(set(fetchData$, signal), Reason.Entrance);
+ *   });
+ *
+ * @see .claude/skills/ccstate/SKILL.md § "Scope of detach() usage"
+ */
+
+import type { TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+export default createRule({
+  name: "no-detach-in-signals",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow detach() in signals/ files — use await or signal chain instead. See .claude/skills/ccstate/SKILL.md § 'Scope of detach() usage'",
+    },
+    schema: [],
+    messages: {
+      noDetachInSignals:
+        "Do not use detach() in signals/. In the signals layer, manage async work with await or the signal chain. detach() is only for DOM event callbacks in the views layer. See .claude/skills/ccstate/SKILL.md § 'Scope of detach() usage'.",
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename();
+    // Only apply to files under src/signals/ (excluding __tests__)
+    if (
+      !filename.includes("/src/signals/") ||
+      filename.includes("/__tests__/")
+    ) {
+      return {};
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "detach"
+        ) {
+          context.report({
+            node,
+            messageId: "noDetachInSignals",
+          });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -37,6 +37,7 @@ export default [
       "ccstate/no-non-zero-api": "error",
       "ccstate/no-new-abort-controller": "error",
       "ccstate/no-direct-local-storage": "error",
+      "ccstate/no-detach-in-signals": "error",
     },
   },
   // Type-aware rules (only for TypeScript files)
@@ -97,6 +98,13 @@ export default [
             "Do not set test timeout. The default timeout (5000ms) is sufficient — a single test should complete within 500ms. Polling intervals are reduced to 10ms in tests, so do not rely on extending timeout to fix flaky tests. Find and fix the underlying timing issue instead.",
         },
       ],
+    },
+  },
+  // Allow detach() in signal infrastructure (definition site)
+  {
+    files: ["src/signals/utils.ts"],
+    rules: {
+      "ccstate/no-detach-in-signals": "off",
     },
   },
   // Allow direct localStorage in the abstraction layer only

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -52,6 +52,7 @@ const setupNotFoundRedirect$ = command(({ set }) => {
 function redirectTo(target: string) {
   return command(({ get, set }) => {
     const signal = get(rootSignal$).signal;
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
     detach(
       set(navigate$, target, { replace: true }, signal),
       Reason.DomCallback,
@@ -68,6 +69,7 @@ function redirectWithParams(buildTarget: (params: ParamData) => string) {
     const params = get(pathParams$) ?? {};
     const target = buildTarget(params);
     const signal = get(rootSignal$).signal;
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
     detach(
       set(navigate$, target, { replace: true }, signal),
       Reason.DomCallback,

--- a/turbo/apps/platform/src/signals/fetch.ts
+++ b/turbo/apps/platform/src/signals/fetch.ts
@@ -202,6 +202,7 @@ export const fetch$ = computed((get) => {
     const response = await fetch(finalUrl, finalInit);
 
     if (response.status === 401) {
+      // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
       detach(clerk.redirectToSignIn(), Reason.DomCallback);
     }
 

--- a/turbo/apps/platform/src/signals/queue-page/queue-page-setup.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-page-setup.ts
@@ -24,5 +24,6 @@ export const setupQueuePage$ = command(async ({ set }, signal: AbortSignal) => {
   }
 
   set(reloadChatThreads$);
+  // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
   detach(set(startQueuePolling$, signal), Reason.Entrance);
 });

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -167,6 +167,7 @@ export const detachedNavigateTo$ = command(
   ) => {
     const signal = get(rootSignal$).signal;
 
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
     detach(
       set(
         navigate$,

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-detail-page-setup.ts
@@ -32,6 +32,7 @@ export const setupScheduleDetailPage$ = command(
     set(setScheduleRunHistoryScheduleId$, scheduleId);
     set(seedScheduleRunCursorHistory$);
 
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
     detach(set(fetchAllOrgSchedules$, signal), Reason.Entrance);
     await Promise.all([
       set(initZeroOnboarding$, signal),

--- a/turbo/apps/platform/src/signals/schedule-page/schedule-page-setup.ts
+++ b/turbo/apps/platform/src/signals/schedule-page/schedule-page-setup.ts
@@ -17,6 +17,7 @@ export const setupSchedulePage$ = command(
       createElement(SidebarLayout, null, createElement(ZeroSchedulePage)),
     );
     set(updateDocumentTitle$, "Schedule");
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
     detach(set(fetchAllOrgSchedules$, signal), Reason.Entrance);
     await set(initZeroOnboarding$, signal);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/user-invitations.ts
+++ b/turbo/apps/platform/src/signals/user-invitations.ts
@@ -50,6 +50,7 @@ const pollUserInvitations$ = command(async ({ set }, signal: AbortSignal) => {
  */
 const orgSwitcherSetup$ = command(
   async ({ set }, el: HTMLElement, signal: AbortSignal) => {
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
     detach(set(watchOrgSwitch$, el, signal), Reason.Entrance);
     await set(pollUserInvitations$, signal);
   },

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -24,6 +24,7 @@ export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
     set(initSlackOrg$, signal),
   ]);
   signal.throwIfAborted();
+  // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
   detach(set(pollSlackConnection$, signal), Reason.Entrance);
 
   if (await set(onboardGuard$, signal)) {

--- a/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-session-page-setup.ts
@@ -62,6 +62,7 @@ export const setupChatSessionPage$ = command(
 
     // chatSessionSnapshot$ auto-fetches from URL. loadSessionFromSnapshot$
     // awaits it, populates server messages, syncs agent, resumes polling.
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
     detach(set(loadSessionFromSnapshot$, signal), Reason.Entrance);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -22,6 +22,7 @@ export const loadInitialData$ = command(
     }
     await set(initZeroOnboarding$, signal);
     signal.throwIfAborted();
+    // eslint-disable-next-line ccstate/no-detach-in-signals -- TODO: move to views layer
     detach(set(initSlackOrg$, signal), Reason.Entrance);
     set(initialDataLoaded$, true);
     set(initSidebarCollapsed$);


### PR DESCRIPTION
## Summary
- Add `ccstate/no-detach-in-signals` ESLint rule that disallows `detach()` calls in `src/signals/` files
- `detach()` is designed for the views layer (DOM event callbacks) — signals should use `await` or signal chain
- Exempt `utils.ts` (definition site) and `__tests__/` from the rule
- Add line-level suppressions (`eslint-disable-next-line`) for 10 existing violations with `TODO` markers

## Test plan
- [x] 7 rule tests pass (views allowed, tests allowed, signals blocked)
- [x] `pnpm turbo run lint` passes with all suppressions
- [x] All 112 custom ESLint rule tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)