### PR TITLE
feat(chat): add /chats page for mobile chat list navigation

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -34,6 +34,7 @@ import { setupConnectorsPage$ } from "./connectors-page/connectors-page-setup.ts
 import { setupDirectedConnectPage$ } from "./connectors-page/directed-connect-page-setup.ts";
 import { setupSignInTokenPage$ } from "./sign-in-token-setup.ts";
 import { setupFirewallAllowPage$ } from "./firewall-allow/firewall-allow-page-setup.ts";
+import { setupChatListPage$ } from "./zero-page/chat-list-page-setup.ts";
 
 /**
  * Catch-all fallback — redirects unknown paths to /.
@@ -73,6 +74,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.selectOrg,
     setup: setupAuthPageWrapper(setupSelectOrgPage$),
+  },
+  {
+    path: ROUTES.chatList,
+    setup: setupAuthPageWrapper(setupChatListPage$),
   },
   {
     path: ROUTES.chat,

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -9,6 +9,7 @@ export const ROUTES = {
   activities: "/activities",
   activityInspect: "/activities/inspect",
   activityDetail: "/activities/:id",
+  chatList: "/chats",
   chat: "/chats/:id",
   schedules: "/schedules",
   scheduleDetail: "/schedules/:id",

--- a/turbo/apps/platform/src/signals/zero-page/chat-list-page-setup.ts
+++ b/turbo/apps/platform/src/signals/zero-page/chat-list-page-setup.ts
@@ -1,0 +1,36 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { SidebarLayout } from "../../views/zero-page/sidebar-layout.tsx";
+import { ZeroChatListPage } from "../../views/zero-page/zero-chat-list-page.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { searchParams$ } from "../route.ts";
+import { setSidebarChatAgent$ } from "./zero-nav.ts";
+import { onboardGuard$ } from "./onboard-guard.ts";
+import { loadInitialData$ } from "./zero-page.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+
+export const setupChatListPage$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const params = get(searchParams$);
+    const agentId = params.get("agentId");
+
+    set(
+      updatePage$,
+      createElement(SidebarLayout, null, createElement(ZeroChatListPage)),
+    );
+    set(updateDocumentTitle$, "Chats");
+
+    await set(loadInitialData$, signal);
+    signal.throwIfAborted();
+    await set(hideAppSkeleton$, signal);
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+
+    if (agentId) {
+      set(setSidebarChatAgent$, agentId);
+    }
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -17,7 +17,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
-import { pathname } from "../../../signals/location.ts";
+import { pathname, search } from "../../../signals/location.ts";
 import { setSidebarExpanded$ } from "../../../signals/zero-page/zero-nav.ts";
 
 const context = testContext();
@@ -269,6 +269,9 @@ describe("sidebar layout - menu toggle passes agent ID to chat list (SIDEBAR-D-0
     await waitFor(() => {
       // Navigates to /chats with agentId search param for the default agent
       expect(pathname()).toBe("/chats");
+      expect(new URLSearchParams(search()).get("agentId")).toBe(
+        DEFAULT_AGENT_ID,
+      );
     });
 
     // Wait for the chat list page to fully render after navigation

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -18,6 +18,7 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { setupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
+import { setSidebarExpanded$ } from "../../../signals/zero-page/zero-nav.ts";
 
 const context = testContext();
 
@@ -150,7 +151,9 @@ describe("sidebar layout - menu toggle navigates to chat list (SIDEBAR-D-050)", 
 
     // Wait for the chat list page to fully render after navigation
     await waitFor(() => {
-      expect(document.title).toContain("Chats");
+      expect(
+        screen.getByRole("heading", { name: /Chats with/ }),
+      ).toBeInTheDocument();
     });
   });
 });
@@ -270,7 +273,31 @@ describe("sidebar layout - menu toggle passes agent ID to chat list (SIDEBAR-D-0
 
     // Wait for the chat list page to fully render after navigation
     await waitFor(() => {
-      expect(document.title).toContain("Chats");
+      expect(
+        screen.getByRole("heading", { name: /Chats with/ }),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("sidebar layout - overlay click collapses sidebar (SIDEBAR-D-054)", () => {
+  it("hides the sidebar overlay when the overlay is clicked", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs();
+    await setupPage({ context, path: "/" });
+
+    // Expand the sidebar via signal to show the overlay
+    context.store.set(setSidebarExpanded$, true);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Sidebar overlay")).toBeInTheDocument();
+    });
+
+    const overlay = screen.getByLabelText("Sidebar overlay");
+    await user.click(overlay);
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Open menu")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/sidebar-layout.test.tsx
@@ -135,8 +135,8 @@ describe("sidebar layout - invite button hidden for non-admins (SIDEBAR-D-049)",
   });
 });
 
-describe("sidebar layout - menu toggle opens sidebar (SIDEBAR-D-050)", () => {
-  it("shows the sidebar overlay when the menu toggle button is clicked", async () => {
+describe("sidebar layout - menu toggle navigates to chat list (SIDEBAR-D-050)", () => {
+  it("navigates to the chat list page when the menu toggle button is clicked", async () => {
     const user = userEvent.setup();
     mockBaseAPIs();
     await setupPage({ context, path: "/" });
@@ -145,7 +145,12 @@ describe("sidebar layout - menu toggle opens sidebar (SIDEBAR-D-050)", () => {
     await user.click(menuButton);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Collapse sidebar")).toBeInTheDocument();
+      expect(pathname()).toBe("/chats");
+    });
+
+    // Wait for the chat list page to fully render after navigation
+    await waitFor(() => {
+      expect(document.title).toContain("Chats");
     });
   });
 });
@@ -232,25 +237,40 @@ describe("sidebar layout - invite button opens member dialog (SIDEBAR-D-052)", (
   });
 });
 
-describe("sidebar layout - overlay click collapses sidebar (SIDEBAR-D-053)", () => {
-  it("hides the sidebar overlay when the overlay is clicked", async () => {
+describe("sidebar layout - menu toggle passes agent ID to chat list (SIDEBAR-D-053)", () => {
+  it("navigates to /chats with agentId query param when a chat agent is active", async () => {
     const user = userEvent.setup();
-    mockBaseAPIs();
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([
+          {
+            id: DEFAULT_AGENT_ID,
+            displayName: "My Agent",
+            description: null,
+            sound: null,
+            avatarUrl: null,
+            headVersionId: "version_1",
+            updatedAt: "2024-01-01T00:00:00Z",
+          },
+        ]);
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
     await setupPage({ context, path: "/" });
 
-    // Open the sidebar via user interaction
     const menuButton = screen.getByLabelText("Open menu");
     await user.click(menuButton);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Collapse sidebar")).toBeInTheDocument();
+      // Navigates to /chats with agentId search param for the default agent
+      expect(pathname()).toBe("/chats");
     });
 
-    const overlay = screen.getByLabelText("Sidebar overlay");
-    await user.click(overlay);
-
+    // Wait for the chat list page to fully render after navigation
     await waitFor(() => {
-      expect(screen.queryByLabelText("Open menu")).toBeInTheDocument();
+      expect(document.title).toContain("Chats");
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -8,8 +8,11 @@ import {
   setZeroShowAboutPage$,
   sidebarExpanded$,
   setSidebarExpanded$,
+  sidebarChatAgentId$,
   isChatRoute,
 } from "../../signals/zero-page/zero-nav.ts";
+import { detachedNavigateTo$ } from "../../signals/route.ts";
+import { defaultAgentId$ } from "../../signals/zero-page/zero-agent-name.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
 import { mobileBreadcrumb$ } from "../../signals/zero-page/zero-mobile-breadcrumb.ts";
 import { ZeroAboutPage } from "./zero-about-page.tsx";
@@ -46,7 +49,13 @@ function AgentAvatarInTopBar({ agentId }: { agentId: string }) {
 }
 
 function MobileTopBar() {
-  const setSidebarExpandedFn = useSet(setSidebarExpanded$);
+  const navigateTo = useSet(detachedNavigateTo$);
+  const currentAgentId = useGet(sidebarChatAgentId$);
+  const defaultAgentIdLoadable = useLastLoadable(defaultAgentId$);
+  const defaultAgent =
+    defaultAgentIdLoadable.state === "hasData"
+      ? defaultAgentIdLoadable.data
+      : null;
   const breadcrumbLoadable = useLastLoadable(mobileBreadcrumb$);
   const breadcrumb =
     breadcrumbLoadable.state === "hasData" ? breadcrumbLoadable.data : null;
@@ -61,13 +70,22 @@ function MobileTopBar() {
 
   const showInvite = isChatRoute(activeId) && isAdmin;
 
+  const handleMenuClick = () => {
+    const agentId = currentAgentId ?? defaultAgent;
+    if (agentId) {
+      navigateTo("/chats", {
+        searchParams: new URLSearchParams({ agentId }),
+      });
+    } else {
+      navigateTo("/chats");
+    }
+  };
+
   return (
     <div className="md:hidden shrink-0 flex items-center h-12 px-3 gap-2 bg-background border-b border-border/50 z-10">
       <button
         type="button"
-        onPointerDown={() => {
-          return setSidebarExpandedFn(true);
-        }}
+        onPointerDown={handleMenuClick}
         className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
         aria-label="Open menu"
       >

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
@@ -1,0 +1,334 @@
+import { useGet, useSet, useLastLoadable, useLoadable } from "ccstate-react";
+import { IconPlus, IconSearch, IconX, IconTrash } from "@tabler/icons-react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Skeleton,
+} from "@vm0/ui";
+import type { ChatThreadListItem } from "@vm0/core";
+import {
+  chatThreads$,
+  deleteChatThread$,
+  createNewChatThread$,
+  creatingNewSession$,
+} from "../../signals/zero-page/zero-chat.ts";
+import {
+  sidebarChatAgentId$,
+  navigateToChat$,
+  chatThreadId$,
+} from "../../signals/zero-page/zero-nav.ts";
+import {
+  agentDisplayName$,
+  defaultAgentId$,
+} from "../../signals/zero-page/zero-agent-name.ts";
+import { zeroSubagents$ } from "../../signals/zero-page/zero-agents.ts";
+import {
+  pendingDeleteThreadId$,
+  setPendingDeleteThreadId$,
+  chatListQuery$,
+  setChatListQuery$,
+} from "../../signals/zero-page/zero-sidebar-state.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+import { Link } from "../router/link.tsx";
+import { useAgentAvatar } from "./zero-sidebar-shared.tsx";
+
+export function ZeroChatListPage() {
+  const recentSessionsLoadable = useLastLoadable(chatThreads$);
+  const recentSessions =
+    recentSessionsLoadable.state === "hasData"
+      ? recentSessionsLoadable.data
+      : [];
+  const loading = recentSessionsLoadable.state === "loading";
+  const error =
+    recentSessionsLoadable.state === "hasError"
+      ? recentSessionsLoadable.error instanceof Error
+        ? recentSessionsLoadable.error.message
+        : "Failed to load chats"
+      : null;
+
+  const currentChatAgentId = useGet(sidebarChatAgentId$);
+  const subagentsLoadable = useLastLoadable(zeroSubagents$);
+  const subagents =
+    subagentsLoadable.state === "hasData" ? subagentsLoadable.data : [];
+  const defaultAgentIdLoadable = useLastLoadable(defaultAgentId$);
+  const defaultAgentRawName =
+    defaultAgentIdLoadable.state === "hasData"
+      ? defaultAgentIdLoadable.data
+      : null;
+  const displayName = useLastLoadable(agentDisplayName$);
+  const displayNameStr =
+    displayName.state === "hasData" ? (displayName.data ?? "Zero") : "Zero";
+
+  const selectedRecentId = useGet(chatThreadId$);
+  const navigateToChat = useSet(navigateToChat$);
+  const createNewChat = useSet(createNewChatThread$);
+  const creatingLoadable = useLoadable(creatingNewSession$);
+  const creating = creatingLoadable.state === "loading";
+  const pageSignal = useGet(pageSignal$);
+
+  const searchTerm = useGet(chatListQuery$);
+  const setSearchTerm = useSet(setChatListQuery$);
+
+  const avatarSrc = useAgentAvatar(
+    currentChatAgentId ?? defaultAgentRawName ?? "",
+  );
+
+  // Filter sessions by current agent
+  const subagentIds = new Set(subagents.map((a) => a.id));
+  const agentSessions = currentChatAgentId
+    ? recentSessions.filter((s) => s.agentId === currentChatAgentId)
+    : recentSessions.filter((s) => !subagentIds.has(s.agentId));
+
+  const matchedAgent = subagents.find((a) => a.id === currentChatAgentId);
+  const agentLabel = currentChatAgentId
+    ? (matchedAgent?.displayName ?? matchedAgent?.id ?? displayNameStr)
+    : displayNameStr;
+
+  const trimmedTerm = searchTerm.trim().toLowerCase();
+  const filteredSessions = trimmedTerm
+    ? agentSessions.filter((s) =>
+        (s.title ?? "").toLowerCase().includes(trimmedTerm),
+      )
+    : agentSessions;
+
+  const onNewChat = () => {
+    detach(
+      createNewChat(currentChatAgentId ?? null, pageSignal),
+      Reason.DomCallback,
+    );
+  };
+
+  const onRecentSelect = (chatThreadId: string) => {
+    navigateToChat(chatThreadId);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      {/* Header */}
+      <div className="shrink-0 px-4 pt-4 pb-2">
+        <div className="flex items-center gap-3 mb-3">
+          {avatarSrc ? (
+            <img
+              src={avatarSrc}
+              alt=""
+              className="h-8 w-8 rounded-full object-cover object-top"
+            />
+          ) : (
+            <div className="h-8 w-8 rounded-full bg-muted" />
+          )}
+          <h1 className="text-lg font-semibold">Chats with {agentLabel}</h1>
+        </div>
+
+        {/* Search */}
+        <div className="flex items-center gap-2 rounded-lg bg-muted/50 px-3 h-10">
+          <IconSearch
+            size={16}
+            stroke={2}
+            className="shrink-0 text-muted-foreground"
+          />
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder={`Search chats with ${agentLabel}`}
+            className="flex-1 min-w-0 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+          />
+          {searchTerm && (
+            <button
+              type="button"
+              onPointerDown={() => setSearchTerm("")}
+              className="shrink-0 text-muted-foreground hover:text-foreground"
+              aria-label="Clear search"
+            >
+              <IconX size={14} stroke={2} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* New chat button */}
+      <div className="shrink-0 px-4 py-2">
+        <button
+          type="button"
+          onPointerDown={onNewChat}
+          disabled={creating}
+          className="flex w-full h-10 items-center justify-center gap-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+        >
+          <IconPlus size={16} stroke={2} />
+          New chat
+        </button>
+      </div>
+
+      {/* Chat list */}
+      <div className="flex-1 overflow-auto px-4 pb-4">
+        <ChatList
+          loading={loading}
+          error={error}
+          sessions={filteredSessions}
+          searchTerm={searchTerm}
+          selectedRecentId={selectedRecentId}
+          onRecentSelect={onRecentSelect}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ChatList({
+  loading,
+  error,
+  sessions,
+  searchTerm,
+  selectedRecentId,
+  onRecentSelect,
+}: {
+  loading: boolean;
+  error: string | null;
+  sessions: ChatThreadListItem[];
+  searchTerm: string;
+  selectedRecentId: string | null;
+  onRecentSelect: (id: string) => void;
+}) {
+  const pendingDeleteThreadId = useGet(pendingDeleteThreadId$);
+  const setPendingDeleteThreadId = useSet(setPendingDeleteThreadId$);
+  const setDelete = useSet(deleteChatThread$);
+  const pageSignal = useGet(pageSignal$);
+
+  function confirmDelete() {
+    if (!pendingDeleteThreadId) {
+      return;
+    }
+    const threadId = pendingDeleteThreadId;
+    setPendingDeleteThreadId(null);
+    detach(setDelete(threadId, pageSignal), Reason.DomCallback);
+  }
+
+  if (loading && sessions.length === 0) {
+    return (
+      <div className="flex flex-col gap-2">
+        {["w-3/4", "w-1/2", "w-2/3", "w-4/5", "w-3/5"].map((w) => (
+          <div key={w} className="flex h-12 items-center rounded-lg px-3">
+            <Skeleton className={`h-4 ${w}`} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="px-3 py-4 text-sm text-destructive">{error}</p>;
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <p className="px-3 py-8 text-sm text-muted-foreground text-center">
+        {searchTerm.trim()
+          ? "No chats match your search"
+          : "Start a conversation and it'll show up here"}
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        {sessions.map((session) => (
+          <ChatListItem
+            key={session.id}
+            session={session}
+            isSelected={selectedRecentId === session.id}
+            onSelect={onRecentSelect}
+            onDelete={() => setPendingDeleteThreadId(session.id)}
+          />
+        ))}
+      </div>
+
+      <Dialog
+        open={pendingDeleteThreadId !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingDeleteThreadId(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete chat?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete this chat. This action cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onPointerDown={() => setPendingDeleteThreadId(null)}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onPointerDown={confirmDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function ChatListItem({
+  session,
+  isSelected,
+  onSelect,
+  onDelete,
+}: {
+  session: ChatThreadListItem;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="group relative">
+      <Link
+        pathname="/chats/:id"
+        options={{ pathParams: { id: session.id } }}
+        onPointerDown={(e) => {
+          if (e.metaKey || e.ctrlKey || e.shiftKey) {
+            return;
+          }
+          e.preventDefault();
+          onSelect(session.id);
+        }}
+        className={`flex h-12 items-center gap-3 rounded-lg px-3 text-left text-sm transition-colors ${
+          isSelected
+            ? "bg-accent text-accent-foreground font-medium"
+            : "text-foreground hover:bg-accent/50"
+        }`}
+      >
+        <span className="truncate min-w-0 flex-1">
+          {session.title ?? "New chat"}
+        </span>
+      </Link>
+      <div className="absolute right-2 top-0 flex h-12 items-center">
+        <button
+          type="button"
+          onPointerDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onDelete();
+          }}
+          className="flex h-8 w-8 items-center justify-center rounded-md invisible group-hover:visible text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+          aria-label="Delete chat"
+        >
+          <IconTrash size={14} stroke={2} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
@@ -80,21 +80,31 @@ export function ZeroChatListPage() {
   );
 
   // Filter sessions by current agent
-  const subagentIds = new Set(subagents.map((a) => a.id));
+  const subagentIds = new Set(
+    subagents.map((a) => {
+      return a.id;
+    }),
+  );
   const agentSessions = currentChatAgentId
-    ? recentSessions.filter((s) => s.agentId === currentChatAgentId)
-    : recentSessions.filter((s) => !subagentIds.has(s.agentId));
+    ? recentSessions.filter((s) => {
+        return s.agentId === currentChatAgentId;
+      })
+    : recentSessions.filter((s) => {
+        return !subagentIds.has(s.agentId);
+      });
 
-  const matchedAgent = subagents.find((a) => a.id === currentChatAgentId);
+  const matchedAgent = subagents.find((a) => {
+    return a.id === currentChatAgentId;
+  });
   const agentLabel = currentChatAgentId
     ? (matchedAgent?.displayName ?? matchedAgent?.id ?? displayNameStr)
     : displayNameStr;
 
   const trimmedTerm = searchTerm.trim().toLowerCase();
   const filteredSessions = trimmedTerm
-    ? agentSessions.filter((s) =>
-        (s.title ?? "").toLowerCase().includes(trimmedTerm),
-      )
+    ? agentSessions.filter((s) => {
+        return (s.title ?? "").toLowerCase().includes(trimmedTerm);
+      })
     : agentSessions;
 
   const onNewChat = () => {
@@ -135,14 +145,18 @@ export function ZeroChatListPage() {
           <input
             type="text"
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => {
+              return setSearchTerm(e.target.value);
+            }}
             placeholder={`Search chats with ${agentLabel}`}
             className="flex-1 min-w-0 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
           />
           {searchTerm && (
             <button
               type="button"
-              onPointerDown={() => setSearchTerm("")}
+              onPointerDown={() => {
+                return setSearchTerm("");
+              }}
               className="shrink-0 text-muted-foreground hover:text-foreground"
               aria-label="Clear search"
             >
@@ -212,11 +226,13 @@ function ChatList({
   if (loading && sessions.length === 0) {
     return (
       <div className="flex flex-col gap-2">
-        {["w-3/4", "w-1/2", "w-2/3", "w-4/5", "w-3/5"].map((w) => (
-          <div key={w} className="flex h-12 items-center rounded-lg px-3">
-            <Skeleton className={`h-4 ${w}`} />
-          </div>
-        ))}
+        {["w-3/4", "w-1/2", "w-2/3", "w-4/5", "w-3/5"].map((w) => {
+          return (
+            <div key={w} className="flex h-12 items-center rounded-lg px-3">
+              <Skeleton className={`h-4 ${w}`} />
+            </div>
+          );
+        })}
       </div>
     );
   }
@@ -238,15 +254,19 @@ function ChatList({
   return (
     <>
       <div className="flex flex-col gap-1">
-        {sessions.map((session) => (
-          <ChatListItem
-            key={session.id}
-            session={session}
-            isSelected={selectedRecentId === session.id}
-            onSelect={onRecentSelect}
-            onDelete={() => setPendingDeleteThreadId(session.id)}
-          />
-        ))}
+        {sessions.map((session) => {
+          return (
+            <ChatListItem
+              key={session.id}
+              session={session}
+              isSelected={selectedRecentId === session.id}
+              onSelect={onRecentSelect}
+              onDelete={() => {
+                return setPendingDeleteThreadId(session.id);
+              }}
+            />
+          );
+        })}
       </div>
 
       <Dialog
@@ -268,7 +288,9 @@ function ChatList({
           <DialogFooter>
             <Button
               variant="outline"
-              onPointerDown={() => setPendingDeleteThreadId(null)}
+              onPointerDown={() => {
+                return setPendingDeleteThreadId(null);
+              }}
             >
               Cancel
             </Button>


### PR DESCRIPTION
## Summary

- Add `/chats?agentId=` route with full-page chat thread list
- Mobile hamburger button navigates to this page instead of opening sidebar overlay
- Gives proper browser history: chat list → session → back → chat list
- Reuses existing `chatThreads$` signal for data
- Works on both mobile and desktop

## Test plan
- [ ] Mobile: tap hamburger → see chat list page with threads
- [ ] Mobile: tap a thread → navigate to chat → press back → return to list
- [ ] Desktop: navigate to `/chats` → see the list page
- [ ] Search works in the chat list
- [ ] New chat button creates a new thread
- [ ] Delete button removes a thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)