### PR TITLE
test(platform): add active tab and connector icon tests for zero-ideation-page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -106,7 +106,7 @@ describe("ideation page - category tabs", () => {
     const githubTab = screen.getByRole("button", { name: "GitHub" });
 
     // Initially "All" tab should have active styling
-    expect(allTab.className).toContain("bg-muted");
+    expect(allTab.className).toContain("bg-muted text-foreground");
     expect(githubTab.className).not.toContain("bg-muted text-foreground");
 
     // Click GitHub tab
@@ -114,7 +114,7 @@ describe("ideation page - category tabs", () => {
 
     // GitHub tab should now have active styling, All should not
     await waitFor(() => {
-      expect(githubTab.className).toContain("bg-muted");
+      expect(githubTab.className).toContain("bg-muted text-foreground");
     });
     expect(allTab.className).not.toContain("bg-muted text-foreground");
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-ideation-page.test.tsx
@@ -96,6 +96,29 @@ describe("ideation page - category tabs", () => {
     }
   });
 
+  it("should highlight the selected category tab as active", async () => {
+    const user = userEvent.setup();
+    await renderIdeationPage();
+
+    const allTab = await waitFor(() => {
+      return screen.getByRole("button", { name: "All" });
+    });
+    const githubTab = screen.getByRole("button", { name: "GitHub" });
+
+    // Initially "All" tab should have active styling
+    expect(allTab.className).toContain("bg-muted");
+    expect(githubTab.className).not.toContain("bg-muted text-foreground");
+
+    // Click GitHub tab
+    await user.click(githubTab);
+
+    // GitHub tab should now have active styling, All should not
+    await waitFor(() => {
+      expect(githubTab.className).toContain("bg-muted");
+    });
+    expect(allTab.className).not.toContain("bg-muted text-foreground");
+  });
+
   it("should filter to a single category when its tab is clicked", async () => {
     const user = userEvent.setup();
     await renderIdeationPage();
@@ -208,6 +231,19 @@ describe("ideation page - use case cards", () => {
     expect(
       screen.getByText("Morning metrics become a slide deck posted to Slack"),
     ).toBeInTheDocument();
+  });
+
+  it("should render connector icons for use cases that have connectors", async () => {
+    await renderIdeationPage();
+
+    // "Daily standup report" has 5 connectors: github, sentry, axiom, plausible, slack
+    const cardTitle = await waitFor(() => {
+      return screen.getByText("Daily standup report");
+    });
+
+    const card = cardTitle.closest(".zero-card")!;
+    const connectorImages = card.querySelectorAll("img");
+    expect(connectorImages).toHaveLength(5);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add test for AGENT-D-076: verify active tab highlights with `bg-muted` class when selected
- Add test for AGENT-D-078: verify connector icons render for use cases that have connectors (e.g. "Daily standup report" with 5 connector images)
- All other required test cases (AGENT-D-077, 079, 080, 081) were already covered by existing tests

Closes #7926

## Test plan
- [x] All 17 tests pass locally (`pnpm vitest run`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes for platform app
- [x] Format check passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)