### PR TITLE
style(platform): unify card styles and add hover states

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-add-provider-dialog.tsx
@@ -1,4 +1,5 @@
 import { useLastResolved, useSet } from "ccstate-react";
+import { IconPlus } from "@tabler/icons-react";
 import {
   Dialog,
   DialogContent,
@@ -31,29 +32,28 @@ function ProviderCardInDialog({
     <button
       type="button"
       onClick={onAdd}
-      className="flex flex-col gap-3 rounded-xl zero-border bg-card p-4 text-left transition-colors hover:bg-muted/50"
+      className="rounded-lg bg-card overflow-hidden transition-colors hover:bg-muted/30 cursor-pointer text-left w-full"
+      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
       data-testid={`org-provider-card-${type}`}
     >
-      <div className="flex items-center gap-3">
-        <div className="shrink-0">
-          <ProviderIcon type={type} size={28} />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="text-sm font-medium text-foreground truncate">
-            {label}
-          </div>
-        </div>
-      </div>
-      {description && (
-        <div className="text-xs text-muted-foreground line-clamp-2">
-          {description}
-        </div>
-      )}
-      <div className="mt-auto">
-        <span className="w-full h-8 rounded-lg zero-chip px-3 text-sm font-medium text-foreground transition-colors text-center flex items-center justify-center">
-          Add
+      <div className="flex items-center gap-2.5 px-4 pt-4 pb-1">
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+          <ProviderIcon type={type} size={20} />
+        </span>
+        <span className="min-w-0 flex-1 text-sm font-medium text-foreground truncate">
+          {label}
+        </span>
+        <span className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md border border-border/60 text-muted-foreground">
+          <IconPlus size={14} stroke={1.5} />
         </span>
       </div>
+      {description && (
+        <div className="px-4 pb-4 pt-1">
+          <div className="text-xs text-muted-foreground line-clamp-2">
+            {description}
+          </div>
+        </div>
+      )}
     </button>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
+++ b/turbo/apps/platform/src/views/zero-page/tiptap-instructions-editor.tsx
@@ -210,7 +210,7 @@ export function TiptapInstructionsEditor({
 
   return (
     <div
-      className={`relative rounded-xl zero-border bg-card transition-colors focus-within:border-primary ${disabled ? "opacity-60 pointer-events-none" : ""}`}
+      className={`zero-card relative transition-colors focus-within:border-primary ${disabled ? "opacity-60 pointer-events-none" : ""}`}
     >
       {editor && (
         <BubbleMenu

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -189,9 +189,14 @@ function AddConnectorsDialog({
           <div className="grid grid-cols-2 gap-3">
             {filtered.map((item) => {
               return (
-                <div
+                <button
+                  type="button"
                   key={item.type}
-                  className="rounded-lg bg-card overflow-hidden"
+                  onClick={() => {
+                    return onSelect(item.type);
+                  }}
+                  disabled={pollingType === item.type}
+                  className="rounded-lg bg-card overflow-hidden transition-colors hover:bg-muted/30 cursor-pointer text-left w-full"
                   style={{ border: "0.7px solid hsl(var(--gray-400))" }}
                 >
                   <div className="flex items-center gap-2.5 px-4 pt-4 pb-1">
@@ -219,16 +224,9 @@ function AddConnectorsDialog({
                         className="shrink-0 text-muted-foreground animate-spin"
                       />
                     ) : (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          return onSelect(item.type);
-                        }}
-                        className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md border border-border/60 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                        aria-label={`Connect ${item.label}`}
-                      >
+                      <span className="shrink-0 flex h-7 w-7 items-center justify-center rounded-md border border-border/60 text-muted-foreground">
                         <IconPlus size={14} stroke={1.5} />
-                      </button>
+                      </span>
                     )}
                   </div>
                   <div className="px-4 pb-4 pt-1">
@@ -236,7 +234,7 @@ function AddConnectorsDialog({
                       {item.helpText ?? ""}
                     </div>
                   </div>
-                </div>
+                </button>
               );
             })}
           </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -196,6 +196,7 @@ function AddConnectorsDialog({
                     return onSelect(item.type);
                   }}
                   disabled={pollingType === item.type}
+                  aria-label={`Connect ${item.label}`}
                   className="rounded-lg bg-card overflow-hidden transition-colors hover:bg-muted/30 cursor-pointer text-left w-full"
                   style={{ border: "0.7px solid hsl(var(--gray-400))" }}
                 >

--- a/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-connectors-page.tsx
@@ -116,10 +116,7 @@ function GlobalConnectorCard({
   })();
 
   return (
-    <div
-      className="flex flex-col rounded-[var(--zero-card-radius)] bg-card shadow-[var(--zero-card-shadow)]"
-      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-    >
+    <div className="zero-card flex flex-col">
       <div className="flex h-14 items-center gap-2.5 px-5">
         <span className="flex h-5 w-5 shrink-0 items-center justify-center">
           {connector.type in CONNECTOR_TYPES ? (
@@ -172,10 +169,7 @@ function AvailableConnectorCard({
   onConnect: () => void;
 }) {
   return (
-    <div
-      className="rounded-[var(--zero-card-radius)] bg-card overflow-hidden"
-      style={{ border: "0.7px solid hsl(var(--gray-400))" }}
-    >
+    <div className="zero-card cursor-pointer overflow-hidden">
       <div className="flex items-center gap-2.5 px-5 pt-4 pb-1">
         <span className="flex h-5 w-5 shrink-0 items-center justify-center">
           {connector.type in CONNECTOR_TYPES ? (
@@ -395,7 +389,7 @@ export function ZeroConnectorsPage() {
                 return (
                   <div
                     key={i}
-                    className="flex flex-col rounded-[var(--zero-card-radius)] border border-border/50 bg-card animate-pulse"
+                    className="zero-card flex flex-col animate-pulse"
                   >
                     <div className="flex h-14 items-center gap-2.5 px-5">
                       <span className="h-5 w-5 shrink-0 rounded-lg bg-muted/50" />

--- a/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-job-detail-page.tsx
@@ -494,7 +494,7 @@ function JobPermissionsTab({
   if (allTypesLoadable.state !== "hasData" || connectorsLoading) {
     return (
       <div className="mx-auto max-w-[900px]">
-        <div className="rounded-[var(--zero-card-radius)] border-[0.7px] border-[hsl(var(--gray-400))] bg-card animate-pulse">
+        <div className="zero-card animate-pulse">
           {Array.from({ length: 4 }, (_, i) => {
             return (
               <div
@@ -521,7 +521,7 @@ function JobPermissionsTab({
   return (
     <div className="mx-auto max-w-[900px] flex flex-col gap-4">
       {connectedConnectors.length === 0 ? (
-        <div className="rounded-[var(--zero-card-radius)] border-[0.7px] border-[hsl(var(--gray-400))] bg-card py-8 text-center">
+        <div className="zero-card py-8 text-center">
           <p className="text-sm text-muted-foreground">
             No connected services yet. Head to the{" "}
             <Link
@@ -535,7 +535,7 @@ function JobPermissionsTab({
         </div>
       ) : (
         <>
-          <div className="rounded-[var(--zero-card-radius)] border-[0.7px] border-[hsl(var(--gray-400))] bg-card">
+          <div className="zero-card">
             <div className="relative border-b border-border/50">
               <div
                 className={cn(


### PR DESCRIPTION
## Summary
- Replace manual border/radius/bg-card patterns with `zero-card` class for consistent shadow (connectors page, job detail permissions, instructions editor)
- Add hover state to connector and provider dialog cards
- Make entire card clickable in connector and provider dialogs (not just the + icon)
- Unify provider dialog card layout to match connector dialog pattern

## Test plan
- [ ] Verify connector cards on connectors page have shadow and hover state
- [ ] Verify instructions editor card has shadow
- [ ] Verify authorization tab cards have shadow
- [ ] Verify connector dialog cards are fully clickable with hover effect
- [ ] Verify provider dialog cards match connector dialog style and are fully clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)