### PR TITLE
feat(computer-use): add key combos and hold-key commands

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -126,7 +126,7 @@ describe("computer-use command visibility", () => {
     expect(hostSubs).toContain("start");
   });
 
-  it("should have screenshot, info, mouse, scroll, and clipboard commands under client subcommand", () => {
+  it("should have screenshot, info, mouse, scroll, clipboard, and keyboard commands under client subcommand", () => {
     const prog = new Command();
     registerZeroCommands(prog);
 
@@ -150,6 +150,8 @@ describe("computer-use command visibility", () => {
     expect(clientSubs).toContain("scroll");
     expect(clientSubs).toContain("read-clipboard");
     expect(clientSubs).toContain("write-clipboard");
+    expect(clientSubs).toContain("key");
+    expect(clientSubs).toContain("hold-key");
   });
 
   it("should have mouse click commands under client subcommand", () => {

--- a/turbo/apps/cli/src/commands/zero/computer-use/client.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/client.ts
@@ -263,3 +263,36 @@ export const clientWriteClipboardCommand = new Command()
       process.stdout.write("ok\n");
     }),
   );
+
+export const clientKeyCommand = new Command()
+  .name("key")
+  .description("Press a key or key combination (e.g., cmd+c, return)")
+  .argument("<combo>", "Key combo string (e.g., cmd+c, ctrl+shift+s, return)")
+  .action(
+    withErrorHandler(async (combo: string) => {
+      await callHost("/keyboard", {
+        method: "POST",
+        body: { action: "key", keys: combo },
+      });
+      process.stdout.write("ok\n");
+    }),
+  );
+
+export const clientHoldKeyCommand = new Command()
+  .name("hold-key")
+  .description("Hold a key or key combination for a duration")
+  .argument("<combo>", "Key combo string (e.g., shift, cmd+shift)")
+  .argument("<durationMs>", "Duration to hold in milliseconds")
+  .action(
+    withErrorHandler(async (combo: string, durationStr: string) => {
+      const durationMs = parseInt(durationStr, 10);
+      if (Number.isNaN(durationMs) || durationMs <= 0) {
+        throw new Error("durationMs must be a positive integer");
+      }
+      await callHost("/keyboard", {
+        method: "POST",
+        body: { action: "hold_key", keys: combo, durationMs },
+      });
+      process.stdout.write("ok\n");
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -15,6 +15,8 @@ import {
   clientScrollCommand,
   clientReadClipboardCommand,
   clientWriteClipboardCommand,
+  clientKeyCommand,
+  clientHoldKeyCommand,
 } from "./client";
 
 const hostCommand = new Command()
@@ -38,7 +40,9 @@ const clientCommand = new Command()
   .addCommand(clientLeftMouseUpCommand)
   .addCommand(clientScrollCommand)
   .addCommand(clientReadClipboardCommand)
-  .addCommand(clientWriteClipboardCommand);
+  .addCommand(clientWriteClipboardCommand)
+  .addCommand(clientKeyCommand)
+  .addCommand(clientHoldKeyCommand);
 
 export const zeroComputerUseCommand = new Command()
   .name("computer-use")
@@ -60,5 +64,7 @@ Examples:
   Release mouse button:              zero computer-use client left-mouse-up 500 500
   Scroll down at position:           zero computer-use client scroll 500 300 down 5
   Read clipboard text:               zero computer-use client read-clipboard
-  Write clipboard text:              zero computer-use client write-clipboard "hello"`,
+  Write clipboard text:              zero computer-use client write-clipboard "hello"
+  Press key combo:                   zero computer-use client key "cmd+c"
+  Hold shift for 2 seconds:          zero computer-use client hold-key "shift" 2000`,
   );

--- a/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
+++ b/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
@@ -47,6 +47,8 @@ vi.mock("../cliclick", () => {
       "double_click",
       "triple_click",
     ]),
+    pressKey: vi.fn().mockResolvedValue(undefined),
+    holdKey: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -70,8 +72,14 @@ import {
   captureRegionScreenshot,
   getScreenInfo,
 } from "../screencapture";
-import { leftClickDrag, leftMouseDown, leftMouseUp } from "../cliclick";
-import { executeMouseAction } from "../cliclick";
+import {
+  leftClickDrag,
+  leftMouseDown,
+  leftMouseUp,
+  executeMouseAction,
+  pressKey,
+  holdKey,
+} from "../cliclick";
 import { scroll } from "../scroll";
 import { readClipboard, writeClipboard } from "../clipboard";
 
@@ -90,6 +98,9 @@ async function setup(): Promise<{ server: Server; port: number }> {
       return passthrough();
     }),
     http.all(`http://127.0.0.1:${port}/clipboard`, () => {
+      return passthrough();
+    }),
+    http.all(`http://127.0.0.1:${port}/keyboard`, () => {
       return passthrough();
     }),
     http.all(`http://127.0.0.1:${port}/unknown`, () => {
@@ -640,6 +651,107 @@ describe("desktop-server", () => {
       expect(res.status).toBe(500);
       const text = await res.text();
       expect(text).toBe("pbcopy failed");
+    });
+
+    it("should execute key press on POST /keyboard with action key", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/keyboard`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ action: "key", keys: "cmd+c" }),
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toEqual({ ok: true });
+      expect(pressKey).toHaveBeenCalledWith("cmd+c");
+    });
+
+    it("should execute hold key on POST /keyboard with action hold_key", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/keyboard`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "hold_key",
+          keys: "shift",
+          durationMs: 1000,
+        }),
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toEqual({ ok: true });
+      expect(holdKey).toHaveBeenCalledWith("shift", 1000);
+    });
+
+    it("should return 400 for invalid durationMs on hold_key", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/keyboard`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          action: "hold_key",
+          keys: "shift",
+          durationMs: -100,
+        }),
+      });
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toContain("durationMs must be a positive number");
+    });
+
+    it("should return 400 for unknown keyboard action", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/keyboard`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ action: "unknown_action" }),
+      });
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toContain("Unknown keyboard action");
+    });
+
+    it("should return 500 when pressKey fails", async () => {
+      vi.mocked(pressKey).mockRejectedValueOnce(
+        new Error('Unknown key: "badkey"'),
+      );
+
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/keyboard`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ action: "key", keys: "badkey" }),
+      });
+      expect(res.status).toBe(500);
+      const text = await res.text();
+      expect(text).toContain("Unknown key");
     });
   });
 });

--- a/turbo/apps/cli/src/lib/computer-use/cliclick.ts
+++ b/turbo/apps/cli/src/lib/computer-use/cliclick.ts
@@ -1,5 +1,6 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
+import { setTimeout as sleep } from "timers/promises";
 
 const execFileAsync = promisify(execFile);
 
@@ -73,4 +74,104 @@ export async function executeMouseAction(
   await checkCliclickInstalled();
   const prefix = ACTION_COMMANDS[action];
   await execFileAsync("cliclick", [`${prefix}:${x},${y}`]);
+}
+
+const VALID_SPECIAL_KEYS = new Set([
+  "cmd",
+  "ctrl",
+  "alt",
+  "shift",
+  "fn",
+  "arrow-up",
+  "arrow-down",
+  "arrow-left",
+  "arrow-right",
+  "tab",
+  "esc",
+  "space",
+  "delete",
+  "return",
+  "enter",
+  "home",
+  "end",
+  "page-up",
+  "page-down",
+  ...Array.from({ length: 19 }, (_, i) => {
+    return `f${i + 1}`;
+  }),
+]);
+
+function isValidKeyName(key: string): boolean {
+  return VALID_SPECIAL_KEYS.has(key) || key.length === 1;
+}
+
+function parseKeyCombo(keys: string): {
+  modifiers: string[];
+  mainKey: string;
+} {
+  const parts = keys.split("+");
+  if (
+    parts.length === 0 ||
+    parts.some((p) => {
+      return p === "";
+    })
+  ) {
+    throw new Error(`Invalid key combo: "${keys}"`);
+  }
+
+  const mainKey = parts[parts.length - 1]!;
+  const modifiers = parts.slice(0, -1);
+
+  for (const key of parts) {
+    if (!isValidKeyName(key)) {
+      throw new Error(
+        `Unknown key: "${key}". Valid keys: single characters, or special keys like cmd, ctrl, alt, shift, tab, esc, return, arrow-up, f1-f19, etc.`,
+      );
+    }
+  }
+
+  return { modifiers, mainKey };
+}
+
+/**
+ * Press a key combination using cliclick.
+ * Accepts combo strings like "cmd+c", "ctrl+shift+s", or single keys like "return".
+ */
+export async function pressKey(keys: string): Promise<void> {
+  const { modifiers, mainKey } = parseKeyCombo(keys);
+
+  if (modifiers.length === 0) {
+    await execFileAsync("cliclick", [`kp:${mainKey}`]);
+    return;
+  }
+
+  const args: string[] = [];
+  for (const mod of modifiers) {
+    args.push(`kd:${mod}`);
+  }
+  args.push(`kp:${mainKey}`);
+  for (let i = modifiers.length - 1; i >= 0; i--) {
+    args.push(`ku:${modifiers[i]}`);
+  }
+  await execFileAsync("cliclick", args);
+}
+
+/**
+ * Hold key(s) down for a specified duration then release.
+ * Accepts combo strings like "shift" or "cmd+shift".
+ */
+export async function holdKey(keys: string, durationMs: number): Promise<void> {
+  const { modifiers, mainKey } = parseKeyCombo(keys);
+  const allKeys = [...modifiers, mainKey];
+
+  const downArgs = allKeys.map((k) => {
+    return `kd:${k}`;
+  });
+  const upArgs = [...allKeys].reverse().map((k) => {
+    return `ku:${k}`;
+  });
+
+  await execFileAsync("cliclick", downArgs);
+  await sleep(durationMs);
+  await execFileAsync("cliclick", upArgs);
 }

--- a/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
+++ b/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
@@ -11,8 +11,15 @@ import {
   captureRegionScreenshot,
   getScreenInfo,
 } from "./screencapture";
-import { leftClickDrag, leftMouseDown, leftMouseUp } from "./cliclick";
-import { executeMouseAction, VALID_ACTIONS } from "./cliclick";
+import {
+  leftClickDrag,
+  leftMouseDown,
+  leftMouseUp,
+  executeMouseAction,
+  VALID_ACTIONS,
+  pressKey,
+  holdKey,
+} from "./cliclick";
 import type { MouseAction } from "./cliclick";
 import { scroll, type ScrollDirection } from "./scroll";
 import { readClipboard, writeClipboard } from "./clipboard";
@@ -228,6 +235,54 @@ async function handleMouseRequest(
   res.end(JSON.stringify({ ok: true }));
 }
 
+interface KeyPressBody {
+  action: "key";
+  keys: string;
+}
+
+interface HoldKeyBody {
+  action: "hold_key";
+  keys: string;
+  durationMs: number;
+}
+
+type KeyboardRequestBody = KeyPressBody | HoldKeyBody;
+
+async function handleKeyboard(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const raw = await readBody(req);
+  const body = JSON.parse(raw) as KeyboardRequestBody;
+
+  switch (body.action) {
+    case "key":
+      await pressKey(body.keys);
+      break;
+    case "hold_key":
+      if (
+        typeof body.durationMs !== "number" ||
+        !Number.isFinite(body.durationMs) ||
+        body.durationMs <= 0
+      ) {
+        res.writeHead(400, { "Content-Type": "text/plain" });
+        res.end("durationMs must be a positive number");
+        return;
+      }
+      await holdKey(body.keys, body.durationMs);
+      break;
+    default:
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end(
+        `Unknown keyboard action: ${(body as Record<string, unknown>).action}`,
+      );
+      return;
+  }
+
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ ok: true }));
+}
+
 /**
  * Allocate a random available port on localhost.
  */
@@ -281,6 +336,8 @@ async function handleRequest(
       await writeClipboard(body.text);
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: true }));
+    } else if (req.method === "POST" && pathname === "/keyboard") {
+      await handleKeyboard(req, res);
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not found");


### PR DESCRIPTION
## Summary

- Add key combination support via cliclick (`cmd+c`, `ctrl+shift+s`, single keys like `return`)
- Add hold-key operation with configurable duration in milliseconds
- Add `POST /keyboard` endpoint with `key` and `hold_key` actions
- Validate key names against cliclick-supported keys (modifiers, special keys, single chars)
- Modifier keys released in reverse order (LIFO) for correct behavior
- Hold-key uses separate press/release cliclick calls with sleep between

Closes #8061

## Test plan

- [x] All 23 computer-use tests pass (17 desktop-server + 6 command visibility)
- [x] TypeScript type-check passes
- [x] Knip finds no unused exports
- [x] Format check passes
- [ ] Manual: `zero computer-use client key "cmd+c"` performs copy shortcut
- [ ] Manual: `zero computer-use client key "return"` presses enter
- [ ] Manual: `zero computer-use client hold-key "shift" 2000` holds shift for 2s
- [ ] Manual: Invalid key names return clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)