### PR TITLE
test(platform): add views tests for grouped-message-card

### DIFF
--- a/turbo/apps/platform/src/views/activity/__tests__/grouped-message-card.test.tsx
+++ b/turbo/apps/platform/src/views/activity/__tests__/grouped-message-card.test.tsx
@@ -1,0 +1,534 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  loadInspectLogFile$,
+  setInspectStepSearch$,
+  type InspectLogData,
+} from "../../../signals/activity-page/inspect-log-signals.ts";
+import type { InspectLogMeta } from "../../../signals/activity-page/inspect-log-parser.ts";
+import type { AgentEvent } from "../../../signals/zero-page/log-types.ts";
+
+const context = testContext();
+
+function makeInspectData(events: AgentEvent[]): InspectLogData {
+  return {
+    meta: {
+      id: "a8000000-0000-4000-8000-000000000001",
+      displayName: "GroupedCard Test Agent",
+      status: "completed",
+      triggerSource: "web",
+      triggerAgentName: null,
+      modelProvider: null,
+      selectedModel: null,
+      framework: "claude-code",
+      error: null,
+      scheduleId: null,
+      prompt: "",
+      appendSystemPrompt: null,
+      createdAt: "2026-03-10T14:00:00Z",
+      startedAt: "2026-03-10T14:00:01Z",
+      completedAt: "2026-03-10T14:00:10Z",
+    } satisfies InspectLogMeta,
+    events,
+    context: null,
+    networkLogs: null,
+  };
+}
+
+async function loadInspectData(data: InspectLogData): Promise<void> {
+  const json = JSON.stringify({ meta: data.meta, events: data.events });
+  const file = new File([json], "test.json", { type: "application/json" });
+  await context.store.set(loadInspectLogFile$, file, context.signal);
+}
+
+async function renderInspectPage(): Promise<void> {
+  await setupPage({ context, path: "/activities/inspect" });
+}
+
+describe("groupedMessageCard", () => {
+  // ACT-D-065
+  it("formats and displays message timestamp", async () => {
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [{ type: "text", text: "Timestamp test message" }],
+            },
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+      ]),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Timestamp test message")).toBeInTheDocument();
+    });
+
+    // formatEventTime("2026-03-10T14:56:02Z") → "Mar 10, HH:MM:SS" (past date)
+    const timestampElements = document.querySelectorAll(
+      ".text-xs.text-muted-foreground",
+    );
+    const hasTimestamp = Array.from(timestampElements).some((el) => {
+      return el.textContent?.match(/Mar 10/);
+    });
+    expect(hasTimestamp).toBeTruthy();
+  });
+
+  // ACT-D-066
+  it("renders text sections for assistant messages", async () => {
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [{ type: "text", text: "First text section" }],
+            },
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+        {
+          sequenceNumber: 1,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [{ type: "text", text: "Second text section" }],
+            },
+          },
+          createdAt: "2026-03-10T14:56:03Z",
+        },
+      ]),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("First text section")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Second text section")).toBeInTheDocument();
+  });
+
+  // ACT-D-067
+  it("renders todo items with their completion status icons", async () => {
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tu-todo-067",
+                  name: "TodoWrite",
+                  input: {
+                    todos: [
+                      { content: "Completed task", status: "completed" },
+                      { content: "In progress task", status: "in_progress" },
+                      { content: "Pending task", status: "pending" },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+      ]),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Todo")).toBeInTheDocument();
+    });
+
+    // Open the details to see all items
+    const details = document.querySelector("details") as HTMLDetailsElement;
+    expect(details).not.toBeNull();
+    details.open = true;
+
+    await waitFor(() => {
+      expect(screen.getByText("Completed task")).toBeInTheDocument();
+      // "In progress task" appears in summary + expanded list — use getAllByText
+      expect(screen.getAllByText("In progress task").length).toBeGreaterThan(0);
+      expect(screen.getByText("Pending task")).toBeInTheDocument();
+    });
+  });
+
+  // ACT-D-068
+  it("renders completedCount/totalCount progress indicator", async () => {
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tu-todo-068",
+                  name: "TodoWrite",
+                  input: {
+                    todos: [
+                      { content: "Done A", status: "completed" },
+                      { content: "Done B", status: "completed" },
+                      { content: "Current task", status: "in_progress" },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+      ]),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("[2/3]")).toBeInTheDocument();
+    });
+  });
+
+  // ACT-D-069
+  it("renders current in-progress task content", async () => {
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tu-todo-069",
+                  name: "TodoWrite",
+                  input: {
+                    todos: [
+                      { content: "First completed task", status: "completed" },
+                      {
+                        content: "Currently running task",
+                        status: "in_progress",
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+      ]),
+    );
+
+    await waitFor(() => {
+      // Content appears in the summary line (inProgressTask.content)
+      expect(
+        screen.getAllByText("Currently running task").length,
+      ).toBeGreaterThan(0);
+    });
+  });
+
+  // ACT-D-070
+  it("renders tool operations and their results", async () => {
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tu-bash-070",
+                  name: "Bash",
+                  input: { command: "echo hello-070" },
+                },
+              ],
+            },
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+        {
+          sequenceNumber: 1,
+          eventType: "user",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "tu-bash-070",
+                  content: "hello-070",
+                  is_error: false,
+                },
+              ],
+            },
+            tool_use_result: { durationMs: 50, bytes: 9 },
+          },
+          createdAt: "2026-03-10T14:56:03Z",
+        },
+      ]),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Bash")).toBeInTheDocument();
+    });
+
+    // Open the tool summary details to see result
+    const toolSummary = screen.getByTestId(
+      "tool-summary",
+    ) as HTMLDetailsElement;
+    toolSummary.open = true;
+
+    await waitFor(() => {
+      expect(screen.getByText("hello-070")).toBeInTheDocument();
+    });
+  });
+
+  // ACT-D-071
+  it("highlights search matches in tool key parameters", async () => {
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tu-bash-071",
+                  name: "Bash",
+                  input: { command: "unique-search-term-071" },
+                },
+              ],
+            },
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+      ]),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Bash")).toBeInTheDocument();
+    });
+
+    // Set search term — this opens tool summary (hasSearchMatch=true) and highlights matches
+    context.store.set(setInspectStepSearch$, "unique-search-term-071");
+
+    await waitFor(() => {
+      const marks = document.querySelectorAll("mark");
+      expect(marks.length).toBeGreaterThan(0);
+    });
+
+    // Tool summary details auto-opens on search match
+    const toolSummary = screen.getByTestId(
+      "tool-summary",
+    ) as HTMLDetailsElement;
+    expect(toolSummary.open).toBeTruthy();
+  });
+
+  // ACT-D-072
+  it("renders appropriate status dots based on message state", async () => {
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tu-todo-072",
+                  name: "TodoWrite",
+                  input: {
+                    todos: [{ content: "Task A", status: "in_progress" }],
+                  },
+                },
+              ],
+            },
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+        {
+          sequenceNumber: 1,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tu-bash-072",
+                  name: "Bash",
+                  input: { command: "echo success" },
+                },
+              ],
+            },
+          },
+          createdAt: "2026-03-10T14:56:03Z",
+        },
+        {
+          sequenceNumber: 2,
+          eventType: "user",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "tu-bash-072",
+                  content: "success",
+                  is_error: false,
+                },
+              ],
+            },
+            tool_use_result: { durationMs: 10, bytes: 7 },
+          },
+          createdAt: "2026-03-10T14:56:04Z",
+        },
+      ]),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Todo")).toBeInTheDocument();
+    });
+
+    // Todo card has "todo" variant status dot
+    expect(document.querySelector('[data-variant="todo"]')).toBeInTheDocument();
+
+    // Bash with result has "success" variant
+    expect(
+      document.querySelector('[data-variant="success"]'),
+    ).toBeInTheDocument();
+  });
+
+  // ACT-D-073
+  it("expands and collapses todo section on click", async () => {
+    const user = userEvent.setup();
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tu-todo-073",
+                  name: "TodoWrite",
+                  input: {
+                    todos: [{ content: "Collapsible task", status: "pending" }],
+                  },
+                },
+              ],
+            },
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+      ]),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Todo")).toBeInTheDocument();
+    });
+
+    // Find the todo details element — it wraps the "Todo" text in summary
+    const todoHeading = screen.getByText("Todo");
+    const details = todoHeading.closest("details") as HTMLDetailsElement;
+    expect(details).not.toBeNull();
+
+    // No search match → initially closed
+    expect(details.open).toBeFalsy();
+
+    const summary = details.querySelector("summary")!;
+
+    // Click to expand
+    await user.click(summary);
+    expect(details.open).toBeTruthy();
+
+    // Click again to collapse
+    await user.click(summary);
+    expect(details.open).toBeFalsy();
+  });
+
+  // ACT-D-074
+  it("expands and collapses tool operation details on click", async () => {
+    const user = userEvent.setup();
+    await renderInspectPage();
+    await loadInspectData(
+      makeInspectData([
+        {
+          sequenceNumber: 0,
+          eventType: "assistant",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_use",
+                  id: "tu-read-074",
+                  name: "Read",
+                  input: { file_path: "/tmp/toggle-test.txt" },
+                },
+              ],
+            },
+          },
+          createdAt: "2026-03-10T14:56:02Z",
+        },
+        {
+          sequenceNumber: 1,
+          eventType: "user",
+          eventData: {
+            message: {
+              content: [
+                {
+                  type: "tool_result",
+                  tool_use_id: "tu-read-074",
+                  content: "file content here",
+                  is_error: false,
+                },
+              ],
+            },
+            tool_use_result: { durationMs: 20, bytes: 17 },
+          },
+          createdAt: "2026-03-10T14:56:03Z",
+        },
+      ]),
+    );
+
+    const toolSummary = await waitFor(() => {
+      const el = screen.getByTestId("tool-summary");
+      expect(el).toBeInTheDocument();
+      return el as HTMLDetailsElement;
+    });
+
+    // Initially closed (no search term)
+    expect(toolSummary.open).toBeFalsy();
+
+    const summary = toolSummary.querySelector("summary")!;
+
+    // Click to expand
+    await user.click(summary);
+    expect(toolSummary.open).toBeTruthy();
+
+    // Click again to collapse
+    await user.click(summary);
+    expect(toolSummary.open).toBeFalsy();
+  });
+});

