### PR TITLE
refactor(platform): replace direct dom manipulation with react patterns

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap/global-method.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/global-method.ts
@@ -6,10 +6,7 @@ import {
   featureSwitch$,
   overrideFeatureSwitch$,
 } from "../external/feature-switch";
-import { loadInspectLogFile$ } from "../activity-page/inspect-log-signals";
-import { detachedNavigateTo$ } from "../route";
-import { pathname } from "../location";
-import { ROUTES } from "../route-paths";
+import { inspectLogInput$ } from "./inspect-log-input";
 
 const L = logger("GlobalMethod");
 
@@ -49,35 +46,7 @@ export const setupGlobalMethod$ = command(
       },
       featureSwitches: {},
       inspectLogs() {
-        const input = document.createElement("input");
-        input.type = "file";
-        input.accept = ".json";
-        input.style.display = "none";
-        document.body.appendChild(input);
-
-        input.addEventListener("change", () => {
-          const file = input.files?.[0];
-          input.remove();
-          if (!file) {
-            return;
-          }
-          set(loadInspectLogFile$, file, signal)
-            .then(() => {
-              if (pathname() !== "/activities/inspect") {
-                set(detachedNavigateTo$, ROUTES.activityInspect);
-              }
-            })
-            .catch((error: unknown) => {
-              L.error("Failed to parse inspect log", error);
-            });
-        });
-
-        // Clean up if dialog is cancelled
-        input.addEventListener("cancel", () => {
-          input.remove();
-        });
-
-        input.click();
+        get(inspectLogInput$)?.click();
       },
     };
 

