### PR TITLE
refactor: use hash-based slug for ngrok domain names

### DIFF
--- a/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
@@ -4,7 +4,7 @@
  * Orchestrates ngrok resource provisioning and connector lifecycle
  * for authenticated local tunneling.
  */
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { eq, and } from "drizzle-orm";
 import type { ComputerConnectorCreateResponse } from "@vm0/core";
 import { connectors } from "../../../db/schema/connector";
@@ -58,15 +58,15 @@ export async function createComputerConnector(
     throw badRequest("NGROK_API_KEY is not configured");
   }
 
-  // Generate unique subdomain name for this user
-  // Truncate org ID to keep subdomain short (ngrok has length limits)
-  // Replace underscores with hyphens — ngrok rejects underscores in domain names
-  const sanitizedOrgId = orgId.replace(/_/g, "-");
-  const orgIdShort = sanitizedOrgId.substring(0, 8);
-  const subdomainName = `vm0-user-${orgIdShort}`;
-  const endpointPrefix = `vm0-user-${sanitizedOrgId}`;
+  // Generate a DNS-safe slug from orgId hash (hex chars only)
+  const slug = createHash("sha256")
+    .update(orgId)
+    .digest("hex")
+    .substring(0, 12);
+  const subdomainName = `vm0-user-${slug}`;
+  const endpointPrefix = `vm0-user-${slug}`;
 
-  const botUserName = `vm0-user-${sanitizedOrgId}`;
+  const botUserName = `vm0-user-${slug}`;
 
   // Provision ngrok resources
   const botUser = await findOrCreateBotUser(apiKey, botUserName);

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -4,7 +4,7 @@
  * Orchestrates ngrok resource provisioning and host lifecycle
  * for computer-use remote desktop sessions.
  */
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { eq, and, gt } from "drizzle-orm";
 import { computerUseHosts } from "../../../db/schema/computer-use-host";
 import { conflict, notFound } from "../../shared/errors";
@@ -66,13 +66,14 @@ export async function registerHost(
     throw new Error("NGROK_API_KEY is not configured");
   }
 
-  // Generate names for ngrok resources
-  // Replace underscores with hyphens — ngrok rejects underscores in domain names
-  const sanitizedOrgId = orgId.replace(/_/g, "-");
-  const orgIdShort = sanitizedOrgId.substring(0, 8);
-  const subdomainName = `vm0-cu-${orgIdShort}`;
-  const endpointPrefix = `vm0-cu-${sanitizedOrgId}`;
-  const botUserName = `vm0-cu-${sanitizedOrgId}`;
+  // Generate a DNS-safe slug from orgId+userId hash (hex chars only)
+  const slug = createHash("sha256")
+    .update(`${orgId}:${userId}`)
+    .digest("hex")
+    .substring(0, 12);
+  const subdomainName = `vm0-cu-${slug}`;
+  const endpointPrefix = `vm0-cu-${slug}`;
+  const botUserName = `vm0-cu-${slug}`;
 
   // Provision ngrok resources
   const botUser = await findOrCreateBotUser(apiKey, botUserName);


### PR DESCRIPTION
## Summary
- Replace orgId-based domain naming with a sha256 hash slug (12 hex chars)
- Eliminates all DNS character issues: underscores, case sensitivity, special chars
- computer-use: `hash(orgId:userId)` — unique per org+user, supports multiple hosts per org
- computer-connector: `hash(orgId)` — unique per org

## Before / After
```
Before: vm0-cu-org_3ANt.ngrok.app  (underscores, case issues)
After:  vm0-cu-a7b3f9e2c1d4.ngrok.app  (hex only, always DNS-safe)
```

## Why
Previous approach sanitized orgId character-by-character (#8096 underscores, #8111 endpointPrefix, #8116 case). A hash eliminates the entire class of problems — hex chars (0-9, a-f) are always DNS-safe.

## Test plan
- [ ] `zero computer-use host start` — registers without ngrok domain errors
- [ ] Two users in same org can each register a host (different hash slugs)
- [ ] `zero connector connect computer` — still works with new naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)