### PR TITLE
test(platform): add tests for zero-works-page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -71,7 +71,9 @@ describe("works page - slack integration status display", () => {
     await renderWorksPage();
 
     await waitFor(() => {
-      expect(screen.getByText("Connected")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("slack-connected-indicator"),
+      ).toBeInTheDocument();
     });
   });
 
@@ -172,8 +174,12 @@ describe("works page - more options dropdown", () => {
     await user.click(screen.getByRole("button", { name: "More options" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Disconnect")).toBeInTheDocument();
-      expect(screen.getByText("Uninstall")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Disconnect" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Uninstall" }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -191,9 +197,11 @@ describe("works page - more options dropdown", () => {
     await user.click(screen.getByRole("button", { name: "More options" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Uninstall")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Uninstall" }),
+      ).toBeInTheDocument();
     });
-    await user.click(screen.getByText("Uninstall"));
+    await user.click(screen.getByRole("button", { name: "Uninstall" }));
 
     const dialog = await screen.findByRole("dialog");
     expect(
@@ -230,9 +238,11 @@ describe("works page - more options dropdown", () => {
     await user.click(screen.getByRole("button", { name: "More options" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Disconnect")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Disconnect" }),
+      ).toBeInTheDocument();
     });
-    await user.click(screen.getByText("Disconnect"));
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
 
     await waitFor(() => {
       expect(disconnectCalled).toBeTruthy();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * Display, conditional, and interaction tests for the /works page (ZeroWorksPage component).
+ *
+ * Tests Slack integration status, buttons, dropdown, dialogs, and API calls via setupPage
+ * following platform testing principles:
+ * - Entry point: setupPage({ path: "/works" })
+ * - Mock (external): HTTP via MSW
+ * - Real (internal): All signals, components, rendering
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function mockSlackAPI(overrides: Record<string, unknown> = {}) {
+  const defaults = {
+    isConnected: false,
+    isInstalled: false,
+    isAdmin: false,
+    installUrl: null,
+    connectUrl: null,
+    reinstallUrl: null,
+    scopeMismatch: false,
+    workspaceName: null,
+    defaultAgentId: null,
+    agentOrgSlug: null,
+    environment: {
+      requiredSecrets: [],
+      requiredVars: [],
+      missingSecrets: [],
+      missingVars: [],
+    },
+  };
+  server.use(
+    http.get("*/api/zero/integrations/slack", () => {
+      return HttpResponse.json({ ...defaults, ...overrides });
+    }),
+  );
+}
+
+async function renderWorksPage() {
+  await setupPage({ context, path: "/works" });
+}
+
+describe("works page - slack integration status display", () => {
+  it("renders the Slack integration card on the works page (CONN-D-058)", async () => {
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    await renderWorksPage();
+
+    // When data is loaded and the user is connected+admin, the More options button
+    // appears — confirming the Slack card rendered with integration status.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "More options" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows a connected indicator when Slack is connected (CONN-D-059)", async () => {
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: false });
+    await renderWorksPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Connected")).toBeInTheDocument();
+    });
+  });
+
+  it("shows permissions update alert when scope mismatch exists (CONN-D-061)", async () => {
+    mockSlackAPI({
+      isConnected: true,
+      isInstalled: true,
+      isAdmin: true,
+      scopeMismatch: true,
+      reinstallUrl: "https://slack.com/oauth/reinstall?state=xyz",
+    });
+    await renderWorksPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /update permissions/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("works page - install and connect button visibility", () => {
+  it("shows Install to Slack button when not installed and user is admin (CONN-C-060)", async () => {
+    mockSlackAPI({
+      isConnected: false,
+      isInstalled: false,
+      isAdmin: true,
+      installUrl: "https://slack.com/oauth/install?state=abc",
+    });
+    await renderWorksPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /install to slack/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows Connect button when installed but not connected (CONN-C-060)", async () => {
+    mockSlackAPI({
+      isConnected: false,
+      isInstalled: true,
+      isAdmin: false,
+      connectUrl: "https://slack.com/oauth/connect?state=xyz",
+    });
+    await renderWorksPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^connect$/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("works page - install to slack interaction", () => {
+  it("clicking Install to Slack opens the install OAuth URL in a new tab (CONN-I-062)", async () => {
+    const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => {
+      return null;
+    });
+
+    mockSlackAPI({
+      isConnected: false,
+      isInstalled: false,
+      isAdmin: true,
+      installUrl: "https://slack.com/oauth/install?state=abc",
+    });
+    await renderWorksPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /install to slack/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /install to slack/i }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining("slack.com/oauth/install"),
+      "_blank",
+    );
+  });
+});
+
+describe("works page - more options dropdown", () => {
+  it("more options popover contains Disconnect and Uninstall items (CONN-I-063)", async () => {
+    const user = userEvent.setup();
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    await renderWorksPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "More options" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "More options" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Disconnect")).toBeInTheDocument();
+      expect(screen.getByText("Uninstall")).toBeInTheDocument();
+    });
+  });
+
+  it("clicking Uninstall opens confirmation dialog with Cancel and Uninstall buttons (CONN-I-064)", async () => {
+    const user = userEvent.setup();
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    await renderWorksPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "More options" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "More options" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Uninstall")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Uninstall"));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(
+      within(dialog).getByRole("button", { name: /cancel/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("button", { name: /uninstall/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking Disconnect calls the disconnect API (CONN-I-066)", async () => {
+    const user = userEvent.setup();
+    let disconnectCalled = false;
+
+    mockSlackAPI({ isConnected: true, isInstalled: true, isAdmin: true });
+    server.use(
+      http.delete("*/api/zero/integrations/slack", ({ request }) => {
+        const url = new URL(request.url);
+        if (!url.searchParams.get("action")) {
+          disconnectCalled = true;
+        }
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    await renderWorksPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "More options" }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "More options" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Disconnect")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Disconnect"));
+
+    await waitFor(() => {
+      expect(disconnectCalled).toBeTruthy();
+    });
+  });
+});
+
+describe("works page - update permissions interaction", () => {
+  it("clicking Update Permissions opens the reinstall OAuth URL in a new tab (CONN-I-065)", async () => {
+    const user = userEvent.setup();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => {
+      return null;
+    });
+
+    mockSlackAPI({
+      isConnected: true,
+      isInstalled: true,
+      isAdmin: true,
+      scopeMismatch: true,
+      reinstallUrl: "https://slack.com/oauth/reinstall?state=xyz",
+    });
+    await renderWorksPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /update permissions/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /update permissions/i }),
+    );
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining("slack.com/oauth/reinstall"),
+      "_blank",
+    );
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-works-page.tsx
@@ -58,7 +58,10 @@ function SlackCardActions({
   return (
     <>
       {isConnected ? (
-        <span className="shrink-0 inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground">
+        <span
+          data-testid="slack-connected-indicator"
+          className="shrink-0 inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-1.5 py-1 text-xs font-medium text-secondary-foreground"
+        >
           <IconCircleCheck className="h-3 w-3 text-green-600" />
           Connected
         </span>
@@ -106,6 +109,7 @@ function SlackCardActions({
             {isConnected && (
               <button
                 type="button"
+                aria-label="Disconnect"
                 className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-left hover:bg-accent hover:text-accent-foreground transition-colors"
                 onClick={onDisconnect}
               >
@@ -115,6 +119,7 @@ function SlackCardActions({
             {isAdmin && (
               <button
                 type="button"
+                aria-label="Uninstall"
                 className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-left text-destructive hover:bg-accent hover:text-accent-foreground transition-colors"
                 onClick={onUninstall}
               >


### PR DESCRIPTION
## Summary

- Adds 10 integration tests for `ZeroWorksPage` at `turbo/apps/platform/src/views/zero-page/__tests__/zero-works-page.test.tsx`
- Covers CONN-D-058 through CONN-I-066: Slack status display, connected indicator, Install/Connect button visibility, permissions update alert, OAuth flows, more options dropdown, uninstall dialog, and disconnect API call
- Uses `setupPage({ path: "/works" })` through the real router with MSW for HTTP mocking

## Test plan

- [x] All 10 `it()` blocks pass locally
- [x] No `vi.mock()` for internal modules — only MSW for HTTP
- [x] No `eslint-disable` or `ts-ignore`
- [x] `vi.clearAllMocks()` in `beforeEach`
- [x] No CSS class assertions (AP-8 compliant)
- [x] No static copy assertions (AP-7 compliant)
- [x] Lint passes with zero errors
- [x] TypeScript type-checks pass

Closes #7939

🤖 Generated with [Claude Code](https://claude.com/claude-code)