### PR TITLE
fix: handle ngrok domain already reserved on computer-use registration

### DIFF
--- a/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
@@ -53,6 +53,7 @@ function setupNgrokMocks() {
   const calls = {
     createBotUser: [] as string[],
     listBotUsers: 0,
+    listReservedDomains: 0,
     createCredential: [] as string[],
     deleteCredential: [] as string[],
     createEndpoint: [] as string[],
@@ -91,6 +92,13 @@ function setupNgrokMocks() {
     http.delete("https://api.ngrok.com/credentials/:id", ({ params }) => {
       calls.deleteCredential.push(params.id as string);
       return new HttpResponse(null, { status: 204 });
+    }),
+    http.get("https://api.ngrok.com/reserved_domains", () => {
+      calls.listReservedDomains++;
+      return HttpResponse.json({
+        reserved_domains: [],
+        next_page_uri: null,
+      });
     }),
     http.post("https://api.ngrok.com/reserved_domains", async ({ request }) => {
       const body = (await request.json()) as {

--- a/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
@@ -211,6 +211,58 @@ export async function createReservedDomain(
   return domain;
 }
 
+interface NgrokReservedDomainsPage {
+  reserved_domains: NgrokDomain[];
+  next_page_uri: string | null;
+}
+
+/**
+ * Find a reserved domain by name. Paginates through all results.
+ */
+async function findReservedDomainByName(
+  apiKey: string,
+  name: string,
+): Promise<NgrokDomain | undefined> {
+  let nextPageUri: string | null = "/reserved_domains";
+
+  while (nextPageUri) {
+    const response = await ngrokFetch(apiKey, nextPageUri);
+    const page = (await response.json()) as NgrokReservedDomainsPage;
+
+    const found = page.reserved_domains.find((d) => {
+      return d.domain.startsWith(`${name}.`);
+    });
+    if (found) {
+      return found;
+    }
+
+    nextPageUri = page.next_page_uri;
+  }
+
+  return undefined;
+}
+
+/**
+ * Find an existing reserved domain by name, or create a new one.
+ */
+export async function findOrCreateReservedDomain(
+  apiKey: string,
+  name: string,
+  region: string = "us",
+): Promise<NgrokDomain> {
+  const existing = await findReservedDomainByName(apiKey, name);
+  if (existing) {
+    log.debug("Found existing reserved domain", {
+      id: existing.id,
+      domain: existing.domain,
+    });
+    return existing;
+  }
+
+  log.debug("Creating new reserved domain", { name });
+  return createReservedDomain(apiKey, name, region);
+}
+
 /**
  * Delete a reserved domain by ID.
  */

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -15,7 +15,7 @@ import {
   deleteCredential,
   createCloudEndpoint,
   deleteCloudEndpoint,
-  createReservedDomain,
+  findOrCreateReservedDomain,
   deleteReservedDomain,
 } from "../computer-connector/ngrok-client";
 
@@ -120,7 +120,7 @@ export async function registerHost(
     domainId = reusableDomain.id;
     log.debug("Reusing existing reserved domain", { domain, domainId });
   } else {
-    const reservedDomain = await createReservedDomain(
+    const reservedDomain = await findOrCreateReservedDomain(
       apiKey,
       subdomainName,
       "us",


### PR DESCRIPTION
## Summary

- Fix 500 error (`ERR_NGROK_413`) when registering computer-use host with an orphaned ngrok reserved domain
- Add `findOrCreateReservedDomain` to ngrok-client (mirrors existing `findOrCreateBotUser` pattern)
- Use it in computer-use registration so orphaned domains are recovered gracefully

## Root Cause

When a host's DB row was deleted but the ngrok reserved domain still exists (orphaned resource from prior cleanup failures), re-registration calls `createReservedDomain` which fails with:

> `ERR_NGROK_413: This domain is already reserved for your account. Failed to reserve 'vm0-cu-66d4a49adace.ngrok.app'.`

Confirmed via Axiom production logs at `2026-04-04T08:47:21Z`.

## Fix

Add `findOrCreateReservedDomain` that lists existing domains first, returning the match if found, otherwise creating a new one. This handles both clean and orphaned states.

## Test plan

- [x] All 12 computer-use tests pass
- [x] Added `GET /reserved_domains` mock handler for `findOrCreateReservedDomain` list call
- [ ] Manual: `zero computer-use host start` with orphaned domain state

🤖 Generated with [Claude Code](https://claude.com/claude-code)