### PR TITLE
fix: remove stale no-invalid-fetch-options allow rule from platform oxlint config

### DIFF
--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -239,7 +239,6 @@
     "no-fallthrough": "deny",
     "no-import-type-side-effects": "deny",
     "no-inferrable-types": "deny",
-    "no-invalid-fetch-options": "allow",
     "no-lonely-if": "deny",
     "no-multi-assign": "deny",
     "no-multi-string": "deny",


### PR DESCRIPTION
## Summary

- Removes the stale `"no-invalid-fetch-options": "allow"` suppression from `apps/platform/.oxlintrc.json`
- The rule was added during a bulk oxlint migration (PR #1222) as a precaution, but running oxlint with the rule enabled produces zero violations
- The only non-standard fetch option in the codebase (`duplex: "half"` in `src/signals/fetch.ts`) is passed to `new Request()`, not `fetch()` directly, so the rule does not flag it

Closes #7841

## Test plan

- [x] Lint passes with zero warnings and errors (`pnpm turbo run lint --filter='@vm0/app'`)
- [x] No new violations introduced by removing the suppression

🤖 Generated with [Claude Code](https://claude.com/claude-code)