### PR TITLE
refactor(web): move clerk-config to shared directory

### DIFF
--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -8,7 +8,7 @@ import {
   JetBrains_Mono,
 } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
-import { getClerkPublishableKey } from "../src/lib/clerk-config";
+import { getClerkPublishableKey } from "../src/lib/shared/clerk-config";
 import { getAppUrl } from "../src/lib/zero/url";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { env } from "../src/env";

--- a/turbo/apps/web/src/lib/shared/clerk-config.ts
+++ b/turbo/apps/web/src/lib/shared/clerk-config.ts
@@ -1,4 +1,4 @@
-import { env } from "../env";
+import { env } from "../../env";
 
 /**
  * Get Clerk publishable key from validated environment variables


### PR DESCRIPTION
## Summary
- Move `clerk-config.ts` from `src/lib/` to `src/lib/shared/` since it is a cross-layer config utility used by the app layer and belongs in the shared directory
- Update import path in `app/layout.tsx` and fix relative env import in the moved file

## Test plan
- [x] Lint passes
- [x] Type check passes for web
- [x] Format check passes
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)