### PR TITLE
test(platform): add markdown display tests

### DIFF
--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { setTheme$ } from "../../../signals/theme.ts";
+
+const context = testContext();
+
+const THREAD_BASE = {
+  title: null,
+  agentId: "c0000000-0000-4000-a000-000000000001",
+  latestSessionId: null,
+  unsavedRuns: [],
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+} as const;
+
+describe("chat-d-064: markdown content renders from props", () => {
+  it("should parse markdown and render as formatted HTML", async () => {
+    server.use(
+      http.get("*/api/zero/chat-threads/:id", () => {
+        return HttpResponse.json({
+          id: "thread-markdown",
+          ...THREAD_BASE,
+          chatMessages: [
+            {
+              role: "assistant",
+              content: "**bold text**",
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/chats/thread-markdown" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("bold text", { selector: "strong, b" }),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("chat-d-065: theme signal applied to markdown rendering", () => {
+  it("should apply theme from theme$ signal as data-color-mode on the markdown wrapper", async () => {
+    server.use(
+      http.get("*/api/zero/chat-threads/:id", () => {
+        return HttpResponse.json({
+          id: "thread-theme",
+          ...THREAD_BASE,
+          chatMessages: [
+            {
+              role: "assistant",
+              content: "hello",
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/chats/thread-theme" });
+
+    await waitFor(() => {
+      expect(screen.getByText("hello")).toBeInTheDocument();
+    });
+
+    context.store.set(setTheme$, "dark");
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-color-mode="dark"]'),
+      ).toBeInTheDocument();
+    });
+
+    context.store.set(setTheme$, "light");
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-color-mode="light"]'),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add test file `turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx` covering CHAT-D-064 and CHAT-D-065
- CHAT-D-064: Verifies that markdown strings (e.g. `**bold text**`) are parsed and rendered as formatted HTML (`<strong>` elements) through the real router at `/chats/:id`
- CHAT-D-065: Verifies that the `theme$` signal value is applied to the markdown wrapper as `data-color-mode` attribute, and responds reactively to signal changes

## Test plan

- [x] Both tests pass with `pnpm vitest run`
- [x] No `vi.mock()` for internal modules — only MSW for HTTP mocking
- [x] No `eslint-disable` or `ts-ignore`
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes (`pnpm check-types`)
- [x] Knip passes (no unused exports/dependencies)

Closes #7934

🤖 Generated with [Claude Code](https://claude.com/claude-code)