### PR TITLE
fix(platform): remove schedule/agents icons and fix avatar-text alignment

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-session-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-session-navigation.test.tsx
@@ -5,7 +5,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
-import { pathname, search } from "../../../signals/location.ts";
+import { pathname } from "../../../signals/location.ts";
 
 const context = testContext();
 
@@ -41,28 +41,6 @@ function mockChatSessionAPIs() {
 }
 
 describe("chat session page wrapper navigation", () => {
-  it("should navigate to agent schedule when clicking schedule button", async () => {
-    const user = userEvent.setup();
-    mockChatSessionAPIs();
-
-    await setupPage({ context, path: "/chats/session-thread-1" });
-
-    // Wait for chat messages to render
-    await waitFor(() => {
-      expect(screen.getByText("Task is running.")).toBeInTheDocument();
-    });
-
-    // Click the schedule button in the session header
-    const scheduledButton = screen.getByLabelText("Scheduled");
-    await user.click(scheduledButton);
-
-    // Verify navigation to /team/c0000000-0000-4000-a000-000000000001 with tab=schedule
-    await waitFor(() => {
-      expect(pathname()).toBe("/agents/c0000000-0000-4000-a000-000000000001");
-      expect(search()).toContain("tab=schedule");
-    });
-  });
-
   it("should navigate to agent profile when clicking chat avatar", async () => {
     const user = userEvent.setup();
     mockChatSessionAPIs();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -86,49 +86,6 @@ describe("zero chat thread page - pin button toggles pin state", () => {
   });
 });
 
-// CHAT-N-047: Sub-agents Link navigates to /agents
-describe("zero chat thread page - sub-agents link navigation", () => {
-  it("navigates to /agents when Sub-agents link is clicked (CHAT-N-047)", async () => {
-    const user = userEvent.setup();
-    mockSubagentThread(THREAD_ID);
-
-    await setupPage({ context, path: `/chats/${THREAD_ID}` });
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Sub-agents")).toBeInTheDocument();
-    });
-
-    const link = screen.getByLabelText("Sub-agents");
-    await user.click(link);
-
-    await waitFor(() => {
-      expect(pathname()).toBe("/agents");
-    });
-  });
-});
-
-// CHAT-N-048: Schedule button navigates to agent with schedule tab
-describe("zero chat thread page - schedule button navigation", () => {
-  it("navigates to /agents/:id with tab=schedule when schedule button is clicked (CHAT-N-048)", async () => {
-    const user = userEvent.setup();
-    mockSubagentThread(THREAD_ID);
-
-    await setupPage({ context, path: `/chats/${THREAD_ID}` });
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Scheduled")).toBeInTheDocument();
-    });
-
-    const scheduleButton = screen.getByLabelText("Scheduled");
-    await user.click(scheduleButton);
-
-    await waitFor(() => {
-      expect(pathname()).toBe(`/agents/${SUB_AGENT_ID}`);
-      expect(search()).toContain("tab=schedule");
-    });
-  });
-});
-
 // CHAT-I-049 / CHAT-I-050: Image preview button opens ImageLightbox
 describe("zero chat thread page - image attachment opens lightbox", () => {
   it("clicking image preview button opens ImageLightbox (CHAT-I-049, CHAT-I-050)", async () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-thread-page-interaction.test.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
-import { pathname, search } from "../../../signals/location.ts";
+import { pathname } from "../../../signals/location.ts";
 import { setMockUserPreferences } from "../../../mocks/handlers/api-user-preferences.ts";
 import {
   mockChatLifecycle,

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -10,8 +10,6 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   IconAlertCircle,
   IconLoader2,
-  IconUsers,
-  IconCalendar,
   IconPhoto,
   IconChartLine,
   IconPlayerStop,
@@ -21,7 +19,6 @@ import {
   IconPin,
 } from "@tabler/icons-react";
 import {
-  Button,
   Skeleton,
   Tooltip,
   TooltipContent,
@@ -70,7 +67,6 @@ import {
 } from "../../signals/zero-page/zero-session-chat-ui.ts";
 import { useAgentAvatar } from "./zero-sidebar-shared.tsx";
 import { zeroSubagents$ } from "../../signals/zero-page/zero-agents.ts";
-import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { useLayoutEffect } from "react";
 
 function scrollToLatestMessage() {
@@ -182,7 +178,6 @@ function ChatThreadHeader() {
   const { currentChatAgentId, resolvedAgentId, displayName, avatarSrc } =
     useChatAgentIdentity();
   const pageSignal = useGet(pageSignal$);
-  const navigateTo = useSet(detachedNavigateTo$);
 
   // Pin pill
   const pinnedLoadable = useLastLoadable(pinnedAgentIds$);
@@ -257,49 +252,7 @@ function ChatThreadHeader() {
         </div>
         <span className="font-semibold text-foreground">{displayName}</span>
       </div>
-      <div className="hidden sm:flex items-center gap-0.5">
-        <TooltipProvider delayDuration={200}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Link
-                pathname="/agents"
-                className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent"
-                aria-label="Sub-agents"
-              >
-                <IconUsers size={18} stroke={1.5} />
-              </Link>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p className="text-xs">Agents</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-        <TooltipProvider delayDuration={200}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-muted-foreground hover:text-foreground"
-                onPointerDown={() => {
-                  if (resolvedAgentId) {
-                    navigateTo("/agents/:id", {
-                      pathParams: { id: resolvedAgentId },
-                      searchParams: new URLSearchParams({ tab: "schedule" }),
-                    });
-                  }
-                }}
-                aria-label="Scheduled"
-              >
-                <IconCalendar size={18} stroke={1.5} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p className="text-xs">Schedule</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
+      <div className="hidden sm:flex items-center gap-0.5" />
     </header>
   );
 }
@@ -862,7 +815,7 @@ function StaticAssistantMessage({
     scrollToLatestMessage();
   }, [content]);
   const avatar = (
-    <div className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 shrink-0 mt-0.5 overflow-hidden rounded-xl">
+    <div className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 shrink-0 @[900px]:mt-0.5 overflow-hidden rounded-xl">
       <AvatarOrPlaceholder
         src={avatarSrc}
         className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 rounded-full object-cover object-top"
@@ -952,7 +905,7 @@ function StaticAssistantMessage({
       >
         <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
           {avatar}
-          <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-1.5 text-sm leading-relaxed min-w-0 break-words">
+          <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
             {hasSummaries && (
               <CollapsibleTimeline
                 summaries={message.summaries!}
@@ -1017,7 +970,7 @@ function StaticAssistantMessage({
       <div className="group flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300">
         <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
           {avatar}
-          <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-1.5 text-sm leading-relaxed min-w-0 break-words">
+          <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
             {hasSummaries && (
               <CollapsibleTimeline
                 summaries={message.summaries!}


### PR DESCRIPTION
## Summary
- Remove Agents and Schedule icon buttons from chat thread header top-right corner
- Adjust assistant message bubble top padding (`pt-1.5` → `pt-2.5`) to vertically center-align avatar with first line of text
- Clean up unused `IconUsers` and `IconCalendar` imports

## Test plan
- [ ] Verify chat thread header no longer shows Agents and Schedule icons
- [ ] Verify avatar and first line of message text are visually center-aligned on wide screens (>=900px)
- [ ] Verify layout still looks correct on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)