### PR TITLE
fix: replace inline scroll anchor with per-message scroll controllers

### DIFF
--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -170,6 +170,62 @@ export function onRef<T extends HTMLElement | SVGSVGElement>(
 }
 
 /**
+ * Per-message scroll controller. Tracks whether auto-scroll is enabled and
+ * the DOM element to scroll into view. Call `scrollDown$` after each data
+ * insert; it awaits a requestAnimationFrame so the browser has painted before
+ * the scroll fires.
+ */
+export function createScrollController() {
+  const el$ = state<HTMLElement | null>(null);
+  const autoScroll$ = state(true);
+
+  const attachEl$ = command(
+    ({ set }, el: HTMLElement, signal: AbortSignal): void => {
+      set(el$, el);
+      signal.addEventListener(
+        "abort",
+        () => {
+          set(el$, null);
+        },
+        { once: true },
+      );
+    },
+  );
+
+  const onRef$ = onRef<HTMLElement>(attachEl$);
+
+  const scrollDown$ = command(async ({ get }): Promise<void> => {
+    if (!get(autoScroll$)) return;
+    const el = get(el$);
+    if (!el) return;
+    await new Promise<void>((r) => {
+      requestAnimationFrame(() => {
+        r();
+      });
+    });
+    if (!get(autoScroll$)) return;
+    el.scrollIntoView({ behavior: "instant", block: "end" });
+  });
+
+  const enable$ = command(({ set }): void => {
+    set(autoScroll$, true);
+  });
+
+  const disable$ = command(({ set }): void => {
+    set(autoScroll$, false);
+  });
+
+  return { onRef$, scrollDown$, enable$, disable$ };
+}
+
+/** Stable no-op ref for message rows that have no scroll controller. */
+export const noopOnRef$ = onRef<HTMLElement>(
+  command(
+    (_store, _el: HTMLElement, _signal: AbortSignal): void => {},
+  ),
+);
+
+/**
  * Create a deferred promise that can be resolved/rejected externally.
  * The promise is automatically rejected when the abort signal is triggered.
  */

