### PR TITLE
fix(cli): add host stop command and handle stale registration on start

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/__tests__/computer-use.test.ts
@@ -108,7 +108,7 @@ describe("computer-use command visibility", () => {
     expect(subNames).toContain("client");
   });
 
-  it("should have start under host subcommand", () => {
+  it("should have start and stop under host subcommand", () => {
     const prog = new Command();
     registerZeroCommands(prog);
 
@@ -124,6 +124,7 @@ describe("computer-use command visibility", () => {
       return c.name();
     });
     expect(hostSubs).toContain("start");
+    expect(hostSubs).toContain("stop");
   });
 
   it("should have screenshot, info, mouse, scroll, clipboard, and keyboard commands under client subcommand", () => {

--- a/turbo/apps/cli/src/commands/zero/computer-use/host.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/host.ts
@@ -4,6 +4,7 @@ import { withErrorHandler } from "../../../lib/command/with-error-handler";
 import {
   registerComputerUseHost,
   unregisterComputerUseHost,
+  ApiRequestError,
 } from "../../../lib/api";
 import {
   getRandomPort,
@@ -13,6 +14,19 @@ import {
   startDesktopTunnel,
   stopDesktopTunnel,
 } from "../../../lib/computer-use/ngrok";
+
+async function registerWithRecovery() {
+  try {
+    return await registerComputerUseHost();
+  } catch (error) {
+    if (error instanceof ApiRequestError && error.status === 409) {
+      console.log(chalk.yellow("Stale registration found, cleaning up..."));
+      await unregisterComputerUseHost();
+      return await registerComputerUseHost();
+    }
+    throw error;
+  }
+}
 
 export const hostStartCommand = new Command()
   .name("start")
@@ -27,7 +41,7 @@ export const hostStartCommand = new Command()
       }
 
       console.log(chalk.cyan("Registering computer-use host..."));
-      const credentials = await registerComputerUseHost();
+      const credentials = await registerWithRecovery();
 
       const port = await getRandomPort();
       const server = await startDesktopServer(credentials.token, port);
@@ -74,6 +88,25 @@ export const hostStartCommand = new Command()
         await stopDesktopTunnel();
         await unregisterComputerUseHost().catch(() => {});
         console.log(chalk.green("✓ Host stopped"));
+      }
+    }),
+  );
+
+export const hostStopCommand = new Command()
+  .name("stop")
+  .description("Stop and unregister the computer-use host")
+  .action(
+    withErrorHandler(async () => {
+      console.log(chalk.cyan("Unregistering computer-use host..."));
+      try {
+        await unregisterComputerUseHost();
+        console.log(chalk.green("✓ Host unregistered"));
+      } catch (error) {
+        if (error instanceof ApiRequestError && error.status === 404) {
+          console.log(chalk.yellow("No active host registration found"));
+          return;
+        }
+        throw error;
       }
     }),
   );

--- a/turbo/apps/cli/src/commands/zero/computer-use/index.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/index.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { hostStartCommand } from "./host";
+import { hostStartCommand, hostStopCommand } from "./host";
 import {
   clientScreenshotCommand,
   clientZoomCommand,
@@ -26,7 +26,8 @@ import {
 const hostCommand = new Command()
   .name("host")
   .description("Manage computer-use host daemon")
-  .addCommand(hostStartCommand);
+  .addCommand(hostStartCommand)
+  .addCommand(hostStopCommand);
 
 const clientCommand = new Command()
   .name("client")
@@ -62,6 +63,7 @@ export const zeroComputerUseCommand = new Command()
     `
 Examples:
   Start the host daemon (on macOS):  zero computer-use host start
+  Stop the host daemon:              zero computer-use host stop
   Take a screenshot (from agent):    zero computer-use client screenshot
   Zoom into a region (from agent):   zero computer-use client zoom --x 0 --y 0 --width 500 --height 500
   Get screen info (from agent):      zero computer-use client info


### PR DESCRIPTION
## Summary
- Auto-recover from 409 conflict on `host start` by unregistering stale host and retrying registration
- Add `zero computer-use host stop` subcommand to manually unregister a computer-use host
- Return clear message (not error) when `host stop` finds no active registration

Closes #8130

## Test plan
- [x] Existing computer-use command tests pass (8/8)
- [x] Test updated to verify `stop` subcommand is registered under `host`
- [x] TypeScript type check passes
- [x] Lint passes
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)