### PR TITLE
fix: preserve schedule timezone when saving instruction edits

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-schedule.test.ts
@@ -1022,6 +1022,48 @@ describe("org schedule signals", () => {
       expect(captured.body?.prompt).toBe("Org-wide daily task");
       expect(captured.body?.cronExpression).toBe("0 8 * * *");
     });
+
+    it("should preserve non-UTC timezone in POST body", async () => {
+      const captured: { body: Record<string, unknown> | null } = {
+        body: null,
+      };
+
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/schedules",
+          async ({ request }) => {
+            captured.body = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              ...mockDeployResponse(),
+            });
+          },
+        ),
+        http.get("http://localhost:3000/api/zero/schedules", () => {
+          return HttpResponse.json({ schedules: [] });
+        }),
+      );
+
+      await setup();
+      await context.store.set(
+        saveOrgSchedule$,
+        {
+          prompt: "Instruction edit save",
+          freq: "every_weekday",
+          date: "2030-01-01",
+          hour: 9,
+          minute: 0,
+          timezone: "Asia/Shanghai",
+          intervalSeconds: 0,
+          agentId: "e0000000-0000-4000-a000-000000000010",
+          editName: "existing-schedule",
+        },
+        context.signal,
+      );
+
+      expect(captured.body).not.toBeNull();
+      expect(captured.body?.timezone).toBe("Asia/Shanghai");
+      expect(captured.body?.name).toBe("existing-schedule");
+    });
   });
 
   describe("toggleOrgScheduleEnabled$", () => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/parse-schedule-time-string.test.ts
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/parse-schedule-time-string.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { parseScheduleTimeString } from "../zero-schedule-card.tsx";
+
+describe("parseScheduleTimeString", () => {
+  it("should always default timezone to UTC", () => {
+    // parseScheduleTimeString parses a human-readable time string, which does
+    // NOT carry timezone information. Callers that re-save a schedule must use
+    // the stored entry.timezone rather than parsed.timezone to avoid silently
+    // overwriting a non-UTC timezone with UTC.
+    const cases = [
+      "Every weekday at 9:00 AM",
+      "Every day at 2:00 PM",
+      "Every week on Wednesday at 10:00 AM",
+      "Every month on day 15 at 9:00 AM",
+      "Every 15 minutes",
+      "Once on 2026-06-15 at 2:30 PM",
+    ];
+    for (const timeStr of cases) {
+      expect(parseScheduleTimeString(timeStr).timezone).toBe("UTC");
+    }
+  });
+
+  it("should parse every_weekday frequency", () => {
+    const result = parseScheduleTimeString("Every weekday at 9:00 AM");
+    expect(result.freq).toBe("every_weekday");
+    expect(result.hour).toBe(9);
+    expect(result.minute).toBe(0);
+  });
+
+  it("should parse every_n_minutes frequency from minutes", () => {
+    const result = parseScheduleTimeString("Every 15 minutes");
+    expect(result.freq).toBe("every_n_minutes");
+    expect(result.loopMinutes).toBe(15);
+  });
+
+  it("should parse every_n_minutes frequency from seconds", () => {
+    const result = parseScheduleTimeString("Every 300 seconds");
+    expect(result.freq).toBe("every_n_minutes");
+    expect(result.loopMinutes).toBe(5);
+  });
+
+  it("should parse once frequency", () => {
+    const result = parseScheduleTimeString("Once on 2026-06-15 at 2:30 PM");
+    expect(result.freq).toBe("once");
+    expect(result.date).toBe("2026-06-15");
+    expect(result.hour).toBe(14);
+    expect(result.minute).toBe(30);
+  });
+
+  it("should parse weekly frequency", () => {
+    const result = parseScheduleTimeString(
+      "Every week on Wednesday at 10:00 AM",
+    );
+    expect(result.freq).toBe("every_week");
+    expect(result.hour).toBe(10);
+    expect(result.minute).toBe(0);
+  });
+
+  it("should parse monthly frequency", () => {
+    const result = parseScheduleTimeString("Every month on day 15 at 9:00 AM");
+    expect(result.freq).toBe("every_month");
+    expect(result.hour).toBe(9);
+    expect(result.minute).toBe(0);
+  });
+
+  it("should parse 'Now' as now frequency", () => {
+    const result = parseScheduleTimeString("Now");
+    expect(result.freq).toBe("now");
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-detail-page.tsx
@@ -1030,7 +1030,7 @@ export function ZeroScheduleDetailPage() {
           date: parsed.date,
           hour: parsed.hour,
           minute: parsed.minute,
-          timezone: parsed.timezone,
+          timezone: entry.timezone ?? parsed.timezone,
           intervalSeconds: parsed.loopMinutes * 60,
           editName: entry.name,
           agentId: entry.agentId,


### PR DESCRIPTION
## Summary
- Fix timezone loss when editing schedule instructions on the detail page — `handleInstructionSavePrompt` used `parsed.timezone` (always UTC) instead of the stored `entry.timezone`
- Add `parseScheduleTimeString` pure function tests documenting that parsed timezone always defaults to UTC
- Add signal-level integration test verifying `saveOrgSchedule$` preserves non-UTC timezone in API requests

Closes #8160

## Test plan
- [ ] Verify `parseScheduleTimeString` tests pass (8 tests)
- [ ] Verify `saveOrgSchedule$` timezone preservation test passes
- [ ] Manually: create a schedule with Asia/Shanghai timezone, edit the instruction text, save, confirm timezone is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)