### PR TITLE
feat(cli): add connector identity to agent view --permissions

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -21,6 +21,35 @@ const mockAgent = {
   firewallPolicies: null,
 };
 
+function mockConnectorListHandler(
+  connectors: Record<string, unknown>[] = [],
+  configuredTypes: string[] = [],
+) {
+  return http.get("http://localhost:3000/api/zero/connectors", () => {
+    return HttpResponse.json({
+      connectors,
+      configuredTypes,
+      connectorProvidedSecretNames: [],
+    });
+  });
+}
+
+function makeConnector(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "1",
+    type: "github",
+    authMethod: "oauth",
+    externalId: "12345",
+    externalUsername: "octocat",
+    externalEmail: "octocat@github.com",
+    oauthScopes: ["repo"],
+    needsReconnect: false,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
 describe("zero agent view command", () => {
   const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
     throw new Error("process.exit called");
@@ -54,6 +83,7 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledTypes: ["github"] });
           },
         ),
+        mockConnectorListHandler(),
       );
 
       await viewCommand.parseAsync(["node", "cli", "my-agent"]);
@@ -86,6 +116,7 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledTypes: ["github"] });
           },
         ),
+        mockConnectorListHandler(),
       );
 
       await viewCommand.parseAsync(["node", "cli", "my-agent"]);
@@ -105,6 +136,7 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledTypes: [] });
           },
         ),
+        mockConnectorListHandler(),
         http.get(
           "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
@@ -138,6 +170,7 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledTypes: [] });
           },
         ),
+        mockConnectorListHandler(),
         http.get(
           "http://localhost:3000/api/zero/agents/my-agent/instructions",
           () => {
@@ -180,6 +213,7 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledTypes: ["github"] });
           },
         ),
