### PR TITLE
test(platform): add views tests for zero-unsaved-bar

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
@@ -74,18 +74,14 @@ describe("zero unsaved bar - unsaved changes indicator (SCHED-D-093)", () => {
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: /^Save$/i }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /^Discard$/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Save")).toBeInTheDocument();
+      expect(screen.getByText("Discard")).toBeInTheDocument();
     });
   });
 });
 
 describe("zero unsaved bar - save button loading state (SCHED-D-094)", () => {
-  it("shows loading spinner on Save button while save is in progress", async () => {
+  it("shows Save button disabled while save is in progress", async () => {
     let resolvePost!: () => void;
     const postPending = new Promise<void>((resolve) => {
       resolvePost = resolve;
@@ -106,23 +102,23 @@ describe("zero unsaved bar - save button loading state (SCHED-D-094)", () => {
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: /^Save$/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Save")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+    await user.click(screen.getByText("Save"));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Save/i })).toBeDisabled();
+      expect(
+        screen.getAllByRole("button").find((el) => {
+          return el.textContent?.trim() === "Save";
+        }),
+      ).toBeDisabled();
     });
 
     resolvePost();
 
     await waitFor(() => {
-      expect(
-        screen.queryByRole("button", { name: /^Save$/i }),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Save")).not.toBeInTheDocument();
     });
   });
 });
@@ -134,17 +130,13 @@ describe("zero unsaved bar - discard button reverts changes (SCHED-D-095)", () =
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: /^Save$/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Save")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: /Discard/i }));
+    await user.click(screen.getByText("Discard"));
 
     await waitFor(() => {
-      expect(
-        screen.queryByRole("button", { name: /^Discard$/i }),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Discard")).not.toBeInTheDocument();
     });
   });
 });
@@ -167,17 +159,13 @@ describe("zero unsaved bar - save button persists changes (SCHED-D-096)", () => 
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: /^Save$/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Save")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+    await user.click(screen.getByText("Save"));
 
     await waitFor(() => {
-      expect(
-        screen.queryByRole("button", { name: /^Save$/i }),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Save")).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
@@ -108,6 +108,7 @@ describe("zero unsaved bar - save button loading state (SCHED-D-094)", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("save-button")).toBeDisabled();
+      expect(screen.getByTestId("save-spinner")).toBeInTheDocument();
     });
 
     resolvePost();
@@ -128,7 +129,7 @@ describe("zero unsaved bar - discard button reverts changes (SCHED-D-095)", () =
       expect(screen.getByTestId("unsaved-bar")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Discard"));
+    await user.click(screen.getByTestId("discard-button"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("unsaved-bar")).not.toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
@@ -74,8 +74,7 @@ describe("zero unsaved bar - unsaved changes indicator (SCHED-D-093)", () => {
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(screen.getByText("Save")).toBeInTheDocument();
-      expect(screen.getByText("Discard")).toBeInTheDocument();
+      expect(screen.getByTestId("unsaved-bar")).toBeInTheDocument();
     });
   });
 });
@@ -102,23 +101,19 @@ describe("zero unsaved bar - save button loading state (SCHED-D-094)", () => {
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(screen.getByText("Save")).toBeInTheDocument();
+      expect(screen.getByTestId("unsaved-bar")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Save"));
+    await user.click(screen.getByTestId("save-button"));
 
     await waitFor(() => {
-      expect(
-        screen.getAllByRole("button").find((el) => {
-          return el.textContent?.trim() === "Save";
-        }),
-      ).toBeDisabled();
+      expect(screen.getByTestId("save-button")).toBeDisabled();
     });
 
     resolvePost();
 
     await waitFor(() => {
-      expect(screen.queryByText("Save")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("unsaved-bar")).not.toBeInTheDocument();
     });
   });
 });
@@ -130,13 +125,13 @@ describe("zero unsaved bar - discard button reverts changes (SCHED-D-095)", () =
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(screen.getByText("Save")).toBeInTheDocument();
+      expect(screen.getByTestId("unsaved-bar")).toBeInTheDocument();
     });
 
     await user.click(screen.getByText("Discard"));
 
     await waitFor(() => {
-      expect(screen.queryByText("Discard")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("unsaved-bar")).not.toBeInTheDocument();
     });
   });
 });
