### PR TITLE
feat: add developer-support server endpoint with consent code and zip bundle

### DIFF
--- a/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestRunInDb,
+  insertOrgMembersCacheEntry,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+import { generateZeroToken } from "../../../../../src/lib/auth/sandbox-token";
+
+const URL = "http://localhost:3000/api/zero/developer-support";
+
+const context = testContext();
+
+async function setupRunContext(user: UserContext) {
+  const { composeId } = await createTestCompose(uniqueId("agent"));
+  const { runId } = await createTestRunInDb(user.userId, composeId, {
+    status: "running",
+  });
+  await insertOrgMembersCacheEntry({
+    orgId: user.orgId,
+    userId: user.userId,
+    role: "admin",
+  });
+  mockClerk({ userId: null });
+  const token = await generateZeroToken(user.userId, runId, user.orgId);
+  return { token, runId, composeId };
+}
+
+function postDeveloperSupport(body: Record<string, unknown>, token: string) {
+  return POST(
+    createTestRequest(URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("POST /api/zero/developer-support", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("returns consent code when consentCode is not provided", async () => {
+    const { token } = await setupRunContext(user);
+
+    const response = await postDeveloperSupport(
+      { title: "Bug report", description: "Something is broken" },
+      token,
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.consentCode).toBeDefined();
+    expect(data.consentCode).toHaveLength(4);
+    expect(data.consentCode).toMatch(/^[0-9A-F]{4}$/);
+  });
+
+  it("returns the same consent code for the same runId (deterministic)", async () => {
+    const { token } = await setupRunContext(user);
+
+    const response1 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc" },
+      token,
+    );
+    const response2 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc" },
+      token,
+    );
+
+    const data1 = await response1.json();
+    const data2 = await response2.json();
+    expect(data1.consentCode).toBe(data2.consentCode);
+  });
+
+  it("returns reference when valid consent code is provided", async () => {
+    const { token } = await setupRunContext(user);
+
+    // Step 1: Get consent code
+    const step1Response = await postDeveloperSupport(
+      { title: "Bug report", description: "Something is broken" },
+      token,
+    );
+    const { consentCode } = await step1Response.json();
+
+    // Step 2: Submit with consent code
+    const step2Response = await postDeveloperSupport(
+      {
+        title: "Bug report",
+        description: "Something is broken",
+        consentCode,
+      },
+      token,
+    );
+
+    expect(step2Response.status).toBe(200);
+    const data = await step2Response.json();
+    expect(data.reference).toBeDefined();
+    expect(data.reference).toMatch(/^ds-[a-f0-9]{8}$/);
+
+    // Verify S3 upload was called
+    expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("developer-support/"),
+      expect.any(Buffer),
+      "application/zip",
+    );
+  });
+
+  it("returns 400 for invalid consent code", async () => {
+    const { token } = await setupRunContext(user);
+
+    const response = await postDeveloperSupport(
+      {
+        title: "Bug report",
+        description: "Something is broken",
+        consentCode: "ZZZZ",
+      },
+      token,
+    );
+
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error.code).toBe("INVALID_CONSENT_CODE");
+  });
+
+  it("returns 401 when no auth header is provided", async () => {
+    const response = await POST(
+      createTestRequest(URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Bug",
+          description: "Desc",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/app/api/zero/developer-support/route.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/route.ts
@@ -1,0 +1,313 @@
+import { createHmac, hkdfSync } from "crypto";
+import archiver from "archiver";
+import { createHandler, tsr } from "../../../../src/lib/ts-rest-handler";
+import { zeroDeveloperSupportContract } from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../src/lib/auth/require-auth";
+import { agentRuns } from "../../../../src/db/schema/agent-run";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../src/db/schema/agent-compose";
+import { zeroAgents } from "../../../../src/db/schema/zero-agent";
+import { eq } from "drizzle-orm";
+import { getSessionChatMessages } from "../../../../src/lib/zero/zero-session-service";
+import { listConnectors } from "../../../../src/lib/zero/connector/connector-service";
+import {
+  uploadS3Buffer,
+  generatePresignedUrl,
+} from "../../../../src/lib/infra/s3/s3-client";
+import { enqueueEmail } from "../../../../src/lib/zero/email/outbox-service";
+import { buildFromAddress } from "../../../../src/lib/zero/email/handlers/shared";
+import { env } from "../../../../src/env";
+import { logger } from "../../../../src/lib/shared/logger";
+
+const log = logger("api:developer-support");
+
+const DOWNLOAD_EXPIRY_SECONDS = 72 * 60 * 60;
+
+// Cache the derived HMAC key for the process lifetime
+let cachedConsentKey: Buffer | null = null;
+
+function getConsentKey(): Buffer {
+  if (!cachedConsentKey) {
+    const keyHex = env().SECRETS_ENCRYPTION_KEY;
+    const masterKey = Buffer.from(keyHex, "hex");
+    cachedConsentKey = Buffer.from(
+      hkdfSync("sha256", masterKey, "", "developer-support-consent", 32),
+    );
+  }
+  return cachedConsentKey;
+}
+
+function generateConsentCode(runId: string): string {
+  const key = getConsentKey();
+  return createHmac("sha256", key)
+    .update(runId)
+    .digest("hex")
+    .slice(0, 4)
+    .toUpperCase();
+}
+
+interface ZipEntry {
+  path: string;
+  content: string;
+}
+
+async function assembleZip(entries: ZipEntry[]): Promise<Buffer> {
+  const archive = archiver("zip", { zlib: { level: 6 } });
+  const chunks: Buffer[] = [];
+
+  const done = new Promise<Buffer>((resolve, reject) => {
+    archive.on("data", (chunk: Buffer) => {
+      return chunks.push(chunk);
+    });
+    archive.on("end", () => {
+      return resolve(Buffer.concat(chunks));
+    });
+    archive.on("error", reject);
+  });
+
+  for (const entry of entries) {
+    archive.append(Buffer.from(entry.content), { name: entry.path });
+  }
+
+  await archive.finalize();
+  return done;
+}
+
+const router = tsr.router(zeroDeveloperSupportContract, {
+  submit: async ({ body, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization, {
+      requiredCapability: "developer-support:write",
+    });
+    if (isAuthError(authCtx)) return authCtx;
+
+    const { userId, orgId, runId } = authCtx;
+    if (!runId || !orgId) {
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            message: "This endpoint requires a zero token with runId and orgId",
+            code: "UNAUTHORIZED",
+          },
+        },
+      };
+    }
+
+    // Step 1: Generate consent code if none provided
+    if (!body.consentCode) {
+      const consentCode = generateConsentCode(runId);
+      return {
+        status: 200 as const,
+        body: { consentCode },
+      };
+    }
+
+    // Step 2: Validate consent code
+    const expectedCode = generateConsentCode(runId);
+    if (body.consentCode !== expectedCode) {
+      return {
+        status: 400 as const,
+        body: {
+          error: {
+            message: "Invalid consent code",
+            code: "INVALID_CONSENT_CODE",
+          },
+        },
+      };
+    }
+
+    const reference = `ds-${crypto.randomUUID().slice(0, 8)}`;
+    const db = globalThis.services.db;
+
+    // Collect data in parallel
+    const [run, connectors] = await Promise.all([
+      db
+        .select({
+          id: agentRuns.id,
+          status: agentRuns.status,
+          createdAt: agentRuns.createdAt,
+          startedAt: agentRuns.startedAt,
+          completedAt: agentRuns.completedAt,
+          agentComposeVersionId: agentRuns.agentComposeVersionId,
+          runnerGroup: agentRuns.runnerGroup,
+          continuedFromSessionId: agentRuns.continuedFromSessionId,
+        })
+        .from(agentRuns)
+        .where(eq(agentRuns.id, runId))
+        .limit(1)
+        .then((rows) => {
+          return rows[0] ?? null;
+        }),
+      listConnectors(orgId, userId).catch((err) => {
+        log.warn("Failed to collect connectors", { error: String(err) });
+        return [];
+      }),
+    ]);
+
+    if (!run) {
+      return {
+        status: 400 as const,
+        body: {
+          error: { message: "Run not found", code: "RUN_NOT_FOUND" },
+        },
+      };
+    }
+
+    // Collect agent config via compose version join
+    let agentConfig: Record<string, unknown> = {};
+    if (run.agentComposeVersionId) {
+      const [agent] = await db
+        .select({
+          displayName: zeroAgents.displayName,
+          description: zeroAgents.description,
+          sound: zeroAgents.sound,
+          customSkills: zeroAgents.customSkills,
+          firewallPolicies: zeroAgents.firewallPolicies,
+        })
+        .from(agentComposeVersions)
+        .innerJoin(
+          agentComposes,
+          eq(agentComposeVersions.composeId, agentComposes.id),
+        )
+        .innerJoin(zeroAgents, eq(zeroAgents.id, agentComposes.id))
+        .where(eq(agentComposeVersions.id, run.agentComposeVersionId))
+        .limit(1);
+
+      if (agent) {
+        agentConfig = {
+          displayName: agent.displayName,
+          description: agent.description,
+          sound: agent.sound,
+          customSkills: agent.customSkills,
+          firewallPolicies: agent.firewallPolicies,
+        };
+      }
+    }
+
+    // Collect session messages if available
+    let conversation: unknown[] = [];
+    const sessionId = run.continuedFromSessionId;
+    if (sessionId) {
+      conversation = await getSessionChatMessages(sessionId);
+    }
+
+    // Safe connector subset (no tokens)
+    const safeConnectors = connectors.map((c) => {
+      return {
+        type: c.type,
+        authMethod: c.authMethod,
+        needsReconnect: c.needsReconnect,
+        externalUsername: c.externalUsername,
+      };
+    });
+
+    // Assemble ZIP
+    const zipEntries: ZipEntry[] = [
+      {
+        path: "manifest.json",
+        content: JSON.stringify(
+          {
+            reference,
+            userId,
+            orgId,
+            runId,
+            sessionId: sessionId ?? null,
+            createdAt: new Date().toISOString(),
+          },
+          null,
+          2,
+        ),
+      },
+      {
+        path: "description.md",
+        content: `# ${body.title}\n\n${body.description}`,
+      },
+      {
+        path: "conversation.json",
+        content: JSON.stringify(conversation, null, 2),
+      },
+      {
+        path: "environment.json",
+        content: JSON.stringify(
+          {
+            runId: run.id,
+            orgId,
+            status: run.status,
+            createdAt: run.createdAt?.toISOString() ?? null,
+            startedAt: run.startedAt?.toISOString() ?? null,
+            completedAt: run.completedAt?.toISOString() ?? null,
+            runnerGroup: run.runnerGroup,
+          },
+          null,
+          2,
+        ),
+      },
+      {
+        path: "connectors.json",
+        content: JSON.stringify(safeConnectors, null, 2),
+      },
+      {
+        path: "agent-config.json",
+        content: JSON.stringify(agentConfig, null, 2),
+      },
+    ];
+
+    const zipBuffer = await assembleZip(zipEntries);
+
+    // Upload to R2
+    const bucket = env().R2_USER_STORAGES_BUCKET_NAME;
+    const s3Key = `developer-support/${orgId}/${reference}.zip`;
+    await uploadS3Buffer(bucket, s3Key, zipBuffer, "application/zip");
+
+    const downloadUrl = await generatePresignedUrl(
+      bucket,
+      s3Key,
+      DOWNLOAD_EXPIRY_SECONDS,
+      "developer-support.zip",
+      true,
+    );
+
+    const expiresAt = new Date(
+      Date.now() + DOWNLOAD_EXPIRY_SECONDS * 1000,
+    ).toISOString();
+
+    // Send email notification
+    await enqueueEmail({
+      from: buildFromAddress("vm0"),
+      to: "contact@vm0.ai",
+      subject: `[Developer Support] ${body.title}`,
+      template: {
+        template: "developer-support",
+        props: {
+          title: body.title,
+          description: body.description,
+          reference,
+          userId,
+          orgId,
+          runId,
+          downloadUrl,
+          expiresAt,
+        },
+      },
+    });
+
+    log.info("Developer support bundle submitted", { reference, runId, orgId });
+
+    return {
+      status: 200 as const,
+      body: { reference },
+    };
+  },
+});
+
+const handler = createHandler(zeroDeveloperSupportContract, router);
+
+export { handler as POST };

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -246,6 +246,7 @@ describe("sandbox-token", () => {
         "schedule:write",
         "slack:write",
         "connector:read",
+        "developer-support:write",
       ]);
     });
 

