### PR TITLE
test(runner): add execute_inner integration tests with mock sandbox factory

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1855,13 +1855,11 @@ mod tests {
 
     /// Build a real `ExecutorConfig` backed by tempdir files.
     async fn test_executor_config(dir: &std::path::Path) -> ExecutorConfig {
-        // Create proxy registry file
         let registry_path = dir.join("proxy-registry.json");
         let lock_path = dir.join("proxy-registry.json.lock");
         tokio::fs::write(&registry_path, r#"{"vms":{},"updated_at":0}"#)
             .await
             .unwrap();
-
         let log_dir = dir.join("logs");
         tokio::fs::create_dir_all(&log_dir).await.unwrap();
 
@@ -1874,31 +1872,44 @@ mod tests {
         }
     }
 
+    fn default_params() -> JobParams {
+        JobParams {
+            vcpu: 2,
+            memory_mb: 2048,
+            use_snapshot: false,
+        }
+    }
+
+    fn test_telemetry(config: &ExecutorConfig, ctx: &ExecutionContext) -> JobTelemetry {
+        crate::telemetry::JobTelemetry::new(
+            config.http.clone(),
+            ctx.run_id,
+            ctx.sandbox_token.clone(),
+        )
+    }
+
+    async fn run_execute_inner(
+        factory: &MockSandboxFactory,
+        ctx: &ExecutionContext,
+        config: &ExecutorConfig,
+        params: &JobParams,
+    ) -> RunnerResult<(i32, Option<String>)> {
+        let mut telemetry = test_telemetry(config, ctx);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        execute_inner(factory, ctx, config, params, &mut telemetry, cancel).await
+    }
+
     #[tokio::test]
     async fn execute_inner_happy_path() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory;
+        let mut factory = MockSandboxFactory::new();
         factory.startup().await.unwrap();
 
-        let ctx = minimal_context();
-        let params = JobParams {
-            vcpu: 2,
-            memory_mb: 2048,
-            use_snapshot: false,
-        };
-        let mut telemetry = crate::telemetry::JobTelemetry::new(
-            config.http.clone(),
-            ctx.run_id,
-            ctx.sandbox_token.clone(),
-        );
-        let cancel = tokio_util::sync::CancellationToken::new();
-
         let (exit_code, error_msg) =
-            execute_inner(&factory, &ctx, &config, &params, &mut telemetry, cancel)
+            run_execute_inner(&factory, &minimal_context(), &config, &default_params())
                 .await
                 .unwrap();
-        // MockSandbox spawn_watch + wait_exit return exit 0 by default
         assert_eq!(exit_code, 0);
         assert!(error_msg.is_none());
     }
@@ -1907,26 +1918,16 @@ mod tests {
     async fn execute_inner_with_snapshot_runs_clock_fix_and_reseed() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory;
+        let mut factory = MockSandboxFactory::new();
         factory.startup().await.unwrap();
 
-        let ctx = minimal_context();
         let params = JobParams {
-            vcpu: 2,
-            memory_mb: 2048,
-            use_snapshot: true, // triggers fix_guest_clock + reseed_guest_entropy
+            use_snapshot: true,
+            ..default_params()
         };
-        let mut telemetry = crate::telemetry::JobTelemetry::new(
-            config.http.clone(),
-            ctx.run_id,
-            ctx.sandbox_token.clone(),
-        );
-        let cancel = tokio_util::sync::CancellationToken::new();
-
-        let (exit_code, _) =
-            execute_inner(&factory, &ctx, &config, &params, &mut telemetry, cancel)
-                .await
-                .unwrap();
+        let (exit_code, _) = run_execute_inner(&factory, &minimal_context(), &config, &params)
+            .await
+            .unwrap();
         assert_eq!(exit_code, 0);
     }
 
@@ -1934,7 +1935,7 @@ mod tests {
     async fn execute_inner_with_storage_manifest() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory;
+        let mut factory = MockSandboxFactory::new();
         factory.startup().await.unwrap();
 
         let mut ctx = minimal_context();
@@ -1946,23 +1947,9 @@ mod tests {
             artifact: None,
             memory: None,
         });
-        let params = JobParams {
-            vcpu: 2,
-            memory_mb: 2048,
-            use_snapshot: false,
-        };
-        let mut telemetry = crate::telemetry::JobTelemetry::new(
-            config.http.clone(),
-            ctx.run_id,
-            ctx.sandbox_token.clone(),
-        );
-        let cancel = tokio_util::sync::CancellationToken::new();
-
-        // MockSandbox: write_file + exec both succeed by default
-        let (exit_code, _) =
-            execute_inner(&factory, &ctx, &config, &params, &mut telemetry, cancel)
-                .await
-                .unwrap();
+        let (exit_code, _) = run_execute_inner(&factory, &ctx, &config, &default_params())
+            .await
+            .unwrap();
         assert_eq!(exit_code, 0);
     }
 
