### PR TITLE
perf(onboarding): consolidate into single server api call

### DIFF
--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -361,7 +361,7 @@ teardown_file() {
 
 @test "create new agent via dialog" {
   echo "# Clicking New agent..." >&3
-  agent-browser find text "New agent" click
+  agent-browser find role button click --name "New agent"
   agent-browser wait 1000
   step_screenshot "create-dialog-opened"
 
@@ -374,15 +374,7 @@ teardown_file() {
   step_screenshot "create-dialog-filled"
 
   echo "# Clicking Create button in dialog..." >&3
-  local snap_i
-  snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
-  local create_ref
-  create_ref=$(echo "$snap_i" | grep -E 'button "Create"' | grep -v 'New agent' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
-  if [[ -n "$create_ref" ]]; then
-    agent-browser click "$create_ref"
-  else
-    agent-browser find text "Create" click
-  fi
+  agent-browser find role button click --name "Create"
 
   echo "# Waiting for agent creation to complete..." >&3
   local create_complete=false

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -349,11 +349,9 @@ teardown_file() {
   wait_for_text "Agents" 20
   step_screenshot "team-page-loaded"
 
-  local snap
-  snap=$(full_snapshot)
-
-  echo "# Waiting for lead agent badge..." >&3
-  wait_for_text "Lead" 15
+  echo "# Waiting for lead agent badge (async load)..." >&3
+  wait_for_text "Lead" 20
+  step_screenshot "team-page-lead-loaded"
 
   echo "# Waiting for Create teammate button..." >&3
   wait_for_text "Create teammate" 10

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -352,11 +352,11 @@ teardown_file() {
   local snap
   snap=$(full_snapshot)
 
-  echo "# Verifying lead agent badge..." >&3
-  contains "$snap" "Lead"
+  echo "# Waiting for lead agent badge..." >&3
+  wait_for_text "Lead" 15
 
-  echo "# Verifying Create teammate button..." >&3
-  contains "$snap" "Create teammate"
+  echo "# Waiting for Create teammate button..." >&3
+  wait_for_text "Create teammate" 10
 
   echo "# Team page verified!" >&3
 }

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -349,24 +349,24 @@ teardown_file() {
   wait_for_text "Agents" 20
   step_screenshot "team-page-loaded"
 
-  echo "# Waiting for lead agent badge (async load)..." >&3
-  wait_for_text "Lead" 20
-  step_screenshot "team-page-lead-loaded"
+  echo "# Waiting for default agent (async load)..." >&3
+  wait_for_text "Your core agent" 20
+  step_screenshot "team-page-agent-loaded"
 
-  echo "# Waiting for Create teammate button..." >&3
-  wait_for_text "Create teammate" 10
+  echo "# Waiting for New agent button..." >&3
+  wait_for_text "New agent" 10
 
   echo "# Team page verified!" >&3
 }
 
 @test "create new agent via dialog" {
-  echo "# Clicking Create teammate..." >&3
-  agent-browser find text "Create teammate" click
+  echo "# Clicking New agent..." >&3
+  agent-browser find text "New agent" click
   agent-browser wait 1000
   step_screenshot "create-dialog-opened"
 
   echo "# Waiting for dialog content..." >&3
-  wait_for_text "Create a new teammate" 10
+  wait_for_text "Create a new agent" 10
 
   echo "# Filling agent name: $AGENT_NAME" >&3
   agent-browser find placeholder "e.g. Research Assistant" fill "$AGENT_NAME"
@@ -377,7 +377,7 @@ teardown_file() {
   local snap_i
   snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
   local create_ref
-  create_ref=$(echo "$snap_i" | grep -E 'button "Create"' | grep -v 'teammate' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  create_ref=$(echo "$snap_i" | grep -E 'button "Create"' | grep -v 'New agent' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
   if [[ -n "$create_ref" ]]; then
     agent-browser click "$create_ref"
   else

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
@@ -14,6 +14,7 @@ import { pathname } from "../../../signals/location.ts";
 const context = testContext();
 
 const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
+const MOCK_MEMBER_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 
 function mockAdminOnboarding() {
   server.use(
@@ -39,7 +40,7 @@ function mockMemberOnboarding() {
         isAdmin: false,
         hasOrg: true,
         hasDefaultAgent: true,
-        defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+        defaultAgentId: MOCK_MEMBER_AGENT_ID,
         defaultAgentMetadata: { displayName: "TeamBot" },
         defaultAgentSkills: [],
       });
@@ -49,72 +50,8 @@ function mockMemberOnboarding() {
 
 function mockAdminCompletionApis() {
   server.use(
-    http.put("*/api/zero/org", () => {
-      return HttpResponse.json({ id: "org_1", slug: "test", name: "Test" });
-    }),
-    http.post("*/api/zero/model-providers", () => {
-      return HttpResponse.json(
-        {
-          provider: {
-            id: "a0000000-0000-4000-a000-000000000099",
-            type: "vm0",
-            framework: "claude-code",
-            secretName: null,
-            authMethod: null,
-            secretNames: null,
-            isDefault: true,
-            selectedModel: null,
-            createdAt: "2026-03-01T00:00:00Z",
-            updatedAt: "2026-03-01T00:00:00Z",
-          },
-          created: true,
-        },
-        { status: 201 },
-      );
-    }),
-    http.post("*/api/zero/agents", () => {
-      return HttpResponse.json(
-        {
-          name: "zero",
-          agentId: MOCK_AGENT_ID,
-          ownerId: "test-user-123",
-          description: null,
-          displayName: null,
-          sound: null,
-          avatarUrl: null,
-          firewallPolicies: null,
-        },
-        { status: 201 },
-      );
-    }),
-    http.put(`*/api/zero/agents/${MOCK_AGENT_ID}/instructions`, () => {
-      return HttpResponse.json({
-        name: "zero",
-        agentId: MOCK_AGENT_ID,
-        ownerId: "test-user-123",
-        description: null,
-        displayName: null,
-        sound: null,
-        avatarUrl: null,
-        firewallPolicies: null,
-      });
-    }),
-    http.put("*/api/zero/default-agent", () => {
+    http.post("*/api/zero/onboarding/setup", () => {
       return HttpResponse.json({ agentId: MOCK_AGENT_ID });
-    }),
-    http.post("*/api/zero/onboarding/complete", () => {
-      return HttpResponse.json({ ok: true });
-    }),
-    http.post("*/api/zero/chat/messages", () => {
-      return HttpResponse.json(
-        {
-          runId: "run-1",
-          threadId: "thread-1",
-          status: "pending",
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-        { status: 201 },
-      );
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });
@@ -126,17 +63,6 @@ function mockMemberCompletionApis() {
   server.use(
     http.post("*/api/zero/onboarding/complete", () => {
       return HttpResponse.json({ ok: true });
-    }),
-    http.post("*/api/zero/chat/messages", () => {
-      return HttpResponse.json(
-        {
-          runId: "run-1",
-          threadId: "thread-1",
-          status: "pending",
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-        { status: 201 },
-      );
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });
@@ -211,7 +137,7 @@ describe("onboardingAddToSlack$", () => {
           isAdmin: false,
           hasOrg: true,
           hasDefaultAgent: true,
-          defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+          defaultAgentId: MOCK_MEMBER_AGENT_ID,
           defaultAgentMetadata: { displayName: "TeamBot" },
           defaultAgentSkills: [],
         });
@@ -229,7 +155,7 @@ describe("onboardingAddToSlack$", () => {
 // ---------------------------------------------------------------------------
 
 describe("onboardingContinueWeb$", () => {
-  it("should navigate to / and reset saving for admin", async () => {
+  it("should navigate to /agents/:id/chat for admin", async () => {
     mockAdminOnboarding();
     mockAdminCompletionApis();
     await setupPage({ context, path: "/onboarding", withoutRender: true });
@@ -251,12 +177,12 @@ describe("onboardingContinueWeb$", () => {
 
     await context.store.set(onboardingContinueWeb$, context.signal);
 
-    expect(pathname()).toBe("/chats/thread-1");
+    expect(pathname()).toBe(`/agents/${MOCK_AGENT_ID}/chat`);
     // Step is set to "done" by completeOnboarding$
     await expect(context.store.get(zeroOnboardingStep$)).resolves.toBe("done");
   });
 
-  it("should navigate to / for member", async () => {
+  it("should navigate to /agents/:id/chat for member", async () => {
     mockMemberOnboarding();
     mockMemberCompletionApis();
     await setupPage({ context, path: "/onboarding", withoutRender: true });
@@ -269,7 +195,7 @@ describe("onboardingContinueWeb$", () => {
           isAdmin: false,
           hasOrg: true,
           hasDefaultAgent: true,
-          defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+          defaultAgentId: MOCK_MEMBER_AGENT_ID,
           defaultAgentMetadata: { displayName: "TeamBot" },
           defaultAgentSkills: [],
         });
@@ -278,6 +204,6 @@ describe("onboardingContinueWeb$", () => {
 
     await context.store.set(onboardingContinueWeb$, context.signal);
 
-    expect(pathname()).toBe("/chats/thread-1");
+    expect(pathname()).toBe(`/agents/${MOCK_MEMBER_AGENT_ID}/chat`);
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
@@ -9,395 +9,93 @@ import {
   setZeroWorkspaceName$,
   toggleZeroConnector$,
 } from "../zero-onboarding.ts";
-import { SEED_INSTRUCTIONS } from "../../../data/the-seed.ts";
 
 const context = testContext();
 
-interface CreateAgentPayload {
+interface SetupPayload {
   displayName?: string;
+  workspaceName?: string;
   sound?: string;
   avatarUrl?: string;
+  selectedConnectors?: string[];
 }
 
-interface InstructionsPayload {
-  content: string;
+function setupHandler(capturePayload?: (payload: SetupPayload) => void) {
+  return http.post("*/api/zero/onboarding/setup", async ({ request }) => {
+    const body = (await request.json()) as SetupPayload;
+    capturePayload?.(body);
+    return HttpResponse.json({
+      agentId: "d0000000-0000-4000-a000-000000000001",
+    });
+  });
 }
 
 describe("completeZeroOnboarding$", () => {
-  it("should create agent via zero agents api with metadata", async () => {
-    let capturedPayload: CreateAgentPayload | null = null;
-    let capturedInstructions: InstructionsPayload | null = null;
+  it("should call setup API with correct metadata", async () => {
+    let capturedPayload: SetupPayload | null = null;
 
     server.use(
-      http.post("*/api/zero/model-providers", () => {
-        return HttpResponse.json(
-          {
-            provider: {
-              id: "a0000000-0000-4000-a000-000000000099",
-              type: "vm0",
-              framework: "claude-code",
-              secretName: null,
-              authMethod: null,
-              secretNames: null,
-              isDefault: true,
-              selectedModel: null,
-              createdAt: "2026-03-01T00:00:00Z",
-              updatedAt: "2026-03-01T00:00:00Z",
-            },
-            created: true,
-          },
-          { status: 201 },
-        );
-      }),
-      http.post("*/api/zero/agents", async ({ request }) => {
-        capturedPayload = (await request.json()) as CreateAgentPayload;
-        return HttpResponse.json(
-          {
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: capturedPayload.displayName ?? null,
-            sound: capturedPayload.sound ?? null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          },
-          { status: 201 },
-        );
-      }),
-      http.put(
-        "*/api/zero/agents/d0000000-0000-4000-a000-000000000001/instructions",
-        async ({ request }) => {
-          capturedInstructions = (await request.json()) as InstructionsPayload;
-          return HttpResponse.json({
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          });
-        },
-      ),
-      http.put("*/api/zero/default-agent", () => {
-        return HttpResponse.json({
-          agentId: "d0000000-0000-4000-a000-000000000001",
-        });
-      }),
-      http.post("*/api/zero/onboarding/complete", () => {
-        return HttpResponse.json({ ok: true });
+      setupHandler((payload) => {
+        capturedPayload = payload;
       }),
     );
 
     await setupPage({ context, path: "/", withoutRender: true });
 
-    // Set agent name to a user-facing display name
     context.store.set(setZeroAgentName$, "My Assistant");
 
     await context.store.set(completeZeroOnboarding$, context.signal);
 
-    // Verify agent was created with metadata (no connectors in create body)
     expect(capturedPayload).toBeTruthy();
     expect(capturedPayload!.displayName).toBe("My Assistant");
     expect(capturedPayload!.sound).toBe("professional");
-
-    // Instructions should be SEED_INSTRUCTIONS
-    expect(capturedInstructions).toBeTruthy();
-    expect(capturedInstructions!.content).toBe(SEED_INSTRUCTIONS);
+    expect(capturedPayload!.avatarUrl).toBe("preset:0");
   });
 
-  it("should set user-connectors after creating agent when connectors are selected", async () => {
-    let capturedUserConnectorsBody: { enabledTypes: string[] } | null = null;
+  it("should send selectedConnectors when user selects connectors", async () => {
+    let capturedPayload: SetupPayload | null = null;
 
     server.use(
-      http.post("*/api/zero/model-providers", () => {
-        return HttpResponse.json(
-          {
-            provider: {
-              id: "a0000000-0000-4000-a000-000000000099",
-              type: "vm0",
-              framework: "claude-code",
-              secretName: null,
-              authMethod: null,
-              secretNames: null,
-              isDefault: true,
-              selectedModel: null,
-              createdAt: "2026-03-01T00:00:00Z",
-              updatedAt: "2026-03-01T00:00:00Z",
-            },
-            created: true,
-          },
-          { status: 201 },
-        );
-      }),
-      http.post("*/api/zero/agents", () => {
-        return HttpResponse.json(
-          {
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          },
-          { status: 201 },
-        );
-      }),
-      http.put(
-        "*/api/zero/agents/d0000000-0000-4000-a000-000000000001/instructions",
-        () => {
-          return HttpResponse.json({
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          });
-        },
-      ),
-      http.put(
-        "*/api/zero/agents/d0000000-0000-4000-a000-000000000001/user-connectors",
-        async ({ request }) => {
-          capturedUserConnectorsBody = (await request.json()) as {
-            enabledTypes: string[];
-          };
-          return HttpResponse.json({ enabledTypes: ["slack"] });
-        },
-      ),
-      http.put("*/api/zero/default-agent", () => {
-        return HttpResponse.json({
-          agentId: "d0000000-0000-4000-a000-000000000001",
-        });
-      }),
-      http.post("*/api/zero/onboarding/complete", () => {
-        return HttpResponse.json({ ok: true });
+      setupHandler((payload) => {
+        capturedPayload = payload;
       }),
     );
 
     await setupPage({ context, path: "/", withoutRender: true });
 
-    // Select a user connector
     context.store.set(toggleZeroConnector$, "slack");
 
     await context.store.set(completeZeroOnboarding$, context.signal);
 
-    // User-selected connectors sent to user-connectors API (not create body)
-    expect(capturedUserConnectorsBody).toBeTruthy();
-    expect(capturedUserConnectorsBody!.enabledTypes).toStrictEqual(["slack"]);
+    expect(capturedPayload).toBeTruthy();
+    expect(capturedPayload!.selectedConnectors).toStrictEqual(["slack"]);
   });
 
-  it("should set default agent after creating compose", async () => {
-    let defaultAgentBody: Record<string, unknown> | null = null;
+  it("should send workspaceName when user sets workspace name", async () => {
+    let capturedPayload: SetupPayload | null = null;
 
     server.use(
-      http.post("*/api/zero/model-providers", () => {
-        return HttpResponse.json(
-          {
-            provider: {
-              id: "a0000000-0000-4000-a000-000000000099",
-              type: "vm0",
-              framework: "claude-code",
-              secretName: null,
-              authMethod: null,
-              secretNames: null,
-              isDefault: true,
-              selectedModel: null,
-              createdAt: "2026-03-01T00:00:00Z",
-              updatedAt: "2026-03-01T00:00:00Z",
-            },
-            created: true,
-          },
-          { status: 201 },
-        );
-      }),
-      http.post("*/api/zero/agents", () => {
-        return HttpResponse.json(
-          {
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          },
-          { status: 201 },
-        );
-      }),
-      http.put(
-        "*/api/zero/agents/d0000000-0000-4000-a000-000000000001/instructions",
-        () => {
-          return HttpResponse.json({
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          });
-        },
-      ),
-      http.put("*/api/zero/default-agent", async ({ request }) => {
-        defaultAgentBody = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json({
-          agentId: "d0000000-0000-4000-a000-000000000001",
-        });
-      }),
-      http.post("*/api/zero/onboarding/complete", () => {
-        return HttpResponse.json({ ok: true });
+      setupHandler((payload) => {
+        capturedPayload = payload;
       }),
     );
 
     await setupPage({ context, path: "/", withoutRender: true });
 
-    await context.store.set(completeZeroOnboarding$, context.signal);
-
-    expect(defaultAgentBody).toStrictEqual({
-      agentId: "d0000000-0000-4000-a000-000000000001",
-    });
-  });
-
-  it("should reset saving to false after completion (step remains unchanged)", async () => {
-    server.use(
-      http.post("*/api/zero/model-providers", () => {
-        return HttpResponse.json(
-          {
-            provider: {
-              id: "a0000000-0000-4000-a000-000000000099",
-              type: "vm0",
-              framework: "claude-code",
-              secretName: null,
-              authMethod: null,
-              secretNames: null,
-              isDefault: true,
-              selectedModel: null,
-              createdAt: "2026-03-01T00:00:00Z",
-              updatedAt: "2026-03-01T00:00:00Z",
-            },
-            created: true,
-          },
-          { status: 201 },
-        );
-      }),
-      http.post("*/api/zero/agents", () => {
-        return HttpResponse.json(
-          {
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          },
-          { status: 201 },
-        );
-      }),
-      http.put(
-        "*/api/zero/agents/d0000000-0000-4000-a000-000000000001/instructions",
-        () => {
-          return HttpResponse.json({
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          });
-        },
-      ),
-      http.put("*/api/zero/default-agent", () => {
-        return HttpResponse.json({
-          agentId: "d0000000-0000-4000-a000-000000000001",
-        });
-      }),
-      http.post("*/api/zero/onboarding/complete", () => {
-        return HttpResponse.json({ ok: true });
-      }),
-    );
-
-    await setupPage({ context, path: "/", withoutRender: true });
+    context.store.set(setZeroWorkspaceName$, "My Workspace");
 
     await context.store.set(completeZeroOnboarding$, context.signal);
-  });
-});
 
-describe("completeZeroOnboarding$ avatar", () => {
-  it("should send preset:0 as avatarUrl for the lead agent", async () => {
-    let capturedPayload: Record<string, unknown> | null = null;
+    expect(capturedPayload).toBeTruthy();
+    expect(capturedPayload!.workspaceName).toBe("My Workspace");
+  });
+
+  it("should not send workspaceName when empty", async () => {
+    let capturedPayload: SetupPayload | null = null;
 
     server.use(
-      http.post("*/api/zero/model-providers", () => {
-        return HttpResponse.json(
-          {
-            provider: {
-              id: "a0000000-0000-4000-a000-000000000099",
-              type: "vm0",
-              framework: "claude-code",
-              secretName: null,
-              authMethod: null,
-              secretNames: null,
-              isDefault: true,
-              selectedModel: null,
-              createdAt: "2026-03-01T00:00:00Z",
-              updatedAt: "2026-03-01T00:00:00Z",
-            },
-            created: true,
-          },
-          { status: 201 },
-        );
-      }),
-      http.post("*/api/zero/agents", async ({ request }) => {
-        capturedPayload = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json(
-          {
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: capturedPayload.avatarUrl ?? null,
-            firewallPolicies: null,
-          },
-          { status: 201 },
-        );
-      }),
-      http.put(
-        "*/api/zero/agents/d0000000-0000-4000-a000-000000000001/instructions",
-        () => {
-          return HttpResponse.json({
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          });
-        },
-      ),
-      http.put("*/api/zero/default-agent", () => {
-        return HttpResponse.json({
-          agentId: "d0000000-0000-4000-a000-000000000001",
-        });
-      }),
-      http.post("*/api/zero/onboarding/complete", () => {
-        return HttpResponse.json({ ok: true });
+      setupHandler((payload) => {
+        capturedPayload = payload;
       }),
     );
 
@@ -406,76 +104,15 @@ describe("completeZeroOnboarding$ avatar", () => {
     await context.store.set(completeZeroOnboarding$, context.signal);
 
     expect(capturedPayload).toBeTruthy();
-    expect(capturedPayload!.avatarUrl).toBe("preset:0");
+    expect(capturedPayload!.workspaceName).toBeUndefined();
   });
-});
 
-describe("completeZeroOnboarding$ auto-init model provider", () => {
-  it("should auto-create vm0 model provider with claude-sonnet-4.6 before creating agent", async () => {
-    let capturedProviderBody: Record<string, unknown> | null = null;
+  it("should not send selectedConnectors when none selected", async () => {
+    let capturedPayload: SetupPayload | null = null;
 
     server.use(
-      http.post("*/api/zero/model-providers", async ({ request }) => {
-        capturedProviderBody = (await request.json()) as Record<
-          string,
-          unknown
-        >;
-        return HttpResponse.json(
-          {
-            provider: {
-              id: "a0000000-0000-4000-a000-000000000099",
-              type: "vm0",
-              framework: "claude-code",
-              secretName: null,
-              authMethod: null,
-              secretNames: null,
-              isDefault: true,
-              selectedModel: null,
-              createdAt: "2026-03-01T00:00:00Z",
-              updatedAt: "2026-03-01T00:00:00Z",
-            },
-            created: true,
-          },
-          { status: 201 },
-        );
-      }),
-      http.post("*/api/zero/agents", () => {
-        return HttpResponse.json(
-          {
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          },
-          { status: 201 },
-        );
-      }),
-      http.put(
-        "*/api/zero/agents/d0000000-0000-4000-a000-000000000001/instructions",
-        () => {
-          return HttpResponse.json({
-            name: "test-agent-uuid",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-owner-id",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            firewallPolicies: null,
-          });
-        },
-      ),
-      http.put("*/api/zero/default-agent", () => {
-        return HttpResponse.json({
-          agentId: "d0000000-0000-4000-a000-000000000001",
-        });
-      }),
-      http.post("*/api/zero/onboarding/complete", () => {
-        return HttpResponse.json({ ok: true });
+      setupHandler((payload) => {
+        capturedPayload = payload;
       }),
     );
 
@@ -483,172 +120,20 @@ describe("completeZeroOnboarding$ auto-init model provider", () => {
 
     await context.store.set(completeZeroOnboarding$, context.signal);
 
-    expect(capturedProviderBody).not.toBeNull();
-    expect(capturedProviderBody!.type).toBe("vm0");
-    expect(capturedProviderBody!.selectedModel).toBe("claude-sonnet-4.6");
+    expect(capturedPayload).toBeTruthy();
+    expect(capturedPayload!.selectedConnectors).toBeUndefined();
   });
-});
 
-/**
- * Shared handlers for agent creation, instructions, default-agent, and
- * onboarding-complete — everything after the org-update step.
- */
-function agentCreationHandlers() {
-  return [
-    http.post("*/api/zero/model-providers", () => {
-      return HttpResponse.json(
-        {
-          provider: {
-            id: "a0000000-0000-4000-a000-000000000099",
-            type: "vm0",
-            framework: "claude-code",
-            secretName: null,
-            authMethod: null,
-            secretNames: null,
-            isDefault: true,
-            selectedModel: null,
-            createdAt: "2026-03-01T00:00:00Z",
-            updatedAt: "2026-03-01T00:00:00Z",
-          },
-          created: true,
-        },
-        { status: 201 },
-      );
-    }),
-    http.post("*/api/zero/agents", () => {
-      return HttpResponse.json(
-        {
-          name: "test-agent-uuid",
-          agentId: "d0000000-0000-4000-a000-000000000001",
-          ownerId: "test-owner-id",
-          description: null,
-          displayName: null,
-          sound: null,
-          avatarUrl: null,
-          firewallPolicies: null,
-        },
-        { status: 201 },
-      );
-    }),
-    http.put(
-      "*/api/zero/agents/d0000000-0000-4000-a000-000000000001/instructions",
-      () => {
-        return HttpResponse.json({
-          name: "test-agent-uuid",
-          agentId: "d0000000-0000-4000-a000-000000000001",
-          ownerId: "test-owner-id",
-          description: null,
-          displayName: null,
-          sound: null,
-          avatarUrl: null,
-          firewallPolicies: null,
-        });
-      },
-    ),
-    http.put("*/api/zero/default-agent", () => {
-      return HttpResponse.json({
-        agentId: "d0000000-0000-4000-a000-000000000001",
-      });
-    }),
-    http.post("*/api/zero/onboarding/complete", () => {
-      return HttpResponse.json({ ok: true });
-    }),
-  ];
-}
-
-function orgUpdateSuccess() {
-  return HttpResponse.json({
-    id: "org_1",
-    slug: "my-workspace",
-    name: "My Workspace",
-    role: "admin",
-  });
-}
-
-describe("completeZeroOnboarding$ slug update", () => {
-  it("should update org name and slug together", async () => {
-    const capturedOrgUpdates: Record<string, unknown>[] = [];
-
-    server.use(
-      http.put("*/api/zero/org", async ({ request }) => {
-        const body = (await request.json()) as Record<string, unknown>;
-        capturedOrgUpdates.push(body);
-        return orgUpdateSuccess();
-      }),
-      ...agentCreationHandlers(),
-    );
+  it("should return agentId from setup response", async () => {
+    server.use(setupHandler());
 
     await setupPage({ context, path: "/", withoutRender: true });
-    context.store.set(setZeroWorkspaceName$, "My Workspace");
 
-    await context.store.set(completeZeroOnboarding$, context.signal);
-
-    expect(capturedOrgUpdates).toHaveLength(1);
-    expect(capturedOrgUpdates[0]).toMatchObject({
-      name: "My Workspace",
-      slug: "my-workspace",
-      force: true,
-    });
-  });
-
-  it("should retry with random suffix on 409 conflict", async () => {
-    const capturedOrgUpdates: Record<string, unknown>[] = [];
-
-    server.use(
-      http.put("*/api/zero/org", async ({ request }) => {
-        const body = (await request.json()) as Record<string, unknown>;
-        capturedOrgUpdates.push(body);
-        // First request with slug → 409 conflict; subsequent requests → 200
-        if (capturedOrgUpdates.length === 1) {
-          return HttpResponse.json(
-            { error: { message: "Conflict", code: "CONFLICT" } },
-            { status: 409 },
-          );
-        }
-        return orgUpdateSuccess();
-      }),
-      ...agentCreationHandlers(),
+    const agentId = await context.store.set(
+      completeZeroOnboarding$,
+      context.signal,
     );
 
-    await setupPage({ context, path: "/", withoutRender: true });
-    context.store.set(setZeroWorkspaceName$, "My Workspace");
-
-    await context.store.set(completeZeroOnboarding$, context.signal);
-
-    expect(capturedOrgUpdates).toHaveLength(2);
-    // First attempt: exact slug
-    expect(capturedOrgUpdates[0]!.slug).toBe("my-workspace");
-    // Second attempt: slug with random suffix
-    expect(capturedOrgUpdates[1]!.slug).toMatch(/^my-workspace-[a-z0-9]+$/);
-    expect(capturedOrgUpdates[1]!.force).toBeTruthy();
-  });
-
-  it("should fall back to name-only update when both slug attempts get 409", async () => {
-    const capturedOrgUpdates: Record<string, unknown>[] = [];
-
-    server.use(
-      http.put("*/api/zero/org", async ({ request }) => {
-        const body = (await request.json()) as Record<string, unknown>;
-        capturedOrgUpdates.push(body);
-        // All slug attempts → 409; name-only → 200
-        if (body.slug) {
-          return HttpResponse.json(
-            { error: { message: "Conflict", code: "CONFLICT" } },
-            { status: 409 },
-          );
-        }
-        return orgUpdateSuccess();
-      }),
-      ...agentCreationHandlers(),
-    );
-
-    await setupPage({ context, path: "/", withoutRender: true });
-    context.store.set(setZeroWorkspaceName$, "My Workspace");
-
-    await context.store.set(completeZeroOnboarding$, context.signal);
-
-    // 2 slug attempts + 1 name-only fallback
-    expect(capturedOrgUpdates).toHaveLength(3);
-    expect(capturedOrgUpdates[2]).toStrictEqual({ name: "My Workspace" });
+    expect(agentId).toBe("d0000000-0000-4000-a000-000000000001");
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -12,7 +12,6 @@ import {
   completeMemberOnboarding$,
 } from "./zero-onboarding.ts";
 import { agentDisplayName$ } from "./zero-agent-name.ts";
-import { sendNewThreadMessage$ } from "./zero-chat.ts";
 import { allConnectorTypes$ } from "./settings/connectors.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
@@ -277,11 +276,8 @@ export const onboardingContinueWeb$ = command(
       return;
     }
 
-    await set(
-      sendNewThreadMessage$,
-      agentId,
-      "Who are you and what can you do?",
-      signal,
-    );
+    set(detachedNavigateTo$, "/agents/:id/chat", {
+      pathParams: { id: agentId },
+    });
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -2,14 +2,10 @@ import { command, computed, state } from "ccstate";
 import {
   onboardingStatusContract,
   onboardingCompleteContract,
-  orgDefaultAgentContract,
-  zeroOrgContract,
-  zeroUserConnectorsContract,
+  onboardingSetupContract,
 } from "@vm0/core";
 import { clerk$ } from "../auth.ts";
 import { zeroClient$ } from "../api-client.ts";
-import { createOrgModelProvider$ } from "../external/org-model-providers.ts";
-import { createZeroAgent } from "./create-zero-agent.ts";
 import { logger } from "../log.ts";
 import { accept } from "../../lib/accept.ts";
 
@@ -141,7 +137,8 @@ export const resetOnboardingStep$ = command(({ set }) => {
 });
 
 /**
- * Complete onboarding: create agent via zero agents API and set as default.
+ * Complete onboarding: single server-side API call that creates agent,
+ * sets default, updates org, and marks onboarding done.
  */
 export const completeZeroOnboarding$ = command(
   async ({ get, set }, signal: AbortSignal) => {
@@ -150,94 +147,25 @@ export const completeZeroOnboarding$ = command(
     const selectedConnectors = get(internalSelectedConnectors$);
     const createClient = get(zeroClient$);
 
-    if (workspaceName.trim()) {
-      const name = workspaceName.trim();
-      const baseSlug = name
-        .toLowerCase()
-        .replace(/[^a-z0-9-]/g, "-")
-        .replace(/-+/g, "-")
-        .replace(/^-|-$/g, "")
-        .slice(0, 64);
-      const orgClient = createClient(zeroOrgContract);
-
-      // Try slug from name first, fall back to slug+random on conflict
-      const slugCandidates = [
-        baseSlug,
-        `${baseSlug.slice(0, 56)}-${Math.random().toString(36).slice(2, 8)}`,
-      ];
-      let updated = false;
-      for (const slug of slugCandidates) {
-        if (slug.length < 3) {
-          continue;
-        }
-        const orgResult = await accept(
-          orgClient.update({ body: { name, slug, force: true } }),
-          [200, 409],
-        );
-        signal.throwIfAborted();
-        if (orgResult.status === 200) {
-          updated = true;
-          break;
-        }
-        // status === 409, try next slug
-      }
-      // If both slug candidates failed, update name only
-      if (!updated) {
-        await accept(orgClient.update({ body: { name } }), [200]);
-        signal.throwIfAborted();
-      }
-    }
-
-    await set(
-      createOrgModelProvider$,
-      {
-        type: "vm0",
-        selectedModel: "claude-sonnet-4.6",
-      },
-      signal,
-    );
-    signal.throwIfAborted();
-
-    // Create agent and upload instructions (server injects seed skills)
-    const agent = await createZeroAgent(createClient, {
-      displayName,
-      sound: "professional",
-      avatarUrl: "preset:0",
-    });
-    signal.throwIfAborted();
-
-    // Set initial connector permissions for the new agent
-    if (selectedConnectors.length > 0) {
-      const userConnectorsClient = createClient(zeroUserConnectorsContract);
-      await accept(
-        userConnectorsClient.update({
-          params: { id: agent.agentId },
-          body: { enabledTypes: selectedConnectors },
-        }),
-        [200],
-      );
-      signal.throwIfAborted();
-    }
-
-    // Set as default agent
-    const defaultAgentClient = createClient(orgDefaultAgentContract);
-    await accept(
-      defaultAgentClient.setDefaultAgent({
-        query: {},
-        body: { agentId: agent.agentId },
+    const setupClient = createClient(onboardingSetupContract);
+    const result = await accept(
+      setupClient.setup({
+        body: {
+          displayName,
+          workspaceName: workspaceName.trim() || undefined,
+          sound: "professional",
+          avatarUrl: "preset:0",
+          selectedConnectors:
+            selectedConnectors.length > 0 ? selectedConnectors : undefined,
+        },
       }),
       [200],
     );
     signal.throwIfAborted();
 
-    // Mark personal onboarding as done so admin doesn't re-enter member flow
-    const completeClient = createClient(onboardingCompleteContract);
-    await accept(completeClient.complete(), [200]);
-    signal.throwIfAborted();
+    const { agentId } = result.body;
 
-    L.debug("Zero onboarding completed", {
-      agentId: agent.agentId,
-    });
+    L.debug("Zero onboarding completed", { agentId });
 
     // Force JWT refresh so updated org metadata is available immediately
     const clerk = await get(clerk$);
@@ -254,7 +182,7 @@ export const completeZeroOnboarding$ = command(
       return x + 1;
     });
 
-    return agent.agentId;
+    return agentId;
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-chat-intro.test.tsx
@@ -5,18 +5,15 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
-import { mockChatLifecycle, PLACEHOLDER } from "./chat-test-helpers.ts";
+import { PLACEHOLDER } from "./chat-test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
 
 const context = testContext();
 
-/**
- * Mock onboarding as needed for an admin, plus chat lifecycle endpoints.
- * Returns control object from mockChatLifecycle and a spy for run creation.
- */
-function mockAdminOnboardingWithChat() {
-  let runCreated = false;
+const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
+const MOCK_MEMBER_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 
+function mockAdminOnboarding() {
   server.use(
     http.get("*/api/zero/onboarding/status", () => {
       return HttpResponse.json({
@@ -29,116 +26,13 @@ function mockAdminOnboardingWithChat() {
         defaultAgentSkills: [],
       });
     }),
-    http.put("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "test-workspace",
-        name: "Test Workspace",
-      });
-    }),
-    http.post("*/api/zero/model-providers", () => {
-      return HttpResponse.json(
-        {
-          provider: {
-            id: "a0000000-0000-4000-a000-000000000099",
-            type: "vm0",
-            framework: "claude-code",
-            secretName: null,
-            authMethod: null,
-            secretNames: null,
-            isDefault: true,
-            selectedModel: null,
-            createdAt: "2026-03-01T00:00:00Z",
-            updatedAt: "2026-03-01T00:00:00Z",
-          },
-          created: true,
-        },
-        { status: 201 },
-      );
-    }),
-    http.post("*/api/zero/agents", () => {
-      return HttpResponse.json(
-        {
-          name: "zero",
-          agentId: "d0000000-0000-4000-a000-000000000001",
-          ownerId: "test-owner-id",
-          description: null,
-          displayName: null,
-          sound: null,
-          avatarUrl: null,
-          connectors: [],
-          firewallPolicies: null,
-        },
-        { status: 201 },
-      );
-    }),
-    http.put("*/api/zero/agents/:name/instructions", () => {
-      return HttpResponse.json({
-        name: "zero",
-        agentId: "d0000000-0000-4000-a000-000000000001",
-        ownerId: "test-owner-id",
-        description: null,
-        displayName: null,
-        sound: null,
-        avatarUrl: null,
-        connectors: [],
-        firewallPolicies: null,
-      });
-    }),
-    http.put("*/api/zero/default-agent", () => {
-      return HttpResponse.json({
-        agentId: "d0000000-0000-4000-a000-000000000001",
-      });
-    }),
-    http.post("*/api/zero/onboarding/complete", () => {
-      return HttpResponse.json({ ok: true });
+    http.post("*/api/zero/onboarding/setup", () => {
+      return HttpResponse.json({ agentId: MOCK_AGENT_ID });
     }),
   );
-
-  // mockChatLifecycle sets up the unified POST /api/zero/chat/messages handler
-  // which also tracks the run prompt. We wrap it to detect intro message creation.
-  const ctrl = mockChatLifecycle();
-
-  // Use a request interceptor to detect when the intro message is sent
-  server.events.on("request:match", ({ request }) => {
-    if (
-      request.method === "POST" &&
-      request.url.includes("/api/zero/chat/messages")
-    ) {
-      runCreated = true;
-    }
-  });
-
-  return {
-    ctrl,
-    wasRunCreated: () => {
-      return runCreated;
-    },
-    /** Switch onboarding status to completed (call before clicking "Continue in web") */
-    completeOnboarding: () => {
-      server.use(
-        http.get("*/api/zero/onboarding/status", () => {
-          return HttpResponse.json({
-            needsOnboarding: false,
-            isAdmin: true,
-            hasOrg: true,
-            hasDefaultAgent: true,
-            defaultAgentId: "d0000000-0000-4000-a000-000000000001",
-            defaultAgentMetadata: null,
-            defaultAgentSkills: [],
-          });
-        }),
-      );
-    },
-  };
 }
 
-/**
- * Mock onboarding as needed for a member, plus chat lifecycle endpoints.
- */
-function mockMemberOnboardingWithChat() {
-  let runCreated = false;
-
+function mockMemberOnboarding() {
   server.use(
     http.get("*/api/zero/onboarding/status", () => {
       return HttpResponse.json({
@@ -146,7 +40,7 @@ function mockMemberOnboardingWithChat() {
         isAdmin: false,
         hasOrg: true,
         hasDefaultAgent: true,
-        defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+        defaultAgentId: MOCK_MEMBER_AGENT_ID,
         defaultAgentMetadata: { displayName: "Zero" },
         defaultAgentSkills: [],
       });
@@ -155,39 +49,6 @@ function mockMemberOnboardingWithChat() {
       return HttpResponse.json({ ok: true });
     }),
   );
-
-  const ctrl = mockChatLifecycle();
-
-  server.events.on("request:match", ({ request }) => {
-    if (
-      request.method === "POST" &&
-      request.url.includes("/api/zero/chat/messages")
-    ) {
-      runCreated = true;
-    }
-  });
-
-  return {
-    ctrl,
-    wasRunCreated: () => {
-      return runCreated;
-    },
-    completeOnboarding: () => {
-      server.use(
-        http.get("*/api/zero/onboarding/status", () => {
-          return HttpResponse.json({
-            needsOnboarding: false,
-            isAdmin: false,
-            hasOrg: true,
-            hasDefaultAgent: true,
-            defaultAgentId: "c0000000-0000-4000-a000-000000000001",
-            defaultAgentMetadata: { displayName: "Zero" },
-            defaultAgentSkills: [],
-          });
-        }),
-      );
-    },
-  };
 }
 
 /** Walk through onboarding steps up to the "Where would you like to work" step. */
@@ -196,37 +57,31 @@ async function walkToWhereStep(
   isMember: boolean,
 ) {
   if (isMember) {
-    // Member with no connectors skips directly to step 4 (where-to-work)
     await waitFor(() => {
       expect(
         screen.getByText(/Where would you like to work with/),
       ).toBeInTheDocument();
     });
   } else {
-    // Admin: step 1 (workspace name) → step 2 (choose tools) → step 3 (connect) → step 4 (where)
     await waitFor(() => {
       expect(screen.getByText(/Name your workspace/)).toBeInTheDocument();
     });
 
-    // Fill workspace name and advance
     const input = screen.getByPlaceholderText("e.g. Acme Corp");
     await user.clear(input);
     await user.type(input, "Test Workspace");
     await user.click(screen.getByText("Next"));
 
-    // Step 2: Choose your tools → Next
     await waitFor(() => {
       expect(screen.getByText("Choose your tools")).toBeInTheDocument();
     });
     await user.click(screen.getByText("Next"));
 
-    // Step 3: Connect your apps → Next
     await waitFor(() => {
       expect(screen.getByText("Connect your apps")).toBeInTheDocument();
     });
     await user.click(screen.getByText("Next"));
 
-    // Step 4: Where to work
     await waitFor(() => {
       expect(
         screen.getByText(/Where would you like to work with/),
@@ -235,103 +90,79 @@ async function walkToWhereStep(
   }
 }
 
-describe("onboarding auto-intro message", () => {
-  it("should send intro message after admin completes onboarding via web", async () => {
+describe("onboarding → chat page (no auto-intro)", () => {
+  it("should navigate to /agents/:id/chat after admin completes onboarding", async () => {
     const user = userEvent.setup();
-    const mock = mockAdminOnboardingWithChat();
+    mockAdminOnboarding();
 
     await setupPage({ context, path: "/onboarding" });
     await walkToWhereStep(user, false);
 
     // Switch onboarding status so post-navigate route doesn't redirect back
-    mock.completeOnboarding();
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: true,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: MOCK_AGENT_ID,
+          defaultAgentMetadata: null,
+          defaultAgentSkills: [],
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
 
     await user.click(screen.getByRole("button", { name: /Continue in web/ }));
 
-    // Verify navigation away from onboarding
+    // Should navigate directly to the agent chat page
     await waitFor(() => {
-      expect(pathname()).not.toBe("/onboarding");
+      expect(pathname()).toBe(`/agents/${MOCK_AGENT_ID}/chat`);
     });
 
-    // Verify the agent run was actually created (intro message was sent)
-    await waitFor(() => {
-      expect(mock.wasRunCreated()).toBeTruthy();
-    });
-
-    // The assistant should be in thinking/running state
-    await waitFor(() => {
-      const shimmer = document.querySelector(".zero-shimmer-text");
-      expect(shimmer).toBeInTheDocument();
-    });
-
-    // Complete the run so the test cleans up
-    mock.ctrl.completeRun("I am Zero, your AI teammate.");
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Send")).toBeInTheDocument();
-    });
-  });
-
-  it("should send intro message after member completes onboarding via web", async () => {
-    const user = userEvent.setup();
-    const mock = mockMemberOnboardingWithChat();
-
-    await setupPage({ context, path: "/onboarding" });
-    await walkToWhereStep(user, true);
-
-    mock.completeOnboarding();
-
-    await user.click(screen.getByRole("button", { name: /Continue in web/ }));
-
-    await waitFor(() => {
-      expect(pathname()).not.toBe("/onboarding");
-    });
-
-    await waitFor(() => {
-      expect(mock.wasRunCreated()).toBeTruthy();
-    });
-
-    await waitFor(() => {
-      const shimmer = document.querySelector(".zero-shimmer-text");
-      expect(shimmer).toBeInTheDocument();
-    });
-
-    mock.ctrl.completeRun("I am Zero, your AI teammate.");
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Send")).toBeInTheDocument();
-    });
-  });
-
-  it("should allow follow-up messages after onboarding intro completes", async () => {
-    const user = userEvent.setup();
-    const mock = mockMemberOnboardingWithChat();
-
-    await setupPage({ context, path: "/onboarding" });
-    await walkToWhereStep(user, true);
-
-    mock.completeOnboarding();
-
-    await user.click(screen.getByRole("button", { name: /Continue in web/ }));
-
-    // Wait for intro run to start
-    await waitFor(() => {
-      expect(mock.wasRunCreated()).toBeTruthy();
-    });
-
-    // Complete the intro run
-    mock.ctrl.completeRun("I am Zero, your AI teammate.");
-
-    // Wait for the chat to be ready for input
+    // Chat input should be ready for user to type (no auto-intro sent)
     const textarea = await waitFor(() => {
       return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
     });
+    expect(textarea).not.toBeDisabled();
+  });
+
+  it("should navigate to /agents/:id/chat after member completes onboarding", async () => {
+    const user = userEvent.setup();
+    mockMemberOnboarding();
+
+    await setupPage({ context, path: "/onboarding" });
+    await walkToWhereStep(user, true);
+
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: false,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: MOCK_MEMBER_AGENT_ID,
+          defaultAgentMetadata: { displayName: "Zero" },
+          defaultAgentSkills: [],
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /Continue in web/ }));
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Send")).toBeInTheDocument();
+      expect(pathname()).toBe(`/agents/${MOCK_MEMBER_AGENT_ID}/chat`);
     });
 
-    // Verify the textarea is interactive (user can type a follow-up)
+    const textarea = await waitFor(() => {
+      return screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement;
+    });
     expect(textarea).not.toBeDisabled();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web-blank-page.test.tsx
@@ -5,16 +5,14 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
-import { mockChatLifecycle } from "./chat-test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
 import { createDeferredPromise } from "../../../signals/utils.ts";
 
 const context = testContext();
 
 const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
-const MOCK_THREAD_ID = "thread-blank-test-1";
 
-function mockMemberOnboardingWithChat() {
+function mockMemberOnboardingDeferred() {
   // Deferred that blocks the POST /complete API response until we release it.
   // This creates a timing window to observe the skeleton while the async
   // onboarding completion is in-flight.
@@ -38,10 +36,7 @@ function mockMemberOnboardingWithChat() {
     }),
   );
 
-  const ctrl = mockChatLifecycle({ threadId: MOCK_THREAD_ID });
-
   return {
-    ctrl,
     releaseComplete: () => {
       completeDeferred.resolve();
     },
@@ -51,7 +46,7 @@ function mockMemberOnboardingWithChat() {
 describe("onboarding continue in web → skeleton → chat page (#7902)", () => {
   it("should show skeleton immediately on click, then hide after chat page loads", async () => {
     const user = userEvent.setup();
-    const mock = mockMemberOnboardingWithChat();
+    const mock = mockMemberOnboardingDeferred();
 
     await setupPage({ context, path: "/onboarding" });
 
@@ -78,13 +73,31 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
       );
     });
 
+    // Switch status to complete and add chat-threads mock for the landing page
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: false,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: MOCK_AGENT_ID,
+          defaultAgentMetadata: { displayName: "Zero" },
+          defaultAgentSkills: [],
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
     // Release the deferred POST response to let onboarding complete and
-    // navigation to the chat page proceed.
+    // navigation to the agent chat page proceed.
     mock.releaseComplete();
 
-    // Verify navigation happened and chat page renders
+    // Verify navigation happened to agent chat page
     await waitFor(() => {
-      expect(pathname()).toBe(`/chats/${MOCK_THREAD_ID}`);
+      expect(pathname()).toBe(`/agents/${MOCK_AGENT_ID}/chat`);
     });
 
     await waitFor(() => {
@@ -98,7 +111,5 @@ describe("onboarding continue in web → skeleton → chat page (#7902)", () => 
         "true",
       );
     });
-
-    mock.ctrl.completeRun("Hello!");
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-continue-web.test.tsx
@@ -5,15 +5,14 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
-import { mockChatLifecycle } from "./chat-test-helpers.ts";
 import { pathname } from "../../../signals/location.ts";
 
 const context = testContext();
 
 const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
-const MOCK_THREAD_ID = "thread-test-1";
+const MOCK_MEMBER_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 
-function mockAdminOnboardingApis() {
+function mockAdminOnboarding() {
   server.use(
     http.get("*/api/zero/onboarding/status", () => {
       return HttpResponse.json({
@@ -26,72 +25,13 @@ function mockAdminOnboardingApis() {
         defaultAgentSkills: [],
       });
     }),
-    http.put("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "test-workspace",
-        name: "Test Workspace",
-      });
-    }),
-    http.post("*/api/zero/model-providers", () => {
-      return HttpResponse.json(
-        {
-          provider: {
-            id: "a0000000-0000-4000-a000-000000000099",
-            type: "vm0",
-            framework: "claude-code",
-            secretName: null,
-            authMethod: null,
-            secretNames: null,
-            isDefault: true,
-            selectedModel: null,
-            createdAt: "2026-03-01T00:00:00Z",
-            updatedAt: "2026-03-01T00:00:00Z",
-          },
-          created: true,
-        },
-        { status: 201 },
-      );
-    }),
-    http.post("*/api/zero/agents", () => {
-      return HttpResponse.json(
-        {
-          name: "zero",
-          agentId: MOCK_AGENT_ID,
-          ownerId: "test-owner-id",
-          description: null,
-          displayName: null,
-          sound: null,
-          avatarUrl: null,
-          connectors: [],
-          firewallPolicies: null,
-        },
-        { status: 201 },
-      );
-    }),
-    http.put("*/api/zero/agents/:name/instructions", () => {
-      return HttpResponse.json({
-        name: "zero",
-        agentId: MOCK_AGENT_ID,
-        ownerId: "test-owner-id",
-        description: null,
-        displayName: null,
-        sound: null,
-        avatarUrl: null,
-        connectors: [],
-        firewallPolicies: null,
-      });
-    }),
-    http.put("*/api/zero/default-agent", () => {
+    http.post("*/api/zero/onboarding/setup", () => {
       return HttpResponse.json({ agentId: MOCK_AGENT_ID });
-    }),
-    http.post("*/api/zero/onboarding/complete", () => {
-      return HttpResponse.json({ ok: true });
     }),
   );
 }
 
-function switchToOnboardingComplete() {
+function switchToAdminComplete() {
   server.use(
     http.get("*/api/zero/onboarding/status", () => {
       return HttpResponse.json({
@@ -104,20 +44,13 @@ function switchToOnboardingComplete() {
         defaultAgentSkills: [],
       });
     }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
   );
 }
 
-function mockAdminOnboardingWithChat() {
-  mockAdminOnboardingApis();
-  const ctrl = mockChatLifecycle({ threadId: MOCK_THREAD_ID });
-
-  return {
-    ctrl,
-    completeOnboarding: switchToOnboardingComplete,
-  };
-}
-
-function mockMemberOnboardingWithChat() {
+function mockMemberOnboarding() {
   server.use(
     http.get("*/api/zero/onboarding/status", () => {
       return HttpResponse.json({
@@ -125,7 +58,7 @@ function mockMemberOnboardingWithChat() {
         isAdmin: false,
         hasOrg: true,
         hasDefaultAgent: true,
-        defaultAgentId: "c0000000-0000-4000-a000-000000000001",
+        defaultAgentId: MOCK_MEMBER_AGENT_ID,
         defaultAgentMetadata: { displayName: "Zero" },
         defaultAgentSkills: [],
       });
@@ -134,27 +67,25 @@ function mockMemberOnboardingWithChat() {
       return HttpResponse.json({ ok: true });
     }),
   );
+}
 
-  const ctrl = mockChatLifecycle({ threadId: MOCK_THREAD_ID });
-
-  return {
-    ctrl,
-    completeOnboarding: () => {
-      server.use(
-        http.get("*/api/zero/onboarding/status", () => {
-          return HttpResponse.json({
-            needsOnboarding: false,
-            isAdmin: false,
-            hasOrg: true,
-            hasDefaultAgent: true,
-            defaultAgentId: "c0000000-0000-4000-a000-000000000001",
-            defaultAgentMetadata: { displayName: "Zero" },
-            defaultAgentSkills: [],
-          });
-        }),
-      );
-    },
-  };
+function switchToMemberComplete() {
+  server.use(
+    http.get("*/api/zero/onboarding/status", () => {
+      return HttpResponse.json({
+        needsOnboarding: false,
+        isAdmin: false,
+        hasOrg: true,
+        hasDefaultAgent: true,
+        defaultAgentId: MOCK_MEMBER_AGENT_ID,
+        defaultAgentMetadata: { displayName: "Zero" },
+        defaultAgentSkills: [],
+      });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
 }
 
 async function walkAdminToWhereStep(user: ReturnType<typeof userEvent.setup>) {
@@ -184,28 +115,26 @@ async function walkAdminToWhereStep(user: ReturnType<typeof userEvent.setup>) {
   });
 }
 
-describe("onboarding continue in web → chat page", () => {
-  it("should navigate to /chat/:threadId after admin completes full onboarding", async () => {
+describe("onboarding continue in web → agent chat page", () => {
+  it("should navigate to /agents/:id/chat after admin completes full onboarding", async () => {
     const user = userEvent.setup();
-    const mock = mockAdminOnboardingWithChat();
+    mockAdminOnboarding();
 
     await setupPage({ context, path: "/onboarding" });
     await walkAdminToWhereStep(user);
 
-    mock.completeOnboarding();
+    switchToAdminComplete();
 
     await user.click(screen.getByRole("button", { name: /Continue in web/ }));
 
     await waitFor(() => {
-      expect(pathname()).toBe(`/chats/${MOCK_THREAD_ID}`);
+      expect(pathname()).toBe(`/agents/${MOCK_AGENT_ID}/chat`);
     });
-
-    mock.ctrl.completeRun("I am Zero, your AI teammate.");
   });
 
-  it("should navigate to /chat/:threadId after member completes onboarding", async () => {
+  it("should navigate to /agents/:id/chat after member completes onboarding", async () => {
     const user = userEvent.setup();
-    const mock = mockMemberOnboardingWithChat();
+    mockMemberOnboarding();
 
     await setupPage({ context, path: "/onboarding" });
 
@@ -216,15 +145,13 @@ describe("onboarding continue in web → chat page", () => {
       ).toBeInTheDocument();
     });
 
-    mock.completeOnboarding();
+    switchToMemberComplete();
 
     await user.click(screen.getByRole("button", { name: /Continue in web/ }));
 
     await waitFor(() => {
-      expect(pathname()).toBe(`/chats/${MOCK_THREAD_ID}`);
+      expect(pathname()).toBe(`/agents/${MOCK_MEMBER_AGENT_ID}/chat`);
     });
-
-    mock.ctrl.completeRun("I am Zero, your AI teammate.");
   });
 });
 
@@ -232,52 +159,15 @@ describe("onboarding continue in web → chat page", () => {
 // Continue in Slack
 // ---------------------------------------------------------------------------
 
-function mockMemberOnboardingForSlack() {
-  server.use(
-    http.get("*/api/zero/onboarding/status", () => {
-      return HttpResponse.json({
-        needsOnboarding: true,
-        isAdmin: false,
-        hasOrg: true,
-        hasDefaultAgent: true,
-        defaultAgentId: "c0000000-0000-4000-a000-000000000001",
-        defaultAgentMetadata: { displayName: "Zero" },
-        defaultAgentSkills: [],
-      });
-    }),
-    http.post("*/api/zero/onboarding/complete", () => {
-      return HttpResponse.json({ ok: true });
-    }),
-  );
-
-  return {
-    completeOnboarding: () => {
-      server.use(
-        http.get("*/api/zero/onboarding/status", () => {
-          return HttpResponse.json({
-            needsOnboarding: false,
-            isAdmin: false,
-            hasOrg: true,
-            hasDefaultAgent: true,
-            defaultAgentId: "c0000000-0000-4000-a000-000000000001",
-            defaultAgentMetadata: { displayName: "Zero" },
-            defaultAgentSkills: [],
-          });
-        }),
-      );
-    },
-  };
-}
-
 describe("onboarding add to Slack → works page", () => {
   it("should navigate to /works after admin completes onboarding via Slack", async () => {
     const user = userEvent.setup();
-    mockAdminOnboardingApis();
+    mockAdminOnboarding();
 
     await setupPage({ context, path: "/onboarding" });
     await walkAdminToWhereStep(user);
 
-    switchToOnboardingComplete();
+    switchToAdminComplete();
 
     await user.click(screen.getByRole("button", { name: /Add .+ to Slack/ }));
 
@@ -288,7 +178,7 @@ describe("onboarding add to Slack → works page", () => {
 
   it("should navigate to /works after member completes onboarding via Slack", async () => {
     const user = userEvent.setup();
-    const mock = mockMemberOnboardingForSlack();
+    mockMemberOnboarding();
 
     await setupPage({ context, path: "/onboarding" });
 
@@ -299,7 +189,7 @@ describe("onboarding add to Slack → works page", () => {
       ).toBeInTheDocument();
     });
 
-    mock.completeOnboarding();
+    switchToMemberComplete();
 
     await user.click(screen.getByRole("button", { name: /Add .+ to Slack/ }));
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/onboarding-navigation.test.tsx
@@ -11,38 +11,6 @@ const context = testContext();
 
 const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
 
-function mockModelProviderResponse() {
-  return {
-    provider: {
-      id: "a0000000-0000-4000-a000-000000000099",
-      type: "vm0",
-      framework: "claude-code",
-      secretName: null,
-      authMethod: null,
-      secretNames: null,
-      isDefault: true,
-      selectedModel: null,
-      createdAt: "2026-03-01T00:00:00Z",
-      updatedAt: "2026-03-01T00:00:00Z",
-    },
-    created: true,
-  };
-}
-
-function mockAgentResponse() {
-  return {
-    name: "zero",
-    agentId: MOCK_AGENT_ID,
-    ownerId: "test-user-123",
-    description: null,
-    displayName: null,
-    sound: null,
-    avatarUrl: null,
-    connectors: [],
-    firewallPolicies: null,
-  };
-}
-
 function mockOnboardingNeededAdmin() {
   server.use(
     http.get("*/api/zero/onboarding/status", () => {
@@ -56,49 +24,13 @@ function mockOnboardingNeededAdmin() {
         defaultAgentSkills: [],
       });
     }),
-    // Mock org name update
-    http.put("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "test-workspace",
-        name: "Test Workspace",
-      });
-    }),
-    // Mock model provider creation
-    http.post("*/api/zero/model-providers", () => {
-      return HttpResponse.json(mockModelProviderResponse(), { status: 201 });
-    }),
-    // Mock the agent creation endpoint
-    http.post("*/api/zero/agents", () => {
-      return HttpResponse.json(mockAgentResponse(), { status: 201 });
-    }),
-    // Mock instructions upload
-    http.put("*/api/zero/agents/:name/instructions", () => {
-      return HttpResponse.json(mockAgentResponse());
-    }),
-    // Mock setting default agent
-    http.put("*/api/zero/default-agent", () => {
+    // Single setup endpoint replaces all individual onboarding API calls
+    http.post("*/api/zero/onboarding/setup", () => {
       return HttpResponse.json({ agentId: MOCK_AGENT_ID });
-    }),
-    // Mock onboarding completion
-    http.post("*/api/zero/onboarding/complete", () => {
-      return HttpResponse.json({ ok: true });
     }),
     // Mock chat threads for the home page
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });
-    }),
-    // Mock chat send for the auto-intro message
-    http.post("*/api/zero/chat/messages", () => {
-      return HttpResponse.json(
-        {
-          runId: "run-intro-1",
-          threadId: "new-thread-1",
-          status: "pending",
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-        { status: 201 },
-      );
     }),
   );
 }
@@ -123,18 +55,6 @@ function mockOnboardingNeededMember() {
     // Mock chat threads for the home page
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });
-    }),
-    // Mock chat send for the auto-intro message
-    http.post("*/api/zero/chat/messages", () => {
-      return HttpResponse.json(
-        {
-          runId: "run-intro-1",
-          threadId: "new-thread-1",
-          status: "pending",
-          createdAt: "2026-03-10T00:00:00Z",
-        },
-        { status: 201 },
-      );
     }),
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/talk-navigation.test.tsx
@@ -108,8 +108,9 @@ describe("talk navigation", () => {
     });
   });
 
-  it("should navigate to /chat/:chatThreadId after completing onboarding and sending auto-intro", async () => {
+  it("should navigate to /agents/:id/chat after completing onboarding", async () => {
     const user = userEvent.setup();
+    const MOCK_AGENT_ID = "d0000000-0000-4000-a000-000000000001";
     // Track onboarding status: starts as needing onboarding, then completes
     let onboardingComplete = false;
 
@@ -121,7 +122,7 @@ describe("talk navigation", () => {
             isAdmin: true,
             hasOrg: true,
             hasDefaultAgent: true,
-            defaultAgentId: "d0000000-0000-4000-a000-000000000001",
+            defaultAgentId: MOCK_AGENT_ID,
             defaultAgentMetadata: null,
             defaultAgentSkills: [],
           });
@@ -136,80 +137,14 @@ describe("talk navigation", () => {
           defaultAgentSkills: [],
         });
       }),
-      // Org name update
-      http.put("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_1",
-          slug: "test-workspace",
-          name: "Test Workspace",
-        });
-      }),
-      // Model provider creation
-      http.post("*/api/zero/model-providers", () => {
-        return HttpResponse.json(
-          {
-            provider: {
-              id: "a0000000-0000-4000-a000-000000000099",
-              type: "vm0",
-              framework: "claude-code",
-              secretName: null,
-              authMethod: null,
-              secretNames: null,
-              isDefault: true,
-              selectedModel: null,
-              createdAt: "2026-03-01T00:00:00Z",
-              updatedAt: "2026-03-01T00:00:00Z",
-            },
-            created: true,
-          },
-          { status: 201 },
-        );
-      }),
-      // Agent creation
-      http.post("*/api/zero/agents", () => {
+      // Single setup endpoint
+      http.post("*/api/zero/onboarding/setup", () => {
         onboardingComplete = true;
-        return HttpResponse.json(
-          {
-            name: "zero",
-            agentId: "d0000000-0000-4000-a000-000000000001",
-            ownerId: "test-user-123",
-            description: null,
-            displayName: null,
-            sound: null,
-            avatarUrl: null,
-            connectors: [],
-            firewallPolicies: null,
-          },
-          { status: 201 },
-        );
-      }),
-      // Instructions upload
-      http.put("*/api/zero/agents/:name/instructions", () => {
-        return HttpResponse.json({
-          name: "zero",
-          agentId: "d0000000-0000-4000-a000-000000000001",
-          ownerId: "test-user-123",
-          description: null,
-          displayName: null,
-          sound: null,
-          avatarUrl: null,
-          connectors: [],
-          firewallPolicies: null,
-        });
-      }),
-      // Default agent
-      http.put("*/api/zero/default-agent", () => {
-        return HttpResponse.json({
-          agentId: "d0000000-0000-4000-a000-000000000001",
-        });
-      }),
-      // Onboarding completion
-      http.post("*/api/zero/onboarding/complete", () => {
-        return HttpResponse.json({ ok: true });
+        return HttpResponse.json({ agentId: MOCK_AGENT_ID });
       }),
     );
 
-    // Mock chat APIs for the auto-intro message
+    // Mock chat APIs for the agent chat page
     mockChatAPIs();
 
     await setupPage({ context, path: "/" });
@@ -245,19 +180,16 @@ describe("talk navigation", () => {
     });
 
     // Click "Continue in web" which triggers:
-    // 1. completeZeroOnboarding$ (create agent, set default)
-    // 2. navigate("/") → setupChatPage$ redirects to /talk/zero
-    // 3. sendNewThreadMessage$(agentId, "Who are you and what can you do?")
-    //    → POST /api/zero/chat/messages → navigates to /chat/:threadId
+    // 1. completeZeroOnboarding$ (single setup API call)
+    // 2. navigate to /agents/:id/chat
     const continueButton = screen.getByRole("button", {
       name: /Continue in web/,
     });
     await user.click(continueButton);
 
-    // The final URL should be /chat/new-thread-id-123 after the auto-intro
-    // message creates a thread and navigates
+    // The final URL should be /agents/:id/chat (no auto-intro message)
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/new-thread-id-123");
+      expect(pathname()).toBe(`/agents/${MOCK_AGENT_ID}/chat`);
     });
   });
 });

--- a/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
@@ -1,4 +1,3 @@
-import { NextResponse } from "next/server";
 import { and, eq } from "drizzle-orm";
 import { onboardingSetupContract } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
@@ -142,12 +141,12 @@ const router = tsr.router(onboardingSetupContract, {
 
     if (!composeResult) {
       return {
-        status: 401 as const,
+        status: 422 as const,
         body: {
           error: {
             message:
               "One or more skills are not cached. Please try again later.",
-            code: "UNAUTHORIZED",
+            code: "UNPROCESSABLE_ENTITY",
           },
         },
       };

--- a/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
@@ -1,0 +1,251 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { onboardingSetupContract } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
+import { updateOrg } from "../../../../../src/lib/zero/org/org-service";
+import { upsertOrgNoSecretModelProvider } from "../../../../../src/lib/zero/model-provider/model-provider-service";
+import { serverSideCompose } from "../../../../../src/lib/infra/compose/server-side-compose";
+import { buildComposeContent } from "../../../../../src/lib/zero/build-compose-content";
+import { SEED_INSTRUCTIONS } from "../../../../../src/lib/zero/seed-instructions";
+import { zeroAgents } from "../../../../../src/db/schema/zero-agent";
+import { orgMetadata } from "../../../../../src/db/schema/org-metadata";
+import { orgMembersMetadata } from "../../../../../src/db/schema/org-members-metadata";
+import { userConnectors } from "../../../../../src/db/schema/user-connector";
+import { logger } from "../../../../../src/lib/shared/logger";
+import { isBadRequest } from "../../../../../src/lib/shared/errors";
+
+const log = logger("api:onboarding-setup");
+
+/**
+ * Try to set org name/slug with retry on conflict.
+ * Mirrors the slug-retry logic that was previously in the frontend.
+ */
+async function tryUpdateOrgNameSlug(
+  orgId: string,
+  userId: string,
+  workspaceName: string,
+): Promise<void> {
+  const name = workspaceName.trim();
+  if (!name) return;
+
+  const baseSlug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 64);
+
+  const slugCandidates = [
+    baseSlug,
+    `${baseSlug.slice(0, 56)}-${Math.random().toString(36).slice(2, 8)}`,
+  ];
+
+  for (const slug of slugCandidates) {
+    if (slug.length < 3) continue;
+    try {
+      await updateOrg(orgId, userId, { name, slug, force: true });
+      return;
+    } catch (error) {
+      if (isBadRequest(error) && String(error).includes("already exists")) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  // Both slug attempts conflicted — update name only
+  await updateOrg(orgId, userId, { name });
+}
+
+const router = tsr.router(onboardingSetupContract, {
+  setup: async ({ body, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+    const { userId } = authCtx;
+
+    const { org, member } = await resolveOrg(authCtx);
+
+    if (member.role !== "admin") {
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            message: "Only org admins can run onboarding setup",
+            code: "UNAUTHORIZED",
+          },
+        },
+      };
+    }
+
+    const db = globalThis.services.db;
+
+    // Idempotency: if a default agent already exists, return it
+    const [orgRow] = await db
+      .select({ defaultAgentId: orgMetadata.defaultAgentId })
+      .from(orgMetadata)
+      .where(eq(orgMetadata.orgId, org.orgId))
+      .limit(1);
+
+    if (orgRow?.defaultAgentId) {
+      const [existing] = await db
+        .select({ id: zeroAgents.id })
+        .from(zeroAgents)
+        .where(
+          and(
+            eq(zeroAgents.id, orgRow.defaultAgentId),
+            eq(zeroAgents.orgId, org.orgId),
+          ),
+        )
+        .limit(1);
+
+      if (existing) {
+        return {
+          status: 200 as const,
+          body: { agentId: existing.id },
+        };
+      }
+    }
+
+    // Parallel group 1: org update + model provider (independent)
+    const parallelGroup1: Promise<unknown>[] = [
+      upsertOrgNoSecretModelProvider(org.orgId, "vm0", "claude-sonnet-4.6"),
+    ];
+    if (body.workspaceName) {
+      parallelGroup1.push(
+        tryUpdateOrgNameSlug(org.orgId, userId, body.workspaceName),
+      );
+    }
+    await Promise.all(parallelGroup1);
+
+    // Create agent with real seed instructions in a single serverSideCompose call
+    const agentName = crypto.randomUUID();
+    const content = buildComposeContent(agentName);
+
+    const composeResult = await serverSideCompose({
+      userId,
+      orgId: org.orgId,
+      content,
+      instructions: SEED_INSTRUCTIONS,
+    });
+
+    if (!composeResult) {
+      return {
+        status: 401 as const,
+        body: {
+          error: {
+            message:
+              "One or more skills are not cached. Please try again later.",
+            code: "UNAUTHORIZED",
+          },
+        },
+      };
+    }
+
+    // Write agent metadata
+    await db
+      .insert(zeroAgents)
+      .values({
+        id: composeResult.composeId,
+        orgId: org.orgId,
+        name: composeResult.composeName,
+        owner: userId,
+        displayName: body.displayName ?? null,
+        description: null,
+        sound: body.sound ?? null,
+        avatarUrl: body.avatarUrl ?? null,
+        customSkills: [],
+      })
+      .onConflictDoUpdate({
+        target: [zeroAgents.orgId, zeroAgents.name],
+        set: {
+          displayName: body.displayName ?? null,
+          sound: body.sound ?? null,
+          avatarUrl: body.avatarUrl ?? null,
+          updatedAt: new Date(),
+        },
+      });
+
+    const agentId = composeResult.composeId;
+
+    // Parallel group 2: connectors + default agent + mark complete
+    const parallelGroup2: Promise<unknown>[] = [
+      // Set default agent
+      db
+        .insert(orgMetadata)
+        .values({ orgId: org.orgId, defaultAgentId: agentId })
+        .onConflictDoUpdate({
+          target: orgMetadata.orgId,
+          set: { defaultAgentId: agentId, updatedAt: new Date() },
+        }),
+      // Mark onboarding complete
+      db
+        .insert(orgMembersMetadata)
+        .values({
+          orgId: org.orgId,
+          userId,
+          onboardingDone: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [orgMembersMetadata.orgId, orgMembersMetadata.userId],
+          set: { onboardingDone: true, updatedAt: new Date() },
+        }),
+    ];
+
+    // Set user connectors if provided
+    if (body.selectedConnectors && body.selectedConnectors.length > 0) {
+      const connectors = body.selectedConnectors;
+      parallelGroup2.push(
+        db.transaction(async (tx) => {
+          await tx
+            .delete(userConnectors)
+            .where(
+              and(
+                eq(userConnectors.orgId, org.orgId),
+                eq(userConnectors.userId, userId),
+                eq(userConnectors.agentId, agentId),
+              ),
+            );
+          await tx.insert(userConnectors).values(
+            connectors.map((connectorType) => {
+              return {
+                orgId: org.orgId,
+                userId,
+                agentId,
+                connectorType,
+              };
+            }),
+          );
+        }),
+      );
+    }
+
+    await Promise.all(parallelGroup2);
+
+    log.info(`Onboarding setup completed for org ${org.orgId}`, { agentId });
+
+    return {
+      status: 200 as const,
+      body: { agentId },
+    };
+  },
+});
+
+const handler = createHandler(onboardingSetupContract, router, {
+  errorHandler: createSafeErrorHandler("onboarding-setup"),
+});
+
+export { handler as POST };

--- a/turbo/apps/web/src/__tests__/onboarding-setup.test.ts
+++ b/turbo/apps/web/src/__tests__/onboarding-setup.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { POST } from "../../app/api/zero/onboarding/setup/route";
+import { GET as getOnboardingStatus } from "../../app/api/zero/onboarding/status/route";
+import { GET as listAgents } from "../../app/api/zero/agents/route";
+import { GET as getUserConnectors } from "../../app/api/zero/agents/[id]/user-connectors/route";
+import { GET as listModelProviders } from "../../app/api/zero/model-providers/route";
+import {
+  createTestRequest,
+  seedSeedSkills,
+  clearSkillsData,
+  getOrgDefaultAgent,
+} from "./api-test-helpers";
+import { testContext } from "./test-helpers";
+import { mockClerk } from "./clerk-mock";
+
+const context = testContext();
+
+const BASE = "http://localhost:3000/api/zero";
+
+function postSetup(body: Record<string, unknown>) {
+  return POST(
+    createTestRequest(`${BASE}/onboarding/setup`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("POST /api/zero/onboarding/setup", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await clearSkillsData();
+    await seedSeedSkills();
+  });
+
+  it("should create agent and complete onboarding in a single call", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const response = await postSetup({
+      displayName: "My Assistant",
+      sound: "professional",
+      avatarUrl: "preset:0",
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.agentId).toBeTruthy();
+
+    // Verify agent was created via list API
+    const agentListRes = await listAgents(createTestRequest(`${BASE}/agents`));
+    const agentList = await agentListRes.json();
+    const agent = agentList.find((a: { agentId: string }) => {
+      return a.agentId === data.agentId;
+    });
+    expect(agent).toBeDefined();
+    expect(agent.displayName).toBe("My Assistant");
+    expect(agent.sound).toBe("professional");
+    expect(agent.avatarUrl).toBe("preset:0");
+
+    // Verify default agent was set
+    const defaultAgent = await getOrgDefaultAgent(orgId);
+    expect(defaultAgent).toBe(data.agentId);
+
+    // Verify onboarding status reports complete
+    const statusRes = await getOnboardingStatus(
+      createTestRequest(`${BASE}/onboarding/status`),
+    );
+    const status = await statusRes.json();
+    expect(status.needsOnboarding).toBe(false);
+    expect(status.hasDefaultAgent).toBe(true);
+  });
+
+  it("should be idempotent — return same agentId on second call", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const first = await postSetup({ displayName: "Zero" });
+    expect(first.status).toBe(200);
+    const firstData = await first.json();
+
+    const second = await postSetup({ displayName: "Different Name" });
+    expect(second.status).toBe(200);
+    const secondData = await second.json();
+
+    expect(secondData.agentId).toBe(firstData.agentId);
+  });
+
+  it("should set user connectors when provided", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const response = await postSetup({
+      displayName: "Zero",
+      selectedConnectors: ["slack", "github"],
+    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    // Verify connectors via GET API
+    const connRes = await getUserConnectors(
+      createTestRequest(`${BASE}/agents/${data.agentId}/user-connectors`),
+    );
+    expect(connRes.status).toBe(200);
+    const connData = await connRes.json();
+    expect(connData.enabledTypes.sort()).toEqual(["github", "slack"]);
+  });
+
+  it("should create vm0 model provider", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const response = await postSetup({ displayName: "Zero" });
+    expect(response.status).toBe(200);
+
+    // Verify model provider via list API
+    const provRes = await listModelProviders(
+      createTestRequest(`${BASE}/model-providers`),
+    );
+    const provData = await provRes.json();
+    const vm0Provider = provData.modelProviders.find((p: { type: string }) => {
+      return p.type === "vm0";
+    });
+    expect(vm0Provider).toBeDefined();
+    expect(vm0Provider.selectedModel).toBe("claude-sonnet-4.6");
+  });
+
+  it("should work with minimal payload (displayName only)", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const response = await postSetup({ displayName: "Zero" });
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.agentId).toBeTruthy();
+  });
+
+  it("should return 401 for unauthenticated requests", async () => {
+    mockClerk({ userId: null });
+
+    const response = await postSetup({ displayName: "Zero" });
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 401 for non-admin members", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+
+    const response = await postSetup({ displayName: "Zero" });
+    expect(response.status).toBe(401);
+  });
+});

--- a/turbo/apps/web/src/lib/zero/seed-instructions.ts
+++ b/turbo/apps/web/src/lib/zero/seed-instructions.ts
@@ -1,0 +1,69 @@
+/**
+ * Default instructions (AGENTS.md) for zero agent onboarding.
+ * Source: https://github.com/vm0-ai/the-seed
+ *
+ * These live server-side so the frontend never sends stale seed instructions.
+ * See also: seed-skills.ts for the companion skill list.
+ */
+export const SEED_INSTRUCTIONS = `## About You
+
+You are an enterprise-grade intelligent assistant with deep, cross-functional expertise. You help users handle everything from day-to-day operations to strategic decision-making. You're not a chatbot — you have a full suite of professional skills and you get things done.
+
+## Your Capabilities
+
+### Research & Analysis
+- **Deep Dive**: Structured research and solution design — gather facts first, then explore multiple approaches
+- **Data Profiling**: Profile unfamiliar datasets — schema, quality, distributions, relationships, all at a glance
+- **Analysis QA**: Quality-check data analyses before delivery — catch bad joins, wrong denominators, timezone mismatches, survivorship bias
+- **SQL Cookbook**: Practical SQL across warehouse dialects (PostgreSQL, Snowflake, BigQuery, Redshift, Databricks)
+- **Stats Methods**: Statistical toolbox — hypothesis testing, A/B test evaluation, outlier detection, trend analysis
+
+### Finance & Accounting
+- **Journal Entries**: Construct and review journal entries (month-end accruals, amortization, depreciation, payroll, revenue recognition)
+- **Account Reconciliation**: Reconcile GL against subledgers, bank statements, and external records
+- **Period Close**: Orchestrate month-end/quarter-end close — task sequencing, dependencies, progress tracking
+- **Flux Analysis**: Decompose financial variances into underlying drivers with narrative explanations
+- **GAAP Reporting**: Produce GAAP-compliant financial statements (P&L, balance sheet, cash flow)
+- **Audit Readiness**: SOX 404 compliance — control testing, sampling strategies, deficiency evaluation
+
+### Legal & Compliance
+- **Contract Redline**: Clause-by-clause agreement review, deviation scoring, and ready-to-send redline markup
+- **NDA Screening**: Rapid NDA evaluation — GREEN (sign-ready), YELLOW (needs review), RED (needs negotiation)
+- **Legal Risk Scoring**: Score risks on a severity × likelihood matrix with escalation paths
+- **Legal Briefing**: Structured briefing packages for legal meetings — context, participant research, action items
+- **Privacy Compliance**: GDPR, CCPA/CPRA, and international privacy law guidance
+- **Reply Templates**: Manage standardized responses for recurring legal inquiries (DSARs, litigation holds, subpoenas)
+
+### Product & Engineering
+- **PRD Writing**: Product requirements documents — problem framing, user stories, prioritization, acceptance criteria
+- **Product Metrics**: Define and analyze metrics across the AARRR funnel, design OKRs and dashboards
+- **Roadmap Planning**: Prioritize with RICE/ICE/MoSCoW, manage dependencies and capacity
+- **Research Synthesis**: Turn raw user research into actionable insights, personas, and opportunity scores
+
+### Marketing
+- **Copywriting**: Marketing copy across channels — blogs, emails, social, landing pages, press releases
+- **Campaign Strategy**: Plan campaigns around five pillars: Goal, Audience, Narrative, Distribution, Measurement
+- **Marketing Analytics**: Cross-channel performance analysis, attribution modeling, and optimization
+- **Brand Guidelines**: Establish and enforce brand voice, tone, messaging pillars, and terminology
+- **Competitor Matrix**: Feature comparison matrices, positioning teardowns, win/loss analysis
+
+### Customer Support
+- **Customer Intel**: Gather information from docs, CRMs, wikis, and tickets to answer customer questions
+- **Customer Reply**: Compose professional, empathetic replies tailored to context, channel, and urgency
+- **Issue Triage**: Classify, prioritize (P1–P4), and route incoming support issues
+- **Escalation Brief**: Assemble escalation packages with repro steps, business impact, and follow-through tracking
+- **KB Authoring**: Distill resolved tickets into knowledge base articles to deflect future volume
+
+### Communication
+- **Status Updates**: Craft project updates tailored to any audience — executives, engineers, partners, customers
+
+### Self-Management
+- **VM0**: Inspect and update your own skills, instructions, and environment via the VM0 platform
+
+## How to Work With Me
+
+Just tell me what you need. I'll pick the right skill automatically. You can also invoke a specific skill directly with \`/skill-name\`.
+
+For complex tasks, I'll align on the approach before diving in. For simple ones, I'll just get it done.
+
+Questions? Just ask.`;

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -475,9 +475,11 @@ export {
 export {
   onboardingStatusContract,
   onboardingCompleteContract,
+  onboardingSetupContract,
   onboardingStatusResponseSchema,
   type OnboardingStatusContract,
   type OnboardingCompleteContract,
+  type OnboardingSetupContract,
   type OnboardingStatusResponse,
 } from "./onboarding";
 export {

--- a/turbo/packages/core/src/contracts/onboarding.ts
+++ b/turbo/packages/core/src/contracts/onboarding.ts
@@ -72,6 +72,7 @@ export const onboardingSetupContract = c.router({
     responses: {
       200: z.object({ agentId: z.string() }),
       401: apiErrorSchema,
+      422: apiErrorSchema,
     },
     summary: "Complete admin onboarding in a single request",
   },

--- a/turbo/packages/core/src/contracts/onboarding.ts
+++ b/turbo/packages/core/src/contracts/onboarding.ts
@@ -57,5 +57,26 @@ export const onboardingCompleteContract = c.router({
   },
 });
 
+export const onboardingSetupContract = c.router({
+  setup: {
+    method: "POST",
+    path: "/api/zero/onboarding/setup",
+    headers: authHeadersSchema,
+    body: z.object({
+      displayName: z.string(),
+      workspaceName: z.string().optional(),
+      sound: z.string().optional(),
+      avatarUrl: z.string().optional(),
+      selectedConnectors: z.array(z.string()).optional(),
+    }),
+    responses: {
+      200: z.object({ agentId: z.string() }),
+      401: apiErrorSchema,
+    },
+    summary: "Complete admin onboarding in a single request",
+  },
+});
+
 export type OnboardingStatusContract = typeof onboardingStatusContract;
 export type OnboardingCompleteContract = typeof onboardingCompleteContract;
+export type OnboardingSetupContract = typeof onboardingSetupContract;


### PR DESCRIPTION
## Summary

- Replace 7 sequential frontend API calls (~9s) with a single `POST /api/zero/onboarding/setup` endpoint
- Server-side parallelization reduces total time to ~2-3s (+ ~1-2s Clerk refresh on client)
- Endpoint is idempotent — returns existing default agent if already configured
- Drop auto-intro chat message; navigate directly to `/agents/:id/chat`

### What changed

**Backend:**
- New `onboardingSetupContract` in `@vm0/core`
- New `POST /api/zero/onboarding/setup` route that performs: org update, model provider upsert, agent creation with seed instructions (single `serverSideCompose`), user connectors, default agent, and onboarding completion — all with `Promise.all` parallelization where possible
- Seed instructions moved server-side (`seed-instructions.ts`)

**Frontend:**
- `completeZeroOnboarding$` simplified to single API call + Clerk refresh
- `onboardingContinueWeb$` navigates to `/agents/:id/chat` instead of sending auto-intro message
- Both admin and member flows no longer send initial chat message

### Performance improvement

| Before | After |
|--------|-------|
| ~9s (7 sequential calls + Clerk refresh) | ~3-5s (1 API call + Clerk refresh) |

Key optimization: eliminates double `serverSideCompose` (was called once with empty instructions, then again with real instructions — each involving S3 uploads).

## Test plan

- [x] All 25 onboarding-related tests updated and passing
- [x] Type check passes
- [x] Lint passes
- [x] Knip finds no issues
- [ ] Manual test: complete admin onboarding flow end-to-end
- [ ] Manual test: complete member onboarding flow end-to-end
- [ ] Verify idempotency: re-running setup returns same agentId

Closes #8030

🤖 Generated with [Claude Code](https://claude.com/claude-code)