--- a/turbo/apps/web/src/lib/zero/email/template-registry.ts
+++ b/turbo/apps/web/src/lib/zero/email/template-registry.ts
@@ -3,6 +3,7 @@ import type { EmailTemplate } from "./types";
 import { AgentReplyEmail } from "./templates/agent-reply";
 import { InboundErrorEmail } from "./templates/inbound-error";
 import { DataExportReadyEmail } from "./templates/data-export-ready";
+import { DeveloperSupportEmail } from "./templates/developer-support";
 
 /**
  * Resolve an EmailTemplate discriminated union to a React element.
@@ -16,5 +17,7 @@ export function resolveTemplate(template: EmailTemplate): ReactElement {
       return InboundErrorEmail(template.props);
     case "data-export-ready":
       return DataExportReadyEmail(template.props);
+    case "developer-support":
+      return DeveloperSupportEmail(template.props);
   }
 }

--- a/turbo/apps/web/src/lib/zero/email/templates/developer-support.tsx
+++ b/turbo/apps/web/src/lib/zero/email/templates/developer-support.tsx
@@ -1,0 +1,121 @@
+import {
+  Html,
+  Head,
+  Body,
+  Container,
+  Text,
+  Link,
+  Hr,
+} from "@react-email/components";
+
+interface DeveloperSupportEmailProps {
+  title: string;
+  description: string;
+  reference: string;
+  userId: string;
+  orgId: string;
+  runId: string;
+  downloadUrl: string;
+  expiresAt: string;
+}
+
+export function DeveloperSupportEmail({
+  title,
+  description,
+  reference,
+  userId,
+  orgId,
+  runId,
+  downloadUrl,
+  expiresAt,
+}: DeveloperSupportEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Body style={bodyStyle}>
+        <Container style={containerStyle}>
+          <Text style={headingStyle}>[Developer Support] {title}</Text>
+          <Text style={textStyle}>Reference: {reference}</Text>
+          <Hr style={hrStyle} />
+          <Text style={labelStyle}>Description</Text>
+          <Text style={textStyle}>{description}</Text>
+          <Hr style={hrStyle} />
+          <Text style={labelStyle}>Context</Text>
+          <Text style={metaStyle}>User ID: {userId}</Text>
+          <Text style={metaStyle}>Org ID: {orgId}</Text>
+          <Text style={metaStyle}>Run ID: {runId}</Text>
+          <Hr style={hrStyle} />
+          <Text style={textStyle}>
+            <Link href={downloadUrl} style={linkStyle}>
+              Download diagnostic bundle
+            </Link>
+          </Text>
+          <Text style={footerStyle}>
+            This download link expires on {expiresAt}.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+const bodyStyle = {
+  backgroundColor: "#f6f9fc",
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+};
+
+const containerStyle = {
+  backgroundColor: "#ffffff",
+  margin: "0 auto",
+  padding: "20px 24px",
+  maxWidth: "600px",
+  borderRadius: "8px",
+};
+
+const headingStyle = {
+  fontSize: "18px",
+  fontWeight: "600" as const,
+  color: "#111827",
+  margin: "0 0 12px",
+};
+
+const textStyle = {
+  fontSize: "14px",
+  color: "#374151",
+  lineHeight: "1.6",
+  margin: "0 0 12px",
+};
+
+const labelStyle = {
+  fontSize: "13px",
+  fontWeight: "600" as const,
+  color: "#6b7280",
+  margin: "0 0 4px",
+  textTransform: "uppercase" as const,
+  letterSpacing: "0.05em",
+};
+
+const metaStyle = {
+  fontSize: "13px",
+  color: "#374151",
+  lineHeight: "1.6",
+  margin: "0 0 2px",
+  fontFamily: "monospace",
+};
+
+const hrStyle = {
+  borderColor: "#e5e7eb",
+  margin: "20px 0",
+};
+
+const footerStyle = {
+  fontSize: "13px",
+  color: "#6b7280",
+  margin: "0",
+};
+
+const linkStyle = {
+  color: "#2563eb",
+  textDecoration: "underline",
+};

--- a/turbo/apps/web/src/lib/zero/email/types.ts
+++ b/turbo/apps/web/src/lib/zero/email/types.ts
@@ -29,10 +29,25 @@ interface DataExportReadyTemplate {
   };
 }
 
+interface DeveloperSupportTemplate {
+  template: "developer-support";
+  props: {
+    title: string;
+    description: string;
+    reference: string;
+    userId: string;
+    orgId: string;
+    runId: string;
+    downloadUrl: string;
+    expiresAt: string;
+  };
+}
+
 export type EmailTemplate =
   | AgentReplyTemplate
   | InboundErrorTemplate
-  | DataExportReadyTemplate;
+  | DataExportReadyTemplate
+  | DeveloperSupportTemplate;
 
 // ============================================================================
 // Post-Send Action Types (discriminated union)

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -23,8 +23,8 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 8 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(8);
+  it("should have exactly 9 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(9);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -35,6 +35,7 @@ export const ZERO_CAPABILITIES = [
   "schedule:write",
   "slack:write",
   "connector:read",
+  "developer-support:write",
 ] as const;
 
 /** Inferred union type of all zero capability strings. */
