### PR TITLE
fix(test): wrap openspy in try/finally to prevent spy leak on assertion failure

### DIFF
--- a/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
+++ b/turbo/apps/platform/src/views/router/__tests__/link-navigation.test.tsx
@@ -111,28 +111,30 @@ describe("link component", () => {
       return null;
     });
 
-    await setupPage({ context, path: "/queues" });
+    try {
+      await setupPage({ context, path: "/queues" });
 
-    const link = await waitFor(() => {
-      return screen.getByText("View logs");
-    });
+      const link = await waitFor(() => {
+        return screen.getByText("View logs");
+      });
 
-    const user = userEvent.setup();
-    await user.click(link);
+      const user = userEvent.setup();
+      await user.click(link);
 
-    // Wait for the activity detail page to fully initialize so there is no
-    // pending async work when the test ends (which would cause an unhandled
-    // rejection from route.ts).
-    await waitFor(() => {
-      expect(pathname()).toBe(EXPECTED_HREF);
-      expect(
-        screen.getByRole("heading", { name: "Link Agent" }),
-      ).toBeInTheDocument();
-    });
+      // Wait for the activity detail page to fully initialize so there is no
+      // pending async work when the test ends (which would cause an unhandled
+      // rejection from route.ts).
+      await waitFor(() => {
+        expect(pathname()).toBe(EXPECTED_HREF);
+        expect(
+          screen.getByRole("heading", { name: "Link Agent" }),
+        ).toBeInTheDocument();
+      });
 
-    expect(openSpy).not.toHaveBeenCalled();
-
-    openSpy.mockRestore();
+      expect(openSpy).not.toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
   });
 
   it("modifier click opens new tab (INFRA-D-013)", async () => {


### PR DESCRIPTION
## Summary

- Fixes P0 spy leak in the `click navigates via custom handler (INFRA-D-012)` test in `link-navigation.test.tsx`
- `openSpy.mockRestore()` was called after the assertion, so if the assertion failed, the spy would leak into subsequent tests
- Wraps the test body in `try/finally` to match the pattern already used correctly in INFRA-D-013

## Test plan
- [ ] CI passes: existing tests still pass
- [ ] No spy leaks between tests if INFRA-D-012 assertion fails

Fixes regression introduced by #8139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)