### PR TITLE
feat(cli): add computer-use zoom for regional screenshot capture

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -142,6 +142,7 @@ describe("computer-use command visibility", () => {
       return c.name();
     });
     expect(clientSubs).toContain("screenshot");
+    expect(clientSubs).toContain("zoom");
     expect(clientSubs).toContain("info");
     expect(clientSubs).toContain("left-click-drag");
     expect(clientSubs).toContain("left-mouse-down");

--- a/turbo/apps/cli/src/commands/zero/computer-use/client.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/client.ts
@@ -40,6 +40,52 @@ export const clientScreenshotCommand = new Command()
     }),
   );
 
+export const clientZoomCommand = new Command()
+  .name("zoom")
+  .description("Capture a region screenshot from the remote host")
+  .requiredOption("--x <number>", "X coordinate of the region")
+  .requiredOption("--y <number>", "Y coordinate of the region")
+  .requiredOption("--width <number>", "Width of the region")
+  .requiredOption("--height <number>", "Height of the region")
+  .action(
+    withErrorHandler(
+      async (opts: { x: string; y: string; width: string; height: string }) => {
+        const params = new URLSearchParams({
+          x: opts.x,
+          y: opts.y,
+          width: opts.width,
+          height: opts.height,
+        });
+        const response = await callHost(`/zoom?${params.toString()}`);
+        const data = (await response.json()) as {
+          width: number;
+          height: number;
+          scaleFactor: number;
+          format: string;
+          image: string;
+        };
+
+        const dir = "/tmp/computer-use";
+        await mkdir(dir, { recursive: true });
+
+        const timestamp = Date.now();
+        const filePath = join(dir, `zoom-${timestamp}.${data.format}`);
+        const buffer = Buffer.from(data.image, "base64");
+        await writeFile(filePath, buffer);
+
+        process.stdout.write(`${filePath}\n`);
+
+        process.stderr.write(
+          JSON.stringify({
+            width: data.width,
+            height: data.height,
+            scaleFactor: data.scaleFactor,
+          }) + "\n",
+        );
+      },
+    ),
+  );
+
 export const clientInfoCommand = new Command()
   .name("info")
   .description("Get screen info from the remote host")

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { hostStartCommand } from "./host";
 import {
   clientScreenshotCommand,
+  clientZoomCommand,
   clientInfoCommand,
   clientLeftClickDragCommand,
   clientLeftMouseDownCommand,
@@ -20,6 +21,7 @@ const clientCommand = new Command()
   .name("client")
   .description("Interact with remote computer-use host")
   .addCommand(clientScreenshotCommand)
+  .addCommand(clientZoomCommand)
   .addCommand(clientInfoCommand)
   .addCommand(clientLeftClickDragCommand)
   .addCommand(clientLeftMouseDownCommand)
@@ -39,6 +41,7 @@ export const zeroComputerUseCommand = new Command()
 Examples:
   Start the host daemon (on macOS):  zero computer-use host start
   Take a screenshot (from agent):    zero computer-use client screenshot
+  Zoom into a region (from agent):   zero computer-use client zoom --x 0 --y 0 --width 500 --height 500
   Get screen info (from agent):      zero computer-use client info
   Drag from A to B:                  zero computer-use client left-click-drag 100 100 500 500
   Press mouse button:                zero computer-use client left-mouse-down 200 300

--- a/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
+++ b/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
@@ -19,6 +19,13 @@ vi.mock("../screencapture", () => {
       scaleFactor: 2,
       format: "jpg",
     }),
+    captureRegionScreenshot: vi.fn().mockResolvedValue({
+      image: "em9vbS1pbWFnZQ==",
+      width: 400,
+      height: 300,
+      scaleFactor: 1,
+      format: "jpg",
+    }),
     getScreenInfo: vi.fn().mockResolvedValue({
       width: 1920,
       height: 1080,
@@ -50,7 +57,11 @@ vi.mock("../clipboard", () => {
 
 import type { Server } from "http";
 import { startDesktopServer, getRandomPort } from "../desktop-server";
-import { captureScreenshot, getScreenInfo } from "../screencapture";
+import {
+  captureScreenshot,
+  captureRegionScreenshot,
+  getScreenInfo,
+} from "../screencapture";
 import { leftClickDrag, leftMouseDown, leftMouseUp } from "../cliclick";
 import { scroll } from "../scroll";
 import { readClipboard, writeClipboard } from "../clipboard";
@@ -73,6 +84,9 @@ async function setup(): Promise<{ server: Server; port: number }> {
       return passthrough();
     }),
     http.all(`http://127.0.0.1:${port}/unknown`, () => {
+      return passthrough();
+    }),
+    http.all(new RegExp(`http://127\\.0\\.0\\.1:${port}/zoom`), () => {
       return passthrough();
     }),
   );
@@ -177,6 +191,85 @@ describe("desktop-server", () => {
       expect(res.status).toBe(500);
       const text = await res.text();
       expect(text).toBe("screencapture failed");
+    });
+
+    it("should return zoom data on GET /zoom with valid params", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(
+        `http://127.0.0.1:${port}/zoom?x=100&y=200&width=400&height=300`,
+        { headers: { "x-vm0-token": TEST_TOKEN } },
+      );
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toEqual({
+        image: "em9vbS1pbWFnZQ==",
+        width: 400,
+        height: 300,
+        scaleFactor: 1,
+        format: "jpg",
+      });
+      expect(captureRegionScreenshot).toHaveBeenCalledWith({
+        x: 100,
+        y: 200,
+        width: 400,
+        height: 300,
+      });
+    });
+
+    it("should return 400 when zoom params are missing", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/zoom`, {
+        headers: { "x-vm0-token": TEST_TOKEN },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 400 when zoom width is negative", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(
+        `http://127.0.0.1:${port}/zoom?x=0&y=0&width=-10&height=100`,
+        { headers: { "x-vm0-token": TEST_TOKEN } },
+      );
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toContain("must be positive");
+    });
+
+    it("should return 400 when zoom region exceeds screen bounds", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(
+        `http://127.0.0.1:${port}/zoom?x=1800&y=0&width=200&height=100`,
+        { headers: { "x-vm0-token": TEST_TOKEN } },
+      );
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toContain("exceeds screen bounds");
+    });
+
+    it("should return 500 when zoom capture fails", async () => {
+      vi.mocked(captureRegionScreenshot).mockRejectedValueOnce(
+        new Error("region capture failed"),
+      );
+
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(
+        `http://127.0.0.1:${port}/zoom?x=0&y=0&width=100&height=100`,
+        { headers: { "x-vm0-token": TEST_TOKEN } },
+      );
+      expect(res.status).toBe(500);
+      const text = await res.text();
+      expect(text).toBe("region capture failed");
     });
 
     it("should execute left_click_drag on POST /mouse", async () => {

--- a/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
+++ b/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
@@ -6,7 +6,11 @@ import {
 } from "http";
 import { createServer as createNetServer } from "net";
 import type { AddressInfo } from "net";
-import { captureScreenshot, getScreenInfo } from "./screencapture";
+import {
+  captureScreenshot,
+  captureRegionScreenshot,
+  getScreenInfo,
+} from "./screencapture";
 import { leftClickDrag, leftMouseDown, leftMouseUp } from "./cliclick";
 import { scroll, type ScrollDirection } from "./scroll";
 import { readClipboard, writeClipboard } from "./clipboard";
@@ -61,6 +65,81 @@ type MouseRequestBody =
   | MouseUpBody
   | MouseScrollBody;
 
+async function handleZoom(
+  searchParams: URLSearchParams,
+  res: ServerResponse,
+): Promise<void> {
+  const x = Number(searchParams.get("x"));
+  const y = Number(searchParams.get("y"));
+  const width = Number(searchParams.get("width"));
+  const height = Number(searchParams.get("height"));
+
+  if (
+    [x, y, width, height].some((v) => {
+      return !Number.isFinite(v);
+    })
+  ) {
+    res.writeHead(400, { "Content-Type": "text/plain" });
+    res.end(
+      "Missing or invalid query parameters: x, y, width, height are required numbers",
+    );
+    return;
+  }
+  if (width <= 0 || height <= 0) {
+    res.writeHead(400, { "Content-Type": "text/plain" });
+    res.end("width and height must be positive");
+    return;
+  }
+  if (x < 0 || y < 0) {
+    res.writeHead(400, { "Content-Type": "text/plain" });
+    res.end("x and y must be non-negative");
+    return;
+  }
+
+  const info = await getScreenInfo();
+  if (x + width > info.width || y + height > info.height) {
+    res.writeHead(400, { "Content-Type": "text/plain" });
+    res.end(`Region exceeds screen bounds (${info.width}x${info.height})`);
+    return;
+  }
+
+  const result = await captureRegionScreenshot({ x, y, width, height });
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(result));
+}
+
+async function handleMouse(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const raw = await readBody(req);
+  const body = JSON.parse(raw) as MouseRequestBody;
+
+  switch (body.action) {
+    case "left_click_drag":
+      await leftClickDrag(body.startX, body.startY, body.endX, body.endY);
+      break;
+    case "left_mouse_down":
+      await leftMouseDown(body.x, body.y);
+      break;
+    case "left_mouse_up":
+      await leftMouseUp(body.x, body.y);
+      break;
+    case "scroll":
+      await scroll(body.x, body.y, body.direction, body.amount);
+      break;
+    default:
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end(
+        `Unknown mouse action: ${(body as unknown as Record<string, unknown>).action}`,
+      );
+      return;
+  }
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ ok: true }));
+}
+
 /**
  * Allocate a random available port on localhost.
  */
