### PR TITLE
fix(e2e): accept 429 rate limit in discord webhook firewall test

### DIFF
--- a/e2e/tests/03-runner/t42-firewall-placeholder.bats
+++ b/e2e/tests/03-runner/t42-firewall-placeholder.bats
@@ -248,8 +248,9 @@ EOF
     # Placeholder is the firewall-placeholder.vm3.ai URL
     assert_output --partial "DISCORD_WEBHOOK_URL=https://firewall-placeholder.vm3.ai/discord-webhook/hook"
 
-    # Discord returns 404 for the fake webhook — proves URL rewrite reached Discord
-    assert_output --partial "API_STATUS=404"
+    # Discord returns 404 for the fake webhook — proves URL rewrite reached Discord.
+    # May also return 429 (rate limited) which equally proves the request reached Discord.
+    assert_output --regexp "API_STATUS=(404|429)"
 
     # Extract run ID
     RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)


### PR DESCRIPTION
## Summary

- Discord may return 429 (rate limited) instead of 404 for the fake webhook ID
- Both status codes prove the URL rewrite reached Discord successfully
- Changed `assert_output --partial "API_STATUS=404"` to `assert_output --regexp "API_STATUS=(404|429)"`

## Test plan

- [ ] `t42-firewall-placeholder` e2e test passes when Discord returns 404
- [ ] `t42-firewall-placeholder` e2e test passes when Discord returns 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)