### PR TITLE
refactor: replace manual delays in tests with deferred promises

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-test-delay.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-test-delay.test.ts
@@ -1,0 +1,65 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-test-delay.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-test-delay", rule, {
+  valid: [
+    // Importing non-delay from msw is fine
+    {
+      code: `import { http, HttpResponse } from "msw";`,
+    },
+    // Importing non-delay from signal-timers is fine
+    {
+      code: `import { timeout } from "signal-timers";`,
+    },
+    // createDeferredPromise is the recommended pattern
+    {
+      code: `import { createDeferredPromise } from "../../signals/utils.ts";`,
+    },
+    // vi.waitFor is fine
+    {
+      code: `await vi.waitFor(() => { expect(x).toBe(1); });`,
+    },
+    // vi.advanceTimersByTimeAsync is fine (fake timers)
+    {
+      code: `await vi.advanceTimersByTimeAsync(3000);`,
+    },
+    // window.setTimeout as member expression is not flagged
+    {
+      code: `window.setTimeout(() => {}, 100);`,
+    },
+  ],
+  invalid: [
+    // delay from signal-timers
+    {
+      code: `import { delay } from "signal-timers";`,
+      errors: [{ messageId: "noDelayImport" }],
+    },
+    // delay from msw
+    {
+      code: `import { delay } from "msw";`,
+      errors: [{ messageId: "noDelayImport" }],
+    },
+    // delay among other msw imports
+    {
+      code: `import { http, HttpResponse, delay } from "msw";`,
+      errors: [{ messageId: "noDelayImport" }],
+    },
+    // setTimeout
+    {
+      code: `setTimeout(() => {}, 100);`,
+      errors: [{ messageId: "noSetTimeout" }],
+    },
+    // setInterval
+    {
+      code: `setInterval(() => {}, 1000);`,
+      errors: [{ messageId: "noSetInterval" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -19,6 +19,7 @@
  * - no-new-abort-controller: Disallow new AbortController() — use signal hierarchy
  * - no-direct-local-storage: Disallow direct localStorage access — use localStorageSignals()
  * - no-detach-in-signals: Disallow detach() in signals/ — use await or signal chain
+ * - no-test-delay: Disallow manual delays/timers in tests — use createDeferredPromise + waitFor
  */
 
 import signalDollarSuffix from "./rules/signal-dollar-suffix.ts";
@@ -40,6 +41,7 @@ import noNewAbortController from "./rules/no-new-abort-controller.ts";
 import preferUserEvent from "./rules/prefer-user-event.ts";
 import noDirectLocalStorage from "./rules/no-direct-local-storage.ts";
 import noDetachInSignals from "./rules/no-detach-in-signals.ts";
+import noTestDelay from "./rules/no-test-delay.ts";
 
 const plugin = {
   meta: {
@@ -66,6 +68,7 @@ const plugin = {
     "prefer-user-event": preferUserEvent,
     "no-direct-local-storage": noDirectLocalStorage,
     "no-detach-in-signals": noDetachInSignals,
+    "no-test-delay": noTestDelay,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/no-test-delay.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-test-delay.ts
@@ -1,0 +1,78 @@
+/**
+ * ESLint rule: no-test-delay
+ *
+ * Disallows manual delay/timer patterns in test files. Tests should use
+ * createDeferredPromise for controlling async flow and vi.waitFor/waitFor
+ * for assertions.
+ *
+ * Detects:
+ * 1. Importing `delay` from `signal-timers`
+ * 2. Importing `delay` from `msw`
+ * 3. Calling `setTimeout()`
+ * 4. Calling `setInterval()`
+ *
+ * Bad:
+ *   import { delay } from "signal-timers";
+ *   import { delay } from "msw";
+ *   await delay(100);
+ *   setTimeout(() => {}, 100);
+ *   setInterval(() => {}, 100);
+ *
+ * Good:
+ *   import { createDeferredPromise } from "../../signals/utils.ts";
+ *   const deferred = createDeferredPromise(context.signal);
+ *   await vi.waitFor(() => { expect(...).toBe(...); });
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+const MESSAGE =
+  "Do not use manual delays or timers in tests. Use createDeferredPromise to control async flow in MSW handlers, and vi.waitFor/waitFor for assertions.";
+
+export default createRule({
+  name: "no-test-delay",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow manual delay/timer patterns in tests",
+    },
+    schema: [],
+    messages: {
+      noDelayImport: MESSAGE,
+      noSetTimeout: MESSAGE,
+      noSetInterval: MESSAGE,
+    },
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node: TSESTree.ImportDeclaration) {
+        const source = node.source.value;
+        if (source !== "signal-timers" && source !== "msw") {
+          return;
+        }
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+            specifier.imported.type === AST_NODE_TYPES.Identifier &&
+            specifier.imported.name === "delay"
+          ) {
+            context.report({ node: specifier, messageId: "noDelayImport" });
+          }
+        }
+      },
+      CallExpression(node: TSESTree.CallExpression) {
+        if (node.callee.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+        if (node.callee.name === "setTimeout") {
+          context.report({ node, messageId: "noSetTimeout" });
+        }
+        if (node.callee.name === "setInterval") {
+          context.report({ node, messageId: "noSetInterval" });
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -77,6 +77,7 @@ export default [
     files: ["**/__tests__/**/*.{ts,tsx}"],
     rules: {
       "ccstate/prefer-user-event": "error",
+      "ccstate/no-test-delay": "error",
       "no-restricted-syntax": [
         "error",
         {

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from "vitest";
-import { delay } from "signal-timers";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
+import { createDeferredPromise } from "../../utils.ts";
 import {
   zeroChatMessages$,
   allFinished$,
@@ -417,15 +417,16 @@ describe("zero-chat signals", () => {
   });
 
   describe("attachment upload and cancel", () => {
-    function useUploadHandler(options?: { delayMs?: number }) {
-      const delayMs = options?.delayMs ?? 0;
+    function useUploadHandler(options?: {
+      deferred?: ReturnType<typeof createDeferredPromise<void>>;
+    }) {
       server.use(
         http.get("*/api/zero/chat-threads", () => {
           return HttpResponse.json({ threads: [] });
         }),
         http.post("*/api/zero/uploads", async () => {
-          if (delayMs > 0) {
-            await delay(delayMs);
+          if (options?.deferred) {
+            await options.deferred.promise;
           }
           return HttpResponse.json({
             id: "upload-1",
@@ -461,7 +462,8 @@ describe("zero-chat signals", () => {
     });
 
     it("should cancel an in-flight upload and remove the attachment", async () => {
-      useUploadHandler({ delayMs: 500 });
+      const uploadDeferred = createDeferredPromise<void>(context.signal);
+      useUploadHandler({ deferred: uploadDeferred });
       await setup();
 
       const uploadPromise = context.store
@@ -469,9 +471,11 @@ describe("zero-chat signals", () => {
         .catch(() => {});
 
       // Wait for the placeholder to appear
-      await delay(10);
+      await vi.waitFor(() => {
+        expect(context.store.get(zeroChatAttachments$)).toHaveLength(1);
+      });
+
       const before = context.store.get(zeroChatAttachments$);
-      expect(before).toHaveLength(1);
 
       // Cancel via removeZeroAttachment$ (which internally calls cancel$)
       context.store.set(removeZeroAttachment$, before[0]!);
@@ -502,6 +506,8 @@ describe("zero-chat signals", () => {
 
     it("should cancel one upload without affecting others", async () => {
       let requestCount = 0;
+      const uploadDeferreds: ReturnType<typeof createDeferredPromise<void>>[] =
+        [];
       server.use(
         http.get("*/api/zero/chat-threads", () => {
           return HttpResponse.json({ threads: [] });
@@ -509,7 +515,9 @@ describe("zero-chat signals", () => {
         http.post("*/api/zero/uploads", async () => {
           requestCount++;
           const currentCount = requestCount;
-          await delay(300);
+          const deferred = createDeferredPromise<void>(context.signal);
+          uploadDeferreds.push(deferred);
+          await deferred.promise;
           return HttpResponse.json({
             id: `upload-${currentCount}`,
             filename: `file-${currentCount}.png`,
@@ -536,13 +544,24 @@ describe("zero-chat signals", () => {
         )
         .catch(() => {});
 
+      // Wait for both requests to reach the MSW handler
       await vi.waitFor(() => {
-        const before = context.store.get(zeroChatAttachments$);
-        expect(before).toHaveLength(2);
+        expect(uploadDeferreds).toHaveLength(2);
+      });
+
+      await vi.waitFor(() => {
+        expect(context.store.get(zeroChatAttachments$)).toHaveLength(2);
       });
 
       const before = context.store.get(zeroChatAttachments$);
       context.store.set(removeZeroAttachment$, before[0]!);
+
+      // Release both upload deferreds so the surviving upload can complete
+      for (const d of uploadDeferreds) {
+        if (!d.settled()) {
+          d.resolve();
+        }
+      }
 
       await Promise.all([promise1, promise2]);
 

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-slack-connect.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-slack-connect.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach } from "vitest";
-import { delay } from "signal-timers";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import {
@@ -28,8 +29,6 @@ async function setup(path: string) {
     path,
     withoutRender: true,
   });
-  // Allow the async init command (detached via Reason.Entrance) to complete
-  await delay(50);
 }
 
 describe("slack-connect-page signals", () => {
@@ -38,13 +37,24 @@ describe("slack-connect-page signals", () => {
       setMockSlackConnectData({ isConnected: true });
       await setup("/settings/slack?w=ws1&u=user1");
 
-      expect(context.store.get(slackConnectStatus$)).toBe("success");
+      await vi.waitFor(() => {
+        expect(context.store.get(slackConnectStatus$)).toBe("success");
+      });
     });
 
     it("should stay idle when not connected", async () => {
-      setMockSlackConnectData({ isConnected: false });
+      let checkCalled = false;
+      server.use(
+        http.get("*/api/zero/integrations/slack/connect", () => {
+          checkCalled = true;
+          return HttpResponse.json({ isConnected: false, isAdmin: false });
+        }),
+      );
       await setup("/settings/slack?w=ws1&u=user1");
 
+      await vi.waitFor(() => {
+        expect(checkCalled).toBeTruthy();
+      });
       expect(context.store.get(slackConnectStatus$)).toBe("idle");
     });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-skeleton-switch.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-skeleton-switch.test.tsx
@@ -1,21 +1,23 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
-import { http, HttpResponse, delay } from "msw";
+import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { detachedNavigateTo$ } from "../../../signals/route.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 
 describe("chat skeleton on switch", () => {
   it("should show skeleton when switching between chats", async () => {
+    const threadBDeferred = createDeferredPromise<void>(context.signal);
+
     server.use(
       http.get("*/api/zero/chat-threads/:id", async ({ params }) => {
         const id = params.id as string;
         if (id === "thread-b") {
-          // Delay thread-B so loading state is observable
-          await delay(200);
+          await threadBDeferred.promise;
         }
         return HttpResponse.json({
           id,
@@ -61,6 +63,9 @@ describe("chat skeleton on switch", () => {
       const skeletons = document.querySelectorAll(".animate-pulse");
       expect(skeletons.length).toBeGreaterThan(0);
     });
+
+    // Release deferred so thread-B content loads
+    threadBDeferred.resolve();
 
     // Eventually thread-B content should load
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/recent-thread-skeleton.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/recent-thread-skeleton.test.tsx
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { delay } from "signal-timers";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
 
 const context = testContext();
@@ -83,10 +83,11 @@ describe("recent thread skeleton (#7546)", () => {
 
     // Make chat-threads API hang so the only way the sidebar can show
     // threads is by retaining the previous useLastLoadable data.
-    // Use a delayed response instead of never-resolving to avoid afterEach timeout.
+    // Deferred never resolves; context.signal rejects it on test cleanup.
+    const hangDeferred = createDeferredPromise<void>(context.signal);
     server.use(
       http.get("*/api/zero/chat-threads", async () => {
-        await delay(5000);
+        await hangDeferred.promise.catch(() => {});
         return HttpResponse.json({ threads: [] });
       }),
     );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-navigation.test.tsx
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http, HttpResponse, delay } from "msw";
+import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 
@@ -145,10 +146,11 @@ describe("sidebar new chat navigation", () => {
   it("should disable button during thread creation", async () => {
     const user = userEvent.setup();
     mockSubagentAPIs();
-    // Override POST to add a delay
+    // Override POST with deferred so we can control when the response arrives
+    const createDeferred = createDeferredPromise<void>(context.signal);
     server.use(
       http.post("*/api/zero/chat-threads", async () => {
-        await delay(500);
+        await createDeferred.promise;
         return HttpResponse.json(
           {
             id: "delayed-thread-id",
@@ -172,6 +174,9 @@ describe("sidebar new chat navigation", () => {
     await waitFor(() => {
       expect(newChatButton).toBeDisabled();
     });
+
+    // Release deferred so creation completes
+    createDeferred.resolve();
 
     // After creation completes, button should be re-enabled
     await waitFor(() => {


### PR DESCRIPTION
## Summary

- Replace all manual delay patterns (`MSW delay`, `signal-timers delay`, `await delay(N)`) in platform tests with deterministic `createDeferredPromise` + `vi.waitFor`/`waitFor` alternatives
- Add `no-test-delay` ESLint rule to enforce the pattern going forward, banning `delay` imports from `msw`/`signal-timers`, `setTimeout`, and `setInterval` in test files

## Test plan

- [x] All 28 existing tests pass across 5 modified test files
- [x] ESLint rule test passes (11 cases)
- [x] Lint passes on all modified files
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)