### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -92,7 +92,7 @@ GO_VERSION="1.26.1"
 CLAUDE_CODE_VERSION="2.1.92"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.24.0"
+AGENT_BROWSER_VERSION="0.24.1"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Routine version bump for pinned packages in `crates/runner/scripts/build-rootfs.sh`.

| Package | Old Version | New Version |
|---------|-------------|-------------|
| `agent-browser` (npm) | 0.24.0 | 0.24.1 |

## Checked (no update needed)

- `go`: 1.26.1 — already latest stable
- `@anthropic-ai/claude-code`: 2.1.92 — already latest
- `@googleworkspace/cli`: 0.22.5 — already latest
- `@xdevplatform/xurl`: 1.0.3 — already latest