### PR TITLE
feat: add accept function and api error class for unified http error handling

### DIFF
--- a/turbo/apps/platform/src/lib/__tests__/accept.test.ts
+++ b/turbo/apps/platform/src/lib/__tests__/accept.test.ts
@@ -1,0 +1,116 @@
+import { toast } from "@vm0/ui/components/ui/sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, accept } from "../accept";
+
+vi.mock("@vm0/ui/components/ui/sonner", () => {
+  return { toast: { error: vi.fn() } };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("accept", () => {
+  it("accepted status → returns result, no toast, no throw", async () => {
+    const response = { status: 200 as const, body: { id: "x" } };
+    const result = await accept(Promise.resolve(response), [200]);
+    expect(result).toStrictEqual(response);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("multiple accepted codes → both pass through", async () => {
+    const response200 = { status: 200 as const, body: { id: "a" } };
+    const response201 = { status: 201 as const, body: { id: "b" } };
+    type TwoStatuses =
+      | { status: 200; body: { id: string } }
+      | { status: 201; body: { id: string } };
+
+    const result200 = await accept(
+      Promise.resolve(response200) as Promise<TwoStatuses>,
+      [200],
+    );
+    expect(result200).toStrictEqual(response200);
+
+    const result201 = await accept(
+      Promise.resolve(response201) as Promise<TwoStatuses>,
+      [201],
+    );
+    expect(result201).toStrictEqual(response201);
+  });
+
+  it("unaccepted status with standard error body → toast + throw with server message", async () => {
+    type OkOrBad =
+      | { status: 200; body: { id: string } }
+      | { status: 400; body: { error: { message: string; code: string } } };
+    const response: OkOrBad = {
+      status: 400,
+      body: { error: { message: "Bad input", code: "BAD_REQUEST" } },
+    };
+
+    await expect(accept(Promise.resolve(response), [200])).rejects.toSatisfy(
+      (err: unknown) => {
+        return (
+          err instanceof ApiError &&
+          err.message === "Bad input" &&
+          err.code === "BAD_REQUEST" &&
+          err.status === 400
+        );
+      },
+    );
+    expect(toast.error).toHaveBeenCalledWith("Bad input");
+  });
+
+  it("unaccepted status with non-standard body → fallback message", async () => {
+    type OkOrFail =
+      | { status: 200; body: { id: string } }
+      | { status: 500; body: null };
+    const response: OkOrFail = { status: 500, body: null };
+
+    await expect(accept(Promise.resolve(response), [200])).rejects.toSatisfy(
+      (err: unknown) => {
+        return (
+          err instanceof ApiError &&
+          err.message === "HTTP 500" &&
+          err.status === 500
+        );
+      },
+    );
+    expect(toast.error).toHaveBeenCalledWith("HTTP 500");
+  });
+
+  it("{ toast: false } → no toast, still throws", async () => {
+    type OkOrForbidden =
+      | { status: 200; body: { id: string } }
+      | { status: 403; body: { error: { message: string; code: string } } };
+    const response: OkOrForbidden = {
+      status: 403,
+      body: { error: { message: "Forbidden", code: "FORBIDDEN" } },
+    };
+
+    await expect(
+      accept(Promise.resolve(response), [200], { toast: false }),
+    ).rejects.toBeInstanceOf(ApiError);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("thrown error is instanceof ApiError with correct fields", async () => {
+    type OkOrForbidden =
+      | { status: 200; body: { id: string } }
+      | { status: 403; body: { error: { message: string; code: string } } };
+    const response: OkOrForbidden = {
+      status: 403,
+      body: { error: { message: "Forbidden", code: "FORBIDDEN" } },
+    };
+
+    await expect(accept(Promise.resolve(response), [200])).rejects.toSatisfy(
+      (err: unknown) => {
+        return (
+          err instanceof ApiError &&
+          err.code === "FORBIDDEN" &&
+          err.status === 403 &&
+          err.name === "ApiError"
+        );
+      },
+    );
+  });
+});

--- a/turbo/apps/platform/src/lib/accept.ts
+++ b/turbo/apps/platform/src/lib/accept.ts
@@ -1,0 +1,56 @@
+import { toast } from "@vm0/ui/components/ui/sonner";
+
+class ApiError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(message: string, code: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function extractError(
+  body: unknown,
+  status: number,
+): { message: string; code: string } {
+  if (
+    body !== null &&
+    typeof body === "object" &&
+    "error" in body &&
+    body.error !== null &&
+    typeof body.error === "object" &&
+    "message" in body.error &&
+    typeof body.error.message === "string"
+  ) {
+    const code =
+      "code" in body.error && typeof body.error.code === "string"
+        ? body.error.code
+        : "UNKNOWN";
+    return { message: body.error.message, code };
+  }
+  return { message: `HTTP ${status}`, code: "UNKNOWN" };
+}
+
+async function accept<
+  T extends { status: number; body: unknown },
+  S extends number,
+>(
+  promise: Promise<T>,
+  codes: S[],
+  options?: { toast?: boolean },
+): Promise<Extract<T, { status: S }>> {
+  const result = await promise;
+  if ((codes as number[]).includes(result.status)) {
+    return result as Extract<T, { status: S }>;
+  }
+  const { message, code } = extractError(result.body, result.status);
+  if (options?.toast !== false) {
+    toast.error(message);
+  }
+  throw new ApiError(message, code, result.status);
+}
+
+export { ApiError, accept };


### PR DESCRIPTION
## Summary

- Adds `ApiError` class (extends `Error`) with `code: string` and `status: number` fields to `apps/platform/src/lib/accept.ts`
- Adds `accept<T, S>` function that awaits ts-rest call promises, returns type-narrowed result on accepted status codes, or toasts + throws `ApiError` on unexpected statuses
- Adds integration tests covering all documented cases: accepted status, multiple codes, standard/non-standard error bodies, `{ toast: false }` option, and `instanceof ApiError` verification

Closes #7873

## Test plan

- [ ] All 6 integration tests in `apps/platform/src/lib/__tests__/accept.test.ts` pass
- [ ] `pnpm turbo run lint` passes with no violations
- [ ] `pnpm check-types` passes with no TypeScript errors
- [ ] `pnpm knip` shows no new unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)