### PR TITLE
chore: update vm0-dev image to 20260404

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "VM0 Development",
-  "image": "ghcr.io/vm0-ai/vm0-dev:20260324",
+  "image": "ghcr.io/vm0-ai/vm0-dev:20260404",
   "features": {
     "ghcr.io/itsmechlark/features/postgresql:1": {
       "version": "17"


### PR DESCRIPTION
## Summary
- Update `vm0-dev` Docker image from `20260324` to `20260404` (adds tmux, per #8167)

## Test plan
- [ ] Verify devcontainer builds and starts correctly with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)