### PR TITLE
fix: handle clipboard write rejection on mobile safari with fallback

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/clipboard.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/clipboard.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for clipboard signals (shared writeToClipboard + copyToClipboard$).
+ *
+ * Entry point: store.set(copyToClipboard$, text, signal)
+ * Mock (external): navigator.clipboard, document.execCommand
+ * Real (internal): signals, state management
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { testContext } from "../../__tests__/test-helpers.ts";
+import { copyToClipboard$, copyStatus$ } from "../clipboard.ts";
+
+const context = testContext();
+
+function setupClipboardMock() {
+  const writeTextMock = vi.fn<(data: string) => Promise<void>>();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: writeTextMock },
+    writable: true,
+    configurable: true,
+  });
+  return writeTextMock;
+}
+
+describe("copyToClipboard$", () => {
+  let writeTextMock: ReturnType<typeof setupClipboardMock>;
+
+  beforeEach(() => {
+    writeTextMock = setupClipboardMock();
+  });
+
+  it("copies text and sets status to copied", async () => {
+    writeTextMock.mockResolvedValue(undefined);
+
+    await context.store.set(copyToClipboard$, "hello", context.signal);
+
+    expect(writeTextMock).toHaveBeenCalledWith("hello");
+    expect(context.store.get(copyStatus$)).toBe("copied");
+  });
+
+  it("falls back to execCommand when clipboard API throws", async () => {
+    writeTextMock.mockRejectedValue(
+      new DOMException("Not allowed", "NotAllowedError"),
+    );
+    const execMock = vi.fn().mockReturnValue(true);
+    document.execCommand = execMock;
+
+    await context.store.set(copyToClipboard$, "fallback text", context.signal);
+
+    expect(execMock).toHaveBeenCalledWith("copy");
+    expect(context.store.get(copyStatus$)).toBe("copied");
+  });
+
+  it("stays idle when both methods fail", async () => {
+    writeTextMock.mockRejectedValue(
+      new DOMException("Not allowed", "NotAllowedError"),
+    );
+    document.execCommand = () => {
+      throw new Error("execCommand failed");
+    };
+
+    await context.store.set(copyToClipboard$, "some text", context.signal);
+
+    expect(context.store.get(copyStatus$)).toBe("idle");
+  });
+});

--- a/turbo/apps/platform/src/signals/zero-page/clipboard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/clipboard.ts
@@ -1,4 +1,40 @@
 import { command, computed, state } from "ccstate";
+import { throwIfAbort } from "../utils.ts";
+
+/**
+ * Write text to the clipboard with a legacy fallback.
+ *
+ * Tries the Clipboard API first. When it throws (e.g. NotAllowedError on iOS
+ * Safari after an async boundary loses the user-gesture context), falls back to
+ * the deprecated `document.execCommand("copy")` approach.
+ *
+ * Returns `true` if the text was copied, `false` if both methods failed.
+ */
+export async function writeToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch (error: unknown) {
+    throwIfAbort(error);
+    // Clipboard API can throw NotAllowedError on iOS Safari when the user
+    // gesture context is lost (e.g. after an async boundary). Fall back to
+    // the legacy execCommand approach.
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      textarea.remove();
+      return true;
+    } catch (fallbackError: unknown) {
+      throwIfAbort(fallbackError);
+      return false;
+    }
+  }
+}
 
 const internalCopyStatus$ = state<"idle" | "copied">("idle");
 
