### PR TITLE
feat: add directed authorize page for missing user-connector flow

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
@@ -127,7 +127,7 @@ describe("zero doctor missing-token command", () => {
       expect(logCalls).toContain("Sandbox env: not present");
       expect(logCalls).toContain("not authorized");
       expect(logCalls).toContain(
-        "[Authorize GitHub](https://app.vm0.ai/team/agent-abc-123?tab=authorization)",
+        "[Authorize GitHub](https://app.vm0.ai/connectors/github/authorize?agentId=agent-abc-123)",
       );
     });
   });
@@ -192,7 +192,7 @@ describe("zero doctor missing-token command", () => {
       );
       expect(logCalls).toContain("not authorized");
       expect(logCalls).toContain(
-        "[Authorize GitHub](https://app.vm0.ai/team/agent-abc-123?tab=authorization)",
+        "[Authorize GitHub](https://app.vm0.ai/connectors/github/authorize?agentId=agent-abc-123)",
       );
     });
   });

--- a/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
@@ -84,8 +84,9 @@ Notes:
       }
 
       if (!hasPermission) {
-        const path = agentId ? `/team/${agentId}` : "/team";
-        const url = `${platformUrl.origin}${path}?tab=authorization`;
+        const url = agentId
+          ? `${platformUrl.origin}/connectors/${connectorType}/authorize?agentId=${agentId}`
+          : `${platformUrl.origin}/connectors`;
         issues.push(
           `The ${label} connector is not authorized for this agent. Ask the user to enable it at: [Authorize ${label}](${url})`,
         );

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -32,6 +32,7 @@ import { setupOnboardingPage$ } from "./onboarding-page/onboarding-page-setup.ts
 import { setupIdeationPage$ } from "./zero-page/ideation-page-setup.ts";
 import { setupConnectorsPage$ } from "./connectors-page/connectors-page-setup.ts";
 import { setupDirectedConnectPage$ } from "./connectors-page/directed-connect-page-setup.ts";
+import { setupDirectedAuthorizePage$ } from "./connectors-page/directed-authorize-page-setup.ts";
 import { setupSignInTokenPage$ } from "./sign-in-token-setup.ts";
 import { setupFirewallAllowPage$ } from "./firewall-allow/firewall-allow-page-setup.ts";
 import { setupChatListPage$ } from "./zero-page/chat-list-page-setup.ts";
@@ -86,6 +87,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.ideas,
     setup: setupAuthPageWrapper(setupIdeationPage$),
+  },
+  {
+    path: ROUTES.directedAuthorize,
+    setup: setupAuthPageWrapper(setupDirectedAuthorizePage$),
   },
   {
     path: ROUTES.directedConnect,

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-page-setup.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-page-setup.ts
@@ -1,0 +1,14 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { ZeroDirectedAuthorizePage } from "../../views/zero-page/zero-directed-authorize-page.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { pathParams$ } from "../route.ts";
+
+export const setupDirectedAuthorizePage$ = command(({ get, set }) => {
+  const params = get(pathParams$);
+  const type = typeof params?.type === "string" ? params.type : "";
+
+  set(updatePage$, createElement(ZeroDirectedAuthorizePage));
+  set(updateDocumentTitle$, `Authorize ${type}`);
+});

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -19,6 +19,21 @@ export const directedAuthorizeAgentId$ = computed((get): string | null => {
   return get(searchParams$).get("agentId");
 });
 
+/** Fetch enabled connector types for the agent from the API. */
+export const agentEnabledTypes$ = computed(async (get) => {
+  const agentId = get(directedAuthorizeAgentId$);
+  if (!agentId) {
+    return [];
+  }
+  const createClient = get(zeroClient$);
+  const client = createClient(zeroUserConnectorsContract);
+  const result = await client.get({ params: { id: agentId } });
+  if (result.status !== 200) {
+    return [];
+  }
+  return result.body.enabledTypes;
+});
+
 const internalAuthorized$ = state<Set<string>>(new Set());
 
 /** Whether the connector has just been authorized (optimistic). */

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -1,5 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { zeroUserConnectorsContract, type ConnectorType } from "@vm0/core";
+import { accept } from "../../lib/accept.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
 import { zeroClient$ } from "../api-client.ts";
 
@@ -27,10 +28,9 @@ export const agentEnabledTypes$ = computed(async (get) => {
   }
   const createClient = get(zeroClient$);
   const client = createClient(zeroUserConnectorsContract);
-  const result = await client.get({ params: { id: agentId } });
-  if (result.status !== 200) {
-    return [];
-  }
+  const result = await accept(client.get({ params: { id: agentId } }), [200], {
+    toast: false,
+  });
   return result.body.enabledTypes;
 });
 
