### PR TITLE
refactor: migrate external & infrastructure signals to accept pattern

### DIFF
--- a/turbo/apps/platform/src/signals/cursor-pagination.ts
+++ b/turbo/apps/platform/src/signals/cursor-pagination.ts
@@ -9,6 +9,7 @@ import { state, computed, command, type Computed, type State } from "ccstate";
 import { logsListContract, type LogsListResponse } from "@vm0/core";
 import { zeroClient$ } from "./api-client.ts";
 import { searchParams$, updateSearchParams$ } from "./route.ts";
+import { accept } from "../lib/accept.ts";
 
 const DEFAULT_LIMIT = 10;
 const VALID_LIMITS = [10, 20, 50, 100] as const;
@@ -138,11 +139,13 @@ function createNavigationCommands(deps: PaginationDeps) {
       }
 
       const client = get(zeroClient$)(logsListContract);
-      const result = await client.list({
-        query: paramsToQuery(intermediateParams),
-      });
+      const result = await accept(
+        client.list({ query: paramsToQuery(intermediateParams) }),
+        [200],
+        { toast: false },
+      );
 
-      if (result.status !== 200 || !result.body.pagination.hasMore) {
+      if (!result.body.pagination.hasMore) {
         set(writeUrlParams$, { cursor: cursor1 });
         return;
       }
@@ -222,10 +225,11 @@ export function createCursorPagination(config: CursorPaginationConfig) {
     }
 
     const client = get(zeroClient$)(logsListContract);
-    const result = await client.list({ query: paramsToQuery(params) });
-    if (result.status !== 200) {
-      throw new Error(`Failed to fetch logs (${result.status})`);
-    }
+    const result = await accept(
+      client.list({ query: paramsToQuery(params) }),
+      [200],
+      { toast: false },
+    );
     return result.body;
   });
 

--- a/turbo/apps/platform/src/signals/external/connectors.ts
+++ b/turbo/apps/platform/src/signals/external/connectors.ts
@@ -6,6 +6,7 @@ import {
   type ConnectorType,
 } from "@vm0/core";
 import { zeroClient$ } from "../api-client";
