### PR TITLE
refactor: remove unused developer-support:write capability

### DIFF
--- a/turbo/apps/web/app/api/zero/developer-support/route.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/route.ts
@@ -84,7 +84,7 @@ const router = tsr.router(zeroDeveloperSupportContract, {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
-      requiredCapability: "developer-support:write",
+      acceptAnySandboxCapability: true,
     });
     if (isAuthError(authCtx)) return authCtx;
 

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -246,7 +246,6 @@ describe("sandbox-token", () => {
         "schedule:write",
         "slack:write",
         "connector:read",
-        "developer-support:write",
       ]);
     });
 

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -24,7 +24,7 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 
 describe("ZERO_CAPABILITIES", () => {
   it("should have exactly 9 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(9);
+    expect(ZERO_CAPABILITIES).toHaveLength(8);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -23,7 +23,7 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 9 capabilities", () => {
+  it("should have exactly 8 capabilities", () => {
     expect(ZERO_CAPABILITIES).toHaveLength(8);
   });
 

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -35,7 +35,6 @@ export const ZERO_CAPABILITIES = [
   "schedule:write",
   "slack:write",
   "connector:read",
-  "developer-support:write",
 ] as const;
 
 /** Inferred union type of all zero capability strings. */
@@ -65,10 +64,6 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     },
     "slack:write": { group: "Integrations", label: "Send Slack messages" },
     "connector:read": { group: "Connectors", label: "View connected services" },
-    "developer-support:write": {
-      group: "Support",
-      label: "Submit developer support requests",
-    },
   };
 
 /**


### PR DESCRIPTION
## Summary

- Remove `developer-support:write` from `ZERO_CAPABILITIES` array and `ZERO_CAPABILITY_META`
- Replace `requiredCapability: "developer-support:write"` with `acceptAnySandboxCapability: true` in the developer-support route
- Update test assertions (capability count 9→8, remove from expected array)

The capability was dead code: the CLI maps `developer-support` to `null` (always visible) and every sandbox token automatically includes all capabilities.

Closes #8015

## Test plan

- [x] All existing developer-support route tests pass (5/5)
- [x] Composes capability tests pass with updated count (8)
- [x] Sandbox token test passes without the capability in expected array
- [x] `grep -r "developer-support:write"` returns zero results
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)