### PR TITLE
feat: add cn.sh and use it for container name resolution

### DIFF
--- a/scripts/cn.sh
+++ b/scripts/cn.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Container name — returns a stable identifier for the current machine/container.
+#
+# Usage:
+#   scripts/cn.sh        # container name only (e.g. cs04, vm04)
+#   scripts/cn.sh -u     # prefixed with git username (e.g. ethan-cs04, ethan-vm04)
+#
+# Resolution order (no -u):
+#   1. $CODESPACE_NAME   — first segment before '-' (e.g. cs04-abc123 -> cs04)
+#   2. $(hostname)       — full hostname
+
+set -euo pipefail
+
+WITH_USER=false
+while getopts "u" opt; do
+  case "$opt" in
+    u) WITH_USER=true ;;
+    *) echo "Usage: $0 [-u]" >&2; exit 1 ;;
+  esac
+done
+
+# Resolve container name
+if [ -n "${CODESPACE_NAME:-}" ]; then
+  CN="${CODESPACE_NAME%%-*}"
+else
+  CN=$(hostname)
+fi
+
+if [ "$WITH_USER" = true ]; then
+  USERNAME=$(git config user.email 2>/dev/null | sed 's/@.*//')
+  echo "${USERNAME}-${CN}"
+else
+  echo "$CN"
+fi

--- a/scripts/sync-env.sh
+++ b/scripts/sync-env.sh
@@ -61,7 +61,7 @@ configure_runner_group() {
   # Derive from git email + hostname (e.g. alice@vm0.ai on macbook -> alice-macbook)
   local username hostname_short
   username=$(git config user.email 2>/dev/null | sed 's/@.*//' | tr '[:upper:].' '[:lower:]-' | sed 's/-$//' || true)
-  hostname_short=$(hostname -s)
+  hostname_short=$("$SCRIPT_DIR/cn.sh")
 
   if [[ -z "$username" ]]; then
     echo "  ✗ RUNNER_DEFAULT_GROUP skipped (git user.email not configured)"

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -67,7 +67,7 @@ else
   if [[ "$DOMAIN" == "vm0.ai" ]]; then
     MODE="named"
     USERNAME="${EMAIL%%@*}"
-    MACHINE_HOSTNAME=$(hostname)
+    MACHINE_HOSTNAME=$(bash "$(dirname "$0")/cn.sh")
 
     # Map well-known ports to service names
     case "$PORT" in


### PR DESCRIPTION
## Summary

- Adds `scripts/cn.sh` — a single source of truth for resolving the current machine/container identifier
- When `$CODESPACE_NAME` is set (GitHub Codespaces), returns the first segment before `-` (e.g. `cs04` from `cs04-abc123`)
- Falls back to `$(hostname)` in non-Codespaces environments
- `-u` flag prepends git username (e.g. `ethan-cs04`)
- Updates `scripts/tunnel.sh` and `scripts/sync-env.sh` to call `cn.sh` instead of reading `hostname` directly

## Test plan

- [ ] Run `scripts/cn.sh` in a Codespaces environment — should return `cs04` (first segment of `$CODESPACE_NAME`)
- [ ] Run `scripts/cn.sh` outside Codespaces — should return `$(hostname)` output
- [ ] Run `scripts/cn.sh -u` — should return `<git-username>-<cn>` in both environments
- [ ] Run `scripts/tunnel.sh <port>` with `$CODESPACE_NAME` set — tunnel FQDN should use short name
- [ ] Run `scripts/sync-env.sh` with `$CODESPACE_NAME` set — `RUNNER_DEFAULT_GROUP` should use short name

🤖 Generated with [Claude Code](https://claude.com/claude-code)