### PR TITLE
feat(cli): show connector permissions in zero whoami sandbox output

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -385,6 +385,243 @@ describe("zero whoami command", () => {
       ).toBe(false);
     });
 
+    it("should show connector permissions with allow/deny/ask icons", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [
+              {
+                id: "1",
+                type: "github",
+                authMethod: "oauth",
+                externalId: "12345",
+                externalUsername: "octocat",
+                externalEmail: "octocat@github.com",
+                oauthScopes: ["repo"],
+                needsReconnect: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            configuredTypes: ["github"],
+            connectorProvidedSecretNames: [],
+          });
+        }),
+        http.get("http://localhost:3000/api/zero/agents/agent-123", () => {
+          return HttpResponse.json({
+            agentId: "agent-123",
+            ownerId: "owner-1",
+            description: null,
+            displayName: null,
+            sound: null,
+            avatarUrl: null,
+            firewallPolicies: {
+              github: {
+                "actions:read": "allow",
+                "actions:write": "deny",
+                "contents:read": "allow",
+                "contents:write": "ask",
+              },
+            },
+            customSkills: [],
+          });
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/agent-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return (
+            line.includes("@octocat") && line.includes("(octocat@github.com)")
+          );
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("✓") && line.includes("actions:read");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("✗") && line.includes("actions:write");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("?") && line.includes("contents:write");
+        }),
+      ).toBe(true);
+    });
+
+    it("should show full access for connector with null policies", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [
+              {
+                id: "1",
+                type: "github",
+                authMethod: "oauth",
+                externalId: "12345",
+                externalUsername: "octocat",
+                externalEmail: "octocat@github.com",
+                oauthScopes: ["repo"],
+                needsReconnect: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            configuredTypes: ["github"],
+            connectorProvidedSecretNames: [],
+          });
+        }),
+        http.get("http://localhost:3000/api/zero/agents/agent-123", () => {
+          return HttpResponse.json({
+            agentId: "agent-123",
+            ownerId: "owner-1",
+            description: null,
+            displayName: null,
+            sound: null,
+            avatarUrl: null,
+            firewallPolicies: null,
+            customSkills: [],
+          });
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/agent-123/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return line.includes("@octocat");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("full access");
+        }),
+      ).toBe(true);
+    });
+
+    it("should show identity only when agent API fails", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [
+              {
+                id: "1",
+                type: "github",
+                authMethod: "oauth",
+                externalId: "12345",
+                externalUsername: "octocat",
+                externalEmail: "octocat@github.com",
+                oauthScopes: ["repo"],
+                needsReconnect: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            configuredTypes: ["github"],
+            connectorProvidedSecretNames: [],
+          });
+        }),
+        http.get("http://localhost:3000/api/zero/agents/agent-123", () => {
+          return HttpResponse.json(
+            { error: { message: "Internal Server Error", code: "INTERNAL" } },
+            { status: 500 },
+          );
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/agent-123/user-connectors",
+          () => {
+            return HttpResponse.json(
+              { error: { message: "Internal Server Error", code: "INTERNAL" } },
+              { status: 500 },
+            );
+          },
+        ),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return line.includes("Connected Services:");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return line.includes("@octocat");
+        }),
+      ).toBe(true);
+      // No permission lines when agent API fails
+      expect(
+        output.some((line) => {
+          return line.includes("✓") || line.includes("✗") || line.includes("?");
+        }),
+      ).toBe(false);
+      expect(
+        output.some((line) => {
+          return line.includes("full access");
+        }),
+      ).toBe(false);
+    });
+
     it("should skip connectors without identity info", async () => {
       const token = buildZeroToken({
         userId: "user-1",

--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -622,6 +622,88 @@ describe("zero whoami command", () => {
       ).toBe(false);
     });
 
+    it("should show identity only when one agent API fails", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [
+              {
+                id: "1",
+                type: "github",
+                authMethod: "oauth",
+                externalId: "12345",
+                externalUsername: "octocat",
+                externalEmail: "octocat@github.com",
+                oauthScopes: ["repo"],
+                needsReconnect: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            configuredTypes: ["github"],
+            connectorProvidedSecretNames: [],
+          });
+        }),
+        http.get("http://localhost:3000/api/zero/agents/agent-123", () => {
+          return HttpResponse.json({
+            agentId: "agent-123",
+            ownerId: "owner-1",
+            description: null,
+            displayName: null,
+            sound: null,
+            avatarUrl: null,
+            firewallPolicies: {
+              github: { "actions:read": "allow" },
+            },
+            customSkills: [],
+          });
+        }),
+        // user-connectors API fails
+        http.get(
+          "http://localhost:3000/api/zero/agents/agent-123/user-connectors",
+          () => {
+            return HttpResponse.json(
+              { error: { message: "Forbidden", code: "FORBIDDEN" } },
+              { status: 403 },
+            );
+          },
+        ),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return line.includes("@octocat");
+        }),
+      ).toBe(true);
+      // No permission lines when one agent API fails
+      expect(
+        output.some((line) => {
+          return line.includes("✓") || line.includes("✗") || line.includes("?");
+        }),
+      ).toBe(false);
+      expect(
+        output.some((line) => {
+          return line.includes("full access");
+        }),
+      ).toBe(false);
+    });
+
     it("should skip connectors without identity info", async () => {
       const token = buildZeroToken({
         userId: "user-1",

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -6,8 +6,18 @@ import {
   getToken,
   decodeZeroTokenPayload,
 } from "../../lib/api/config";
-import { listZeroConnectors } from "../../lib/api";
+import {
+  listZeroConnectors,
+  getZeroAgent,
+  getZeroAgentUserConnectors,
+} from "../../lib/api";
 import { withErrorHandler } from "../../lib/command";
+import {
+  isFirewallConnectorType,
+  getConnectorFirewall,
+  resolveFirewallPolicies,
+  type FirewallPolicies,
+} from "@vm0/core";
 
 /**
  * Detect if running inside a zero sandbox (agent runtime).
@@ -16,6 +26,62 @@ import { withErrorHandler } from "../../lib/command";
  */
 function isInsideSandbox(): boolean {
   return !!process.env.ZERO_AGENT_ID;
+}
+
+function formatConnectorIdentity(connector: {
+  externalUsername: string | null;
+  externalEmail: string | null;
+  needsReconnect: boolean;
+}): string {
+  let identity = "";
+  if (connector.externalUsername && connector.externalEmail) {
+    identity = `@${connector.externalUsername} (${connector.externalEmail})`;
+  } else if (connector.externalUsername) {
+    identity = `@${connector.externalUsername}`;
+  } else if (connector.externalEmail) {
+    identity = connector.externalEmail;
+  }
+  if (connector.needsReconnect) {
+    identity += ` ${chalk.yellow("(needs reconnect)")}`;
+  }
+  return identity;
+}
+
+function printConnectorPermissions(
+  type: string,
+  resolvedPolicies: FirewallPolicies | null,
+): void {
+  if (!isFirewallConnectorType(type)) return;
+
+  const policies = resolvedPolicies?.[type] ?? null;
+  if (!policies) {
+    console.log(chalk.dim("    full access — no permission rules configured"));
+    return;
+  }
+
+  const config = getConnectorFirewall(type);
+  const permissions = config.apis.flatMap((a) => {
+    return a.permissions ?? [];
+  });
+  if (permissions.length === 0) return;
+
+  const nameWidth = Math.max(
+    ...permissions.map((p) => {
+      return p.name.length;
+    }),
+  );
+
+  for (const perm of permissions) {
+    const policy = policies[perm.name] ?? "deny";
+    const icon =
+      policy === "allow"
+        ? chalk.green("✓")
+        : policy === "ask"
+          ? chalk.yellow("?")
+          : chalk.dim("✗");
+    const desc = perm.description ?? "";
+    console.log(`    ${icon} ${perm.name.padEnd(nameWidth)}  ${desc}`);
+  }
 }
 
 async function showSandboxInfo(): Promise<void> {
@@ -33,29 +99,44 @@ async function showSandboxInfo(): Promise<void> {
     console.log(`  ${payload.capabilities.join(", ")}`);
   }
 
-  // Connected Services section
+  // Connected Services section (identity + permissions)
   try {
-    const result = await listZeroConnectors();
-    const identities = result.connectors.filter((c) => {
+    const [connectorsResult, agentResult, enabledResult] =
+      await Promise.allSettled([
+        listZeroConnectors(),
+        getZeroAgent(agentId!),
+        getZeroAgentUserConnectors(agentId!),
+      ]);
+
+    // If connector API failed, skip entire section
+    if (connectorsResult.status === "rejected") return;
+
+    const identities = connectorsResult.value.connectors.filter((c) => {
       return c.externalUsername !== null || c.externalEmail !== null;
     });
 
-    if (identities.length > 0) {
-      console.log();
-      console.log(chalk.bold("Connected Services:"));
-      for (const connector of identities) {
-        let identity = "";
-        if (connector.externalUsername && connector.externalEmail) {
-          identity = `@${connector.externalUsername} (${connector.externalEmail})`;
-        } else if (connector.externalUsername) {
-          identity = `@${connector.externalUsername}`;
-        } else if (connector.externalEmail) {
-          identity = connector.externalEmail;
-        }
-        if (connector.needsReconnect) {
-          identity += ` ${chalk.yellow("(needs reconnect)")}`;
-        }
-        console.log(`  ${connector.type.padEnd(14)}${identity}`);
+    if (identities.length === 0) return;
+
+    // Resolve permissions if both agent APIs succeeded
+    let resolvedPolicies: FirewallPolicies | null = null;
+    const permissionDataAvailable =
+      agentResult.status === "fulfilled" &&
+      enabledResult.status === "fulfilled";
+    if (permissionDataAvailable) {
+      resolvedPolicies = resolveFirewallPolicies(
+        agentResult.value.firewallPolicies,
+        enabledResult.value,
+      );
+    }
+
+    console.log();
+    console.log(chalk.bold("Connected Services:"));
+    for (const connector of identities) {
+      const identity = formatConnectorIdentity(connector);
+      console.log(`  ${connector.type.padEnd(14)}${identity}`);
+
+      if (permissionDataAvailable) {
+        printConnectorPermissions(connector.type, resolvedPolicies);
       }
     }
   } catch {


### PR DESCRIPTION
## Summary

- Display per-connector permission details (✓ allow / ✗ deny / ? ask) alongside identity info in `zero whoami` sandbox mode
- Fetch agent firewall policies and enabled connectors via `Promise.allSettled()` for graceful degradation
- Fall back to identity-only display when permission APIs are unavailable

Closes #7854

## Changes

### `whoami.ts`
- Added `getZeroAgent()` and `getZeroAgentUserConnectors()` API calls alongside existing `listZeroConnectors()`
- All three calls run concurrently via `Promise.allSettled()`
- Extracted `formatConnectorIdentity()` and `printConnectorPermissions()` helpers to reduce function complexity
- For each connected service, shows permissions inline below identity line

### `whoami.test.ts`
- Added test: connector permissions with allow/deny/ask icons
- Added test: full access display for null policies
- Added test: graceful fallback when agent API fails (identity-only)

## Test plan

- [x] All 15 whoami tests pass (12 existing + 3 new)
- [x] Agent view tests pass (no regression)
- [x] Lint passes (complexity within limits after extraction)
- [x] Type check passes
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)