### PR TITLE
test(platform): add interaction tests for zero-activity-detail-page

### DIFF
--- a/turbo/apps/platform/src/views/activity/__tests__/zero-activity-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/activity/__tests__/zero-activity-detail-page-interaction.test.tsx
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { FeatureSwitchKey, type RunContextResponse } from "@vm0/core";
+import type {
+  LogDetail,
+  AgentEventsResponse,
+} from "../../../signals/zero-page/log-types.ts";
+
+const context = testContext();
+
+const BASE_LOG_ID = "b0000000-0000-4000-b000-000000000001";
+
+function makeLogDetail(): LogDetail {
+  return {
+    id: BASE_LOG_ID,
+    sessionId: "session_int",
+    agentId: "test-agent",
+    displayName: "Interaction Test Agent",
+    framework: "claude-code",
+    modelProvider: null,
+    selectedModel: null,
+    triggerSource: "web",
+    triggerAgentName: null,
+    scheduleId: null,
+    status: "completed",
+    prompt: "What is the capital of France?",
+    appendSystemPrompt: "You are a helpful assistant.",
+    error: null,
+    createdAt: "2026-03-10T14:56:00Z",
+    startedAt: "2026-03-10T14:56:01Z",
+    completedAt: "2026-03-10T14:56:10Z",
+    artifact: { name: null, version: null },
+  };
+}
+
+function makeEventsResponse(): AgentEventsResponse {
+  return {
+    events: [
+      {
+        sequenceNumber: 0,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [
+              { type: "text", text: "Paris is the capital of France." },
+            ],
+          },
+        },
+        createdAt: "2026-03-10T14:56:02Z",
+      },
+      {
+        sequenceNumber: 1,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [{ type: "text", text: "The Eiffel Tower is in Paris." }],
+          },
+        },
+        createdAt: "2026-03-10T14:56:03Z",
+      },
+    ],
+    hasMore: false,
+    framework: "claude-code",
+  };
+}
+
+function setupBaseMocks() {
+  server.use(
+    http.get("*/api/zero/logs/:id", ({ params }) => {
+      if (params["id"] === BASE_LOG_ID) {
+        return HttpResponse.json(makeLogDetail());
+      }
+      return HttpResponse.json(
+        { error: { message: "Not found", code: "NOT_FOUND" } },
+        { status: 404 },
+      );
+    }),
+    http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+      return HttpResponse.json(makeEventsResponse());
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+describe("zeroActivityDetailPageInteraction", () => {
+  it("should filter steps when searching (ACT-D-028)", async () => {
+    setupBaseMocks();
+    const user = userEvent.setup();
+
+    await setupPage({
+      context,
+      path: `/activities/${BASE_LOG_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Interaction Test Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("2 total")).toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByPlaceholderText("Search steps");
+    await user.type(searchInput, "Eiffel");
+
+    await waitFor(() => {
+      expect(screen.getByText(/1\/2 matched/)).toBeInTheDocument();
+    });
+  });
+
+  it("should trigger download when download button is clicked (ACT-D-029)", async () => {
+    setupBaseMocks();
+
+    server.use(
+      http.get("*/api/zero/runs/:id/context", () => {
+        return HttpResponse.json(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }),
+      http.get("*/api/zero/runs/:id/network", () => {
+        return HttpResponse.json(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    const createObjectURLSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:test");
+    vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {
+        return undefined;
+      });
+
+    const user = userEvent.setup();
+
+    await setupPage({
+      context,
+      path: `/activities/${BASE_LOG_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Interaction Test Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    const downloadIcon = document.querySelector(".tabler-icon-download");
+    expect(downloadIcon).not.toBeNull();
+    const downloadButton = (downloadIcon as HTMLElement).closest("button");
+    expect(downloadButton).not.toBeNull();
+    await user.click(downloadButton as HTMLElement);
+
+    await waitFor(() => {
+      expect(clickSpy).toHaveBeenCalledWith();
+    });
+
+    expect(createObjectURLSpy).toHaveBeenCalledWith(expect.any(Blob));
+
+    createObjectURLSpy.mockRestore();
+    clickSpy.mockRestore();
+  });
+
+  it("should switch to context tab when clicked (ACT-D-030)", async () => {
+    setupBaseMocks();
+
+    const contextResponse: RunContextResponse = {
+      prompt: "What is the capital of France?",
+      appendSystemPrompt: null,
+      secretNames: [],
+      vars: null,
+      environment: {},
+      firewalls: [],
+      volumes: [],
+      artifact: null,
+      memory: null,
+    };
+
+    server.use(
+      http.get("*/api/zero/runs/:id/context", () => {
+        return HttpResponse.json(contextResponse);
+      }),
+    );
+
+    const user = userEvent.setup();
+
+    await setupPage({
+      context,
+      path: `/activities/${BASE_LOG_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ZeroDebug]: true },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Interaction Test Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    const contextTab = screen.getByRole("tab", { name: "Context" });
+    await user.click(contextTab);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Prompt", level: 3 }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should expand and collapse the system prompt section (ACT-D-031)", async () => {
+    setupBaseMocks();
+
+    const user = userEvent.setup();
+
+    await setupPage({
+      context,
+      path: `/activities/${BASE_LOG_ID}`,
+      featureSwitches: { [FeatureSwitchKey.ShowSystemPrompt]: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("System Prompt")).toBeInTheDocument();
+    });
+
+    // The <details> element is initially closed — content paragraph is not visible
+    const promptParagraph = () => {
+      return screen.getAllByText("You are a helpful assistant.").find((el) => {
+        return el.tagName === "P";
+      });
+    };
+    expect(promptParagraph()).not.toBeVisible();
+
+    await user.click(screen.getByText("System Prompt"));
+
+    await waitFor(() => {
+      expect(promptParagraph()).toBeVisible();
+    });
+
+    await user.click(screen.getByText("System Prompt"));
+
+    await waitFor(() => {
+      expect(promptParagraph()).not.toBeVisible();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
@@ -139,13 +139,13 @@ describe("zeroActivityDetailPageInteraction", () => {
       }),
     );
 
-    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:test");
+    const createObjectURLSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:test");
     vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
-    const clickSpy = vi
-      .spyOn(HTMLAnchorElement.prototype, "click")
-      .mockImplementation(() => {
-        return undefined;
-      });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {
+      return undefined;
+    });
 
     const user = userEvent.setup();
 
@@ -166,8 +166,16 @@ describe("zeroActivityDetailPageInteraction", () => {
     await user.click(downloadButton);
 
     await waitFor(() => {
-      expect(clickSpy).toHaveBeenCalledWith();
+      expect(createObjectURLSpy).toHaveBeenCalledOnce();
     });
+    const capturedArg = createObjectURLSpy.mock.calls[0]?.[0];
+    assert(
+      capturedArg instanceof Blob,
+      "createObjectURL should be called with a Blob",
+    );
+    expect(capturedArg.type).toBe("application/json;charset=utf-8;");
+    const blobText = await capturedArg.text();
+    expect(blobText).toContain(BASE_LOG_ID);
   });
 
   it("should switch to context tab when clicked (ACT-D-030)", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
@@ -143,9 +143,11 @@ describe("zeroActivityDetailPageInteraction", () => {
       .spyOn(URL, "createObjectURL")
       .mockReturnValue("blob:test");
     vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
-    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {
-      return undefined;
-    });
+    const anchorClickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {
+        return undefined;
+      });
 
     const user = userEvent.setup();
 
@@ -176,6 +178,7 @@ describe("zeroActivityDetailPageInteraction", () => {
     expect(capturedArg.type).toBe("application/json;charset=utf-8;");
     const blobText = await capturedArg.text();
     expect(blobText).toContain(BASE_LOG_ID);
+    expect(anchorClickSpy).toHaveBeenCalledOnce();
   });
 
   it("should switch to context tab when clicked (ACT-D-030)", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
@@ -90,6 +90,10 @@ function setupBaseMocks() {
 }
 
 describe("zeroActivityDetailPageInteraction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("should filter steps when searching (ACT-D-028)", async () => {
     setupBaseMocks();
     const user = userEvent.setup();
@@ -135,9 +139,7 @@ describe("zeroActivityDetailPageInteraction", () => {
       }),
     );
 
-    const createObjectURLSpy = vi
-      .spyOn(URL, "createObjectURL")
-      .mockReturnValue("blob:test");
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:test");
     vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
     const clickSpy = vi
       .spyOn(HTMLAnchorElement.prototype, "click")
@@ -158,20 +160,14 @@ describe("zeroActivityDetailPageInteraction", () => {
       ).toBeInTheDocument();
     });
 
-    const downloadIcon = document.querySelector(".tabler-icon-download");
-    expect(downloadIcon).not.toBeNull();
-    const downloadButton = (downloadIcon as HTMLElement).closest("button");
-    expect(downloadButton).not.toBeNull();
-    await user.click(downloadButton as HTMLElement);
+    const downloadButton = screen.getByRole("button", {
+      name: "Download raw data",
+    });
+    await user.click(downloadButton);
 
     await waitFor(() => {
       expect(clickSpy).toHaveBeenCalledWith();
     });
-
-    expect(createObjectURLSpy).toHaveBeenCalledWith(expect.any(Blob));
-
-    createObjectURLSpy.mockRestore();
-    clickSpy.mockRestore();
   });
 
   it("should switch to context tab when clicked (ACT-D-030)", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -299,6 +299,7 @@ export function ActivityHeaderCard({
                   <Button
                     variant="ghost"
                     size="sm"
+                    aria-label="Download raw data"
                     className="h-7 w-7 ml-auto shrink-0 rounded-lg text-muted-foreground hover:text-foreground p-0"
                     onClick={() => {
                       if (onDownload) {


### PR DESCRIPTION
Closes #7910

## Summary

- Add `zero-activity-detail-page-interaction.test.tsx` under `src/views/activity/__tests__/` with four interaction tests:
  - ACT-D-028: search input filters steps to matching messages
  - ACT-D-029: download button triggers download via `URL.createObjectURL` and anchor click
  - ACT-D-030: Context tab switch renders `ContextContent` with Prompt heading
  - ACT-D-031: collapsible system prompt `<details>` expands and collapses on click

## Test plan

- [ ] All 4 tests pass: `pnpm vitest run apps/platform/src/views/activity/__tests__/zero-activity-detail-page-interaction.test.tsx`
- [ ] No `vi.mock()` for internal modules — only MSW for HTTP mocking
- [ ] No `eslint-disable` or `@ts-ignore`
- [ ] Lint passes: `pnpm turbo run lint --filter="@vm0/app"`
- [ ] Types pass: `pnpm check-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)