### PR TITLE
fix: lowercase org id in ngrok names to match domain normalization

### DIFF
--- a/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
@@ -61,7 +61,7 @@ export async function createComputerConnector(
   // Generate unique subdomain name for this user
   // Truncate org ID to keep subdomain short (ngrok has length limits)
   // Replace underscores with hyphens — ngrok rejects underscores in domain names
-  const sanitizedOrgId = orgId.replace(/_/g, "-");
+  const sanitizedOrgId = orgId.replace(/_/g, "-").toLowerCase();
   const orgIdShort = sanitizedOrgId.substring(0, 8);
   const subdomainName = `vm0-user-${orgIdShort}`;
   const endpointPrefix = `vm0-user-${sanitizedOrgId}`;

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -68,7 +68,7 @@ export async function registerHost(
 
   // Generate names for ngrok resources
   // Replace underscores with hyphens — ngrok rejects underscores in domain names
-  const sanitizedOrgId = orgId.replace(/_/g, "-");
+  const sanitizedOrgId = orgId.replace(/_/g, "-").toLowerCase();
   const orgIdShort = sanitizedOrgId.substring(0, 8);
   const subdomainName = `vm0-cu-${orgIdShort}`;
   const endpointPrefix = `vm0-cu-${sanitizedOrgId}`;


### PR DESCRIPTION
## Summary
- ngrok normalizes domain names to lowercase, but credential ACL checks are case-sensitive
- The mixed-case org ID (e.g., `org-3ANttyrbWYJk6JKR...`) in the ACL didn't match the lowercased domain ngrok bound (`org-3anttyrbwyjk6jkr...`), causing `ERR_NGROK_316`
- Add `.toLowerCase()` to the sanitized org ID so ACL and domain always match

## Root Cause
Tester reported after #8111 merge:
```
ERR_NGROK_316: The credential ACL policy does not permit binding this name.
Name: desktop.vm0-cu-org-3anttyrbwyjk6jkrstrlesbsdle.internal
```

## Test plan
- [ ] Run `zero computer-use host start` — ngrok tunnel should bind successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)