### PR TITLE
fix(test/platform): replace css class selector with data-testid in sidebar-d-046

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -87,11 +87,10 @@ describe("sidebar layout - breadcrumb name renders (SIDEBAR-D-046)", () => {
     await setupPage({ context, path: `/agents/${DEFAULT_AGENT_ID}` });
 
     await waitFor(() => {
-      // The breadcrumb name renders as a truncated span next to the section link
-      const spans = screen.getAllByText("My Agent").filter((el) => {
-        return el.classList.contains("truncate");
-      });
-      expect(spans.length).toBeGreaterThan(0);
+      // The breadcrumb name renders as a truncated span with data-testid="breadcrumb-name"
+      expect(screen.getByTestId("breadcrumb-name")).toHaveTextContent(
+        "My Agent",
+      );
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -89,7 +89,9 @@ function MobileTopBar() {
               {breadcrumb.name && (
                 <>
                   <span className="text-foreground/30 select-none">/</span>
-                  <span className="truncate">{breadcrumb.name}</span>
+                  <span className="truncate" data-testid="breadcrumb-name">
+                    {breadcrumb.name}
+                  </span>
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary
- Add `data-testid="breadcrumb-name"` to the breadcrumb name `<span>` in `sidebar-layout.tsx`
- Update SIDEBAR-D-046 test to use `getByTestId("breadcrumb-name")` instead of `classList.contains("truncate")`
- Fixes P1 testing convention violation (AP-7: implementation detail testing via CSS class selector) identified during PR #8152 review

## Test plan
- [x] SIDEBAR-D-046 now uses semantic `data-testid` query instead of CSS class selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)