+        mockConnectorListHandler(),
       );
 
       await viewCommand.parseAsync([
@@ -207,6 +241,7 @@ describe("zero agent view command", () => {
             return HttpResponse.json({ enabledTypes: ["github"] });
           },
         ),
+        mockConnectorListHandler(),
       );
 
       await viewCommand.parseAsync([
@@ -236,6 +271,7 @@ describe("zero agent view command", () => {
             });
           },
         ),
+        mockConnectorListHandler(),
       );
 
       await viewCommand.parseAsync([
@@ -248,6 +284,170 @@ describe("zero agent view command", () => {
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("custom-connector");
       expect(logCalls).toContain("No firewall configured.");
+    });
+  });
+
+  describe("connector identity", () => {
+    it("should show identity in connector summary line", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        mockConnectorListHandler([makeConnector()], ["github"]),
+      );
+
+      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("github @octocat (full access)");
+    });
+
+    it("should show Account line with identity in permissions detail", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        mockConnectorListHandler([makeConnector()], ["github"]),
+      );
+
+      await viewCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--permissions",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Account: @octocat (octocat@github.com)");
+    });
+
+    it("should work without identity when connector API fails", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json(
+            { error: { message: "Forbidden", code: "FORBIDDEN" } },
+            { status: 403 },
+          );
+        }),
+      );
+
+      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("github (full access)");
+      expect(logCalls).not.toContain("Account:");
+    });
+
+    it("should skip Account line for connectors without identity", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        mockConnectorListHandler(
+          [
+            makeConnector({
+              authMethod: "api-token",
+              externalUsername: null,
+              externalEmail: null,
+            }),
+          ],
+          ["github"],
+        ),
+      );
+
+      await viewCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--permissions",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).not.toContain("Account:");
+    });
+
+    it("should show needs reconnect warning in Account line", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        mockConnectorListHandler(
+          [makeConnector({ needsReconnect: true })],
+          ["github"],
+        ),
+      );
+
+      await viewCommand.parseAsync([
+        "node",
+        "cli",
+        "my-agent",
+        "--permissions",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Account: @octocat (octocat@github.com)");
+      expect(logCalls).toContain("(needs reconnect)");
+    });
+
+    it("should show email-only identity when no username", async () => {
+      server.use(
+        http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
+          return HttpResponse.json(mockAgent);
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/agents/my-agent/user-connectors",
+          () => {
+            return HttpResponse.json({ enabledTypes: ["github"] });
+          },
+        ),
+        mockConnectorListHandler(
+          [
+            makeConnector({
+              externalUsername: null,
+              externalEmail: "user@example.com",
+            }),
+          ],
+          ["github"],
+        ),
+      );
+
+      await viewCommand.parseAsync(["node", "cli", "my-agent"]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("github user@example.com (full access)");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -4,6 +4,7 @@ import {
   getZeroAgent,
   getZeroAgentInstructions,
   getZeroAgentUserConnectors,
+  listZeroConnectors,
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 import {
@@ -11,6 +12,7 @@ import {
   getConnectorFirewall,
   resolveFirewallPolicies,
   type FirewallPolicyValue,
+  type ConnectorResponse,
 } from "@vm0/core";
 
 interface ConnectorPermissionInfo {
@@ -52,10 +54,41 @@ function getConnectorPermissionInfo(
   return { type, hasFirewall: true, permissions, policies, allowed, total };
 }
 
-function formatConnectorSummary(info: ConnectorPermissionInfo): string {
-  if (!info.hasFirewall) return info.type;
-  if (!info.policies) return `${info.type} (full access)`;
-  return `${info.type} (${info.allowed}/${info.total} allowed)`;
+function formatConnectorIdentity(
+  connector: ConnectorResponse | undefined,
+): string {
+  if (!connector) return "";
+  if (connector.externalUsername) return `@${connector.externalUsername}`;
+  if (connector.externalEmail) return connector.externalEmail;
+  return "";
+}
+
+function formatConnectorSummary(
+  info: ConnectorPermissionInfo,
+  identity?: ConnectorResponse,
+): string {
+  const id = formatConnectorIdentity(identity);
+  const idStr = id ? ` ${id}` : "";
+  if (!info.hasFirewall) return `${info.type}${idStr}`;
+  if (!info.policies) return `${info.type}${idStr} (full access)`;
+  return `${info.type}${idStr} (${info.allowed}/${info.total} allowed)`;
+}
+
+function printAccountLine(connector: ConnectorResponse | undefined): void {
+  if (!connector) return;
+  let identity = "";
+  if (connector.externalUsername && connector.externalEmail) {
+    identity = `@${connector.externalUsername} (${connector.externalEmail})`;
+  } else if (connector.externalUsername) {
+    identity = `@${connector.externalUsername}`;
+  } else if (connector.externalEmail) {
+    identity = connector.externalEmail;
+  }
+  if (!identity) return;
+  if (connector.needsReconnect) {
+    identity += ` ${chalk.yellow("(needs reconnect)")}`;
+  }
+  console.log(`  Account: ${identity}`);
 }
 
 export const viewCommand = new Command()
@@ -79,25 +112,38 @@ Examples:
         agentId: string,
         options: { instructions?: boolean; permissions?: boolean },
       ) => {
-        const agent = await getZeroAgent(agentId);
+        const [agent, connectorTypes, connectorIdentities] = await Promise.all([
+          getZeroAgent(agentId),
+          getZeroAgentUserConnectors(agentId),
+          listZeroConnectors().catch(() => {
+            return { connectors: [] as ConnectorResponse[] };
+          }),
+        ]);
+
+        const identityMap = new Map<string, ConnectorResponse>(
+          connectorIdentities.connectors.map((c) => {
+            return [c.type, c];
+          }),
+        );
 
         console.log(chalk.bold(agent.agentId));
         if (agent.displayName) console.log(chalk.dim(agent.displayName));
         console.log();
         console.log(`Agent ID:     ${agent.agentId}`);
-        const connectors = await getZeroAgentUserConnectors(agentId);
 
         const resolvedPolicies = resolveFirewallPolicies(
           agent.firewallPolicies,
-          connectors,
+          connectorTypes,
         );
 
-        const connectorInfos = connectors.map((type) => {
+        const connectorInfos = connectorTypes.map((type) => {
           return getConnectorPermissionInfo(type, resolvedPolicies);
         });
 
         if (connectorInfos.length > 0) {
-          const summaries = connectorInfos.map(formatConnectorSummary);
+          const summaries = connectorInfos.map((info) => {
+            return formatConnectorSummary(info, identityMap.get(info.type));
+          });
           console.log(`Connectors:   ${summaries.join(", ")}`);
         }
 
@@ -113,12 +159,14 @@ Examples:
           for (const info of connectorInfos) {
             if (!info.hasFirewall) {
               console.log(chalk.dim(`── ${info.type} ──`));
+              printAccountLine(identityMap.get(info.type));
               console.log("  No firewall configured.");
               continue;
             }
 
             if (!info.policies) {
               console.log(chalk.dim(`── ${info.type} (full access) ──`));
+              printAccountLine(identityMap.get(info.type));
               console.log(
                 "  No permission rules configured — all API calls allowed.",
               );
@@ -130,6 +178,7 @@ Examples:
                 `── ${info.type} (${info.allowed}/${info.total} allowed) ──`,
               ),
             );
+            printAccountLine(identityMap.get(info.type));
 
             const nameWidth = Math.max(
               ...info.permissions.map((p) => {


### PR DESCRIPTION
## Summary

- Add connector identity (username/email) to `zero agent view` summary line and `--permissions` detail view
- Call `listZeroConnectors()` with graceful degradation when API is unavailable
- Display "Account:" line in permissions detail with identity and `(needs reconnect)` warning
- Unify visual style with `zero whoami` connector display

Closes #7859

## Test plan

- [x] Identity shown in summary line: `github @octocat (full access)`
- [x] Account line shown in `--permissions` detail: `Account: @octocat (octocat@github.com)`
- [x] Graceful degradation when connector API fails (no identity, command still works)
- [x] Account line skipped for connectors without identity data
- [x] `(needs reconnect)` warning shown when applicable
- [x] Email-only identity displayed when no username
- [x] All 14 tests pass (8 existing + 6 new)
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)