### PR TITLE
ci: increase test-app shards from 4 to 8

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -480,7 +480,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     container:
       image: ghcr.io/vm0-ai/vm0-toolchain:20260324
     steps:
@@ -488,7 +488,7 @@ jobs:
       - uses: ./.github/actions/toolchain-init
       - name: Test App
         working-directory: turbo
-        run: pnpm vitest run --project=@vm0/app --shard=${{ matrix.shard }}/4 --coverage.enabled --coverage.reporter=json
+        run: pnpm vitest run --project=@vm0/app --shard=${{ matrix.shard }}/8 --coverage.enabled --coverage.reporter=json
       - name: Upload coverage to Codecov
         if: success() || failure()
         uses: codecov/codecov-action@v6


### PR DESCRIPTION
## Summary
- Increase `test-app` CI job from 4 shards to 8 for faster parallel test execution

## Test plan
- [ ] CI pipeline runs all 8 shards successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)