### PR TITLE
test(crates): add unit tests to improve coverage from 57.4% to 58.2%

### DIFF
--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -174,4 +174,74 @@ mod tests {
         assert_eq!(parse_meminfo_value("  0 kB"), 0);
         assert_eq!(parse_meminfo_value(""), 0);
     }
+
+    #[test]
+    fn parse_meminfo_value_large_values() {
+        assert_eq!(parse_meminfo_value("  16384000 kB"), 16384000);
+        assert_eq!(parse_meminfo_value("1 kB"), 1);
+    }
+
+    #[test]
+    fn parse_meminfo_value_non_numeric() {
+        assert_eq!(parse_meminfo_value("  abc kB"), 0);
+    }
+
+    #[test]
+    fn cpu_tracker_multiple_reads_are_consistent() {
+        let mut tracker = CpuTracker::new();
+        let mut prev = 0.0;
+        for _ in 0..5 {
+            let pct = tracker.get_cpu_percent();
+            assert!((0.0..=100.0).contains(&pct), "pct={pct} out of range");
+            prev = pct;
+        }
+        // Last value should still be in valid range
+        assert!((0.0..=100.0).contains(&prev));
+    }
+
+    #[test]
+    fn get_memory_info_returns_valid_values() {
+        let (used, total) = get_memory_info();
+        // On Linux with /proc, total > 0
+        if std::path::Path::new("/proc/meminfo").exists() {
+            assert!(total > 0, "total memory should be > 0");
+            assert!(used <= total, "used should be <= total");
+        }
+    }
+
+    #[test]
+    fn get_disk_info_returns_valid_values() {
+        let (used, total) = get_disk_info();
+        assert!(total > 0, "total disk should be > 0");
+        assert!(used <= total, "used should be <= total");
+    }
+
+    #[test]
+    fn collect_metrics_returns_complete_entry() {
+        let mut tracker = CpuTracker::new();
+        let entry = collect_metrics(&mut tracker);
+        assert!(!entry.ts.is_empty());
+        assert!((0.0..=100.0).contains(&entry.cpu));
+        assert!(entry.mem_total > 0);
+        assert!(entry.disk_total > 0);
+    }
+
+    #[test]
+    fn metrics_entry_serializes_to_json() {
+        let entry = MetricsEntry {
+            ts: "2026-01-01T00:00:00Z".to_string(),
+            cpu: 42.5,
+            mem_used: 1024,
+            mem_total: 4096,
+            disk_used: 8192,
+            disk_total: 16384,
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["ts"], "2026-01-01T00:00:00Z");
+        assert_eq!(json["cpu"], 42.5);
+        assert_eq!(json["mem_used"], 1024);
+        assert_eq!(json["mem_total"], 4096);
+        assert_eq!(json["disk_used"], 8192);
+        assert_eq!(json["disk_total"], 16384);
+    }
 }