--- a/turbo/apps/platform/src/signals/bootstrap/inspect-log-input.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/inspect-log-input.ts
@@ -1,0 +1,26 @@
+import { state, computed, command } from "ccstate";
+import { loadInspectLogFile$ } from "../activity-page/inspect-log-signals";
+import { detachedNavigateTo$ } from "../route";
+import { pathname } from "../location";
+import { ROUTES } from "../route-paths";
+
+const internalInspectLogInput$ = state<HTMLInputElement | null>(null);
+
+export const inspectLogInput$ = computed((get) => {
+  return get(internalInspectLogInput$);
+});
+
+export const setInspectLogInput$ = command(
+  ({ set }, el: HTMLInputElement | null) => {
+    set(internalInspectLogInput$, el);
+  },
+);
+
+export const handleInspectLogFileChange$ = command(
+  async ({ set }, file: File, signal: AbortSignal) => {
+    await set(loadInspectLogFile$, file, signal);
+    if (pathname() !== "/activities/inspect") {
+      set(detachedNavigateTo$, ROUTES.activityInspect);
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/billing.ts
+++ b/turbo/apps/platform/src/signals/zero-page/billing.ts
@@ -49,6 +49,8 @@ const internalDialogOpen$ = state(false);
 const billingReload$ = state(0);
 const internalDowngradeDialogOpen$ = state(false);
 const internalPendingEnabled$ = state<boolean | null>(null);
+const internalFormThreshold$ = state("");
+const internalFormAmount$ = state("");
 
 // ---------------------------------------------------------------------------
 // Selectors
@@ -67,6 +69,27 @@ export const pendingEnabled$ = computed((get) => {
 export const setPendingEnabled$ = command(({ set }, value: boolean | null) => {
   set(internalPendingEnabled$, value);
 });
+
+export const formThreshold$ = computed((get) => {
+  return get(internalFormThreshold$);
+});
+export const formAmount$ = computed((get) => {
+  return get(internalFormAmount$);
+});
+
+export const setFormThreshold$ = command(({ set }, value: string) => {
+  set(internalFormThreshold$, value);
+});
+export const setFormAmount$ = command(({ set }, value: string) => {
+  set(internalFormAmount$, value);
+});
+
+export const syncFormFromConfig$ = command(
+  ({ set }, config: { threshold: string; amount: string }) => {
+    set(internalFormThreshold$, config.threshold);
+    set(internalFormAmount$, config.amount);
+  },
+);
 
 /**
  * Async computed signal that fetches billing status on first access.

--- a/turbo/apps/platform/src/views/inspect-log-file-input.tsx
+++ b/turbo/apps/platform/src/views/inspect-log-file-input.tsx
@@ -1,0 +1,33 @@
+import type { ChangeEvent } from "react";
+import { useGet, useSet } from "ccstate-react";
+import {
+  setInspectLogInput$,
+  handleInspectLogFileChange$,
+} from "../signals/bootstrap/inspect-log-input.ts";
+import { rootSignal$ } from "../signals/root-signal.ts";
+import { detach, Reason } from "../signals/utils.ts";
+
+export function InspectLogFileInput() {
+  const setEl = useSet(setInspectLogInput$);
+  const handleFileChange = useSet(handleInspectLogFileChange$);
+  const { signal: rootSignal } = useGet(rootSignal$);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    e.target.value = "";
+    detach(handleFileChange(file, rootSignal), Reason.DomCallback);
+  };
+
+  return (
+    <input
+      type="file"
+      accept=".json"
+      ref={setEl}
+      className="hidden"
+      onChange={handleChange}
+    />
+  );
+}

--- a/turbo/apps/platform/src/views/router.tsx
+++ b/turbo/apps/platform/src/views/router.tsx
@@ -2,6 +2,7 @@ import { useGet } from "ccstate-react";
 import { page$ } from "../signals/react-router.ts";
 import { appSkeletonVisible$ } from "../signals/app-skeleton.ts";
 import { AppSkeleton } from "./zero-page/app-skeleton.tsx";
+import { InspectLogFileInput } from "./inspect-log-file-input.tsx";
 
 export function Router() {
   const page = useGet(page$);
@@ -11,6 +12,7 @@ export function Router() {
     <>
       {page ?? null}
       <AppSkeleton visible={!page || skeletonVisible} />
+      <InspectLogFileInput />
     </>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/billing-dialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -23,6 +24,11 @@ import {
   autoRechargeConfig$,
   pendingEnabled$,
   setPendingEnabled$,
+  formThreshold$,
+  formAmount$,
+  setFormThreshold$,
+  setFormAmount$,
+  syncFormFromConfig$,
 } from "../../signals/zero-page/billing.ts";
 import {
   selectedPlanTier$,
@@ -141,32 +147,38 @@ export function AutoRechargeSection({
   const pendingEnabled = useGet(pendingEnabled$);
   const setPendingEnabled = useSet(setPendingEnabled$);
 
+  const thresholdValue = useGet(formThreshold$);
+  const amountValue = useGet(formAmount$);
+  const setThreshold = useSet(setFormThreshold$);
+  const setAmount = useSet(setFormAmount$);
+  const syncForm = useSet(syncFormFromConfig$);
+
+  // Sync form fields when server config changes (initial load or after save)
+  const { threshold: serverThreshold, amount: serverAmount } = config;
+  useEffect(() => {
+    syncForm({ threshold: serverThreshold, amount: serverAmount });
+  }, [syncForm, serverThreshold, serverAmount]);
+
   if (currentTier === "free") {
     return null;
   }
 
-  const { enabled, threshold, amount } = config;
+  const { enabled } = config;
   const displayEnabled = pendingEnabled !== null ? pendingEnabled : enabled;
-  const amountNum = Number(amount);
+  const amountNum = Number(amountValue);
   const amountParsed = Number.isFinite(amountNum) ? amountNum : 0;
   const dollarAmount =
     amountParsed > 0 ? (amountParsed / CREDITS_PER_DOLLAR).toFixed(2) : "0.00";
 
-  const thresholdId = `org-auto-recharge-threshold-${variant}`;
-  const amountId = `org-auto-recharge-amount-${variant}`;
-
-  const readInputNumbers = () => {
-    const thresholdEl = document.getElementById(thresholdId);
-    const amountEl = document.getElementById(amountId);
-    const tRaw =
-      thresholdEl instanceof HTMLInputElement ? thresholdEl.value : "";
-    const aRaw = amountEl instanceof HTMLInputElement ? amountEl.value : "";
-    const tVal = Number(tRaw);
-    const aVal = Number(aRaw);
+  const parseFormNumbers = () => {
+    const tVal = Number(thresholdValue);
+    const aVal = Number(amountValue);
     return {
       threshold:
-        tRaw !== "" && Number.isFinite(tVal) ? tVal : Number(threshold),
-      amount: aRaw !== "" && Number.isFinite(aVal) ? aVal : amountNum,
+        thresholdValue !== "" && Number.isFinite(tVal)
+          ? tVal
+          : Number(serverThreshold),
+      amount: amountValue !== "" && Number.isFinite(aVal) ? aVal : amountNum,
     };
   };
 
@@ -176,7 +188,7 @@ export function AutoRechargeSection({
     amount?: number;
   }) => {
     const e = overrides?.enabled ?? enabled;
-    const inputs = readInputNumbers();
+    const inputs = parseFormNumbers();
     const t = overrides?.threshold ?? inputs.threshold;
     const a = overrides?.amount ?? inputs.amount;
     detach(
@@ -189,7 +201,7 @@ export function AutoRechargeSection({
   };
 
   const persistIfValid = () => {
-    const { threshold: t, amount: a } = readInputNumbers();
+    const { threshold: t, amount: a } = parseFormNumbers();
     if (!loading && (!displayEnabled || (t > 0 && a >= CREDITS_PER_DOLLAR))) {
       if (displayEnabled) {
         setPendingEnabled(null);
@@ -225,8 +237,8 @@ export function AutoRechargeSection({
                   saveCurrent({ enabled: false });
                   return;
                 }
-                const t = Number(threshold);
-                const a = amountNum;
+                const t = Number(serverThreshold);
+                const a = Number(serverAmount);
                 if (!loading && t > 0 && a >= CREDITS_PER_DOLLAR) {
                   saveCurrent({ enabled: true, threshold: t, amount: a });
                 } else {
@@ -252,11 +264,12 @@ export function AutoRechargeSection({
                   </p>
                 </div>
                 <Input
-                  key={`threshold-${threshold}`}
-                  id={thresholdId}
                   type="number"
                   min={1}
-                  defaultValue={threshold}
+                  value={thresholdValue}
+                  onChange={(e) => {
+                    setThreshold(e.target.value);
+                  }}
                   onBlur={() => {
                     return persistIfValid();
                   }}
@@ -277,12 +290,13 @@ export function AutoRechargeSection({
                 </div>
                 <div className="relative w-[200px] shrink-0">
                   <Input
-                    key={`amount-${amount}`}
-                    id={amountId}
                     type="number"
                     min={CREDITS_PER_DOLLAR}
                     step={CREDITS_PER_DOLLAR}
-                    defaultValue={amount}
+                    value={amountValue}
+                    onChange={(e) => {
+                      setAmount(e.target.value);
+                    }}
                     onBlur={() => {
                       return persistIfValid();
                     }}
@@ -337,11 +351,12 @@ export function AutoRechargeSection({
               When credits drop below
             </span>
             <Input
-              key={`dialog-threshold-${threshold}`}
-              id={thresholdId}
               type="number"
               min={1}
-              defaultValue={threshold}
+              value={thresholdValue}
+              onChange={(e) => {
+                setThreshold(e.target.value);
+              }}
               placeholder="e.g. 1000"
             />
           </label>
@@ -352,12 +367,13 @@ export function AutoRechargeSection({
             </span>
             <div className="flex items-center gap-2">
               <Input
-                key={`dialog-amount-${amount}`}
-                id={amountId}
                 type="number"
                 min={CREDITS_PER_DOLLAR}
                 step={CREDITS_PER_DOLLAR}
-                defaultValue={amount}
+                value={amountValue}
+                onChange={(e) => {
+                  setAmount(e.target.value);
+                }}
                 placeholder="e.g. 10000"
                 className="flex-1"
               />


### PR DESCRIPTION
## Summary
- Convert billing-dialog auto-recharge form from uncontrolled inputs + `document.getElementById` to React controlled inputs with ccstate state atoms
- Move `inspectLogs` hidden file input from imperative `document.createElement` into React render tree with ccstate ref pattern
- Eliminate all `document.getElementById` and `document.createElement` calls from platform application code

## Test plan
- [x] 27 org-billing-tab tests pass (including auto-recharge form hydration, input editing, and save)
- [x] 6 global-method tests pass
- [x] Lint, type-check, knip, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)