### PR TITLE
refactor(platform): migrate schedules & agents signals to accept pattern

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
@@ -615,7 +615,7 @@ describe("zero-schedule signals", () => {
           },
           context.signal,
         ),
-      ).rejects.toThrow("Failed to enable schedule (404)");
+      ).rejects.toThrow("Schedule not found");
     });
 
     it("should optimistically update local state without refetching", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/agents-list.ts
+++ b/turbo/apps/platform/src/signals/zero-page/agents-list.ts
@@ -1,16 +1,14 @@
 import { command, computed, state } from "ccstate";
 import { zeroTeamContract } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
+import { accept } from "../../lib/accept.ts";
 
 const internalReloadAgents$ = state(0);
 export const agents$ = computed(async (get) => {
   get(internalReloadAgents$);
   const teamClient = get(zeroClient$)(zeroTeamContract);
-  const agentsResult = await teamClient.list();
-  if (agentsResult.status !== 200) {
-    throw new Error(`Failed to fetch agents (${agentsResult.status})`);
-  }
-  return agentsResult.body;
+  const result = await accept(teamClient.list(), [200]);
+  return result.body;
 });
 
 export const reloadAgents$ = command(({ set }) => {

--- a/turbo/apps/platform/src/signals/zero-page/job-detail/schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/job-detail/schedule.ts
@@ -231,7 +231,8 @@ export const saveZeroJobSchedule$ = command(
     }
 
     const client = get(zeroClient$)(zeroSchedulesMainContract);
-    await accept(client.deploy({ body }), [200, 201]);
+    // toast: false — error is captured by useLoadableSet in the consuming view and displayed in the dialog
+    await accept(client.deploy({ body }), [200, 201], { toast: false });
     signal.throwIfAborted();
 
     toast.success(params.editName ? "Schedule updated" : "Schedule created");

--- a/turbo/apps/platform/src/signals/zero-page/schedule-card.ts
+++ b/turbo/apps/platform/src/signals/zero-page/schedule-card.ts
@@ -58,10 +58,6 @@ export const setEditingScheduleId$ = command(
   },
 );
 
-export const { get$: saveError$, set$: setSaveError$ } = cell<string | null>(
-  null,
-);
-
 export const { get$: togglingIds$, set$: setTogglingIds$ } = cell<Set<string>>(
   new Set(),
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-connectors.ts
@@ -5,6 +5,7 @@ import { zeroClient$ } from "../api-client.ts";
 import { currentAgentId$ } from "./agent.ts";
 import { defaultAgentId$ } from "./zero-agent-name.ts";
 import { currentChatThread$ } from "./zero-chat.ts";
+import { accept } from "../../lib/accept.ts";
 
 // ---------------------------------------------------------------------------
 // Agent name resolution
@@ -32,10 +33,9 @@ const zeroAgent$ = computed(async (get) => {
   }
 
   const client = get(zeroClient$)(zeroAgentsByIdContract);
-  const result = await client.get({ params: { id: agentId } });
-  if (result.status !== 200) {
-    throw new Error(`Failed to fetch agent: ${result.status}`);
-  }
+  const result = await accept(client.get({ params: { id: agentId } }), [200], {
+    toast: false,
+  });
   return result.body;
 });
 
@@ -50,10 +50,11 @@ const seededConnectors$ = computed(async (get) => {
     return [];
   }
   const client = get(zeroClient$)(zeroUserConnectorsContract);
-  const result = await client.get({ params: { id: agent.agentId } });
-  if (result.status !== 200) {
-    return [];
-  }
+  const result = await accept(
+    client.get({ params: { id: agent.agentId } }),
+    [200],
+    { toast: false },
+  );
   return result.body.enabledTypes;
 });
 
@@ -96,19 +97,14 @@ const syncConnectorsToCompose$ = command(
     }
 
     const client = get(zeroClient$)(zeroUserConnectorsContract);
-    const result = await client.update({
-      params: { id: agent.agentId },
-      body: { enabledTypes: connectorValues },
-    });
+    await accept(
+      client.update({
+        params: { id: agent.agentId },
+        body: { enabledTypes: connectorValues },
+      }),
+      [200],
+    );
     signal.throwIfAborted();
-
-    if (result.status !== 200) {
-      const detail =
-        result.status === 401 || result.status === 403 || result.status === 404
-          ? result.body.error.message
-          : `status ${result.status}`;
-      throw new Error(`Save failed: ${detail}`);
-    }
 
     await set(reloadOnboardingStatus$);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -10,7 +10,6 @@ import {
   type ScheduleResponse,
 } from "@vm0/core";
 import { throwIfAbort } from "../utils.ts";
-import { logger } from "../log.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
 import {
@@ -20,13 +19,7 @@ import {
   type ScheduleBody,
   type CronTimeOption,
 } from "./cron.ts";
-
-const L = logger("ZeroSchedule");
-
-function scheduleSaveFailure(message: string): never {
-  toast.error(message);
-  throw new Error(message);
-}
+import { accept } from "../../lib/accept.ts";
 
 // ---------------------------------------------------------------------------
 // State
@@ -170,13 +163,8 @@ export const fetchZeroSchedules$ = command(
 
     try {
       const client = get(zeroClient$)(zeroSchedulesMainContract);
-      const result = await client.list();
+      const result = await accept(client.list(), [200], { toast: false });
       signal.throwIfAborted();
-
-      if (result.status !== 200) {
-        set(internalSchedules$, []);
-        return;
-      }
 
       // Filter schedules for this agent's composeId
       const agentSchedules = result.body.schedules.filter((s) => {
@@ -185,7 +173,6 @@ export const fetchZeroSchedules$ = command(
       set(internalSchedules$, agentSchedules);
     } catch (error) {
       throwIfAbort(error);
-      L.error("Failed to fetch zero schedules:", error);
       set(internalSchedules$, []);
     }
   },
@@ -271,25 +258,14 @@ export const saveZeroSchedule$ = command(
     signal.throwIfAborted();
     const composeId = status.defaultAgentId;
     if (!composeId) {
-      scheduleSaveFailure("No default agent configured");
+      throw new Error("No default agent configured");
     }
 
     const body = buildScheduleBody(composeId, params);
 
     const client = get(zeroClient$)(zeroSchedulesMainContract);
-    const result = await client.deploy({ body });
+    await accept(client.deploy({ body }), [200, 201]);
     signal.throwIfAborted();
-
-    if (result.status !== 200 && result.status !== 201) {
-      const message =
-        result.status === 400 ||
-        result.status === 401 ||
-        result.status === 403 ||
-        result.status === 404
-          ? result.body.error.message
-          : `Save failed (${result.status})`;
-      throw new Error(message);
-    }
 
     toast.success(params.editName ? "Schedule updated" : "Schedule created");
     await set(fetchZeroSchedules$, signal);
@@ -310,22 +286,19 @@ export const toggleZeroScheduleEnabled$ = command(
     signal.throwIfAborted();
     const composeId = status.defaultAgentId;
     if (!composeId) {
-      scheduleSaveFailure("No default agent configured");
+      throw new Error("No default agent configured");
     }
 
     const client = get(zeroClient$)(zeroSchedulesEnableContract);
     const action = params.enabled ? "enable" : "disable";
-    const result = await client[action]({
-      params: { name: params.name },
-      body: { agentId: composeId },
-    });
+    await accept(
+      client[action]({
+        params: { name: params.name },
+        body: { agentId: composeId },
+      }),
+      [200],
+    );
     signal.throwIfAborted();
-
-    if (result.status !== 200) {
-      const message = `Failed to ${action} schedule (${result.status})`;
-      toast.error(message);
-      throw new Error(message);
-    }
 
     // Optimistic update: patch the local schedule state instead of refetching
     const current = get(internalSchedules$);
@@ -352,19 +325,14 @@ export const deleteZeroSchedule$ = command(
     }
 
     const client = get(zeroClient$)(zeroSchedulesByNameContract);
-    const result = await client.delete({
-      params: { name: scheduleName },
-      query: { agentId: composeId },
-    });
+    await accept(
+      client.delete({
+        params: { name: scheduleName },
+        query: { agentId: composeId },
+      }),
+      [204],
+    );
     signal.throwIfAborted();
-
-    if (result.status !== 204) {
-      const msg =
-        result.status === 401 || result.status === 403 || result.status === 404
-          ? result.body.error.message
-          : `status ${result.status}`;
-      throw new Error(`Delete failed: ${msg}`);
-    }
 
     toast.success("Schedule deleted");
     await set(fetchZeroSchedules$, signal);
@@ -427,15 +395,10 @@ export const fetchAllOrgSchedules$ = command(
   async ({ get, set }, _signal: AbortSignal) => {
     try {
       const client = get(zeroClient$)(zeroSchedulesMainContract);
-      const result = await client.list();
-      if (result.status !== 200) {
-        set(internalAllSchedules$, []);
-        return;
-      }
+      const result = await accept(client.list(), [200], { toast: false });
       set(internalAllSchedules$, result.body.schedules);
     } catch (error) {
       throwIfAbort(error);
-      L.error("Failed to fetch all org schedules:", error);
       set(internalAllSchedules$, []);
     } finally {
       set(internalAllSchedulesLoaded$, true);
@@ -452,19 +415,8 @@ export const saveOrgSchedule$ = command(
     const body = buildScheduleBody(params.agentId, params);
 
     const client = get(zeroClient$)(zeroSchedulesMainContract);
-    const result = await client.deploy({ body });
+    const result = await accept(client.deploy({ body }), [200, 201]);
     signal.throwIfAborted();
-
-    if (result.status !== 200 && result.status !== 201) {
-      const message =
-        result.status === 400 ||
-        result.status === 401 ||
-        result.status === 403 ||
-        result.status === 404
-          ? result.body.error.message
-          : `Save failed (${result.status})`;
-      throw new Error(message);
-    }
 
     const scheduleId = result.body.schedule.id;
 
@@ -483,17 +435,14 @@ export const toggleOrgScheduleEnabled$ = command(
   ) => {
     const client = get(zeroClient$)(zeroSchedulesEnableContract);
     const action = params.enabled ? "enable" : "disable";
-    const result = await client[action]({
-      params: { name: params.name },
-      body: { agentId: params.agentId },
-    });
+    await accept(
+      client[action]({
+        params: { name: params.name },
+        body: { agentId: params.agentId },
+      }),
+      [200],
+    );
     signal.throwIfAborted();
-
-    if (result.status !== 200) {
-      const message = `Failed to ${action} schedule (${result.status})`;
-      toast.error(message);
-      throw new Error(message);
-    }
 
     await set(fetchAllOrgSchedules$, signal);
   },
@@ -506,19 +455,14 @@ export const deleteOrgSchedule$ = command(
     signal: AbortSignal,
   ) => {
     const client = get(zeroClient$)(zeroSchedulesByNameContract);
-    const result = await client.delete({
-      params: { name: params.name },
-      query: { agentId: params.agentId },
-    });
+    await accept(
+      client.delete({
+        params: { name: params.name },
+        query: { agentId: params.agentId },
+      }),
+      [204],
+    );
     signal.throwIfAborted();
-
-    if (result.status !== 204) {
-      const msg =
-        result.status === 401 || result.status === 403 || result.status === 404
-          ? result.body.error.message
-          : `status ${result.status}`;
-      throw new Error(`Delete failed: ${msg}`);
-    }
 
     toast.success("Schedule deleted");
     await set(fetchAllOrgSchedules$, signal);
@@ -536,20 +480,18 @@ export const runScheduleNow$ = command(
       return toast.dismiss(toastId);
     });
     const client = get(zeroClient$)(zeroScheduleRunContract);
-    const result = await client.run({ body: { scheduleId } });
-    signal.throwIfAborted();
-
-    if (result.status !== 201) {
-      const message =
-        result.status === 400 ||
-        result.status === 401 ||
-        result.status === 404 ||
-        result.status === 409
-          ? result.body.error.message
-          : `Run failed (${result.status})`;
+    let result;
+    try {
+      result = await accept(client.run({ body: { scheduleId } }), [201], {
+        toast: false,
+      });
+    } catch (error) {
+      throwIfAbort(error);
+      const message = error instanceof Error ? error.message : "Run failed";
       toast.error(message, { id: toastId });
-      throw new Error(message);
+      throw error;
     }
+    signal.throwIfAborted();
 
     const data = result.body;
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -415,7 +415,10 @@ export const saveOrgSchedule$ = command(
     const body = buildScheduleBody(params.agentId, params);
 
     const client = get(zeroClient$)(zeroSchedulesMainContract);
-    const result = await accept(client.deploy({ body }), [200, 201]);
+    // toast: false — error is captured by useLoadableSet in the consuming view and displayed in the dialog
+    const result = await accept(client.deploy({ body }), [200, 201], {
+      toast: false,
+    });
     signal.throwIfAborted();
 
     const scheduleId = result.body.schedule.id;

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -657,7 +657,10 @@ function JobScheduleTab({ displayName }: { displayName: string }) {
   const entries = useLastResolved(zeroJobScheduleEntries$) ?? [];
   const loading = scheduleLoadable.state === "loading";
   const scheduleError = loadableErrorMessage(scheduleLoadable);
-  const saveSchedule = useSet(saveZeroJobSchedule$);
+  const [saveLoadable, saveScheduleTracked] =
+    useLoadableSet(saveZeroJobSchedule$);
+  const saveError =
+    saveLoadable.state === "hasError" ? String(saveLoadable.error) : null;
   const deleteSchedule = useSet(deleteZeroJobSchedule$);
   const toggleEnabled = useSet(toggleZeroJobScheduleEnabled$);
   const runScheduleNow = useSet(runScheduleNow$);
@@ -678,8 +681,9 @@ function JobScheduleTab({ displayName }: { displayName: string }) {
       entries={entries}
       loading={loading}
       scheduleError={scheduleError}
+      saveError={saveError}
       onSave={(params) => {
-        return saveSchedule(params, pageSignal);
+        return saveScheduleTracked(params, pageSignal);
       }}
       onDelete={(name) => {
         return deleteSchedule(name, pageSignal);

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -369,7 +369,7 @@ export function ZeroScheduleCard({
           () => {
             detach(setAddScheduleOpen(false, signal), Reason.DomCallback);
           },
-          (_error: unknown) => {
+          () => {
             // error is captured by useLoadableSet in the consuming view and passed as saveError prop
           },
         ),
@@ -421,7 +421,7 @@ export function ZeroScheduleCard({
           () => {
             detach(setEditingScheduleId(null, signal), Reason.DomCallback);
           },
-          (_error: unknown) => {
+          () => {
             // error is captured by useLoadableSet in the consuming view and passed as saveError prop
           },
         ),

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -10,8 +10,6 @@ import {
   setAddScheduleOpen$,
   editingScheduleId$,
   setEditingScheduleId$,
-  saveError$,
-  setSaveError$,
   togglingIds$,
   setTogglingIds$,
   runningIds$,
@@ -28,7 +26,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@vm0/ui";
-import { throwIfAbort, detach, Reason } from "../../signals/utils.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   ScheduleFormDialog,
@@ -246,6 +244,8 @@ interface ZeroScheduleCardProps {
   saving?: boolean;
   /** Default timezone for new schedules. Falls back to browser timezone. */
   defaultTimezone?: string;
+  /** Error message to display in the save dialog. Provided by consuming view via useLoadableSet. */
+  saveError?: string | null;
 }
 
 export function ZeroScheduleCard({
@@ -258,6 +258,7 @@ export function ZeroScheduleCard({
   onRunNow,
   onOpenDetails,
   saving,
+  saveError,
 }: ZeroScheduleCardProps) {
   const signal = useGet(pageSignal$);
   const scheduleViewMode = useGet(scheduleViewMode$);
@@ -270,8 +271,6 @@ export function ZeroScheduleCard({
   const setAddScheduleOpen = useSet(setAddScheduleOpen$);
   const editingScheduleId = useGet(editingScheduleId$);
   const setEditingScheduleId = useSet(setEditingScheduleId$);
-  const saveError = useGet(saveError$);
-  const setSaveError = useSet(setSaveError$);
   const togglingIds = useGet(togglingIds$);
   const setTogglingIds = useSet(setTogglingIds$);
 
@@ -282,7 +281,6 @@ export function ZeroScheduleCard({
     : null;
 
   const openAddSchedule = () => {
-    setSaveError(null);
     detach(setAddScheduleOpen(true, signal), Reason.DomCallback);
   };
 
@@ -290,7 +288,6 @@ export function ZeroScheduleCard({
   const setPendingDelete = useSet(setPendingDeleteEntry$);
 
   const openEditSchedule = (entry: ScheduleEntry) => {
-    setSaveError(null);
     detach(setEditingScheduleId(entry.id, signal), Reason.DomCallback);
   };
 
@@ -354,7 +351,6 @@ export function ZeroScheduleCard({
 
   const handleCreateSave = (values: ScheduleFormValues) => {
     if (onSave) {
-      setSaveError(null);
       detach(
         onSave({
           prompt: values.prompt.trim(),
@@ -369,18 +365,14 @@ export function ZeroScheduleCard({
             values.freq === "every_week" ? values.dayOfWeek : undefined,
           dayOfMonth:
             values.freq === "every_month" ? values.dayOfMonth : undefined,
-        })
-          .then(() => {
+        }).then(
+          () => {
             detach(setAddScheduleOpen(false, signal), Reason.DomCallback);
-          })
-          .catch((error: unknown) => {
-            throwIfAbort(error);
-            setSaveError(
-              error instanceof Error
-                ? error.message
-                : "Failed to save schedule",
-            );
-          }),
+          },
+          (_error: unknown) => {
+            // error is captured by useLoadableSet in the consuming view and passed as saveError prop
+          },
+        ),
         Reason.DomCallback,
       );
       return;
@@ -410,7 +402,6 @@ export function ZeroScheduleCard({
 
   const handleEditSave = (values: ScheduleFormValues) => {
     if (onSave) {
-      setSaveError(null);
       detach(
         onSave({
           prompt: values.prompt.trim(),
@@ -426,18 +417,14 @@ export function ZeroScheduleCard({
           dayOfMonth:
             values.freq === "every_month" ? values.dayOfMonth : undefined,
           editName: editingEntry?.name,
-        })
-          .then(() => {
+        }).then(
+          () => {
             detach(setEditingScheduleId(null, signal), Reason.DomCallback);
-          })
-          .catch((error: unknown) => {
-            throwIfAbort(error);
-            setSaveError(
-              error instanceof Error
-                ? error.message
-                : "Failed to save schedule",
-            );
-          }),
+          },
+          (_error: unknown) => {
+            // error is captured by useLoadableSet in the consuming view and passed as saveError prop
+          },
+        ),
         Reason.DomCallback,
       );
       return;

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
@@ -14,6 +14,7 @@ interface ZeroScheduleTabProps {
   entries: ScheduleEntry[];
   loading?: boolean;
   scheduleError?: string | null;
+  saveError?: string | null;
   onSave: (params: ZeroScheduleSaveParams) => Promise<void>;
   onDelete: (name: string) => Promise<void>;
   onToggleEnabled: (params: {
@@ -67,6 +68,7 @@ export function ZeroScheduleTab({
   entries,
   loading,
   scheduleError,
+  saveError,
   onSave,
   onDelete,
   onToggleEnabled,
@@ -121,6 +123,7 @@ export function ZeroScheduleTab({
         onOpenDetails={onOpenDetails}
         saving={saving}
         defaultTimezone={userTimezone ?? undefined}
+        saveError={saveError}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Closes #7877

Migrates Group C (Schedules & Agents) signal files to use the unified `accept()` helper from `src/lib/accept.ts`, replacing scattered manual status checks, error extractors, and `toast.error` calls.

- `agents-list.ts`: Replace manual status check in `agents$` computed with `accept(teamClient.list(), [200])`
- `zero-connectors.ts`: Replace 3 status checks — `zeroAgent$` and `seededConnectors$` use `accept(..., { toast: false })` for silent errors; `syncConnectorsToCompose$` uses plain `accept()` with automatic toast
- `zero-schedule.ts`: Remove `scheduleSaveFailure` helper; replace ~9 status checks across all fetch/save/toggle/delete/run commands; fetch commands use `accept(..., { toast: false })` to preserve silent-fallback behavior
- `zero-schedule-card.tsx`: Remove internal `saveError$`/`setSaveError$` state; replace `.catch(setSaveError)` with `useLoadableSet` error tracking via prop
- `schedule-card.ts`: Remove unused `saveError$` and `setSaveError$` signals
- `zero-schedule-tab.tsx`: Add `saveError` prop to pass through from consuming view
- `zero-job-detail-page.tsx`: Use `useLoadableSet(saveZeroJobSchedule$)` to track save error and pass it as `saveError` prop

**Not changed:** ESLint allowlist in `eslint.config.js` (per issue instructions — cleanup in #7883)

## Test plan

- [x] `pnpm turbo run lint` — passes (0 errors, 0 warnings)
- [x] `pnpm check-types` — passes
- [x] All 15 platform signal test files pass (155 tests), including updated error message assertion in `zero-schedule.test.ts`
- [x] Knip — no unused exports or dependencies detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)