--- a/crates/guest-agent/src/metrics.rs
+++ b/crates/guest-agent/src/metrics.rs
@@ -189,14 +189,13 @@ mod tests {
     #[test]
     fn cpu_tracker_multiple_reads_are_consistent() {
         let mut tracker = CpuTracker::new();
-        let mut prev = 0.0;
-        for _ in 0..5 {
+        for i in 0..5 {
             let pct = tracker.get_cpu_percent();
-            assert!((0.0..=100.0).contains(&pct), "pct={pct} out of range");
-            prev = pct;
+            assert!(
+                (0.0..=100.0).contains(&pct),
+                "read {i}: pct={pct} out of range"
+            );
         }
-        // Last value should still be in valid range
-        assert!((0.0..=100.0).contains(&prev));
     }
 
     #[test]
@@ -227,21 +226,15 @@ mod tests {
     }
 
     #[test]
-    fn metrics_entry_serializes_to_json() {
-        let entry = MetricsEntry {
-            ts: "2026-01-01T00:00:00Z".to_string(),
-            cpu: 42.5,
-            mem_used: 1024,
-            mem_total: 4096,
-            disk_used: 8192,
-            disk_total: 16384,
-        };
-        let json = serde_json::to_value(&entry).unwrap();
-        assert_eq!(json["ts"], "2026-01-01T00:00:00Z");
-        assert_eq!(json["cpu"], 42.5);
-        assert_eq!(json["mem_used"], 1024);
-        assert_eq!(json["mem_total"], 4096);
-        assert_eq!(json["disk_used"], 8192);
-        assert_eq!(json["disk_total"], 16384);
+    fn collect_metrics_serializes_to_valid_jsonl() {
+        let mut tracker = CpuTracker::new();
+        let entry = collect_metrics(&mut tracker);
+        let json = serde_json::to_string(&entry).unwrap();
+        // Verify it round-trips through the same path metrics_loop uses.
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed["ts"].is_string());
+        assert!(parsed["cpu"].is_f64());
+        assert!(parsed["mem_total"].is_u64());
+        assert!(parsed["disk_total"].is_u64());
     }
 }

--- a/crates/guest-agent/src/telemetry.rs
+++ b/crates/guest-agent/src/telemetry.rs
@@ -226,4 +226,66 @@ mod tests {
         let val: u64 = fs::read_to_string(&pos).unwrap().trim().parse().unwrap();
         assert_eq!(val, 42);
     }
+
+    #[test]
+    fn read_file_delta_truncated_file() {
+        // Position file says we read 100 bytes, but file is shorter → no new data.
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("log.txt");
+        let pos = dir.path().join("log.pos");
+        fs::write(&file, "short").unwrap();
+        fs::write(&pos, "100").unwrap();
+
+        let (content, new_pos) = read_file_delta(file.to_str().unwrap(), pos.to_str().unwrap());
+        assert!(content.is_empty());
+        assert_eq!(new_pos, 100);
+    }
+
+    #[test]
+    fn read_file_delta_corrupt_pos_file() {
+        // Corrupt position file → starts from 0.
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("log.txt");
+        let pos = dir.path().join("log.pos");
+        fs::write(&file, "data").unwrap();
+        fs::write(&pos, "notanumber").unwrap();
+
+        let (content, new_pos) = read_file_delta(file.to_str().unwrap(), pos.to_str().unwrap());
+        assert_eq!(content, "data");
+        assert_eq!(new_pos, 4);
+    }
+
+    #[test]
+    fn read_jsonl_delta_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("empty.jsonl");
+        let pos = dir.path().join("empty.pos");
+        fs::write(&file, "").unwrap();
+
+        let (entries, new_pos) = read_jsonl_delta(file.to_str().unwrap(), pos.to_str().unwrap());
+        assert!(entries.is_empty());
+        assert_eq!(new_pos, 0);
+    }
+
+    #[test]
+    fn read_jsonl_delta_all_invalid_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("bad.jsonl");
+        let pos = dir.path().join("bad.pos");
+        fs::write(&file, "bad1\nbad2\nbad3\n").unwrap();
+
+        let (entries, new_pos) = read_jsonl_delta(file.to_str().unwrap(), pos.to_str().unwrap());
+        assert!(entries.is_empty());
+        assert!(new_pos > 0);
+    }
+
+    #[test]
+    fn save_position_overwrites_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let pos = dir.path().join("overwrite.pos");
+        save_position(pos.to_str().unwrap(), 10);
+        save_position(pos.to_str().unwrap(), 20);
+        let val: u64 = fs::read_to_string(&pos).unwrap().trim().parse().unwrap();
+        assert_eq!(val, 20);
+    }
 }

