### PR TITLE
test(platform): add sidebar-layout views tests

### DIFF
--- a/turbo/apps/platform/src/views/sidebar/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/sidebar/__tests__/sidebar-layout.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * Tests for SidebarLayout and MobileTopBar components.
+ *
+ * Covers breadcrumb rendering, admin-only invite button visibility,
+ * menu toggle behavior, overlay click, and breadcrumb navigation.
+ *
+ * Follows platform testing principles:
+ * - Entry point: setupPage({ context, path })
+ * - Mock (external): HTTP via MSW
+ * - Real (internal): All signals, components, rendering
+ */
+
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+import {
+  zeroSidebarCollapsed$,
+  setZeroSidebarCollapsed$,
+} from "../../../signals/zero-page/zero-nav.ts";
+import { orgManageDialogOpen$ } from "../../../signals/zero-page/settings/org-manage-dialog.ts";
+import { activeTab$ } from "../../../signals/zero-page/settings/org-manage-tabs-state.ts";
+
+const context = testContext();
+
+const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
+
+function mockBaseAPIs(role: "admin" | "member" = "admin") {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: DEFAULT_AGENT_ID,
+          displayName: null,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+      ]);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    http.get("*/api/zero/org", () => {
+      return HttpResponse.json({
+        id: "org_1",
+        slug: "test-org",
+        name: "Test Org",
+        role,
+      });
+    }),
+  );
+}
+
+describe("sidebar layout - breadcrumb section text (SIDEBAR-D-045)", () => {
+  it("renders the breadcrumb section name in the mobile top bar", async () => {
+    mockBaseAPIs();
+    await setupPage({ context, path: "/agents" });
+    await waitFor(() => {
+      // The breadcrumb renders a link in the mobile top bar pointing to /agents
+      expect(
+        screen.getAllByRole("link").some((el) => {
+          return (
+            el.getAttribute("href") === "/agents" &&
+            el.textContent?.trim() === "Agents"
+          );
+        }),
+      ).toBeTruthy();
+    });
+  });
+});
+
+describe("sidebar layout - breadcrumb name renders (SIDEBAR-D-046)", () => {
+  it("renders the agent display name as breadcrumb item name", async () => {
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: DEFAULT_AGENT_ID,
+            displayName: "My Agent",
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        ]);
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: `/agents/${DEFAULT_AGENT_ID}` });
+
+    await waitFor(() => {
+      // The breadcrumb name renders as a truncated span next to the section link
+      const spans = screen.getAllByText("My Agent").filter((el) => {
+        return el.classList.contains("truncate");
+      });
+      expect(spans.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("sidebar layout - breadcrumb avatar displays for agent pages (SIDEBAR-D-047)", () => {
+  it("shows an agent avatar image in the breadcrumb for chat routes", async () => {
+    mockBaseAPIs();
+    await setupPage({ context, path: "/" });
+    await waitFor(() => {
+      // AgentAvatarInTopBar renders an img with role="presentation" inside the mobile top bar
+      const avatars = screen.getAllByRole("presentation");
+      expect(avatars.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("sidebar layout - invite button shows for admins (SIDEBAR-D-048)", () => {
+  it("renders the Invite button on chat routes for admin users", async () => {
+    mockBaseAPIs("admin");
+    await setupPage({ context, path: "/" });
+    await waitFor(() => {
+      expect(screen.getByText("Invite")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("sidebar layout - invite button hidden for non-admins (SIDEBAR-D-049)", () => {
+  it("does not render the Invite button for non-admin users", async () => {
+    mockBaseAPIs("member");
+    await setupPage({ context, path: "/" });
+    await waitFor(() => {
+      expect(screen.queryByText("Invite")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("sidebar layout - menu toggle opens sidebar (SIDEBAR-D-050)", () => {
+  it("calls setSidebarCollapsed(false) when the menu toggle button is clicked", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs();
+    context.store.set(setZeroSidebarCollapsed$, true);
+    await setupPage({ context, path: "/" });
+
+    const menuButton = screen.getByLabelText("Open menu");
+    await user.click(menuButton);
+
+    await waitFor(() => {
+      expect(context.store.get(zeroSidebarCollapsed$)).toBeFalsy();
+    });
+  });
+});
+
+describe("sidebar layout - breadcrumb section link navigates (SIDEBAR-D-051)", () => {
+  it("navigates to the section root when clicking the breadcrumb section link", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: DEFAULT_AGENT_ID,
+            displayName: "My Agent",
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        ]);
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: `/agents/${DEFAULT_AGENT_ID}` });
+
+    // Click the breadcrumb link to /agents in the mobile top bar
+    const agentsLink = await waitFor(() => {
+      const links = screen.getAllByRole("link").filter((el) => {
+        return (
+          el.getAttribute("href") === "/agents" &&
+          el.textContent?.trim() === "Agents"
+        );
+      });
+      expect(links.length).toBeGreaterThan(0);
+      return links[0];
+    });
+    await user.click(agentsLink);
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/agents");
+    });
+  });
+});
+
+describe("sidebar layout - invite button opens member dialog (SIDEBAR-D-052)", () => {
+  it("opens the org manage dialog on the members tab when Invite is clicked", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs("admin");
+    server.use(
+      http.get("*/api/zero/org/logo", () => {
+        return HttpResponse.json({ logoUrl: null });
+      }),
+    );
+
+    await setupPage({ context, path: "/" });
+
+    const inviteButton = await waitFor(() => {
+      return screen.getByText("Invite");
+    });
+    await user.click(inviteButton);
+
+    await waitFor(() => {
+      expect(context.store.get(orgManageDialogOpen$)).toBeTruthy();
+    });
+    expect(context.store.get(activeTab$)).toBe("members");
+  });
+});
+
+describe("sidebar layout - overlay click collapses sidebar (SIDEBAR-D-053)", () => {
+  it("calls setSidebarCollapsed(true) when the overlay is clicked", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs();
+    context.store.set(setZeroSidebarCollapsed$, false);
+    await setupPage({ context, path: "/" });
+
+    const overlay = await waitFor(() => {
+      return document.querySelector<HTMLElement>('[class*="bg-black"]');
+    });
+    expect(overlay).toBeTruthy();
+
+    await user.click(overlay!);
+
+    await waitFor(() => {
+      expect(context.store.get(zeroSidebarCollapsed$)).toBeTruthy();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -24,7 +24,7 @@ const context = testContext();
 
 const DEFAULT_AGENT_ID = "c0000000-0000-4000-a000-000000000001";
 
-function mockBaseAPIs(role: "admin" | "member" = "admin") {
+function mockBaseAPIs() {
   server.use(
     http.get("*/api/zero/team", () => {
       return HttpResponse.json([
@@ -41,14 +41,6 @@ function mockBaseAPIs(role: "admin" | "member" = "admin") {
     }),
     http.get("*/api/zero/chat-threads", () => {
       return HttpResponse.json({ threads: [] });
-    }),
-    http.get("*/api/zero/org", () => {
-      return HttpResponse.json({
-        id: "org_1",
-        slug: "test-org",
-        name: "Test Org",
-        role,
-      });
     }),
   );
 }
@@ -117,7 +109,7 @@ describe("sidebar layout - breadcrumb avatar displays for agent pages (SIDEBAR-D
 
 describe("sidebar layout - invite button shows for admins (SIDEBAR-D-048)", () => {
   it("renders the Invite button on chat routes for admin users", async () => {
-    mockBaseAPIs("admin");
+    mockBaseAPIs();
     await setupPage({ context, path: "/" });
     await waitFor(() => {
       expect(screen.getByText("Invite")).toBeInTheDocument();
@@ -127,7 +119,17 @@ describe("sidebar layout - invite button shows for admins (SIDEBAR-D-048)", () =
 
 describe("sidebar layout - invite button hidden for non-admins (SIDEBAR-D-049)", () => {
   it("does not render the Invite button for non-admin users", async () => {
-    mockBaseAPIs("member");
+    mockBaseAPIs();
+    server.use(
+      http.get("*/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "org_1",
+          slug: "test-org",
+          name: "Test Org",
+          role: "member",
+        });
+      }),
+    );
     await setupPage({ context, path: "/" });
     await waitFor(() => {
       expect(screen.queryByText("Invite")).not.toBeInTheDocument();
@@ -198,10 +200,19 @@ describe("sidebar layout - breadcrumb section link navigates (SIDEBAR-D-051)", (
 describe("sidebar layout - invite button opens member dialog (SIDEBAR-D-052)", () => {
   it("opens the org manage dialog on the members tab when Invite is clicked", async () => {
     const user = userEvent.setup();
-    mockBaseAPIs("admin");
+    mockBaseAPIs();
     server.use(
       http.get("*/api/zero/org/logo", () => {
         return HttpResponse.json({ logoUrl: null });
+      }),
+      http.get("*/api/zero/org/members", () => {
+        return HttpResponse.json({
+          slug: "test-org",
+          role: "admin",
+          members: [],
+          pendingInvitations: [],
+          createdAt: "2024-01-01T00:00:00Z",
+        });
       }),
     );
 
@@ -214,6 +225,13 @@ describe("sidebar layout - invite button opens member dialog (SIDEBAR-D-052)", (
 
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    // Verify the Members tab is active (not General, Billing, etc.)
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Members" }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -18,12 +18,7 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
-import {
-  zeroSidebarCollapsed$,
-  setZeroSidebarCollapsed$,
-} from "../../../signals/zero-page/zero-nav.ts";
-import { orgManageDialogOpen$ } from "../../../signals/zero-page/settings/org-manage-dialog.ts";
-import { activeTab$ } from "../../../signals/zero-page/settings/org-manage-tabs-state.ts";
+import { setZeroSidebarCollapsed$ } from "../../../signals/zero-page/zero-nav.ts";
 
 const context = testContext();
 
@@ -114,9 +109,8 @@ describe("sidebar layout - breadcrumb avatar displays for agent pages (SIDEBAR-D
     mockBaseAPIs();
     await setupPage({ context, path: "/" });
     await waitFor(() => {
-      // AgentAvatarInTopBar renders an img with role="presentation" inside the mobile top bar
-      const avatars = screen.getAllByRole("presentation");
-      expect(avatars.length).toBeGreaterThan(0);
+      // AgentAvatarInTopBar renders an img with data-testid="agent-avatar" inside the mobile top bar
+      expect(screen.getByTestId("agent-avatar")).toBeInTheDocument();
     });
   });
 });
@@ -142,7 +136,7 @@ describe("sidebar layout - invite button hidden for non-admins (SIDEBAR-D-049)",
 });
 
 describe("sidebar layout - menu toggle opens sidebar (SIDEBAR-D-050)", () => {
-  it("calls setSidebarCollapsed(false) when the menu toggle button is clicked", async () => {
+  it("shows the sidebar when the menu toggle button is clicked", async () => {
     const user = userEvent.setup();
     mockBaseAPIs();
     context.store.set(setZeroSidebarCollapsed$, true);
@@ -152,7 +146,8 @@ describe("sidebar layout - menu toggle opens sidebar (SIDEBAR-D-050)", () => {
     await user.click(menuButton);
 
     await waitFor(() => {
-      expect(context.store.get(zeroSidebarCollapsed$)).toBeFalsy();
+      // When sidebar is open, the overlay becomes visible in the DOM
+      expect(screen.getByLabelText("Sidebar overlay")).toBeInTheDocument();
     });
   });
 });
@@ -218,28 +213,28 @@ describe("sidebar layout - invite button opens member dialog (SIDEBAR-D-052)", (
     await user.click(inviteButton);
 
     await waitFor(() => {
-      expect(context.store.get(orgManageDialogOpen$)).toBeTruthy();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
-    expect(context.store.get(activeTab$)).toBe("members");
   });
 });
 
 describe("sidebar layout - overlay click collapses sidebar (SIDEBAR-D-053)", () => {
-  it("calls setSidebarCollapsed(true) when the overlay is clicked", async () => {
+  it("hides the overlay when the overlay is clicked", async () => {
     const user = userEvent.setup();
     mockBaseAPIs();
     context.store.set(setZeroSidebarCollapsed$, false);
     await setupPage({ context, path: "/" });
 
     const overlay = await waitFor(() => {
-      return document.querySelector<HTMLElement>('[class*="bg-black"]');
+      return screen.getByLabelText("Sidebar overlay");
     });
-    expect(overlay).toBeTruthy();
 
-    await user.click(overlay!);
+    await user.click(overlay);
 
     await waitFor(() => {
-      expect(context.store.get(zeroSidebarCollapsed$)).toBeTruthy();
+      expect(
+        screen.queryByLabelText("Sidebar overlay"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -39,6 +39,7 @@ function AgentAvatarInTopBar({ agentId }: { agentId: string }) {
       src={src}
       alt=""
       role="presentation"
+      data-testid="agent-avatar"
       className="h-6 w-6 shrink-0 rounded-full object-cover object-top"
     />
   );
@@ -142,6 +143,7 @@ function SidebarLayoutInner({ children }: { children: ReactNode }) {
       {!sidebarCollapsed && (
         <div
           className="fixed inset-0 z-30 bg-black/40 md:hidden"
+          aria-label="Sidebar overlay"
           onClick={() => {
             return setSidebarCollapsed(true);
           }}


### PR DESCRIPTION
## Summary
- Add 9 test cases (SIDEBAR-D-045 through SIDEBAR-D-053) for `SidebarLayout` and `MobileTopBar` components
- Tests cover breadcrumb section text, breadcrumb name, avatar display, invite button visibility, menu toggle, breadcrumb navigation, invite dialog, and overlay click
- All tests use MSW for HTTP mocking with no `vi.mock()` for internal modules

## Test plan
- [x] SIDEBAR-D-045: Breadcrumb section text renders
- [x] SIDEBAR-D-046: Breadcrumb name renders
- [x] SIDEBAR-D-047: Breadcrumb avatar displays for agent pages
- [x] SIDEBAR-D-048: Invite button shows for admins on correct routes
- [x] SIDEBAR-D-049: Invite button hidden for non-admins
- [x] SIDEBAR-D-050: Menu toggle opens sidebar
- [x] SIDEBAR-D-051: Breadcrumb section link navigates
- [x] SIDEBAR-D-052: Invite button opens member dialog
- [x] SIDEBAR-D-053: Overlay click collapses sidebar

Closes #7978

🤖 Generated with [Claude Code](https://claude.com/claude-code)