### PR TITLE
fix: prevent ngrok resource leaks in computer-use and connector services

### DIFF
--- a/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
@@ -190,6 +190,27 @@ describe("POST /api/zero/computer-use/register", () => {
     expect(ngrokCalls.createEndpoint.length).toBe(1);
   });
 
+  it("should clean up resources when endpoint creation fails", async () => {
+    const userId = uniqueId("zcu-fail");
+    await setupOrg(userId);
+    const ngrokCalls = setupNgrokMocks();
+
+    // Override endpoint creation to fail
+    server.use(
+      http.post("https://api.ngrok.com/endpoints", () => {
+        return HttpResponse.json({ error: "internal error" }, { status: 500 });
+      }),
+    );
+
+    const response = await POST(createPostRequest());
+    expect(response.status).toBe(500);
+
+    // Verify all previously-created resources were cleaned up
+    expect(ngrokCalls.deleteBotUser).toEqual(["bot_test_cu_123"]);
+    expect(ngrokCalls.deleteCredential).toEqual(["cr_test_cu_456"]);
+    expect(ngrokCalls.deleteReservedDomain).toEqual(["rd_test_cu_abc"]);
+  });
+
   it("should return 200 on re-registration (idempotent)", async () => {
     const userId = uniqueId("zcu-dup");
     await setupOrg(userId);

--- a/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
@@ -60,6 +60,7 @@ function setupNgrokMocks() {
     deleteEndpoint: [] as string[],
     createReservedDomain: [] as string[],
     deleteReservedDomain: [] as string[],
+    deleteBotUser: [] as string[],
   };
 
   server.use(
@@ -127,6 +128,10 @@ function setupNgrokMocks() {
     }),
     http.delete("https://api.ngrok.com/endpoints/:id", ({ params }) => {
       calls.deleteEndpoint.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.delete("https://api.ngrok.com/bot_users/:id", ({ params }) => {
+      calls.deleteBotUser.push(params.id as string);
       return new HttpResponse(null, { status: 204 });
     }),
   );
@@ -299,6 +304,7 @@ describe("DELETE /api/zero/computer-use/unregister", () => {
     expect(ngrokCalls.deleteCredential).toEqual(["cr_test_cu_456"]);
     expect(ngrokCalls.deleteEndpoint).toEqual(["ep_test_cu_789"]);
     expect(ngrokCalls.deleteReservedDomain).toEqual(["rd_test_cu_abc"]);
+    expect(ngrokCalls.deleteBotUser).toEqual(["bot_test_cu_123"]);
 
     // Verify GET returns 404 after unregister
     const getResponse = await GET(createTestRequest(hostUrl()));

--- a/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
@@ -163,6 +163,27 @@ describe("POST /api/zero/connectors/computer", () => {
     expect(ngrokCalls.createEndpoint.length).toBe(1);
   });
 
+  it("should clean up resources when endpoint creation fails", async () => {
+    const userId = uniqueId("zcomp-fail");
+    await setupOrg(userId);
+    const ngrokCalls = setupNgrokMocks();
+
+    // Override endpoint creation to fail
+    server.use(
+      http.post("https://api.ngrok.com/endpoints", () => {
+        return HttpResponse.json({ error: "internal error" }, { status: 500 });
+      }),
+    );
+
+    const response = await POST(createPostRequest());
+    expect(response.status).toBe(500);
+
+    // Verify all previously-created resources were cleaned up
+    expect(ngrokCalls.deleteBotUser).toEqual(["bot_test_123"]);
+    expect(ngrokCalls.deleteCredential).toEqual(["cr_test_456"]);
+    expect(ngrokCalls.deleteReservedDomain).toEqual(["rd_test_abc"]);
+  });
+
   it("should return 409 if connector already exists", async () => {
     const userId = uniqueId("zcomp-dup");
     await setupOrg(userId);

--- a/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
@@ -34,8 +34,10 @@ function setupNgrokMocks() {
     deleteCredential: [] as string[],
     createEndpoint: [] as string[],
     deleteEndpoint: [] as string[],
+    listReservedDomains: 0,
     createReservedDomain: [] as string[],
     deleteReservedDomain: [] as string[],
+    deleteBotUser: [] as string[],
   };
 
   server.use(
@@ -69,6 +71,13 @@ function setupNgrokMocks() {
       calls.deleteCredential.push(params.id as string);
       return new HttpResponse(null, { status: 204 });
     }),
+    http.get("https://api.ngrok.com/reserved_domains", () => {
+      calls.listReservedDomains++;
+      return HttpResponse.json({
+        reserved_domains: [],
+        next_page_uri: null,
+      });
+    }),
     http.post("https://api.ngrok.com/reserved_domains", async ({ request }) => {
       const body = (await request.json()) as {
         name: string;
@@ -96,6 +105,10 @@ function setupNgrokMocks() {
     }),
     http.delete("https://api.ngrok.com/endpoints/:id", ({ params }) => {
       calls.deleteEndpoint.push(params.id as string);
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.delete("https://api.ngrok.com/bot_users/:id", ({ params }) => {
+      calls.deleteBotUser.push(params.id as string);
       return new HttpResponse(null, { status: 204 });
     }),
   );
@@ -238,6 +251,7 @@ describe("DELETE /api/zero/connectors/computer", () => {
     expect(ngrokCalls.deleteCredential).toEqual(["cr_test_456"]);
     expect(ngrokCalls.deleteEndpoint).toEqual(["ep_test_789"]);
     expect(ngrokCalls.deleteReservedDomain).toEqual(["rd_test_abc"]);
+    expect(ngrokCalls.deleteBotUser).toEqual(["bot_test_123"]);
 
     // Verify GET returns 404
     const getResponse = await GET(createTestRequest(computerUrl()));

--- a/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
@@ -19,8 +19,10 @@ import {
   deleteCredential,
   createCloudEndpoint,
   deleteCloudEndpoint,
-  createReservedDomain,
+  findOrCreateReservedDomain,
   deleteReservedDomain,
+  deleteBotUser,
+  safeDelete,
 } from "./ngrok-client";
 
 const log = logger("service:computer-connector");
@@ -68,149 +70,185 @@ export async function createComputerConnector(
 
   const botUserName = `vm0-user-${slug}`;
 
-  // Provision ngrok resources
-  const botUser = await findOrCreateBotUser(apiKey, botUserName);
-  const credential = await createCredential(apiKey, botUser.id, [
-    `bind:*.${endpointPrefix}.internal`,
-  ]);
+  // Provision ngrok resources — clean up on partial failure
+  let botUserId: string | undefined;
+  let credentialId: string | undefined;
+  let domainId: string | undefined;
+  let endpointId: string | undefined;
+  let connectorRowId: string | undefined;
 
-  // Create reserved domain - ngrok will assign: {subdomainName}.ngrok-free.app
-  const reservedDomain = await createReservedDomain(
-    apiKey,
-    subdomainName,
-    "us",
-  );
-  const domain = reservedDomain.domain; // e.g., "vm0-user-abc12345.ngrok-free.app"
-
-  const bridgeToken = randomUUID();
-
-  // Create Cloud Endpoint with traffic policy
-  // Create traffic policy to verify bridge token and forward to internal endpoint
-  // Domain format: *.vm0-user-abc12345.ngrok-free.app
-  // Service URLs: test.vm0-user-abc12345.ngrok-free.app, api.vm0-user-abc12345.ngrok-free.app, etc.
-  const trafficPolicy = JSON.stringify({
-    on_http_request: [
-      {
-        // Deny if no x-vm0-token or token doesn't match
-        expressions: [
-          `!('x-vm0-token' in req.headers) || req.headers['x-vm0-token'][0] != '${bridgeToken}'`,
-        ],
-        actions: [{ type: "deny", config: { status_code: 403 } }],
-      },
-      {
-        actions: [
-          {
-            type: "forward-internal",
-            config: {
-              // Extract service name from subdomain
-              // e.g., test.vm0-user-abc12345.ngrok-free.app → test.vm0-user-{orgId}.internal
-              // The full endpointPrefix (vm0-user-{orgId}) is used for ACL matching
-              url: `https://$\{conn.server_name.split('.${domain}')[0]}.${endpointPrefix}.internal`,
-              on_error: "continue",
-            },
-          },
-          {
-            type: "custom-response",
-            config: { status_code: 502, body: "Agent offline" },
-          },
-        ],
-      },
-    ],
-  });
-
-  // Create cloud endpoint with wildcard subdomain
-  // Format: https://*.vm0-user-abc12345.ngrok-free.app
-  const endpointUrl = `https://*.${domain}`;
-  const cloudEndpoint = await createCloudEndpoint(
-    apiKey,
-    endpointUrl,
-    trafficPolicy,
-  );
-
-  // Create connector row
-  // Store ngrok resource IDs:
-  // - externalId: Bot User ID
-  // - externalUsername: Credential ID
-  // - externalEmail: Cloud Endpoint ID
-  // - oauthScopes: null (not used for computer connector)
-  const db = globalThis.services.db;
-  const [connectorRow] = await db
-    .insert(connectors)
-    .values({
-      userId,
-      orgId,
-      type: "computer",
-      authMethod: "api",
-      externalId: botUser.id,
-      externalUsername: credential.id,
-      externalEmail: cloudEndpoint.id,
-      oauthScopes: null,
-    })
-    .returning();
-
-  if (!connectorRow) {
-    throw new Error("Failed to create connector");
-  }
-
-  // Store secrets (ngrok token is one-time use, returned to client only)
-  await Promise.all([
-    upsertSecretByOrg(
-      orgId,
-      userId,
-      "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
-      bridgeToken,
-      "connector",
-      "Computer connector: COMPUTER_CONNECTOR_BRIDGE_TOKEN",
-    ),
-    upsertSecretByOrg(
-      orgId,
-      userId,
-      "COMPUTER_CONNECTOR_DOMAIN_ID",
-      reservedDomain.id,
-      "connector",
-      "Computer connector: COMPUTER_CONNECTOR_DOMAIN_ID",
-    ),
-    upsertSecretByOrg(
-      orgId,
-      userId,
-      "COMPUTER_CONNECTOR_DOMAIN",
-      domain,
-      "connector",
-      "Computer connector: COMPUTER_CONNECTOR_DOMAIN",
-    ),
-  ]);
-
-  log.debug("Computer connector created", {
-    connectorId: connectorRow.id,
-    botUserId: botUser.id,
-    domain,
-  });
-
-  return {
-    id: connectorRow.id,
-    ngrokToken: credential.token,
-    bridgeToken,
-    endpointPrefix,
-    domain,
-  };
-}
-
-/**
- * Helper to safely delete ngrok resource, ignoring 404 errors.
- */
-async function safeDeleteNgrokResource(
-  deleteFn: () => Promise<void>,
-  resourceName: string,
-  resourceId: string,
-): Promise<void> {
   try {
-    await deleteFn();
-  } catch (error) {
-    if (error instanceof Error && error.message.includes("404")) {
-      log.debug(`${resourceName} already deleted`, { id: resourceId });
-    } else {
-      throw error;
+    const botUser = await findOrCreateBotUser(apiKey, botUserName);
+    botUserId = botUser.id;
+
+    const credential = await createCredential(apiKey, botUser.id, [
+      `bind:*.${endpointPrefix}.internal`,
+    ]);
+    credentialId = credential.id;
+
+    const reservedDomain = await findOrCreateReservedDomain(
+      apiKey,
+      subdomainName,
+      "us",
+    );
+    const domain = reservedDomain.domain; // e.g., "vm0-user-abc12345.ngrok-free.app"
+    domainId = reservedDomain.id;
+
+    const bridgeToken = randomUUID();
+
+    // Traffic policy: verify bridge token and forward to internal endpoint
+    const trafficPolicy = JSON.stringify({
+      on_http_request: [
+        {
+          expressions: [
+            `!('x-vm0-token' in req.headers) || req.headers['x-vm0-token'][0] != '${bridgeToken}'`,
+          ],
+          actions: [{ type: "deny", config: { status_code: 403 } }],
+        },
+        {
+          actions: [
+            {
+              type: "forward-internal",
+              config: {
+                url: `https://$\{conn.server_name.split('.${domain}')[0]}.${endpointPrefix}.internal`,
+                on_error: "continue",
+              },
+            },
+            {
+              type: "custom-response",
+              config: { status_code: 502, body: "Agent offline" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const endpointUrl = `https://*.${domain}`;
+    const cloudEndpoint = await createCloudEndpoint(
+      apiKey,
+      endpointUrl,
+      trafficPolicy,
+    );
+    endpointId = cloudEndpoint.id;
+
+    // Create connector row
+    const db = globalThis.services.db;
+    const [connectorRow] = await db
+      .insert(connectors)
+      .values({
+        userId,
+        orgId,
+        type: "computer",
+        authMethod: "api",
+        externalId: botUserId,
+        externalUsername: credentialId,
+        externalEmail: cloudEndpoint.id,
+        oauthScopes: null,
+      })
+      .returning();
+
+    if (!connectorRow) {
+      throw new Error("Failed to create connector");
     }
+    connectorRowId = connectorRow.id;
+
+    // Store secrets (ngrok token is one-time use, returned to client only)
+    await Promise.all([
+      upsertSecretByOrg(
+        orgId,
+        userId,
+        "COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+        bridgeToken,
+        "connector",
+        "Computer connector: COMPUTER_CONNECTOR_BRIDGE_TOKEN",
+      ),
+      upsertSecretByOrg(
+        orgId,
+        userId,
+        "COMPUTER_CONNECTOR_DOMAIN_ID",
+        domainId,
+        "connector",
+        "Computer connector: COMPUTER_CONNECTOR_DOMAIN_ID",
+      ),
+      upsertSecretByOrg(
+        orgId,
+        userId,
+        "COMPUTER_CONNECTOR_DOMAIN",
+        domain,
+        "connector",
+        "Computer connector: COMPUTER_CONNECTOR_DOMAIN",
+      ),
+    ]);
+
+    log.debug("Computer connector created", {
+      connectorId: connectorRow.id,
+      botUserId,
+      domain,
+    });
+
+    return {
+      id: connectorRow.id,
+      ngrokToken: credential.token,
+      bridgeToken,
+      endpointPrefix,
+      domain,
+    };
+  } catch (error) {
+    // Clean up any resources created before the failure (best-effort to avoid masking original error)
+    log.error("Failed to create computer connector, cleaning up", { orgId });
+    const eid = endpointId;
+    const cid = credentialId;
+    const did = domainId;
+    const bid = botUserId;
+    const rid = connectorRowId;
+    if (eid) {
+      await safeDelete(
+        () => {
+          return deleteCloudEndpoint(apiKey, eid);
+        },
+        "Cloud endpoint",
+        eid,
+        true,
+      );
+    }
+    if (cid) {
+      await safeDelete(
+        () => {
+          return deleteCredential(apiKey, cid);
+        },
+        "Credential",
+        cid,
+        true,
+      );
+    }
+    if (did) {
+      await safeDelete(
+        () => {
+          return deleteReservedDomain(apiKey, did);
+        },
+        "Reserved domain",
+        did,
+        true,
+      );
+    }
+    if (bid) {
+      await safeDelete(
+        () => {
+          return deleteBotUser(apiKey, bid);
+        },
+        "Bot user",
+        bid,
+        true,
+      );
+    }
+    if (rid) {
+      const db = globalThis.services.db;
+      await db
+        .delete(connectors)
+        .where(eq(connectors.id, rid))
+        .catch(() => {});
+    }
+    throw error;
   }
 }
 
@@ -226,9 +264,9 @@ export async function deleteComputerConnector(
   const [connector] = await db
     .select({
       id: connectors.id,
+      externalId: connectors.externalId,
       externalUsername: connectors.externalUsername,
       externalEmail: connectors.externalEmail,
-      oauthScopes: connectors.oauthScopes,
     })
     .from(connectors)
     .where(
@@ -248,7 +286,7 @@ export async function deleteComputerConnector(
 
   // Delete ngrok resources (ignore 404 errors if already deleted)
   if (apiKey && connector.externalUsername) {
-    await safeDeleteNgrokResource(
+    await safeDelete(
       () => {
         return deleteCredential(apiKey, connector.externalUsername!);
       },
@@ -258,7 +296,7 @@ export async function deleteComputerConnector(
   }
 
   if (apiKey && connector.externalEmail) {
-    await safeDeleteNgrokResource(
+    await safeDelete(
       () => {
         return deleteCloudEndpoint(apiKey, connector.externalEmail!);
       },
@@ -289,12 +327,23 @@ export async function deleteComputerConnector(
         encryptionKey,
       );
 
-      await safeDeleteNgrokResource(
+      await safeDelete(
         () => {
           return deleteReservedDomain(apiKey, domainId);
         },
         "Reserved domain",
         domainId,
+      );
+    }
+
+    // Delete Bot User last (other resources depend on it)
+    if (connector.externalId) {
+      await safeDelete(
+        () => {
+          return deleteBotUser(apiKey, connector.externalId!);
+        },
+        "Bot user",
+        connector.externalId,
       );
     }
   }

--- a/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
@@ -190,7 +190,7 @@ export async function deleteCloudEndpoint(
  * @param region - Region (e.g., "us", "eu", "ap", "au", "sa", "jp", "in")
  * @returns The created reserved domain
  */
-export async function createReservedDomain(
+async function createReservedDomain(
   apiKey: string,
   name: string,
   region: string = "us",
@@ -273,4 +273,44 @@ export async function deleteReservedDomain(
   await ngrokFetch(apiKey, `/reserved_domains/${domainId}`, {
     method: "DELETE",
   });
+}
+
+/**
+ * Delete a Bot User by ID.
+ */
+export async function deleteBotUser(
+  apiKey: string,
+  botUserId: string,
+): Promise<void> {
+  await ngrokFetch(apiKey, `/bot_users/${botUserId}`, {
+    method: "DELETE",
+  });
+}
+
+/**
+ * Safely delete an ngrok resource, ignoring 404 (already deleted).
+ *
+ * @param bestEffort - If true, log and swallow all errors (use in cleanup-on-failure paths
+ *   to avoid masking the original error). If false (default), only swallow 404.
+ */
+export async function safeDelete(
+  deleteFn: () => Promise<void>,
+  resourceName: string,
+  resourceId: string,
+  bestEffort = false,
+): Promise<void> {
+  try {
+    await deleteFn();
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("404")) {
+      log.debug(`${resourceName} already deleted`, { id: resourceId });
+    } else if (bestEffort) {
+      log.warn(`Failed to clean up ${resourceName}`, {
+        id: resourceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } else {
+      throw error;
+    }
+  }
 }

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -17,6 +17,8 @@ import {
   deleteCloudEndpoint,
   findOrCreateReservedDomain,
   deleteReservedDomain,
+  deleteBotUser,
+  safeDelete,
 } from "../computer-connector/ngrok-client";
 
 const log = logger("service:computer-use");
@@ -69,7 +71,7 @@ export async function registerHost(
 
     // Delete credential and endpoint (need new token + routing), keep domain
     if (existing.ngrokCredentialId) {
-      await safeDeleteNgrokResource(
+      await safeDelete(
         () => {
           return deleteCredential(apiKey, existing.ngrokCredentialId!);
         },
@@ -78,7 +80,7 @@ export async function registerHost(
       );
     }
     if (existing.ngrokEndpointId) {
-      await safeDeleteNgrokResource(
+      await safeDelete(
         () => {
           return deleteCloudEndpoint(apiKey, existing.ngrokEndpointId!);
         },
@@ -106,116 +108,154 @@ export async function registerHost(
   const endpointPrefix = `vm0-cu-${slug}`;
   const botUserName = `vm0-cu-${slug}`;
 
-  // Provision ngrok resources
-  const botUser = await findOrCreateBotUser(apiKey, botUserName);
-  const credential = await createCredential(apiKey, botUser.id, [
-    `bind:*.${endpointPrefix}.internal`,
-  ]);
+  // Provision ngrok resources — clean up on partial failure
+  let botUserId: string | undefined;
+  let credentialId: string | undefined;
+  let domainId: string | undefined;
+  let endpointId: string | undefined;
 
-  // Reuse existing domain or create new one
-  let domain: string;
-  let domainId: string;
-  if (reusableDomain) {
-    domain = reusableDomain.domain;
-    domainId = reusableDomain.id;
-    log.debug("Reusing existing reserved domain", { domain, domainId });
-  } else {
-    const reservedDomain = await findOrCreateReservedDomain(
-      apiKey,
-      subdomainName,
-      "us",
-    );
-    domain = reservedDomain.domain;
-    domainId = reservedDomain.id;
-  }
+  try {
+    const botUser = await findOrCreateBotUser(apiKey, botUserName);
+    botUserId = botUser.id;
 
-  const bridgeToken = randomUUID();
+    const credential = await createCredential(apiKey, botUser.id, [
+      `bind:*.${endpointPrefix}.internal`,
+    ]);
+    credentialId = credential.id;
 
-  // Traffic policy: verify bridge token and forward to internal endpoint
-  const trafficPolicy = JSON.stringify({
-    on_http_request: [
-      {
-        expressions: [
-          `!('x-vm0-token' in req.headers) || req.headers['x-vm0-token'][0] != '${bridgeToken}'`,
-        ],
-        actions: [{ type: "deny", config: { status_code: 403 } }],
-      },
-      {
-        actions: [
-          {
-            type: "forward-internal",
-            config: {
-              url: `https://$\{conn.server_name.split('.${domain}')[0]}.${endpointPrefix}.internal`,
-              on_error: "continue",
+    // Reuse existing domain or create new one
+    let domain: string;
+    if (reusableDomain) {
+      domain = reusableDomain.domain;
+      domainId = reusableDomain.id;
+      log.debug("Reusing existing reserved domain", { domain, domainId });
+    } else {
+      const reservedDomain = await findOrCreateReservedDomain(
+        apiKey,
+        subdomainName,
+        "us",
+      );
+      domain = reservedDomain.domain;
+      domainId = reservedDomain.id;
+    }
+
+    const bridgeToken = randomUUID();
+
+    // Traffic policy: verify bridge token and forward to internal endpoint
+    const trafficPolicy = JSON.stringify({
+      on_http_request: [
+        {
+          expressions: [
+            `!('x-vm0-token' in req.headers) || req.headers['x-vm0-token'][0] != '${bridgeToken}'`,
+          ],
+          actions: [{ type: "deny", config: { status_code: 403 } }],
+        },
+        {
+          actions: [
+            {
+              type: "forward-internal",
+              config: {
+                url: `https://$\{conn.server_name.split('.${domain}')[0]}.${endpointPrefix}.internal`,
+                on_error: "continue",
+              },
             },
-          },
-          {
-            type: "custom-response",
-            config: { status_code: 502, body: "Host offline" },
-          },
-        ],
-      },
-    ],
-  });
+            {
+              type: "custom-response",
+              config: { status_code: 502, body: "Host offline" },
+            },
+          ],
+        },
+      ],
+    });
 
-  const endpointUrl = `https://*.${domain}`;
-  const cloudEndpoint = await createCloudEndpoint(
-    apiKey,
-    endpointUrl,
-    trafficPolicy,
-  );
+    const endpointUrl = `https://*.${domain}`;
+    const cloudEndpoint = await createCloudEndpoint(
+      apiKey,
+      endpointUrl,
+      trafficPolicy,
+    );
+    endpointId = cloudEndpoint.id;
 
-  // Create host row
-  const [hostRow] = await db
-    .insert(computerUseHosts)
-    .values({
-      orgId,
-      userId,
+    // Create host row
+    const [hostRow] = await db
+      .insert(computerUseHosts)
+      .values({
+        orgId,
+        userId,
+        domain,
+        token: bridgeToken,
+        ngrokBotUserId: botUserId,
+        ngrokCredentialId: credentialId,
+        ngrokEndpointId: cloudEndpoint.id,
+        ngrokDomainId: domainId,
+        expiresAt: new Date(Date.now() + HOST_TTL_MS),
+      })
+      .returning();
+
+    if (!hostRow) {
+      throw new Error("Failed to create computer-use host");
+    }
+
+    log.debug("Computer-use host registered", {
+      hostId: hostRow.id,
+      botUserId,
+      domain,
+    });
+
+    return {
+      id: hostRow.id,
       domain,
       token: bridgeToken,
-      ngrokBotUserId: botUser.id,
-      ngrokCredentialId: credential.id,
-      ngrokEndpointId: cloudEndpoint.id,
-      ngrokDomainId: domainId,
-      expiresAt: new Date(Date.now() + HOST_TTL_MS),
-    })
-    .returning();
-
-  if (!hostRow) {
-    throw new Error("Failed to create computer-use host");
-  }
-
-  log.debug("Computer-use host registered", {
-    hostId: hostRow.id,
-    botUserId: botUser.id,
-    domain,
-  });
-
-  return {
-    id: hostRow.id,
-    domain,
-    token: bridgeToken,
-    ngrokToken: credential.token,
-    endpointPrefix,
-  };
-}
-
-/**
- * Helper to safely delete ngrok resource, ignoring 404 errors.
- */
-async function safeDeleteNgrokResource(
-  deleteFn: () => Promise<void>,
-  resourceName: string,
-  resourceId: string,
-): Promise<void> {
-  try {
-    await deleteFn();
+      ngrokToken: credential.token,
+      endpointPrefix,
+    };
   } catch (error) {
-    if (error instanceof Error && error.message.includes("404")) {
-      log.debug(`${resourceName} already deleted`, { id: resourceId });
-    } else {
-      throw error;
+    log.error("Failed to register host, cleaning up", { orgId, userId });
+    const eid = endpointId;
+    const cid = credentialId;
+    const did = domainId;
+    const bid = botUserId;
+    if (eid) {
+      await safeDelete(
+        () => {
+          return deleteCloudEndpoint(apiKey, eid);
+        },
+        "Cloud endpoint",
+        eid,
+        true,
+      );
     }
+    if (cid) {
+      await safeDelete(
+        () => {
+          return deleteCredential(apiKey, cid);
+        },
+        "Credential",
+        cid,
+        true,
+      );
+    }
+    if (did && !reusableDomain) {
+      await safeDelete(
+        () => {
+          return deleteReservedDomain(apiKey, did);
+        },
+        "Reserved domain",
+        did,
+        true,
+      );
+    }
+    if (bid) {
+      await safeDelete(
+        () => {
+          return deleteBotUser(apiKey, bid);
+        },
+        "Bot user",
+        bid,
+        true,
+      );
+    }
+    throw error;
   }
 }
 
@@ -247,7 +287,7 @@ export async function unregisterHost(
 
   if (apiKey) {
     if (host.ngrokCredentialId) {
-      await safeDeleteNgrokResource(
+      await safeDelete(
         () => {
           return deleteCredential(apiKey, host.ngrokCredentialId!);
         },
@@ -257,7 +297,7 @@ export async function unregisterHost(
     }
 
     if (host.ngrokEndpointId) {
-      await safeDeleteNgrokResource(
+      await safeDelete(
         () => {
           return deleteCloudEndpoint(apiKey, host.ngrokEndpointId!);
         },
@@ -267,12 +307,22 @@ export async function unregisterHost(
     }
 
     if (host.ngrokDomainId) {
-      await safeDeleteNgrokResource(
+      await safeDelete(
         () => {
           return deleteReservedDomain(apiKey, host.ngrokDomainId!);
         },
         "Reserved domain",
         host.ngrokDomainId,
+      );
+    }
+
+    if (host.ngrokBotUserId) {
+      await safeDelete(
+        () => {
+          return deleteBotUser(apiKey, host.ngrokBotUserId!);
+        },
+        "Bot user",
+        host.ngrokBotUserId,
       );
     }
   }


### PR DESCRIPTION
## Summary
- Add comprehensive rollback-on-failure for ngrok resource provisioning (bot user, credential, domain, endpoint) with best-effort cleanup that won't mask the original error
- Fix bot user and reserved domain leaks in `unregisterHost` and `deleteComputerConnector` paths
- Remove unused `createReservedDomain` export (replaced by `findOrCreateReservedDomain`)

## Test plan
- [x] Existing connector tests pass (9/9)
- [x] Tests verify all 4 ngrok resource types are deleted on cleanup
- [x] Lint, knip, format all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)