### PR TITLE
feat(computer-use): add mouse movement and cursor position

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -177,4 +177,23 @@ describe("computer-use command visibility", () => {
     expect(clientSubs).toContain("double-click");
     expect(clientSubs).toContain("triple-click");
   });
+
+  it("should have mouse-move and cursor-position under client subcommand", () => {
+    const prog = new Command();
+    registerZeroCommands(prog);
+
+    const computerUse = prog.commands.find((c) => {
+      return c.name() === "computer-use";
+    });
+    const client = computerUse!.commands.find((c) => {
+      return c.name() === "client";
+    });
+    expect(client).toBeDefined();
+
+    const clientSubs = client!.commands.map((c) => {
+      return c.name();
+    });
+    expect(clientSubs).toContain("mouse-move");
+    expect(clientSubs).toContain("cursor-position");
+  });
 });

--- a/turbo/apps/cli/src/commands/zero/computer-use/client.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/client.ts
@@ -327,3 +327,20 @@ export const clientOpenAppCommand = new Command()
       process.stdout.write("ok\n");
     }),
   );
+
+export const clientMouseMoveCommand = mouseClickCommand(
+  "mouse-move",
+  "move",
+  "Move mouse pointer to coordinates",
+);
+
+export const clientCursorPositionCommand = new Command()
+  .name("cursor-position")
+  .description("Get current cursor position from the remote host")
+  .action(
+    withErrorHandler(async () => {
+      const response = await callHost("/cursor-position");
+      const data = (await response.json()) as { x: number; y: number };
+      process.stdout.write(JSON.stringify(data) + "\n");
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -19,6 +19,8 @@ import {
   clientHoldKeyCommand,
   clientTypeCommand,
   clientOpenAppCommand,
+  clientMouseMoveCommand,
+  clientCursorPositionCommand,
 } from "./client";
 
 const hostCommand = new Command()
@@ -46,7 +48,9 @@ const clientCommand = new Command()
   .addCommand(clientKeyCommand)
   .addCommand(clientHoldKeyCommand)
   .addCommand(clientTypeCommand)
-  .addCommand(clientOpenAppCommand);
+  .addCommand(clientOpenAppCommand)
+  .addCommand(clientMouseMoveCommand)
+  .addCommand(clientCursorPositionCommand);
 
 export const zeroComputerUseCommand = new Command()
   .name("computer-use")
@@ -73,5 +77,7 @@ Examples:
   Hold shift for 2 seconds:          zero computer-use client hold-key "shift" 2000
   Type text:                         zero computer-use client type "Hello, world!"
   Open an application:               zero computer-use client open-app Safari
-  Open by bundle ID:                 zero computer-use client open-app "com.apple.Safari"`,
+  Open by bundle ID:                 zero computer-use client open-app "com.apple.Safari"
+  Move mouse to (100, 200):          zero computer-use client mouse-move 100 200
+  Get cursor position:               zero computer-use client cursor-position`,
   );

--- a/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
+++ b/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
@@ -40,12 +40,14 @@ vi.mock("../cliclick", () => {
     leftMouseDown: vi.fn().mockResolvedValue(undefined),
     leftMouseUp: vi.fn().mockResolvedValue(undefined),
     executeMouseAction: vi.fn().mockResolvedValue(undefined),
+    getCursorPosition: vi.fn().mockResolvedValue({ x: 250, y: 150 }),
     VALID_ACTIONS: new Set([
       "left_click",
       "right_click",
       "middle_click",
       "double_click",
       "triple_click",
+      "move",
     ]),
     pressKey: vi.fn().mockResolvedValue(undefined),
     holdKey: vi.fn().mockResolvedValue(undefined),
@@ -84,6 +86,7 @@ import {
   leftMouseDown,
   leftMouseUp,
   executeMouseAction,
+  getCursorPosition,
   pressKey,
   holdKey,
   typeText,
@@ -107,6 +110,9 @@ async function setup(): Promise<{ server: Server; port: number }> {
       return passthrough();
     }),
     http.all(`http://127.0.0.1:${port}/clipboard`, () => {
+      return passthrough();
+    }),
+    http.all(`http://127.0.0.1:${port}/cursor-position`, () => {
       return passthrough();
     }),
     http.all(`http://127.0.0.1:${port}/keyboard`, () => {
@@ -663,6 +669,55 @@ describe("desktop-server", () => {
       expect(res.status).toBe(500);
       const text = await res.text();
       expect(text).toBe("pbcopy failed");
+    });
+
+    it("should execute move on POST /mouse with action move", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/mouse`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ action: "move", x: 100, y: 200 }),
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toEqual({ ok: true });
+      expect(executeMouseAction).toHaveBeenCalledWith("move", 100, 200);
+    });
+
+    it("should return cursor position on GET /cursor-position", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/cursor-position`, {
+        headers: { "x-vm0-token": TEST_TOKEN },
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toEqual({ x: 250, y: 150 });
+      expect(getCursorPosition).toHaveBeenCalledOnce();
+    });
+
+    it("should return 500 when getCursorPosition fails", async () => {
+      vi.mocked(getCursorPosition).mockRejectedValueOnce(
+        new Error("cliclick not found. Install with: brew install cliclick"),
+      );
+
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/cursor-position`, {
+        headers: { "x-vm0-token": TEST_TOKEN },
+      });
+      expect(res.status).toBe(500);
+      const text = await res.text();
+      expect(text).toContain("cliclick not found");
     });
 
     it("should execute key press on POST /keyboard with action key", async () => {

--- a/turbo/apps/cli/src/lib/computer-use/cliclick.ts
+++ b/turbo/apps/cli/src/lib/computer-use/cliclick.ts
@@ -39,7 +39,8 @@ export type MouseAction =
   | "right_click"
   | "middle_click"
   | "double_click"
-  | "triple_click";
+  | "triple_click"
+  | "move";
 
 const ACTION_COMMANDS: Record<MouseAction, string> = {
   left_click: "c",
@@ -47,6 +48,7 @@ const ACTION_COMMANDS: Record<MouseAction, string> = {
   middle_click: "mc",
   double_click: "dc",
   triple_click: "tc",
+  move: "m",
 };
 
 export const VALID_ACTIONS = new Set<string>(Object.keys(ACTION_COMMANDS));
@@ -64,7 +66,7 @@ async function checkCliclickInstalled(): Promise<void> {
 }
 
 /**
- * Execute a mouse click action at the given coordinates using cliclick.
+ * Execute a mouse action at the given coordinates using cliclick.
  */
 export async function executeMouseAction(
   action: MouseAction,
@@ -74,6 +76,30 @@ export async function executeMouseAction(
   await checkCliclickInstalled();
   const prefix = ACTION_COMMANDS[action];
   await execFileAsync("cliclick", [`${prefix}:${x},${y}`]);
+}
+
+/**
+ * Get the current cursor position using cliclick.
+ * Returns coordinates in points.
+ */
+export async function getCursorPosition(): Promise<{
+  x: number;
+  y: number;
+}> {
+  await checkCliclickInstalled();
+  const { stdout } = await execFileAsync("cliclick", ["p"]);
+  const parts = stdout.trim().split(",");
+  const xStr = parts[0];
+  const yStr = parts[1];
+  if (parts.length !== 2 || xStr === undefined || yStr === undefined) {
+    throw new Error(`Unexpected cliclick output: ${stdout.trim()}`);
+  }
+  const x = parseInt(xStr, 10);
+  const y = parseInt(yStr, 10);
+  if (Number.isNaN(x) || Number.isNaN(y)) {
+    throw new Error(`Failed to parse cursor position: ${stdout.trim()}`);
+  }
+  return { x, y };
 }
 
 const VALID_SPECIAL_KEYS = new Set([

--- a/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
+++ b/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
@@ -16,6 +16,7 @@ import {
   leftMouseDown,
   leftMouseUp,
   executeMouseAction,
+  getCursorPosition,
   VALID_ACTIONS,
   pressKey,
   holdKey,
@@ -388,6 +389,10 @@ async function handleRequest(
       await handleKeyboard(req, res);
     } else if (req.method === "POST" && pathname === "/open-application") {
       await handleOpenApplication(req, res);
+    } else if (req.method === "GET" && pathname === "/cursor-position") {
+      const position = await getCursorPosition();
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(position));
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not found");

--- a/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
+++ b/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
@@ -356,6 +356,16 @@ export async function getRandomPort(): Promise<number> {
   });
 }
 
+async function handleCursorPosition(res: ServerResponse): Promise<void> {
+  const position = await getCursorPosition();
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(position));
+}
+
+function routeKey(method: string, pathname: string): string {
+  return `${method} ${pathname}`;
+}
+
 async function handleRequest(
   token: string,
   req: IncomingMessage,
@@ -369,33 +379,44 @@ async function handleRequest(
 
   const url = new URL(req.url ?? "/", "http://localhost");
   const { pathname, searchParams } = url;
+  const key = routeKey(req.method ?? "GET", pathname);
 
   try {
-    if (req.method === "GET" && pathname === "/screenshot") {
-      const result = await captureScreenshot();
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(result));
-    } else if (req.method === "GET" && pathname === "/info") {
-      const info = await getScreenInfo();
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(info));
-    } else if (req.method === "GET" && pathname === "/zoom") {
-      await handleZoom(searchParams, res);
-    } else if (req.method === "POST" && pathname === "/mouse") {
-      await handleMouseRequest(req, res);
-    } else if (pathname === "/clipboard") {
-      await handleClipboard(req, res);
-    } else if (req.method === "POST" && pathname === "/keyboard") {
-      await handleKeyboard(req, res);
-    } else if (req.method === "POST" && pathname === "/open-application") {
-      await handleOpenApplication(req, res);
-    } else if (req.method === "GET" && pathname === "/cursor-position") {
-      const position = await getCursorPosition();
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(position));
-    } else {
-      res.writeHead(404, { "Content-Type": "text/plain" });
-      res.end("Not found");
+    switch (key) {
+      case "GET /screenshot": {
+        const result = await captureScreenshot();
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result));
+        break;
+      }
+      case "GET /info": {
+        const info = await getScreenInfo();
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(info));
+        break;
+      }
+      case "GET /zoom":
+        await handleZoom(searchParams, res);
+        break;
+      case "POST /mouse":
+        await handleMouseRequest(req, res);
+        break;
+      case "GET /clipboard":
+      case "POST /clipboard":
+        await handleClipboard(req, res);
+        break;
+      case "POST /keyboard":
+        await handleKeyboard(req, res);
+        break;
+      case "POST /open-application":
+        await handleOpenApplication(req, res);
+        break;
+      case "GET /cursor-position":
+        await handleCursorPosition(res);
+        break;
+      default:
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("Not found");
     }
   } catch (error) {
     const message =


### PR DESCRIPTION
## Summary

- Add mouse move (hover) operation via `cliclick m:x,y`
- Add cursor position query via `cliclick p` with `GET /cursor-position` endpoint
- Extend `POST /mouse` to accept `action: "move"` for mouse movement
- Add two new client subcommands: `mouse-move <x> <y>` and `cursor-position`

Depends on #8082
Closes #8057

## Test plan

- [x] All 25 computer-use tests pass (17 desktop-server + 8 command visibility)
- [x] TypeScript type-check passes
- [x] Knip finds no unused exports
- [x] Format check passes
- [ ] Manual: `zero computer-use client mouse-move 100 200` moves cursor to (100, 200)
- [ ] Manual: `zero computer-use client cursor-position` returns current coordinates

🤖 Generated with [Claude Code](https://claude.com/claude-code)