### PR TITLE
fix: increase wait_for_log timeout to fix flaky stuck-tool test

### DIFF
--- a/e2e/helpers/setup.bash
+++ b/e2e/helpers/setup.bash
@@ -63,7 +63,7 @@ wait_for_log() {
         echo "# wait_for_log: no expected strings after --"
         return 1
     fi
-    local _wfl_timeout=20
+    local _wfl_timeout=30
     local _wfl_elapsed=0
     while (( _wfl_elapsed < _wfl_timeout )); do
         # Append --all for non-search commands to fetch complete logs


### PR DESCRIPTION
## Summary
- Increase `wait_for_log` timeout from 20s to 30s
- Fixes flaky `t43-stuck-tool-watchdog.bats` that occasionally times out waiting for "Tool timeout" in system logs

## Root cause
The watchdog detects the stuck tool at ~T=5-8s and logs via `log_warn!`. The message reaches system logs via `final_upload` telemetry, but API propagation delay can exceed 20s.

## Test plan
- [ ] `t43-stuck-tool-watchdog` passes consistently
- [ ] Other tests using `wait_for_log` unaffected (extra 10s headroom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)