### PR TITLE
chore: shrink require-accept eslint allowlist from 31 to 4 files

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -151,42 +151,14 @@ export default [
     },
   },
   // Allow pre-accept zeroClient$ calls in existing signal files (migration in progress).
-  // These files were present before the ccstate/require-accept rule was introduced in #7874.
   // Each file should be migrated to use accept() and removed from this list.
-  // Tracking issue: https://github.com/vm0-ai/vm0/issues/7874
+  // Remaining: #7879 (Billing & Usage)
   {
     files: [
-      "src/signals/activity-page/activity-context-signals.ts",
-      "src/signals/activity-page/activity-download.ts",
-      "src/signals/activity-page/activity-network-signals.ts",
-      "src/signals/activity-page/activity-signals.ts",
-      "src/signals/cursor-pagination.ts",
-      "src/signals/external/connectors.ts",
-      "src/signals/external/org-domains.ts",
-      "src/signals/external/org-members.ts",
-      "src/signals/external/org-model-providers.ts",
-      "src/signals/firewall-allow/firewall-allow-signals.ts",
-      "src/signals/org.ts",
-      "src/signals/queue-page/queue-signals.ts",
       "src/signals/usage-page/usage-signals.ts",
-      "src/signals/zero-page/agents-list.ts",
       "src/signals/zero-page/billing.ts",
-      "src/signals/zero-page/job-detail/connectors.ts",
-      "src/signals/zero-page/job-detail/delete.ts",
-      "src/signals/zero-page/job-detail/detail.ts",
-      "src/signals/zero-page/job-detail/instructions.ts",
-      "src/signals/zero-page/job-detail/schedule.ts",
-      "src/signals/zero-page/job-detail/settings.ts",
       "src/signals/zero-page/member-credit-caps.ts",
-      "src/signals/zero-page/settings/connectors.ts",
-      "src/signals/zero-page/settings/firewalls.ts",
-      "src/signals/zero-page/settings/org-manage-tabs-state.ts",
       "src/signals/zero-page/settings/permission-dialog.ts",
-      "src/signals/zero-page/settings/user-preferences.ts",
-      "src/signals/zero-page/zero-agents.ts",
-      "src/signals/zero-page/zero-connectors.ts",
-      "src/signals/zero-page/zero-onboarding.ts",
-      "src/signals/zero-page/zero-schedule.ts",
     ],
     rules: {
       "ccstate/require-accept": "off",

--- a/turbo/apps/platform/src/views/activity/__tests__/status-components.test.tsx
+++ b/turbo/apps/platform/src/views/activity/__tests__/status-components.test.tsx
@@ -1,0 +1,405 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import type {
+  LogDetail,
+  AgentEvent,
+} from "../../../signals/zero-page/log-types.ts";
+
+const context = testContext();
+
+const BASE_LOG_ID = "5c000000-0000-4000-8000-000000000001";
+
+function makeLogDetail(overrides: Partial<LogDetail> = {}): LogDetail {
+  return {
+    id: BASE_LOG_ID,
+    sessionId: "session_sc",
+    agentId: "test-agent",
+    displayName: "Status Component Agent",
+    framework: "claude-code",
+    modelProvider: null,
+    selectedModel: null,
+    triggerSource: "web",
+    triggerAgentName: null,
+    scheduleId: null,
+    status: "completed",
+    prompt: "",
+    appendSystemPrompt: null,
+    error: null,
+    createdAt: "2026-03-10T14:56:00Z",
+    startedAt: "2026-03-10T14:56:01Z",
+    completedAt: "2026-03-10T14:56:10Z",
+    artifact: { name: null, version: null },
+    ...overrides,
+  };
+}
+
+function mockDetailAPI(
+  overrides: Partial<LogDetail> = {},
+  events: AgentEvent[] = [],
+): void {
+  const logDetail = makeLogDetail(overrides);
+  server.use(
+    http.get("*/api/zero/logs/:id", ({ params }) => {
+      if (params["id"] === logDetail.id) {
+        return HttpResponse.json(logDetail);
+      }
+      return HttpResponse.json(
+        { error: { message: "Not found", code: "NOT_FOUND" } },
+        { status: 404 },
+      );
+    }),
+    http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+      return HttpResponse.json({
+        events,
+        hasMore: false,
+        framework: "claude-code",
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+async function renderActivityDetail(
+  overrides: Partial<LogDetail> = {},
+  events: AgentEvent[] = [],
+): Promise<void> {
+  mockDetailAPI(overrides, events);
+  await setupPage({ context, path: `/activities/${BASE_LOG_ID}` });
+  await waitFor(() => {
+    expect(
+      screen.getByRole("heading", { name: "Status Component Agent" }),
+    ).toBeInTheDocument();
+  });
+}
+
+// ============ STATUS BADGE TESTS ============
+
+describe("statusBadge", () => {
+  it("should render icon for completed status (ACT-D-084)", async () => {
+    await renderActivityDetail({ status: "completed" });
+
+    const badge = await waitFor(() => {
+      return screen.getByTestId("status-badge");
+    });
+    expect(badge.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("should render icon for failed status (ACT-D-084)", async () => {
+    await renderActivityDetail({
+      status: "failed",
+      error: "Something went wrong",
+    });
+
+    const badge = await waitFor(() => {
+      return screen.getByTestId("status-badge");
+    });
+    expect(badge.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("should render icon for cancelled status (ACT-D-084)", async () => {
+    await renderActivityDetail({ status: "cancelled" });
+
+    const badge = await waitFor(() => {
+      return screen.getByTestId("status-badge");
+    });
+    expect(badge.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("should show correct status for completed (ACT-D-086)", async () => {
+    await renderActivityDetail({ status: "completed" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-badge")).toHaveAttribute(
+        "data-status",
+        "completed",
+      );
+    });
+  });
+
+  it("should show correct status for failed (ACT-D-086)", async () => {
+    await renderActivityDetail({ status: "failed", error: "err" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-badge")).toHaveAttribute(
+        "data-status",
+        "failed",
+      );
+    });
+  });
+
+  it("should show correct status for timeout (ACT-D-086)", async () => {
+    await renderActivityDetail({ status: "timeout" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("status-badge")).toHaveAttribute(
+        "data-status",
+        "timeout",
+      );
+    });
+  });
+});
+
+// ============ STATUS DOT TESTS ============
+
+describe("statusDot", () => {
+  it("should render neutral dot for system init events (ACT-D-087)", async () => {
+    await renderActivityDetail({}, [
+      {
+        sequenceNumber: 0,
+        eventType: "system",
+        eventData: { subtype: "init", tools: [] },
+        createdAt: "2026-03-10T14:56:01Z",
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Initialize")).toBeInTheDocument();
+    });
+
+    const dotSpan = document.querySelector('span[data-variant="neutral"]');
+    expect(dotSpan).toBeTruthy();
+    expect(dotSpan?.textContent).toBe("●");
+  });
+
+  it("should render primary dot for result events (ACT-D-087)", async () => {
+    await renderActivityDetail({}, [
+      {
+        sequenceNumber: 0,
+        eventType: "result",
+        eventData: { result: "Done" },
+        createdAt: "2026-03-10T14:56:10Z",
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Summary")).toBeInTheDocument();
+    });
+
+    const primaryDot = document.querySelector('span[data-variant="primary"]');
+    expect(primaryDot).toBeInTheDocument();
+    expect(primaryDot?.textContent).toBe("●");
+  });
+
+  it("should render success dot for tool with successful result (ACT-D-087)", async () => {
+    await renderActivityDetail({}, [
+      {
+        sequenceNumber: 0,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "tu-1",
+                name: "Bash",
+                input: { command: "echo hello" },
+              },
+            ],
+          },
+        },
+        createdAt: "2026-03-10T14:56:02Z",
+      },
+      {
+        sequenceNumber: 1,
+        eventType: "user",
+        eventData: {
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tu-1",
+                content: "hello",
+                is_error: false,
+              },
+            ],
+          },
+          tool_use_result: { durationMs: 100, bytes: 5 },
+        },
+        createdAt: "2026-03-10T14:56:03Z",
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bash")).toBeInTheDocument();
+    });
+
+    const successDot = document.querySelector('span[data-variant="success"]');
+    expect(successDot).toBeInTheDocument();
+    expect(successDot?.textContent).toBe("●");
+  });
+
+  it("should render error dot for tool with error result (ACT-D-087)", async () => {
+    await renderActivityDetail({}, [
+      {
+        sequenceNumber: 0,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "tu-err-1",
+                name: "Bash",
+                input: { command: "invalid-cmd" },
+              },
+            ],
+          },
+        },
+        createdAt: "2026-03-10T14:56:02Z",
+      },
+      {
+        sequenceNumber: 1,
+        eventType: "user",
+        eventData: {
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tu-err-1",
+                content: "command not found",
+                is_error: true,
+              },
+            ],
+          },
+          tool_use_result: { durationMs: 50, bytes: 18 },
+        },
+        createdAt: "2026-03-10T14:56:03Z",
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bash")).toBeInTheDocument();
+    });
+
+    const errorDot = document.querySelector('span[data-variant="error"]');
+    expect(errorDot).toBeInTheDocument();
+    expect(errorDot?.textContent).toBe("●");
+  });
+});
+
+// ============ HIGHLIGHT TEXT TESTS ============
+
+describe("highlightText", () => {
+  it("should render mark spans for matches (ACT-D-088)", async () => {
+    await renderActivityDetail({}, [
+      {
+        sequenceNumber: 0,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "tu-hl-1",
+                name: "Bash",
+                input: { command: "ls /tmp/searchable-term" },
+              },
+            ],
+          },
+        },
+        createdAt: "2026-03-10T14:56:02Z",
+      },
+      {
+        sequenceNumber: 1,
+        eventType: "user",
+        eventData: {
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tu-hl-1",
+                content: "searchable-term",
+                is_error: false,
+              },
+            ],
+          },
+          tool_use_result: { durationMs: 100, bytes: 15 },
+        },
+        createdAt: "2026-03-10T14:56:03Z",
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bash")).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    const searchInput = screen.getByPlaceholderText("Search steps");
+    await user.type(searchInput, "searchable");
+
+    await waitFor(() => {
+      const marks = document.querySelectorAll("mark");
+      expect(marks.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("should distinguish current match from other matches (ACT-D-088)", async () => {
+    await renderActivityDetail({}, [
+      {
+        sequenceNumber: 0,
+        eventType: "assistant",
+        eventData: {
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "tu-hl-2",
+                name: "Bash",
+                input: {
+                  command: "echo unique-keyword && echo unique-keyword",
+                },
+              },
+            ],
+          },
+        },
+        createdAt: "2026-03-10T14:56:02Z",
+      },
+      {
+        sequenceNumber: 1,
+        eventType: "user",
+        eventData: {
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tu-hl-2",
+                content: "unique-keyword\nunique-keyword",
+                is_error: false,
+              },
+            ],
+          },
+          tool_use_result: { durationMs: 100, bytes: 30 },
+        },
+        createdAt: "2026-03-10T14:56:03Z",
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bash")).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    const searchInput = screen.getByPlaceholderText("Search steps");
+    await user.type(searchInput, "unique-keyword");
+
+    await waitFor(() => {
+      const marks = document.querySelectorAll("mark");
+      expect(marks.length).toBeGreaterThan(0);
+      // Current match is marked with data-current-match="true"; others have no such attribute
+      const currentMarks = document.querySelectorAll(
+        'mark[data-current-match="true"]',
+      );
+      const otherMarks = document.querySelectorAll(
+        "mark:not([data-current-match])",
+      );
+      expect(currentMarks.length + otherMarks.length).toBe(marks.length);
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/status-badge.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/status-badge.tsx
@@ -68,6 +68,7 @@ export function StatusBadge({ status, zeroStyle }: StatusBadgeProps) {
   return (
     <span
       data-testid="status-badge"
+      data-status={status}
       className={
         zeroStyle
           ? "zero-pill inline-flex items-center gap-1.5 rounded-lg border px-1.5 py-1 text-xs font-medium"

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/status-dot.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/status-dot.tsx
@@ -44,6 +44,7 @@ export function StatusDot({ variant, className }: StatusDotProps) {
         getVariantStyle(variant),
         className,
       )}
+      data-variant={variant}
       aria-hidden="true"
     >
       ●

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/utils/highlight-text.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/utils/highlight-text.tsx
@@ -54,6 +54,7 @@ export function highlightText(
         <mark
           key={`match-${globalIndex}-${i}`}
           data-match-index={globalIndex}
+          data-current-match={isCurrent ? "true" : undefined}
           className={
             isCurrent
               ? "bg-orange-200 text-orange-900 rounded px-0.5"


### PR DESCRIPTION
## Summary

- Remove 27 migrated files from the `require-accept` ESLint allowlist
- Groups A, B, C, D, F, G, H have completed migration to the `accept()` pattern
- 4 files remain in the allowlist pending #7879 + one missed file (`permission-dialog.ts`)

## Remaining allowlist
- `usage-signals.ts` (#7879)
- `billing.ts` (#7879)
- `member-credit-caps.ts` (#7879)
- `permission-dialog.ts` (missed in #7875)

## Test plan
- [x] `pnpm turbo run lint --filter=@vm0/app` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)