### PR TITLE
feat(computer-use): add open application command

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -153,6 +153,7 @@ describe("computer-use command visibility", () => {
     expect(clientSubs).toContain("key");
     expect(clientSubs).toContain("hold-key");
     expect(clientSubs).toContain("type");
+    expect(clientSubs).toContain("open-app");
   });
 
   it("should have mouse click commands under client subcommand", () => {

--- a/turbo/apps/cli/src/commands/zero/computer-use/client.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/client.ts
@@ -310,3 +310,20 @@ export const clientTypeCommand = new Command()
       process.stdout.write("ok\n");
     }),
   );
+
+export const clientOpenAppCommand = new Command()
+  .name("open-app")
+  .description("Open or activate a macOS application by name or bundle ID")
+  .argument(
+    "<nameOrBundleId>",
+    "App name (e.g., Safari) or bundle ID (e.g., com.apple.Safari)",
+  )
+  .action(
+    withErrorHandler(async (nameOrBundleId: string) => {
+      await callHost("/open-application", {
+        method: "POST",
+        body: { nameOrBundleId },
+      });
+      process.stdout.write("ok\n");
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -18,6 +18,7 @@ import {
   clientKeyCommand,
   clientHoldKeyCommand,
   clientTypeCommand,
+  clientOpenAppCommand,
 } from "./client";
 
 const hostCommand = new Command()
@@ -44,7 +45,8 @@ const clientCommand = new Command()
   .addCommand(clientWriteClipboardCommand)
   .addCommand(clientKeyCommand)
   .addCommand(clientHoldKeyCommand)
-  .addCommand(clientTypeCommand);
+  .addCommand(clientTypeCommand)
+  .addCommand(clientOpenAppCommand);
 
 export const zeroComputerUseCommand = new Command()
   .name("computer-use")
@@ -69,5 +71,7 @@ Examples:
   Write clipboard text:              zero computer-use client write-clipboard "hello"
   Press key combo:                   zero computer-use client key "cmd+c"
   Hold shift for 2 seconds:          zero computer-use client hold-key "shift" 2000
-  Type text:                         zero computer-use client type "Hello, world!"`,
+  Type text:                         zero computer-use client type "Hello, world!"
+  Open an application:               zero computer-use client open-app Safari
+  Open by bundle ID:                 zero computer-use client open-app "com.apple.Safari"`,
   );

--- a/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
+++ b/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
@@ -66,6 +66,12 @@ vi.mock("../clipboard", () => {
   };
 });
 
+vi.mock("../application", () => {
+  return {
+    openApplication: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
 import type { Server } from "http";
 import { startDesktopServer, getRandomPort } from "../desktop-server";
 import {
@@ -84,6 +90,7 @@ import {
 } from "../cliclick";
 import { scroll } from "../scroll";
 import { readClipboard, writeClipboard } from "../clipboard";
+import { openApplication } from "../application";
 
 const TEST_TOKEN = "test-bridge-token-abc123";
 
@@ -103,6 +110,9 @@ async function setup(): Promise<{ server: Server; port: number }> {
       return passthrough();
     }),
     http.all(`http://127.0.0.1:${port}/keyboard`, () => {
+      return passthrough();
+    }),
+    http.all(`http://127.0.0.1:${port}/open-application`, () => {
       return passthrough();
     }),
     http.all(`http://127.0.0.1:${port}/unknown`, () => {
@@ -811,6 +821,63 @@ describe("desktop-server", () => {
       expect(res.status).toBe(500);
       const text = await res.text();
       expect(text).toBe("cliclick not found");
+    });
+
+    it("should open application on POST /open-application", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/open-application`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ nameOrBundleId: "Safari" }),
+      });
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data).toEqual({ ok: true });
+      expect(openApplication).toHaveBeenCalledWith("Safari");
+    });
+
+    it("should return 400 for empty nameOrBundleId on POST /open-application", async () => {
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/open-application`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ nameOrBundleId: "" }),
+      });
+      expect(res.status).toBe(400);
+      const text = await res.text();
+      expect(text).toContain("non-empty string");
+    });
+
+    it("should return 500 when openApplication fails", async () => {
+      vi.mocked(openApplication).mockRejectedValueOnce(
+        new Error("The application could not be found"),
+      );
+
+      const { server, port } = await setup();
+      testServer = server;
+
+      const res = await fetch(`http://127.0.0.1:${port}/open-application`, {
+        method: "POST",
+        headers: {
+          "x-vm0-token": TEST_TOKEN,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ nameOrBundleId: "NonExistentApp" }),
+      });
+      expect(res.status).toBe(500);
+      const text = await res.text();
+      expect(text).toBe("The application could not be found");
     });
   });
 });

