### PR TITLE
test(platform): add router, error boundary, and select-org-page tests

### DIFF
--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -56,7 +56,7 @@
       }
     },
     {
-      "files": ["**/__tests__/**/*.{ts,tsx}"],
+      "files": ["**/__tests__/**/*.{ts,tsx}", "src/test/mocks/**/*.{ts,tsx}"],
       "plugins": ["jest", "vitest"],
       "rules": {
         "no-restricted-imports": "allow",

--- a/turbo/apps/platform/src/test/mocks/clerk-react.ts
+++ b/turbo/apps/platform/src/test/mocks/clerk-react.ts
@@ -1,4 +1,5 @@
 // Mock for @clerk/clerk-react
+import { createElement } from "react";
 import type { ReactNode } from "react";
 
 interface ClerkProviderProps {
@@ -11,4 +12,20 @@ export function ClerkProvider({ children }: ClerkProviderProps) {
 
 export function OrganizationSwitcher(): string {
   return "OrganizationSwitcher";
+}
+
+interface OrgListProps {
+  hidePersonal?: boolean;
+  skipInvitationScreen?: boolean;
+}
+
+export function OrganizationList({
+  hidePersonal,
+  skipInvitationScreen,
+}: OrgListProps) {
+  return createElement("div", {
+    "data-testid": "organization-list",
+    "data-hide-personal": String(!!hidePersonal),
+    "data-skip-invitation-screen": String(!!skipInvitationScreen),
+  });
 }

--- a/turbo/apps/platform/src/test/mocks/clerk-react.ts
+++ b/turbo/apps/platform/src/test/mocks/clerk-react.ts
@@ -1,6 +1,5 @@
 // Mock for @clerk/clerk-react
-import { createElement } from "react";
-import type { ReactNode } from "react";
+import { createElement, type ReactNode } from "react";
 
 interface ClerkProviderProps {
   children: ReactNode;

--- a/turbo/apps/platform/src/views/error-boundary.tsx
+++ b/turbo/apps/platform/src/views/error-boundary.tsx
@@ -45,18 +45,24 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   public render() {
-    if (this.state.hasError && this.state.error && this.state.errorInfo) {
-      const fallbackProps: ErrorFallbackProps = {
-        error: this.state.error,
-        errorInfo: this.state.errorInfo,
-        sentryEventId: this.state.sentryEventId,
-      };
+    if (this.state.hasError) {
+      if (this.state.error && this.state.errorInfo) {
+        const fallbackProps: ErrorFallbackProps = {
+          error: this.state.error,
+          errorInfo: this.state.errorInfo,
+          sentryEventId: this.state.sentryEventId,
+        };
 
-      if (this.props.fallback) {
-        return this.props.fallback(fallbackProps);
+        if (this.props.fallback) {
+          return this.props.fallback(fallbackProps);
+        }
+
+        return <DefaultErrorFallback {...fallbackProps} />;
       }
 
-      return <DefaultErrorFallback {...fallbackProps} />;
+      // hasError is true but errorInfo not yet set (componentDidCatch hasn't fired).
+      // Return null to avoid re-throwing by rendering children again.
+      return null;
     }
 
     return this.props.children;

--- a/turbo/apps/platform/src/views/error-boundary.tsx
+++ b/turbo/apps/platform/src/views/error-boundary.tsx
@@ -12,7 +12,6 @@ interface ErrorFallbackProps {
 interface Props {
   children?: ReactNode;
   fallback?: (props: ErrorFallbackProps) => ReactNode;
-  captureSentryEvent?: (error: Error) => void;
 }
 
 interface State {

--- a/turbo/apps/platform/src/views/infra/__tests__/router-error-boundary.test.tsx
+++ b/turbo/apps/platform/src/views/infra/__tests__/router-error-boundary.test.tsx
@@ -32,10 +32,12 @@ describe("main - toaster", () => {
     toast("test");
 
     await waitFor(() => {
-      const toaster = document.querySelector("[data-sonner-toaster]");
+      const toaster = document.querySelector<HTMLElement>(
+        "[data-sonner-toaster]",
+      );
       expect(toaster).not.toBeNull();
-      expect(toaster?.getAttribute("data-y-position")).toBe("top");
-      expect(toaster?.getAttribute("data-x-position")).toBe("center");
+      expect(toaster?.dataset.yPosition).toBe("top");
+      expect(toaster?.dataset.xPosition).toBe("center");
     });
   });
 });
@@ -55,7 +57,7 @@ describe("router - page signal rendering", () => {
 });
 
 describe("router - app skeleton", () => {
-  it("AppSkeleton shows when skeletonVisible is true (INFRA-D-003)", async () => {
+  it("appSkeleton shows when skeletonVisible is true (INFRA-D-003)", async () => {
     await setupPage({
       context,
       path: "/select-org",
@@ -70,7 +72,7 @@ describe("router - app skeleton", () => {
     });
   });
 
-  it("AppSkeleton hides once page loads (INFRA-D-004)", async () => {
+  it("appSkeleton hides once page loads (INFRA-D-004)", async () => {
     await setupPage({
       context,
       path: "/select-org",
@@ -111,7 +113,7 @@ function renderWithRoot(ui: ReactElement): {
     container,
     unmount: () => {
       root.unmount();
-      document.body.removeChild(container);
+      container.remove();
     },
   };
 }

--- a/turbo/apps/platform/src/views/infra/__tests__/router-error-boundary.test.tsx
+++ b/turbo/apps/platform/src/views/infra/__tests__/router-error-boundary.test.tsx
@@ -187,7 +187,9 @@ describe("error boundary", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("event-id")).toBeInTheDocument();
+      expect(screen.getByTestId("event-id")).not.toHaveTextContent(
+        "no-event-id",
+      );
     });
     unmount();
   });

--- a/turbo/apps/platform/src/views/infra/__tests__/router-error-boundary.test.tsx
+++ b/turbo/apps/platform/src/views/infra/__tests__/router-error-boundary.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * Display tests for router.tsx, error-boundary.tsx, default-error-boundary.tsx,
+ * main.tsx, and select-org-page.tsx.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import { createRoot } from "react-dom/client";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { ErrorBoundary } from "../../error-boundary.tsx";
+import { showAppSkeleton$ } from "../../../signals/app-skeleton.ts";
+import { toast } from "@vm0/ui/components/ui/sonner";
+import type { ErrorInfo, ReactElement } from "react";
+
+const context = testContext();
+
+function ThrowError({ message }: { message: string }): never {
+  throw new Error(message);
+}
+
+describe("main - toaster", () => {
+  it("toast notification container renders with top-center position (INFRA-D-001)", async () => {
+    await setupPage({
+      context,
+      path: "/select-org",
+      org: { activeOrg: null, memberships: [{ id: "org_1" }] },
+    });
+
+    // Trigger a toast so the <ol data-sonner-toaster> element renders.
+    // Sonner only renders the positioned list when there are active toasts.
+    toast("test");
+
+    await waitFor(() => {
+      const toaster = document.querySelector("[data-sonner-toaster]");
+      expect(toaster).not.toBeNull();
+      expect(toaster?.getAttribute("data-y-position")).toBe("top");
+      expect(toaster?.getAttribute("data-x-position")).toBe("center");
+    });
+  });
+});
+
+describe("router - page signal rendering", () => {
+  it("dynamic page content renders from page$ signal (INFRA-D-002)", async () => {
+    await setupPage({
+      context,
+      path: "/select-org",
+      org: { activeOrg: null, memberships: [{ id: "org_1" }] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Select an Organization")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("router - app skeleton", () => {
+  it("AppSkeleton shows when skeletonVisible is true (INFRA-D-003)", async () => {
+    await setupPage({
+      context,
+      path: "/select-org",
+      org: { activeOrg: null, memberships: [{ id: "org_1" }] },
+    });
+
+    context.store.set(showAppSkeleton$);
+
+    await waitFor(() => {
+      const skeleton = screen.getByTestId("app-skeleton");
+      expect(skeleton).not.toHaveAttribute("aria-hidden");
+    });
+  });
+
+  it("AppSkeleton hides once page loads (INFRA-D-004)", async () => {
+    await setupPage({
+      context,
+      path: "/select-org",
+      org: { activeOrg: null, memberships: [{ id: "org_1" }] },
+    });
+
+    await waitFor(() => {
+      const skeleton = screen.getByTestId("app-skeleton");
+      expect(skeleton).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+});
+
+// Error boundary tests use createRoot directly (bypassing @testing-library/react's act() wrapper).
+// @testing-library/react wraps all renders in act(), and React 19 inside act() pushes error
+// boundary errors to thrownErrors which act() re-throws synchronously, making it impossible
+// to test error boundaries via the standard render() call.
+//
+// Instead we:
+// 1. Use createRoot directly (no act() wrapper) to render the error boundary
+// 2. Suppress console.error (setup.ts spy throws on console.error; ErrorBoundary.componentDidCatch
+//    calls it) with a spy
+// 3. Suppress window error events (React 19 always dispatches these for caught errors too)
+//    by adding a listener that calls preventDefault() on the event
+const suppressWindowError = (e: ErrorEvent) => {
+  e.preventDefault();
+};
+
+function renderWithRoot(ui: ReactElement): {
+  container: HTMLElement;
+  unmount: () => void;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container, { onCaughtError: () => {} });
+  root.render(ui);
+  return {
+    container,
+    unmount: () => {
+      root.unmount();
+      document.body.removeChild(container);
+    },
+  };
+}
+
+describe("error boundary", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    window.addEventListener("error", suppressWindowError);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    window.removeEventListener("error", suppressWindowError);
+  });
+
+  it("error object displays in fallback (INFRA-D-005)", async () => {
+    const { unmount } = renderWithRoot(
+      <ErrorBoundary
+        fallback={({ error }) => {
+          return <div data-testid="error-msg">{error.message}</div>;
+        }}
+      >
+        <ThrowError message="test-error-object" />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("error-msg")).toHaveTextContent(
+        "test-error-object",
+      );
+    });
+    unmount();
+  });
+
+  it("error info displays in fallback (INFRA-D-006)", async () => {
+    const { unmount } = renderWithRoot(
+      <ErrorBoundary
+        fallback={({ errorInfo }: { errorInfo: ErrorInfo }) => {
+          return (
+            <div data-testid="error-info">
+              {errorInfo.componentStack ?? "no-stack"}
+            </div>
+          );
+        }}
+      >
+        <ThrowError message="test-error-info" />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("error-info")).not.toHaveTextContent(
+        "no-stack",
+      );
+    });
+    unmount();
+  });
+
+  it("sentry event ID renders in fallback (INFRA-D-007)", async () => {
+    const { unmount } = renderWithRoot(
+      <ErrorBoundary
+        fallback={({ sentryEventId }) => {
+          return (
+            <div data-testid="event-id">{sentryEventId ?? "no-event-id"}</div>
+          );
+        }}
+      >
+        <ThrowError message="sentry-event-test" />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("event-id")).toBeInTheDocument();
+    });
+    unmount();
+  });
+
+  it("children render normally when no error; fallback renders on error (INFRA-D-008)", async () => {
+    const { unmount: unmountA } = renderWithRoot(
+      <ErrorBoundary
+        fallback={() => {
+          return <div data-testid="fallback">fallback</div>;
+        }}
+      >
+        <div data-testid="children">normal content</div>
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("children")).toBeInTheDocument();
+      expect(screen.queryByTestId("fallback")).not.toBeInTheDocument();
+    });
+    unmountA();
+
+    const { unmount: unmountB } = renderWithRoot(
+      <ErrorBoundary
+        fallback={() => {
+          return <div data-testid="fallback">fallback</div>;
+        }}
+      >
+        <ThrowError message="trigger-fallback" />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("fallback")).toBeInTheDocument();
+      expect(screen.queryByTestId("children")).not.toBeInTheDocument();
+    });
+    unmountB();
+  });
+
+  it("static error message renders in DefaultErrorFallback (INFRA-D-009)", async () => {
+    const { unmount } = renderWithRoot(
+      <ErrorBoundary>
+        <ThrowError message="default-fallback-test" />
+      </ErrorBoundary>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Oops! Something went sideways"),
+      ).toBeInTheDocument();
+    });
+    unmount();
+  });
+});
+
+describe("select org page", () => {
+  it("organization list renders with Clerk component and correct props (INFRA-D-028)", async () => {
+    await setupPage({
+      context,
+      path: "/select-org",
+      org: { activeOrg: null, memberships: [{ id: "org_1" }] },
+    });
+
+    await waitFor(() => {
+      const orgList = screen.getByTestId("organization-list");
+      expect(orgList).toBeInTheDocument();
+      expect(orgList).toHaveAttribute("data-hide-personal", "true");
+      expect(orgList).toHaveAttribute("data-skip-invitation-screen", "true");
+    });
+  });
+});


### PR DESCRIPTION
Closes #7946

## Summary

- Adds 10 test cases (INFRA-D-001 through INFRA-D-009 and INFRA-D-028) in `router-error-boundary.test.tsx` covering toaster rendering, page signal routing, skeleton loading states, error boundary fallback rendering, and organization selection page
- Fixes a bug in `ErrorBoundary.render()` where rendering children with `hasError: true` but before `componentDidCatch` fires would cause a double-throw — now returns `null` during the intermediate state
- Adds `OrganizationList` mock component to `clerk-react.ts` mock using `createElement` to stay within TypeScript project constraints
- Uses `createRoot` directly for error boundary tests to bypass `act()`'s error re-throw behavior in React 19

## Test plan

- [ ] All 10 test cases pass: `pnpm vitest run src/views/infra/__tests__/router-error-boundary.test.tsx`
- [ ] No lint errors: `pnpm eslint src/views/error-boundary.tsx src/views/infra/__tests__/router-error-boundary.test.tsx src/test/mocks/clerk-react.ts`
- [ ] Type checks pass: `pnpm check-types`

🤖 Generated with [Claude Code](https://claude.com/claude-code)