@@ -64,6 +65,10 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     },
     "slack:write": { group: "Integrations", label: "Send Slack messages" },
     "connector:read": { group: "Connectors", label: "View connected services" },
+    "developer-support:write": {
+      group: "Support",
+      label: "Submit developer support requests",
+    },
   };
 
 /**

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -734,3 +734,10 @@ export {
   type AskUserAnswerStatus,
   type AskUserAnswerResponse,
 } from "./zero-ask-user";
+export {
+  zeroDeveloperSupportContract,
+  developerSupportBodySchema,
+  consentCodeResponseSchema,
+  submitResponseSchema,
+  type ZeroDeveloperSupportContract,
+} from "./zero-developer-support";

--- a/turbo/packages/core/src/contracts/zero-developer-support.ts
+++ b/turbo/packages/core/src/contracts/zero-developer-support.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const developerSupportBodySchema = z.object({
+  title: z.string().min(1, "Title is required"),
+  description: z.string().min(1, "Description is required"),
+  consentCode: z.string().optional(),
+});
+
+const consentCodeResponseSchema = z.object({
+  consentCode: z.string(),
+});
+
+const submitResponseSchema = z.object({
+  reference: z.string(),
+});
+
+export const zeroDeveloperSupportContract = c.router({
+  submit: {
+    method: "POST",
+    path: "/api/zero/developer-support",
+    headers: authHeadersSchema,
+    body: developerSupportBodySchema,
+    responses: {
+      200: z.union([consentCodeResponseSchema, submitResponseSchema]),
+      400: apiErrorSchema,
+      401: apiErrorSchema,
+    },
+    summary:
+      "Developer support: consent code generation or diagnostic submission",
+  },
+});
+
+export type ZeroDeveloperSupportContract = typeof zeroDeveloperSupportContract;
+export {
+  developerSupportBodySchema,
+  consentCodeResponseSchema,
+  submitResponseSchema,
+};


### PR DESCRIPTION
## Summary

- Add `POST /api/zero/developer-support` endpoint with two-step consent flow
- Step 1 (no consentCode): generates deterministic HMAC consent code from runId
- Step 2 (with consentCode): validates code, collects diagnostic data (run metadata, agent config, connectors, conversation), assembles ZIP bundle, uploads to R2, sends email notification to dev team
- Add `developer-support:write` capability to ZERO_CAPABILITIES (auto-included in all zero tokens)
- Add developer-support email template with reference ID, context metadata, and download link

Closes #7904

## Test plan

- [x] Integration test: consent code generation (step 1)
- [x] Integration test: deterministic consent code (same runId returns same code)
- [x] Integration test: valid consent code returns reference and uploads ZIP to R2
- [x] Integration test: invalid consent code returns 400
- [x] Integration test: missing auth returns 401
- [x] Type-check passes for web and core packages
- [x] Lint passes with 0 errors
- [x] Knip finds no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)