@@ -11,8 +47,14 @@ export const copyStatus$ = computed((get) => {
 /**
  * Copy text to clipboard and show "copied" status for 5 seconds.
  */
-export const copyToClipboard$ = command(({ get, set }, text: string) => {
-  return navigator.clipboard.writeText(text).then(() => {
+export const copyToClipboard$ = command(
+  async ({ get, set }, text: string, signal: AbortSignal) => {
+    const ok = await writeToClipboard(text);
+    signal.throwIfAborted();
+    if (!ok) {
+      return;
+    }
+
     const existingTimeoutId = get(internalCopyTimeoutId$);
     if (existingTimeoutId !== null) {
       window.clearTimeout(existingTimeoutId);
@@ -25,5 +67,5 @@ export const copyToClipboard$ = command(({ get, set }, text: string) => {
       set(internalCopyTimeoutId$, null);
     }, 5000);
     set(internalCopyTimeoutId$, timeoutId);
-  });
-});
+  },
+);

--- a/turbo/apps/platform/src/signals/zero-page/zero-session-chat-ui.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-session-chat-ui.ts
@@ -1,5 +1,5 @@
 import { state, computed, command } from "ccstate";
-import { throwIfAbort } from "../utils.ts";
+import { writeToClipboard } from "./clipboard.ts";
 
 // ---------------------------------------------------------------------------
 // Collapsible timeline expanded state
@@ -36,29 +36,11 @@ export const copiedMessageIdValue$ = computed((get) => {
 
 export const copyMessageContent$ = command(
   async ({ set }, messageId: string, content: string, signal: AbortSignal) => {
-    try {
-      await navigator.clipboard.writeText(content);
-    } catch (error: unknown) {
-      throwIfAbort(error);
-      // Clipboard API can throw NotAllowedError on iOS Safari when the user
-      // gesture context is lost (e.g. after an async boundary). Fall back to
-      // the legacy execCommand approach.
-      try {
-        const textarea = document.createElement("textarea");
-        textarea.value = content;
-        textarea.style.position = "fixed";
-        textarea.style.opacity = "0";
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand("copy");
-        textarea.remove();
-      } catch (fallbackError: unknown) {
-        throwIfAbort(fallbackError);
-        // Both methods failed — nothing more we can do.
-        return;
-      }
-    }
+    const ok = await writeToClipboard(content);
     signal.throwIfAborted();
+    if (!ok) {
+      return;
+    }
     set(copiedMessageId$, messageId);
     window.setTimeout(() => {
       return set(copiedMessageId$, null);

--- a/turbo/apps/platform/src/signals/zero-page/zero-session-chat-ui.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-session-chat-ui.ts
@@ -1,4 +1,5 @@
 import { state, computed, command } from "ccstate";
+import { throwIfAbort } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
 // Collapsible timeline expanded state
@@ -34,12 +35,33 @@ export const copiedMessageIdValue$ = computed((get) => {
 });
 
 export const copyMessageContent$ = command(
-  ({ set }, messageId: string, content: string) => {
-    return navigator.clipboard.writeText(content).then(() => {
-      set(copiedMessageId$, messageId);
-      window.setTimeout(() => {
-        return set(copiedMessageId$, null);
-      }, 2000);
-    });
+  async ({ set }, messageId: string, content: string, signal: AbortSignal) => {
+    try {
+      await navigator.clipboard.writeText(content);
+    } catch (error: unknown) {
+      throwIfAbort(error);
+      // Clipboard API can throw NotAllowedError on iOS Safari when the user
+      // gesture context is lost (e.g. after an async boundary). Fall back to
+      // the legacy execCommand approach.
+      try {
+        const textarea = document.createElement("textarea");
+        textarea.value = content;
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        textarea.remove();
+      } catch (fallbackError: unknown) {
+        throwIfAbort(fallbackError);
+        // Both methods failed — nothing more we can do.
+        return;
+      }
+    }
+    signal.throwIfAborted();
+    set(copiedMessageId$, messageId);
+    window.setTimeout(() => {
+      return set(copiedMessageId$, null);
+    }, 2000);
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-copy-message.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-copy-message.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Tests for copyMessageContent$ signal (clipboard copy with iOS fallback).
+ *
+ * Entry point: store.set(copyMessageContent$, messageId, content, signal)
+ * Mock (external): navigator.clipboard, document.execCommand
+ * Real (internal): signals, state management
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import {
+  copyMessageContent$,
+  copiedMessageIdValue$,
+} from "../../../signals/zero-page/zero-session-chat-ui.ts";
+
+const context = testContext();
+
+function setupClipboardMock() {
+  const writeTextMock = vi.fn<(data: string) => Promise<void>>();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: writeTextMock },
+    writable: true,
+    configurable: true,
+  });
+  return writeTextMock;
+}
+
+describe("copyMessageContent$", () => {
+  let writeTextMock: ReturnType<typeof setupClipboardMock>;
+
+  beforeEach(() => {
+    writeTextMock = setupClipboardMock();
+  });
+
+  it("copies text via clipboard API and sets copied state", async () => {
+    writeTextMock.mockResolvedValue(undefined);
+
+    await context.store.set(
+      copyMessageContent$,
+      "msg-1",
+      "Hello world",
+      context.signal,
+    );
+
+    expect(writeTextMock).toHaveBeenCalledWith("Hello world");
+    expect(context.store.get(copiedMessageIdValue$)).toBe("msg-1");
+  });
+
+  it("falls back to execCommand when clipboard API throws", async () => {
+    writeTextMock.mockRejectedValue(
+      new DOMException("Not allowed", "NotAllowedError"),
+    );
+    const execMock = vi.fn().mockReturnValue(true);
+    document.execCommand = execMock;
+
+    await context.store.set(
+      copyMessageContent$,
+      "msg-2",
+      "Fallback text",
+      context.signal,
+    );
+
+    expect(writeTextMock).toHaveBeenCalledWith("Fallback text");
+    expect(execMock).toHaveBeenCalledWith("copy");
+    // Should still mark as copied after successful fallback
+    expect(context.store.get(copiedMessageIdValue$)).toBe("msg-2");
+  });
+
+  it("does not set copied state when both methods fail", async () => {
+    writeTextMock.mockRejectedValue(
+      new DOMException("Not allowed", "NotAllowedError"),
+    );
+    document.execCommand = () => {
+      throw new Error("execCommand failed");
+    };
+
+    // Should not throw — error is fully contained
+    await context.store.set(
+      copyMessageContent$,
+      "msg-3",
+      "Some text",
+      context.signal,
+    );
+
+    expect(context.store.get(copiedMessageIdValue$)).toBeNull();
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/components/settings/setup-prompt.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/setup-prompt.tsx
@@ -1,5 +1,6 @@
 import { useGet, useSet } from "ccstate-react";
 import { detach, Reason } from "../../../../signals/utils";
+import { pageSignal$ } from "../../../../signals/page-signal.ts";
 import {
   copyStatus$,
   copyToClipboard$,
@@ -8,6 +9,7 @@ import {
 export function ClaudeCodeSetupPrompt() {
   const copyStatus = useGet(copyStatus$);
   const copyToClipboard = useSet(copyToClipboard$);
+  const pageSignal = useGet(pageSignal$);
 
   return (
     <p className="text-xs text-muted-foreground">
@@ -15,7 +17,10 @@ export function ClaudeCodeSetupPrompt() {
       <code
         className="cursor-pointer rounded border border-border bg-gray-50 px-1 py-0.5 font-mono hover:bg-gray-100 active:bg-gray-200"
         onClick={() => {
-          detach(copyToClipboard("claude setup-token"), Reason.DomCallback);
+          detach(
+            copyToClipboard("claude setup-token", pageSignal),
+            Reason.DomCallback,
+          );
         }}
         title="Click to copy"
       >

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -845,7 +845,7 @@ function StaticAssistantMessage({
     if (!content) {
       return;
     }
-    detach(copyMessage(message.id, content), Reason.DomCallback);
+    detach(copyMessage(message.id, content, pageSignal), Reason.DomCallback);
   };
 
   const logButton = message.legacyRunId ? (


### PR DESCRIPTION
Closes #8221

## Summary
- Convert `copyMessageContent$` from `.then()/.catch()` to async/await with try/catch to properly contain the `NotAllowedError` rejection on iOS Safari
- Add `document.execCommand('copy')` fallback when `navigator.clipboard.writeText()` is denied
- If both methods fail, silently return without setting copied state

## Test plan
- [x] 3 new signal-level tests: clipboard API success, fallback to execCommand, both methods fail
- [x] Lint and knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)