### PR TITLE
fix: replace underscores in org id for ngrok subdomain names

### DIFF
--- a/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
@@ -60,7 +60,8 @@ export async function createComputerConnector(
 
   // Generate unique subdomain name for this user
   // Truncate org ID to keep subdomain short (ngrok has length limits)
-  const orgIdShort = orgId.substring(0, 8);
+  // Replace underscores with hyphens — ngrok rejects underscores in domain names
+  const orgIdShort = orgId.substring(0, 8).replace(/_/g, "-");
   const subdomainName = `vm0-user-${orgIdShort}`;
   const endpointPrefix = `vm0-user-${orgId}`;
 

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -67,7 +67,8 @@ export async function registerHost(
   }
 
   // Generate names for ngrok resources
-  const orgIdShort = orgId.substring(0, 8);
+  // Replace underscores with hyphens — ngrok rejects underscores in domain names
+  const orgIdShort = orgId.substring(0, 8).replace(/_/g, "-");
   const subdomainName = `vm0-cu-${orgIdShort}`;
   const endpointPrefix = `vm0-cu-${orgId}`;
   const botUserName = `vm0-cu-${orgId}`;


### PR DESCRIPTION
## Summary
- Clerk orgIds use format `org_XXXX` — the underscore causes ngrok to reject the reserved domain with `ERR_NGROK_438`
- Replace underscores with hyphens in the subdomain portion of both computer-use and computer-connector services

## Root Cause
Axiom prod logs showed:
```
ngrok API error: 400 /reserved_domains
ERR_NGROK_438: Invalid '_' in domain name. Failed to reserve 'vm0-cu-org_3ant.ngrok.app'.
```

## Test plan
- [ ] Run `zero computer-use host start` — should no longer return 500
- [ ] Verify generated subdomain uses hyphens (e.g., `vm0-cu-org-3ant` instead of `vm0-cu-org_3ant`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)