### PR TITLE
fix(docs): fix flaky check-types by reordering fumadocs-mdx and next typegen

### DIFF
--- a/turbo/apps/docs/package.json
+++ b/turbo/apps/docs/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev --turbo --port 3001",
     "start": "next start",
     "lint": "oxlint && eslint . --max-warnings 0",
-    "check-types": "fumadocs-mdx && next typegen && tsc --noEmit",
+    "check-types": "next typegen && fumadocs-mdx && tsc --noEmit",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Reorder `check-types` script from `fumadocs-mdx && next typegen && tsc` to `next typegen && fumadocs-mdx && tsc`
- Fixes intermittent `TS2306: .source/server.ts is not a module` failures in CI

## Root Cause
`createMDX()` in fumadocs-mdx calls `init()` **without `await`** ([source](https://github.com/fuma-nama/fumadocs/blob/main/packages/mdx/src/next/index.ts)). When `next typegen` loads `next.config.mjs`, it triggers an unawaited async write to `.source/`. If the process exits before the write completes, `.source/server.ts` is truncated mid-write, losing its `export` statement. `tsc` then reports "is not a module", cascading into `PageData` missing `body`/`toc`/`full`.

Evidence from CI logs — failed vs successful run of the same commit:

| | Failed (job 69999089077) | Successful (job 69999557027) |
|---|---|---|
| 1st MDX gen | `52.82ms` | `62.89ms` |
| 2nd MDX gen (by `next typegen`) | **missing** — process exited before completion | `24.49ms` — completed |
| tsc result | `TS2306: not a module` | ✅ pass |

## Fix
Run `next typegen` first (may truncate `.source/`), then `fumadocs-mdx` which uses properly awaited `postInstall()` to regenerate complete files, then `tsc` reads correct output.

## Test plan
- [x] Verified `next typegen` does not depend on `.source/` (generates `.next/types/` from route structure only)
- [x] Verified `fumadocs-mdx` always overwrites (unconditional `fs.writeFile`, no cache check)
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [ ] CI `lint-types` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)