### PR TITLE
test(platform): add zero-sidebar display tests

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -1,0 +1,455 @@
+/**
+ * Display tests for ZeroSidebar component.
+ *
+ * Tests cover chat thread list, loading/error states, search, agent cards,
+ * active nav highlighting, pinned agents, Slack scope mismatch indicator,
+ * and new chat button enabled/disabled states.
+ *
+ * Follows platform testing principles:
+ * - Entry point: setupPage({ context, path })
+ * - Mock (external): HTTP via MSW
+ * - Real (internal): All signals, components, rendering
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
+
+const context = testContext();
+
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function mockBaseAPIs(
+  overrides: {
+    threads?: {
+      id: string;
+      title: string;
+      agentId: string;
+      createdAt: string;
+      updatedAt: string;
+    }[];
+    agents?: {
+      id: string;
+      displayName: string | null;
+      description: string | null;
+      sound: null;
+      avatarUrl: null;
+      headVersionId: string;
+      updatedAt: string;
+    }[];
+  } = {},
+) {
+  const agents = overrides.agents ?? [
+    {
+      id: DEFAULT_AGENT_ID,
+      displayName: null,
+      description: null,
+      sound: null,
+      avatarUrl: null,
+      headVersionId: "version_1",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  ];
+  const threads = overrides.threads ?? [];
+
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json(agents);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads });
+    }),
+  );
+}
+
+function getSidebar(): HTMLElement {
+  return screen.getByRole("navigation", { name: "Sidebar" });
+}
+
+beforeEach(() => {
+  setMockUserPreferences({ pinnedAgentIds: [] });
+});
+
+describe("zero sidebar - chat thread list display (SIDEBAR-D-001)", () => {
+  it("renders two chat threads in the sidebar", async () => {
+    mockBaseAPIs({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Deploy to production",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        },
+        {
+          id: "thread-2",
+          title: "Fix the bug",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-09T00:00:00Z",
+          updatedAt: "2026-03-09T00:00:00Z",
+        },
+      ],
+    });
+    await setupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      const sidebar = getSidebar();
+      expect(
+        within(sidebar).getByText("Deploy to production"),
+      ).toBeInTheDocument();
+      expect(within(sidebar).getByText("Fix the bug")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero sidebar - loading state (SIDEBAR-D-002)", () => {
+  it("shows skeleton placeholders while chat threads are loading", async () => {
+    const deferred = createDeferredPromise<void>(context.signal);
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: DEFAULT_AGENT_ID,
+            displayName: null,
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        ]);
+      }),
+      http.get("*/api/zero/chat-threads", async () => {
+        await deferred.promise;
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/" });
+
+    // While the chat-threads request is hanging, skeletons should be visible
+    await waitFor(() => {
+      const sidebar = getSidebar();
+      expect(sidebar.querySelectorAll(".animate-pulse").length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    deferred.resolve();
+  });
+});
+
+describe("zero sidebar - search results filter (SIDEBAR-D-003)", () => {
+  it("shows only matching thread after typing a search term", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Deploy to production",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        },
+        {
+          id: "thread-2",
+          title: "Fix the bug",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-09T00:00:00Z",
+          updatedAt: "2026-03-09T00:00:00Z",
+        },
+      ],
+    });
+
+    await setupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(
+        within(getSidebar()).getByText("Deploy to production"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Search chats" }));
+    const searchInput = screen.getByPlaceholderText(/Search chat with/);
+    await user.type(searchInput, "deploy");
+
+    expect(
+      within(getSidebar()).getByText("Deploy to production"),
+    ).toBeInTheDocument();
+    expect(
+      within(getSidebar()).queryByText("Fix the bug"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("zero sidebar - search term displays in input (SIDEBAR-D-004)", () => {
+  it("shows the typed search term in the search input", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Deploy to production",
+          agentId: DEFAULT_AGENT_ID,
+          createdAt: "2026-03-10T00:00:00Z",
+          updatedAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+
+    await setupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(
+        within(getSidebar()).getByText("Deploy to production"),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Search chats" }));
+    const searchInput = screen.getByPlaceholderText(/Search chat with/);
+    await user.type(searchInput, "deploy");
+
+    expect(searchInput).toHaveValue("deploy");
+  });
+});
+
+describe("zero sidebar - error state (SIDEBAR-D-005)", () => {
+  it("displays an error message when chat-threads fetch fails", async () => {
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: DEFAULT_AGENT_ID,
+            displayName: null,
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        ]);
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Internal server error",
+              code: "INTERNAL_SERVER_ERROR",
+            },
+          },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      const sidebar = getSidebar();
+      // The error paragraph appears inside the sidebar with text-destructive
+      expect(sidebar.querySelector("p.text-destructive")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero sidebar - agent cards display (SIDEBAR-D-006)", () => {
+  it("shows default agent and pinned sub-agent names in the sidebar", async () => {
+    mockBaseAPIs({
+      agents: [
+        {
+          id: DEFAULT_AGENT_ID,
+          displayName: null,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "agent-research",
+          displayName: "Research Agent",
+          description: "Finds information",
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_2",
+          updatedAt: "2024-01-02T00:00:00Z",
+        },
+      ],
+    });
+    setMockUserPreferences({ pinnedAgentIds: ["agent-research"] });
+
+    await setupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      const sidebar = getSidebar();
+      // Default agent displays as "Zero" (or the raw id)
+      expect(within(sidebar).getByText("Zero")).toBeInTheDocument();
+      // Pinned sub-agent shows its displayName
+      expect(within(sidebar).getByText("Research Agent")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero sidebar - active tab indicator (SIDEBAR-D-007)", () => {
+  it("highlights the Agents nav link with aria-current=page when on /agents", async () => {
+    mockBaseAPIs();
+
+    await setupPage({ context, path: "/agents" });
+
+    await waitFor(() => {
+      const nav = getSidebar();
+      const agentsLink = within(nav).getByRole("link", { name: "Agents" });
+      expect(agentsLink).toHaveAttribute("aria-current", "page");
+    });
+  });
+});
+
+describe("zero sidebar - pinned agents display (SIDEBAR-D-008)", () => {
+  it("shows the Pinned section header in the sidebar", async () => {
+    mockBaseAPIs();
+
+    await setupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      const sidebar = getSidebar();
+      expect(within(sidebar).getByText("Pinned")).toBeInTheDocument();
+    });
+  });
+
+  it("shows pinned agent name once preferences resolve", async () => {
+    mockBaseAPIs({
+      agents: [
+        {
+          id: DEFAULT_AGENT_ID,
+          displayName: null,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "agent-writer",
+          displayName: "Writer Agent",
+          description: "Creates content",
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_2",
+          updatedAt: "2024-01-02T00:00:00Z",
+        },
+      ],
+    });
+    setMockUserPreferences({ pinnedAgentIds: ["agent-writer"] });
+
+    await setupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      const sidebar = getSidebar();
+      expect(within(sidebar).getByText("Writer Agent")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero sidebar - Slack scope mismatch indicator (SIDEBAR-D-009)", () => {
+  it("shows the Where Zero works link when Slack scope mismatch is true", async () => {
+    server.use(
+      http.get("*/api/zero/integrations/slack", () => {
+        return HttpResponse.json({
+          isConnected: true,
+          isInstalled: true,
+          isAdmin: true,
+          scopeMismatch: true,
+          workspaceName: "Test Workspace",
+          installUrl: null,
+          connectUrl: null,
+          reinstallUrl: null,
+          defaultAgentId: null,
+          agentOrgSlug: null,
+          environment: {
+            requiredSecrets: [],
+            requiredVars: [],
+            missingSecrets: [],
+            missingVars: [],
+          },
+        });
+      }),
+    );
+    mockBaseAPIs();
+
+    await setupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /Where Zero works/i }),
+      ).toBeInTheDocument();
+    });
+
+    // The mismatch badge (sibling span) should be present inside the footer link
+    const worksLink = screen.getByRole("link", { name: /Where Zero works/i });
+    // The badge is a sibling span rendered next to the label text
+    const badge = worksLink.querySelector("span.rounded-full");
+    expect(badge).toBeInTheDocument();
+  });
+});
+
+describe("zero sidebar - new chat button enabled/disabled state (SIDEBAR-D-010)", () => {
+  it("shows the new chat button as enabled when not creating a session", async () => {
+    mockBaseAPIs();
+    await setupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      const newChatButton = screen.getByRole("button", {
+        name: /New chat with/i,
+      });
+      expect(newChatButton).not.toBeDisabled();
+    });
+  });
+
+  it("disables the new chat button while a POST to chat-threads is in flight", async () => {
+    const user = userEvent.setup();
+    const deferred = createDeferredPromise<void>(context.signal);
+
+    mockBaseAPIs();
+    server.use(
+      http.post("*/api/zero/chat-threads", async () => {
+        await deferred.promise;
+        return HttpResponse.json(
+          {
+            id: "new-thread",
+            title: null,
+            agentId: DEFAULT_AGENT_ID,
+            createdAt: "2026-03-10T00:00:00Z",
+            updatedAt: "2026-03-10T00:00:00Z",
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /New chat with/i }),
+      ).toBeInTheDocument();
+    });
+
+    // Trigger new chat creation
+    await user.click(screen.getByRole("button", { name: /New chat with/i }));
+
+    // Button should become disabled while POST is in flight
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /New chat with/i }),
+      ).toBeDisabled();
+    });
+
+    deferred.resolve();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-display.test.tsx
@@ -136,9 +136,9 @@ describe("zero sidebar - loading state (SIDEBAR-D-002)", () => {
     // While the chat-threads request is hanging, skeletons should be visible
     await waitFor(() => {
       const sidebar = getSidebar();
-      expect(sidebar.querySelectorAll(".animate-pulse").length).toBeGreaterThan(
-        0,
-      );
+      expect(
+        within(sidebar).getAllByTestId("sidebar-skeleton").length,
+      ).toBeGreaterThan(0);
     });
 
     deferred.resolve();
@@ -252,8 +252,9 @@ describe("zero sidebar - error state (SIDEBAR-D-005)", () => {
 
     await waitFor(() => {
       const sidebar = getSidebar();
-      // The error paragraph appears inside the sidebar with text-destructive
-      expect(sidebar.querySelector("p.text-destructive")).toBeInTheDocument();
+      expect(
+        within(sidebar).getByTestId("chat-threads-error"),
+      ).toBeInTheDocument();
     });
   });
 });
