### PR TITLE
test(platform): add zero-chat-composer interaction tests

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
@@ -81,29 +81,37 @@ describe("zero chat composer - textarea interaction", () => {
 
 describe("zero chat composer - file input", () => {
   // CHAT-I-023
-  it("triggers file picker when Attach button is clicked", async () => {
+  it("shows attachment chip after a file is selected via the file input", async () => {
     const user = userEvent.setup();
     mockChatLifecycle();
+    server.use(
+      http.post("*/api/zero/uploads", () => {
+        return HttpResponse.json({
+          id: "upload-1",
+          filename: "test.png",
+          contentType: "image/png",
+          size: 1024,
+          url: "https://example.com/test.png",
+        });
+      }),
+    );
 
     await setupPage({ context, path: CHAT_PATH });
 
-    const attachButton = await waitFor(() => {
-      return screen.getByRole("button", { name: "Attach" });
+    const fileInput = await waitFor(() => {
+      const el = document.querySelector<HTMLInputElement>('input[type="file"]');
+      expect(el).toBeInTheDocument();
+      return el as HTMLInputElement;
     });
 
-    const fileInput =
-      document.querySelector<HTMLInputElement>('input[type="file"]');
-    expect(fileInput).toBeInTheDocument();
-    if (!fileInput) {
-      throw new Error("file input not found");
-    }
+    const file = new File(["content"], "test.png", { type: "image/png" });
+    await user.upload(fileInput, file);
 
-    const clickSpy = vi.fn();
-    fileInput.click = clickSpy;
-
-    await user.click(attachButton);
-
-    expect(clickSpy).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /test\.png/ }),
+      ).toBeInTheDocument();
+    });
   });
 });
 
@@ -129,14 +137,40 @@ describe("zero chat composer - connectors popover", () => {
   });
 
   // CHAT-I-025
-  it("calls PUT user-connectors when a connector switch is toggled", async () => {
+  it("updates connector switch label in UI after toggling a connector", async () => {
     const user = userEvent.setup();
-    let putCalled = false;
     mockChatLifecycle();
-    mockConnectors();
+
+    // Stateful connector: starts with GitHub enabled; after PUT, GET returns empty
+    let githubEnabled = true;
     server.use(
+      http.get("*/api/zero/connectors", () => {
+        return HttpResponse.json({
+          connectors: [
+            {
+              id: "d0000001-0000-4000-a000-000000000001",
+              type: "github",
+              authMethod: "oauth",
+              externalId: null,
+              externalUsername: "testuser",
+              externalEmail: null,
+              oauthScopes: ["repo"],
+              needsReconnect: false,
+              createdAt: "2026-01-01T00:00:00Z",
+              updatedAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+          configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+          connectorProvidedSecretNames: [],
+        });
+      }),
+      http.get(`*/api/zero/agents/${AGENT_ID}/user-connectors`, () => {
+        return HttpResponse.json({
+          enabledTypes: githubEnabled ? ["github"] : [],
+        });
+      }),
       http.put(`*/api/zero/agents/${AGENT_ID}/user-connectors`, () => {
-        putCalled = true;
+        githubEnabled = false;
         return HttpResponse.json({ enabledTypes: [] });
       }),
     );
@@ -155,8 +189,11 @@ describe("zero chat composer - connectors popover", () => {
 
     await user.click(githubSwitch);
 
+    // After toggling, the UI should reflect that GitHub is now removed
     await waitFor(() => {
-      expect(putCalled).toBeTruthy();
+      expect(
+        screen.getByRole("switch", { name: "Add GitHub" }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-composer-interaction.test.tsx
@@ -1,0 +1,348 @@
+import { describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  mockChatLifecycle,
+  sendMessageInUI,
+  PLACEHOLDER,
+} from "./chat-test-helpers.ts";
+
+const context = testContext();
+
+const AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+const CHAT_PATH = `/agents/${AGENT_ID}/chat`;
+
+function mockConnectors() {
+  server.use(
+    http.get("*/api/zero/connectors", () => {
+      return HttpResponse.json({
+        connectors: [
+          {
+            id: "d0000001-0000-4000-a000-000000000001",
+            type: "github",
+            authMethod: "oauth",
+            externalId: null,
+            externalUsername: "testuser",
+            externalEmail: null,
+            oauthScopes: ["repo"],
+            needsReconnect: false,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z",
+          },
+          {
+            id: "d0000002-0000-4000-a000-000000000002",
+            type: "linear",
+            authMethod: "oauth",
+            externalId: null,
+            externalUsername: "linearuser",
+            externalEmail: null,
+            oauthScopes: [],
+            needsReconnect: false,
+            createdAt: "2026-01-02T00:00:00Z",
+            updatedAt: "2026-01-02T00:00:00Z",
+          },
+        ],
+        configuredTypes: Object.keys(CONNECTOR_TYPES) as ConnectorType[],
+        connectorProvidedSecretNames: [],
+      });
+    }),
+    http.get(`*/api/zero/agents/${AGENT_ID}/user-connectors`, () => {
+      return HttpResponse.json({ enabledTypes: ["github"] });
+    }),
+    http.put(`*/api/zero/agents/${AGENT_ID}/user-connectors`, () => {
+      return HttpResponse.json({ enabledTypes: ["github", "linear"] });
+    }),
+  );
+}
+
+describe("zero chat composer - textarea interaction", () => {
+  // CHAT-I-022
+  it("updates textarea value to reflect typed text", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+
+    await setupPage({ context, path: CHAT_PATH });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    await user.clear(textarea);
+    await user.type(textarea, "Hello world");
+
+    expect(textarea.value).toBe("Hello world");
+  });
+});
+
+describe("zero chat composer - file input", () => {
+  // CHAT-I-023
+  it("triggers file picker when Attach button is clicked", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+
+    await setupPage({ context, path: CHAT_PATH });
+
+    const attachButton = await waitFor(() => {
+      return screen.getByRole("button", { name: "Attach" });
+    });
+
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(fileInput).toBeInTheDocument();
+    if (!fileInput) {
+      throw new Error("file input not found");
+    }
+
+    const clickSpy = vi.fn();
+    fileInput.click = clickSpy;
+
+    await user.click(attachButton);
+
+    expect(clickSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe("zero chat composer - connectors popover", () => {
+  // CHAT-I-024
+  it("opens popover displaying connected connectors when clicked", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+    mockConnectors();
+
+    await setupPage({ context, path: CHAT_PATH });
+
+    const connectorsButton = await waitFor(() => {
+      return screen.getByRole("button", { name: "Connectors" });
+    });
+
+    await user.click(connectorsButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("GitHub")).toBeInTheDocument();
+      expect(screen.getByText("Linear")).toBeInTheDocument();
+    });
+  });
+
+  // CHAT-I-025
+  it("calls PUT user-connectors when a connector switch is toggled", async () => {
+    const user = userEvent.setup();
+    let putCalled = false;
+    mockChatLifecycle();
+    mockConnectors();
+    server.use(
+      http.put(`*/api/zero/agents/${AGENT_ID}/user-connectors`, () => {
+        putCalled = true;
+        return HttpResponse.json({ enabledTypes: [] });
+      }),
+    );
+
+    await setupPage({ context, path: CHAT_PATH });
+
+    const connectorsButton = await waitFor(() => {
+      return screen.getByRole("button", { name: "Connectors" });
+    });
+    await user.click(connectorsButton);
+
+    // GitHub is enabled, so the switch label should be "Remove GitHub"
+    const githubSwitch = await waitFor(() => {
+      return screen.getByRole("switch", { name: "Remove GitHub" });
+    });
+
+    await user.click(githubSwitch);
+
+    await waitFor(() => {
+      expect(putCalled).toBeTruthy();
+    });
+  });
+
+  // CHAT-I-026
+  it("shows add connectors dialog when Add connectors button is clicked", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+
+    await setupPage({ context, path: CHAT_PATH });
+
+    const connectorsButton = await waitFor(() => {
+      return screen.getByRole("button", { name: "Connectors" });
+    });
+    await user.click(connectorsButton);
+
+    const addButton = await waitFor(() => {
+      return screen.getByText("Add connectors");
+    });
+    await user.click(addButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", {
+          name: /Available connectors to connect/,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero chat composer - send and stop actions", () => {
+  // CHAT-I-027
+  it("sends message when Send button is clicked", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+
+    await setupPage({ context, path: CHAT_PATH });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+
+    await user.clear(textarea);
+    await user.type(textarea, "Hello");
+
+    const sendButton = await waitFor(() => {
+      return screen.getByRole("button", { name: "Send" });
+    });
+    await user.click(sendButton);
+
+    // After sending, the Stop button should appear (message is being processed)
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+    });
+  });
+
+  // CHAT-I-028
+  it("displays Stop button while sending and cancels when clicked", async () => {
+    const user = userEvent.setup();
+    const ctrl = mockChatLifecycle();
+
+    await setupPage({ context, path: CHAT_PATH });
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    await sendMessageInUI(user, textarea, "Hello");
+
+    // Stop button should appear during send
+    const stopButton = await waitFor(() => {
+      return screen.getByRole("button", { name: "Stop" });
+    });
+    expect(stopButton).toBeInTheDocument();
+
+    ctrl.cancelRun();
+    await user.click(stopButton);
+
+    // After cancellation, send button should return
+    await waitFor(() => {
+      expect(screen.getByLabelText("Send")).toBeInTheDocument();
+    });
+  });
+
+  // CHAT-C-031
+  it("shows Stop button only during an active sending operation", async () => {
+    const user = userEvent.setup();
+    const ctrl = mockChatLifecycle();
+
+    await setupPage({ context, path: CHAT_PATH });
+
+    // Initially: no Stop button, Send button is present
+    await waitFor(() => {
+      expect(screen.getByLabelText("Send")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("Stop")).toBeNull();
+
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
+    await sendMessageInUI(user, textarea, "Hello");
+
+    // While sending: Stop button visible, Send hidden
+    await waitFor(() => {
+      expect(screen.getByLabelText("Stop")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Send")).not.toBeInTheDocument();
+    });
+
+    ctrl.completeRun("Done");
+
+    // After completion: Stop gone, Send returns
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Stop")).not.toBeInTheDocument();
+      expect(screen.getByLabelText("Send")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero chat composer - add connectors dialog", () => {
+  // CHAT-I-029
+  it("filters connector list based on search query", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+
+    await setupPage({ context, path: CHAT_PATH });
+
+    const connectorsButton = await waitFor(() => {
+      return screen.getByRole("button", { name: "Connectors" });
+    });
+    await user.click(connectorsButton);
+
+    const addButton = await waitFor(() => {
+      return screen.getByText("Add connectors");
+    });
+    await user.click(addButton);
+
+    const searchInput = await waitFor(() => {
+      return screen.getByPlaceholderText("Search connectors...");
+    });
+
+    // Before filtering: GitHub should be visible
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Connect GitHub" }),
+      ).toBeInTheDocument();
+    });
+
+    // Type a filter that won't match GitHub
+    await user.clear(searchInput);
+    await user.type(searchInput, "Slack");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Connect GitHub" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Connect Slack" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // CHAT-I-030
+  it("opens ConnectModal when a Connect button is clicked", async () => {
+    const user = userEvent.setup();
+    mockChatLifecycle();
+
+    await setupPage({ context, path: CHAT_PATH });
+
+    const connectorsButton = await waitFor(() => {
+      return screen.getByRole("button", { name: "Connectors" });
+    });
+    await user.click(connectorsButton);
+
+    const addButton = await waitFor(() => {
+      return screen.getByText("Add connectors");
+    });
+    await user.click(addButton);
+
+    // Verify unconnected connectors are listed
+    const connectGitHubButton = await waitFor(() => {
+      return screen.getByRole("button", { name: "Connect GitHub" });
+    });
+    await user.click(connectGitHubButton);
+
+    // ConnectModal should appear as a dialog
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes #7930

## Summary
- Add `zero-chat-composer-interaction.test.tsx` with 10 interaction tests covering CHAT-I-022 through CHAT-C-031
- Tests cover: textarea input (I-022), file picker (I-023), connectors popover (I-024), connector toggle (I-025), add connectors dialog (I-026), send button (I-027), stop button (I-028), search filtering (I-029), connect button flow (I-030), and stop button visibility (C-031)
- Uses `setupPage` + MSW pattern; no `vi.mock()` for internal modules

## Test plan
- [x] All 10 `it()` blocks pass locally
- [x] No `vi.mock()` for internal modules
- [x] No `eslint-disable` or `@ts-ignore`
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Types pass (`pnpm check-types`)
- [x] Format passes (`pnpm format`)
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)