@@ -88,47 +167,27 @@ async function handleRequest(
     return;
   }
 
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const { pathname, searchParams } = url;
+
   try {
-    if (req.method === "GET" && req.url === "/screenshot") {
+    if (req.method === "GET" && pathname === "/screenshot") {
       const result = await captureScreenshot();
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(result));
-    } else if (req.method === "GET" && req.url === "/info") {
+    } else if (req.method === "GET" && pathname === "/info") {
       const info = await getScreenInfo();
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(info));
-    } else if (req.method === "POST" && req.url === "/mouse") {
-      const raw = await readBody(req);
-      const body = JSON.parse(raw) as MouseRequestBody;
-
-      switch (body.action) {
-        case "left_click_drag":
-          await leftClickDrag(body.startX, body.startY, body.endX, body.endY);
-          break;
-        case "left_mouse_down":
-          await leftMouseDown(body.x, body.y);
-          break;
-        case "left_mouse_up":
-          await leftMouseUp(body.x, body.y);
-          break;
-        case "scroll":
-          await scroll(body.x, body.y, body.direction, body.amount);
-          break;
-        default:
-          res.writeHead(400, { "Content-Type": "text/plain" });
-          res.end(
-            `Unknown mouse action: ${(body as unknown as Record<string, unknown>).action}`,
-          );
-          return;
-      }
-
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: true }));
-    } else if (req.method === "GET" && req.url === "/clipboard") {
+    } else if (req.method === "GET" && pathname === "/zoom") {
+      await handleZoom(searchParams, res);
+    } else if (req.method === "POST" && pathname === "/mouse") {
+      await handleMouse(req, res);
+    } else if (req.method === "GET" && pathname === "/clipboard") {
       const text = await readClipboard();
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ text }));
-    } else if (req.method === "POST" && req.url === "/clipboard") {
+    } else if (req.method === "POST" && pathname === "/clipboard") {
       const raw = await readBody(req);
       const body = JSON.parse(raw) as { text: string };
       await writeClipboard(body.text);

--- a/turbo/apps/cli/src/lib/computer-use/screencapture.ts
+++ b/turbo/apps/cli/src/lib/computer-use/screencapture.ts
@@ -18,6 +18,13 @@ interface ScreenshotResult extends ScreenInfo {
   format: string;
 }
 
+interface RegionParams {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 /**
  * Capture a screenshot on macOS using the screencapture command.
  * Returns the image as a base64 string along with screen metadata.
@@ -35,6 +42,39 @@ export async function captureScreenshot(): Promise<ScreenshotResult> {
       width: info.width,
       height: info.height,
       scaleFactor: info.scaleFactor,
+      format: "jpg",
+    };
+  } finally {
+    await unlink(tmpPath).catch(() => {});
+  }
+}
+
+/**
+ * Capture a screenshot of a specific screen region on macOS.
+ * Uses screencapture -R x,y,w,h to crop to the given rectangle.
+ */
+export async function captureRegionScreenshot(
+  region: RegionParams,
+): Promise<ScreenshotResult> {
+  const tmpPath = join(tmpdir(), `vm0-zoom-${randomUUID()}.jpg`);
+
+  try {
+    const regionArg = `${region.x},${region.y},${region.width},${region.height}`;
+    await execFileAsync("screencapture", [
+      "-x",
+      "-t",
+      "jpg",
+      "-R",
+      regionArg,
+      tmpPath,
+    ]);
+    const buffer = await readFile(tmpPath);
+
+    return {
+      image: buffer.toString("base64"),
+      width: region.width,
+      height: region.height,
+      scaleFactor: 1,
       format: "jpg",
     };
   } finally {


### PR DESCRIPTION
## Summary

- Add `/zoom` endpoint to desktop server that captures a specific screen region using macOS `screencapture -R` flag
- Add `captureRegionScreenshot()` function with region coordinates parameter
- Add `zero computer-use client zoom` command with `--x`, `--y`, `--width`, `--height` options
- Server-side validation: required params, positive dimensions, non-negative coordinates, screen bounds checking
- 5 new integration tests for the zoom endpoint (valid params, missing params, negative width, out-of-bounds, capture failure)

Closes #8055

## Test plan

- [x] `GET /zoom?x=100&y=200&width=400&height=300` returns 200 with cropped image data
- [x] `GET /zoom` with missing params returns 400
- [x] `GET /zoom` with negative width returns 400
- [x] `GET /zoom` with out-of-bounds region returns 400
- [x] `GET /zoom` capture failure returns 500
- [x] `zoom` registered as client subcommand
- [x] All 989 CLI tests pass
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)