@@ -390,11 +391,10 @@ describe("zero sidebar - Slack scope mismatch indicator (SIDEBAR-D-009)", () => 
       ).toBeInTheDocument();
     });
 
-    // The mismatch badge (sibling span) should be present inside the footer link
-    const worksLink = screen.getByRole("link", { name: /Where Zero works/i });
-    // The badge is a sibling span rendered next to the label text
-    const badge = worksLink.querySelector("span.rounded-full");
-    expect(badge).toBeInTheDocument();
+    // The mismatch badge should be present in the sidebar
+    expect(
+      screen.getByTestId("slack-scope-mismatch-indicator"),
+    ).toBeInTheDocument();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -626,7 +626,11 @@ function RecentChatList({
       <>
         {["w-3/4", "w-1/2", "w-2/3"].map((w) => {
           return (
-            <div key={w} className="flex h-8 items-center rounded-lg p-2">
+            <div
+              key={w}
+              data-testid="sidebar-skeleton"
+              className="flex h-8 items-center rounded-lg p-2"
+            >
               <Skeleton className={`h-4 ${w}`} />
             </div>
           );
@@ -635,7 +639,14 @@ function RecentChatList({
     );
   }
   if (error) {
-    return <p className="px-2 py-2 text-xs text-destructive">{error}</p>;
+    return (
+      <p
+        data-testid="chat-threads-error"
+        className="px-2 py-2 text-xs text-destructive"
+      >
+        {error}
+      </p>
+    );
   }
   if (sessions.length === 0) {
     return (
@@ -1616,7 +1627,10 @@ export function ZeroSidebar() {
                     )}
                     <span className="truncate flex-1">{label}</span>
                     {id === "works" && slackScopeMismatch && (
-                      <span className="h-2 w-2 shrink-0 rounded-full bg-red-500" />
+                      <span
+                        data-testid="slack-scope-mismatch-indicator"
+                        className="h-2 w-2 shrink-0 rounded-full bg-red-500"
+                      />
                     )}
                   </Link>
                 );


### PR DESCRIPTION
Closes #7971

Adds display tests for the zero-sidebar component covering:

- SIDEBAR-D-001: Chat thread list renders with sessions
- SIDEBAR-D-002: Loading state shows skeleton placeholders while sessions load
- SIDEBAR-D-003: Search results filter session list
- SIDEBAR-D-004: Search term displays in input
- SIDEBAR-D-005: Error message displays on fetch failure
- SIDEBAR-D-006: Agent cards display with default agent and pinned sub-agent names
- SIDEBAR-D-007: Active tab indicator highlights current tab (Agents nav link)
- SIDEBAR-D-008: Pinned section header visible and pinned agents appear after preferences resolve
- SIDEBAR-D-009: Slack scope mismatch indicator shows next to "Where Zero works" link
- SIDEBAR-D-010: New chat button enabled/disabled state

🤖 Generated with Claude Code