### PR TITLE
fix: handle 401 response in ts-rest api client

### DIFF
--- a/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
+++ b/turbo/apps/platform/src/signals/__tests__/api-client.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../mocks/server.ts";
+import { zeroClient$ } from "../api-client.ts";
+import { zeroOrgContract } from "@vm0/core";
+import { testContext } from "./test-helpers.ts";
+import { setupPage } from "../../__tests__/page-helper.ts";
+import { mockedClerk } from "../../__tests__/mock-auth.ts";
+
+const context = testContext();
+
+describe("zeroClient$ 401 redirect", () => {
+  it("should redirect to sign-in when API returns 401", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    server.use(
+      http.get("http://localhost:3000/api/zero/org", () => {
+        return HttpResponse.json(
+          { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+          { status: 401 },
+        );
+      }),
+    );
+
+    mockedClerk.redirectToSignIn.mockClear();
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroOrgContract);
+    const result = await client.get();
+
+    expect(result.status).toBe(401);
+    expect(mockedClerk.redirectToSignIn).toHaveBeenCalledWith();
+  });
+
+  it("should not redirect on non-401 errors", async () => {
+    await setupPage({
+      context,
+      path: "/",
+      withoutRender: true,
+    });
+
+    server.use(
+      http.get("http://localhost:3000/api/zero/org", () => {
+        return HttpResponse.json(
+          { error: { message: "Forbidden", code: "FORBIDDEN" } },
+          { status: 403 },
+        );
+      }),
+    );
+
+    mockedClerk.redirectToSignIn.mockClear();
+
+    const createClient = context.store.get(zeroClient$);
+    const client = createClient(zeroOrgContract);
+    const result = await client.get();
+
+    expect(result.status).toBe(403);
+    expect(mockedClerk.redirectToSignIn).not.toHaveBeenCalled();
+  });
+});

--- a/turbo/apps/platform/src/signals/api-client.ts
+++ b/turbo/apps/platform/src/signals/api-client.ts
@@ -14,6 +14,7 @@ import {
 } from "@ts-rest/core";
 import { clerk$ } from "./auth.ts";
 import { apiBase$ } from "./fetch.ts";
+import { detach, Reason } from "./utils.ts";
 
 /**
  * Type alias for the factory function returned by `get(zeroClient$)`.
@@ -66,7 +67,13 @@ export const zeroClient$ = computed((get) => {
           ? { ...args.headers, Authorization: `Bearer ${token}` }
           : args.headers;
 
-        return tsRestFetchApi({ ...args, headers });
+        const response = await tsRestFetchApi({ ...args, headers });
+
+        if (response.status === 401) {
+          detach(clerk.redirectToSignIn(), Reason.DomCallback);
+        }
+
+        return response;
       },
     });
   };

--- a/turbo/apps/platform/src/signals/api-client.ts
+++ b/turbo/apps/platform/src/signals/api-client.ts
@@ -14,7 +14,9 @@ import {
 } from "@ts-rest/core";
 import { clerk$ } from "./auth.ts";
 import { apiBase$ } from "./fetch.ts";
-import { detach, Reason } from "./utils.ts";
+import { logger } from "./log.ts";
+
+const L = logger("ApiClient");
 
 /**
  * Type alias for the factory function returned by `get(zeroClient$)`.
@@ -70,7 +72,17 @@ export const zeroClient$ = computed((get) => {
         const response = await tsRestFetchApi({ ...args, headers });
 
         if (response.status === 401) {
-          detach(clerk.redirectToSignIn(), Reason.DomCallback);
+          // Fire-and-forget: the redirect navigates the page away so the promise
+          // may never settle. We must not await — callers need the 401 response.
+          const redirectResult = clerk.redirectToSignIn();
+          if (redirectResult instanceof Promise) {
+            redirectResult.catch((error: unknown) => {
+              if (error instanceof Error && error.name === "AbortError") {
+                return;
+              }
+              L.error("Sign-in redirect failed", error);
+            });
+          }
         }
 
         return response;


### PR DESCRIPTION
## Summary

- `zeroClient$` (ts-rest API client) was missing 401 → `redirectToSignIn()` handling that `fetch$` already had
- When a user's session expired, ts-rest API calls threw unhandled promise rejections instead of redirecting to the login page
- This affected all 38 files using `zeroClient$` — the fix in the shared `api-client.ts` covers them all

## Root Cause

The platform has two fetch paths:
1. **`fetch$`** (custom fetch signal) — had 401 redirect ✅
2. **`zeroClient$`** (ts-rest client via `tsRestFetchApi`) — bypassed `fetch$` entirely, no 401 handling ❌

Sentry reported this as `ApiError: Not authenticated` on Mobile Safari (iOS 18.7), but it could happen on any browser when the session expires.

## Test plan

- [x] Added integration tests verifying 401 triggers `redirectToSignIn()`
- [x] Added integration test verifying non-401 errors (403) do NOT trigger redirect
- [x] Existing tests pass

Closes #8219

🤖 Generated with [Claude Code](https://claude.com/claude-code)