### PR TITLE
refactor: consolidate pr-review testing checks into code-quality bad smell system

### DIFF
--- a/.claude/skills/code-quality/SKILL.md
+++ b/.claude/skills/code-quality/SKILL.md
@@ -147,6 +147,18 @@ review "authentication changes"     # Review by description
    - Suggest using real filesystem with temp directories
    - Note: One known exception in ip-pool.test.ts (technical debt)
 
+   **Unit Tests for Internal Functions (Bad Smell #18)**
+   - Flag test files that directly import and test internal/private functions
+   - Tests should only exercise public entry points (API routes, CLI commands, exported module interfaces)
+   - Internal logic should be covered indirectly through integration tests
+   - Only integration tests are acceptable — no unit tests for internal functions
+
+   **Test Initialization Flow (Bad Smell #19)**
+   - Flag tests that bypass production initialization flow
+   - Platform tests must use `setupPage()` or equivalent production initialization
+   - Tests should not manually construct internal state that production code initializes differently
+   - Test setup should mirror how the code actually runs in production
+
 6. **Generate Review Files**
 
    Create individual review file for each commit with this structure:
@@ -207,6 +219,8 @@ review "authentication changes"     # Review by description
    - Mock cleanup (Bad Smell #8): [assessment]
    - Direct DB ops (Bad Smell #12): [locations]
    - Filesystem mocking (Bad Smell #17): [locations]
+   - Unit tests for internals (Bad Smell #18): [locations]
+   - Test initialization bypass (Bad Smell #19): [locations]
 
    ## Files Changed
    {list of files}
@@ -250,7 +264,7 @@ review "authentication changes"     # Review by description
    - Defensive programming: {count}
    - Dynamic imports: {count}
    - Type safety issues: {count}
-   - [etc for all 17 categories]
+   - [etc for all 19 categories]
 
    ### Mock Usage Summary
    - Total new mocks: {count}


### PR DESCRIPTION
## Summary

- Add Bad Smell #18 (Unit Tests for Internal Functions) to `code-quality` skill
- Add Bad Smell #19 (Test Initialization Flow) to `code-quality` skill
- Update per-commit review template section 7 to include #18 and #19
- Update bad smell statistics reference from 17 to 19 categories

The 8 testing rules that were in pr-review Step 4 are already covered by existing bad smell categories (#1, #7, #8, #10, #15, #16, #17). Only 2 rules needed to be added as new bad smell categories (#18 and #19).

Changes to `pr-review` skill (simplifying Step 4, PR comment template, verdict rule, and best practices) will be done separately in the team-skills repository.

Closes #7853

## Test plan

- [x] Verify `code-quality/SKILL.md` has Bad Smell #18 and #19 in Review Criteria section
- [x] Verify section 7 of per-commit review template includes lines for #18 and #19
- [x] Verify summary statistics updated to reference 19 categories
- [x] Verify `docs/bad-smell.md` is NOT modified (intentional — delegates testing patterns to docs/testing.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)