### PR TITLE
refactor: replace dynamic import with static import in connector logos setup

### DIFF
--- a/turbo/apps/platform/src/signals/icon-size.ts
+++ b/turbo/apps/platform/src/signals/icon-size.ts
@@ -1,0 +1,18 @@
+import { command, state, computed } from "ccstate";
+
+const ICON_SIZES = [16, 32, 48, 96, 128, 256] as const;
+export type IconSize = (typeof ICON_SIZES)[number];
+
+const internalIconSize$ = state<IconSize>(128);
+
+export const iconSize$ = computed((get) => {
+  return get(internalIconSize$);
+});
+
+export const iconSizes$ = computed(() => {
+  return ICON_SIZES;
+});
+
+export const setIconSize$ = command(({ set }, size: IconSize) => {
+  set(internalIconSize$, size);
+});

--- a/turbo/apps/platform/src/signals/internal-connector-logos-setup.ts
+++ b/turbo/apps/platform/src/signals/internal-connector-logos-setup.ts
@@ -1,24 +1,7 @@
-import { command, state, computed } from "ccstate";
+import { command } from "ccstate";
 import { createElement } from "react";
 import { InternalConnectorLogos } from "../views/internal-connector-logos.tsx";
 import { updatePage$ } from "./react-router.ts";
-
-const ICON_SIZES = [16, 32, 48, 96, 128, 256] as const;
-export type IconSize = (typeof ICON_SIZES)[number];
-
-const internalIconSize$ = state<IconSize>(128);
-
-export const iconSize$ = computed((get) => {
-  return get(internalIconSize$);
-});
-
-export const iconSizes$ = computed(() => {
-  return ICON_SIZES;
-});
-
-export const setIconSize$ = command(({ set }, size: IconSize) => {
-  set(internalIconSize$, size);
-});
 
 export const setupInternalConnectorLogos$ = command(({ set }) => {
   set(updatePage$, createElement(InternalConnectorLogos));

--- a/turbo/apps/platform/src/signals/internal-connector-logos-setup.ts
+++ b/turbo/apps/platform/src/signals/internal-connector-logos-setup.ts
@@ -1,5 +1,6 @@
 import { command, state, computed } from "ccstate";
 import { createElement } from "react";
+import { InternalConnectorLogos } from "../views/internal-connector-logos.tsx";
 import { updatePage$ } from "./react-router.ts";
 
 const ICON_SIZES = [16, 32, 48, 96, 128, 256] as const;
@@ -19,10 +20,6 @@ export const setIconSize$ = command(({ set }, size: IconSize) => {
   set(internalIconSize$, size);
 });
 
-export const setupInternalConnectorLogos$ = command(
-  async ({ set }, _signal: AbortSignal) => {
-    const { InternalConnectorLogos } =
-      await import("../views/internal-connector-logos.tsx");
-    set(updatePage$, createElement(InternalConnectorLogos));
-  },
-);
+export const setupInternalConnectorLogos$ = command(({ set }) => {
+  set(updatePage$, createElement(InternalConnectorLogos));
+});

--- a/turbo/apps/platform/src/views/internal-connector-logos.tsx
+++ b/turbo/apps/platform/src/views/internal-connector-logos.tsx
@@ -6,7 +6,7 @@ import {
   iconSizes$,
   setIconSize$,
   type IconSize,
-} from "../signals/internal-connector-logos-setup.ts";
+} from "../signals/icon-size.ts";
 
 function getIconType(url: string): string {
   if (url.startsWith("data:image/svg+xml")) {


### PR DESCRIPTION
## Summary

- Replace dynamic `import()` with static `import` in `internal-connector-logos-setup.ts`
- Remove unnecessary `async` and `AbortSignal` parameter since the command is now synchronous

Closes #7836

> **Note:** Only 1 of the 3 files in the issue needed changes:
> - `cli/auth.ts` — no dynamic imports exist (false positive)
> - `cli/ngrok.ts` — dynamic import is intentional for GLIBC compatibility (#6825)

## Test plan

- [ ] Verify connector logos internal page still loads correctly
- [ ] Verify platform build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)