### PR TITLE
fix(platform): show skeleton overlay during onboarding-to-chat transition

### DIFF
--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -7,6 +7,10 @@ export const appSkeletonVisible$ = computed((get) => {
   return get(internalVisible$);
 });
 
+export const showAppSkeleton$ = command(({ set }) => {
+  set(internalVisible$, true);
+});
+
 export const hideAppSkeleton$ = command(
   async ({ set }, signal: AbortSignal) => {
     await delay(0, { signal });

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -17,6 +17,7 @@ import { allConnectorTypes$ } from "./settings/connectors.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
 import { reloadBillingStatus$ } from "./billing.ts";
+import { showAppSkeleton$ } from "../app-skeleton.ts";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 
 // ---------------------------------------------------------------------------
@@ -245,6 +246,8 @@ const completeOnboarding$ = command(
 
 export const onboardingAddToSlack$ = command(
   async ({ get, set }, signal: AbortSignal) => {
+    set(showAppSkeleton$);
+
     const result = await set(completeOnboarding$, signal);
     if (!result) {
       return;
@@ -266,6 +269,8 @@ export const onboardingAddToSlack$ = command(
 
 export const onboardingContinueWeb$ = command(
   async ({ set }, signal: AbortSignal) => {
+    set(showAppSkeleton$);
+
     const agentId = await set(completeOnboarding$, signal);
 
     if (!agentId) {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
@@ -68,7 +68,7 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
     });
 
     // Skeleton should be hidden after onboarding page loaded
-    expect(context.store.get(appSkeletonVisible$)).toBe(false);
+    expect(context.store.get(appSkeletonVisible$)).toBeFalsy();
 
     mock.completeOnboarding();
 
@@ -84,7 +84,7 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
     });
 
     // Skeleton should be hidden after chat page setup completes
-    expect(context.store.get(appSkeletonVisible$)).toBe(false);
+    expect(context.store.get(appSkeletonVisible$)).toBeFalsy();
 
     mock.ctrl.completeRun("Hello!");
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
@@ -62,7 +62,10 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
     });
 
     // Skeleton should be hidden after onboarding page loaded
-    expect(screen.getByTestId("app-skeleton")).toHaveClass("opacity-0");
+    expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
 
     // Click starts the async onboarding completion; the POST API is deferred
     // so the command is in-flight while we assert skeleton visibility.
@@ -70,7 +73,9 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
 
     // Skeleton must be visible during the transition (the fix for #7902)
     await waitFor(() => {
-      expect(screen.getByTestId("app-skeleton")).toHaveClass("opacity-100");
+      expect(screen.getByTestId("app-skeleton")).not.toHaveAttribute(
+        "aria-hidden",
+      );
     });
 
     // Release the deferred POST response to let onboarding complete and
@@ -88,7 +93,10 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
 
     // Skeleton should be hidden after chat page setup completes
     await waitFor(() => {
-      expect(screen.getByTestId("app-skeleton")).toHaveClass("opacity-0");
+      expect(screen.getByTestId("app-skeleton")).toHaveAttribute(
+        "aria-hidden",
+        "true",
+      );
     });
 
     mock.ctrl.completeRun("Hello!");

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { mockChatLifecycle } from "./chat-test-helpers.ts";
+import { pathname } from "../../../signals/location.ts";
+import { appSkeletonVisible$ } from "../../../signals/app-skeleton.ts";
+
+const context = testContext();
+
+const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
+const MOCK_THREAD_ID = "thread-blank-test-1";
+
+function mockMemberOnboardingWithChat() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: true,
+        isAdmin: false,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: MOCK_AGENT_ID,
+        defaultAgentMetadata: { displayName: "Zero" },
+        defaultAgentSkills: [],
+      });
+    }),
+    http.post("*/api/zero/onboarding/complete", () => {
+      return HttpResponse.json({ ok: true });
+    }),
+  );
+
+  const ctrl = mockChatLifecycle({ threadId: MOCK_THREAD_ID });
+
+  return {
+    ctrl,
+    completeOnboarding: () => {
+      server.use(
+        http.get("*/api/zero/onboarding/status", () => {
+          return HttpResponse.json({
+            needsOnboarding: false,
+            isAdmin: false,
+            hasOrg: true,
+            hasDefaultAgent: true,
+            defaultAgentId: MOCK_AGENT_ID,
+            defaultAgentMetadata: { displayName: "Zero" },
+            defaultAgentSkills: [],
+          });
+        }),
+      );
+    },
+  };
+}
+
+describe("onboarding continue in web → skeleton → chat page (#7902)", () => {
+  it("should show skeleton immediately on click, then hide after chat page loads", async () => {
+    const user = userEvent.setup();
+    const mock = mockMemberOnboardingWithChat();
+
+    await setupPage({ context, path: "/onboarding" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Where would you like to work with/),
+      ).toBeInTheDocument();
+    });
+
+    // Skeleton should be hidden after onboarding page loaded
+    expect(context.store.get(appSkeletonVisible$)).toBe(false);
+
+    mock.completeOnboarding();
+
+    await user.click(screen.getByRole("button", { name: /Continue in web/ }));
+
+    // Verify navigation happened and chat page renders
+    await waitFor(() => {
+      expect(pathname()).toBe(`/chats/${MOCK_THREAD_ID}`);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
+    // Skeleton should be hidden after chat page setup completes
+    expect(context.store.get(appSkeletonVisible$)).toBe(false);
+
+    mock.ctrl.completeRun("Hello!");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
@@ -7,7 +7,7 @@ import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { mockChatLifecycle } from "./chat-test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
-import { appSkeletonVisible$ } from "../../../signals/app-skeleton.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 
@@ -15,6 +15,11 @@ const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
 const MOCK_THREAD_ID = "thread-blank-test-1";
 
 function mockMemberOnboardingWithChat() {
+  // Deferred that blocks the POST /complete API response until we release it.
+  // This creates a timing window to observe the skeleton while the async
+  // onboarding completion is in-flight.
+  const completeDeferred = createDeferredPromise<void>(context.signal);
+
   server.use(
     http.get("*/api/zero/onboarding/status", () => {
       return HttpResponse.json({
@@ -27,7 +32,8 @@ function mockMemberOnboardingWithChat() {
         defaultAgentSkills: [],
       });
     }),
-    http.post("*/api/zero/onboarding/complete", () => {
+    http.post("*/api/zero/onboarding/complete", async () => {
+      await completeDeferred.promise;
       return HttpResponse.json({ ok: true });
     }),
   );
@@ -36,20 +42,8 @@ function mockMemberOnboardingWithChat() {
 
   return {
     ctrl,
-    completeOnboarding: () => {
-      server.use(
-        http.get("*/api/zero/onboarding/status", () => {
-          return HttpResponse.json({
-            needsOnboarding: false,
-            isAdmin: false,
-            hasOrg: true,
-            hasDefaultAgent: true,
-            defaultAgentId: MOCK_AGENT_ID,
-            defaultAgentMetadata: { displayName: "Zero" },
-            defaultAgentSkills: [],
-          });
-        }),
-      );
+    releaseComplete: () => {
+      completeDeferred.resolve();
     },
   };
 }
@@ -68,11 +62,20 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
     });
 
     // Skeleton should be hidden after onboarding page loaded
-    expect(context.store.get(appSkeletonVisible$)).toBeFalsy();
+    expect(screen.getByTestId("app-skeleton")).toHaveClass("opacity-0");
 
-    mock.completeOnboarding();
-
+    // Click starts the async onboarding completion; the POST API is deferred
+    // so the command is in-flight while we assert skeleton visibility.
     await user.click(screen.getByRole("button", { name: /Continue in web/ }));
+
+    // Skeleton must be visible during the transition (the fix for #7902)
+    await waitFor(() => {
+      expect(screen.getByTestId("app-skeleton")).toHaveClass("opacity-100");
+    });
+
+    // Release the deferred POST response to let onboarding complete and
+    // navigation to the chat page proceed.
+    mock.releaseComplete();
 
     // Verify navigation happened and chat page renders
     await waitFor(() => {
@@ -84,7 +87,9 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
     });
 
     // Skeleton should be hidden after chat page setup completes
-    expect(context.store.get(appSkeletonVisible$)).toBeFalsy();
+    await waitFor(() => {
+      expect(screen.getByTestId("app-skeleton")).toHaveClass("opacity-0");
+    });
 
     mock.ctrl.completeRun("Hello!");
   });

--- a/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
+++ b/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
@@ -51,6 +51,7 @@ const skeletonCSS = `
 export function AppSkeleton({ visible = true }: { visible?: boolean }) {
   return (
     <div
+      data-testid="app-skeleton"
       className={`fixed inset-0 z-50 flex items-center justify-center bg-background ${
         visible
           ? "opacity-100"

--- a/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
+++ b/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
@@ -52,6 +52,7 @@ export function AppSkeleton({ visible = true }: { visible?: boolean }) {
   return (
     <div
       data-testid="app-skeleton"
+      aria-hidden={visible ? undefined : true}
       className={`fixed inset-0 z-50 flex items-center justify-center bg-background ${
         visible
           ? "opacity-100"


### PR DESCRIPTION
## Summary

- Show the app skeleton overlay immediately when clicking "Continue in web" or "Add to Slack" on the onboarding page
- The skeleton covers the stale onboarding UI during the async completion + navigation, preventing a blank page flash
- The target page's setup (`hideAppSkeleton$`) hides the skeleton once content is ready

## Changes

- `app-skeleton.ts`: Add `showAppSkeleton$` command to re-show the skeleton overlay
- `zero-onboarding-actions.ts`: Call `showAppSkeleton$` at the start of `onboardingContinueWeb$` and `onboardingAddToSlack$`
- New test verifying the skeleton → chat page transition flow

## Test plan

- [x] Existing onboarding tests pass (navigation, chat intro, continue-web, add-to-slack)
- [x] New test verifies skeleton visibility during onboarding → chat transition
- [ ] Manual: click "Continue in web" on onboarding page — should see skeleton loading screen, then chat page

Closes #7902

🤖 Generated with [Claude Code](https://claude.com/claude-code)