### PR TITLE
fix: sanitize underscores in full org id for all ngrok domain names

### DIFF
--- a/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
@@ -61,11 +61,12 @@ export async function createComputerConnector(
   // Generate unique subdomain name for this user
   // Truncate org ID to keep subdomain short (ngrok has length limits)
   // Replace underscores with hyphens — ngrok rejects underscores in domain names
-  const orgIdShort = orgId.substring(0, 8).replace(/_/g, "-");
+  const sanitizedOrgId = orgId.replace(/_/g, "-");
+  const orgIdShort = sanitizedOrgId.substring(0, 8);
   const subdomainName = `vm0-user-${orgIdShort}`;
-  const endpointPrefix = `vm0-user-${orgId}`;
+  const endpointPrefix = `vm0-user-${sanitizedOrgId}`;
 
-  const botUserName = `vm0-user-${orgId}`;
+  const botUserName = `vm0-user-${sanitizedOrgId}`;
 
   // Provision ngrok resources
   const botUser = await findOrCreateBotUser(apiKey, botUserName);

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -68,10 +68,11 @@ export async function registerHost(
 
   // Generate names for ngrok resources
   // Replace underscores with hyphens — ngrok rejects underscores in domain names
-  const orgIdShort = orgId.substring(0, 8).replace(/_/g, "-");
+  const sanitizedOrgId = orgId.replace(/_/g, "-");
+  const orgIdShort = sanitizedOrgId.substring(0, 8);
   const subdomainName = `vm0-cu-${orgIdShort}`;
-  const endpointPrefix = `vm0-cu-${orgId}`;
-  const botUserName = `vm0-cu-${orgId}`;
+  const endpointPrefix = `vm0-cu-${sanitizedOrgId}`;
+  const botUserName = `vm0-cu-${sanitizedOrgId}`;
 
   // Provision ngrok resources
   const botUser = await findOrCreateBotUser(apiKey, botUserName);


### PR DESCRIPTION
## Summary
- Previous fix (#8096) only sanitized the truncated subdomain, but `endpointPrefix` and `botUserName` also embed the org ID into ngrok domain names
- CLI creates tunnel domains like `desktop.vm0-cu-{orgId}.internal` — the full org ID with underscore causes `ERR_NGROK_355`
- Now sanitize the full org ID once and derive all ngrok names from the sanitized version

## Root Cause
Tester reported after #8096 merge:
```
ERR_NGROK_355: Invalid '_' in domain name.
Failed to create an endpoint with the domain 'desktop.vm0-cu-org_3anttyrbwyjk6jkrstrlesbsdle.internal'
```

## Test plan
- [ ] Run `zero computer-use host start` — should no longer fail with underscore domain error
- [ ] Verify all ngrok resource names use hyphens instead of underscores

🤖 Generated with [Claude Code](https://claude.com/claude-code)