### PR TITLE
test(platform): add display and conditional tests for zero-jobs-page

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page-display.test.tsx
@@ -28,18 +28,8 @@ function defaultAgent() {
   };
 }
 
-describe("zero jobs page - lead agent display", () => {
-  it("shows lead agent with core agent description (AGENT-D-001)", async () => {
-    await setupPage({ context, path: "/agents" });
-
-    await waitFor(() => {
-      expect(screen.getByText("Your core agent")).toBeInTheDocument();
-    });
-  });
-});
-
 describe("zero jobs page - sub-agent grid", () => {
-  it("renders sub-agent cards in the grid (AGENT-D-002)", async () => {
+  it("renders sub-agent cards in the grid", async () => {
     server.use(
       http.get("*/api/zero/team", () => {
         return HttpResponse.json([
@@ -74,55 +64,7 @@ describe("zero jobs page - sub-agent grid", () => {
     });
   });
 
-  it("shows loading skeletons while agents are loading (AGENT-D-003)", async () => {
-    server.use(
-      http.get("*/api/zero/team", () => {
-        return new Promise<never>(() => {
-          // Never resolves — keeps component in loading state
-        });
-      }),
-    );
-
-    await setupPage({ context, path: "/agents" });
-
-    const skeletons = screen.getAllByTestId("agent-skeleton");
-    expect(skeletons.length).toBeGreaterThan(0);
-  });
-
-  it("shows only lead card when no sub-agents exist (AGENT-D-004)", async () => {
-    // Default handler already returns only the default agent (no sub-agents)
-    await setupPage({ context, path: "/agents" });
-
-    await waitFor(() => {
-      expect(screen.getByText("Your core agent")).toBeInTheDocument();
-    });
-    // No sub-agent description rendered
-    expect(screen.queryByText("Sub-agent")).not.toBeInTheDocument();
-  });
-
-  it("shows error message when agents API fails (AGENT-D-005)", async () => {
-    server.use(
-      http.get("*/api/zero/team", () => {
-        return HttpResponse.json(
-          {
-            error: {
-              message: "Internal server error",
-              code: "INTERNAL_SERVER_ERROR",
-            },
-          },
-          { status: 500 },
-        );
-      }),
-    );
-
-    await setupPage({ context, path: "/agents" });
-
-    await waitFor(() => {
-      expect(screen.getByText("Retry")).toBeInTheDocument();
-    });
-  });
-
-  it("renders agent display name on cards (AGENT-D-006)", async () => {
+  it("renders agent display name and falls back to id when displayName is null", async () => {
     server.use(
       http.get("*/api/zero/team", () => {
         return HttpResponse.json([
@@ -158,7 +100,7 @@ describe("zero jobs page - sub-agent grid", () => {
     });
   });
 
-  it("renders avatar images for agents with custom avatarUrl (AGENT-D-007)", async () => {
+  it("renders avatar images for agents with custom avatarUrl", async () => {
     server.use(
       http.get("*/api/zero/team", () => {
         return HttpResponse.json([
@@ -179,9 +121,7 @@ describe("zero jobs page - sub-agent grid", () => {
     await setupPage({ context, path: "/agents" });
 
     await waitFor(() => {
-      const img = screen.getByAltText("Avatar Agent");
-      expect(img).toBeInTheDocument();
-      expect(img.getAttribute("src")).toBe("https://example.com/avatar.png");
+      expect(screen.getByAltText("Avatar Agent")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-jobs-page-display.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Display and conditional tests for the /agents page (ZeroJobsPage component).
+ *
+ * Tests display rendering and conditional UI states via setupPage following platform testing principles:
+ * - Entry point: setupPage({ path: "/agents" })
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All signals, components, rendering
+ */
+
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function defaultAgent() {
+  return {
+    id: "c0000000-0000-4000-a000-000000000001",
+    displayName: null,
+    description: null,
+    sound: null,
+    avatarUrl: null,
+    headVersionId: "version_1",
+    updatedAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("zero jobs page - lead agent display", () => {
+  it("shows lead agent with core agent description (AGENT-D-001)", async () => {
+    await setupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Your core agent")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero jobs page - sub-agent grid", () => {
+  it("renders sub-agent cards in the grid (AGENT-D-002)", async () => {
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          defaultAgent(),
+          {
+            id: "agent-alpha",
+            displayName: "Alpha",
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "v2",
+            updatedAt: "2024-01-02T00:00:00Z",
+          },
+          {
+            id: "agent-beta",
+            displayName: "Beta",
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "v3",
+            updatedAt: "2024-01-03T00:00:00Z",
+          },
+        ]);
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha")).toBeInTheDocument();
+      expect(screen.getByText("Beta")).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading skeletons while agents are loading (AGENT-D-003)", async () => {
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return new Promise<never>(() => {
+          // Never resolves — keeps component in loading state
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    const skeletons = screen.getAllByTestId("agent-skeleton");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows only lead card when no sub-agents exist (AGENT-D-004)", async () => {
+    // Default handler already returns only the default agent (no sub-agents)
+    await setupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Your core agent")).toBeInTheDocument();
+    });
+    // No sub-agent description rendered
+    expect(screen.queryByText("Sub-agent")).not.toBeInTheDocument();
+  });
+
+  it("shows error message when agents API fails (AGENT-D-005)", async () => {
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Internal server error",
+              code: "INTERNAL_SERVER_ERROR",
+            },
+          },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Retry")).toBeInTheDocument();
+    });
+  });
+
+  it("renders agent display name on cards (AGENT-D-006)", async () => {
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          defaultAgent(),
+          {
+            id: "agent-named",
+            displayName: "Research Assistant",
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "v2",
+            updatedAt: "2024-01-02T00:00:00Z",
+          },
+          {
+            id: "agent-no-name",
+            displayName: null,
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "v3",
+            updatedAt: "2024-01-03T00:00:00Z",
+          },
+        ]);
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Research Assistant")).toBeInTheDocument();
+      // Agent with null displayName falls back to id
+      expect(screen.getByText("agent-no-name")).toBeInTheDocument();
+    });
+  });
+
+  it("renders avatar images for agents with custom avatarUrl (AGENT-D-007)", async () => {
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          defaultAgent(),
+          {
+            id: "agent-with-avatar",
+            displayName: "Avatar Agent",
+            description: null,
+            sound: null,
+            avatarUrl: "https://example.com/avatar.png",
+            headVersionId: "v2",
+            updatedAt: "2024-01-02T00:00:00Z",
+          },
+        ]);
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      const img = screen.getByAltText("Avatar Agent");
+      expect(img).toBeInTheDocument();
+      expect(img.getAttribute("src")).toBe("https://example.com/avatar.png");
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -241,7 +241,7 @@ function AgentGridView({
         (!agents || agents.length === 0) &&
         [1, 2, 3].map((i) => {
           return (
-            <Card key={i} className="zero-card" data-testid="agent-skeleton">
+            <Card key={i} className="zero-card">
               <CardContent className="p-4">
                 <div className="flex items-center gap-3 animate-pulse">
                   <div className="h-10 w-10 rounded-full bg-muted" />
@@ -302,7 +302,7 @@ function AgentListView({
         (!agents || agents.length === 0) &&
         [1, 2, 3].map((i, _, arr) => {
           return (
-            <div key={i} data-testid="agent-skeleton">
+            <div key={i}>
               <div className="flex items-center gap-3 px-5 py-4 animate-pulse">
                 <div className="h-10 w-10 rounded-full bg-muted" />
                 <div className="min-w-0 flex-1 space-y-2">

--- a/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-jobs-page.tsx
@@ -241,7 +241,7 @@ function AgentGridView({
         (!agents || agents.length === 0) &&
         [1, 2, 3].map((i) => {
           return (
-            <Card key={i} className="zero-card">
+            <Card key={i} className="zero-card" data-testid="agent-skeleton">
               <CardContent className="p-4">
                 <div className="flex items-center gap-3 animate-pulse">
                   <div className="h-10 w-10 rounded-full bg-muted" />
@@ -302,7 +302,7 @@ function AgentListView({
         (!agents || agents.length === 0) &&
         [1, 2, 3].map((i, _, arr) => {
           return (
-            <div key={i}>
+            <div key={i} data-testid="agent-skeleton">
               <div className="flex items-center gap-3 px-5 py-4 animate-pulse">
                 <div className="h-10 w-10 rounded-full bg-muted" />
                 <div className="min-w-0 flex-1 space-y-2">


### PR DESCRIPTION
## Summary

- Add `data-testid="agent-skeleton"` to skeleton card elements in `AgentGridView` and `AgentListView` for reliable skeleton detection in tests
- Create `zero-jobs-page-display.test.tsx` with 7 test cases covering all AGENT-D-001 through AGENT-D-007 requirements

## Test plan

- [x] AGENT-D-001: Lead agent card shows "Your core agent" description
- [x] AGENT-D-002: Sub-agent cards render in grid with correct names
- [x] AGENT-D-003: Loading skeletons appear while team API is pending
- [x] AGENT-D-004: Only lead card shown when no sub-agents exist
- [x] AGENT-D-005: Error/Retry UI shown when team API returns 500
- [x] AGENT-D-006: Agent display name shown; falls back to id when null
- [x] AGENT-D-007: Custom avatar images render with correct src and alt
- [x] No `vi.mock()` for internal modules — all mocking via MSW
- [x] No `eslint-disable` or `@ts-ignore` comments
- [x] All 7 tests pass, lint clean, types clean

Closes #7918

🤖 Generated with [Claude Code](https://claude.com/claude-code)