### PR TITLE
feat(platform): add no-direct-fetch eslint rule

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-direct-fetch.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-direct-fetch.test.ts
@@ -1,0 +1,55 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-direct-fetch.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-direct-fetch", rule, {
+  valid: [
+    {
+      // Allowed: using zeroClient$ instead
+      code: `
+        const client = get(zeroClient$)(someContract);
+        await client.doSomething();
+      `,
+    },
+    {
+      // Allowed: defining fetch$ itself
+      code: `export const fetch$ = atom(() => fetch);`,
+    },
+    {
+      // Allowed: importing fetch$ (file-level exemptions handle allowed usages)
+      code: `import { fetch$ } from "./fetch";`,
+    },
+    {
+      // Allowed: unrelated identifiers
+      code: `const result = get(otherSignal$);`,
+    },
+  ],
+  invalid: [
+    {
+      code: `const fetchFn = get(fetch$);`,
+      errors: [{ messageId: "noDirectFetch" }],
+    },
+    {
+      code: `const result = await get(fetch$)("/api/zero/something", { method: "POST" });`,
+      errors: [{ messageId: "noDirectFetch" }],
+    },
+    {
+      code: `use(fetch$);`,
+      errors: [{ messageId: "noDirectFetch" }],
+    },
+    {
+      code: `
+        function doRequest() {
+          return get(fetch$)("/api/endpoint");
+        }
+      `,
+      errors: [{ messageId: "noDirectFetch" }],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -19,6 +19,7 @@
  * - no-new-abort-controller: Disallow new AbortController() — use signal hierarchy
  * - no-direct-local-storage: Disallow direct localStorage access — use localStorageSignals()
  * - no-detach-in-signals: Disallow detach() in signals/ — use await or signal chain
+ * - no-direct-fetch: Disallow direct fetch$ usage — use zeroClient$ instead
  */
 
 import signalDollarSuffix from "./rules/signal-dollar-suffix.ts";
@@ -40,6 +41,7 @@ import noNewAbortController from "./rules/no-new-abort-controller.ts";
 import preferUserEvent from "./rules/prefer-user-event.ts";
 import noDirectLocalStorage from "./rules/no-direct-local-storage.ts";
 import noDetachInSignals from "./rules/no-detach-in-signals.ts";
+import noDirectFetch from "./rules/no-direct-fetch.ts";
 
 const plugin = {
   meta: {
@@ -66,6 +68,7 @@ const plugin = {
     "prefer-user-event": preferUserEvent,
     "no-direct-local-storage": noDirectLocalStorage,
     "no-detach-in-signals": noDetachInSignals,
+    "no-direct-fetch": noDirectFetch,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/no-direct-fetch.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-direct-fetch.ts
@@ -1,0 +1,61 @@
+/**
+ * ESLint rule: no-direct-fetch
+ *
+ * Disallows direct usage of `fetch$`. All API calls should use `zeroClient$`
+ * which provides type-safe request/response handling via ts-rest contracts.
+ *
+ * Good:
+ *   const client = get(zeroClient$)(someContract);
+ *   const result = await client.doSomething();
+ *
+ * Bad:
+ *   const fetchFn = get(fetch$);
+ *   await fetchFn("/api/zero/something", { method: "POST" });
+ */
+
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+import { createRule } from "../utils.ts";
+
+export default createRule({
+  name: "no-direct-fetch",
+  defaultOptions: [],
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow direct usage of fetch$ — use zeroClient$ for type-safe API calls instead",
+    },
+    schema: [],
+    messages: {
+      noDirectFetch:
+        "Do not use fetch$ directly. Use zeroClient$ from signals/api-client.ts for type-safe API calls instead.",
+    },
+  },
+  create(context) {
+    return {
+      Identifier(node: TSESTree.Identifier) {
+        if (node.name !== "fetch$") {
+          return;
+        }
+
+        // Allow the definition of fetch$ itself (e.g. `export const fetch$ = ...`)
+        if (
+          node.parent.type === AST_NODE_TYPES.VariableDeclarator &&
+          node.parent.id === node
+        ) {
+          return;
+        }
+
+        // Allow import specifiers (e.g. `import { fetch$ } from ...`)
+        if (node.parent.type === AST_NODE_TYPES.ImportSpecifier) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: "noDirectFetch",
+        });
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -38,6 +38,7 @@ export default [
       "ccstate/no-new-abort-controller": "error",
       "ccstate/no-direct-local-storage": "error",
       "ccstate/no-detach-in-signals": "error",
+      "ccstate/no-direct-fetch": "error",
     },
   },
   // Type-aware rules (only for TypeScript files)
@@ -105,6 +106,23 @@ export default [
     files: ["src/signals/utils.ts"],
     rules: {
       "ccstate/no-detach-in-signals": "off",
+    },
+  },
+  // Allow direct fetch$ in the abstraction layers and tests.
+  // View files below use fetch$ for multipart file uploads that lack ts-rest
+  // contracts — migrate them to zeroClient$ when contracts are added.
+  {
+    files: [
+      "src/signals/fetch.ts",
+      "src/signals/api-client.ts",
+      "src/signals/zero-page/chat-draft.ts",
+      "src/signals/__tests__/fetch.test.ts",
+      "src/views/zero-page/components/org-manage/org-general-tab.tsx",
+      "src/views/zero-page/zero-jobs-page.tsx",
+      "src/views/zero-page/zero-settings-tab.tsx",
+    ],
+    rules: {
+      "ccstate/no-direct-fetch": "off",
     },
   },
   // Allow direct localStorage in the abstraction layer only


### PR DESCRIPTION
## Summary
- Add custom ESLint rule `ccstate/no-direct-fetch` that forbids direct usage of `fetch$` in platform code
- All API calls should use the type-safe `zeroClient$` factory instead, which provides compile-time type checking via ts-rest contracts
- Exempt files that legitimately need raw fetch: abstraction layers (`fetch.ts`, `api-client.ts`), multipart file uploads (`chat-draft.ts`, avatar upload views), and tests

## Test plan
- [x] Verified rule catches `fetch$` references in non-exempt files
- [x] Verified exempt files pass lint without errors
- [x] Full `eslint . --max-warnings 0` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)