### PR TITLE
refactor(cli): unify connector display style between whoami and agent view

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -237,7 +237,7 @@ describe("zero whoami command", () => {
       const output = getAllOutput();
       expect(
         output.some((line) => {
-          return line.includes("Connected Services:");
+          return line.includes("Connectors:");
         }),
       ).toBe(true);
       expect(
@@ -341,7 +341,7 @@ describe("zero whoami command", () => {
       ).toBe(true);
       expect(
         output.some((line) => {
-          return line.includes("Connected Services:");
+          return line.includes("Connectors:");
         }),
       ).toBe(false);
     });
@@ -380,7 +380,7 @@ describe("zero whoami command", () => {
       ).toBe(true);
       expect(
         output.some((line) => {
-          return line.includes("Connected Services:");
+          return line.includes("Connectors:");
         }),
       ).toBe(false);
     });
@@ -601,7 +601,7 @@ describe("zero whoami command", () => {
       const output = getAllOutput();
       expect(
         output.some((line) => {
-          return line.includes("Connected Services:");
+          return line.includes("Connectors:");
         }),
       ).toBe(true);
       expect(
@@ -758,7 +758,7 @@ describe("zero whoami command", () => {
       const output = getAllOutput();
       expect(
         output.some((line) => {
-          return line.includes("Connected Services:");
+          return line.includes("Connectors:");
         }),
       ).toBe(true);
       expect(

--- a/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/__tests__/view.test.ts
@@ -253,9 +253,7 @@ describe("zero agent view command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("full access");
-      expect(logCalls).toContain(
-        "No permission rules configured — all API calls allowed.",
-      );
+      expect(logCalls).toContain("no permission rules configured");
     });
 
     it("should handle non-firewall connectors gracefully", async () => {
@@ -283,7 +281,6 @@ describe("zero agent view command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("custom-connector");
-      expect(logCalls).toContain("No firewall configured.");
     });
   });
 
@@ -308,7 +305,7 @@ describe("zero agent view command", () => {
       expect(logCalls).toContain("github @octocat (full access)");
     });
 
-    it("should show Account line with identity in permissions detail", async () => {
+    it("should show full identity in permissions detail", async () => {
       server.use(
         http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
           return HttpResponse.json(mockAgent);
@@ -330,7 +327,7 @@ describe("zero agent view command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Account: @octocat (octocat@github.com)");
+      expect(logCalls).toContain("@octocat (octocat@github.com)");
     });
 
     it("should work without identity when connector API fails", async () => {
@@ -356,10 +353,10 @@ describe("zero agent view command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("github (full access)");
-      expect(logCalls).not.toContain("Account:");
+      expect(logCalls).not.toContain("@octocat");
     });
 
-    it("should skip Account line for connectors without identity", async () => {
+    it("should skip identity for connectors without identity data", async () => {
       server.use(
         http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
           return HttpResponse.json(mockAgent);
@@ -390,10 +387,10 @@ describe("zero agent view command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).not.toContain("Account:");
+      expect(logCalls).not.toContain("@");
     });
 
-    it("should show needs reconnect warning in Account line", async () => {
+    it("should show needs reconnect warning in identity line", async () => {
       server.use(
         http.get("http://localhost:3000/api/zero/agents/my-agent", () => {
           return HttpResponse.json(mockAgent);
@@ -418,7 +415,7 @@ describe("zero agent view command", () => {
       ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
-      expect(logCalls).toContain("Account: @octocat (octocat@github.com)");
+      expect(logCalls).toContain("@octocat (octocat@github.com)");
       expect(logCalls).toContain("(needs reconnect)");
     });
 

--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -74,8 +74,10 @@ function formatConnectorSummary(
   return `${info.type}${idStr} (${info.allowed}/${info.total} allowed)`;
 }
 
-function printAccountLine(connector: ConnectorResponse | undefined): void {
-  if (!connector) return;
+function formatDetailIdentity(
+  connector: ConnectorResponse | undefined,
+): string {
+  if (!connector) return "";
   let identity = "";
   if (connector.externalUsername && connector.externalEmail) {
     identity = `@${connector.externalUsername} (${connector.externalEmail})`;
@@ -84,11 +86,11 @@ function printAccountLine(connector: ConnectorResponse | undefined): void {
   } else if (connector.externalEmail) {
     identity = connector.externalEmail;
   }
-  if (!identity) return;
+  if (!identity) return "";
   if (connector.needsReconnect) {
     identity += ` ${chalk.yellow("(needs reconnect)")}`;
   }
-  console.log(`  Account: ${identity}`);
+  return identity;
 }
 
 export const viewCommand = new Command()
@@ -156,29 +158,19 @@ Examples:
 
         if (options.permissions && connectorInfos.length > 0) {
           console.log();
+          console.log(chalk.bold("Connectors:"));
           for (const info of connectorInfos) {
-            if (!info.hasFirewall) {
-              console.log(chalk.dim(`── ${info.type} ──`));
-              printAccountLine(identityMap.get(info.type));
-              console.log("  No firewall configured.");
-              continue;
-            }
+            const identity = formatDetailIdentity(identityMap.get(info.type));
+            console.log(`  ${info.type.padEnd(14)}${identity}`);
+
+            if (!info.hasFirewall) continue;
 
             if (!info.policies) {
-              console.log(chalk.dim(`── ${info.type} (full access) ──`));
-              printAccountLine(identityMap.get(info.type));
               console.log(
-                "  No permission rules configured — all API calls allowed.",
+                chalk.dim("    full access — no permission rules configured"),
               );
               continue;
             }
-
-            console.log(
-              chalk.dim(
-                `── ${info.type} (${info.allowed}/${info.total} allowed) ──`,
-              ),
-            );
-            printAccountLine(identityMap.get(info.type));
 
             const nameWidth = Math.max(
               ...info.permissions.map((p) => {
@@ -195,7 +187,9 @@ Examples:
                     ? chalk.yellow("?")
                     : chalk.dim("✗");
               const desc = perm.description ?? "";
-              console.log(`  ${icon} ${perm.name.padEnd(nameWidth)}  ${desc}`);
+              console.log(
+                `    ${icon} ${perm.name.padEnd(nameWidth)}  ${desc}`,
+              );
             }
           }
         }

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -130,7 +130,7 @@ async function showSandboxInfo(): Promise<void> {
     }
 
     console.log();
-    console.log(chalk.bold("Connected Services:"));
+    console.log(chalk.bold("Connectors:"));
     for (const connector of identities) {
       const identity = formatConnectorIdentity(connector);
       console.log(`  ${connector.type.padEnd(14)}${identity}`);


### PR DESCRIPTION
## Summary

- Rename "Connected Services" section to "Connectors" in `zero whoami` for consistency with `zero agent view`
- Remove `── type (N/M allowed) ──` divider lines from `agent view --permissions`
- Replace `Account:` prefix with `type.padEnd(14) + identity` format matching `whoami`
- Unify permission indent to 4 spaces and "full access" wording across both commands

After this change, both commands use identical connector display format:
```
Connectors:
  github        @octocat (octocat@github.com)
    ✓ repo-read       Read repository contents
    ✗ repo-write      Push to repositories
  slack         @john.doe (needs reconnect)
    full access — no permission rules configured
```

## Test plan

- [x] All 30 existing tests pass (16 whoami + 14 view)
- [x] CLI lint, type-check, format, knip pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)