### PR TITLE
refactor: migrate activity & firewall signals to accept pattern

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-context-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-context-signals.ts
@@ -2,6 +2,7 @@ import { computed } from "ccstate";
 import { zeroRunContextContract } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { currentRunId$ } from "./activity-signals.ts";
+import { accept } from "../../lib/accept.ts";
 
 /**
  * Run context snapshot fetched from Axiom via the context API.
@@ -14,12 +15,10 @@ export const zeroActivityContext$ = computed(async (get) => {
   }
 
   const client = get(zeroClient$)(zeroRunContextContract);
-  const result = await client.getContext({
-    params: { id: runId },
-  });
-
-  if (result.status !== 200) {
-    return null;
-  }
+  const result = await accept(
+    client.getContext({ params: { id: runId } }),
+    [200],
+    { toast: false },
+  );
   return result.body;
 });

--- a/turbo/apps/platform/src/signals/activity-page/activity-download.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-download.ts
@@ -2,6 +2,7 @@ import { command } from "ccstate";
 import { zeroRunContextContract, zeroRunNetworkLogsContract } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { logger } from "../log.ts";
+import { accept } from "../../lib/accept.ts";
 
 const L = logger("ActivityDownload");
 
@@ -21,19 +22,25 @@ export const fetchDownloadExtra$ = command(
     const extra: { context?: unknown; networkLogs?: unknown } = {};
 
     const [contextResult, networkResult] = await Promise.allSettled([
-      get(zeroClient$)(zeroRunContextContract)
-        .getContext({ params: { id: runId } })
-        .then((r) => {
-          return r.status === 200 ? r.body : null;
+      accept(
+        get(zeroClient$)(zeroRunContextContract).getContext({
+          params: { id: runId },
         }),
-      get(zeroClient$)(zeroRunNetworkLogsContract)
-        .getNetworkLogs({
+        [200],
+        { toast: false },
+      ).then((r) => {
+        return r.body;
+      }),
+      accept(
+        get(zeroClient$)(zeroRunNetworkLogsContract).getNetworkLogs({
           params: { id: runId },
           query: { limit: 500, order: "asc" },
-        })
-        .then((r) => {
-          return r.status === 200 ? r.body : null;
         }),
+        [200],
+        { toast: false },
+      ).then((r) => {
+        return r.body;
+      }),
     ]);
 
     if (contextResult.status === "fulfilled" && contextResult.value) {

--- a/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
@@ -2,6 +2,7 @@ import { computed } from "ccstate";
 import { zeroRunNetworkLogsContract } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { currentRunId$ } from "./activity-signals.ts";
+import { accept } from "../../lib/accept.ts";
 
 /**
  * Network logs fetched from Axiom via the zero network API.
@@ -14,13 +15,13 @@ export const zeroActivityNetworkLogs$ = computed(async (get) => {
   }
 
   const client = get(zeroClient$)(zeroRunNetworkLogsContract);
-  const result = await client.getNetworkLogs({
-    params: { id: runId },
-    query: { limit: 500, order: "asc" },
-  });
-
-  if (result.status !== 200) {
-    return null;
-  }
+  const result = await accept(
+    client.getNetworkLogs({
+      params: { id: runId },
+      query: { limit: 500, order: "asc" },
+    }),
+    [200],
+    { toast: false },
+  );
   return result.body;
 });

--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -6,6 +6,7 @@ import { createCursorPagination } from "../cursor-pagination.ts";
 import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
 import { zeroClient$ } from "../api-client.ts";
 import { createRunLoop } from "../zero-page/polling.ts";
+import { accept } from "../../lib/accept.ts";
 
 // ---------------------------------------------------------------------------
 // Filters — URL-derived
@@ -44,10 +45,7 @@ const orgAgents$ = computed((get) => {
 
 const fetchOrgAgents$ = command(async ({ get, set }, _signal: AbortSignal) => {
   const client = get(zeroClient$)(zeroComposesListContract);
-  const result = await client.list({ query: {} });
-  if (result.status !== 200) {
-    throw new Error(`Failed to fetch org agents (${result.status})`);
-  }
+  const result = await accept(client.list({ query: {} }), [200]);
   const agents: AgentOption[] = result.body.composes.map(
     (c: ComposeListItem) => {
       return {

--- a/turbo/apps/platform/src/signals/firewall-allow/firewall-allow-signals.ts
+++ b/turbo/apps/platform/src/signals/firewall-allow/firewall-allow-signals.ts
@@ -13,6 +13,7 @@ import {
 } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { pathParams$, searchParams$ } from "../route.ts";
+import { accept } from "../../lib/accept.ts";
 
 // ---------------------------------------------------------------------------
 // Route params
@@ -53,10 +54,9 @@ export const firewallAllowAgent$ = computed(async (get) => {
     return null;
   }
   const client = get(zeroClient$)(zeroAgentsByIdContract);
-  const result = await client.get({ params: { id: agentId } });
-  if (result.status !== 200) {
-    throw new Error(`Failed to fetch agent (${result.status})`);
-  }
+  const result = await accept(client.get({ params: { id: agentId } }), [200], {
+    toast: false,
+  });
   return result.body;
 });
 
@@ -103,13 +103,11 @@ export const firewallAccessRequests$ = computed(async (get) => {
   }
 
   const client = get(zeroClient$)(firewallAccessRequestsListContract);
-  const result = await client.list({
-    query: { agentId, status: "pending" },
-  });
-
-  if (result.status !== 200) {
-    throw new Error(`Failed to fetch access requests (${result.status})`);
-  }
+  const result = await accept(
+    client.list({ query: { agentId, status: "pending" } }),
+    [200],
+    { toast: false },
+  );
 
   // Filter to only requests for this firewall ref
   return result.body.filter((r) => {
@@ -129,20 +127,8 @@ const saveFirewallPolicies$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const client = get(zeroClient$)(zeroAgentFirewallPoliciesContract);
-    const result = await client.update({
-      body: { agentId, policies },
-    });
+    await accept(client.update({ body: { agentId, policies } }), [200]);
     signal.throwIfAborted();
-    if (result.status !== 200) {
-      const detail =
-        result.status === 400 ||
-        result.status === 401 ||
-        result.status === 403 ||
-        result.status === 404
-          ? result.body.error.message
-          : `status ${result.status}`;
-      throw new Error(`Save failed: ${detail}`);
-    }
     set(internalAgentReload$, (prev) => {
       return prev + 1;
     });
@@ -161,20 +147,8 @@ const resolveAccessRequest$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const client = get(zeroClient$)(firewallAccessRequestsResolveContract);
-    const result = await client.resolve({
-      body: { requestId, action },
-    });
+    await accept(client.resolve({ body: { requestId, action } }), [200]);
     signal.throwIfAborted();
-    if (result.status !== 200) {
-      const detail =
-        result.status === 400 ||
-        result.status === 401 ||
-        result.status === 403 ||
-        result.status === 404
-          ? result.body.error.message
-          : `status ${result.status}`;
-      throw new Error(`Resolve failed: ${detail}`);
-    }
     set(internalRequestsReload$, (prev) => {
       return prev + 1;
     });
@@ -202,20 +176,8 @@ const createAccessRequest$ = command(
     signal: AbortSignal,
   ): Promise<void> => {
     const client = get(zeroClient$)(firewallAccessRequestsCreateContract);
-    const result = await client.create({
-      body: params,
-    });
+    await accept(client.create({ body: params }), [201]);
     signal.throwIfAborted();
-    if (result.status !== 201) {
-      const detail =
-        result.status === 400 ||
-        result.status === 401 ||
-        result.status === 403 ||
-        result.status === 404
-          ? result.body.error.message
-          : `status ${result.status}`;
-      throw new Error(`Request failed: ${detail}`);
-    }
     set(internalRequestsReload$, (prev) => {
       return prev + 1;
     });


### PR DESCRIPTION
## Summary

- Migrates Group G signal files (Activity & Firewall) from manual HTTP status-check patterns to the centralized `accept()` utility
- 5 files changed, 9 total API call sites migrated
- ESLint allowlist not modified (per issue constraint)

## Changes

| File | Calls | Pattern |
|------|-------|---------|
| `activity-context-signals.ts` | 1 | computed: `accept([200], { toast: false })` |
| `activity-network-signals.ts` | 1 | computed: `accept([200], { toast: false })` |
| `activity-signals.ts` | 1 | command: `accept([200])` (toasts on error) |
| `activity-download.ts` | 2 | `Promise.allSettled` with `accept([200], { toast: false })` |
| `firewall-allow-signals.ts` | 5 | computeds with `{ toast: false }`, commands without; `createAccessRequest$` uses `[201]` |

## Test plan

- [x] `pnpm check-types` — passes
- [x] `pnpm turbo run lint --filter=@vm0/app` — passes
- [x] `pnpm vitest run` — 836 tests pass

Closes #7881

🤖 Generated with [Claude Code](https://claude.com/claude-code)