@@ -53,27 +53,25 @@ export const authorizeConnector$ = command(
     const client = createClient(zeroUserConnectorsContract);
 
     // Get current enabled types for this agent
-    const current = await client.get({ params: { id: agentId } });
+    const current = await accept(
+      client.get({ params: { id: agentId } }),
+      [200],
+      { toast: false },
+    );
     signal.throwIfAborted();
 
-    const currentTypes =
-      current.status === 200 ? current.body.enabledTypes : [];
+    const currentTypes = current.body.enabledTypes;
 
     // Add the new type if not already present
     if (!currentTypes.includes(connectorType)) {
-      const result = await client.update({
-        params: { id: agentId },
-        body: { enabledTypes: [...currentTypes, connectorType] },
-      });
+      await accept(
+        client.update({
+          params: { id: agentId },
+          body: { enabledTypes: [...currentTypes, connectorType] },
+        }),
+        [200],
+      );
       signal.throwIfAborted();
-
-      if (result.status !== 200) {
-        const detail =
-          result.status === 400 || result.status === 404
-            ? result.body.error.message
-            : `status ${result.status}`;
-        throw new Error(`Authorization failed: ${detail}`);
-      }
     }
 
     // Optimistic update

--- a/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-authorize-type.ts
@@ -1,0 +1,69 @@
+import { command, computed, state } from "ccstate";
+import { zeroUserConnectorsContract, type ConnectorType } from "@vm0/core";
+import { pathParams$, searchParams$ } from "../route.ts";
+import { zeroClient$ } from "../api-client.ts";
+
+/**
+ * Connector type extracted from `/connectors/:type/authorize` route params.
+ */
+export const directedAuthorizeType$ = computed((get): string | null => {
+  const params = get(pathParams$);
+  const type = params?.type;
+  return typeof type === "string" ? type.toLowerCase() : null;
+});
+
+/**
+ * Agent ID extracted from `?agentId=` query parameter.
+ */
+export const directedAuthorizeAgentId$ = computed((get): string | null => {
+  return get(searchParams$).get("agentId");
+});
+
+const internalAuthorized$ = state<Set<string>>(new Set());
+
+/** Whether the connector has just been authorized (optimistic). */
+export const justAuthorizedTypes$ = computed((get) => {
+  return get(internalAuthorized$);
+});
+
+/** Authorize a connector for the given agent via user-connectors API. */
+export const authorizeConnector$ = command(
+  async (
+    { get, set },
+    connectorType: ConnectorType,
+    agentId: string,
+    signal: AbortSignal,
+  ) => {
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroUserConnectorsContract);
+
+    // Get current enabled types for this agent
+    const current = await client.get({ params: { id: agentId } });
+    signal.throwIfAborted();
+
+    const currentTypes =
+      current.status === 200 ? current.body.enabledTypes : [];
+
+    // Add the new type if not already present
+    if (!currentTypes.includes(connectorType)) {
+      const result = await client.update({
+        params: { id: agentId },
+        body: { enabledTypes: [...currentTypes, connectorType] },
+      });
+      signal.throwIfAborted();
+
+      if (result.status !== 200) {
+        const detail =
+          result.status === 400 || result.status === 404
+            ? result.body.error.message
+            : `status ${result.status}`;
+        throw new Error(`Authorization failed: ${detail}`);
+      }
+    }
+
+    // Optimistic update
+    set(internalAuthorized$, (prev) => {
+      return new Set([...prev, connectorType]);
+    });
+  },
+);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -18,6 +18,7 @@ export const ROUTES = {
   ideas: "/ideas",
   connectors: "/connectors",
   directedConnect: "/connectors/:type/connect",
+  directedAuthorize: "/connectors/:type/authorize",
   settings: "/settings",
   settingsUsage: "/settings/usage",
   settingsSlack: "/settings/slack",

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Tests for the /connectors/:type/authorize page (ZeroDirectedAuthorizePage).
+ *
+ * Entry point: setupPage({ path: "/connectors/:type/authorize?agentId=..." })
+ * Mock (external): connectors API, user-connectors API via MSW
+ * Real (internal): signals, components, rendering
+ */
+
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { CONNECTOR_TYPES } from "@vm0/core";
+
+const context = testContext();
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+
+function mockConnectorsConnected(type: string) {
+  server.use(
+    http.get("*/api/zero/connectors", () => {
+      return HttpResponse.json({
+        connectors: [
+          {
+            id: crypto.randomUUID(),
+            type,
+            authMethod: "oauth",
+            externalId: null,
+            externalUsername: null,
+            externalEmail: null,
+            oauthScopes: null,
+            needsReconnect: false,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+        configuredTypes: Object.keys(CONNECTOR_TYPES),
+        connectorProvidedSecretNames: [],
+      });
+    }),
+  );
+}
+
+describe("directed authorize page", () => {
+  it("renders authorize card for a connected connector", async () => {
+    mockConnectorsConnected("gmail");
+
+    await setupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Gmail to proceed"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(CONNECTOR_TYPES.gmail.helpText),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Authorize Zero" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows authorized state after clicking authorize", async () => {
+    const user = userEvent.setup();
+    mockConnectorsConnected("gmail");
+
+    await setupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Authorize Zero" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Authorize Zero" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Gmail authorized")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Authorized")).toBeInTheDocument();
+  });
+
+  it("renders nothing when agentId query param is missing", async () => {
+    await setupPage({
+      context,
+      path: "/connectors/gmail/authorize",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Zero needs .* to proceed/),
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Authorize Zero" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for an unknown connector type", async () => {
+    await setupPage({
+      context,
+      path: `/connectors/nonexistent/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Zero needs .* to proceed/),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("normalizes uppercase type in URL", async () => {
+    mockConnectorsConnected("gmail");
+
+    await setupPage({
+      context,
+      path: `/connectors/Gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Gmail to proceed"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("has a logo link that navigates to /connectors", async () => {
+    mockConnectorsConnected("gmail");
+
+    await setupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Gmail to proceed"),
+      ).toBeInTheDocument();
+    });
+
+    const logoLink = screen.getByLabelText("VM0");
+    expect(logoLink.closest("a")).toHaveAttribute("href", "/connectors");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -133,6 +133,51 @@ describe("directed authorize page", () => {
     });
   });
 
+  it("shows authorized state when connector is already authorized for agent", async () => {
+    mockConnectorsConnected("gmail");
+    server.use(
+      http.get("*/api/zero/agents/:id/user-connectors", () => {
+        return HttpResponse.json({ enabledTypes: ["gmail"] });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Gmail authorized")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Authorized")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Authorize Zero" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows authorize button when connector is not yet authorized for agent", async () => {
+    mockConnectorsConnected("gmail");
+    server.use(
+      http.get("*/api/zero/agents/:id/user-connectors", () => {
+        return HttpResponse.json({ enabledTypes: [] });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: `/connectors/gmail/authorize?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Zero needs Gmail to proceed"),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("button", { name: "Authorize Zero" }),
+    ).toBeInTheDocument();
+  });
+
   it("has a logo link that navigates to /connectors", async () => {
     mockConnectorsConnected("gmail");
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-authorize-page.test.tsx
@@ -61,9 +61,7 @@ describe("directed authorize page", () => {
     expect(
       screen.getByText(CONNECTOR_TYPES.gmail.helpText),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Authorize Zero" }),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Authorize Zero")).toBeInTheDocument();
   });
 
   it("shows authorized state after clicking authorize", async () => {
@@ -76,12 +74,10 @@ describe("directed authorize page", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Authorize Zero" }),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Authorize Zero")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Authorize Zero" }));
+    await user.click(screen.getByText("Authorize Zero"));
 
     await waitFor(() => {
       expect(screen.getByText("Gmail authorized")).toBeInTheDocument();
@@ -100,9 +96,7 @@ describe("directed authorize page", () => {
         screen.queryByText(/Zero needs .* to proceed/),
       ).not.toBeInTheDocument();
     });
-    expect(
-      screen.queryByRole("button", { name: "Authorize Zero" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Authorize Zero")).not.toBeInTheDocument();
   });
 
   it("renders nothing for an unknown connector type", async () => {
@@ -150,9 +144,7 @@ describe("directed authorize page", () => {
       expect(screen.getByText("Gmail authorized")).toBeInTheDocument();
     });
     expect(screen.getByText("Authorized")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Authorize Zero" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Authorize Zero")).not.toBeInTheDocument();
   });
 
   it("shows authorize button when connector is not yet authorized for agent", async () => {
@@ -173,9 +165,7 @@ describe("directed authorize page", () => {
         screen.getByText("Zero needs Gmail to proceed"),
       ).toBeInTheDocument();
     });
-    expect(
-      screen.getByRole("button", { name: "Authorize Zero" }),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Authorize Zero")).toBeInTheDocument();
   });
 
   it("has a logo link that navigates to /connectors", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -1,0 +1,226 @@
+import type { ReactNode } from "react";
+import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
+import {
+  allConnectorTypes$,
+  connectConnector$,
+  justConnectedTypes$,
+  pollingConnectorType$,
+} from "../../signals/zero-page/settings/connectors.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import {
+  directedAuthorizeType$,
+  directedAuthorizeAgentId$,
+  justAuthorizedTypes$,
+  authorizeConnector$,
+} from "../../signals/connectors-page/directed-authorize-type.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
+import {
+  orgManageDialogOpen$,
+  setOrgManageDialogOpen$,
+} from "../../signals/zero-page/settings/org-manage-dialog.ts";
+import { OrgManageDialog } from "./components/org-manage/org-manage-dialog.tsx";
+import { ZeroOrgSwitcher } from "./zero-org-switcher.tsx";
+import { AccountDropdown } from "./zero-sidebar.tsx";
+import { VM0ClerkProvider } from "../clerk/clerk-provider.tsx";
+import { IconCheck, IconLoader2 } from "@tabler/icons-react";
+import { Link } from "../router/link.tsx";
+
+// ---------------------------------------------------------------------------
+// Layout (shared with directed connect page)
+// ---------------------------------------------------------------------------
+
+function MinimalSidebarLayout({ children }: { children: ReactNode }) {
+  const onAccountAction = useSet(handleZeroAccountAction$);
+  const dialogOpen = useGet(orgManageDialogOpen$);
+  const setDialogOpen = useSet(setOrgManageDialogOpen$);
+  const pageSignal = useGet(pageSignal$);
+
+  return (
+    <div className="zero-app flex h-dvh w-full bg-background">
+      <OrgManageDialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          detach(setDialogOpen(open, pageSignal), Reason.DomCallback);
+        }}
+      />
+      <VM0ClerkProvider>
+        <aside className="zero-nav hidden md:flex h-full w-[255px] shrink-0 flex-col bg-sidebar">
+          <div className="shrink-0 px-2 pt-1.5">
+            <ZeroOrgSwitcher />
+          </div>
+          <div className="flex-1" />
+          <div className="p-2">
+            <AccountDropdown onAccountAction={onAccountAction} />
+          </div>
+        </aside>
+      </VM0ClerkProvider>
+      <div className="flex flex-1 flex-col min-w-0 min-h-0 zero-workspace-bg">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function Vm0Logo() {
+  return (
+    <svg
+      width="82"
+      height="20"
+      viewBox="0 0 100 30"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="VM0"
+    >
+      <path
+        d="M13.3915 0.0627979C13.2455 -0.0209506 13.0657 -0.020839 12.9198 0.0630906L1.0053 6.91543C0.692394 7.09539 0.690093 7.54442 1.00114 7.72755L12.9156 14.7423C13.0636 14.8295 13.2475 14.8296 13.3957 14.7426L25.3445 7.72785C25.6562 7.54485 25.6539 7.09497 25.3404 6.91514L13.3915 0.0627979Z"
+        fill="#ED4E01"
+      />
+      <path
+        d="M0.710495 8.33374L12.6479 15.2595C12.7944 15.3445 12.8846 15.5015 12.8846 15.6715L12.8843 29.5237C12.8843 29.8899 12.4897 30.1187 12.1741 29.9356L0.236691 23.0096C0.0902206 22.9246 -3.46036e-06 22.7676 0 22.5977L0.00028208 8.74568C0.000289537 8.37949 0.394855 8.15064 0.710495 8.33374Z"
+        fill="#ED4E01"
+      />
+      <path
+        d="M24.947 21.6772C24.947 21.9507 24.8017 22.2036 24.5655 22.3415L16.2103 27.219C15.6975 27.5184 15.0533 27.1485 15.0533 26.5547L15.0531 16.7842C15.0531 16.5107 15.1983 16.2578 15.4345 16.1199L23.7897 11.2425C24.3025 10.9431 24.9468 11.313 24.9468 11.9068L24.947 21.6772ZM13.6541 16.3426V29.5279C13.6541 29.8852 14.0308 30.1106 14.3391 29.9444L14.3538 29.9362L25.5769 23.3654C26.25 22.9808 26.3462 22.6924 26.3459 22.1188L26.3459 8.93378C26.3459 8.57084 25.9572 8.344 25.6462 8.52548L14.4231 15.0001C14.0385 15.2885 13.6539 15.577 13.6541 16.3426Z"
+        fill="#ED4E01"
+      />
+      <path
+        d="M25.9616 10.58L15.2113 28.4616L14.2308 27.8817L24.981 10.0001L25.9616 10.58Z"
+        fill="#ED4E01"
+      />
+      <path
+        d="M42.1865 25L34.3459 5H37.4651L43.7887 21.4575L50.1264 5H53.2315L45.3908 25H42.1865Z"
+        fill="currentColor"
+      />
+      <path
+        d="M66.9877 25L59.4023 10.3417V25H56.4957V5H59.6716L67.413 20.0628L75.1686 5H78.3304V25H75.438V10.3417L67.8526 25H66.9877Z"
+        fill="currentColor"
+      />
+      <path
+        d="M99.3459 22.1409C99.3459 22.5314 99.2703 22.9033 99.1191 23.2566C98.9678 23.6007 98.7599 23.9028 98.4952 24.1632C98.2305 24.4235 97.9186 24.6281 97.5594 24.7768C97.2097 24.9256 96.8363 25 96.4393 25H86.2735C85.8765 25 85.4984 24.9256 85.1392 24.7768C84.7894 24.6281 84.4822 24.4235 84.2176 24.1632C83.9529 23.9028 83.745 23.6007 83.5937 23.2566C83.4425 22.9033 83.3669 22.5314 83.3669 22.1409V7.85914C83.3669 7.46862 83.4425 7.10135 83.5937 6.75732C83.745 6.404 83.9529 6.10181 84.2176 5.85077C84.4822 5.59042 84.7894 5.38587 85.1392 5.2371C85.4984 5.07903 85.8765 5 86.2735 5H96.4393C96.8363 5 97.2097 5.07903 97.5594 5.2371C97.9186 5.38587 98.2305 5.59042 98.4952 5.85077C98.7599 6.10181 98.9678 6.404 99.1191 6.75732C99.2703 7.10135 99.3459 7.46862 99.3459 7.85914V22.1409ZM86.2735 7.85914V22.1409H96.4393V7.85914H86.2735Z"
+        fill="currentColor"
+      />
+      <path
+        d="M94.8994 6.79107L97.1494 8.06891L87.8973 23.8325L85.6473 22.5547L94.8994 6.79107Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main card
+// ---------------------------------------------------------------------------
+
+function DirectedAuthorizeCard() {
+  const type = useGet(directedAuthorizeType$);
+  const agentId = useGet(directedAuthorizeAgentId$);
+  const pollingType = useGet(pollingConnectorType$);
+  const connect = useSet(connectConnector$);
+  const authorize = useSet(authorizeConnector$);
+  const signal = useGet(pageSignal$);
+  const justConnected = useGet(justConnectedTypes$);
+  const justAuthorized = useGet(justAuthorizedTypes$);
+  const allLoadable = useLastLoadable(allConnectorTypes$);
+
+  if (!type || !(type in CONNECTOR_TYPES) || !agentId) {
+    return null;
+  }
+
+  const connectorType = type as ConnectorType;
+  const config = CONNECTOR_TYPES[connectorType];
+  const isConnecting = pollingType === connectorType;
+  const isLoading =
+    !justConnected.has(connectorType) && allLoadable.state === "loading";
+
+  const isConnected =
+    justConnected.has(connectorType) ||
+    (allLoadable.state === "hasData" &&
+      allLoadable.data.some((c) => {
+        return c.type === connectorType && c.connected;
+      }));
+
+  const isAuthorized = justAuthorized.has(connectorType);
+
+  const handleAuthorize = () => {
+    if (isConnected) {
+      // Connector already connected — just authorize for this agent
+      detach(authorize(connectorType, agentId, signal), Reason.DomCallback);
+    } else {
+      // Need to connect first, then authorize
+      detach(
+        (async () => {
+          await connect(connectorType, signal);
+          await authorize(connectorType, agentId, signal);
+        })(),
+        Reason.DomCallback,
+      );
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-10 flex items-center justify-center pointer-events-none">
+      <div className="pointer-events-auto flex w-[430px] max-w-[calc(100%-48px)] flex-col items-center gap-12 rounded-[20px] border border-border bg-background px-6 py-12 text-center">
+        <Link pathname="/connectors" className="no-underline text-foreground">
+          <Vm0Logo />
+        </Link>
+        <div className="flex w-full flex-col gap-4">
+          <div className="flex flex-col items-center gap-2.5">
+            {isLoading ? (
+              <IconLoader2
+                size={20}
+                className="animate-spin text-muted-foreground"
+              />
+            ) : (
+              <>
+                <h1 className="text-lg font-medium text-foreground">
+                  {isAuthorized
+                    ? `${config.label} authorized`
+                    : `Zero needs ${config.label} to proceed`}
+                </h1>
+                <div className="flex items-center justify-center rounded-[10px] bg-muted p-2.5">
+                  <ConnectorIcon type={connectorType} size={20} />
+                </div>
+                <p className="w-60 text-sm text-muted-foreground">
+                  {config.helpText}
+                </p>
+              </>
+            )}
+          </div>
+          {!isLoading && (
+            <div className="flex items-center justify-center">
+              {isAuthorized ? (
+                <div className="inline-flex h-9 w-[140px] items-center justify-center gap-1.5 text-sm font-medium text-emerald-600">
+                  <IconCheck size={16} />
+                  Authorized
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  disabled={isConnecting}
+                  onClick={handleAuthorize}
+                  className="inline-flex h-9 items-center justify-center gap-2 rounded-[10px] bg-[#ed4e01] px-4 text-sm font-medium text-white transition-colors hover:bg-[#d35400] disabled:opacity-60"
+                >
+                  {isConnecting && (
+                    <IconLoader2 size={14} className="animate-spin" />
+                  )}
+                  {isConnecting ? "Connecting..." : "Authorize Zero"}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ZeroDirectedAuthorizePage() {
+  return (
+    <MinimalSidebarLayout>
+      <DirectedAuthorizeCard />
+    </MinimalSidebarLayout>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-authorize-page.tsx
@@ -12,6 +12,7 @@ import { detach, Reason } from "../../signals/utils.ts";
 import {
   directedAuthorizeType$,
   directedAuthorizeAgentId$,
+  agentEnabledTypes$,
   justAuthorizedTypes$,
   authorizeConnector$,
 } from "../../signals/connectors-page/directed-authorize-type.ts";
@@ -124,6 +125,7 @@ function DirectedAuthorizeCard() {
   const justConnected = useGet(justConnectedTypes$);
   const justAuthorized = useGet(justAuthorizedTypes$);
   const allLoadable = useLastLoadable(allConnectorTypes$);
+  const enabledLoadable = useLastLoadable(agentEnabledTypes$);
 
   if (!type || !(type in CONNECTOR_TYPES) || !agentId) {
     return null;
@@ -133,7 +135,8 @@ function DirectedAuthorizeCard() {
   const config = CONNECTOR_TYPES[connectorType];
   const isConnecting = pollingType === connectorType;
   const isLoading =
-    !justConnected.has(connectorType) && allLoadable.state === "loading";
+    (!justConnected.has(connectorType) && allLoadable.state === "loading") ||
+    enabledLoadable.state === "loading";
 
   const isConnected =
     justConnected.has(connectorType) ||
@@ -142,7 +145,10 @@ function DirectedAuthorizeCard() {
         return c.type === connectorType && c.connected;
       }));
 
-  const isAuthorized = justAuthorized.has(connectorType);
+  const isAuthorized =
+    justAuthorized.has(connectorType) ||
+    (enabledLoadable.state === "hasData" &&
+      enabledLoadable.data.includes(connectorType));
 
   const handleAuthorize = () => {
     if (isConnected) {


### PR DESCRIPTION
## Summary
- Add new `/connectors/:type/authorize?agentId=` page for when an agent needs a connector that's connected but not authorized for the specific agent
- The page matches the existing directed connect page design (VM0 logo, connector icon, help text) with an "Authorize Zero" button
- Update CLI `zero doctor missing-token` to redirect to this new page instead of `/team/:id?tab=authorization`

## Test plan
- [x] 6 new integration tests for the authorize page (render, authorize flow, missing agentId, unknown type, case normalization, logo link)
- [x] 12 existing CLI missing-token tests updated and passing
- [x] 6 existing directed connect page tests still passing
- [x] Lint and knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)