### PR TITLE
refactor(cli): add --permissions flag to zero whoami

### DIFF
--- a/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/whoami.test.ts
@@ -63,8 +63,8 @@ describe("zero whoami command", () => {
       });
   }
 
-  async function runWhoami(): Promise<void> {
-    await zeroWhoamiCommand.parseAsync(["node", "cli"]);
+  async function runWhoami(args: string[] = []): Promise<void> {
+    await zeroWhoamiCommand.parseAsync(["node", "cli", ...args]);
   }
 
   describe("sandbox mode (ZERO_AGENT_ID set)", () => {
@@ -385,7 +385,72 @@ describe("zero whoami command", () => {
       ).toBe(false);
     });
 
-    it("should show connector permissions with allow/deny/ask icons", async () => {
+    it("should show identity without permission details by default", async () => {
+      const token = buildZeroToken({
+        userId: "user-1",
+        runId: "run-abc",
+        orgId: "org-xyz",
+        scope: "zero",
+        capabilities: ["agent:read", "connector:read"],
+        iat: 1000,
+        exp: 2000,
+      });
+      vi.stubEnv("ZERO_AGENT_ID", "agent-123");
+      vi.stubEnv("ZERO_TOKEN", token);
+      vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+
+      server.use(
+        http.get("http://localhost:3000/api/zero/connectors", () => {
+          return HttpResponse.json({
+            connectors: [
+              {
+                id: "1",
+                type: "github",
+                authMethod: "oauth",
+                externalId: "12345",
+                externalUsername: "octocat",
+                externalEmail: "octocat@github.com",
+                oauthScopes: ["repo"],
+                needsReconnect: false,
+                createdAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+              },
+            ],
+            configuredTypes: ["github"],
+            connectorProvidedSecretNames: [],
+          });
+        }),
+      );
+
+      await runWhoami();
+
+      const output = getAllOutput();
+      expect(
+        output.some((line) => {
+          return line.includes("Connectors:");
+        }),
+      ).toBe(true);
+      expect(
+        output.some((line) => {
+          return (
+            line.includes("@octocat") && line.includes("(octocat@github.com)")
+          );
+        }),
+      ).toBe(true);
+      // No permission icons in default mode
+      expect(
+        output.some((line) => {
+          return line.includes("✓") || line.includes("✗") || line.includes("?");
+        }),
+      ).toBe(false);
+      expect(
+        output.some((line) => {
+          return line.includes("full access");
+        }),
+      ).toBe(false);
+    });
+
+    it("should show connector permissions with --permissions flag", async () => {
       const token = buildZeroToken({
         userId: "user-1",
         runId: "run-abc",
@@ -447,7 +512,7 @@ describe("zero whoami command", () => {
         ),
       );
 
-      await runWhoami();
+      await runWhoami(["--permissions"]);
 
       const output = getAllOutput();
       expect(
@@ -474,7 +539,7 @@ describe("zero whoami command", () => {
       ).toBe(true);
     });
 
-    it("should show full access for connector with null policies", async () => {
+    it("should show full access with --permissions for connector with null policies", async () => {
       const token = buildZeroToken({
         userId: "user-1",
         runId: "run-abc",
@@ -529,7 +594,7 @@ describe("zero whoami command", () => {
         ),
       );
 
-      await runWhoami();
+      await runWhoami(["--permissions"]);
 
       const output = getAllOutput();
       expect(
@@ -544,7 +609,7 @@ describe("zero whoami command", () => {
       ).toBe(true);
     });
 
-    it("should show identity only when agent API fails", async () => {
+    it("should show identity only when agent API fails with --permissions", async () => {
       const token = buildZeroToken({
         userId: "user-1",
         runId: "run-abc",
@@ -596,7 +661,7 @@ describe("zero whoami command", () => {
         ),
       );
 
-      await runWhoami();
+      await runWhoami(["--permissions"]);
 
       const output = getAllOutput();
       expect(
@@ -622,7 +687,7 @@ describe("zero whoami command", () => {
       ).toBe(false);
     });
 
-    it("should show identity only when one agent API fails", async () => {
+    it("should show identity only when one agent API fails with --permissions", async () => {
       const token = buildZeroToken({
         userId: "user-1",
         runId: "run-abc",
@@ -683,7 +748,7 @@ describe("zero whoami command", () => {
         ),
       );
 
-      await runWhoami();
+      await runWhoami(["--permissions"]);
 
       const output = getAllOutput();
       expect(

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -84,7 +84,7 @@ function printConnectorPermissions(
   }
 }
 
-async function showSandboxInfo(): Promise<void> {
+async function showSandboxInfo(showPermissions: boolean): Promise<void> {
   const agentId = process.env.ZERO_AGENT_ID;
   const payload = decodeZeroTokenPayload();
 
@@ -99,44 +99,60 @@ async function showSandboxInfo(): Promise<void> {
     console.log(`  ${payload.capabilities.join(", ")}`);
   }
 
-  // Connected Services section (identity + permissions)
+  // Connected Services section
   try {
-    const [connectorsResult, agentResult, enabledResult] =
-      await Promise.allSettled([
-        listZeroConnectors(),
-        getZeroAgent(agentId!),
-        getZeroAgentUserConnectors(agentId!),
-      ]);
+    if (showPermissions) {
+      // Full mode: fetch all 3 APIs for permission details
+      const [connectorsResult, agentResult, enabledResult] =
+        await Promise.allSettled([
+          listZeroConnectors(),
+          getZeroAgent(agentId!),
+          getZeroAgentUserConnectors(agentId!),
+        ]);
 
-    // If connector API failed, skip entire section
-    if (connectorsResult.status === "rejected") return;
+      if (connectorsResult.status === "rejected") return;
 
-    const identities = connectorsResult.value.connectors.filter((c) => {
-      return c.externalUsername !== null || c.externalEmail !== null;
-    });
+      const identities = connectorsResult.value.connectors.filter((c) => {
+        return c.externalUsername !== null || c.externalEmail !== null;
+      });
 
-    if (identities.length === 0) return;
+      if (identities.length === 0) return;
 
-    // Resolve permissions if both agent APIs succeeded
-    let resolvedPolicies: FirewallPolicies | null = null;
-    const permissionDataAvailable =
-      agentResult.status === "fulfilled" &&
-      enabledResult.status === "fulfilled";
-    if (permissionDataAvailable) {
-      resolvedPolicies = resolveFirewallPolicies(
-        agentResult.value.firewallPolicies,
-        enabledResult.value,
-      );
-    }
-
-    console.log();
-    console.log(chalk.bold("Connectors:"));
-    for (const connector of identities) {
-      const identity = formatConnectorIdentity(connector);
-      console.log(`  ${connector.type.padEnd(14)}${identity}`);
-
+      let resolvedPolicies: FirewallPolicies | null = null;
+      const permissionDataAvailable =
+        agentResult.status === "fulfilled" &&
+        enabledResult.status === "fulfilled";
       if (permissionDataAvailable) {
-        printConnectorPermissions(connector.type, resolvedPolicies);
+        resolvedPolicies = resolveFirewallPolicies(
+          agentResult.value.firewallPolicies,
+          enabledResult.value,
+        );
+      }
+
+      console.log();
+      console.log(chalk.bold("Connectors:"));
+      for (const connector of identities) {
+        const identity = formatConnectorIdentity(connector);
+        console.log(`  ${connector.type.padEnd(14)}${identity}`);
+
+        if (permissionDataAvailable) {
+          printConnectorPermissions(connector.type, resolvedPolicies);
+        }
+      }
+    } else {
+      // Default mode: only fetch connector identities (1 API call)
+      const connectors = await listZeroConnectors();
+      const identities = connectors.connectors.filter((c) => {
+        return c.externalUsername !== null || c.externalEmail !== null;
+      });
+
+      if (identities.length === 0) return;
+
+      console.log();
+      console.log(chalk.bold("Connectors:"));
+      for (const connector of identities) {
+        const identity = formatConnectorIdentity(connector);
+        console.log(`  ${connector.type.padEnd(14)}${identity}`);
       }
     }
   } catch {
@@ -176,20 +192,23 @@ async function showLocalInfo(): Promise<void> {
 export const zeroWhoamiCommand = new Command()
   .name("whoami")
   .description("Show agent identity, run ID, and capabilities")
+  .option("--permissions", "Show full permission details for each connector")
   .addHelpText(
     "after",
     `
 Examples:
   zero whoami
+  zero whoami --permissions
 
 Notes:
   - Inside sandbox: shows agent ID, run ID, org ID, and granted capabilities
+  - Use --permissions to see detailed permission breakdown per connector
   - Your agent ID is also available as $ZERO_AGENT_ID`,
   )
   .action(
-    withErrorHandler(async () => {
+    withErrorHandler(async (options: { permissions?: boolean }) => {
       if (isInsideSandbox()) {
-        await showSandboxInfo();
+        await showSandboxInfo(options.permissions ?? false);
       } else {
         await showLocalInfo();
       }


### PR DESCRIPTION
## Summary

- Add `--permissions` flag to `zero whoami` command
- Default mode shows only connector identity (1 API call instead of 3)
- `--permissions` mode shows full permission details with ✓/✗/? icons (previous default behavior)
- Aligns with existing `zero agent view --permissions` pattern

## Test plan

- [x] All 17 existing tests pass (updated for new default behavior)
- [x] New test: default mode shows identity without permission details
- [x] Permission detail tests now use `--permissions` flag
- [x] Agent API failure tests use `--permissions` flag
- [x] Lint, type-check, format pass

Closes #7906

🤖 Generated with [Claude Code](https://claude.com/claude-code)