### PR TITLE
feat(cli): check cliclick dependency on computer-use host start

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/host.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/host.ts
@@ -9,6 +9,7 @@ import {
   getRandomPort,
   startDesktopServer,
 } from "../../../lib/computer-use/desktop-server";
+import { isCliclickInstalled } from "../../../lib/computer-use/cliclick";
 import {
   startDesktopTunnel,
   stopDesktopTunnel,
@@ -24,6 +25,16 @@ export const hostStartCommand = new Command()
           "Computer-use host requires macOS\n\n" +
             "The host daemon uses macOS-specific commands (screencapture, system_profiler).",
         );
+      }
+
+      if (!(await isCliclickInstalled())) {
+        console.log(
+          chalk.yellow(
+            "⚠ cliclick not found. Mouse and keyboard operations will not be available.\n" +
+              "  Install with: brew install cliclick",
+          ),
+        );
+        console.log();
       }
 
       console.log(chalk.cyan("Registering computer-use host..."));

--- a/turbo/apps/cli/src/lib/computer-use/cliclick.ts
+++ b/turbo/apps/cli/src/lib/computer-use/cliclick.ts
@@ -54,6 +54,19 @@ const ACTION_COMMANDS: Record<MouseAction, string> = {
 export const VALID_ACTIONS = new Set<string>(Object.keys(ACTION_COMMANDS));
 
 /**
+ * Check whether cliclick is available on the system.
+ * Returns true if installed, false otherwise.
+ */
+export async function isCliclickInstalled(): Promise<boolean> {
+  try {
+    await execFileAsync("which", ["cliclick"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Verify that cliclick is installed on the system.
  * Throws with install instructions if not found.
  */


### PR DESCRIPTION
## Summary
- Add startup check for `cliclick` when running `zero computer-use host start`
- Print a yellow warning if `cliclick` is not found, with install instructions (`brew install cliclick`)
- Host continues to start normally — screenshot/info operations still work without cliclick

Closes #8127

## Test plan
- [ ] Verify lint, type check, and tests pass in CI
- [ ] On macOS without cliclick: confirm warning is printed and host starts successfully
- [ ] On macOS with cliclick: confirm no warning is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>