### PR TITLE
fix: suppress act warnings and fix duplicate react keys in chat timeline

### DIFF
--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -120,7 +120,7 @@
       }
     },
     {
-      "files": ["src/signals/log.ts"],
+      "files": ["src/signals/log.ts", "src/test/setup.ts"],
       "rules": {
         "no-console": "allow"
       }

--- a/turbo/apps/platform/src/signals/__tests__/log.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/log.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   logger,
   Level,
@@ -7,8 +7,18 @@ import {
 } from "../log.ts";
 
 describe("setLogErrorHandler", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     resetLoggerForTest();
+    // The global setup overrides console.error to throw on unexpected calls.
+    // This test suite intentionally triggers console.error via the log module,
+    // so we suppress it here.
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
   });
 
   it("should invoke handler on error()", () => {

--- a/turbo/apps/platform/src/test/setup.ts
+++ b/turbo/apps/platform/src/test/setup.ts
@@ -19,6 +19,23 @@ vi.hoisted(() => {
 
 beforeAll(() => {
   server.listen({ onUnhandledRequest: "error" });
+
+  // Override console.error to throw on unexpected errors.
+  // - NotSupportedError / AbortError: expected happy-dom noise, silently ignored.
+  // - "not wrapped in act(...)": unavoidable with our async bootstrap pattern
+  //   (render() runs inside act, then route setup updates page$ outside act).
+  //   Silently ignored.
+  // - Everything else: thrown so real problems surface early.
+  console.error = (...message: unknown[]) => {
+    const str = message.map(String).join(" ");
+    if (str.includes("NotSupportedError") || str.includes("AbortError")) {
+      return;
+    }
+    if (str.includes("not wrapped in act(")) {
+      return;
+    }
+    throw message[0] as Error;
+  };
 });
 
 // Reset handlers after each test

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -588,7 +588,14 @@ function RunActivityLineView({
     );
   }
 
-  const items = deduplicateSummaries(rawSummaries);
+  const rawItems = deduplicateSummaries(rawSummaries);
+  const items = rawItems.map((summary, position) => {
+    return {
+      key: `${position}-${summary}`,
+      summary,
+      isLast: position === rawItems.length - 1,
+    };
+  });
 
   return (
     <div className="relative flex flex-col gap-3">
@@ -600,11 +607,10 @@ function RunActivityLineView({
           <div className="w-px h-full bg-border/60 zero-dashed-line" />
         </div>
       )}
-      {items.map((summary, idx) => {
-        const isLast = idx === items.length - 1;
+      {items.map(({ key, summary, isLast }) => {
         return (
           <p
-            key={idx}
+            key={key}
             className={`flex items-center gap-2.5 min-w-0 text-xs truncate animate-in fade-in slide-in-from-bottom-1 duration-300 ${
               isLast ? "" : "text-muted-foreground"
             }`}
@@ -656,7 +662,13 @@ function CollapsibleTimeline({
     return null;
   }
 
-  const items = deduplicateSummaries(summaries);
+  const rawItems = deduplicateSummaries(summaries);
+  const items = rawItems.map((summary, position) => {
+    return {
+      key: `${position}-${summary}`,
+      summary,
+    };
+  });
 
   return (
     <div className="mb-6">
@@ -686,10 +698,10 @@ function CollapsibleTimeline({
               <div className="w-px h-full zero-dashed-line" />
             </div>
           )}
-          {items.map((summary, idx) => {
+          {items.map(({ key, summary }) => {
             return (
               <p
-                key={idx}
+                key={key}
                 className="flex items-center gap-2 min-w-0 text-xs text-muted-foreground truncate"
               >
                 <span className="h-3 w-3 shrink-0 flex items-center justify-center relative z-[1] rounded-full bg-card">

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -604,7 +604,7 @@ function RunActivityLineView({
         const isLast = idx === items.length - 1;
         return (
           <p
-            key={summary}
+            key={idx}
             className={`flex items-center gap-2.5 min-w-0 text-xs truncate animate-in fade-in slide-in-from-bottom-1 duration-300 ${
               isLast ? "" : "text-muted-foreground"
             }`}
@@ -686,10 +686,10 @@ function CollapsibleTimeline({
               <div className="w-px h-full zero-dashed-line" />
             </div>
           )}
-          {items.map((summary) => {
+          {items.map((summary, idx) => {
             return (
               <p
-                key={summary}
+                key={idx}
                 className="flex items-center gap-2 min-w-0 text-xs text-muted-foreground truncate"
               >
                 <span className="h-3 w-3 shrink-0 flex items-center justify-center relative z-[1] rounded-full bg-card">


### PR DESCRIPTION
## Summary

Closes #7828

- Add `console.error` override in test setup that throws on unexpected errors, silences expected happy-dom noise (`NotSupportedError`, `AbortError`) and unavoidable React `act()` warnings from the async bootstrap pattern
- Fix duplicate React key warning in chat activity timeline (`RunActivityLineView` and `CollapsibleTimeline`) where multiple tool-use events could produce identical summary text — use array index as key instead
- Mock `console.error` in `log.test.ts` since it intentionally triggers error-level logging

## Test plan

- [x] `log.test.ts` — 11/11 pass (was 3/11 with override)
- [x] `chat-activity-line-visibility.test.tsx` — 2/2 pass (was 1/2)
- [x] `chat-completion.test.tsx` — 4/4 pass (was 3/4)
- [x] All `@vm0/app` platform tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>