+import { accept } from "../../lib/accept.ts";
 
 /**
  * Reload trigger for connector signals.
@@ -20,13 +21,8 @@ export const connectors$ = computed(async (get) => {
   get(internalReloadConnectors$);
   const createClient = get(zeroClient$);
   const client = createClient(zeroConnectorsMainContract);
-  const result = await client.list();
-
-  if (result.status === 200) {
-    return result.body as ConnectorListResponse;
-  }
-
-  throw new Error(`Failed to fetch connectors: ${result.status}`);
+  const result = await accept(client.list(), [200], { toast: false });
+  return result.body as ConnectorListResponse;
 });
 
 /**
@@ -45,11 +41,7 @@ export const deleteConnector$ = command(
   async ({ get, set }, type: ConnectorType, _signal: AbortSignal) => {
     const createClient = get(zeroClient$);
     const client = createClient(zeroConnectorsByTypeContract);
-    const result = await client.delete({ params: { type } });
-
-    if (result.status !== 204) {
-      throw new Error(`Failed to delete connector: ${result.status}`);
-    }
+    await accept(client.delete({ params: { type } }), [204]);
 
     set(internalReloadConnectors$, (x) => {
       return x + 1;

--- a/turbo/apps/platform/src/signals/external/org-domains.ts
+++ b/turbo/apps/platform/src/signals/external/org-domains.ts
@@ -2,6 +2,8 @@ import { command, computed, state } from "ccstate";
 import { zeroOrgDomainsContract } from "@vm0/core";
 import { org$ } from "../org";
 import { zeroClient$ } from "../api-client";
+import { accept } from "../../lib/accept.ts";
+import { throwIfAbort } from "../utils.ts";
 
 const domainsVersion$ = state(0);
 
@@ -18,12 +20,13 @@ const domainsResponse$ = computed(async (get) => {
 
   const createClient = get(zeroClient$);
   const client = createClient(zeroOrgDomainsContract);
-  const result = await client.list();
-
-  if (result.status === 200) {
+  try {
+    const result = await accept(client.list(), [200], { toast: false });
     return result.body;
+  } catch (error) {
+    throwIfAbort(error);
+    return null;
   }
-  return null;
 });
 
 export const orgDomains$ = computed(async (get) => {

--- a/turbo/apps/platform/src/signals/external/org-members.ts
+++ b/turbo/apps/platform/src/signals/external/org-members.ts
@@ -7,6 +7,8 @@ import {
 } from "@vm0/core";
 import { org$ } from "../org";
 import { zeroClient$ } from "../api-client";
+import { accept } from "../../lib/accept.ts";
+import { throwIfAbort } from "../utils.ts";
 
 export type { OrgMember, OrgPendingInvitation, OrgMembershipRequest };
 
@@ -21,13 +23,13 @@ const orgMembersResponse$ = computed(async (get) => {
 
   const createClient = get(zeroClient$);
   const client = createClient(zeroOrgMembersContract);
-  const result = await client.members();
-
-  if (result.status === 200) {
+  try {
+    const result = await accept(client.members(), [200], { toast: false });
     return result.body;
+  } catch (error) {
+    throwIfAbort(error);
+    return null;
   }
-
-  return null;
 });
 
 export const orgMembers$ = computed(async (get) => {

--- a/turbo/apps/platform/src/signals/org.ts
+++ b/turbo/apps/platform/src/signals/org.ts
@@ -2,11 +2,9 @@ import { command, computed, state } from "ccstate";
 import { zeroOrgContract, type OrgResponse } from "@vm0/core";
 import { user$ } from "./auth.ts";
 import { zeroClient$ } from "./api-client.ts";
-import { logger } from "./log.ts";
+import { accept } from "../lib/accept.ts";
 
 const reloadOrg$ = state(0);
-
-const L = logger("Org");
 
 /**
  * Re-export for backward compatibility with mocks and consumers.
@@ -26,19 +24,13 @@ export const org$ = computed(async (get) => {
 
   const createClient = get(zeroClient$);
   const client = createClient(zeroOrgContract);
-  const result = await client.get();
-
-  L.debug(`Fetched /api/zero/org with status ${result.status}`);
+  const result = await accept(client.get(), [200, 404], { toast: false });
 
   if (result.status === 404) {
     return undefined;
   }
 
-  if (result.status === 200) {
-    return result.body;
-  }
-
-  throw new Error(`Failed to fetch org: ${result.status}`);
+  return result.body;
 });
 
 /**

--- a/turbo/apps/platform/src/signals/queue-page/__tests__/queue-signals.test.ts
+++ b/turbo/apps/platform/src/signals/queue-page/__tests__/queue-signals.test.ts
@@ -78,6 +78,6 @@ describe("cancelQueueRun$", () => {
 
     await expect(
       context.store.set(cancelQueueRun$, "run-1", context.signal),
-    ).rejects.toThrow("Failed to cancel run");
+    ).rejects.toThrow("Forbidden");
   });
 });

--- a/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
@@ -9,6 +9,7 @@ import {
 } from "@vm0/core";
 import { throwIfAbort } from "../utils.ts";
 import { zeroClient$ } from "../api-client.ts";
+import { accept } from "../../lib/accept.ts";
 
 const POLL_INTERVAL = 5000;
 
@@ -23,10 +24,7 @@ export const queueData$ = computed((get) => {
 
 const fetchQueueData$ = command(async ({ get, set }, _signal: AbortSignal) => {
   const client = get(zeroClient$)(zeroRunsQueueContract);
-  const result = await client.getQueue();
-  if (result.status !== 200) {
-    throw new Error(`Failed to fetch queue (${result.status})`);
-  }
+  const result = await accept(client.getQueue(), [200], { toast: false });
   set(internalQueueData$, result.body);
 });
 
@@ -54,13 +52,8 @@ export const startQueuePolling$ = command(
 export const cancelQueueRun$ = command(
   async ({ get, set }, runId: string, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroRunsCancelContract);
-    const result = await client.cancel({
-      params: { id: runId },
-    });
+    await accept(client.cancel({ params: { id: runId } }), [200]);
     signal.throwIfAborted();
-    if (result.status !== 200) {
-      throw new Error(`Failed to cancel run (${result.status})`);
-    }
     // Refresh queue data after cancel
     await set(fetchQueueData$, signal);
   },

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-activity.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-activity.test.ts
@@ -157,7 +157,7 @@ describe("zero-activity signals", () => {
       await context.store.set(initZeroActivityAgentName$, context.signal);
 
       await expect(context.store.get(zeroActivityData$)).rejects.toThrow(
-        "Failed to fetch logs",
+        "Internal server error",
       );
     });
 


### PR DESCRIPTION
## Summary

- Migrate 6 signal files (Group H) to use `accept()` from `src/lib/accept.ts` for unified HTTP error handling
- Background fetches use `{ toast: false }`, user-initiated actions (deleteConnector$, cancelQueueRun$) show toasts on error
- ESLint allowlist entries intentionally preserved per acceptance criteria
- Updated test expectations to match `ApiError` message format from `accept()`

### Files modified:
- `src/signals/org.ts` — accept with [200, 404], toast: false
- `src/signals/external/connectors.ts` — connectors$ (toast: false), deleteConnector$ (toast on error)
- `src/signals/external/org-members.ts` — try/catch with throwIfAbort, fallback to null
- `src/signals/external/org-domains.ts` — try/catch with throwIfAbort, fallback to null
- `src/signals/cursor-pagination.ts` — data$ and goForwardTwoPages$ (toast: false)
- `src/signals/queue-page/queue-signals.ts` — fetchQueueData$ (toast: false), cancelQueueRun$ (toast on error)

Closes #7882

## Test plan

- [x] All 284 signal tests pass (`pnpm vitest run apps/platform/src/signals`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes for platform (`pnpm check-types`)
- [x] Knip finds no issues
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)