### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -89,7 +89,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.1"
-CLAUDE_CODE_VERSION="2.1.91"
+CLAUDE_CODE_VERSION="2.1.92"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.24.0"


### PR DESCRIPTION
## Changes

| Package | Old Version | New Version |
|---------|-------------|-------------|
| `CLAUDE_CODE_VERSION` (Claude Code CLI) | `2.1.91` | `2.1.92` |

All other pinned versions (`GO_VERSION`, `GWS_CLI_VERSION`, `XURL_VERSION`, `AGENT_BROWSER_VERSION`) are already at their latest releases.