--- a/turbo/apps/platform/src/views/activity/__tests__/grouped-message-card.test.tsx
+++ b/turbo/apps/platform/src/views/activity/__tests__/grouped-message-card.test.tsx
@@ -72,13 +72,9 @@ describe("groupedMessageCard", () => {
     });
 
     // formatEventTime("2026-03-10T14:56:02Z") → "Mar 10, HH:MM:SS" (past date)
-    const timestampElements = document.querySelectorAll(
-      ".text-xs.text-muted-foreground",
-    );
-    const hasTimestamp = Array.from(timestampElements).some((el) => {
-      return el.textContent?.match(/Mar 10/);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Mar 10/).length).toBeGreaterThan(0);
     });
-    expect(hasTimestamp).toBeTruthy();
   });
 
   // ACT-D-066
@@ -117,6 +113,7 @@ describe("groupedMessageCard", () => {
 
   // ACT-D-067
   it("renders todo items with their completion status icons", async () => {
+    const user = userEvent.setup();
     await renderInspectPage();
     await loadInspectData(
       makeInspectData([
@@ -150,10 +147,12 @@ describe("groupedMessageCard", () => {
       expect(screen.getByText("Todo")).toBeInTheDocument();
     });
 
-    // Open the details to see all items
-    const details = document.querySelector("details") as HTMLDetailsElement;
+    // Open the details by clicking the summary to see all items
+    const todoHeading = screen.getByText("Todo");
+    const details = todoHeading.closest("details") as HTMLDetailsElement;
     expect(details).not.toBeNull();
-    details.open = true;
+    const summary = details.querySelector("summary")!;
+    await user.click(summary);
 
     await waitFor(() => {
       expect(screen.getByText("Completed task")).toBeInTheDocument();
@@ -242,6 +241,7 @@ describe("groupedMessageCard", () => {
 
   // ACT-D-070
   it("renders tool operations and their results", async () => {
+    const user = userEvent.setup();
     await renderInspectPage();
     await loadInspectData(
       makeInspectData([
@@ -287,11 +287,12 @@ describe("groupedMessageCard", () => {
       expect(screen.getByText("Bash")).toBeInTheDocument();
     });
 
-    // Open the tool summary details to see result
+    // Open the tool summary details by clicking the summary to see result
     const toolSummary = screen.getByTestId(
       "tool-summary",
     ) as HTMLDetailsElement;
-    toolSummary.open = true;
+    const toolSummarySummary = toolSummary.querySelector("summary")!;
+    await user.click(toolSummarySummary);
 
     await waitFor(() => {
       expect(screen.getByText("hello-070")).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Adds 10 test cases (ACT-D-065 through ACT-D-074) for the `GroupedMessageCard` component in `turbo/apps/platform/src/views/activity/__tests__/grouped-message-card.test.tsx`
- Uses the `/activities/inspect` page approach with `loadInspectLogFile$` signal — no MSW mocking needed
- Covers timestamp rendering, text sections, todo items with status, progress indicators, in-progress task content, tool operations with results, search highlighting with `<mark>` elements, status dot variants, and collapsible section toggle interactions

## Test plan

- [x] All 10 `it()` blocks pass locally
- [x] No `vi.mock()` for internal modules
- [x] No `eslint-disable` or `ts-ignore`
- [x] TypeScript type check passes
- [x] Lint passes with zero warnings
- [x] Format applied

Closes #7914

🤖 Generated with [Claude Code](https://claude.com/claude-code)