--- a/crates/guest-common/src/log.rs
+++ b/crates/guest-common/src/log.rs
@@ -28,3 +28,22 @@ macro_rules! log_error {
         eprintln!("[{}] [ERROR] [{}] {}", $crate::log::timestamp(), $tag, format!($($arg)*));
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_is_rfc3339() {
+        let ts = timestamp();
+        // RFC3339 with millis: "2026-01-01T00:00:00.000Z"
+        assert!(ts.ends_with('Z'), "timestamp should end with Z: {ts}");
+        assert!(ts.contains('T'), "timestamp should contain T: {ts}");
+        assert_eq!(ts.len(), 24, "unexpected timestamp length: {ts}");
+        // Verify it parses as a valid datetime
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(&ts).is_ok(),
+            "not a valid RFC3339: {ts}"
+        );
+    }
+}

--- a/crates/guest-common/src/telemetry.rs
+++ b/crates/guest-common/src/telemetry.rs
@@ -66,54 +66,29 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn sandbox_op_entry_serializes_correctly() {
-        let entry = SandboxOpEntry {
-            ts: "2026-01-01T00:00:00.000Z".to_string(),
-            action_type: "vm_create".to_string(),
-            duration_ms: 1500,
-            success: true,
-            error: None,
-        };
-        let json = serde_json::to_value(&entry).unwrap();
-        assert_eq!(json["ts"], "2026-01-01T00:00:00.000Z");
-        assert_eq!(json["action_type"], "vm_create");
-        assert_eq!(json["duration_ms"], 1500);
-        assert_eq!(json["success"], true);
-        assert!(json.get("error").is_none());
-    }
-
-    #[test]
-    fn sandbox_op_entry_with_error() {
-        let entry = SandboxOpEntry {
-            ts: "2026-01-01T00:00:00.000Z".to_string(),
-            action_type: "vm_create".to_string(),
-            duration_ms: 500,
-            success: false,
-            error: Some("timeout".to_string()),
-        };
-        let json = serde_json::to_value(&entry).unwrap();
-        assert_eq!(json["error"], "timeout");
-        assert!(!json["success"].as_bool().unwrap());
-    }
-
-    #[test]
-    fn record_sandbox_op_writes_jsonl() {
-        // Set VM0_RUN_ID to a test value to control the log file path.
-        // We write to the actual SANDBOX_OPS_LOG path, then verify.
+    fn record_sandbox_op_writes_and_appends_jsonl() {
+        // Single test because all calls share the same static log path.
         let log_path = sandbox_ops_log();
-        // Clean up any existing file
         let _ = std::fs::remove_file(log_path);
 
-        record_sandbox_op("test_op", Duration::from_millis(42), true, None);
+        record_sandbox_op("op_a", Duration::from_millis(10), true, None);
+        record_sandbox_op("op_b", Duration::from_millis(20), false, Some("fail"));
 
-        let content = std::fs::read_to_string(log_path).unwrap_or_default();
-        if !content.is_empty() {
-            let line = content.lines().last().unwrap();
-            let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
-            assert_eq!(parsed["action_type"], "test_op");
-            assert_eq!(parsed["duration_ms"], 42);
-            assert!(parsed["success"].as_bool().unwrap());
-        }
+        let content = std::fs::read_to_string(log_path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let a: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(a["action_type"], "op_a");
+        assert_eq!(a["duration_ms"], 10);
+        assert!(a["success"].as_bool().unwrap());
+        assert!(a["ts"].is_string());
+
+        let b: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(b["action_type"], "op_b");
+        assert_eq!(b["error"], "fail");
+        assert!(!b["success"].as_bool().unwrap());
+
         let _ = std::fs::remove_file(log_path);
     }
 }

--- a/crates/guest-common/src/telemetry.rs
+++ b/crates/guest-common/src/telemetry.rs
@@ -59,3 +59,61 @@ pub fn record_sandbox_op(
 
     let _ = writeln!(file, "{json}");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn sandbox_op_entry_serializes_correctly() {
+        let entry = SandboxOpEntry {
+            ts: "2026-01-01T00:00:00.000Z".to_string(),
+            action_type: "vm_create".to_string(),
+            duration_ms: 1500,
+            success: true,
+            error: None,
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["ts"], "2026-01-01T00:00:00.000Z");
+        assert_eq!(json["action_type"], "vm_create");
+        assert_eq!(json["duration_ms"], 1500);
+        assert_eq!(json["success"], true);
+        assert!(json.get("error").is_none());
+    }
+
+    #[test]
+    fn sandbox_op_entry_with_error() {
+        let entry = SandboxOpEntry {
+            ts: "2026-01-01T00:00:00.000Z".to_string(),
+            action_type: "vm_create".to_string(),
+            duration_ms: 500,
+            success: false,
+            error: Some("timeout".to_string()),
+        };
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["error"], "timeout");
+        assert!(!json["success"].as_bool().unwrap());
+    }
+
+    #[test]
+    fn record_sandbox_op_writes_jsonl() {
+        // Set VM0_RUN_ID to a test value to control the log file path.
+        // We write to the actual SANDBOX_OPS_LOG path, then verify.
+        let log_path = sandbox_ops_log();
+        // Clean up any existing file
+        let _ = std::fs::remove_file(log_path);
+
+        record_sandbox_op("test_op", Duration::from_millis(42), true, None);
+
+        let content = std::fs::read_to_string(log_path).unwrap_or_default();
+        if !content.is_empty() {
+            let line = content.lines().last().unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert_eq!(parsed["action_type"], "test_op");
+            assert_eq!(parsed["duration_ms"], 42);
+            assert!(parsed["success"].as_bool().unwrap());
+        }
+        let _ = std::fs::remove_file(log_path);
+    }
+}

