### PR TITLE
feat(zero): add `zero whoami` to agent system prompt

### DIFF
--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -75,7 +75,8 @@ function buildAgentToolsPrompt(): string {
     "- Slack messaging and file uploads: `zero slack --help`. Your replies are automatically sent to the originating thread — only use these commands for different channels/threads. Never use SLACK_TOKEN directly — it's a user OAuth token.",
     "- Diagnose missing tokens or expired connectors: `zero doctor missing-token --help`.",
     "- Troubleshoot firewall denials and permission changes: `zero doctor firewall-deny --help` and `zero doctor firewall-permissions-change --help`.",
-    "- Update your own configuration: `zero agent edit --help`. Review current settings with `zero agent view $ZERO_AGENT_ID --instructions` first.",
+    "- Inspect yourself: `zero whoami` for identity and permissions, `zero agent view $ZERO_AGENT_ID --instructions` for your current settings.",
+    "- Update your own configuration: `zero agent edit --help`.",
     "- Manage custom skills: `zero skill --help`.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Add `zero whoami` to the agent system prompt so sandbox agents can inspect their identity and permissions
- Split the old "Update your own configuration" bullet into two concerns: "Inspect yourself" and "Update your own configuration"

Closes #7640

## Test plan
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes (`pnpm check-types --filter=web`)
- [x] Format check passes (`pnpm format`)
- [x] Knip passes (via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)