### PR TITLE
chore(platform): remove require-accept allowlist and migrate permission-dialog

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -150,20 +150,6 @@ export default [
       "ccstate/no-new-abort-controller": "off",
     },
   },
-  // Allow pre-accept zeroClient$ calls in existing signal files (migration in progress).
-  // Each file should be migrated to use accept() and removed from this list.
-  // Remaining: #7879 (Billing & Usage)
-  {
-    files: [
-      "src/signals/usage-page/usage-signals.ts",
-      "src/signals/zero-page/billing.ts",
-      "src/signals/zero-page/member-credit-caps.ts",
-      "src/signals/zero-page/settings/permission-dialog.ts",
-    ],
-    rules: {
-      "ccstate/require-accept": "off",
-    },
-  },
   {
     ignores: [
       "dist/**",

--- a/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/permission-dialog.ts
@@ -6,6 +6,7 @@ import {
 } from "@vm0/core";
 import { zeroClient$ } from "../../api-client.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
+import { accept } from "../../../lib/accept.ts";
 
 // ---------------------------------------------------------------------------
 // Agent selection
@@ -61,17 +62,22 @@ export const confirmPermissionDialog$ = command(
     await Promise.allSettled(
       [...selected].map(async (agentId) => {
         signal.throwIfAborted();
-        const existing = await client.get({ params: { id: agentId } });
+        const existing = await accept(
+          client.get({ params: { id: agentId } }),
+          [200],
+        );
         signal.throwIfAborted();
-        const current =
-          existing.status === 200 ? existing.body.enabledTypes : [];
+        const current = existing.body.enabledTypes;
         if (current.includes(connectorType)) {
           return;
         }
-        await client.update({
-          params: { id: agentId },
-          body: { enabledTypes: [...current, connectorType] },
-        });
+        await accept(
+          client.update({
+            params: { id: agentId },
+            body: { enabledTypes: [...current, connectorType] },
+          }),
+          [200],
+        );
       }),
     );
     signal.throwIfAborted();


### PR DESCRIPTION
## Summary

- Migrated `permission-dialog.ts` to use `accept()` for both `client.get()` and `client.update()` calls, removing the manual `existing.status === 200` guard
- Removed the 4-file ESLint override block for `ccstate/require-accept` from `eslint.config.js` — all allowlisted files are now fully migrated

Closes #7883

## Test plan

- [x] `pnpm turbo run lint` — zero errors, no `ccstate/require-accept` violations
- [x] `pnpm check-types` — passes cleanly
- [x] `pnpm vitest` — 996 tests pass (143 test files)
- [x] `pnpm knip` — no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)