--- a/crates/runner/src/dns.rs
+++ b/crates/runner/src/dns.rs
@@ -328,4 +328,49 @@ mod tests {
         let entry = parse_query_line(line).unwrap();
         assert_eq!(entry.source_ip, "10.200.0.2");
     }
+
+    #[test]
+    fn write_jsonl_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dns.jsonl");
+        let entry = DnsQueryEntry {
+            source_ip: "10.200.0.2".to_string(),
+            domain: "api.github.com".to_string(),
+        };
+        write_jsonl(&path, &entry);
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed["type"], "dns");
+        assert_eq!(parsed["host"], "api.github.com");
+        assert_eq!(parsed["port"], 53);
+        assert!(parsed["timestamp"].is_string());
+    }
+
+    #[test]
+    fn write_jsonl_appends_multiple_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dns.jsonl");
+        for domain in ["a.com", "b.com", "c.com"] {
+            write_jsonl(
+                &path,
+                &DnsQueryEntry {
+                    source_ip: "10.0.0.1".to_string(),
+                    domain: domain.to_string(),
+                },
+            );
+        }
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 3);
+        for (i, domain) in ["a.com", "b.com", "c.com"].iter().enumerate() {
+            let parsed: serde_json::Value = serde_json::from_str(lines[i]).unwrap();
+            assert_eq!(parsed["host"], *domain);
+        }
+    }
+
+    #[test]
+    fn find_available_port_returns_nonzero() {
+        let port = find_available_port().unwrap();
+        assert!(port > 0);
+    }
 }

--- a/crates/runner/src/retry.rs
+++ b/crates/runner/src/retry.rs
@@ -162,4 +162,69 @@ mod tests {
         assert_eq!(rs.backoff, Duration::from_secs(1));
         assert_eq!(rs.consecutive_failures, 0);
     }
