### PR TITLE
feat: add dns proxy for sandbox vms using dnsmasq

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -651,6 +651,17 @@ jobs:
           echo "  HTTPS go: ok"
           echo "PASS: HTTPS through proxy"
 
+          # Test 7: verify DNS resolution works inside sandbox
+          # Uses getent (libc-bin, always available) instead of nslookup (requires dnsutils).
+          echo "--- Test: DNS resolution ---"
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- getent hosts github.com 2>&1) \
+            || fail "user DNS resolution failed: $OUTPUT"
+          echo "  user: $OUTPUT"
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" --sudo -- getent hosts example.com 2>&1) \
+            || fail "root DNS resolution failed: $OUTPUT"
+          echo "  root: $OUTPUT"
+          echo "PASS: DNS resolution"
+
           # Stop transient service (kills sandbox, submit terminates naturally)
           sudo "$BIN_DIR/runner" service stop --name "$SVC"
           trap - EXIT

--- a/ansible/playbooks/provision-runner.yml
+++ b/ansible/playbooks/provision-runner.yml
@@ -26,8 +26,16 @@
           - iproute2
           - iptables
           - procps
+          - dnsmasq
         state: present
         update_cache: true
+      become: true
+
+    - name: Disable system dnsmasq (runner manages its own instance)
+      systemd:
+        name: dnsmasq
+        enabled: false
+        state: stopped
       become: true
 
     - name: Check if Docker is installed

--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -31,6 +31,7 @@ GUEST_AGENT=""
 GUEST_DOWNLOAD=""
 GUEST_INIT=""
 GUEST_MOCK_CLAUDE=""
+DNS_NAMESERVER=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -43,11 +44,12 @@ while [[ $# -gt 0 ]]; do
     --guest-download)   GUEST_DOWNLOAD="$2";   shift 2 ;;
     --guest-init)       GUEST_INIT="$2";       shift 2 ;;
     --guest-mock-claude) GUEST_MOCK_CLAUDE="$2"; shift 2 ;;
+    --dns-nameserver)   DNS_NAMESERVER="$2";   shift 2 ;;
     *) echo "error: unknown argument: $1" >&2; exit 1 ;;
   esac
 done
 
-for var in OUTPUT_DIR WORK_DIR CA_DIR INPUT_HASH DISK_MB GUEST_AGENT GUEST_DOWNLOAD GUEST_INIT GUEST_MOCK_CLAUDE; do
+for var in OUTPUT_DIR WORK_DIR CA_DIR INPUT_HASH DISK_MB GUEST_AGENT GUEST_DOWNLOAD GUEST_INIT GUEST_MOCK_CLAUDE DNS_NAMESERVER; do
   if [[ -z "${!var}" ]]; then
     echo "error: --$(echo "$var" | tr '_' '-' | tr '[:upper:]' '[:lower:]') is required" >&2
     exit 1
@@ -66,9 +68,7 @@ CA_KEY_FILE="mitmproxy-ca-key.pem"
 CA_COMBINED_FILE="mitmproxy-ca.pem"
 CA_ROOTFS_DEST="usr/local/share/ca-certificates/vm0-proxy-ca.crt"
 
-RESOLV_CONF="nameserver 8.8.8.8
-nameserver 8.8.4.4
-nameserver 1.1.1.1
+RESOLV_CONF="nameserver ${DNS_NAMESERVER}
 "
 
 CONTAINER_NAME="vm0-rootfs-tmp-$$"

--- a/crates/runner/src/cmd/benchmark.rs
+++ b/crates/runner/src/cmd/benchmark.rs
@@ -94,6 +94,7 @@ pub async fn run_benchmark(
     let mut runtime = runtime_provider
         .create_runtime(sandbox::RuntimeConfig {
             proxy_port: Some(mitm.port()),
+            dns_port: None, // benchmark does not use custom DNS proxy
         })
         .await?;
     let mut factory = runtime.create_factory(factory_config).await?;

--- a/crates/runner/src/cmd/rootfs.rs
+++ b/crates/runner/src/cmd/rootfs.rs
@@ -233,6 +233,10 @@ pub async fn run_rootfs(args: RootfsArgs) -> RunnerResult<String> {
             &guest_init_str,
             "--guest-mock-claude",
             &guest_mock_claude_str,
+            // Dummy nameserver — all UDP 53 is iptables-REDIRECT'd to dnsmasq.
+            // Must be routable (not loopback/gateway) so packets leave the VM.
+            "--dns-nameserver",
+            "8.8.8.8",
         ])
         .stdin(std::process::Stdio::null())
         .status()

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 
 use crate::config::{self, ProfileConfig};
 use crate::deps;
+use crate::dns;
 use crate::error::{RunnerError, RunnerResult};
 use crate::executor::{self, ExecutorConfig};
 use crate::host;