@@ -159,13 +154,13 @@ describe("zero unsaved bar - save button persists changes (SCHED-D-096)", () => 
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(screen.getByText("Save")).toBeInTheDocument();
+      expect(screen.getByTestId("unsaved-bar")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Save"));
+    await user.click(screen.getByTestId("save-button"));
 
     await waitFor(() => {
-      expect(screen.queryByText("Save")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("unsaved-bar")).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Views tests for zero-unsaved-bar.tsx
+ * Tests unsaved changes indicator, save/discard button behavior, and loading state.
+ */
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+const SCHEDULE_ID = "f0000001-0000-4000-a000-000000000001";
+
+function createMockSchedule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SCHEDULE_ID,
+    agentId: "c0000000-0000-4000-a000-000000000001",
+    displayName: "Zero",
+    name: "morning-briefing",
+    triggerType: "cron",
+    cronExpression: "0 9 * * 1-5",
+    atTime: null,
+    intervalSeconds: null,
+    timezone: "America/New_York",
+    prompt: "Summarize yesterday's threads",
+    description: "Daily morning briefing",
+    enabled: true,
+    nextRunAt: null,
+    lastRunAt: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+    userId: "test-user-123",
+    appendSystemPrompt: null,
+    vars: null,
+    secretNames: null,
+    volumeVersions: null,
+    retryStartedAt: null,
+    consecutiveFailures: 0,
+    ...overrides,
+  };
+}
+
+function mockAPIs(overrides: Record<string, unknown> = {}) {
+  server.use(
+    http.get("*/api/zero/schedules", () => {
+      return HttpResponse.json({ schedules: [createMockSchedule(overrides)] });
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+  );
+}
+
+async function loadAndMakeDirty(user: ReturnType<typeof userEvent.setup>) {
+  await setupPage({ context, path: `/schedules/${SCHEDULE_ID}` });
+  await waitFor(() => {
+    expect(
+      screen.getByPlaceholderText("Leave blank to auto-generate"),
+    ).toBeInTheDocument();
+  });
+  await user.type(
+    screen.getByPlaceholderText("Leave blank to auto-generate"),
+    "My description",
+  );
+}
+
+describe("zero unsaved bar - unsaved changes indicator (SCHED-D-093)", () => {
+  it("shows unsaved changes indicator when settings form is dirty", async () => {
+    const user = userEvent.setup();
+    mockAPIs();
+    await loadAndMakeDirty(user);
+
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero unsaved bar - save button loading state (SCHED-D-094)", () => {
+  it("shows loading spinner on Save button while save is in progress", async () => {
+    let resolvePost!: () => void;
+    const postPending = new Promise<void>((resolve) => {
+      resolvePost = resolve;
+    });
+
+    server.use(
+      http.post("*/api/zero/schedules", async () => {
+        await postPending;
+        return HttpResponse.json({
+          schedule: createMockSchedule(),
+          created: false,
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    mockAPIs();
+    await loadAndMakeDirty(user);
+
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      const saveButton = screen.getByRole("button", { name: /Save/i });
+      expect(saveButton.querySelector(".animate-spin")).toBeInTheDocument();
+    });
+
+    resolvePost();
+  });
+});
+
+describe("zero unsaved bar - discard button reverts changes (SCHED-D-095)", () => {
+  it("hides unsaved changes bar when Discard is clicked", async () => {
+    const user = userEvent.setup();
+    mockAPIs();
+    await loadAndMakeDirty(user);
+
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Discard/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("You have unsaved changes"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero unsaved bar - save button persists changes (SCHED-D-096)", () => {
+  it("hides unsaved changes bar after successful save", async () => {
+    server.use(
+      http.post("*/api/zero/schedules", () => {
+        return HttpResponse.json({
+          schedule: createMockSchedule({
+            description: "Daily morning briefingMy description",
+          }),
+          created: false,
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    mockAPIs();
+    await loadAndMakeDirty(user);
+
+    await waitFor(() => {
+      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("You have unsaved changes"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-unsaved-bar.test.tsx
@@ -74,7 +74,12 @@ describe("zero unsaved bar - unsaved changes indicator (SCHED-D-093)", () => {
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^Save$/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^Discard$/i }),
+      ).toBeInTheDocument();
     });
   });
 });
@@ -101,17 +106,24 @@ describe("zero unsaved bar - save button loading state (SCHED-D-094)", () => {
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^Save$/i }),
+      ).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("button", { name: /^Save$/i }));
 
     await waitFor(() => {
-      const saveButton = screen.getByRole("button", { name: /Save/i });
-      expect(saveButton.querySelector(".animate-spin")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Save/i })).toBeDisabled();
     });
 
     resolvePost();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /^Save$/i }),
+      ).not.toBeInTheDocument();
+    });
   });
 });
 
@@ -122,14 +134,16 @@ describe("zero unsaved bar - discard button reverts changes (SCHED-D-095)", () =
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^Save$/i }),
+      ).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("button", { name: /Discard/i }));
 
     await waitFor(() => {
       expect(
-        screen.queryByText("You have unsaved changes"),
+        screen.queryByRole("button", { name: /^Discard$/i }),
       ).not.toBeInTheDocument();
     });
   });
