### PR TITLE
test(platform): add billing-dialog interaction and state tests

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-display.test.tsx
@@ -14,33 +14,9 @@ import { setupPage } from "../../../__tests__/page-helper.ts";
 import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
 import { setBillingDialogOpen$ } from "../../../signals/zero-page/billing.ts";
 import { setSelectedPlanTier$ } from "../../../signals/zero-page/billing-dialog-state.ts";
+import { mockBillingPageAPIs } from "./billing-dialog-test-helpers.ts";
 
 const context = testContext();
-
-function mockAPIs() {
-  server.use(
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-  );
-}
 
 async function openBillingDialogAndWait() {
   context.store.set(setBillingDialogOpen$, true);
@@ -51,7 +27,7 @@ async function openBillingDialogAndWait() {
 
 describe("chat-d-067: AutoRechargeSection renders threshold value", () => {
   it("displays the threshold value in the threshold input", async () => {
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -71,7 +47,7 @@ describe("chat-d-067: AutoRechargeSection renders threshold value", () => {
 
 describe("chat-d-068: AutoRechargeSection renders amount value in credits", () => {
   it("displays the recharge amount in the credits input", async () => {
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -91,7 +67,7 @@ describe("chat-d-068: AutoRechargeSection renders amount value in credits", () =
 
 describe("chat-d-069: AutoRechargeSection renders dollarAmount calculated from amount / CREDITS_PER_DOLLAR", () => {
   it("displays the dollar equivalent calculated as amount / 1000", async () => {
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -131,7 +107,7 @@ describe("chat-s-070: Loading state disables Save button during save", () => {
     );
 
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -162,7 +138,7 @@ describe("chat-s-070: Loading state disables Save button during save", () => {
 
 describe("chat-c-071: AutoRechargeSection fields render conditionally based on displayEnabled", () => {
   it("hides threshold and amount inputs when enabled is false", async () => {
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -184,7 +160,7 @@ describe("chat-c-071: AutoRechargeSection fields render conditionally based on d
   });
 
   it("shows threshold and amount inputs when enabled is true", async () => {
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -204,7 +180,7 @@ describe("chat-c-071: AutoRechargeSection fields render conditionally based on d
 
 describe("chat-d-072-073: BillingDialog renders status.tier and credit count", () => {
   it("displays the current plan tier and locale-formatted credits in the description", async () => {
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -231,7 +207,7 @@ describe("chat-d-072-073: BillingDialog renders status.tier and credit count", (
 
 describe("chat-d-075: Selected plan ring highlight renders on chosen PlanCard", () => {
   it("renders aria-pressed on the selected PlanCard", async () => {
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -252,7 +228,7 @@ describe("chat-d-075: Selected plan ring highlight renders on chosen PlanCard", 
 describe("chat-c-076: Button text changes based on isUpgrade/isDowngrade determination", () => {
   it("shows Upgrade to Team when team is selected and pro is current", async () => {
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -279,7 +255,7 @@ describe("chat-c-076: Button text changes based on isUpgrade/isDowngrade determi
 
   it("shows Downgrade when free is selected and pro is current", async () => {
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -323,7 +299,7 @@ describe("chat-c-077: Action button is disabled during redirect", () => {
     );
 
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-display.test.tsx
@@ -4,19 +4,26 @@
  * Covers AutoRechargeSection (dialog variant) and BillingDialog display rendering.
  * Entry point: setupPage({ path: "/" }) + context.store.set(setBillingDialogOpen$, true)
  */
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
-import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
+import {
+  resetMockBilling,
+  setMockBillingStatus,
+} from "../../../mocks/handlers/api-billing.ts";
 import { setBillingDialogOpen$ } from "../../../signals/zero-page/billing.ts";
 import { setSelectedPlanTier$ } from "../../../signals/zero-page/billing-dialog-state.ts";
 import { mockBillingPageAPIs } from "./billing-dialog-test-helpers.ts";
 
 const context = testContext();
+
+beforeEach(() => {
+  resetMockBilling();
+});
 
 async function openBillingDialogAndWait() {
   context.store.set(setBillingDialogOpen$, true);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
@@ -1,0 +1,363 @@
+/**
+ * Interaction and state tests for billing-dialog.tsx.
+ *
+ * Covers AutoRechargeSection switch/input interactions and BillingDialog plan selection.
+ * Entry point: setupPage({ path: "/" }) + context.store.set(setBillingDialogOpen$, true)
+ */
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
+import {
+  downgradeDialogOpen$,
+  setBillingDialogOpen$,
+} from "../../../signals/zero-page/billing.ts";
+
+const context = testContext();
+
+function mockAPIs() {
+  server.use(
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: "c0000000-0000-4000-a000-000000000001",
+          name: "zero",
+          displayName: null,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
+    }),
+    http.get("*/api/zero/org/logo", () => {
+      return HttpResponse.json({ logoUrl: null });
+    }),
+  );
+}
+
+async function openBillingDialogAndWait() {
+  context.store.set(setBillingDialogOpen$, true);
+  await waitFor(() => {
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+}
+
+describe("chat-i-078: auto-recharge switch toggles enabled state", () => {
+  it("calls PUT auto-recharge with enabled: true when switch is clicked while disabled", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          enabled: true,
+          threshold: null,
+          amount: null,
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: false, threshold: null, amount: null },
+    });
+    await setupPage({ context, path: "/" });
+    await openBillingDialogAndWait();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("switch", { name: /auto-recharge/i }),
+      ).toHaveAttribute("aria-checked", "false");
+    });
+
+    await user.click(screen.getByRole("switch", { name: /auto-recharge/i }));
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({ enabled: true });
+    });
+  });
+});
+
+describe("chat-s-084: auto-recharge toggle state reflects enabled value from server", () => {
+  it("shows aria-checked=false when auto-recharge is disabled", async () => {
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: false, threshold: null, amount: null },
+    });
+    await setupPage({ context, path: "/" });
+    await openBillingDialogAndWait();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("switch", { name: /auto-recharge/i }),
+      ).toHaveAttribute("aria-checked", "false");
+    });
+  });
+
+  it("shows aria-checked=true when auto-recharge is enabled", async () => {
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: true, threshold: 1000, amount: 10_000 },
+    });
+    await setupPage({ context, path: "/" });
+    await openBillingDialogAndWait();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("switch", { name: /auto-recharge/i }),
+      ).toHaveAttribute("aria-checked", "true");
+    });
+  });
+});
+
+describe("chat-i-079: threshold input updates form state on change", () => {
+  it("calls PUT auto-recharge with new threshold when Save is clicked after changing threshold", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          enabled: true,
+          threshold: 2000,
+          amount: 10_000,
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: true, threshold: 1000, amount: 10_000 },
+    });
+    await setupPage({ context, path: "/" });
+    await openBillingDialogAndWait();
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("e.g. 1000")).toBeInTheDocument();
+    });
+
+    const thresholdInput = screen.getByPlaceholderText("e.g. 1000");
+    await user.clear(thresholdInput);
+    await user.type(thresholdInput, "2000");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({ threshold: 2000 });
+    });
+  });
+});
+
+describe("chat-i-080: amount input updates form state on change", () => {
+  it("calls PUT auto-recharge with new amount when Save is clicked after changing amount", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          enabled: true,
+          threshold: 1000,
+          amount: 20_000,
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: true, threshold: 1000, amount: 10_000 },
+    });
+    await setupPage({ context, path: "/" });
+    await openBillingDialogAndWait();
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("e.g. 10000")).toBeInTheDocument();
+    });
+
+    const amountInput = screen.getByPlaceholderText("e.g. 10000");
+    await user.clear(amountInput);
+    await user.type(amountInput, "20000");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({ amount: 20_000 });
+    });
+  });
+});
+
+describe("chat-i-081: save button saves auto-recharge settings", () => {
+  it("calls PUT auto-recharge with correct values when Save is clicked", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.put("*/api/zero/billing/auto-recharge", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({
+          enabled: true,
+          threshold: 2000,
+          amount: 5000,
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+      autoRecharge: { enabled: true, threshold: 2000, amount: 5000 },
+    });
+    await setupPage({ context, path: "/" });
+    await openBillingDialogAndWait();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(capturedBody).toMatchObject({ enabled: true });
+    });
+  });
+});
+
+describe("chat-i-082: plan card click updates selected tier", () => {
+  it("sets Team card to aria-pressed=true when clicked", async () => {
+    const user = userEvent.setup();
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+    await setupPage({ context, path: "/" });
+    await openBillingDialogAndWait();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^Team$/i })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Team$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^Team$/i })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+  });
+});
+
+describe("chat-i-083: upgrade/downgrade button triggers plan change action", () => {
+  it("calls POST checkout with tier=team when Upgrade to Team is clicked", async () => {
+    let capturedCheckoutBody: unknown;
+    server.use(
+      http.post("*/api/zero/billing/checkout", async ({ request }) => {
+        capturedCheckoutBody = await request.json();
+        return HttpResponse.json({
+          url: "https://checkout.stripe.com/test?tier=team",
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+    await setupPage({ context, path: "/" });
+    await openBillingDialogAndWait();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^Team$/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Team$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Upgrade to Team/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Upgrade to Team/i }));
+
+    await waitFor(() => {
+      expect(capturedCheckoutBody).toMatchObject({ tier: "team" });
+    });
+  });
+
+  it("opens downgrade dialog when Downgrade is clicked after selecting Free", async () => {
+    const user = userEvent.setup();
+    mockAPIs();
+    setMockBillingStatus({
+      tier: "pro",
+      credits: 20_000,
+      subscriptionStatus: "active",
+      hasSubscription: true,
+    });
+    await setupPage({ context, path: "/" });
+    await openBillingDialogAndWait();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^Free$/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Free$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^Downgrade$/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Downgrade$/i }));
+
+    await waitFor(() => {
+      expect(context.store.get(downgradeDialogOpen$)).toBeTruthy();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
@@ -4,45 +4,28 @@
  * Covers AutoRechargeSection switch/input interactions and BillingDialog plan selection.
  * Entry point: setupPage({ path: "/" }) + context.store.set(setBillingDialogOpen$, true)
  */
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
-import { setMockBillingStatus } from "../../../mocks/handlers/api-billing.ts";
+import {
+  resetMockBilling,
+  setMockBillingStatus,
+} from "../../../mocks/handlers/api-billing.ts";
 import {
   downgradeDialogOpen$,
   setBillingDialogOpen$,
 } from "../../../signals/zero-page/billing.ts";
+import { mockBillingPageAPIs } from "./billing-dialog-test-helpers.ts";
 
 const context = testContext();
 
-function mockAPIs() {
-  server.use(
-    http.get("*/api/zero/chat-threads", () => {
-      return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/team", () => {
-      return HttpResponse.json([
-        {
-          id: "c0000000-0000-4000-a000-000000000001",
-          name: "zero",
-          displayName: null,
-          description: null,
-          sound: null,
-          avatarUrl: null,
-          headVersionId: "version_1",
-          updatedAt: "2024-01-01T00:00:00Z",
-        },
-      ]);
-    }),
-    http.get("*/api/zero/org/logo", () => {
-      return HttpResponse.json({ logoUrl: null });
-    }),
-  );
-}
+beforeEach(() => {
+  resetMockBilling();
+});
 
 async function openBillingDialogAndWait() {
   context.store.set(setBillingDialogOpen$, true);
@@ -66,7 +49,7 @@ describe("chat-i-078: auto-recharge switch toggles enabled state", () => {
     );
 
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -93,7 +76,7 @@ describe("chat-i-078: auto-recharge switch toggles enabled state", () => {
 
 describe("chat-s-084: auto-recharge toggle state reflects enabled value from server", () => {
   it("shows aria-checked=false when auto-recharge is disabled", async () => {
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -112,7 +95,7 @@ describe("chat-s-084: auto-recharge toggle state reflects enabled value from ser
   });
 
   it("shows aria-checked=true when auto-recharge is enabled", async () => {
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -146,7 +129,7 @@ describe("chat-i-079: threshold input updates form state on change", () => {
     );
 
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -188,7 +171,7 @@ describe("chat-i-080: amount input updates form state on change", () => {
     );
 
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -230,7 +213,7 @@ describe("chat-i-081: save button saves auto-recharge settings", () => {
     );
 
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -248,7 +231,11 @@ describe("chat-i-081: save button saves auto-recharge settings", () => {
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
-      expect(capturedBody).toMatchObject({ enabled: true });
+      expect(capturedBody).toMatchObject({
+        enabled: true,
+        threshold: 2000,
+        amount: 5000,
+      });
     });
   });
 });
@@ -256,7 +243,7 @@ describe("chat-i-081: save button saves auto-recharge settings", () => {
 describe("chat-i-082: plan card click updates selected tier", () => {
   it("sets Team card to aria-pressed=true when clicked", async () => {
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -297,7 +284,7 @@ describe("chat-i-083: upgrade/downgrade button triggers plan change action", () 
     );
 
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,
@@ -330,7 +317,7 @@ describe("chat-i-083: upgrade/downgrade button triggers plan change action", () 
 
   it("opens downgrade dialog when Downgrade is clicked after selecting Free", async () => {
     const user = userEvent.setup();
-    mockAPIs();
+    mockBillingPageAPIs();
     setMockBillingStatus({
       tier: "pro",
       credits: 20_000,

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-interaction.test.tsx
@@ -237,6 +237,10 @@ describe("chat-i-081: save button saves auto-recharge settings", () => {
         amount: 5000,
       });
     });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+    });
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-test-helpers.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/billing-dialog-test-helpers.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+
+export function mockBillingPageAPIs() {
+  server.use(
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: "c0000000-0000-4000-a000-000000000001",
+          name: "zero",
+          displayName: null,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
+    }),
+    http.get("*/api/zero/org/logo", () => {
+      return HttpResponse.json({ logoUrl: null });
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

- Adds 9 interaction and state tests for `billing-dialog.tsx` covering cases CHAT-I-078 through CHAT-I-083 and CHAT-S-084
- Tests cover: auto-recharge switch toggle, threshold/amount input persistence via Save, Save button, plan card selection, and upgrade/downgrade button actions
- All tests use the established platform pattern: `setupPage({ path: "/" })` + MSW mock handlers for HTTP interception

## Test plan

- [x] All 9 tests pass locally
- [x] Lint passes (no `eslint-disable` or `@ts-ignore`)
- [x] Type checks pass
- [x] No `vi.mock()` for internal modules — only MSW for HTTP interception

Closes #7936

🤖 Generated with [Claude Code](https://claude.com/claude-code)