### PR TITLE
feat: add zero developer-support cli command and agent prompt

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -27,6 +27,7 @@ describe("zero CLI program", () => {
       "variable",
       "whoami",
       "ask-user",
+      "developer-support",
     ];
     for (const name of expectedCommands) {
       expect(commandNames).toContain(name);
@@ -50,7 +51,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 14 commands", () => {
-    expect(commandNames).toHaveLength(14);
+  it("should have exactly 15 commands", () => {
+    expect(commandNames).toHaveLength(15);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/__tests__/developer-support.test.ts
+++ b/turbo/apps/cli/src/commands/zero/__tests__/developer-support.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for zero developer-support command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server";
+import { zeroDeveloperSupportCommand } from "../developer-support";
+import chalk from "chalk";
+
+const ENDPOINT_URL = "http://localhost:3000/api/zero/developer-support";
+
+describe("zero developer-support command", () => {
+  const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    chalk.level = 0;
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  afterEach(() => {
+    mockExit.mockClear();
+    mockConsoleLog.mockClear();
+    mockConsoleError.mockClear();
+  });
+
+  describe("step 1: consent code request", () => {
+    it("should print consent code when --consent-code is not provided", async () => {
+      server.use(
+        http.post(ENDPOINT_URL, () => {
+          return HttpResponse.json({ consentCode: "A7X3" }, { status: 200 });
+        }),
+      );
+
+      await zeroDeveloperSupportCommand.parseAsync([
+        "node",
+        "cli",
+        "--title",
+        "GitHub 403 error",
+        "--description",
+        "Connector connected but API returns 403",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        "Consent required to share chat history with developers.",
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith("Code: A7X3");
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        "Ask the user to confirm by providing this code.",
+      );
+    });
+  });
+
+  describe("step 2: submit with consent code", () => {
+    it("should print reference when valid consent code is provided", async () => {
+      server.use(
+        http.post(ENDPOINT_URL, () => {
+          return HttpResponse.json(
+            { reference: "ds-abc12345" },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await zeroDeveloperSupportCommand.parseAsync([
+        "node",
+        "cli",
+        "--title",
+        "GitHub 403 error",
+        "--description",
+        "Connector connected but API returns 403",
+        "--consent-code",
+        "A7X3",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        "Developer support request submitted successfully.",
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith("Reference: ds-abc12345");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should show error for invalid consent code", async () => {
+      server.use(
+        http.post(ENDPOINT_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Invalid consent code",
+                code: "INVALID_CONSENT_CODE",
+              },
+            },
+            { status: 400 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await zeroDeveloperSupportCommand.parseAsync([
+          "node",
+          "cli",
+          "--title",
+          "Bug report",
+          "--description",
+          "Something is broken",
+          "--consent-code",
+          "ZZZZ",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid consent code"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should show auth error when not authenticated", async () => {
+      server.use(
+        http.post(ENDPOINT_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Not authenticated",
+                code: "UNAUTHORIZED",
+              },
+            },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await zeroDeveloperSupportCommand.parseAsync([
+          "node",
+          "cli",
+          "--title",
+          "Bug report",
+          "--description",
+          "Something is broken",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/developer-support.ts
+++ b/turbo/apps/cli/src/commands/zero/developer-support.ts
@@ -1,0 +1,56 @@
+import { Command } from "commander";
+import { withErrorHandler } from "../../lib/command";
+import {
+  requestDeveloperSupportConsent,
+  submitDeveloperSupport,
+} from "../../lib/api";
+
+export const zeroDeveloperSupportCommand = new Command()
+  .name("developer-support")
+  .description("Submit a diagnostic report to the dev team")
+  .requiredOption("--title <text>", "Issue title")
+  .requiredOption("--description <text>", "Diagnostic description")
+  .option("--consent-code <code>", "User-provided verification code")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Step 1 — Get consent code:
+    zero developer-support --title "GitHub 403 error" --description "Connector connected but API returns 403"
+
+  Step 2 — Submit with code:
+    zero developer-support --title "GitHub 403 error" --description "Connector connected but API returns 403" --consent-code A7X3
+
+Notes:
+  - The consent code must be provided by the user to confirm sharing their conversation
+  - The dev team will receive a diagnostic bundle with conversation, environment, and connector info`,
+  )
+  .action(
+    withErrorHandler(
+      async (options: {
+        title: string;
+        description: string;
+        consentCode?: string;
+      }) => {
+        if (!options.consentCode) {
+          const { consentCode } = await requestDeveloperSupportConsent({
+            title: options.title,
+            description: options.description,
+          });
+          console.log(
+            "Consent required to share chat history with developers.",
+          );
+          console.log(`Code: ${consentCode}`);
+          console.log("Ask the user to confirm by providing this code.");
+        } else {
+          const { reference } = await submitDeveloperSupport({
+            title: options.title,
+            description: options.description,
+            consentCode: options.consentCode,
+          });
+          console.log("Developer support request submitted successfully.");
+          console.log(`Reference: ${reference}`);
+        }
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-developer-support.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-developer-support.ts
@@ -1,0 +1,26 @@
+import { initClient } from "@ts-rest/core";
+import { zeroDeveloperSupportContract } from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function requestDeveloperSupportConsent(body: {
+  title: string;
+  description: string;
+}): Promise<{ consentCode: string }> {
+  const config = await getClientConfig();
+  const client = initClient(zeroDeveloperSupportContract, config);
+  const result = await client.submit({ body, headers: {} });
+  if (result.status === 200) return result.body as { consentCode: string };
+  handleError(result, "Failed to request developer support consent");
+}
+
+export async function submitDeveloperSupport(body: {
+  title: string;
+  description: string;
+  consentCode: string;
+}): Promise<{ reference: string }> {
+  const config = await getClientConfig();
+  const client = initClient(zeroDeveloperSupportContract, config);
+  const result = await client.submit({ body, headers: {} });
+  if (result.status === 200) return result.body as { reference: string };
+  handleError(result, "Failed to submit developer support request");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -168,3 +168,9 @@ export {
 
 // Domain modules - Zero Ask User
 export { postAskUserQuestion, getAskUserAnswer } from "./domains/zero-ask-user";
+
+// Domain modules - Zero Developer Support
+export {
+  requestDeveloperSupportConsent,
+  submitDeveloperSupport,
+} from "./domains/zero-developer-support";

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -17,6 +17,7 @@ import { zeroWhoamiCommand } from "./commands/zero/whoami";
 import { zeroAskUserCommand } from "./commands/zero/ask-user";
 import { zeroSkillCommand } from "./commands/zero/skill";
 import { zeroLogsCommand } from "./commands/zero/logs";
+import { zeroDeveloperSupportCommand } from "./commands/zero/developer-support";
 import {
   decodeZeroTokenPayload,
   type ZeroTokenPayload,
@@ -38,6 +39,7 @@ const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   slack: "slack:write",
   whoami: null,
   "ask-user": null,
+  "developer-support": null,
 };
 
 const DEFAULT_COMMANDS: Command[] = [
@@ -55,6 +57,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroWhoamiCommand,
   zeroAskUserCommand,
   zeroSkillCommand,
+  zeroDeveloperSupportCommand,
 ];
 
 function shouldHideCommand(

--- a/turbo/apps/web/src/lib/zero/agent-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/agent-prompt.ts
@@ -78,5 +78,6 @@ function buildAgentToolsPrompt(): string {
     "- Inspect yourself: `zero whoami` for identity and permissions, `zero agent view $ZERO_AGENT_ID --instructions` for your current settings.",
     "- Update your own configuration: `zero agent edit --help`.",
     "- Manage custom skills: `zero skill --help`.",
+    "- Report issues to the dev team: `zero developer-support --help`. Requires a two-step consent flow: (1) call without --consent-code to get a code, (2) ask the user to type it, (3) call again with --consent-code. Never submit without the user typing the consent code.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Add `zero developer-support` CLI command with two-step consent code flow for submitting diagnostic reports
- Create API client functions (`requestDeveloperSupportConsent`, `submitDeveloperSupport`) following the ts-rest pattern
- Register command in `zero.ts` with `null` capability (always visible in sandbox)
- Update agent system prompt to document the developer-support command and consent flow
- Add integration tests with MSW mocking

Closes #7905

## Test plan
- [x] `zero developer-support --title "test" --description "test"` returns 4-char consent code
- [x] `zero developer-support --title "test" --description "test" --consent-code XXXX` with valid code submits successfully
- [x] Invalid consent code returns error message
- [x] Missing auth returns auth error
- [x] All existing tests pass
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)