### PR TITLE
chore: add tmux to development docker image

### DIFF
--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -178,5 +178,10 @@ RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/publ
     && apt-get install -y --no-install-recommends stripe \
     && rm -rf /var/lib/apt/lists/*
 
+# Install tmux for terminal multiplexing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tmux \
+    && rm -rf /var/lib/apt/lists/*
+
 # Default command
 CMD ["/usr/bin/zsh"]


### PR DESCRIPTION
## Summary
- Add tmux to the `development` stage of the Docker toolchain image
- Placed as the last `RUN` instruction before `CMD` to minimize cache invalidation
- Only affects `vm0-dev` image; `toolchain` and `toolchain-rust` images are unchanged

## Test plan
- [ ] Docker image builds successfully in CI
- [ ] tmux is available in the devcontainer after image rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)