### PR TITLE
fix: stabilize flaky chat tagline test (CHAT-D-002)

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-chat-page-display.test.tsx
@@ -30,10 +30,8 @@ describe("zero chat page display - tagline with userName via TypewriterText", ()
       },
     });
 
-    await waitFor(() => {
-      const h2 = screen.getByRole("heading", { level: 2 });
-      expect(h2.textContent).toContain("Alice");
-    });
+    const tagline = await screen.findByTestId("chat-tagline");
+    expect(tagline.getAttribute("aria-label")).toContain("Alice");
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -340,7 +340,7 @@ export function ZeroChatPage() {
               )}
             </div>
             <div className="flex-1 min-w-0 flex flex-col justify-center">
-              <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight text-foreground">
+              <h2 aria-label={tagline} data-testid="chat-tagline" className="text-2xl sm:text-3xl font-semibold tracking-tight text-foreground">
                 <TypewriterText text={tagline} />
               </h2>
             </div>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -340,7 +340,11 @@ export function ZeroChatPage() {
               )}
             </div>
             <div className="flex-1 min-w-0 flex flex-col justify-center">
-              <h2 aria-label={tagline} data-testid="chat-tagline" className="text-2xl sm:text-3xl font-semibold tracking-tight text-foreground">
+              <h2
+                aria-label={tagline}
+                data-testid="chat-tagline"
+                className="text-2xl sm:text-3xl font-semibold tracking-tight text-foreground"
+              >
                 <TypewriterText text={tagline} />
               </h2>
             </div>


### PR DESCRIPTION
## Summary

- Adds `aria-label={tagline}` and `data-testid="chat-tagline"` to the `<h2>` in `ZeroChatPage` — the full tagline text is now available as an attribute immediately on render, independent of the `TypewriterText` animation
- Replaces the `waitFor` + `textContent` assertion with `findByTestId("chat-tagline")` + `getAttribute("aria-label")`, eliminating both timing sensitivity and random-content dependency

## Root cause

`INITIAL_TAGLINE_INDEX = Math.floor(Math.random() * 18)` picks a random tagline at module load time. Some taglines place "Alice" late in the string (e.g. *"Another day, another win, Alice."* — character 26), requiring 27 × 40ms = 1,080ms of TypewriterText animation before the assertion could pass. The default `waitFor` timeout is 1,000ms, causing ~23% flake.

## Test plan

- [ ] CI passes on this PR (no flake on the CHAT-D-002 test)
- [ ] `zero-chat-page-display.test.tsx` assertions remain semantically correct — still verifies the user's first name appears in the tagline

🤖 Generated with [Claude Code](https://claude.com/claude-code)