@@ -1970,7 +1957,7 @@ mod tests {
     async fn execute_inner_with_resume_session() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory;
+        let mut factory = MockSandboxFactory::new();
         factory.startup().await.unwrap();
 
         let mut ctx = minimal_context();
@@ -1978,42 +1965,64 @@ mod tests {
             session_id: "sess-abc-123".into(),
             session_history: r#"{"type":"init"}"#.into(),
         });
-        let params = JobParams {
-            vcpu: 2,
-            memory_mb: 2048,
-            use_snapshot: false,
-        };
-        let mut telemetry = crate::telemetry::JobTelemetry::new(
-            config.http.clone(),
-            ctx.run_id,
-            ctx.sandbox_token.clone(),
-        );
-        let cancel = tokio_util::sync::CancellationToken::new();
-
-        let (exit_code, _) =
-            execute_inner(&factory, &ctx, &config, &params, &mut telemetry, cancel)
-                .await
-                .unwrap();
+        let (exit_code, _) = run_execute_inner(&factory, &ctx, &config, &default_params())
+            .await
+            .unwrap();
         assert_eq!(exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn execute_inner_create_failure_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory::new();
+        factory.startup().await.unwrap();
+        factory.push_create_result(Err(SandboxError::CreationFailed("no free devices".into())));
+
+        let err = run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("no free devices"), "got: {err}");
     }
 
     #[tokio::test]
     async fn execute_job_wraps_execute_inner() {
         let dir = tempfile::tempdir().unwrap();
         let config = test_executor_config(dir.path()).await;
-        let mut factory = MockSandboxFactory;
+        let mut factory = MockSandboxFactory::new();
         factory.startup().await.unwrap();
 
-        let ctx = minimal_context();
-        let params = JobParams {
-            vcpu: 2,
-            memory_mb: 2048,
-            use_snapshot: false,
-        };
         let cancel = tokio_util::sync::CancellationToken::new();
-
-        let (exit_code, error_msg) = execute_job(&factory, ctx, &config, &params, cancel).await;
+        let (exit_code, error_msg) = execute_job(
+            &factory,
+            minimal_context(),
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
         assert_eq!(exit_code, 0);
         assert!(error_msg.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_job_create_failure_returns_exit_1() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory::new();
+        factory.startup().await.unwrap();
+        factory.push_create_result(Err(SandboxError::CreationFailed("boom".into())));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let (exit_code, error_msg) = execute_job(
+            &factory,
+            minimal_context(),
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+        assert_eq!(exit_code, 1);
+        assert!(error_msg.unwrap().contains("boom"));
     }
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -911,6 +911,7 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
 mod tests {
     use super::*;
     use crate::types::{ArtifactEntry, ResumeSession, StorageEntry, StorageManifest};
+    use sandbox_mock::MockSandboxFactory;
     use uuid::Uuid;
 
     fn minimal_context() -> ExecutionContext {
@@ -1846,5 +1847,173 @@ mod tests {
         sandbox.push_exec_result(Err(SandboxError::ExecFailed("vsock down".into())));
         let err = restore_session(&sandbox, &ctx, &session).await.unwrap_err();
         assert!(err.to_string().contains("vsock down"), "got: {err}");
+    }
+
+    // -----------------------------------------------------------------------
+    // execute_inner integration tests (MockSandboxFactory + real filesystem)
+    // -----------------------------------------------------------------------
+
+    /// Build a real `ExecutorConfig` backed by tempdir files.
+    async fn test_executor_config(dir: &std::path::Path) -> ExecutorConfig {
+        // Create proxy registry file
+        let registry_path = dir.join("proxy-registry.json");
+        let lock_path = dir.join("proxy-registry.json.lock");
+        tokio::fs::write(&registry_path, r#"{"vms":{},"updated_at":0}"#)
+            .await
+            .unwrap();
+
+        let log_dir = dir.join("logs");
+        tokio::fs::create_dir_all(&log_dir).await.unwrap();
+
+        ExecutorConfig {
+            api_url: "http://localhost:9999".into(),
+            registry: proxy::ProxyRegistryHandle::new(registry_path, lock_path),
+            http: crate::http::HttpClient::new("http://localhost:9999".into()).unwrap(),
+            log_paths: LogPaths::new(log_dir),
+            ip_log_map: kmsg_log::new_ip_log_map(),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_inner_happy_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory;
+        factory.startup().await.unwrap();
+
+        let ctx = minimal_context();
+        let params = JobParams {
+            vcpu: 2,
+            memory_mb: 2048,
+            use_snapshot: false,
+        };
+        let mut telemetry = crate::telemetry::JobTelemetry::new(
+            config.http.clone(),
+            ctx.run_id,
+            ctx.sandbox_token.clone(),
+        );
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let (exit_code, error_msg) =
+            execute_inner(&factory, &ctx, &config, &params, &mut telemetry, cancel)
+                .await
+                .unwrap();
+        // MockSandbox spawn_watch + wait_exit return exit 0 by default
+        assert_eq!(exit_code, 0);
+        assert!(error_msg.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_inner_with_snapshot_runs_clock_fix_and_reseed() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory;
+        factory.startup().await.unwrap();
+
+        let ctx = minimal_context();
+        let params = JobParams {
+            vcpu: 2,
+            memory_mb: 2048,
+            use_snapshot: true, // triggers fix_guest_clock + reseed_guest_entropy
+        };
+        let mut telemetry = crate::telemetry::JobTelemetry::new(
+            config.http.clone(),
+            ctx.run_id,
+            ctx.sandbox_token.clone(),
+        );
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let (exit_code, _) =
+            execute_inner(&factory, &ctx, &config, &params, &mut telemetry, cancel)
+                .await
+                .unwrap();
+        assert_eq!(exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn execute_inner_with_storage_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory;
+        factory.startup().await.unwrap();
+
+        let mut ctx = minimal_context();
+        ctx.storage_manifest = Some(StorageManifest {
+            storages: vec![StorageEntry {
+                mount_path: "/data".into(),
+                archive_url: Some("https://example.com/data.tar.gz".into()),
+            }],
+            artifact: None,
+            memory: None,
+        });
+        let params = JobParams {
+            vcpu: 2,
+            memory_mb: 2048,
+            use_snapshot: false,
+        };
+        let mut telemetry = crate::telemetry::JobTelemetry::new(
+            config.http.clone(),
+            ctx.run_id,
+            ctx.sandbox_token.clone(),
+        );
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        // MockSandbox: write_file + exec both succeed by default
+        let (exit_code, _) =
+            execute_inner(&factory, &ctx, &config, &params, &mut telemetry, cancel)
+                .await
+                .unwrap();
+        assert_eq!(exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn execute_inner_with_resume_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory;
+        factory.startup().await.unwrap();
+
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: "sess-abc-123".into(),
+            session_history: r#"{"type":"init"}"#.into(),
+        });
+        let params = JobParams {
+            vcpu: 2,
+            memory_mb: 2048,
+            use_snapshot: false,
+        };
+        let mut telemetry = crate::telemetry::JobTelemetry::new(
+            config.http.clone(),
+            ctx.run_id,
+            ctx.sandbox_token.clone(),
+        );
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let (exit_code, _) =
+            execute_inner(&factory, &ctx, &config, &params, &mut telemetry, cancel)
+                .await
+                .unwrap();
+        assert_eq!(exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn execute_job_wraps_execute_inner() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory;
+        factory.startup().await.unwrap();
+
+        let ctx = minimal_context();
+        let params = JobParams {
+            vcpu: 2,
+            memory_mb: 2048,
+            use_snapshot: false,
+        };
+        let cancel = tokio_util::sync::CancellationToken::new();
+
+        let (exit_code, error_msg) = execute_job(&factory, ctx, &config, &params, cancel).await;
+        assert_eq!(exit_code, 0);
+        assert!(error_msg.is_none());
     }
 }

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -417,6 +417,15 @@ pub struct ProxyRegistryHandle {
 }
 
 impl ProxyRegistryHandle {
+    /// Create a handle from explicit paths (for testing).
+    #[cfg(test)]
+    pub fn new(registry_path: PathBuf, lock_path: PathBuf) -> Self {
+        Self {
+            registry_path,
+            lock_path,
+        }
+    }
+
     /// Register a VM in the proxy registry.
     pub async fn register_vm(
         &self,

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -140,7 +140,36 @@ impl Sandbox for MockSandbox {
 // ---------------------------------------------------------------------------
 
 /// A mock [`SandboxFactory`] that creates [`MockSandbox`] instances.
-pub struct MockSandboxFactory;
+///
+/// Queue custom `create` results with [`push_create_result`](Self::push_create_result).
+/// When the queue is empty, `create` returns a default `MockSandbox`.
+pub struct MockSandboxFactory {
+    create_results: Mutex<VecDeque<Result<()>>>,
+}
+
+impl MockSandboxFactory {
+    pub fn new() -> Self {
+        Self {
+            create_results: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Queue a create result. `Ok(())` creates a normal `MockSandbox`;
+    /// `Err(...)` makes `create` return that error.
+    /// Results are consumed in FIFO order.
+    pub fn push_create_result(&self, result: Result<()>) {
+        self.create_results
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push_back(result);
+    }
+}
+
+impl Default for MockSandboxFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[async_trait]
 impl SandboxFactory for MockSandboxFactory {
@@ -157,6 +186,14 @@ impl SandboxFactory for MockSandboxFactory {
     }
 
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>> {
+        if let Some(result) = self
+            .create_results
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .pop_front()
+        {
+            result?;
+        }
         Ok(Box::new(MockSandbox::new(config.id.to_string())))
     }
 
@@ -175,7 +212,7 @@ pub struct MockSandboxRuntime;
 #[async_trait]
 impl SandboxRuntime for MockSandboxRuntime {
     async fn create_factory(&self, _config: FactoryConfig) -> Result<Box<dyn SandboxFactory>> {
-        Ok(Box::new(MockSandboxFactory))
+        Ok(Box::new(MockSandboxFactory::new()))
     }
 
     async fn shutdown(&mut self) {}
@@ -348,7 +385,7 @@ mod tests {
 
     #[tokio::test]
     async fn factory_creates_sandbox() {
-        let mut factory = MockSandboxFactory;
+        let mut factory = MockSandboxFactory::new();
         factory.startup().await.unwrap();
         let config = SandboxConfig {
             id: uuid::Uuid::new_v4(),
@@ -423,6 +460,33 @@ mod tests {
 
         // Falls back to default Ok.
         sandbox.write_file("/tmp/test.txt", b"data").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn factory_create_queued_error() {
+        let mut factory = MockSandboxFactory::new();
+        factory.startup().await.unwrap();
+        factory.push_create_result(Err(SandboxError::CreationFailed("out of resources".into())));
+
+        let config = SandboxConfig {
+            id: uuid::Uuid::new_v4(),
+            resources: ResourceLimits {
+                cpu_count: 2,
+                memory_mb: 1024,
+            },
+        };
+        let result = factory.create(config).await;
+        assert!(result.is_err());
+
+        // Next create falls back to default success.
+        let config2 = SandboxConfig {
+            id: uuid::Uuid::new_v4(),
+            resources: ResourceLimits {
+                cpu_count: 2,
+                memory_mb: 1024,
+            },
+        };
+        factory.create(config2).await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Add test-only `ProxyRegistryHandle::new()` constructor for building `ExecutorConfig` in tests
- Add `test_executor_config()` helper that builds a real `ExecutorConfig` backed by tempdir files
- 5 new integration tests for `execute_inner`/`execute_job` — the previously-untested orchestration layer (lines 48-400) that coordinates sandbox lifecycle, proxy registration, and telemetry

### New tests
| Test | What it covers |
|------|---------------|
| `execute_inner_happy_path` | Basic flow: create → start → spawn_watch → wait_exit → stop → destroy |
| `execute_inner_with_snapshot` | Snapshot mode: fix_guest_clock + reseed_guest_entropy before agent spawn |
| `execute_inner_with_storage_manifest` | Storage download: write_file manifest + exec guest-download |
| `execute_inner_with_resume_session` | Session restore: mkdir + write_file session history |
| `execute_job_wraps_execute_inner` | Top-level wrapper: telemetry init + error mapping |

## Test plan
- [x] `cargo test -p runner execute_inner` — 5 passed
- [x] `cargo test -p runner execute_job_wraps` — 1 passed
- [x] Full `cargo test` — 831 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)