### PR TITLE
test(crates): add serde and env parsing tests for runner types and guest-init

### DIFF
--- a/crates/guest-init/src/init.rs
+++ b/crates/guest-init/src/init.rs
@@ -115,18 +115,12 @@ impl std::fmt::Display for InitError {
 
 impl std::error::Error for InitError {}
 
-/// Parse `/etc/environment` and set each `KEY=VALUE` pair via `set_var`.
+/// Parse environment file content into key-value pairs.
 ///
 /// Skips blank lines, comments, and lines without `=`.
-/// SAFETY: caller must ensure no other threads are running.
-unsafe fn load_etc_environment() {
-    let content = match fs::read_to_string("/etc/environment") {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("[guest-init] Warning: failed to read /etc/environment: {e}");
-            return;
-        }
-    };
+/// Values may be optionally wrapped in double quotes which are stripped.
+fn parse_env_content(content: &str) -> Vec<(&str, &str)> {
+    let mut pairs = Vec::new();
     for line in content.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
@@ -136,8 +130,100 @@ unsafe fn load_etc_environment() {
             let key = key.trim();
             let value = value.trim().trim_matches('"');
             if !key.is_empty() {
-                unsafe { std::env::set_var(key, value) };
+                pairs.push((key, value));
             }
         }
+    }
+    pairs
+}
+
+/// Parse `/etc/environment` and set each `KEY=VALUE` pair via `set_var`.
+///
+/// SAFETY: caller must ensure no other threads are running.
+unsafe fn load_etc_environment() {
+    let content = match fs::read_to_string("/etc/environment") {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[guest-init] Warning: failed to read /etc/environment: {e}");
+            return;
+        }
+    };
+    for (key, value) in parse_env_content(&content) {
+        unsafe { std::env::set_var(key, value) };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_env_basic() {
+        let content = "LANG=en_US.UTF-8\nPATH=/usr/bin:/bin";
+        let pairs = parse_env_content(content);
+        assert_eq!(
+            pairs,
+            vec![("LANG", "en_US.UTF-8"), ("PATH", "/usr/bin:/bin")]
+        );
+    }
+
+    #[test]
+    fn parse_env_quoted_values() {
+        let content = r#"FOO="bar baz""#;
+        let pairs = parse_env_content(content);
+        assert_eq!(pairs, vec![("FOO", "bar baz")]);
+    }
+
+    #[test]
+    fn parse_env_skips_comments_and_blanks() {
+        let content = "# comment\n\nKEY=value\n  \n# another comment\n";
+        let pairs = parse_env_content(content);
+        assert_eq!(pairs, vec![("KEY", "value")]);
+    }
+
+    #[test]
+    fn parse_env_skips_lines_without_equals() {
+        let content = "no_equals_sign\nGOOD=yes";
+        let pairs = parse_env_content(content);
+        assert_eq!(pairs, vec![("GOOD", "yes")]);
+    }
+
+    #[test]
+    fn parse_env_trims_whitespace() {
+        let content = "  KEY  =  value  ";
+        let pairs = parse_env_content(content);
+        assert_eq!(pairs, vec![("KEY", "value")]);
+    }
+
+    #[test]
+    fn parse_env_empty_value() {
+        let content = "EMPTY=";
+        let pairs = parse_env_content(content);
+        assert_eq!(pairs, vec![("EMPTY", "")]);
+    }
+
+    #[test]
+    fn parse_env_value_with_equals() {
+        let content = "NODE_EXTRA_CA_CERTS=/etc/ssl/ca.pem";
+        let pairs = parse_env_content(content);
+        assert_eq!(pairs, vec![("NODE_EXTRA_CA_CERTS", "/etc/ssl/ca.pem")]);
+    }
+
+    #[test]
+    fn parse_env_empty_key_skipped() {
+        let content = "=value";
+        let pairs = parse_env_content(content);
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn init_error_display() {
+        let err = InitError::Mount {
+            target: "/proc".into(),
+            source: nix::Error::EACCES,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("/proc"));
+        assert!(msg.contains("EACCES"));
     }
 }

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -237,6 +237,65 @@ mod tests {
     }
 
     #[test]
+    fn execution_context_all_optional_fields() {
+        let json = json!({
+            "runId": "550e8400-e29b-41d4-a716-446655440000",
+            "prompt": "analyze code",
+            "sandboxToken": "tok-456",
+            "workingDir": "/workspace",
+            "cliAgentType": "claude_code",
+            "appendSystemPrompt": "be concise",
+            "agentComposeVersionId": "sha256-abc",
+            "vars": {"API_KEY": "secret"},
+            "checkpointId": "660e8400-e29b-41d4-a716-446655440000",
+            "storageManifest": {
+                "storages": [{"mountPath": "/data", "archiveUrl": "https://s3/archive.tar.gz"}],
+                "artifact": {
+                    "mountPath": "/artifacts",
+                    "vasStorageName": "art-1",
+                    "vasVersionId": "v1"
+                },
+                "memory": {
+                    "mountPath": "/memory",
+                    "vasStorageName": "mem-1",
+                    "vasVersionId": "v2"
+                }
+            },
+            "environment": {"NODE_ENV": "production"},
+            "resumeSession": {"sessionId": "sess-1", "sessionHistory": "/tmp/history"},
+            "secretValues": ["s1", "s2"],
+            "encryptedSecrets": "enc-blob",
+            "secretConnectorMap": {"github": "oauth"},
+            "debugNoMockClaude": true,
+            "apiStartTime": 1700000000000.0,
+            "userTimezone": "America/New_York",
+            "memoryName": "project-mem",
+            "firewalls": [{
+                "name": "github",
+                "ref": "github",
+                "apis": [{"base": "https://api.github.com", "auth": {"headers": {}}}]
+            }],
+            "disallowedTools": ["CronCreate"],
+            "tools": ["Bash", "Read"],
+            "settings": "{\"hooks\":{}}",
+            "experimentalProfile": "browser"
+        });
+        let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
+        assert_eq!(ctx.append_system_prompt.as_deref(), Some("be concise"));
+        assert_eq!(ctx.vars.as_ref().unwrap()["API_KEY"], "secret");
+        assert_eq!(ctx.environment.as_ref().unwrap()["NODE_ENV"], "production");
+        assert_eq!(ctx.resume_session.as_ref().unwrap().session_id, "sess-1");
+        assert_eq!(ctx.secret_values.as_ref().unwrap().len(), 2);
+        assert_eq!(ctx.encrypted_secrets.as_deref(), Some("enc-blob"));
+        assert!(ctx.debug_no_mock_claude.unwrap());
+        assert_eq!(ctx.firewalls.as_ref().unwrap()[0].name, "github");
+        assert_eq!(ctx.disallowed_tools.as_ref().unwrap(), &["CronCreate"]);
+        assert_eq!(ctx.tools.as_ref().unwrap(), &["Bash", "Read"]);
+        assert_eq!(ctx.settings.as_deref(), Some("{\"hooks\":{}}"));
+        assert!(ctx.storage_manifest.is_some());
+    }
+
+    #[test]
     fn firewall_round_trip() {
         let fw = Firewall {
             name: "github".into(),

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -175,3 +175,152 @@ pub struct CompleteRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn poll_response_with_job() {
+        let json = json!({
+            "job": {
+                "runId": "550e8400-e29b-41d4-a716-446655440000",
+                "experimentalProfile": "browser"
+            }
+        });
+        let resp: PollResponse = serde_json::from_value(json).unwrap();
+        let job = resp.job.unwrap();
+        assert_eq!(
+            job.run_id,
+            "550e8400-e29b-41d4-a716-446655440000"
+                .parse::<Uuid>()
+                .unwrap()
+        );
+        assert_eq!(job.experimental_profile.as_deref(), Some("browser"));
+    }
+
+    #[test]
+    fn poll_response_no_job() {
+        let json = json!({ "job": null });
+        let resp: PollResponse = serde_json::from_value(json).unwrap();
+        assert!(resp.job.is_none());
+    }
+
+    #[test]
+    fn job_optional_profile_defaults_to_none() {
+        let json = json!({
+            "runId": "550e8400-e29b-41d4-a716-446655440000"
+        });
+        let job: Job = serde_json::from_value(json).unwrap();
+        assert!(job.experimental_profile.is_none());
+    }
+
+    #[test]
+    fn execution_context_minimal() {
+        let json = json!({
+            "runId": "550e8400-e29b-41d4-a716-446655440000",
+            "prompt": "hello",
+            "sandboxToken": "tok-123",
+            "workingDir": "/home/user",
+            "cliAgentType": "claude_code"
+        });
+        let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
+        assert_eq!(ctx.prompt, "hello");
+        assert_eq!(ctx.sandbox_token, "tok-123");
+        assert_eq!(ctx.working_dir, "/home/user");
+        assert_eq!(ctx.cli_agent_type, "claude_code");
+        assert!(ctx.append_system_prompt.is_none());
+        assert!(ctx.vars.is_none());
+        assert!(ctx.firewalls.is_none());
+        assert!(ctx.secret_values.is_none());
+    }
+
+    #[test]
+    fn firewall_round_trip() {
+        let fw = Firewall {
+            name: "github".into(),
+            ref_key: "github".into(),
+            apis: vec![FirewallApi {
+                id: "api-1".into(),
+                base: "https://api.github.com".into(),
+                auth: FirewallAuth {
+                    headers: [("Authorization".into(), "Bearer tok".into())]
+                        .into_iter()
+                        .collect(),
+                    base: None,
+                },
+                permissions: Some(vec![FirewallPermission {
+                    name: "metadata:read".into(),
+                    description: Some("read repo metadata".into()),
+                    rules: vec!["GET /repos/{owner}/{repo}".into()],
+                }]),
+            }],
+        };
+        let json = serde_json::to_value(&fw).unwrap();
+        // `ref_key` serializes as "ref"
+        assert_eq!(json["ref"], "github");
+        assert!(json.get("ref_key").is_none());
+        // round-trip
+        let deserialized: Firewall = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized.ref_key, "github");
+        assert_eq!(
+            deserialized.apis[0].permissions.as_ref().unwrap()[0].name,
+            "metadata:read"
+        );
+    }
+
+    #[test]
+    fn firewall_auth_base_omitted_when_none() {
+        let auth = FirewallAuth {
+            headers: HashMap::new(),
+            base: None,
+        };
+        let json = serde_json::to_value(&auth).unwrap();
+        assert!(json.get("base").is_none());
+    }
+
+    #[test]
+    fn complete_request_camel_case() {
+        let req = CompleteRequest {
+            run_id: "550e8400-e29b-41d4-a716-446655440000".parse().unwrap(),
+            exit_code: 0,
+            error: None,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json.get("runId").is_some());
+        assert!(json.get("exitCode").is_some());
+        // error omitted when None
+        assert!(json.get("error").is_none());
+    }
+
+    #[test]
+    fn complete_request_with_error() {
+        let req = CompleteRequest {
+            run_id: "550e8400-e29b-41d4-a716-446655440000".parse().unwrap(),
+            exit_code: 1,
+            error: Some("timeout".into()),
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["error"], "timeout");
+    }
+
+    #[test]
+    fn storage_manifest_camel_case() {
+        let json = json!({
+            "storages": [{"mountPath": "/workspace"}],
+            "artifact": {
+                "mountPath": "/artifacts",
+                "vasStorageName": "my-artifact",
+                "vasVersionId": "v1"
+            }
+        });
+        let manifest: StorageManifest = serde_json::from_value(json).unwrap();
+        assert_eq!(manifest.storages[0].mount_path, "/workspace");
+        assert_eq!(
+            manifest.artifact.as_ref().unwrap().vas_storage_name,
+            "my-artifact"
+        );
+        assert!(manifest.memory.is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- Add 9 serde round-trip tests for `runner/src/types.rs` covering camelCase renaming, `skip_serializing_if`, `rename = "ref"`, and default values for API contract types (PollResponse, Job, ExecutionContext, Firewall, CompleteRequest, StorageManifest)
- Add 9 tests for `guest-init/src/init.rs` by extracting `/etc/environment` parsing into a testable pure function (`parse_env_content`) and testing comment handling, quoted values, whitespace trimming, empty keys, and `InitError` Display

## Test plan
- [x] `cargo test -p runner types::tests` — 9 tests pass
- [x] `cargo test -p guest-init init::tests` — 9 tests pass
- [x] clippy + fmt pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)