--- a/turbo/apps/platform/src/signals/zero-page/polling.ts
+++ b/turbo/apps/platform/src/signals/zero-page/polling.ts
@@ -1,4 +1,4 @@
-import { command, computed, state, type Computed } from "ccstate";
+import { command, computed, state, type Command, type Computed } from "ccstate";
 import type { AgentEvent } from "./log-types.ts";
 import { delay } from "signal-timers";
 import {
@@ -168,7 +168,10 @@ const THINKING_MESSAGES = [
   "Just a moment...",
 ] as const;
 
-export function createRunLoop(runId: string) {
+export function createRunLoop(
+  runId: string,
+  afterDataInsert$?: Command<Promise<void> | void>,
+) {
   const {
     detail$: runDetail$,
     reload$: reloadRunStatus$,
@@ -242,6 +245,9 @@ export function createRunLoop(runId: string) {
 
       const lastPage = await get(nextPage$);
       signal.throwIfAborted();
+      if (afterDataInsert$) {
+        await set(afterDataInsert$);
+      }
       if (finished && !lastPage.hasMore) {
         break;
       }

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -1,6 +1,6 @@
 import { command, computed, state, type Computed } from "ccstate";
 import type { AgentEvent, LogStatus } from "./log-types.ts";
-import { resetSignal, throwIfAbort } from "../utils.ts";
+import { createScrollController, resetSignal, throwIfAbort } from "../utils.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { logger } from "../log.ts";
@@ -76,6 +76,7 @@ export interface UserChatMessage {
   content: string;
   attachments?: ZeroChatMessageAttachment[];
   createdAt?: string;
+  scrollController?: ReturnType<typeof createScrollController>;
 }
 
 export interface AssistantChatMessage {
@@ -91,6 +92,7 @@ export interface AssistantChatMessage {
   summaries$?: Computed<Promise<string[]>>;
   beginLoop$?: ReturnType<typeof createRunLoop>["beginLoop$"];
   createdAt?: string;
+  scrollController?: ReturnType<typeof createScrollController>;
 }
 
 export type ZeroChatMessage = UserChatMessage | AssistantChatMessage;
@@ -508,7 +510,8 @@ function createActiveRunMessage(
   runId: string,
   prompt: string,
 ): { userMessage: UserChatMessage; assistantMessage: AssistantChatMessage } {
-  const runLoop = createRunLoop(runId);
+  const scrollController = createScrollController();
+  const runLoop = createRunLoop(runId, scrollController.scrollDown$);
 
   const result$ = computed(async (get) => {
     const pages = await get(runLoop.pagedEventsList$);
@@ -536,6 +539,7 @@ function createActiveRunMessage(
       result$,
       summaries$,
       beginLoop$: runLoop.beginLoop$,
+      scrollController,
     },
   };
 }
@@ -897,10 +901,12 @@ const prepareUserMessage$ = command(
               };
             })
           : undefined,
+      scrollController: createScrollController(),
     };
     set(internalLocalMessages$, (prev) => {
       return [...prev, userMessage];
     });
+    void set(userMessage.scrollController.scrollDown$);
 
     // Clear the draft after preparing the message
     if (draft) {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -30,7 +30,8 @@ import {
 } from "@vm0/ui";
 import { RUN_ERROR_GUIDANCE } from "@vm0/core";
 import { Markdown } from "../components/markdown.tsx";
-import { detach, Reason } from "../../signals/utils.ts";
+import { detach, noopOnRef$, Reason } from "../../signals/utils.ts";
+import { appStore } from "../../signals/app-store.ts";
 import { FileAttachmentChip, ImageLightbox } from "./zero-attachment-chips.tsx";
 import {
   lightboxUrl$ as attachmentLightboxUrl$,
@@ -70,6 +71,7 @@ import {
 import { useAgentAvatar } from "./zero-sidebar-shared.tsx";
 import { zeroSubagents$ } from "../../signals/zero-page/zero-agents.ts";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
+import { useRef } from "react";
 function AvatarOrPlaceholder({
   src,
   className,
@@ -263,10 +265,19 @@ export function ZeroChatThreadPage() {
       : null;
   const messagesLoading = messagesLoadable.state === "loading";
 
-  // Auto-scroll when messages change — ref callback runs at commit time
-  const scrollAnchorRef = (el: HTMLDivElement | null) => {
-    if (el && messages.length > 0) {
-      el.scrollIntoView({ behavior: "instant" });
+  const atBottomRef = useRef(true);
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+    if (atBottom === atBottomRef.current) return;
+    atBottomRef.current = atBottom;
+    for (const msg of messages) {
+      const ctrl = msg.scrollController;
+      if (!ctrl) continue;
+      detach(
+        appStore.set(atBottom ? ctrl.enable$ : ctrl.disable$),
+        Reason.DomCallback,
+      );
     }
   };
 
@@ -275,7 +286,7 @@ export function ZeroChatThreadPage() {
       <ChatThreadHeader />
 
       {/* Scrollable area — messages + sticky composer share the same scroll context */}
-      <div className="flex-1 overflow-auto flex flex-col min-h-0">
+      <div className="flex-1 overflow-auto flex flex-col min-h-0" onScroll={handleScroll}>
         <main className="flex-1 px-4 sm:px-6 py-4 items-center @container">
           <div className="w-full max-w-[900px] mx-auto flex flex-1 flex-col gap-6 pb-4 overflow-visible">
             {sessionError && (
@@ -299,7 +310,6 @@ export function ZeroChatThreadPage() {
             {messages.map((msg) => {
               return <ChatMessageRow key={msg.id} message={msg} />;
             })}
-            <div ref={scrollAnchorRef} />
           </div>
         </main>
 
@@ -393,10 +403,19 @@ function ChatSkeleton() {
 // ---------------------------------------------------------------------------
 
 function ChatMessageRow({ message }: { message: ZeroChatMessage }) {
+  const setRef = useSet(message.scrollController?.onRef$ ?? noopOnRef$);
   if (message.role === "user") {
-    return <UserMessage message={message} />;
+    return (
+      <div ref={setRef}>
+        <UserMessage message={message} />
+      </div>
+    );
   }
-  return <AssistantMessage message={message} />;
+  return (
+    <div ref={setRef}>
+      <AssistantMessage message={message} />
+    </div>
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

After sending a message, the chat page scrolled to a middle/incorrect position instead of the bottom. Two root causes:

1. **`scrollAnchorRef` was an inline function**, so it was recreated on every render. React treats changed ref callbacks as unmount+remount, calling `scrollIntoView` on every single render — including all intermediate states during streaming.
2. **`scrollIntoView({ behavior: "instant" })` defaults to `block: "start"`**, which aligns the anchor's top to the viewport top. Since the anchor sits between the message list and the sticky composer, this landed the scroll at an incorrect middle position.

## Solution

Replace the global anchor with per-message scroll controllers.

### `signals/utils.ts` — `createScrollController()`
Each locally-created message gets its own controller with:
- `onRef$` — binds the message row's DOM element via the existing `onRef` utility
- `scrollDown$` — awaits a `requestAnimationFrame`, then calls `scrollIntoView({ block: "end" })` so the bottom of the message aligns with the viewport bottom
- `enable$` / `disable$` — toggled by the container's scroll handler
- `noopOnRef$` — stable singleton fallback for historical messages without a controller

### `signals/zero-page/polling.ts`
`createRunLoop` accepts an optional `afterDataInsert$` command. It's called after each event page is fetched, triggering scroll once the data is available and the rAF fires.

### `signals/zero-page/zero-chat.ts`
- `createActiveRunMessage` creates a `scrollController` and passes `scrollDown$` to `createRunLoop`
- `prepareUserMessage$` creates a controller for the user's outgoing message and fires an initial `scrollDown$` so the new message is immediately visible

### `views/zero-page/zero-chat-thread-page.tsx`
- Removes `scrollAnchorRef` and the anchor div
- Adds `onScroll` to the scroll container; uses a `useRef` guard so `enable$`/`disable$` are only dispatched when the at-bottom state *changes* (not on every scroll pixel)
- `ChatMessageRow` attaches `setRef` to a wrapper div on every row (noop for rows without a controller)

## Test plan
- [ ] Send a message in an existing thread — page scrolls to bottom showing the new message
- [ ] Streaming response — page tracks the bottom of the growing message
- [ ] Scroll up during streaming — auto-scroll disables, page stays in place
- [ ] Scroll back to the bottom — auto-scroll re-enables on next poll cycle
- [ ] Historical threads load and scroll to bottom correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)