### PR TITLE
test(platform): add views tests for zero-schedule-card and zero-schedule-tab

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-card-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-card-tab.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
+import type { ScheduleResponse } from "@vm0/core";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
@@ -10,7 +11,9 @@ import { createDeferredPromise } from "../../../signals/utils.ts";
 const context = testContext();
 const AGENT_ID = "e0000000-0000-4000-a000-000000000010";
 
-function defaultSchedule() {
+function defaultSchedule(
+  overrides: Partial<ScheduleResponse> = {},
+): ScheduleResponse {
   return {
     id: "f0000002-0000-4000-a000-000000000001",
     agentId: AGENT_ID,
@@ -32,15 +35,14 @@ function defaultSchedule() {
     appendSystemPrompt: null,
     vars: null,
     secretNames: null,
-    artifactName: null,
-    artifactVersion: null,
     volumeVersions: null,
     retryStartedAt: null,
     consecutiveFailures: 0,
+    ...overrides,
   };
 }
 
-function mockBaseAPIs(schedules: ReturnType<typeof defaultSchedule>[]) {
+function mockBaseAPIs(schedules: ScheduleResponse[]) {
   server.use(
     http.get("*/api/zero/team", () => {
       return HttpResponse.json([
@@ -111,11 +113,11 @@ async function openMenuAndClick(
       }),
     ).toBeDefined();
   });
-  await user.click(
-    screen.getAllByRole("menuitem").find((el) => {
-      return el.textContent?.includes(action);
-    })!,
-  );
+  const item = screen.getAllByRole("menuitem").find((el) => {
+    return el.textContent?.includes(action);
+  });
+  expect(item).toBeDefined();
+  await user.click(item as HTMLElement);
 }
 
 describe("zero-schedule-card - schedule list", () => {
@@ -142,12 +144,14 @@ describe("zero-schedule-card - schedule list", () => {
   });
 
   it("renders the prompt text for each schedule entry (SCHED-D-036)", async () => {
-    mockBaseAPIs([defaultSchedule()]);
+    mockBaseAPIs([
+      defaultSchedule({ prompt: "Check overnight alerts and summarize" }),
+    ]);
     await navigateToScheduleTab();
 
     await waitFor(() => {
       expect(
-        screen.getAllByText("Summarize yesterday's threads")[0],
+        screen.getAllByText("Check overnight alerts and summarize")[0],
       ).toBeInTheDocument();
     });
   });
@@ -203,7 +207,7 @@ describe("zero-schedule-card - view mode", () => {
       return /Calendar/i.test(el.textContent ?? "");
     });
     expect(calendarTab).toBeDefined();
-    await user.click(calendarTab!);
+    await user.click(calendarTab as HTMLElement);
 
     await waitFor(() => {
       expect(screen.getByText("Week view")).toBeInTheDocument();
@@ -348,50 +352,8 @@ describe("zero-schedule-card - delete", () => {
 describe("zero-schedule-tab - loading state", () => {
   it("renders skeleton while schedule data is loading (SCHED-D-043)", async () => {
     const hangDeferred = createDeferredPromise<void>(context.signal);
+    mockBaseAPIs([defaultSchedule()]);
     server.use(
-      http.get("*/api/zero/team", () => {
-        return HttpResponse.json([
-          {
-            id: "c0000000-0000-4000-a000-000000000001",
-            name: "zero",
-            displayName: null,
-            description: null,
-            sound: null,
-            avatarUrl: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-          },
-          {
-            id: "agent-detail-id",
-            name: "my-agent",
-            displayName: "My Agent",
-            description: "A helpful agent",
-            sound: null,
-            avatarUrl: null,
-            headVersionId: "version_2",
-            updatedAt: "2024-01-02T00:00:00Z",
-          },
-        ]);
-      }),
-      http.get("*/api/zero/chat-threads", () => {
-        return HttpResponse.json({ threads: [] });
-      }),
-      http.get("*/api/zero/agents/my-agent", () => {
-        return HttpResponse.json({
-          name: "my-agent",
-          agentId: AGENT_ID,
-          ownerId: "test-owner-id",
-          description: "A helpful agent",
-          displayName: "My Agent",
-          sound: null,
-          avatarUrl: null,
-          connectors: [],
-          firewallPolicies: null,
-        });
-      }),
-      http.get("*/api/zero/agents/:name/instructions", () => {
-        return HttpResponse.json({ content: null, filename: null });
-      }),
       http.get("*/api/zero/schedules", async () => {
         await hangDeferred.promise;
         return HttpResponse.json({ schedules: [] });
@@ -404,15 +366,8 @@ describe("zero-schedule-tab - loading state", () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "My Agent" }),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("schedule-tab-skeleton")).toBeInTheDocument();
     });
-
-    // Schedule entries should not be visible while loading
-    expect(screen.queryAllByText("Summarize yesterday's threads")).toHaveLength(
-      0,
-    );
 
     hangDeferred.resolve();
     await pagePromise;
@@ -421,50 +376,8 @@ describe("zero-schedule-tab - loading state", () => {
 
 describe("zero-schedule-tab - error state", () => {
   it("displays error message when schedule fetch fails (SCHED-D-044)", async () => {
+    mockBaseAPIs([]);
     server.use(
-      http.get("*/api/zero/team", () => {
-        return HttpResponse.json([
-          {
-            id: "c0000000-0000-4000-a000-000000000001",
-            name: "zero",
-            displayName: null,
-            description: null,
-            sound: null,
-            avatarUrl: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-          },
-          {
-            id: "agent-detail-id",
-            name: "my-agent",
-            displayName: "My Agent",
-            description: "A helpful agent",
-            sound: null,
-            avatarUrl: null,
-            headVersionId: "version_2",
-            updatedAt: "2024-01-02T00:00:00Z",
-          },
-        ]);
-      }),
-      http.get("*/api/zero/chat-threads", () => {
-        return HttpResponse.json({ threads: [] });
-      }),
-      http.get("*/api/zero/agents/my-agent", () => {
-        return HttpResponse.json({
-          name: "my-agent",
-          agentId: AGENT_ID,
-          ownerId: "test-owner-id",
-          description: "A helpful agent",
-          displayName: "My Agent",
-          sound: null,
-          avatarUrl: null,
-          connectors: [],
-          firewallPolicies: null,
-        });
-      }),
-      http.get("*/api/zero/agents/:name/instructions", () => {
-        return HttpResponse.json({ content: null, filename: null });
-      }),
       http.get("*/api/zero/schedules", () => {
         return HttpResponse.json(
           {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-card-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-schedule-card-tab.test.tsx
@@ -1,0 +1,487 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+import { createDeferredPromise } from "../../../signals/utils.ts";
+
+const context = testContext();
+const AGENT_ID = "e0000000-0000-4000-a000-000000000010";
+
+function defaultSchedule() {
+  return {
+    id: "f0000002-0000-4000-a000-000000000001",
+    agentId: AGENT_ID,
+    displayName: null,
+    name: "morning-briefing",
+    triggerType: "cron",
+    cronExpression: "0 9 * * 1-5",
+    atTime: null,
+    intervalSeconds: null,
+    timezone: "UTC",
+    prompt: "Summarize yesterday's threads",
+    description: null,
+    enabled: true,
+    nextRunAt: null,
+    lastRunAt: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    updatedAt: "2026-03-01T00:00:00Z",
+    userId: "test-user-123",
+    appendSystemPrompt: null,
+    vars: null,
+    secretNames: null,
+    artifactName: null,
+    artifactVersion: null,
+    volumeVersions: null,
+    retryStartedAt: null,
+    consecutiveFailures: 0,
+  };
+}
+
+function mockBaseAPIs(schedules: ReturnType<typeof defaultSchedule>[]) {
+  server.use(
+    http.get("*/api/zero/team", () => {
+      return HttpResponse.json([
+        {
+          id: "c0000000-0000-4000-a000-000000000001",
+          name: "zero",
+          displayName: null,
+          description: null,
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_1",
+          updatedAt: "2024-01-01T00:00:00Z",
+        },
+        {
+          id: "agent-detail-id",
+          name: "my-agent",
+          displayName: "My Agent",
+          description: "A helpful agent",
+          sound: null,
+          avatarUrl: null,
+          headVersionId: "version_2",
+          updatedAt: "2024-01-02T00:00:00Z",
+        },
+      ]);
+    }),
+    http.get("*/api/zero/chat-threads", () => {
+      return HttpResponse.json({ threads: [] });
+    }),
+    http.get("*/api/zero/agents/my-agent", () => {
+      return HttpResponse.json({
+        name: "my-agent",
+        agentId: AGENT_ID,
+        ownerId: "test-owner-id",
+        description: "A helpful agent",
+        displayName: "My Agent",
+        sound: null,
+        avatarUrl: null,
+        connectors: [],
+        firewallPolicies: null,
+      });
+    }),
+    http.get("*/api/zero/agents/:name/instructions", () => {
+      return HttpResponse.json({ content: null, filename: null });
+    }),
+    http.get("*/api/zero/schedules", () => {
+      return HttpResponse.json({ schedules });
+    }),
+  );
+}
+
+async function navigateToScheduleTab() {
+  await setupPage({ context, path: "/agents/my-agent?tab=schedule" });
+}
+
+async function openMenuAndClick(
+  user: ReturnType<typeof userEvent.setup>,
+  timeLabel: string,
+  action: "Edit" | "Delete" | "Run now",
+) {
+  const menuTrigger = screen.getAllByLabelText(
+    `More actions for ${timeLabel}`,
+  )[0];
+  await user.click(menuTrigger);
+  await waitFor(() => {
+    expect(
+      screen.getAllByRole("menuitem").find((el) => {
+        return el.textContent?.includes(action);
+      }),
+    ).toBeDefined();
+  });
+  await user.click(
+    screen.getAllByRole("menuitem").find((el) => {
+      return el.textContent?.includes(action);
+    })!,
+  );
+}
+
+describe("zero-schedule-card - schedule list", () => {
+  it("renders schedule entries in card list view (SCHED-D-034)", async () => {
+    mockBaseAPIs([defaultSchedule()]);
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Summarize yesterday's threads")[0],
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders the formatted time for each schedule entry (SCHED-D-035)", async () => {
+    mockBaseAPIs([defaultSchedule()]);
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/Every weekday at 9:00 AM/)[0],
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders the prompt text for each schedule entry (SCHED-D-036)", async () => {
+    mockBaseAPIs([defaultSchedule()]);
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Summarize yesterday's threads")[0],
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders ZeroScheduleCard with agent displayName in title (SCHED-D-045)", async () => {
+    mockBaseAPIs([defaultSchedule()]);
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("My Agent's scheduled tasks"),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero-schedule-card - view mode", () => {
+  it("shows List and Calendar view tabs with list view active by default (SCHED-D-037)", async () => {
+    mockBaseAPIs([defaultSchedule()]);
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Summarize yesterday's threads")[0],
+      ).toBeInTheDocument();
+    });
+
+    // Both view mode tabs should be present in the card header
+    const listTab = screen.getAllByRole("tab").find((el) => {
+      return /^List$/i.test(el.textContent?.trim() ?? "");
+    });
+    const calendarTab = screen.getAllByRole("tab").find((el) => {
+      return /^Calendar$/i.test(el.textContent?.trim() ?? "");
+    });
+    expect(listTab).toBeDefined();
+    expect(calendarTab).toBeDefined();
+    // List view is showing (no "Week view" heading visible)
+    expect(screen.queryByText("Week view")).not.toBeInTheDocument();
+  });
+
+  it("switches to calendar view when Calendar tab is clicked (SCHED-D-040)", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs([defaultSchedule()]);
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Summarize yesterday's threads")[0],
+      ).toBeInTheDocument();
+    });
+
+    const calendarTab = screen.getAllByRole("tab").find((el) => {
+      return /Calendar/i.test(el.textContent ?? "");
+    });
+    expect(calendarTab).toBeDefined();
+    await user.click(calendarTab!);
+
+    await waitFor(() => {
+      expect(screen.getByText("Week view")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero-schedule-card - add schedule dialog", () => {
+  it("opens schedule form dialog when Add schedule button is clicked (SCHED-D-039)", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs([defaultSchedule()]);
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Summarize yesterday's threads")[0],
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Add schedule"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Add schedule" }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Prompt")).toBeInTheDocument();
+  });
+});
+
+describe("zero-schedule-card - save error", () => {
+  it("displays save error message in dialog when schedule save fails (SCHED-D-038)", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs([defaultSchedule()]);
+    server.use(
+      http.post("*/api/zero/schedules", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Schedule limit reached",
+              code: "INTERNAL_SERVER_ERROR",
+            },
+          },
+          { status: 400 },
+        );
+      }),
+    );
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Summarize yesterday's threads")[0],
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Add schedule"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Prompt")).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByLabelText("Prompt"));
+    await user.type(screen.getByLabelText("Prompt"), "New task");
+    await user.click(screen.getByText("Create"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Schedule limit reached/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("zero-schedule-card - delete", () => {
+  it("closing delete dialog preserves the schedule entry (SCHED-D-041)", async () => {
+    const user = userEvent.setup();
+    let deleteCalled = false;
+    mockBaseAPIs([defaultSchedule()]);
+    server.use(
+      http.delete("*/api/zero/schedules/:name", () => {
+        deleteCalled = true;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Summarize yesterday's threads")[0],
+      ).toBeInTheDocument();
+    });
+
+    await openMenuAndClick(user, "Every weekday at 9:00 AM", "Delete");
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Cancel"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Delete schedule?")).not.toBeInTheDocument();
+    });
+    expect(deleteCalled).toBeFalsy();
+    expect(
+      screen.getAllByText("Summarize yesterday's threads")[0],
+    ).toBeInTheDocument();
+  });
+
+  it("calls delete API when delete is confirmed (SCHED-D-042)", async () => {
+    const user = userEvent.setup();
+    let deletedName: string | null = null;
+    mockBaseAPIs([defaultSchedule()]);
+    server.use(
+      http.delete("*/api/zero/schedules/:name", ({ params }) => {
+        deletedName = params["name"] as string;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("Summarize yesterday's threads")[0],
+      ).toBeInTheDocument();
+    });
+
+    await openMenuAndClick(user, "Every weekday at 9:00 AM", "Delete");
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete schedule?")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Delete"));
+
+    await waitFor(() => {
+      expect(deletedName).toBe("morning-briefing");
+    });
+  });
+});
+
+describe("zero-schedule-tab - loading state", () => {
+  it("renders skeleton while schedule data is loading (SCHED-D-043)", async () => {
+    const hangDeferred = createDeferredPromise<void>(context.signal);
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: "c0000000-0000-4000-a000-000000000001",
+            name: "zero",
+            displayName: null,
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "agent-detail-id",
+            name: "my-agent",
+            displayName: "My Agent",
+            description: "A helpful agent",
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_2",
+            updatedAt: "2024-01-02T00:00:00Z",
+          },
+        ]);
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+      http.get("*/api/zero/agents/my-agent", () => {
+        return HttpResponse.json({
+          name: "my-agent",
+          agentId: AGENT_ID,
+          ownerId: "test-owner-id",
+          description: "A helpful agent",
+          displayName: "My Agent",
+          sound: null,
+          avatarUrl: null,
+          connectors: [],
+          firewallPolicies: null,
+        });
+      }),
+      http.get("*/api/zero/agents/:name/instructions", () => {
+        return HttpResponse.json({ content: null, filename: null });
+      }),
+      http.get("*/api/zero/schedules", async () => {
+        await hangDeferred.promise;
+        return HttpResponse.json({ schedules: [] });
+      }),
+    );
+
+    const pagePromise = setupPage({
+      context,
+      path: "/agents/my-agent?tab=schedule",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "My Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    // Schedule entries should not be visible while loading
+    expect(screen.queryAllByText("Summarize yesterday's threads")).toHaveLength(
+      0,
+    );
+
+    hangDeferred.resolve();
+    await pagePromise;
+  });
+});
+
+describe("zero-schedule-tab - error state", () => {
+  it("displays error message when schedule fetch fails (SCHED-D-044)", async () => {
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: "c0000000-0000-4000-a000-000000000001",
+            name: "zero",
+            displayName: null,
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+          {
+            id: "agent-detail-id",
+            name: "my-agent",
+            displayName: "My Agent",
+            description: "A helpful agent",
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_2",
+            updatedAt: "2024-01-02T00:00:00Z",
+          },
+        ]);
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+      http.get("*/api/zero/agents/my-agent", () => {
+        return HttpResponse.json({
+          name: "my-agent",
+          agentId: AGENT_ID,
+          ownerId: "test-owner-id",
+          description: "A helpful agent",
+          displayName: "My Agent",
+          sound: null,
+          avatarUrl: null,
+          connectors: [],
+          firewallPolicies: null,
+        });
+      }),
+      http.get("*/api/zero/agents/:name/instructions", () => {
+        return HttpResponse.json({ content: null, filename: null });
+      }),
+      http.get("*/api/zero/schedules", () => {
+        return HttpResponse.json(
+          {
+            error: {
+              message: "Failed to load schedules",
+              code: "INTERNAL_SERVER_ERROR",
+            },
+          },
+          { status: 500 },
+        );
+      }),
+    );
+
+    await navigateToScheduleTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load schedules")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
@@ -29,7 +29,7 @@ const SKELETON_KEYS = ["s-0", "s-1", "s-2", "s-3", "s-4"] as const;
 
 function ScheduleTabSkeleton() {
   return (
-    <Card className="zero-card">
+    <Card className="zero-card" data-testid="schedule-tab-skeleton">
       <CardContent className="p-0 flex flex-col">
         <div className="flex flex-wrap items-end justify-between gap-4 px-5 pt-5 pb-4 border-b border-border/50">
           <div className="min-w-0 flex flex-col gap-1.5">


### PR DESCRIPTION
## Summary

- Adds 12 integration tests for `ZeroScheduleCard` and `ZeroScheduleTab` via the `/agents/my-agent?tab=schedule` route
- Tests cover schedule list rendering, view mode switching, add/save/delete flows, loading skeleton, and error states
- Closes #7968

## Test cases

| ID | Description |
|----|-------------|
| SCHED-D-034 | Schedule list renders in card view |
| SCHED-D-035 | Schedule time display renders |
| SCHED-D-036 | Schedule prompt/description renders |
| SCHED-D-037 | View mode indicator shows list or calendar |
| SCHED-D-038 | Save error message renders |
| SCHED-D-039 | Add schedule button opens dialog |
| SCHED-D-040 | View mode tabs switch views |
| SCHED-D-041 | Delete cancel preserves schedule |
| SCHED-D-042 | Delete confirm removes schedule |
| SCHED-D-043 | Loading skeleton renders while fetching |
| SCHED-D-044 | Error message displays on fetch failure |
| SCHED-D-045 | Schedule list renders via ZeroScheduleCard |

## Test plan

- [x] All 12 test cases pass locally
- [x] No `vi.mock()` for internal modules — only MSW for HTTP mocking
- [x] No `eslint-disable` or `@ts-ignore`
- [x] `pnpm format` — formatted
- [x] `pnpm turbo run lint` — no lint errors
- [x] `pnpm check-types` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)