### PR TITLE
feat(computer-use): add text input command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -152,6 +152,7 @@ describe("computer-use command visibility", () => {
     expect(clientSubs).toContain("write-clipboard");
     expect(clientSubs).toContain("key");
     expect(clientSubs).toContain("hold-key");
+    expect(clientSubs).toContain("type");
   });
 
   it("should have mouse click commands under client subcommand", () => {

--- a/turbo/apps/cli/src/commands/zero/computer-use/client.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/client.ts
@@ -296,3 +296,17 @@ export const clientHoldKeyCommand = new Command()
       process.stdout.write("ok\n");
     }),
   );
+
+export const clientTypeCommand = new Command()
+  .name("type")
+  .description("Type text at the current cursor position")
+  .argument("<text>", "Text to type")
+  .action(
+    withErrorHandler(async (text: string) => {
+      await callHost("/keyboard", {
+        method: "POST",
+        body: { action: "type", text },
+      });
+      process.stdout.write("ok\n");
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -17,6 +17,7 @@ import {
   clientWriteClipboardCommand,
   clientKeyCommand,
   clientHoldKeyCommand,
+  clientTypeCommand,
 } from "./client";
 
 const hostCommand = new Command()
@@ -42,7 +43,8 @@ const clientCommand = new Command()
   .addCommand(clientReadClipboardCommand)
   .addCommand(clientWriteClipboardCommand)
   .addCommand(clientKeyCommand)
-  .addCommand(clientHoldKeyCommand);
+  .addCommand(clientHoldKeyCommand)
+  .addCommand(clientTypeCommand);
 
 export const zeroComputerUseCommand = new Command()
   .name("computer-use")
@@ -66,5 +68,6 @@ Examples:
   Read clipboard text:               zero computer-use client read-clipboard
   Write clipboard text:              zero computer-use client write-clipboard "hello"
   Press key combo:                   zero computer-use client key "cmd+c"
-  Hold shift for 2 seconds:          zero computer-use client hold-key "shift" 2000`,
+  Hold shift for 2 seconds:          zero computer-use client hold-key "shift" 2000
+  Type text:                         zero computer-use client type "Hello, world!"`,
   );

--- a/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
+++ b/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
@@ -49,6 +49,7 @@ vi.mock("../cliclick", () => {
     ]),
     pressKey: vi.fn().mockResolvedValue(undefined),
     holdKey: vi.fn().mockResolvedValue(undefined),
+    typeText: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -79,6 +80,7 @@ import {
   executeMouseAction,
   pressKey,
   holdKey,
+  typeText,
 } from "../cliclick";
 import { scroll } from "../scroll";
 import { readClipboard, writeClipboard } from "../clipboard";
@@ -716,6 +718,42 @@ describe("desktop-server", () => {
       expect(text).toContain("durationMs must be a positive number");
     });
 
+    it("should type text on POST /keyboard with action type", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/keyboard`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ action: "type", text: "Hello, world!" }),
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toEqual({ ok: true });
+      expect(typeText).toHaveBeenCalledWith("Hello, world!");
+    });
+
+    it("should return 400 for empty text on POST /keyboard type", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/keyboard`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ action: "type", text: "" }),
+      });
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toContain("non-empty string");
+    });
+
     it("should return 400 for unknown keyboard action", async () => {
       const { server, port } = await setup();
       testServer = server;
@@ -752,6 +790,27 @@ describe("desktop-server", () => {
       expect(res.status).toBe(500);
       const text = await res.text();
       expect(text).toContain("Unknown key");
+    });
+
+    it("should return 500 when typeText fails", async () => {
+      vi.mocked(typeText).mockRejectedValueOnce(
+        new Error("cliclick not found"),
+      );
+
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/keyboard`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ action: "type", text: "test" }),
+      });
+      expect(res.status).toBe(500);
+      const text = await res.text();
+      expect(text).toBe("cliclick not found");
     });
   });
 });

--- a/turbo/apps/cli/src/lib/computer-use/cliclick.ts
+++ b/turbo/apps/cli/src/lib/computer-use/cliclick.ts
@@ -175,3 +175,10 @@ export async function holdKey(keys: string, durationMs: number): Promise<void> {
   await sleep(durationMs);
   await execFileAsync("cliclick", upArgs);
 }
+
+/**
+ * Type text at the current cursor position using cliclick.
+ */
+export async function typeText(text: string): Promise<void> {
+  await execFileAsync("cliclick", [`t:${text}`]);
+}

--- a/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
+++ b/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
@@ -19,6 +19,7 @@ import {
   VALID_ACTIONS,
   pressKey,
   holdKey,
+  typeText,
 } from "./cliclick";
 import type { MouseAction } from "./cliclick";
 import { scroll, type ScrollDirection } from "./scroll";
@@ -246,7 +247,12 @@ interface HoldKeyBody {
   durationMs: number;
 }
 
-type KeyboardRequestBody = KeyPressBody | HoldKeyBody;
+interface TypeTextBody {
+  action: "type";
+  text: string;
+}
+
+type KeyboardRequestBody = KeyPressBody | HoldKeyBody | TypeTextBody;
 
 async function handleKeyboard(
   req: IncomingMessage,
@@ -270,6 +276,14 @@ async function handleKeyboard(
         return;
       }
       await holdKey(body.keys, body.durationMs);
+      break;
+    case "type":
+      if (typeof body.text !== "string" || body.text.length === 0) {
+        res.writeHead(400, { "Content-Type": "text/plain" });
+        res.end("text must be a non-empty string");
+        return;
+      }
+      await typeText(body.text);
       break;
     default:
       res.writeHead(400, { "Content-Type": "text/plain" });


### PR DESCRIPTION
## Summary

- Add `typeText()` function in cliclick.ts wrapping `cliclick t:{text}`
- Add `POST /keyboard` endpoint with `type` action and text validation
- Add `type <text>` client subcommand for typing at current cursor position

Closes #8060

## Test plan

- [x] All 22 computer-use tests pass (16 desktop-server + 6 command visibility)
- [x] TypeScript type-check passes
- [x] Knip finds no unused exports
- [x] Format check passes
- [ ] Manual: `zero computer-use client type "Hello, world!"` types text at cursor
- [ ] Manual: Special characters handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)