### PR TITLE
fix(nbd): set disconnected flag only after successful disconnect

### DIFF
--- a/crates/nbd-cow/src/lib.rs
+++ b/crates/nbd-cow/src/lib.rs
@@ -291,10 +291,13 @@ impl NbdCowDevice {
         // disconnected our device and recycled the index; blindly calling
         // disconnect(device_index) would tear down the new owner's device.
         if !self.disconnected {
-            self.disconnected = true;
             match self.device_ownership() {
-                DeviceOwnership::Ours => netlink::disconnect(self.device_index)?,
+                DeviceOwnership::Ours => {
+                    netlink::disconnect(self.device_index)?;
+                    self.disconnected = true;
+                }
                 DeviceOwnership::Foreign(pid) => {
+                    self.disconnected = true;
                     tracing::warn!(
                         device_index = self.device_index,
                         foreign_pid = pid,
@@ -302,6 +305,7 @@ impl NbdCowDevice {
                     );
                 }
                 DeviceOwnership::Unknown(err) => {
+                    self.disconnected = true;
                     tracing::warn!(
                         device_index = self.device_index,
                         error = %err,


### PR DESCRIPTION
## Summary

- `shutdown_inner` previously set `self.disconnected = true` **before** calling `netlink::disconnect()`. If disconnect failed (e.g., kernel still releasing Firecracker's fds after kill), all subsequent retry calls from `factory.rs` and `snapshot.rs` would skip disconnect and return `Ok` vacuously — making the 5×500ms destroy retry loops completely ineffective.
- Move `self.disconnected = true` to **after** successful disconnect, so callers can genuinely retry. The `Foreign`/`Unknown` ownership branches still set the flag immediately since retrying would not help.
- This reduces zombie NBD device linger time from ~60s (kernel `dead_conn_timeout`) to ~0.5–2.5s (retry loop).

## Test plan

- [x] `cargo check -p nbd-cow` and `cargo check -p sandbox-fc` pass
- [x] All 35 nbd-cow unit tests pass
- [ ] CI passes (integration tests require root + nbd module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)