+
+    #[test]
+    fn record_initial_failure_sets_state() {
+        let mut rs: RetryState<()> =
+            RetryState::new(Duration::from_secs(1), Duration::from_secs(60), None);
+        rs.record_initial_failure();
+        assert_eq!(rs.consecutive_failures(), 1);
+        assert!(rs.restart_at.is_some());
+    }
+
+    #[test]
+    fn timer_ready_requires_no_handle_and_past_restart() {
+        let mut rs: RetryState<()> =
+            RetryState::new(Duration::from_secs(0), Duration::from_secs(60), None);
+        // No restart_at → not ready
+        assert!(!rs.timer_ready());
+        // Set restart_at to now (backoff is 0s)
+        rs.schedule();
+        std::thread::sleep(Duration::from_millis(1));
+        assert!(rs.timer_ready());
+    }
+
+    #[test]
+    fn clear_timer_clears_restart_at() {
+        let mut rs: RetryState<()> =
+            RetryState::new(Duration::from_secs(0), Duration::from_secs(60), None);
+        rs.schedule();
+        assert!(rs.restart_at.is_some());
+        rs.clear_timer();
+        assert!(rs.restart_at.is_none());
+        assert!(!rs.timer_ready());
+    }
+
+    #[test]
+    fn backoff_doubles_up_to_max() {
+        let mut rs: RetryState<()> =
+            RetryState::new(Duration::from_secs(1), Duration::from_secs(8), None);
+        assert_eq!(rs.backoff(), Duration::from_secs(1));
+        let _ = rs.on_failure();
+        assert_eq!(rs.backoff(), Duration::from_secs(2));
+        let _ = rs.on_failure();
+        assert_eq!(rs.backoff(), Duration::from_secs(4));
+        let _ = rs.on_failure();
+        assert_eq!(rs.backoff(), Duration::from_secs(8));
+        let _ = rs.on_failure();
+        assert_eq!(rs.backoff(), Duration::from_secs(8)); // capped
+    }
+
+    #[test]
+    fn circuit_breaker_not_tripped_below_threshold() {
+        let mut rs: RetryState<()> =
+            RetryState::new(Duration::from_secs(1), Duration::from_secs(60), Some(3));
+        assert!(rs.on_failure()); // 1
+        assert!(rs.on_failure()); // 2
+        assert!(!rs.on_failure()); // 3 = max → trips
+    }
+
+    #[test]
+    fn no_circuit_breaker_when_none() {
+        let mut rs: RetryState<()> =
+            RetryState::new(Duration::from_secs(1), Duration::from_secs(60), None);
+        for _ in 0..100 {
+            assert!(rs.on_failure());
+        }
+    }
 }

--- a/crates/runner/src/retry.rs
+++ b/crates/runner/src/retry.rs
@@ -178,9 +178,8 @@ mod tests {
             RetryState::new(Duration::from_secs(0), Duration::from_secs(60), None);
         // No restart_at → not ready
         assert!(!rs.timer_ready());
-        // Set restart_at to now (backoff is 0s)
-        rs.schedule();
-        std::thread::sleep(Duration::from_millis(1));
+        // Set restart_at to the past so it's immediately ready.
+        rs.restart_at = Some(Instant::now() - Duration::from_secs(1));
         assert!(rs.timer_ready());
     }
 


### PR DESCRIPTION
## Summary
- Add tests across 6 files (319 lines) covering pure functions testable without hardware
- Improve overall Rust test coverage from 57.4% to 58.2% (+0.8pp, +308 lines)
- Key per-file improvements:
  - `guest-agent/metrics.rs`: 46.0% → 86.7%
  - `runner/retry.rs`: 70.2% → 87.0%
  - `runner/dns.rs`: 38.5% → 57.9%
  - `guest-agent/telemetry.rs`: 61.8% → 71.2%
  - `guest-common/telemetry.rs`: 92.6% → 95.6%
  - `guest-common/log.rs`: 100% (new tests added)

## Test plan
- [x] `cargo test -p runner -p guest-agent -p guest-common` — all 281 tests pass
- [x] `cargo clippy --all-targets --all-features` — no warnings
- [x] Coverage verified via `cargo llvm-cov`

🤖 Generated with [Claude Code](https://claude.com/claude-code)