### PR TITLE
refactor(web): move realtime from shared to infra

### DIFF
--- a/turbo/apps/web/app/api/runners/realtime/token/route.ts
+++ b/turbo/apps/web/app/api/runners/realtime/token/route.ts
@@ -2,7 +2,7 @@ import { createHandler, tsr } from "../../../../../src/lib/ts-rest-handler";
 import { runnerRealtimeTokenContract, createErrorResponse } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getRunnerAuth } from "../../../../../src/lib/auth/runner-auth";
-import { generateRunnerGroupToken } from "../../../../../src/lib/shared/realtime/client";
+import { generateRunnerGroupToken } from "../../../../../src/lib/infra/realtime/client";
 import { isOfficialRunnerGroup } from "../../../../../src/lib/infra/run/runner-group";
 import { logger } from "../../../../../src/lib/shared/logger";
 

--- a/turbo/apps/web/src/lib/infra/realtime/client.ts
+++ b/turbo/apps/web/src/lib/infra/realtime/client.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import Ably from "ably";
 import { env } from "../../../env";
-import { logger } from "../logger";
+import { logger } from "../../shared/logger";
 
 const log = logger("realtime");
 

--- a/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
@@ -13,7 +13,7 @@ import {
 import { encryptSecretsMap } from "../../../shared/crypto/secrets-encryption";
 import { isOfficialRunnerGroup } from "../runner-group";
 import { forbidden } from "../../../shared/errors";
-import { publishJobNotification } from "../../../shared/realtime/client";
+import { publishJobNotification } from "../../realtime/client";
 import { logger } from "../../../shared/logger";
 import { recordSandboxOperation } from "../../../shared/metrics";
 import type { PreparedContext, ExecutorResult } from "./types";

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -41,7 +41,7 @@ import {
   type ConnectorType,
 } from "@vm0/core";
 import { agentRunQueue } from "../../../db/schema/agent-run-queue";
-import { publishCancelNotification } from "../../shared/realtime/client";
+import { publishCancelNotification } from "../realtime/client";
 
 const log = logger("service:run");
 


### PR DESCRIPTION
## Summary
- Move `turbo/apps/web/src/lib/shared/realtime/` to `turbo/apps/web/src/lib/infra/realtime/`
- The realtime module (Ably client) is only consumed by `infra/run` and belongs in the infra layer, not shared
- Update all import paths in `run-service.ts`, `runner-executor.ts`, and the API route

## Test plan
- [x] TypeScript type check passes (`pnpm turbo run check-types --filter=web`)
- [x] Lint passes (`pnpm turbo run lint --filter=web`)
- [x] Format check passes (`pnpm format`)
- [x] Knip passes (no unused exports/files)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)