### PR TITLE
refactor: make computer-use host registration idempotent

### DIFF
--- a/turbo/apps/cli/src/commands/zero/computer-use/host.ts
+++ b/turbo/apps/cli/src/commands/zero/computer-use/host.ts
@@ -16,19 +16,6 @@ import {
   stopDesktopTunnel,
 } from "../../../lib/computer-use/ngrok";
 
-async function registerWithRecovery() {
-  try {
-    return await registerComputerUseHost();
-  } catch (error) {
-    if (error instanceof ApiRequestError && error.status === 409) {
-      console.log(chalk.yellow("Stale registration found, cleaning up..."));
-      await unregisterComputerUseHost();
-      return await registerComputerUseHost();
-    }
-    throw error;
-  }
-}
-
 export const hostStartCommand = new Command()
   .name("start")
   .description("Start the computer-use host daemon (macOS only)")
@@ -52,7 +39,7 @@ export const hostStartCommand = new Command()
       }
 
       console.log(chalk.cyan("Registering computer-use host..."));
-      const credentials = await registerWithRecovery();
+      const credentials = await registerComputerUseHost();
 
       const port = await getRandomPort();
       const server = await startDesktopServer(credentials.token, port);

--- a/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
@@ -177,7 +177,7 @@ describe("POST /api/zero/computer-use/register", () => {
     expect(ngrokCalls.createEndpoint.length).toBe(1);
   });
 
-  it("should return 409 if host already registered", async () => {
+  it("should return 200 on re-registration (idempotent)", async () => {
     const userId = uniqueId("zcu-dup");
     await setupOrg(userId);
     setupNgrokMocks();
@@ -185,8 +185,12 @@ describe("POST /api/zero/computer-use/register", () => {
     const response1 = await POST(createPostRequest());
     expect(response1.status).toBe(200);
 
+    setupNgrokMocks();
     const response2 = await POST(createPostRequest());
-    expect(response2.status).toBe(409);
+    expect(response2.status).toBe(200);
+    const data = await response2.json();
+    expect(data.domain).toBeDefined();
+    expect(data.token).toBeDefined();
   });
 });
 

--- a/turbo/apps/web/app/api/zero/computer-use/register/route.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/register/route.ts
@@ -16,7 +16,6 @@ import {
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { registerHost } from "../../../../../src/lib/zero/computer-use/computer-use-service";
-import { isConflict } from "../../../../../src/lib/shared/errors";
 
 const router = tsr.router(zeroComputerUseRegisterContract, {
   register: async ({ headers }) => {
@@ -36,18 +35,8 @@ const router = tsr.router(zeroComputerUseRegisterContract, {
       return createErrorResponse("FORBIDDEN", "Computer use is not enabled");
     }
 
-    try {
-      const result = await registerHost(org.orgId, userId);
-      return { status: 200 as const, body: result };
-    } catch (error) {
-      if (isConflict(error)) {
-        return createErrorResponse(
-          "CONFLICT",
-          "Computer-use host already registered",
-        );
-      }
-      throw error;
-    }
+    const result = await registerHost(org.orgId, userId);
+    return { status: 200 as const, body: result };
   },
 });
 

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -7,7 +7,7 @@
 import { createHash, randomUUID } from "crypto";
 import { eq, and, gt } from "drizzle-orm";
 import { computerUseHosts } from "../../../db/schema/computer-use-host";
-import { conflict, notFound } from "../../shared/errors";
+import { notFound } from "../../shared/errors";
 import { logger } from "../../shared/logger";
 import {
   findOrCreateBotUser,
@@ -44,7 +44,7 @@ export async function registerHost(
 ): Promise<RegisterHostResult> {
   const db = globalThis.services.db;
 
-  // Check for existing host
+  // If existing host found, clean it up first (idempotent re-registration)
   const [existing] = await db
     .select({ id: computerUseHosts.id })
     .from(computerUseHosts)
@@ -57,7 +57,8 @@ export async function registerHost(
     .limit(1);
 
   if (existing) {
-    throw conflict("Computer-use host already registered");
+    log.debug("Cleaning up existing host registration", { orgId, userId });
+    await unregisterHost(orgId, userId);
   }
 
   const env = globalThis.services.env;


### PR DESCRIPTION
## Summary

- `registerHost` now auto-cleans existing registrations instead of throwing 409 Conflict, making re-registration idempotent
- Removed `isConflict`/409 handling from the register route handler (no longer needed)
- Removed `registerWithRecovery()` wrapper from CLI host command (server handles cleanup now)

Closes #8136

## Test plan

- [x] `pnpm check-types` — passes
- [x] `pnpm turbo run lint` — passes (warnings are pre-existing)
- [x] `pnpm format` — no changes needed
- [x] `pnpm knip` — no unused exports/deps
- [x] `pnpm vitest` — all relevant tests pass (8 pre-existing failures unrelated to computer-use)
- [x] Grep for `isConflict` in computer-use routes — gone
- [x] Grep for `registerWithRecovery` — gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)