@@ -173,6 +174,12 @@ pub async fn run_start(
     let ip_log_map = kmsg_log::new_ip_log_map();
     let kmsg_handle = kmsg_log::spawn(ip_log_map.clone());
 
+    // Start DNS proxy (dnsmasq) for domain-level DNS interception and logging.
+    // Shares ip_log_map with kmsg — both use source IP (peer veth) as key.
+    let dns_handle = dns::start(ip_log_map.clone())
+        .await
+        .map_err(|e| RunnerError::Internal(format!("dns proxy: {e}")))?;
+
     // Resource budget from host resources + config.
     let config::SandboxConfig {
         max_concurrent,
@@ -216,6 +223,7 @@ pub async fn run_start(
     let runtime = runtime_provider
         .create_runtime(sandbox::RuntimeConfig {
             proxy_port: Some(mitm.port()),
+            dns_port: Some(dns_handle.port()),
         })
         .await
         .map_err(|e| RunnerError::Internal(format!("sandbox runtime: {e}")))?;
@@ -281,6 +289,7 @@ pub async fn run_start(
         min_vcpu,
         min_memory_mb,
         kmsg_handle,
+        dns_handle,
     };
 
     run(config).await
@@ -307,6 +316,7 @@ struct RunConfig {
     min_vcpu: u32,
     min_memory_mb: u32,
     kmsg_handle: kmsg_log::KmsgHandle,
+    dns_handle: dns::DnsProxy,
 }
 
 type MitmRestartHandle = tokio::task::JoinHandle<RunnerResult<tokio::process::Child>>;
@@ -331,6 +341,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         min_vcpu,
         min_memory_mb,
         kmsg_handle,
+        dns_handle,
     } = config;
 
     // Build per-profile factories via the sandbox runtime.
@@ -556,6 +567,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Stop the kmsg monitor and wait for the `dmesg -w` child process
     // to be killed and reaped.
     kmsg_handle.stop().await;
+    dns_handle.stop().await;
 
     status.set_mode(RunnerMode::Stopped).await;
     info!("runner stopped");

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -1,0 +1,344 @@
+//! DNS proxy for sandbox VMs using dnsmasq.
+//!
+//! Spawns a dnsmasq process that serves as the DNS resolver for all VMs.
+//! DNS queries are intercepted via iptables REDIRECT (PREROUTING chain)
+//! and forwarded to upstream resolvers (8.8.8.8, 8.8.4.4).
+//!
+//! Defense-in-depth:
+//! - Layer 1: iptables REDIRECT → dnsmasq port (working path, preserves source IP)
+//! - Layer 2: iptables DROP external UDP 53 / TCP 853 (bypass prevention)
+//!
+//! VM resolv.conf points to an external nameserver (e.g. 8.8.8.8) as a dummy
+//! target. The REDIRECT rule in PREROUTING intercepts all UDP 53 from the VM
+//! subnet and redirects to dnsmasq before the packet reaches FORWARD/POSTROUTING.
+//!
+//! Log format: dnsmasq `--log-queries` outputs to stderr, parsed by a background
+//! async task that writes per-VM network JSONL entries (same pattern as kmsg_log).
+
+use std::path::Path;
+use std::process::Stdio;
+
+use chrono::Utc;
+use tokio::io::AsyncBufReadExt;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::kmsg_log::IpLogMap;
+
+/// IP address that `firewall-placeholder.vm3.ai` resolves to.
+///
+/// This must be a routable (non-loopback) IP so the VM's TCP connection
+/// leaves the VM via TAP and gets caught by the TCP REDIRECT rule to
+/// mitmproxy. The actual value doesn't matter — any routable IP works.
+/// We use TEST-NET-2 (RFC 5737) to make intent obvious.
+const PLACEHOLDER_IP: &str = "198.51.100.1";
+
+/// Handle to the dnsmasq process and its log monitor.
+pub struct DnsProxy {
+    cancel: CancellationToken,
+    task: tokio::task::JoinHandle<()>,
+    child: tokio::process::Child,
+    port: u16,
+}
+
+impl DnsProxy {
+    /// Stop the DNS proxy and wait for cleanup.
+    pub async fn stop(mut self) {
+        self.cancel.cancel();
+        let _ = self.child.start_kill();
+        let _ = self.child.wait().await;
+        let _ = (&mut self.task).await;
+        info!("dns proxy stopped");
+    }
+
+    /// Return the port dnsmasq is listening on.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl Drop for DnsProxy {
+    /// Kill dnsmasq and abort the log task if `stop()` was never called.
+    ///
+    /// Prevents orphaned dnsmasq processes when `run_start()` fails after
+    /// `dns::start()` (e.g., runtime creation error). Harmless if `stop()`
+    /// already ran — `start_kill` on an exited child is a no-op.
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+        self.cancel.cancel();
+        self.task.abort();
+    }
+}
+
+/// Find an available UDP port by binding to port 0.
+fn find_available_port() -> std::io::Result<u16> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0")?;
+    Ok(socket.local_addr()?.port())
+}
+
+/// Start dnsmasq and spawn a background task to parse its query log.
+///
+/// dnsmasq listens on a dynamically allocated port and forwards to upstream DNS.
+/// `firewall-placeholder.vm3.ai` is resolved to [`PLACEHOLDER_IP`] so the VM
+/// can connect to it and mitmproxy intercepts via TCP REDIRECT (fixes #7665).
+pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
+    let port = find_available_port()?;
+    let port_str = port.to_string();
+    let address_arg = format!("/firewall-placeholder.vm3.ai/{PLACEHOLDER_IP}");
+
+    let mut child = tokio::process::Command::new("dnsmasq")
+        .args([
+            "--no-daemon",
+            "--no-resolv",
+            "--port",
+            &port_str,
+            "--server",
+            "8.8.8.8",
+            "--server",
+            "8.8.4.4",
+            "--log-queries",
+            "--log-facility=-",
+            "--address",
+            &address_arg,
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    // Give dnsmasq a moment to bind, then verify it's still running.
+    // Catches port-already-in-use, missing binary (spawn itself errors),
+    // and bad config that causes immediate exit.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    match child.try_wait() {
+        Ok(Some(status)) => {
+            return Err(std::io::Error::other(format!(
+                "dnsmasq exited immediately with {status}"
+            )));
+        }
+        Err(e) => {
+            return Err(std::io::Error::other(format!(
+                "dnsmasq process check failed: {e}"
+            )));
+        }
+        Ok(None) => {} // still running — good
+    }
+
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| std::io::Error::other("failed to capture dnsmasq stderr"))?;
+
+    let cancel = CancellationToken::new();
+    let token = cancel.clone();
+    let task = tokio::spawn(async move {
+        if let Err(e) = tail_stderr(stderr, &ip_log_map, token).await {
+            warn!(error = %e, "dns log monitor exited");
+        }
+    });
+
+    info!(port, "dns proxy started");
+    Ok(DnsProxy {
+        cancel,
+        task,
+        child,
+        port,
+    })
+}
+
+/// Tail dnsmasq stderr and write DNS query entries to per-VM network JSONL.
+///
+/// dnsmasq `--log-queries --log-facility=-` outputs lines like:
+/// ```text
+/// dnsmasq[1234]: query[A] api.github.com from 10.200.0.2
+/// dnsmasq[1234]: forwarded api.github.com to 8.8.8.8
+/// dnsmasq[1234]: reply api.github.com is 140.82.121.4
+/// ```
+///
+/// We only parse `query[...]` lines — they contain the domain and source IP.
+async fn tail_stderr(
+    stderr: tokio::process::ChildStderr,
+    ip_log_map: &IpLogMap,
+    cancel: CancellationToken,
+) -> std::io::Result<()> {
+    let mut lines = tokio::io::BufReader::new(stderr).lines();
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            result = lines.next_line() => {
+                let line = match result {
+                    Ok(Some(l)) => l,
+                    Ok(None) => {
+                        if !cancel.is_cancelled() {
+                            warn!("dnsmasq exited unexpectedly (stderr EOF)");
+                        }
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "dnsmasq stderr read error");
+                        break;
+                    }
+                };
+
+                if let Some(entry) = parse_query_line(&line) {
+                    let log_path = {
+                        let map = ip_log_map.lock().await;
+                        map.get(&entry.source_ip).cloned()
+                    };
+                    if let Some(path) = log_path {
+                        write_jsonl(&path, &entry);
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Parsed DNS query entry.
+struct DnsQueryEntry {
+    source_ip: String,
+    domain: String,
+}
+
+/// Parse a dnsmasq query log line.
+///
+/// Matches: `dnsmasq[PID]: query[TYPE] DOMAIN from IP`
+fn parse_query_line(line: &str) -> Option<DnsQueryEntry> {
+    // Find "query[" marker
+    let q_start = line.find("query[")?;
+    let q_end = line[q_start..].find(']')? + q_start;
+
+    // Domain is after "] "
+    let after_bracket = line.get(q_end + 2..)?;
+    let domain_end = after_bracket.find(' ')?;
+    let domain = after_bracket[..domain_end].to_string();
+
+    // Source IP is after " from "
+    let from_pos = after_bracket.find(" from ")?;
+    let ip_start = from_pos + 6;
+    let ip_str = after_bracket.get(ip_start..)?;
+    // IP ends at whitespace or end of string
+    let ip_end = ip_str
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(ip_str.len());
+    let source_ip = ip_str[..ip_end].to_string();
+
+    if source_ip.is_empty() {
+        return None;
+    }
+
+    Some(DnsQueryEntry { source_ip, domain })
+}
+
+/// Append a JSON line to the network log file.
+fn write_jsonl(path: &Path, entry: &DnsQueryEntry) {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    // [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
+    let json = serde_json::json!({
+        "timestamp": Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+        "type": "dns",
+        "host": entry.domain,
+        "port": 53,
+    });
+
+    let mut line = serde_json::to_string(&json).unwrap_or_default();
+    line.push('\n');
+
+    let result = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o644)
+        .open(path)
+        .and_then(|mut f| f.write_all(line.as_bytes()));
+
+    if let Err(e) = result {
+        debug!(path = %path.display(), error = %e, "failed to write dns network log");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_a_query() {
+        let line = "dnsmasq[1234]: query[A] example.com from 10.200.0.2";
+        let entry = parse_query_line(line).unwrap();
+        assert_eq!(entry.source_ip, "10.200.0.2");
+        assert_eq!(entry.domain, "example.com");
+    }
+
+    #[test]
+    fn parse_aaaa_query() {
+        let line = "dnsmasq[5678]: query[AAAA] google.com from 10.200.0.6";
+        let entry = parse_query_line(line).unwrap();
+        assert_eq!(entry.source_ip, "10.200.0.6");
+        assert_eq!(entry.domain, "google.com");
+    }
+
+    #[test]
+    fn parse_mx_query() {
+        let line = "dnsmasq[9999]: query[MX] mail.example.com from 10.200.0.10";
+        let entry = parse_query_line(line).unwrap();
+        assert_eq!(entry.domain, "mail.example.com");
+    }
+
+    #[test]
+    fn parse_txt_query() {
+        let line = "dnsmasq[1111]: query[TXT] _dmarc.example.com from 10.200.0.2";
+        let entry = parse_query_line(line).unwrap();
+        assert_eq!(entry.domain, "_dmarc.example.com");
+    }
+
+    #[test]
+    fn ignore_reply_lines() {
+        let line = "dnsmasq[1234]: reply example.com is 93.184.216.34";
+        assert!(parse_query_line(line).is_none());
+    }
+
+    #[test]
+    fn ignore_forwarded_lines() {
+        let line = "dnsmasq[1234]: forwarded example.com to 8.8.8.8";
+        assert!(parse_query_line(line).is_none());
+    }
+
+    #[test]
+    fn ignore_malformed() {
+        assert!(parse_query_line("").is_none());
+        assert!(parse_query_line("not a dns log").is_none());
+        assert!(parse_query_line("dnsmasq[1]: query[A]").is_none());
+    }
+
+    #[test]
+    fn parse_ip_with_port_suffix() {
+        // Some dnsmasq versions append #port to the source address.
+        let line = "dnsmasq[1234]: query[A] example.com from 10.200.0.2#54321";
+        let entry = parse_query_line(line).unwrap();
+        assert_eq!(entry.source_ip, "10.200.0.2");
+        assert_eq!(entry.domain, "example.com");
+    }
+
+    #[test]
+    fn parse_domain_containing_from() {
+        let line = "dnsmasq[1234]: query[A] from.example.com from 10.200.0.2";
+        let entry = parse_query_line(line).unwrap();
+        assert_eq!(entry.domain, "from.example.com");
+        assert_eq!(entry.source_ip, "10.200.0.2");
+    }
+
+    #[test]
+    fn ignore_ipv6_source() {
+        // VMs use IPv4 only; IPv6 sources should be ignored.
+        let line = "dnsmasq[1234]: query[A] example.com from ::1";
+        assert!(parse_query_line(line).is_none());
+    }
+
+    #[test]
+    fn parse_trailing_carriage_return() {
+        let line = "dnsmasq[1234]: query[A] example.com from 10.200.0.2\r";
+        let entry = parse_query_line(line).unwrap();
+        assert_eq!(entry.source_ip, "10.200.0.2");
+    }
+}

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -25,14 +25,6 @@ use tracing::{debug, info, warn};
 
 use crate::kmsg_log::IpLogMap;
 
-/// IP address that `firewall-placeholder.vm3.ai` resolves to.
-///
-/// This must be a routable (non-loopback) IP so the VM's TCP connection
-/// leaves the VM via TAP and gets caught by the TCP REDIRECT rule to
-/// mitmproxy. The actual value doesn't matter — any routable IP works.
-/// We use TEST-NET-2 (RFC 5737) to make intent obvious.
-const PLACEHOLDER_IP: &str = "198.51.100.1";
-
 /// Handle to the dnsmasq process and its log monitor.
 pub struct DnsProxy {
     cancel: CancellationToken,
@@ -79,12 +71,9 @@ fn find_available_port() -> std::io::Result<u16> {
 /// Start dnsmasq and spawn a background task to parse its query log.
 ///
 /// dnsmasq listens on a dynamically allocated port and forwards to upstream DNS.
-/// `firewall-placeholder.vm3.ai` is resolved to [`PLACEHOLDER_IP`] so the VM
-/// can connect to it and mitmproxy intercepts via TCP REDIRECT (fixes #7665).
 pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
     let port = find_available_port()?;
     let port_str = port.to_string();
-    let address_arg = format!("/firewall-placeholder.vm3.ai/{PLACEHOLDER_IP}");
 
     let mut child = tokio::process::Command::new("dnsmasq")
         .args([
@@ -98,8 +87,6 @@ pub async fn start(ip_log_map: IpLogMap) -> std::io::Result<DnsProxy> {
             "8.8.4.4",
             "--log-queries",
             "--log-facility=-",
-            "--address",
-            &address_arg,
         ])
         .stdout(Stdio::null())
         .stderr(Stdio::piped())

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -132,7 +132,7 @@ async fn execute_inner(
     if let Err(e) = config.registry.register_vm(&source_ip, &registration).await {
         warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");
     }
-    // Register source IP in kmsg log map so non-TCP traffic is logged.
+    // Register source IP in log map so non-TCP and DNS traffic is logged.
     config
         .ip_log_map
         .lock()

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -216,6 +216,7 @@ fn write_jsonl(path: &Path, entry: &LogEntry) {
     use std::io::Write;
     use std::os::unix::fs::OpenOptionsExt;
 
+    // [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
     let json = serde_json::json!({
         "timestamp": Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
         "type": entry.protocol,

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -2,6 +2,7 @@ mod ca;
 mod cmd;
 mod config;
 mod deps;
+mod dns;
 mod error;
 mod executor;
 mod host;

--- a/crates/sandbox-fc/src/config.rs
+++ b/crates/sandbox-fc/src/config.rs
@@ -11,6 +11,8 @@ pub struct FirecrackerConfig {
     pub profile: String,
     /// Port of the HTTP/HTTPS proxy. When set, iptables rules redirect traffic through it.
     pub proxy_port: Option<u16>,
+    /// Port of the DNS proxy. When set, iptables rules redirect DNS queries through it.
+    pub dns_port: Option<u16>,
     /// Snapshot to restore from. When set, VMs boot via snapshot restore instead of fresh boot.
     pub snapshot: Option<SnapshotConfig>,
 }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -211,6 +211,7 @@ impl SandboxFactory for FirecrackerFactory {
             let t = std::time::Instant::now();
             let netns_pool = NetnsPool::create(NetnsPoolConfig {
                 proxy_port: self.config.proxy_port,
+                dns_port: self.config.dns_port,
             })
             .await
             .map_err(|e| SandboxError::CreationFailed(format!("netns pool: {e}")))?;

--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -96,6 +96,8 @@ pub struct PooledNetns {
 pub struct NetnsPoolConfig {
     /// Proxy port for HTTP/HTTPS redirect (only adds redirect rules when set).
     pub proxy_port: Option<u16>,
+    /// DNS proxy port for DNS query redirect (only adds redirect rules when set).
+    pub dns_port: Option<u16>,
 }
 
 // ---------------------------------------------------------------------------
@@ -440,6 +442,85 @@ async fn add_non_tcp_log_rule(name: &str, peer_ip: &str) -> Result<()> {
     Ok(())
 }
 
+/// Redirect all outbound DNS (UDP 53) to the local dnsmasq port.
+///
+/// VM resolv.conf points to an external nameserver as a dummy target.
+/// This PREROUTING REDIRECT intercepts the packet before FORWARD/MASQUERADE,
+/// preserving the original source IP (peer veth) for per-VM log routing.
+async fn add_dns_redirect_rule(name: &str, peer_ip: &str, dns_port: u16) -> Result<()> {
+    let src = format!("{peer_ip}/30");
+    let port_str = dns_port.to_string();
+    exec_iptables(&[
+        "-t",
+        "nat",
+        "-A",
+        "PREROUTING",
+        "-s",
+        &src,
+        "-p",
+        "udp",
+        "--dport",
+        "53",
+        "-j",
+        "REDIRECT",
+        "--to-port",
+        &port_str,
+        "-m",
+        "comment",
+        "--comment",
+        name,
+    ])
+    .await?;
+    Ok(())
+}
+
+/// Drop external DNS traffic that bypasses the REDIRECT rule.
+///
+/// Blocks UDP 53 and TCP 853 (DNS over TLS) in FORWARD chain.
+/// DNS over HTTPS (TCP 443) is handled by mitmproxy at HTTP level.
+async fn add_dns_drop_rules(name: &str, peer_ip: &str) -> Result<()> {
+    let src = format!("{peer_ip}/30");
+    // Block UDP 53 in FORWARD (catches any traffic not caught by PREROUTING REDIRECT)
+    exec_iptables(&[
+        "-I",
+        "FORWARD",
+        "1",
+        "-s",
+        &src,
+        "-p",
+        "udp",
+        "--dport",
+        "53",
+        "-j",
+        "DROP",
+        "-m",
+        "comment",
+        "--comment",
+        name,
+    ])
+    .await?;
+    // Block DNS over TLS (TCP 853)
+    exec_iptables(&[
+        "-I",
+        "FORWARD",
+        "1",
+        "-s",
+        &src,
+        "-p",
+        "tcp",
+        "--dport",
+        "853",
+        "-j",
+        "DROP",
+        "-m",
+        "comment",
+        "--comment",
+        name,
+    ])
+    .await?;
+    Ok(())
+}
+
 async fn get_default_interface() -> Result<String> {
     let result = exec("ip", &["route", "get", "8.8.8.8"]).await?;
     let iface = result
@@ -579,6 +660,7 @@ pub struct NetnsPool {
     next_ns_index: u32,
     pool_index: u32,
     proxy_port: Option<u16>,
+    dns_port: Option<u16>,
     default_iface: String,
     /// Held for the lifetime of the pool to reserve the pool index.
     _lock: Flock<File>,
@@ -622,6 +704,7 @@ impl NetnsPool {
             next_ns_index: 0,
             pool_index: index,
             proxy_port: config.proxy_port,
+            dns_port: config.dns_port,
             default_iface,
             _lock: lock,
         };
@@ -642,11 +725,13 @@ impl NetnsPool {
                     ns_index,
                     default_iface,
                     None,
+                    None,
                 ));
             }
 
             // Proxy namespaces (connectivity + REDIRECT rules).
             if let Some(proxy_port) = pool.proxy_port {
+                let dns_port = pool.dns_port;
                 for _ in 0..BUFFER_SIZE {
                     let ns_index = pool.next_ns_index;
                     pool.next_ns_index += 1;
@@ -657,6 +742,7 @@ impl NetnsPool {
                         ns_index,
                         default_iface,
                         Some(proxy_port),
+                        dns_port,
                     ));
                 }
             }
@@ -739,7 +825,7 @@ impl NetnsPool {
         }
         // Tier 3: on-demand.
         info!("pool exhausted, creating namespace on-demand");
-        let ns = self.create_on_demand(None).await?;
+        let ns = self.create_on_demand(None, None).await?;
         self.maybe_replenish_plain();
         Ok(ns)
     }
@@ -773,13 +859,19 @@ impl NetnsPool {
         }
         // Tier 3: on-demand.
         info!("proxy pool exhausted, creating namespace on-demand");
-        let ns = self.create_on_demand(self.proxy_port).await?;
+        let ns = self
+            .create_on_demand(self.proxy_port, self.dns_port)
+            .await?;
         self.maybe_replenish_proxy();
         Ok(ns)
     }
 
     /// Create a new namespace on-demand, allocating the next index.
-    async fn create_on_demand(&mut self, proxy_port: Option<u16>) -> Result<PooledNetns> {
+    async fn create_on_demand(
+        &mut self,
+        proxy_port: Option<u16>,
+        dns_port: Option<u16>,
+    ) -> Result<PooledNetns> {
         let ns_index = self.next_ns_index;
         if ns_index >= MAX_NAMESPACES {
             return Err(NetworkError::NamespaceLimitReached {
@@ -792,6 +884,7 @@ impl NetnsPool {
             ns_index,
             self.default_iface.clone(),
             proxy_port,
+            dns_port,
         )
         .await
     }
@@ -837,6 +930,7 @@ impl NetnsPool {
             ns_index,
             default_iface,
             None,
+            None,
         ));
     }
 
@@ -858,11 +952,13 @@ impl NetnsPool {
         self.next_ns_index += 1;
         let pool_index = self.pool_index;
         let default_iface = self.default_iface.clone();
+        let dns_port = self.dns_port;
         self.pending_proxy.spawn(create_single_namespace(
             pool_index,
             ns_index,
             default_iface,
             Some(proxy_port),
+            dns_port,
         ));
     }
 
@@ -982,6 +1078,7 @@ async fn create_single_namespace(
     ns_index: u32,
     default_iface: String,
     proxy_port: Option<u16>,
+    dns_port: Option<u16>,
 ) -> Result<PooledNetns> {
     if ns_index >= MAX_NAMESPACES {
         return Err(NetworkError::NamespaceLimitReached {
@@ -1018,6 +1115,18 @@ async fn create_single_namespace(
                 }
                 if let Err(e) = add_non_tcp_log_rule(&ns_name, &peer_ip).await {
                     error!(name = %ns_name, error = %e, "failed to add non-TCP log rule, cleaning up");
+                    delete_namespace_resources(&ns_name, &host_device).await;
+                    return Err(e);
+                }
+            }
+            if let Some(port) = dns_port {
+                if let Err(e) = add_dns_redirect_rule(&ns_name, &peer_ip, port).await {
+                    error!(name = %ns_name, error = %e, "failed to add DNS redirect rule, cleaning up");
+                    delete_namespace_resources(&ns_name, &host_device).await;
+                    return Err(e);
+                }
+                if let Err(e) = add_dns_drop_rules(&ns_name, &peer_ip).await {
+                    error!(name = %ns_name, error = %e, "failed to add DNS drop rules, cleaning up");
                     delete_namespace_resources(&ns_name, &host_device).await;
                     return Err(e);
                 }

--- a/crates/sandbox-fc/src/runtime.rs
+++ b/crates/sandbox-fc/src/runtime.rs
@@ -22,6 +22,7 @@ pub struct FirecrackerRuntime {
     netns_pool: Arc<tokio::sync::Mutex<NetnsPool>>,
     device_pool: Arc<tokio::sync::Mutex<DevicePool>>,
     proxy_port: Option<u16>,
+    dns_port: Option<u16>,
 }
 
 impl FirecrackerRuntime {
@@ -34,6 +35,7 @@ impl FirecrackerRuntime {
         let t = std::time::Instant::now();
         let netns_pool = NetnsPool::create(NetnsPoolConfig {
             proxy_port: config.proxy_port,
+            dns_port: config.dns_port,
         })
         .await
         .map_err(|e| SandboxError::CreationFailed(format!("netns pool: {e}")))?;
@@ -54,6 +56,7 @@ impl FirecrackerRuntime {
             netns_pool: Arc::new(tokio::sync::Mutex::new(netns_pool)),
             device_pool: Arc::new(tokio::sync::Mutex::new(device_pool)),
             proxy_port: config.proxy_port,
+            dns_port: config.dns_port,
         })
     }
 
@@ -66,6 +69,7 @@ impl FirecrackerRuntime {
             base_dir: config.base_dir,
             profile: config.profile,
             proxy_port: self.proxy_port,
+            dns_port: self.dns_port,
             snapshot,
         }
     }

--- a/crates/sandbox-fc/src/snapshot.rs
+++ b/crates/sandbox-fc/src/snapshot.rs
@@ -129,9 +129,12 @@ pub async fn create_snapshot(
     info!(device = %cow_device.device_path().display(), "NBD COW device created");
 
     // 3. Create network namespace (pool of 1, index auto-allocated via flock).
-    let mut netns_pool = NetnsPool::create(NetnsPoolConfig { proxy_port: None })
-        .await
-        .map_err(|e| SnapshotError::Setup(format!("netns pool: {e}")))?;
+    let mut netns_pool = NetnsPool::create(NetnsPoolConfig {
+        proxy_port: None,
+        dns_port: None,
+    })
+    .await
+    .map_err(|e| SnapshotError::Setup(format!("netns pool: {e}")))?;
 
     // Guard: ensure netns cleanup on any exit path.
     let result = run_snapshot_workflow(

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -367,7 +367,10 @@ mod tests {
     async fn runtime_provider_creates_runtime() {
         let provider = MockRuntimeProvider;
         let mut runtime = provider
-            .create_runtime(RuntimeConfig { proxy_port: None })
+            .create_runtime(RuntimeConfig {
+                proxy_port: None,
+                dns_port: None,
+            })
             .await
             .unwrap();
         runtime.shutdown().await;

--- a/crates/sandbox/src/config.rs
+++ b/crates/sandbox/src/config.rs
@@ -39,4 +39,6 @@ pub struct FactoryConfig {
 pub struct RuntimeConfig {
     /// Proxy port for network traffic interception. Shared across all factories.
     pub proxy_port: Option<u16>,
+    /// DNS proxy port for DNS query interception. Shared across all factories.
+    pub dns_port: Option<u16>,
 }

--- a/e2e/tests/03-runner/t45-vm0-network-logging.bats
+++ b/e2e/tests/03-runner/t45-vm0-network-logging.bats
@@ -4,8 +4,9 @@
 #
 # TCP: All outbound TCP is redirected through mitmproxy (transparent mode).
 #      Non-HTTP TCP (e.g. SSH) passes through as raw TCP.
+# DNS: Queries intercepted via iptables REDIRECT to dnsmasq, logged as type "dns".
 # Non-TCP: Logged via iptables LOG + /dev/kmsg (UDP, ICMP, etc).
-# Both types are written to the same per-run network JSONL file.
+# All types are written to the same per-run network JSONL file.
 
 load '../../helpers/setup'
 
@@ -66,19 +67,15 @@ EOF
     wait_for_log "$RUN_ID" --network -- "TCP" ":22" ":443"
 }
 
-@test "t45-1: udp dns queries appear in network logs" {
+@test "t45-1: dns queries logged via dnsmasq" {
     create_agent
 
-    # Run a command that triggers both UDP and HTTP (TCP) traffic.
-    # python3 sends a raw UDP DNS query to 8.8.8.8:53; curl makes an HTTP request.
-    # Both should appear in the same network log file.
-    # Note: dig/nslookup are not available in the sandbox image.
+    # DNS queries are intercepted by iptables REDIRECT to dnsmasq and logged
+    # as type "dns". getent triggers a standard libc DNS lookup.
     run $VM0_CLI run "$AGENT_NAME" \
         --artifact-name "$ARTIFACT_NAME" \
-        "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.sendto(b'\\x00\\x01\\x01\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x07example\\x03com\\x00\\x00\\x01\\x00\\x01',('8.8.8.8',53)); s.recv(512); s.close(); print('UDP_OK=true')\" && curl -s -o /dev/null -w 'HTTP=%{http_code}' https://example.com"
+        "getent hosts example.com"
     assert_success
-    assert_output --partial "UDP_OK=true"
-    assert_output --partial "HTTP=200"
 
     RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
     [ -n "$RUN_ID" ] || {
@@ -86,8 +83,29 @@ EOF
         return 1
     }
 
-    # Verify network logs contain HTTP and UDP entries.
-    # formatNetworkOther renders: [timestamp] UDP   <size> <host>:<port>
-    # DNS uses port 53, so match both the protocol and port.
-    wait_for_log "$RUN_ID" --network -- "example.com" "UDP" ":53"
+    # Verify network logs contain DNS entries.
+    # DNS entries render as: [timestamp] DNS   example.com:53
+    wait_for_log "$RUN_ID" --network -- "example.com" "DNS" ":53"
+}
+
+@test "t45-2: non-dns udp appears in network logs" {
+    create_agent
+
+    # Send a UDP packet to a non-DNS port (port 9999) to verify that
+    # non-DNS UDP traffic is still logged via iptables LOG + /dev/kmsg.
+    # DNS (UDP 53) is redirected to dnsmasq, but other UDP goes through FORWARD.
+    run $VM0_CLI run "$AGENT_NAME" \
+        --artifact-name "$ARTIFACT_NAME" \
+        "python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_DGRAM); s.sendto(b'hello',('8.8.8.8',9999)); s.close(); print('UDP_SENT=true')\""
+    assert_success
+    assert_output --partial "UDP_SENT=true"
+
+    RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
+    [ -n "$RUN_ID" ] || {
+        echo "# Failed to extract Run ID"
+        return 1
+    }
+
+    # UDP entries render as: [timestamp] UDP   <size> 8.8.8.8:9999
+    wait_for_log "$RUN_ID" --network -- "UDP" ":9999"
 }

--- a/turbo/apps/cli/src/commands/logs/index.ts
+++ b/turbo/apps/cli/src/commands/logs/index.ts
@@ -156,16 +156,16 @@ function formatNetworkTcp(entry: NetworkLogEntry): string {
 }
 
 /**
- * Format a non-TCP/non-HTTP log entry (UDP, ICMP, etc).
- * These come from iptables LOG via /dev/kmsg, not mitmproxy.
+ * Format a non-TCP/non-HTTP log entry (UDP, ICMP, DNS, etc).
+ * These come from iptables LOG via /dev/kmsg or dnsmasq query log.
  */
 function formatNetworkOther(entry: NetworkLogEntry): string {
   const proto = (entry.type || "???").toUpperCase();
   const host = entry.host || "unknown";
   const port = entry.port || 0;
-  const size = entry.request_size || 0;
+  const size = entry.request_size ? ` ${formatBytes(entry.request_size)}` : "";
 
-  return `[${entry.timestamp}] ${chalk.magenta(proto.padEnd(5))} ${formatBytes(size)} ${chalk.dim(`${host}:${port}`)}`;
+  return `[${entry.timestamp}] ${chalk.magenta(proto.padEnd(5))}${size} ${chalk.dim(`${host}:${port}`)}`;
 }
 
 /**

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -72,6 +72,9 @@ function typeColor(type: string): string {
   if (type === "UDP" || type === "ICMP") {
     return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400";
   }
+  if (type === "DNS") {
+    return "bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400";
+  }
   if (type === "DENY") {
     return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
   }


### PR DESCRIPTION
## Summary
- Spawn a per-runner dnsmasq instance that intercepts all VM DNS queries via iptables PREROUTING REDIRECT, enabling domain-level DNS logging in per-VM network JSONL
- Defense-in-depth: FORWARD DROP rules block direct DNS (UDP 53) and DNS-over-TLS (TCP 853) bypass
- CLI and web frontend support `type: "dns"` network log entries with proper formatting and color

## Changes
- `crates/runner/src/dns.rs` — new module: dnsmasq lifecycle, stderr query log parsing, JSONL writing
- `crates/sandbox-fc/src/network/pool.rs` — DNS REDIRECT + FORWARD DROP iptables rules per namespace
- `crates/runner/scripts/build-rootfs.sh` — single dummy nameserver for REDIRECT interception
- `crates/runner/src/cmd/start.rs` — DNS proxy integration into runner lifecycle
- `turbo/apps/cli/src/commands/logs/index.ts` — format DNS entries, hide 0B for entries without request_size
- `turbo/apps/platform/src/views/zero-page/components/network-content.tsx` — teal badge for DNS type
- `ansible/playbooks/provision-runner.yml` — install dnsmasq, disable system service
- `.github/workflows/crates.yml` — CI test: DNS resolution with `getent hosts`
- `e2e/tests/03-runner/t45-vm0-network-logging.bats` — DNS and non-DNS UDP e2e tests

## Test plan
- [x] 11 unit tests for dnsmasq log line parsing (A/AAAA/MX/TXT, #port suffix, IPv6 filter, domain containing "from", trailing \r, malformed input)
- [ ] CI Test 6: DNS resolution inside sandbox via `getent hosts`
- [ ] e2e t45-1: DNS queries logged via dnsmasq
- [ ] e2e t45-2: non-DNS UDP appears in network logs
- [ ] e2e t45-0: non-HTTP TCP still passes through mitmproxy

Closes #7861

🤖 Generated with [Claude Code](https://claude.com/claude-code)