### PR TITLE
feat(cli): add computer-use host/client framework with screenshot and info operations

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -28,6 +28,7 @@ describe("zero CLI program", () => {
       "whoami",
       "ask-user",
       "developer-support",
+      "computer-use",
     ];
     for (const name of expectedCommands) {
       expect(commandNames).toContain(name);
@@ -51,7 +52,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 15 commands", () => {
-    expect(commandNames).toHaveLength(15);
+  it("should have exactly 16 commands", () => {
+    expect(commandNames).toHaveLength(16);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for computer-use command registration and visibility.
+ *
+ * Entry point: registerZeroCommands()
+ * Mock (external): none
+ * Real (internal): Command registration, capability checking
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Command } from "commander";
+import { registerZeroCommands } from "../../../../zero";
+
+function buildZeroToken(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256" })).toString(
+    "base64url",
+  );
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = "test-signature";
+  return `vm0_sandbox_${header}.${body}.${signature}`;
+}
+
+describe("computer-use command visibility", () => {
+  beforeEach(() => {
+    vi.stubEnv("ZERO_TOKEN", "");
+  });
+
+  it("should be visible when no ZERO_TOKEN is set", () => {
+    const prog = new Command();
+    registerZeroCommands(prog);
+
+    const cmd = prog.commands.find((c) => {
+      return c.name() === "computer-use";
+    });
+    expect(cmd).toBeDefined();
+  });
+
+  it("should be visible when ZERO_TOKEN includes computer-use:write", () => {
+    const token = buildZeroToken({
+      userId: "u1",
+      runId: "r1",
+      orgId: "o1",
+      scope: "zero",
+      capabilities: ["computer-use:write"],
+      iat: 1000,
+      exp: 2000,
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = new Command();
+    registerZeroCommands(prog);
+
+    const names = prog.commands
+      .filter((c) => {
+        // Commander marks hidden commands but still registers them
+        // Check that it's not hidden by checking the _hidden property
+        return !Object.getOwnPropertyDescriptor(c, "_hidden")?.value;
+      })
+      .map((c) => {
+        return c.name();
+      });
+    expect(names).toContain("computer-use");
+  });
+
+  it("should be hidden when ZERO_TOKEN lacks computer-use:write", () => {
+    const token = buildZeroToken({
+      userId: "u1",
+      runId: "r1",
+      orgId: "o1",
+      scope: "zero",
+      capabilities: ["agent:read"],
+      iat: 1000,
+      exp: 2000,
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = new Command();
+    registerZeroCommands(prog);
+
+    // Command is registered but hidden
+    const cmd = prog.commands.find((c) => {
+      return c.name() === "computer-use";
+    });
+    expect(cmd).toBeDefined();
+  });
+
+  it("should have host and client subcommands", () => {
+    const prog = new Command();
+    registerZeroCommands(prog);
+
+    const computerUse = prog.commands.find((c) => {
+      return c.name() === "computer-use";
+    });
+    expect(computerUse).toBeDefined();
+
+    const subNames = computerUse!.commands.map((c) => {
+      return c.name();
+    });
+    expect(subNames).toContain("host");
+    expect(subNames).toContain("client");
+  });
+
+  it("should have start under host subcommand", () => {
+    const prog = new Command();
+    registerZeroCommands(prog);
+
+    const computerUse = prog.commands.find((c) => {
+      return c.name() === "computer-use";
+    });
+    const host = computerUse!.commands.find((c) => {
+      return c.name() === "host";
+    });
+    expect(host).toBeDefined();
+
+    const hostSubs = host!.commands.map((c) => {
+      return c.name();
+    });
+    expect(hostSubs).toContain("start");
+  });
+
+  it("should have screenshot and info under client subcommand", () => {
+    const prog = new Command();
+    registerZeroCommands(prog);
+
+    const computerUse = prog.commands.find((c) => {
+      return c.name() === "computer-use";
+    });
+    const client = computerUse!.commands.find((c) => {
+      return c.name() === "client";
+    });
+    expect(client).toBeDefined();
+
+    const clientSubs = client!.commands.map((c) => {
+      return c.name();
+    });
+    expect(clientSubs).toContain("screenshot");
+    expect(clientSubs).toContain("info");
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Command } from "commander";
+import { Command, Help } from "commander";
 import { registerZeroCommands } from "../../../../zero";
 
 function buildZeroToken(payload: Record<string, unknown>): string {
@@ -17,6 +17,28 @@ function buildZeroToken(payload: Record<string, unknown>): string {
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const signature = "test-signature";
   return `vm0_sandbox_${header}.${body}.${signature}`;
+}
+
+function visibleCommandNames(prog: Command): string[] {
+  return new Help()
+    .visibleCommands(prog)
+    .map((cmd) => {
+      return cmd.name();
+    })
+    .filter((name) => {
+      return name !== "help";
+    });
+}
+
+function hiddenCommandNames(prog: Command): string[] {
+  const visible = new Set(visibleCommandNames(prog));
+  return prog.commands
+    .map((cmd) => {
+      return cmd.name();
+    })
+    .filter((name) => {
+      return !visible.has(name);
+    });
 }
 
 describe("computer-use command visibility", () => {
@@ -49,16 +71,7 @@ describe("computer-use command visibility", () => {
     const prog = new Command();
     registerZeroCommands(prog);
 
-    const names = prog.commands
-      .filter((c) => {
-        // Commander marks hidden commands but still registers them
-        // Check that it's not hidden by checking the _hidden property
-        return !Object.getOwnPropertyDescriptor(c, "_hidden")?.value;
-      })
-      .map((c) => {
-        return c.name();
-      });
-    expect(names).toContain("computer-use");
+    expect(visibleCommandNames(prog)).toContain("computer-use");
   });
 
   it("should be hidden when ZERO_TOKEN lacks computer-use:write", () => {
@@ -76,11 +89,7 @@ describe("computer-use command visibility", () => {
     const prog = new Command();
     registerZeroCommands(prog);
 
-    // Command is registered but hidden
-    const cmd = prog.commands.find((c) => {
-      return c.name() === "computer-use";
-    });
-    expect(cmd).toBeDefined();
+    expect(hiddenCommandNames(prog)).toContain("computer-use");
   });
 
   it("should have host and client subcommands", () => {

--- a/turbo/apps/cli/src/commands/zero/computer-use/client.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/client.ts
@@ -1,0 +1,57 @@
+import { Command } from "commander";
+import { writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import { callHost } from "../../../lib/computer-use/client";
+
+export const clientScreenshotCommand = new Command()
+  .name("screenshot")
+  .description("Capture a screenshot from the remote host")
+  .action(
+    withErrorHandler(async () => {
+      const response = await callHost("/screenshot");
+      const data = (await response.json()) as {
+        width: number;
+        height: number;
+        scaleFactor: number;
+        format: string;
+        image: string;
+      };
+
+      const dir = "/tmp/computer-use";
+      await mkdir(dir, { recursive: true });
+
+      const timestamp = Date.now();
+      const filePath = join(dir, `screenshot-${timestamp}.${data.format}`);
+      const buffer = Buffer.from(data.image, "base64");
+      await writeFile(filePath, buffer);
+
+      // Path to stdout for programmatic consumption
+      process.stdout.write(`${filePath}\n`);
+
+      // Metadata to stderr for human/debug consumption
+      process.stderr.write(
+        JSON.stringify({
+          width: data.width,
+          height: data.height,
+          scaleFactor: data.scaleFactor,
+        }) + "\n",
+      );
+    }),
+  );
+
+export const clientInfoCommand = new Command()
+  .name("info")
+  .description("Get screen info from the remote host")
+  .action(
+    withErrorHandler(async () => {
+      const response = await callHost("/info");
+      const data = (await response.json()) as {
+        width: number;
+        height: number;
+        scaleFactor: number;
+      };
+
+      process.stdout.write(JSON.stringify(data) + "\n");
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/computer-use/host.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/host.ts
@@ -1,0 +1,79 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { withErrorHandler } from "../../../lib/command/with-error-handler";
+import {
+  registerComputerUseHost,
+  unregisterComputerUseHost,
+} from "../../../lib/api";
+import {
+  getRandomPort,
+  startDesktopServer,
+} from "../../../lib/computer-use/desktop-server";
+import {
+  startDesktopTunnel,
+  stopDesktopTunnel,
+} from "../../../lib/computer-use/ngrok";
+
+export const hostStartCommand = new Command()
+  .name("start")
+  .description("Start the computer-use host daemon (macOS only)")
+  .action(
+    withErrorHandler(async () => {
+      if (process.platform !== "darwin") {
+        throw new Error(
+          "Computer-use host requires macOS\n\n" +
+            "The host daemon uses macOS-specific commands (screencapture, system_profiler).",
+        );
+      }
+
+      console.log(chalk.cyan("Registering computer-use host..."));
+      const credentials = await registerComputerUseHost();
+
+      const port = await getRandomPort();
+      const server = await startDesktopServer(credentials.token, port);
+
+      try {
+        await startDesktopTunnel(
+          credentials.ngrokToken,
+          credentials.endpointPrefix,
+          port,
+        );
+
+        console.log();
+        console.log(chalk.green("✓ Computer-use host active"));
+        console.log(`  Desktop: desktop.${credentials.domain}`);
+        console.log();
+        console.log(chalk.dim("Press ^C twice to disconnect"));
+        console.log();
+
+        let sigintCount = 0;
+        await new Promise<void>((resolve) => {
+          const keepAlive = setInterval(() => {}, 60_000);
+          const done = () => {
+            clearInterval(keepAlive);
+            process.removeListener("SIGINT", onSigint);
+            resolve();
+          };
+          const onSigint = () => {
+            sigintCount++;
+            if (sigintCount === 1) {
+              console.log(
+                chalk.dim("\nPress ^C again to disconnect and exit..."),
+              );
+            } else {
+              done();
+            }
+          };
+          process.on("SIGINT", onSigint);
+          process.once("SIGTERM", done);
+        });
+      } finally {
+        console.log();
+        console.log(chalk.cyan("Stopping computer-use host..."));
+        server.close();
+        await stopDesktopTunnel();
+        await unregisterComputerUseHost().catch(() => {});
+        console.log(chalk.green("✓ Host stopped"));
+      }
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import { hostStartCommand } from "./host";
+import { clientScreenshotCommand, clientInfoCommand } from "./client";
+
+const hostCommand = new Command()
+  .name("host")
+  .description("Manage computer-use host daemon")
+  .addCommand(hostStartCommand);
+
+const clientCommand = new Command()
+  .name("client")
+  .description("Interact with remote computer-use host")
+  .addCommand(clientScreenshotCommand)
+  .addCommand(clientInfoCommand);
+
+export const zeroComputerUseCommand = new Command()
+  .name("computer-use")
+  .description("Remote desktop control for cloud agents")
+  .addCommand(hostCommand)
+  .addCommand(clientCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Start the host daemon (on macOS):  zero computer-use host start
+  Take a screenshot (from agent):    zero computer-use client screenshot
+  Get screen info (from agent):      zero computer-use client info`,
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-computer-use.ts
@@ -1,0 +1,69 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroComputerUseRegisterContract,
+  zeroComputerUseUnregisterContract,
+  zeroComputerUseHostContract,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+/**
+ * Register a computer-use host (POST /api/zero/computer-use/register)
+ */
+export async function registerComputerUseHost(): Promise<{
+  id: string;
+  domain: string;
+  token: string;
+  ngrokToken: string;
+  endpointPrefix: string;
+}> {
+  const config = await getClientConfig();
+  const client = initClient(zeroComputerUseRegisterContract, config);
+
+  const result = await client.register({});
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to register computer-use host");
+}
+
+/**
+ * Unregister a computer-use host (DELETE /api/zero/computer-use/unregister)
+ */
+export async function unregisterComputerUseHost(): Promise<void> {
+  const config = await getClientConfig();
+  const client = initClient(zeroComputerUseUnregisterContract, config);
+
+  const result = await client.unregister({});
+
+  if (result.status === 204) {
+    return;
+  }
+
+  handleError(result, "Failed to unregister computer-use host");
+}
+
+/**
+ * Get the active computer-use host (GET /api/zero/computer-use/host)
+ * Returns null if no active host exists (404)
+ */
+export async function getComputerUseHost(): Promise<{
+  domain: string;
+  token: string;
+} | null> {
+  const config = await getClientConfig();
+  const client = initClient(zeroComputerUseHostContract, config);
+
+  const result = await client.getHost({});
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  if (result.status === 404) {
+    return null;
+  }
+
+  handleError(result, "Failed to get computer-use host");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -174,3 +174,10 @@ export {
   requestDeveloperSupportConsent,
   submitDeveloperSupport,
 } from "./domains/zero-developer-support";
+
+// Domain modules - Zero Computer Use
+export {
+  registerComputerUseHost,
+  unregisterComputerUseHost,
+  getComputerUseHost,
+} from "./domains/zero-computer-use";

--- a/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
+++ b/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the desktop HTTP server.
+ *
+ * Entry point: startDesktopServer()
+ * Mock (external): screencapture module (macOS system commands)
+ * Real (internal): HTTP server, token validation, routing
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { http, passthrough } from "msw";
+import { server as mswServer } from "../../../mocks/server";
+
+vi.mock("../screencapture", () => {
+  return {
+    captureScreenshot: vi.fn().mockResolvedValue({
+      image: "dGVzdC1pbWFnZQ==",
+      width: 1920,
+      height: 1080,
+      scaleFactor: 2,
+      format: "jpg",
+    }),
+    getScreenInfo: vi.fn().mockResolvedValue({
+      width: 1920,
+      height: 1080,
+      scaleFactor: 2,
+    }),
+  };
+});
+
+import type { Server } from "http";
+import { startDesktopServer, getRandomPort } from "../desktop-server";
+import { captureScreenshot, getScreenInfo } from "../screencapture";
+
+const TEST_TOKEN = "test-bridge-token-abc123";
+
+async function setup(): Promise<{ server: Server; port: number }> {
+  const port = await getRandomPort();
+  mswServer.use(
+    http.all(`http://127.0.0.1:${port}/screenshot`, () => {
+      return passthrough();
+    }),
+    http.all(`http://127.0.0.1:${port}/info`, () => {
+      return passthrough();
+    }),
+    http.all(`http://127.0.0.1:${port}/unknown`, () => {
+      return passthrough();
+    }),
+  );
+  const server = await startDesktopServer(TEST_TOKEN, port);
+  return { server, port };
+}
+
+describe("desktop-server", () => {
+  let testServer: Server | undefined;
+
+  afterEach(() => {
+    testServer?.close();
+    testServer = undefined;
+  });
+
+  describe("getRandomPort", () => {
+    it("should return a valid port number", async () => {
+      const p = await getRandomPort();
+      expect(p).toBeGreaterThan(0);
+      expect(p).toBeLessThan(65536);
+    });
+  });
+
+  describe("startDesktopServer", () => {
+    it("should return 403 when no token is provided", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/screenshot`);
+      expect(res.status).toBe(403);
+    });
+
+    it("should return 403 when wrong token is provided", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/screenshot`, {
+        headers: { "x-vm0-token": "wrong-token" },
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("should return 404 for unknown routes", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/unknown`, {
+        headers: { "x-vm0-token": TEST_TOKEN },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("should return screenshot data on GET /screenshot", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/screenshot`, {
+        headers: { "x-vm0-token": TEST_TOKEN },
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toEqual({
+        image: "dGVzdC1pbWFnZQ==",
+        width: 1920,
+        height: 1080,
+        scaleFactor: 2,
+        format: "jpg",
+      });
+      expect(captureScreenshot).toHaveBeenCalledOnce();
+    });
+
+    it("should return screen info on GET /info", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/info`, {
+        headers: { "x-vm0-token": TEST_TOKEN },
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toEqual({
+        width: 1920,
+        height: 1080,
+        scaleFactor: 2,
+      });
+      expect(getScreenInfo).toHaveBeenCalledOnce();
+    });
+
+    it("should return 500 when screenshot capture fails", async () => {
+      vi.mocked(captureScreenshot).mockRejectedValueOnce(
+        new Error("screencapture failed"),
+      );
+
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/screenshot`, {
+        headers: { "x-vm0-token": TEST_TOKEN },
+      });
+      expect(res.status).toBe(500);
+      const text = await res.text();
+      expect(text).toBe("screencapture failed");
+    });
+  });
+});

--- a/turbo/apps/cli/src/lib/computer-use/client.ts
+++ b/turbo/apps/cli/src/lib/computer-use/client.ts
@@ -1,0 +1,52 @@
+import { getComputerUseHost } from "../api";
+
+let cachedHost: { domain: string; token: string; cachedAt: number } | null =
+  null;
+const CACHE_TTL_MS = 30_000;
+
+/**
+ * Discover the active computer-use host for the current org/user.
+ * Results are cached for 30 seconds.
+ */
+async function discoverHost(): Promise<{
+  domain: string;
+  token: string;
+}> {
+  if (cachedHost && Date.now() - cachedHost.cachedAt < CACHE_TTL_MS) {
+    return { domain: cachedHost.domain, token: cachedHost.token };
+  }
+
+  const host = await getComputerUseHost();
+  if (!host) {
+    throw new Error(
+      "No active computer-use host found\n\n" +
+        "Start a host with: zero computer-use host start",
+    );
+  }
+
+  cachedHost = { ...host, cachedAt: Date.now() };
+  return host;
+}
+
+/**
+ * Make an HTTP request to the computer-use host.
+ */
+export async function callHost(path: string): Promise<Response> {
+  const { domain, token } = await discoverHost();
+  const url = `https://desktop.${domain}${path}`;
+
+  const response = await fetch(url, {
+    headers: { "x-vm0-token": token },
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => {
+      return "";
+    });
+    throw new Error(
+      `Host returned ${response.status}: ${body || response.statusText}`,
+    );
+  }
+
+  return response;
+}

--- a/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
+++ b/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
@@ -64,7 +64,7 @@ export function startDesktopServer(
   token: string,
   port: number,
 ): Promise<Server> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const server = createServer((req, res) => {
       handleRequest(token, req, res).catch(() => {
         if (!res.headersSent) {
@@ -74,6 +74,7 @@ export function startDesktopServer(
       });
     });
 
+    server.on("error", reject);
     server.listen(port, "127.0.0.1", () => {
       resolve(server);
     });

--- a/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
+++ b/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
@@ -1,0 +1,81 @@
+import {
+  createServer,
+  type Server,
+  type IncomingMessage,
+  type ServerResponse,
+} from "http";
+import { createServer as createNetServer } from "net";
+import type { AddressInfo } from "net";
+import { captureScreenshot, getScreenInfo } from "./screencapture";
+
+/**
+ * Allocate a random available port on localhost.
+ */
+export async function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createNetServer();
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      server.close(() => {
+        resolve(port);
+      });
+    });
+    server.on("error", reject);
+  });
+}
+
+async function handleRequest(
+  token: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if (req.headers["x-vm0-token"] !== token) {
+    res.writeHead(403, { "Content-Type": "text/plain" });
+    res.end("Forbidden");
+    return;
+  }
+
+  try {
+    if (req.method === "GET" && req.url === "/screenshot") {
+      const result = await captureScreenshot();
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(result));
+    } else if (req.method === "GET" && req.url === "/info") {
+      const info = await getScreenInfo();
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(info));
+    } else {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not found");
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Internal server error";
+    res.writeHead(500, { "Content-Type": "text/plain" });
+    res.end(message);
+  }
+}
+
+/**
+ * Start the desktop HTTP server.
+ * Validates x-vm0-token on every request and serves /screenshot and /info endpoints.
+ */
+export function startDesktopServer(
+  token: string,
+  port: number,
+): Promise<Server> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      handleRequest(token, req, res).catch(() => {
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "text/plain" });
+          res.end("Internal server error");
+        }
+      });
+    });
+
+    server.listen(port, "127.0.0.1", () => {
+      resolve(server);
+    });
+  });
+}

--- a/turbo/apps/cli/src/lib/computer-use/ngrok.ts
+++ b/turbo/apps/cli/src/lib/computer-use/ngrok.ts
@@ -1,0 +1,36 @@
+// Dynamic import is intentional: @ngrok/ngrok contains native binaries that
+// crash on systems with GLIBC version mismatches. Lazy-loading ensures the
+// crash only affects the command that needs ngrok, not the entire CLI.
+// See: https://github.com/vm0-ai/vm0/issues/6825
+async function loadNgrok(): Promise<typeof import("@ngrok/ngrok")> {
+  try {
+    const mod = await import("@ngrok/ngrok");
+    return mod.default;
+  } catch (cause) {
+    throw new Error(
+      "Failed to load ngrok tunnel module. " +
+        "This may be caused by a system library (GLIBC) incompatibility. " +
+        "See: https://github.com/vm0-ai/vm0/issues/6825",
+      { cause },
+    );
+  }
+}
+
+export async function startDesktopTunnel(
+  ngrokToken: string,
+  endpointPrefix: string,
+  port: number,
+): Promise<void> {
+  const ngrok = await loadNgrok();
+
+  await ngrok.forward({
+    addr: `localhost:${port}`,
+    authtoken: ngrokToken,
+    domain: `desktop.${endpointPrefix}.internal`,
+  });
+}
+
+export async function stopDesktopTunnel(): Promise<void> {
+  const ngrok = await loadNgrok();
+  await ngrok.kill();
+}

--- a/turbo/apps/cli/src/lib/computer-use/screencapture.ts
+++ b/turbo/apps/cli/src/lib/computer-use/screencapture.ts
@@ -1,0 +1,89 @@
+import { execFile } from "child_process";
+import { readFile, unlink } from "fs/promises";
+import { randomUUID } from "crypto";
+import { join } from "path";
+import { tmpdir } from "os";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+interface ScreenInfo {
+  width: number;
+  height: number;
+  scaleFactor: number;
+}
+
+interface ScreenshotResult extends ScreenInfo {
+  image: string;
+  format: string;
+}
+
+/**
+ * Capture a screenshot on macOS using the screencapture command.
+ * Returns the image as a base64 string along with screen metadata.
+ */
+export async function captureScreenshot(): Promise<ScreenshotResult> {
+  const tmpPath = join(tmpdir(), `vm0-screenshot-${randomUUID()}.jpg`);
+
+  try {
+    await execFileAsync("screencapture", ["-x", "-t", "jpg", tmpPath]);
+    const buffer = await readFile(tmpPath);
+    const info = await getScreenInfo();
+
+    return {
+      image: buffer.toString("base64"),
+      width: info.width,
+      height: info.height,
+      scaleFactor: info.scaleFactor,
+      format: "jpg",
+    };
+  } finally {
+    await unlink(tmpPath).catch(() => {});
+  }
+}
+
+interface DisplayResolution {
+  _spdisplays_pixels?: string;
+  _spdisplays_resolution?: string;
+  spdisplays_resolution?: string;
+}
+
+interface DisplayData {
+  spdisplays_ndrvs?: DisplayResolution[];
+}
+
+/**
+ * Get screen resolution and scale factor on macOS using system_profiler.
+ */
+export async function getScreenInfo(): Promise<ScreenInfo> {
+  const { stdout } = await execFileAsync("system_profiler", [
+    "SPDisplaysDataType",
+    "-json",
+  ]);
+
+  const data = JSON.parse(stdout) as { SPDisplaysDataType?: DisplayData[] };
+  const displays = data.SPDisplaysDataType ?? [];
+
+  for (const gpu of displays) {
+    const screens = gpu.spdisplays_ndrvs ?? [];
+    for (const screen of screens) {
+      const pixelStr = screen._spdisplays_pixels;
+      if (pixelStr) {
+        const match = pixelStr.match(/(\d+)\s*x\s*(\d+)/);
+        if (match?.[1] && match[2]) {
+          const width = parseInt(match[1], 10);
+          const height = parseInt(match[2], 10);
+
+          const resStr =
+            screen._spdisplays_resolution ?? screen.spdisplays_resolution ?? "";
+          const isRetina = /retina/i.test(resStr);
+          const scaleFactor = isRetina ? 2 : 1;
+
+          return { width, height, scaleFactor };
+        }
+      }
+    }
+  }
+
+  return { width: 1920, height: 1080, scaleFactor: 1 };
+}

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -18,6 +18,7 @@ import { zeroAskUserCommand } from "./commands/zero/ask-user";
 import { zeroSkillCommand } from "./commands/zero/skill";
 import { zeroLogsCommand } from "./commands/zero/logs";
 import { zeroDeveloperSupportCommand } from "./commands/zero/developer-support";
+import { zeroComputerUseCommand } from "./commands/zero/computer-use";
 import {
   decodeZeroTokenPayload,
   type ZeroTokenPayload,
@@ -40,6 +41,7 @@ const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   whoami: null,
   "ask-user": null,
   "developer-support": null,
+  "computer-use": "computer-use:write",
 };
 
 const DEFAULT_COMMANDS: Command[] = [
@@ -58,6 +60,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroAskUserCommand,
   zeroSkillCommand,
   zeroDeveloperSupportCommand,
+  zeroComputerUseCommand,
 ];
 
 function shouldHideCommand(


### PR DESCRIPTION
## Summary

Closes #8054

- Add `zero computer-use host start` command — starts desktop HTTP server + ngrok tunnel on macOS for remote desktop control
- Add `zero computer-use client screenshot` — captures remote screenshot, writes JPEG to `/tmp/computer-use/`
- Add `zero computer-use client info` — returns screen resolution and scale factor as JSON
- Add API client functions for register/unregister/host discovery endpoints (from #8053)
- Add capability-based visibility: `computer-use` command hidden for agents without `computer-use:write`

### New files (10)
- `apps/cli/src/lib/api/domains/zero-computer-use.ts` — API client (register, unregister, getHost)
- `apps/cli/src/lib/computer-use/screencapture.ts` — macOS screencapture + system_profiler wrappers
- `apps/cli/src/lib/computer-use/desktop-server.ts` — Node.js HTTP server with token validation
- `apps/cli/src/lib/computer-use/ngrok.ts` — ngrok tunnel management (single desktop tunnel)
- `apps/cli/src/lib/computer-use/client.ts` — host discovery with 30s cache + HTTP client
- `apps/cli/src/commands/zero/computer-use/index.ts` — command group registration
- `apps/cli/src/commands/zero/computer-use/host.ts` — host start command with lifecycle management
- `apps/cli/src/commands/zero/computer-use/client.ts` — screenshot + info client commands

### Modified files (3)
- `apps/cli/src/zero.ts` — register command + capability map entry
- `apps/cli/src/lib/api/index.ts` — export new API functions

## Test plan
- [x] Desktop server tests: token validation (403), routing (404), screenshot/info endpoints, error handling (500) — 7 tests
- [x] Command visibility tests: visible without token, visible with capability, hidden without capability, subcommand structure — 6 tests
- [x] Zero CLI registration test: updated to include computer-use (16 commands) — 4 tests
- [x] All 984 existing CLI tests pass
- [x] Type check, lint, format, knip all pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)