### PR TITLE
fix(onboarding): prevent double-click and handle 409 conflict

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding-actions.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../zero-onboarding-actions.ts";
 import { setZeroAgentName$, zeroOnboardingStep$ } from "../zero-onboarding.ts";
 import { pathname } from "../../../signals/location.ts";
+import { createDeferredPromise } from "../../utils.ts";
 
 const context = testContext();
 
@@ -205,5 +206,59 @@ describe("onboardingContinueWeb$", () => {
     await context.store.set(onboardingContinueWeb$, context.signal);
 
     expect(pathname()).toBe(`/agents/${MOCK_MEMBER_AGENT_ID}/chat`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Double-click guard
+// ---------------------------------------------------------------------------
+
+describe("onboarding double-click guard", () => {
+  it("should only send one setup request when continueWeb is invoked concurrently", async () => {
+    mockAdminOnboarding();
+
+    const deferred = createDeferredPromise<void>(context.signal);
+    let requestCount = 0;
+
+    server.use(
+      http.post("*/api/zero/onboarding/setup", async () => {
+        requestCount++;
+        // Hold the first request open until we release it
+        await deferred.promise;
+        return HttpResponse.json({ agentId: MOCK_AGENT_ID });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/onboarding", withoutRender: true });
+
+    // Switch status to complete after the command runs
+    server.use(
+      http.get("*/api/zero/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: true,
+          hasOrg: true,
+          hasDefaultAgent: true,
+          defaultAgentId: MOCK_AGENT_ID,
+          defaultAgentMetadata: null,
+          defaultAgentSkills: [],
+        });
+      }),
+    );
+
+    // Fire two concurrent invocations (simulates double-click)
+    const first = context.store.set(onboardingContinueWeb$, context.signal);
+    const second = context.store.set(onboardingContinueWeb$, context.signal);
+
+    // Release the held request
+    deferred.resolve();
+
+    await Promise.all([first, second]);
+
+    // Only one setup request should have been made
+    expect(requestCount).toBe(1);
   });
 });

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-onboarding.test.ts
@@ -136,4 +136,24 @@ describe("completeZeroOnboarding$", () => {
 
     expect(agentId).toBe("d0000000-0000-4000-a000-000000000001");
   });
+
+  it("should treat 409 conflict as success", async () => {
+    server.use(
+      http.post("*/api/zero/onboarding/setup", () => {
+        return HttpResponse.json(
+          { agentId: "d0000000-0000-4000-a000-000000000002" },
+          { status: 409 },
+        );
+      }),
+    );
+
+    await setupPage({ context, path: "/", withoutRender: true });
+
+    const agentId = await context.store.set(
+      completeZeroOnboarding$,
+      context.signal,
+    );
+
+    expect(agentId).toBe("d0000000-0000-4000-a000-000000000002");
+  });
 });

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -1,4 +1,4 @@
-import { command, computed } from "ccstate";
+import { command, computed, state } from "ccstate";
 import {
   zeroNeedsOnboarding$,
   zeroNeedsMemberOnboarding$,
@@ -231,15 +231,25 @@ export const onboardingDisplayName$ = computed(async (get) => {
   return await get(agentDisplayName$);
 });
 
+const onboardingSubmitting$ = state(false);
+
 const completeOnboarding$ = command(
   async ({ get, set }, signal: AbortSignal) => {
-    set(reloadBillingStatus$);
+    if (get(onboardingSubmitting$)) {
+      return undefined;
+    }
+    set(onboardingSubmitting$, true);
+    try {
+      set(reloadBillingStatus$);
 
-    const isAdmin = await get(zeroNeedsOnboarding$);
-    signal.throwIfAborted();
-    return isAdmin
-      ? await set(completeZeroOnboarding$, signal)
-      : await set(completeMemberOnboarding$, signal);
+      const isAdmin = await get(zeroNeedsOnboarding$);
+      signal.throwIfAborted();
+      return isAdmin
+        ? await set(completeZeroOnboarding$, signal)
+        : await set(completeMemberOnboarding$, signal);
+    } finally {
+      set(onboardingSubmitting$, false);
+    }
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding.ts
@@ -159,7 +159,7 @@ export const completeZeroOnboarding$ = command(
             selectedConnectors.length > 0 ? selectedConnectors : undefined,
         },
       }),
-      [200],
+      [200, 409],
     );
     signal.throwIfAborted();
 

--- a/turbo/packages/core/src/contracts/onboarding.ts
+++ b/turbo/packages/core/src/contracts/onboarding.ts
@@ -72,6 +72,7 @@ export const onboardingSetupContract = c.router({
     responses: {
       200: z.object({ agentId: z.string() }),
       401: apiErrorSchema,
+      409: z.object({ agentId: z.string() }),
       422: apiErrorSchema,
     },
     summary: "Complete admin onboarding in a single request",


### PR DESCRIPTION
## Summary
- Add a `submitting` guard flag in `completeOnboarding$` to prevent concurrent requests when users rapidly click the onboarding completion buttons
- Accept HTTP 409 as a success response in the onboarding setup contract (defensive measure against conflict responses)
- Add 409 response schema to `onboardingSetupContract`

Closes #7851

## Test plan
- [ ] Verify rapid-clicking "Add to Slack" or "Continue on Web" buttons only triggers one request
- [ ] Verify normal single-click onboarding flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)