### PR TITLE
refactor(test): remove ineffective vi.mock in zero-chat-page test

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page.test.tsx
@@ -1,4 +1,3 @@
-import type { ConnectorType } from "@vm0/core";
 import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -7,49 +6,6 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { getCategories } from "../zero-ideation-data.ts";
-
-/** Deterministic cards for tests (landing uses random prompts from ideation data). */
-vi.mock("../zero-ideation-page.tsx", async (importOriginal) => {
-  const mod =
-    await importOriginal<typeof import("../zero-ideation-page.tsx")>();
-  return {
-    ...mod,
-    getRandomPrompts: (count: number) => {
-      const prompts: {
-        title: string;
-        description: string;
-        prompt: string;
-        connectors: ConnectorType[];
-      }[] = [
-        {
-          title: "Daily standup report",
-          description:
-            "Pull GitHub, Sentry, Axiom, and Plausible data every morning, generate a pptx, and post to a Slack channel",
-          prompt:
-            "Set up a daily standup report that pulls data from GitHub, Sentry, Axiom, and Plausible every morning, generates a pptx, and posts it to #all-vm0",
-          connectors: ["github", "sentry", "axiom", "plausible", "slack"],
-        },
-        {
-          title: "Morning brief",
-          description:
-            "Pull updates from Gmail, Calendar, and Notion to give you a clear plan for the day",
-          prompt:
-            "Set up a morning brief that pulls updates from Gmail, Calendar, and Notion every morning and posts a daily plan to Slack",
-          connectors: ["gmail", "google-calendar", "notion", "slack"],
-        },
-        {
-          title: "Batch-create issues",
-          description:
-            "Give Zero multiple issue instructions at once \u2014 it creates and assigns them automatically",
-          prompt:
-            "Create the following GitHub issues and assign them to the right people: 1) ... 2) ... 3) ...",
-          connectors: ["github"],
-        },
-      ];
-      return prompts.slice(0, count);
-    },
-  };
-});
 
 const context = testContext();
 


### PR DESCRIPTION
## Summary

- Remove no-op `vi.mock("../zero-ideation-page.tsx")` that targeted the wrong module — `getRandomPrompts` is exported from `zero-ideation-data.ts`, not `zero-ideation-page.tsx`
- Remove unused `ConnectorType` import that was only needed by the mock
- Tests already handle non-deterministic prompts by dynamically matching against the dataset

Closes #7831

## Test plan

- [x] All 22 tests in `zero-chat-page.test.tsx` pass after removal
- [x] Pre-commit hooks (prettier, knip, commitlint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)