### PR TITLE
fix(developer-support): collect agent events from axiom instead of empty chat messages

### DIFF
--- a/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
@@ -248,6 +248,128 @@ describe("POST /api/zero/developer-support", () => {
     expect(data.error.code).toBe("SESSION_REQUIRED");
   });
 
+  it("queries Axiom for agent events from session runs", async () => {
+    const { token } = await setupRunContext(user);
+
+    // Step 1: Get consent code
+    const step1 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc" },
+      token,
+    );
+    const { consentCode } = await step1.json();
+
+    // Mock Axiom to return test events
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      {
+        eventType: "assistant",
+        eventData: { message: "hello" },
+        _time: "2024-01-01T00:00:00Z",
+        sequenceNumber: 1,
+      },
+    ]);
+
+    // Step 2: Submit with consent code
+    const step2 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc", consentCode },
+      token,
+    );
+    expect(step2.status).toBe(200);
+
+    // Verify Axiom was queried
+    expect(context.mocks.axiom.queryAxiom).toHaveBeenCalledTimes(1);
+    const aplQuery = context.mocks.axiom.queryAxiom.mock.calls[0]![0] as string;
+    expect(aplQuery).toContain("agent-run-events");
+    expect(aplQuery).toContain("limit 2000");
+  });
+
+  it("collects events from all runs in session including first run", async () => {
+    const sessionId = crypto.randomUUID();
+
+    // Create first run (completed, has result.agentSessionId)
+    const { composeId: composeId1 } = await createTestCompose(
+      uniqueId("agent"),
+    );
+    const { runId: firstRunId } = await createTestRunInDb(
+      user.userId,
+      composeId1,
+      {
+        status: "completed",
+        result: {
+          agentSessionId: sessionId,
+          checkpointId: "cp-1",
+          conversationId: "cv-1",
+        },
+      },
+    );
+
+    // Create continuation run (the current run)
+    const { composeId: composeId2 } = await createTestCompose(
+      uniqueId("agent"),
+    );
+    const { runId: currentRunId } = await createTestRunInDb(
+      user.userId,
+      composeId2,
+      {
+        status: "running",
+        continuedFromSessionId: sessionId,
+      },
+    );
+
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
+    mockClerk({ userId: null });
+    const token = await generateZeroToken(
+      user.userId,
+      currentRunId,
+      user.orgId,
+    );
+
+    // Get consent code and submit
+    const step1 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc" },
+      token,
+    );
+    const { consentCode } = await step1.json();
+
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      { eventType: "assistant", eventData: {}, sequenceNumber: 1 },
+    ]);
+
+    await postDeveloperSupport(
+      { title: "Bug", description: "Desc", consentCode },
+      token,
+    );
+
+    // Verify APL contains both run IDs
+    const aplQuery = context.mocks.axiom.queryAxiom.mock.calls[0]![0] as string;
+    expect(aplQuery).toContain(firstRunId);
+    expect(aplQuery).toContain(currentRunId);
+  });
+
+  it("creates bundle with empty events when Axiom query fails", async () => {
+    const { token } = await setupRunContext(user);
+
+    const step1 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc" },
+      token,
+    );
+    const { consentCode } = await step1.json();
+
+    context.mocks.axiom.queryAxiom.mockRejectedValueOnce(
+      new Error("Axiom down"),
+    );
+
+    const step2 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc", consentCode },
+      token,
+    );
+    expect(step2.status).toBe(200);
+    expect((await step2.json()).reference).toBeDefined();
+  });
+
   it("returns 401 when no auth header is provided", async () => {
     const response = await POST(
       createTestRequest(URL, {

--- a/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
@@ -233,19 +233,33 @@ describe("POST /api/zero/developer-support", () => {
     expect(data.error.code).toBe("INVALID_CONSENT_CODE");
   });
 
-  it("returns 400 when run has no session", async () => {
-    const { token } = await setupRunContext(user, {
+  it("falls back to current runId when run has no session", async () => {
+    const { token, runId } = await setupRunContext(user, {
       continuedFromSessionId: null,
     });
 
-    const response = await postDeveloperSupport(
+    // Step 1: Get consent code (uses runId as HMAC seed)
+    const step1 = await postDeveloperSupport(
       { title: "Bug", description: "Desc" },
       token,
     );
+    expect(step1.status).toBe(200);
+    const { consentCode } = await step1.json();
+    expect(consentCode).toBeDefined();
 
-    expect(response.status).toBe(400);
-    const data = await response.json();
-    expect(data.error.code).toBe("SESSION_REQUIRED");
+    // Step 2: Submit with consent code — should query Axiom with just current runId
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([]);
+
+    const step2 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc", consentCode },
+      token,
+    );
+    expect(step2.status).toBe(200);
+    expect((await step2.json()).reference).toBeDefined();
+
+    // Verify Axiom was queried with the current runId only
+    const aplQuery = context.mocks.axiom.queryAxiom.mock.calls[0]![0] as string;
+    expect(aplQuery).toContain(runId);
   });
 
   it("queries Axiom for agent events from session runs", async () => {

--- a/turbo/apps/web/app/api/zero/developer-support/route.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/route.ts
@@ -13,8 +13,12 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { zeroAgents } from "../../../../src/db/schema/zero-agent";
-import { eq } from "drizzle-orm";
-import { getSessionChatMessages } from "../../../../src/lib/zero/zero-session-service";
+import { eq, or, sql } from "drizzle-orm";
+import {
+  queryAxiom,
+  getDatasetName,
+  DATASETS,
+} from "../../../../src/lib/shared/axiom";
 import { listConnectors } from "../../../../src/lib/zero/connector/connector-service";
 import {
   uploadS3Buffer,
@@ -204,8 +208,45 @@ const router = tsr.router(zeroDeveloperSupportContract, {
       }
     }
 
-    // Collect session messages
-    const conversation = await getSessionChatMessages(sessionId);
+    // Collect all run IDs in the session
+    // - Continuation runs: continuedFromSessionId = sessionId
+    // - First run: result->>'agentSessionId' = sessionId (created the session)
+    const sessionRuns = await db
+      .select({ id: agentRuns.id })
+      .from(agentRuns)
+      .where(
+        or(
+          eq(agentRuns.continuedFromSessionId, sessionId),
+          sql`${agentRuns.result}->>'agentSessionId' = ${sessionId}`,
+        ),
+      );
+
+    // Query Axiom for agent events from all session runs
+    const agentEvents = await (async () => {
+      if (sessionRuns.length === 0) return [];
+      const runIdList = sessionRuns
+        .map((r) => {
+          return `"${r.id}"`;
+        })
+        .join(", ");
+      const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
+      const apl = `['${dataset}']
+| where runId in (${runIdList})
+| order by _time asc, sequenceNumber asc
+| limit 2000`;
+      return queryAxiom(apl);
+    })().catch((err) => {
+      log.warn("Failed to collect agent events from Axiom", {
+        error: String(err),
+      });
+      return [];
+    });
+
+    log.info("Collected agent events for diagnostic bundle", {
+      reference,
+      runCount: sessionRuns.length,
+      eventCount: agentEvents.length,
+    });
 
     // Safe connector subset (no tokens)
     const safeConnectors = connectors.map((c) => {
@@ -239,8 +280,12 @@ const router = tsr.router(zeroDeveloperSupportContract, {
         content: `# ${body.title}\n\n${body.description}`,
       },
       {
-        path: "conversation.json",
-        content: JSON.stringify(conversation, null, 2),
+        path: "agent-events.jsonl",
+        content: agentEvents
+          .map((e) => {
+            return JSON.stringify(e);
+          })
+          .join("\n"),
       },
       {
         path: "environment.json",

--- a/turbo/apps/web/app/api/zero/developer-support/route.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/route.ts
@@ -87,6 +87,9 @@ const router = tsr.router(zeroDeveloperSupportContract, {
   submit: async ({ body, headers }) => {
     initServices();
 
+    // acceptAnySandboxCapability: developer-support can be invoked from any
+    // sandbox capability (cli, web, scheduled, etc.) — there is no dedicated
+    // capability for this endpoint.
     const authCtx = await requireAuth(headers.authorization, {
       acceptAnySandboxCapability: true,
     });
@@ -133,22 +136,13 @@ const router = tsr.router(zeroDeveloperSupportContract, {
     }
 
     const sessionId = run.continuedFromSessionId;
-    if (!sessionId) {
-      return {
-        status: 400 as const,
-        body: {
-          error: {
-            message:
-              "Developer support requires an active session. This command is only available in multi-turn conversations.",
-            code: "SESSION_REQUIRED",
-          },
-        },
-      };
-    }
+    // Use sessionId for consent HMAC when available, fall back to runId for
+    // first-run (no session yet) so developer-support works in single-turn too.
+    const consentSeed = sessionId ?? runId;
 
     // Step 1: Generate consent code if none provided
     if (!body.consentCode) {
-      const consentCode = generateConsentCode(sessionId);
+      const consentCode = generateConsentCode(consentSeed);
       return {
         status: 200 as const,
         body: { consentCode },
@@ -156,7 +150,7 @@ const router = tsr.router(zeroDeveloperSupportContract, {
     }
 
     // Step 2: Validate consent code
-    const expectedCode = generateConsentCode(sessionId);
+    const expectedCode = generateConsentCode(consentSeed);
     if (body.consentCode !== expectedCode) {
       return {
         status: 400 as const,
@@ -208,25 +202,31 @@ const router = tsr.router(zeroDeveloperSupportContract, {
       }
     }
 
-    // Collect all run IDs in the session
-    // - Continuation runs: continuedFromSessionId = sessionId
-    // - First run: result->>'agentSessionId' = sessionId (created the session)
-    const sessionRuns = await db
-      .select({ id: agentRuns.id })
-      .from(agentRuns)
-      .where(
-        or(
-          eq(agentRuns.continuedFromSessionId, sessionId),
-          sql`${agentRuns.result}->>'agentSessionId' = ${sessionId}`,
-        ),
-      );
+    // Collect all run IDs for agent events.
+    // With a session: find continuation runs + first run (via result->>'agentSessionId').
+    // Without a session (first run): fall back to just the current runId.
+    const sessionRunIds: string[] = sessionId
+      ? (
+          await db
+            .select({ id: agentRuns.id })
+            .from(agentRuns)
+            .where(
+              or(
+                eq(agentRuns.continuedFromSessionId, sessionId),
+                sql`${agentRuns.result}->>'agentSessionId' = ${sessionId}`,
+              ),
+            )
+        ).map((r) => {
+          return r.id;
+        })
+      : [runId];
 
     // Query Axiom for agent events from all session runs
     const agentEvents = await (async () => {
-      if (sessionRuns.length === 0) return [];
-      const runIdList = sessionRuns
-        .map((r) => {
-          return `"${r.id}"`;
+      if (sessionRunIds.length === 0) return [];
+      const runIdList = sessionRunIds
+        .map((id) => {
+          return `"${id}"`;
         })
         .join(", ");
       const dataset = getDatasetName(DATASETS.AGENT_RUN_EVENTS);
@@ -244,7 +244,7 @@ const router = tsr.router(zeroDeveloperSupportContract, {
 
     log.info("Collected agent events for diagnostic bundle", {
       reference,
-      runCount: sessionRuns.length,
+      runCount: sessionRunIds.length,
       eventCount: agentEvents.length,
     });
 


### PR DESCRIPTION
## Summary

- Replace `getSessionChatMessages()` (always returns empty `[]`) with Axiom `AGENT_RUN_EVENTS` query across all runs in the session
- Discover all session runs via `continuedFromSessionId` + `result->>'agentSessionId'` pattern
- Output file renamed from `conversation.json` to `agent-events.jsonl` (JSONL format)
- Graceful degradation: if Axiom fails, bundle still created with empty events file

Closes #8032

## Test plan

- [x] Verify Axiom is queried with correct APL containing run IDs and 2000 event limit
- [x] Verify multi-run session (first run + continuation) collects all run IDs in APL query
- [x] Verify bundle is still created when Axiom query fails (graceful degradation)
- [x] All 11 existing + 3 new tests pass
- [x] Lint, knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)