### PR TITLE
fix(runner): flush tokio file in drain_stdout_to_file to prevent data loss

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -508,6 +508,12 @@ async fn drain_stdout_to_file(
             break;
         }
     }
+    // Flush to ensure the last spawn_blocking write completes before we return.
+    // tokio::fs::File::poll_write returns Ready before the blocking write finishes,
+    // so without flush the caller may observe incomplete file contents.
+    if let Err(e) = tokio::io::AsyncWriteExt::flush(&mut file).await {
+        warn!(error = %e, path = %path.display(), "failed to flush stdout log");
+    }
 }
 
 /// Copy guest log files to host (best-effort, post-job).


### PR DESCRIPTION
## Summary

- `drain_stdout_to_file` drops the `tokio::fs::File` without flushing after the channel closes
- `tokio::fs::File::poll_write` returns `Ready` before the underlying `spawn_blocking` write completes — the last write may still be in-flight when the file is dropped
- This causes the `drain_stdout_writes_chunks_to_file` test to flake (~5% failure rate) and could lose the last stdout chunk in production

## Fix

Add `flush().await` after the write loop exits. This waits for the in-flight `spawn_blocking` write to complete before returning. Zero performance impact — the write was happening anyway, we just weren't waiting for it.

## Test plan

- [x] `drain_stdout_writes_chunks_to_file` passes 100/100 runs (was ~95/100 before fix)
- [x] All 364 runner tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)