@@ -153,14 +167,16 @@ describe("zero unsaved bar - save button persists changes (SCHED-D-096)", () => 
     await loadAndMakeDirty(user);
 
     await waitFor(() => {
-      expect(screen.getByText("You have unsaved changes")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^Save$/i }),
+      ).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("button", { name: /^Save$/i }));
 
     await waitFor(() => {
       expect(
-        screen.queryByText("You have unsaved changes"),
+        screen.queryByRole("button", { name: /^Save$/i }),
       ).not.toBeInTheDocument();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
@@ -15,7 +15,10 @@ export function ZeroUnsavedBar({
 }: ZeroUnsavedBarProps) {
   return createPortal(
     <div className="zero-app fixed bottom-6 left-0 right-0 z-40 flex justify-center px-4">
-      <div className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg">
+      <div
+        data-testid="unsaved-bar"
+        className="zero-card flex max-w-md items-center justify-between gap-4 px-5 py-4 shadow-lg"
+      >
         <div className="flex items-center gap-2 text-sm text-foreground">
           <IconPencil
             size={18}
@@ -35,6 +38,7 @@ export function ZeroUnsavedBar({
             Discard
           </Button>
           <Button
+            data-testid="save-button"
             size="sm"
             className="h-9 rounded-lg px-4 bg-primary text-primary-foreground hover:bg-primary/90"
             onClick={onSave}

--- a/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-unsaved-bar.tsx
@@ -29,6 +29,7 @@ export function ZeroUnsavedBar({
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <Button
+            data-testid="discard-button"
             variant="ghost"
             size="sm"
             className="text-destructive hover:bg-destructive/10 hover:text-destructive"
@@ -46,6 +47,7 @@ export function ZeroUnsavedBar({
           >
             {saving ? (
               <IconLoader2
+                data-testid="save-spinner"
                 size={14}
                 stroke={1.5}
                 className="animate-spin mr-1.5"


### PR DESCRIPTION
## Summary

- Adds views test file `zero-unsaved-bar.test.tsx` covering the 4 test cases from issue #7972
- SCHED-D-093: unsaved changes indicator renders when settings form is dirty
- SCHED-D-094: save button shows loading spinner while POST is in-flight
- SCHED-D-095: discard button hides the unsaved changes bar by reverting form state
- SCHED-D-096: save button hides the unsaved changes bar after successful save

## Test plan

- [x] All 4 test cases pass (`pnpm vitest --run zero-unsaved-bar`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes (`pnpm check-types`)
- [x] Format passes (`pnpm format`)
- [x] Knip passes (no unused exports or deps)
- [x] No `vi.mock()` for internal modules — only MSW for HTTP
- [x] No `eslint-disable` or `ts-ignore`

Closes #7972

🤖 Generated with [Claude Code](https://claude.com/claude-code)