### PR TITLE
fix: resolve computer-use re-registration endpoint conflict

### DIFF
--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -44,9 +44,15 @@ export async function registerHost(
 ): Promise<RegisterHostResult> {
   const db = globalThis.services.db;
 
-  // If existing host found, clean it up first (idempotent re-registration)
+  const env = globalThis.services.env;
+  const apiKey = env.NGROK_API_KEY;
+  if (!apiKey) {
+    throw new Error("NGROK_API_KEY is not configured");
+  }
+
+  // If existing host found, partially clean up (keep domain and bot user)
   const [existing] = await db
-    .select({ id: computerUseHosts.id })
+    .select()
     .from(computerUseHosts)
     .where(
       and(
@@ -56,15 +62,35 @@ export async function registerHost(
     )
     .limit(1);
 
+  let reusableDomain: { domain: string; id: string } | null = null;
+
   if (existing) {
     log.debug("Cleaning up existing host registration", { orgId, userId });
-    await unregisterHost(orgId, userId);
-  }
 
-  const env = globalThis.services.env;
-  const apiKey = env.NGROK_API_KEY;
-  if (!apiKey) {
-    throw new Error("NGROK_API_KEY is not configured");
+    // Delete credential and endpoint (need new token + routing), keep domain
+    if (existing.ngrokCredentialId) {
+      await safeDeleteNgrokResource(
+        () => deleteCredential(apiKey, existing.ngrokCredentialId!),
+        "Credential",
+        existing.ngrokCredentialId,
+      );
+    }
+    if (existing.ngrokEndpointId) {
+      await safeDeleteNgrokResource(
+        () => deleteCloudEndpoint(apiKey, existing.ngrokEndpointId!),
+        "Cloud endpoint",
+        existing.ngrokEndpointId,
+      );
+    }
+
+    // Preserve domain for reuse (same user = same deterministic slug)
+    if (existing.ngrokDomainId && existing.domain) {
+      reusableDomain = { domain: existing.domain, id: existing.ngrokDomainId };
+    }
+
+    await db
+      .delete(computerUseHosts)
+      .where(eq(computerUseHosts.id, existing.id));
   }
 
   // Generate a DNS-safe slug from orgId+userId hash (hex chars only)
@@ -82,12 +108,22 @@ export async function registerHost(
     `bind:*.${endpointPrefix}.internal`,
   ]);
 
-  const reservedDomain = await createReservedDomain(
-    apiKey,
-    subdomainName,
-    "us",
-  );
-  const domain = reservedDomain.domain;
+  // Reuse existing domain or create new one
+  let domain: string;
+  let domainId: string;
+  if (reusableDomain) {
+    domain = reusableDomain.domain;
+    domainId = reusableDomain.id;
+    log.debug("Reusing existing reserved domain", { domain, domainId });
+  } else {
+    const reservedDomain = await createReservedDomain(
+      apiKey,
+      subdomainName,
+      "us",
+    );
+    domain = reservedDomain.domain;
+    domainId = reservedDomain.id;
+  }
 
   const bridgeToken = randomUUID();
 
@@ -136,7 +172,7 @@ export async function registerHost(
       ngrokBotUserId: botUser.id,
       ngrokCredentialId: credential.id,
       ngrokEndpointId: cloudEndpoint.id,
-      ngrokDomainId: reservedDomain.id,
+      ngrokDomainId: domainId,
       expiresAt: new Date(Date.now() + HOST_TTL_MS),
     })
     .returning();

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -70,14 +70,18 @@ export async function registerHost(
     // Delete credential and endpoint (need new token + routing), keep domain
     if (existing.ngrokCredentialId) {
       await safeDeleteNgrokResource(
-        () => deleteCredential(apiKey, existing.ngrokCredentialId!),
+        () => {
+          return deleteCredential(apiKey, existing.ngrokCredentialId!);
+        },
         "Credential",
         existing.ngrokCredentialId,
       );
     }
     if (existing.ngrokEndpointId) {
       await safeDeleteNgrokResource(
-        () => deleteCloudEndpoint(apiKey, existing.ngrokEndpointId!),
+        () => {
+          return deleteCloudEndpoint(apiKey, existing.ngrokEndpointId!);
+        },
         "Cloud endpoint",
         existing.ngrokEndpointId,
       );


### PR DESCRIPTION
## Summary

- Fix 500 error on computer-use host re-registration caused by ngrok endpoint conflict (`ERR_NGROK_18017`)
- Use partial cleanup on re-registration: delete only credential and endpoint, preserve reserved domain and bot user
- Confirmed via Axiom production logs that this was the exact error (`pooling was set to disabled when another endpoint exists for this url`)

## Root Cause

When a user re-registered their computer-use host, `registerHost` called full `unregisterHost` which deleted ALL ngrok resources. This caused:
1. **Endpoint conflict**: Old cloud endpoint not fully cleaned up before new one created
2. **Domain re-creation failure**: ngrok doesn't allow immediate re-reservation of deleted domain names

## Fix

Replaced full `unregisterHost` call with targeted partial cleanup:
- Delete credential (need new auth token)
- Delete cloud endpoint (need new routing with new bridge token)  
- **Keep** reserved domain (deterministic per user, safely reusable)
- **Keep** bot user (deterministic per user, safely reusable)

## Test plan

- [x] All 12 computer-use tests pass (including idempotent re-registration test)
- [ ] Manual verification: `zero computer-use host start` twice in succession

🤖 Generated with [Claude Code](https://claude.com/claude-code)