### PR TITLE
test(platform): add tests for add-connection-dialog and connector-icons

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -266,18 +266,6 @@ export const submitApiToken$ = command(
 // Polling state (for connect flow)
 // ---------------------------------------------------------------------------
 
-const internalConnectorPollInterval$ = state(2000);
-
-export const setConnectorPollIntervalForTest$ = command(
-  ({ set }, interval: number) => {
-    set(internalConnectorPollInterval$, interval);
-  },
-);
-
-const connectorPollInterval$ = computed((get) => {
-  return get(internalConnectorPollInterval$);
-});
-
 const internalPollingType$ = state<ConnectorType | null>(null);
 
 export const pollingConnectorType$ = computed((get) => {
@@ -338,7 +326,7 @@ export const connectConnector$ = command(
     // (app.* vs www.*), so BroadcastChannel cannot be used.
     let freshConnectors: ConnectorResponse[] = [];
     while (true) {
-      await delay(get(connectorPollInterval$), { signal });
+      await delay(2000, { signal });
 
       set(reloadConnectors$);
       const { connectors: polled } = await get(connectors$);

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -266,6 +266,18 @@ export const submitApiToken$ = command(
 // Polling state (for connect flow)
 // ---------------------------------------------------------------------------
 
+const internalConnectorPollInterval$ = state(2000);
+
+export const setConnectorPollIntervalForTest$ = command(
+  ({ set }, interval: number) => {
+    set(internalConnectorPollInterval$, interval);
+  },
+);
+
+const connectorPollInterval$ = computed((get) => {
+  return get(internalConnectorPollInterval$);
+});
+
 const internalPollingType$ = state<ConnectorType | null>(null);
 
 export const pollingConnectorType$ = computed((get) => {
@@ -326,7 +338,7 @@ export const connectConnector$ = command(
     // (app.* vs www.*), so BroadcastChannel cannot be used.
     let freshConnectors: ConnectorResponse[] = [];
     while (true) {
-      await delay(2000, { signal });
+      await delay(get(connectorPollInterval$), { signal });
 
       set(reloadConnectors$);
       const { connectors: polled } = await get(connectors$);

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -8,19 +8,15 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
-import {
-  setSelectedConnectorType$,
-  setConnectorPollIntervalForTest$,
-} from "../../../signals/zero-page/settings/connectors.ts";
+import { setSelectedConnectorType$ } from "../../../signals/zero-page/settings/connectors.ts";
 import { mockConnectors } from "../../zero-page/__tests__/zero-connectors-page-test-helpers.ts";
-import { ConnectorIcon } from "../../zero-page/components/settings/connector-icons.tsx";
 
 const context = testContext();
 
@@ -128,52 +124,6 @@ describe("connect modal - loading states", () => {
       expect(screen.getByText("Connecting...")).toBeInTheDocument();
     });
   });
-
-  it("settles and returns to form after failed OAuth (CONN-D-021)", async () => {
-    // Return empty connectors so the popup-closed path exits with isConnected=false,
-    // keeping the dialog open. This tests the full settle cycle: Connecting → idle.
-    // The "Saving permissions..." text is part of this settle cycle but is architecturally
-    // ephemeral (React 18 batches the state transition into a single render).
-    server.use(
-      http.get("*/api/zero/connectors", () => {
-        return HttpResponse.json({
-          connectors: [],
-          configuredTypes: Object.keys(CONNECTOR_TYPES),
-          connectorProvidedSecretNames: [],
-        });
-      }),
-    );
-
-    // Popup closes immediately so the poll loop exits after the delay.
-    vi.spyOn(window, "open").mockReturnValue({ closed: true } as Window);
-
-    await openConnectModal("github");
-
-    // Reduce the OAuth polling interval so the settle phase completes quickly.
-    context.store.set(setConnectorPollIntervalForTest$, 10);
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Sign in with GitHub" }),
-      ).toBeInTheDocument();
-    });
-
-    const user = userEvent.setup();
-    await user.click(
-      screen.getByRole("button", { name: "Sign in with GitHub" }),
-    );
-
-    // After the settle phase completes (popup closed, not connected), the dialog
-    // returns to idle state showing the OAuth button again.
-    await waitFor(
-      () => {
-        expect(
-          screen.getByRole("button", { name: "Sign in with GitHub" }),
-        ).toBeInTheDocument();
-      },
-      { interval: 10 },
-    );
-  });
 });
 
 describe("connect modal - interactions", () => {
@@ -278,20 +228,22 @@ describe("connect modal - state management", () => {
   });
 });
 
-describe("connector icon", () => {
-  it("renders img element for standard connector types (CONN-D-041)", () => {
-    const { container } = render(<ConnectorIcon type="axiom" />);
-    expect(container.querySelector("img")).toBeInTheDocument();
+describe("connector icon - via dialog", () => {
+  it("renders img element for standard connector types (CONN-D-041)", async () => {
+    await openConnectModal("axiom");
+
+    await waitFor(() => {
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.querySelector("img")).toBeInTheDocument();
+    });
   });
 
-  it("renders inline SVG for deel connector type (CONN-D-041)", () => {
-    const { container } = render(<ConnectorIcon type="deel" />);
-    expect(container.querySelector("svg")).toBeInTheDocument();
-  });
+  it("renders inline SVG for deel connector type (CONN-D-042)", async () => {
+    await openConnectModal("deel");
 
-  it("scales container to specified size (CONN-D-042)", () => {
-    const { container } = render(<ConnectorIcon type="axiom" size={20} />);
-    const span = container.querySelector("span");
-    expect(span).toHaveStyle({ width: "20px", height: "20px" });
+    await waitFor(() => {
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.querySelector("svg")).toBeInTheDocument();
+    });
   });
 });

--- a/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx
@@ -1,0 +1,297 @@
+/**
+ * Tests for ConnectModal (add-connection-dialog.tsx) and ConnectorIcon (connector-icons.tsx).
+ *
+ * Tests page-level behavior via setupPage following platform testing principles:
+ * - Entry point: setupPage({ path: "/connectors" })
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All signals, components, rendering
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  setSelectedConnectorType$,
+  setConnectorPollIntervalForTest$,
+} from "../../../signals/zero-page/settings/connectors.ts";
+import { mockConnectors } from "../../zero-page/__tests__/zero-connectors-page-test-helpers.ts";
+import { ConnectorIcon } from "../../zero-page/components/settings/connector-icons.tsx";
+
+const context = testContext();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function openConnectModal(connectorType: ConnectorType) {
+  await setupPage({ context, path: "/connectors" });
+  await waitFor(() => {
+    expect(
+      screen.getByRole("heading", { name: "Connectors" }),
+    ).toBeInTheDocument();
+  });
+  context.store.set(setSelectedConnectorType$, connectorType);
+}
+
+describe("connect modal - display", () => {
+  it("shows connector icon and label (CONN-D-016)", async () => {
+    await openConnectModal("axiom");
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    // Label shown in dialog header
+    expect(screen.getByRole("heading", { name: "Axiom" })).toBeInTheDocument();
+
+    // Icon rendered as img element inside the dialog
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.querySelector("img")).toBeInTheDocument();
+  });
+
+  it("shows connected status text when connector is connected (CONN-D-017)", async () => {
+    mockConnectors([{ type: "axiom" }]);
+
+    await openConnectModal("axiom");
+
+    await waitFor(() => {
+      expect(screen.getByText("Connected")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("connect modal - content by auth method", () => {
+  it("shows OAuth button for OAuth connectors (CONN-C-018)", async () => {
+    await openConnectModal("github");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Sign in with GitHub" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows API token form for api-token connectors (CONN-C-019)", async () => {
+    await openConnectModal("axiom");
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("xaat-...")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+});
+
+describe("connect modal - loading states", () => {
+  it("shows Connecting... while OAuth is in progress (CONN-D-020)", async () => {
+    // Keep popup "open" so polling never exits
+    vi.spyOn(window, "open").mockReturnValue({ closed: false } as Window);
+
+    // Allow the initial connectors load to succeed (returns empty), then block
+    // subsequent polling calls so the polling loop stays in flight.
+    let callCount = 0;
+    server.use(
+      http.get("*/api/zero/connectors", () => {
+        callCount++;
+        if (callCount === 1) {
+          return HttpResponse.json({
+            connectors: [],
+            configuredTypes: Object.keys(CONNECTOR_TYPES),
+            connectorProvidedSecretNames: [],
+          });
+        }
+        return new Promise<never>(() => {
+          // Never resolves — keeps polling in flight
+        });
+      }),
+    );
+
+    await openConnectModal("github");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Sign in with GitHub" }),
+      ).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Sign in with GitHub" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Connecting...")).toBeInTheDocument();
+    });
+  });
+
+  it("settles and returns to form after failed OAuth (CONN-D-021)", async () => {
+    // Return empty connectors so the popup-closed path exits with isConnected=false,
+    // keeping the dialog open. This tests the full settle cycle: Connecting → idle.
+    // The "Saving permissions..." text is part of this settle cycle but is architecturally
+    // ephemeral (React 18 batches the state transition into a single render).
+    server.use(
+      http.get("*/api/zero/connectors", () => {
+        return HttpResponse.json({
+          connectors: [],
+          configuredTypes: Object.keys(CONNECTOR_TYPES),
+          connectorProvidedSecretNames: [],
+        });
+      }),
+    );
+
+    // Popup closes immediately so the poll loop exits after the delay.
+    vi.spyOn(window, "open").mockReturnValue({ closed: true } as Window);
+
+    await openConnectModal("github");
+
+    // Reduce the OAuth polling interval so the settle phase completes quickly.
+    context.store.set(setConnectorPollIntervalForTest$, 10);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Sign in with GitHub" }),
+      ).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Sign in with GitHub" }),
+    );
+
+    // After the settle phase completes (popup closed, not connected), the dialog
+    // returns to idle state showing the OAuth button again.
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", { name: "Sign in with GitHub" }),
+        ).toBeInTheDocument();
+      },
+      { interval: 10 },
+    );
+  });
+});
+
+describe("connect modal - interactions", () => {
+  it("oAuth button initiates sign-in flow (CONN-I-022)", async () => {
+    // Return a closed popup so the connector flow doesn't hang waiting for polling
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue({ closed: true } as Window);
+
+    await openConnectModal("github");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Sign in with GitHub" }),
+      ).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(
+      screen.getByRole("button", { name: "Sign in with GitHub" }),
+    );
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/api/zero/connectors/github/authorize"),
+      "_blank",
+      expect.any(String),
+    );
+  });
+
+  it("save button submits API token secrets (CONN-I-023)", async () => {
+    const user = userEvent.setup();
+    let submittedSecret: { name: string; value: string } | undefined;
+
+    server.use(
+      http.post("*/api/zero/secrets", async ({ request }) => {
+        submittedSecret = (await request.json()) as {
+          name: string;
+          value: string;
+        };
+        return HttpResponse.json(
+          {
+            id: crypto.randomUUID(),
+            name: submittedSecret.name,
+            type: "user",
+            description: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await openConnectModal("axiom");
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("xaat-...")).toBeInTheDocument();
+    });
+
+    await user.type(
+      screen.getByPlaceholderText("xaat-..."),
+      "test-token-value",
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(submittedSecret).toBeDefined();
+      expect(submittedSecret?.name).toBe("AXIOM_TOKEN");
+      expect(submittedSecret?.value).toBe("test-token-value");
+    });
+  });
+});
+
+describe("connect modal - state management", () => {
+  it("dialog opens and closes correctly (CONN-S-024)", async () => {
+    const user = userEvent.setup();
+    await setupPage({ context, path: "/connectors" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Connectors" }),
+      ).toBeInTheDocument();
+    });
+
+    // Dialog is initially closed
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // Open dialog
+    context.store.set(setSelectedConnectorType$, "axiom");
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    // Close dialog via the close button
+    const closeButton = screen.getByRole("button", { name: /close/i });
+    await user.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("connector icon", () => {
+  it("renders img element for standard connector types (CONN-D-041)", () => {
+    const { container } = render(<ConnectorIcon type="axiom" />);
+    expect(container.querySelector("img")).toBeInTheDocument();
+  });
+
+  it("renders inline SVG for deel connector type (CONN-D-041)", () => {
+    const { container } = render(<ConnectorIcon type="deel" />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("scales container to specified size (CONN-D-042)", () => {
+    const { container } = render(<ConnectorIcon type="axiom" size={20} />);
+    const span = container.querySelector("span");
+    expect(span).toHaveStyle({ width: "20px", height: "20px" });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `turbo/apps/platform/src/views/conn/__tests__/add-connection-dialog.test.tsx` covering 12 test cases (CONN-D-016 to CONN-D-042)
- Tests ConnectModal display states, auth method rendering, loading states, interactions, and state management
- Tests ConnectorIcon rendering for standard (img) and deel (SVG) types, and size scaling
- Makes OAuth polling interval configurable via `setConnectorPollIntervalForTest$` to enable settle-phase testing without timing hacks

Closes #7942

## Test plan

- [x] All 12 `it()` blocks pass locally
- [x] No `vi.mock()` for internal modules
- [x] No `eslint-disable` or `ts-ignore`
- [x] Lint, type check, format all pass
- [x] Existing connector tests (zero-connectors-page, connector-permission-dialog) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)