--- a/turbo/apps/cli/src/lib/computer-use/application.ts
+++ b/turbo/apps/cli/src/lib/computer-use/application.ts
@@ -1,0 +1,14 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Open or activate a macOS application by name or bundle ID.
+ * Detects bundle IDs by the presence of dots (e.g., com.apple.Safari).
+ */
+export async function openApplication(nameOrBundleId: string): Promise<void> {
+  const isBundleId = nameOrBundleId.includes(".");
+  const flag = isBundleId ? "-b" : "-a";
+  await execFileAsync("open", [flag, nameOrBundleId]);
+}

--- a/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
+++ b/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
@@ -24,6 +24,7 @@ import {
 import type { MouseAction } from "./cliclick";
 import { scroll, type ScrollDirection } from "./scroll";
 import { readClipboard, writeClipboard } from "./clipboard";
+import { openApplication } from "./application";
 
 /**
  * Read the full request body as a string.
@@ -297,6 +298,47 @@ async function handleKeyboard(
   res.end(JSON.stringify({ ok: true }));
 }
 
+async function handleClipboard(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if (req.method === "GET") {
+    const text = await readClipboard();
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ text }));
+  } else if (req.method === "POST") {
+    const raw = await readBody(req);
+    const body = JSON.parse(raw) as { text: string };
+    await writeClipboard(body.text);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  } else {
+    res.writeHead(404, { "Content-Type": "text/plain" });
+    res.end("Not found");
+  }
+}
+
+async function handleOpenApplication(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const raw = await readBody(req);
+  const body = JSON.parse(raw) as { nameOrBundleId: unknown };
+
+  if (
+    typeof body.nameOrBundleId !== "string" ||
+    body.nameOrBundleId.length === 0
+  ) {
+    res.writeHead(400, { "Content-Type": "text/plain" });
+    res.end("nameOrBundleId must be a non-empty string");
+    return;
+  }
+
+  await openApplication(body.nameOrBundleId);
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ ok: true }));
+}
+
 /**
  * Allocate a random available port on localhost.
  */
@@ -340,18 +382,12 @@ async function handleRequest(
       await handleZoom(searchParams, res);
     } else if (req.method === "POST" && pathname === "/mouse") {
       await handleMouseRequest(req, res);
-    } else if (req.method === "GET" && pathname === "/clipboard") {
-      const text = await readClipboard();
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ text }));
-    } else if (req.method === "POST" && pathname === "/clipboard") {
-      const raw = await readBody(req);
-      const body = JSON.parse(raw) as { text: string };
-      await writeClipboard(body.text);
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: true }));
+    } else if (pathname === "/clipboard") {
+      await handleClipboard(req, res);
     } else if (req.method === "POST" && pathname === "/keyboard") {
       await handleKeyboard(req, res);
+    } else if (req.method === "POST" && pathname === "/open-application") {
+      await handleOpenApplication(req, res);
     } else {
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("Not found");


### PR DESCRIPTION
## Summary

- Add `application.ts` with `openApplication()` function using macOS `open` command
- Auto-detect bundle IDs (contains dots → `open -b`) vs app names (`open -a`)
- Add `POST /open-application` endpoint with nameOrBundleId validation
- Add `open-app <nameOrBundleId>` client subcommand

Closes #8063

## Test plan

- [x] All 24 computer-use tests pass (18 desktop-server + 6 command visibility)
- [x] TypeScript type-check passes
- [x] Knip finds no unused exports
- [x] Format check passes
- [ ] Manual: `zero computer-use client open-app Safari` opens Safari
- [ ] Manual: `zero computer-use client open-app "com.apple.Safari"` opens via bundle ID
- [ ] Manual: Non-existent app returns clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)