### PR TITLE
fix(computer-use): prevent ngrok 400 errors in register endpoint

### DIFF
--- a/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
@@ -211,6 +211,120 @@ describe("POST /api/zero/computer-use/register", () => {
     expect(ngrokCalls.deleteReservedDomain).toEqual(["rd_test_cu_abc"]);
   });
 
+  it("should recover when reserved domain already exists (400)", async () => {
+    const userId = uniqueId("zcu-dup-dom");
+    await setupOrg(userId);
+    const ngrokCalls = setupNgrokMocks();
+
+    let domainCreateAttempt = 0;
+    // Override: first POST /reserved_domains returns 400 (duplicate),
+    // then GET with filter returns the existing domain
+    server.use(
+      http.post(
+        "https://api.ngrok.com/reserved_domains",
+        async ({ request }) => {
+          domainCreateAttempt++;
+          const body = (await request.json()) as {
+            name: string;
+            region: string;
+          };
+          if (domainCreateAttempt === 1) {
+            return HttpResponse.json(
+              {
+                error_code: "ERR_NGROK_400",
+                msg: "domain already reserved",
+                status_code: 400,
+              },
+              { status: 400 },
+            );
+          }
+          ngrokCalls.createReservedDomain.push(body.name);
+          return HttpResponse.json({
+            id: "rd_test_cu_existing",
+            domain: `${body.name}.ngrok-free.app`,
+            region: body.region,
+            cname_target: null,
+          });
+        },
+      ),
+      http.get("https://api.ngrok.com/reserved_domains", ({ request }) => {
+        const url = new URL(request.url);
+        const filter = url.searchParams.get("filter");
+        if (filter) {
+          // Return existing domain when filter is used (fallback lookup)
+          return HttpResponse.json({
+            reserved_domains: [
+              {
+                id: "rd_test_cu_existing",
+                domain: "vm0-cu-existing.ngrok-free.app",
+                region: "us",
+                cname_target: null,
+              },
+            ],
+            next_page_uri: null,
+          });
+        }
+        ngrokCalls.listReservedDomains++;
+        return HttpResponse.json({
+          reserved_domains: [],
+          next_page_uri: null,
+        });
+      }),
+    );
+
+    const response = await POST(createPostRequest());
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.domain).toBeDefined();
+  });
+
+  it("should recover from orphan endpoint (400 on /endpoints)", async () => {
+    const userId = uniqueId("zcu-orphan-ep");
+    await setupOrg(userId);
+    const ngrokCalls = setupNgrokMocks();
+
+    let endpointCreateAttempt = 0;
+    let capturedEndpointUrl = "";
+    // Override: first POST /endpoints returns 400 (duplicate URL),
+    // GET /endpoints returns the orphan with matching URL, DELETE succeeds, retry POST succeeds
+    server.use(
+      http.post("https://api.ngrok.com/endpoints", async ({ request }) => {
+        endpointCreateAttempt++;
+        const body = (await request.json()) as { url: string };
+        capturedEndpointUrl = body.url;
+        if (endpointCreateAttempt === 1) {
+          return HttpResponse.json(
+            {
+              error_code: "ERR_NGROK_334",
+              msg: "endpoint URL already online",
+              status_code: 400,
+            },
+            { status: 400 },
+          );
+        }
+        ngrokCalls.createEndpoint.push(body.url);
+        return HttpResponse.json({
+          id: "ep_test_cu_new",
+          url: body.url,
+        });
+      }),
+      http.get("https://api.ngrok.com/endpoints", () => {
+        // Return an orphan endpoint matching the URL being created
+        return HttpResponse.json({
+          endpoints: [{ id: "ep_test_cu_orphan", url: capturedEndpointUrl }],
+          next_page_uri: null,
+        });
+      }),
+    );
+
+    const response = await POST(createPostRequest());
+    expect(response.status).toBe(200);
+
+    // Verify orphan was deleted before retry
+    expect(ngrokCalls.deleteEndpoint).toContain("ep_test_cu_orphan");
+  });
+
   it("should return 200 on re-registration (idempotent)", async () => {
     const userId = uniqueId("zcu-dup");
     await setupOrg(userId);

--- a/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
@@ -38,6 +38,42 @@ interface NgrokDomain {
 }
 
 /**
+ * Tag property for ngrok API errors so callers can match on status code
+ * without fragile string parsing.
+ */
+const NGROK_ERROR_TAG = Symbol("NgrokApiError");
+
+interface NgrokApiError extends Error {
+  [NGROK_ERROR_TAG]: true;
+  statusCode: number;
+}
+
+function createNgrokApiError(
+  statusCode: number,
+  path: string,
+  detail: string,
+): NgrokApiError {
+  const err = new Error(
+    `ngrok API error: ${statusCode} ${path}: ${detail}`,
+  ) as NgrokApiError;
+  err[NGROK_ERROR_TAG] = true;
+  err.statusCode = statusCode;
+  return err;
+}
+
+/**
+ * Check whether an error is an ngrok API error with a specific HTTP status code.
+ */
+function isNgrokError(error: unknown, statusCode: number): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    NGROK_ERROR_TAG in error &&
+    (error as NgrokApiError).statusCode === statusCode
+  );
+}
+
+/**
  * Make an authenticated request to the ngrok API.
  */
 async function ngrokFetch(
@@ -73,7 +109,7 @@ async function ngrokFetch(
       // body is not JSON — use raw text
     }
 
-    throw new Error(`ngrok API error: ${response.status} ${path}: ${detail}`);
+    throw createNgrokApiError(response.status, path, detail);
   }
 
   return response;
@@ -189,6 +225,8 @@ interface NgrokEndpointsPage {
 
 /**
  * Find a cloud endpoint by URL. Paginates through all results.
+ * Note: ngrok's /endpoints API does not support the filter parameter
+ * that /reserved_domains and /bot_users support, so pagination is required.
  */
 async function findEndpointByUrl(
   apiKey: string,
@@ -332,16 +370,6 @@ export async function deleteBotUser(
 }
 
 /**
- * Check whether an error is an ngrok API error with a specific HTTP status code.
- */
-function isNgrokError(error: unknown, statusCode: number): boolean {
-  return (
-    error instanceof Error &&
-    error.message.includes(`ngrok API error: ${statusCode}`)
-  );
-}
-
-/**
  * Safely delete an ngrok resource, ignoring 404 (already deleted).
  *
  * @param bestEffort - If true, log and swallow all errors (use in cleanup-on-failure paths
@@ -356,7 +384,7 @@ export async function safeDelete(
   try {
     await deleteFn();
   } catch (error) {
-    if (error instanceof Error && error.message.includes("404")) {
+    if (isNgrokError(error, 404)) {
       log.debug(`${resourceName} already deleted`, { id: resourceId });
     } else if (bestEffort) {
       log.warn(`Failed to clean up ${resourceName}`, {

--- a/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
@@ -59,9 +59,21 @@ async function ngrokFetch(
   if (!response.ok) {
     const body = await response.text();
     log.error(`ngrok API error: ${response.status} ${path}`, { body });
-    throw new Error(
-      `ngrok API error: ${response.status} ${response.statusText}`,
-    );
+
+    // Parse structured ngrok error for a more useful message
+    let detail = body;
+    try {
+      const parsed = JSON.parse(body) as { msg?: string; error_code?: string };
+      if (parsed.msg) {
+        detail = parsed.error_code
+          ? `${parsed.error_code}: ${parsed.msg}`
+          : parsed.msg;
+      }
+    } catch {
+      // body is not JSON — use raw text
+    }
+
+    throw new Error(`ngrok API error: ${response.status} ${path}: ${detail}`);
   }
 
   return response;
@@ -82,47 +94,36 @@ async function createBotUser(
 }
 
 /**
- * Find a Bot User by name. Paginates through all results.
- * Returns undefined if not found.
+ * Find a Bot User by name using ngrok's filter API.
  */
 async function findBotUserByName(
   apiKey: string,
   name: string,
 ): Promise<NgrokBotUser | undefined> {
-  let nextPageUri: string | null = "/bot_users";
-
-  while (nextPageUri) {
-    const response = await ngrokFetch(apiKey, nextPageUri);
-    const page = (await response.json()) as NgrokBotUsersPage;
-
-    const found = page.bot_users.find((u) => {
-      return u.name === name;
-    });
-    if (found) {
-      return found;
-    }
-
-    nextPageUri = page.next_page_uri;
-  }
-
-  return undefined;
+  const filter = encodeURIComponent(`obj.name == '${name}'`);
+  const response = await ngrokFetch(apiKey, `/bot_users?filter=${filter}`);
+  const page = (await response.json()) as NgrokBotUsersPage;
+  return page.bot_users[0];
 }
 
 /**
- * Find an existing Bot User by name, or create a new one.
+ * Create a Bot User, or return the existing one if it already exists.
+ * Uses optimistic create: tries POST first, falls back to lookup on 400.
  */
 export async function findOrCreateBotUser(
   apiKey: string,
   name: string,
 ): Promise<NgrokBotUser> {
-  const existing = await findBotUserByName(apiKey, name);
-  if (existing) {
-    log.debug("Found existing ngrok bot user", { id: existing.id, name });
-    return existing;
+  try {
+    log.debug("Creating new ngrok bot user", { name });
+    return await createBotUser(apiKey, name);
+  } catch (error) {
+    if (!isNgrokError(error, 400)) throw error;
+    log.debug("Bot user creation returned 400, looking up existing", { name });
+    const existing = await findBotUserByName(apiKey, name);
+    if (existing) return existing;
+    throw error;
   }
-
-  log.debug("Creating new ngrok bot user", { name });
-  return createBotUser(apiKey, name);
 }
 
 /**
@@ -181,6 +182,57 @@ export async function deleteCloudEndpoint(
   });
 }
 
+interface NgrokEndpointsPage {
+  endpoints: NgrokEndpoint[];
+  next_page_uri: string | null;
+}
+
+/**
+ * Find a cloud endpoint by URL. Paginates through all results.
+ */
+async function findEndpointByUrl(
+  apiKey: string,
+  url: string,
+): Promise<NgrokEndpoint | undefined> {
+  let nextPageUri: string | null = "/endpoints";
+
+  while (nextPageUri) {
+    const response = await ngrokFetch(apiKey, nextPageUri);
+    const page = (await response.json()) as NgrokEndpointsPage;
+    const found = page.endpoints.find((e) => {
+      return e.url === url;
+    });
+    if (found) return found;
+    nextPageUri = page.next_page_uri;
+  }
+
+  return undefined;
+}
+
+/**
+ * Create a cloud endpoint, recovering from orphan duplicates.
+ * If creation fails with 400 (URL already in use), finds and deletes the
+ * orphan endpoint, then retries.
+ */
+export async function findOrCreateCloudEndpoint(
+  apiKey: string,
+  url: string,
+  trafficPolicy: string,
+): Promise<NgrokEndpoint> {
+  try {
+    return await createCloudEndpoint(apiKey, url, trafficPolicy);
+  } catch (error) {
+    if (!isNgrokError(error, 400)) throw error;
+    log.warn("Cloud endpoint creation returned 400, cleaning up orphan", {
+      url,
+    });
+    const existing = await findEndpointByUrl(apiKey, url);
+    if (!existing) throw error;
+    await deleteCloudEndpoint(apiKey, existing.id);
+    return createCloudEndpoint(apiKey, url, trafficPolicy);
+  }
+}
+
 /**
  * Create a reserved domain with ngrok-assigned subdomain.
  * ngrok will automatically assign a subdomain like "abc123.ngrok-free.app"
@@ -217,50 +269,42 @@ interface NgrokReservedDomainsPage {
 }
 
 /**
- * Find a reserved domain by name. Paginates through all results.
+ * Find a reserved domain by name using ngrok's filter API.
  */
 async function findReservedDomainByName(
   apiKey: string,
   name: string,
 ): Promise<NgrokDomain | undefined> {
-  let nextPageUri: string | null = "/reserved_domains";
-
-  while (nextPageUri) {
-    const response = await ngrokFetch(apiKey, nextPageUri);
-    const page = (await response.json()) as NgrokReservedDomainsPage;
-
-    const found = page.reserved_domains.find((d) => {
-      return d.domain.startsWith(`${name}.`);
-    });
-    if (found) {
-      return found;
-    }
-
-    nextPageUri = page.next_page_uri;
-  }
-
-  return undefined;
+  const filter = encodeURIComponent(`obj.domain.startsWith('${name}.')`);
+  const response = await ngrokFetch(
+    apiKey,
+    `/reserved_domains?filter=${filter}`,
+  );
+  const page = (await response.json()) as NgrokReservedDomainsPage;
+  return page.reserved_domains[0];
 }
 
 /**
- * Find an existing reserved domain by name, or create a new one.
+ * Create a reserved domain, or return the existing one if it already exists.
+ * Uses optimistic create: tries POST first, falls back to lookup on 400.
  */
 export async function findOrCreateReservedDomain(
   apiKey: string,
   name: string,
   region: string = "us",
 ): Promise<NgrokDomain> {
-  const existing = await findReservedDomainByName(apiKey, name);
-  if (existing) {
-    log.debug("Found existing reserved domain", {
-      id: existing.id,
-      domain: existing.domain,
+  try {
+    log.debug("Creating new reserved domain", { name });
+    return await createReservedDomain(apiKey, name, region);
+  } catch (error) {
+    if (!isNgrokError(error, 400)) throw error;
+    log.debug("Reserved domain creation returned 400, looking up existing", {
+      name,
     });
-    return existing;
+    const existing = await findReservedDomainByName(apiKey, name);
+    if (existing) return existing;
+    throw error;
   }
-
-  log.debug("Creating new reserved domain", { name });
-  return createReservedDomain(apiKey, name, region);
 }
 
 /**
@@ -285,6 +329,16 @@ export async function deleteBotUser(
   await ngrokFetch(apiKey, `/bot_users/${botUserId}`, {
     method: "DELETE",
   });
+}
+
+/**
+ * Check whether an error is an ngrok API error with a specific HTTP status code.
+ */
+function isNgrokError(error: unknown, statusCode: number): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes(`ngrok API error: ${statusCode}`)
+  );
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -5,7 +5,7 @@
  * for computer-use remote desktop sessions.
  */
 import { createHash, randomUUID } from "crypto";
-import { eq, and, gt } from "drizzle-orm";
+import { eq, and, gt, sql } from "drizzle-orm";
 import { computerUseHosts } from "../../../db/schema/computer-use-host";
 import { notFound } from "../../shared/errors";
 import { logger } from "../../shared/logger";
@@ -13,9 +13,9 @@ import {
   findOrCreateBotUser,
   createCredential,
   deleteCredential,
-  createCloudEndpoint,
   deleteCloudEndpoint,
   findOrCreateReservedDomain,
+  findOrCreateCloudEndpoint,
   deleteReservedDomain,
   deleteBotUser,
   safeDelete,
@@ -52,211 +52,221 @@ export async function registerHost(
     throw new Error("NGROK_API_KEY is not configured");
   }
 
-  // If existing host found, partially clean up (keep domain and bot user)
-  const [existing] = await db
-    .select()
-    .from(computerUseHosts)
-    .where(
-      and(
-        eq(computerUseHosts.orgId, orgId),
-        eq(computerUseHosts.userId, userId),
-      ),
-    )
-    .limit(1);
-
-  let reusableDomain: { domain: string; id: string } | null = null;
-
-  if (existing) {
-    log.debug("Cleaning up existing host registration", { orgId, userId });
-
-    // Delete credential and endpoint (need new token + routing), keep domain
-    if (existing.ngrokCredentialId) {
-      await safeDelete(
-        () => {
-          return deleteCredential(apiKey, existing.ngrokCredentialId!);
-        },
-        "Credential",
-        existing.ngrokCredentialId,
-      );
-    }
-    if (existing.ngrokEndpointId) {
-      await safeDelete(
-        () => {
-          return deleteCloudEndpoint(apiKey, existing.ngrokEndpointId!);
-        },
-        "Cloud endpoint",
-        existing.ngrokEndpointId,
-      );
-    }
-
-    // Preserve domain for reuse (same user = same deterministic slug)
-    if (existing.ngrokDomainId && existing.domain) {
-      reusableDomain = { domain: existing.domain, id: existing.ngrokDomainId };
-    }
-
-    await db
-      .delete(computerUseHosts)
-      .where(eq(computerUseHosts.id, existing.id));
-  }
-
-  // Generate a DNS-safe slug from orgId+userId hash (hex chars only)
-  const slug = createHash("sha256")
-    .update(`${orgId}:${userId}`)
-    .digest("hex")
-    .substring(0, 12);
-  const subdomainName = `vm0-cu-${slug}`;
-  const endpointPrefix = `vm0-cu-${slug}`;
-  const botUserName = `vm0-cu-${slug}`;
-
-  // Provision ngrok resources — clean up on partial failure
-  let botUserId: string | undefined;
-  let credentialId: string | undefined;
-  let domainId: string | undefined;
-  let endpointId: string | undefined;
-
-  try {
-    const botUser = await findOrCreateBotUser(apiKey, botUserName);
-    botUserId = botUser.id;
-
-    const credential = await createCredential(apiKey, botUser.id, [
-      `bind:*.${endpointPrefix}.internal`,
-    ]);
-    credentialId = credential.id;
-
-    // Reuse existing domain or create new one
-    let domain: string;
-    if (reusableDomain) {
-      domain = reusableDomain.domain;
-      domainId = reusableDomain.id;
-      log.debug("Reusing existing reserved domain", { domain, domainId });
-    } else {
-      const reservedDomain = await findOrCreateReservedDomain(
-        apiKey,
-        subdomainName,
-        "us",
-      );
-      domain = reservedDomain.domain;
-      domainId = reservedDomain.id;
-    }
-
-    const bridgeToken = randomUUID();
-
-    // Traffic policy: verify bridge token and forward to internal endpoint
-    const trafficPolicy = JSON.stringify({
-      on_http_request: [
-        {
-          expressions: [
-            `!('x-vm0-token' in req.headers) || req.headers['x-vm0-token'][0] != '${bridgeToken}'`,
-          ],
-          actions: [{ type: "deny", config: { status_code: 403 } }],
-        },
-        {
-          actions: [
-            {
-              type: "forward-internal",
-              config: {
-                url: `https://$\{conn.server_name.split('.${domain}')[0]}.${endpointPrefix}.internal`,
-                on_error: "continue",
-              },
-            },
-            {
-              type: "custom-response",
-              config: { status_code: 502, body: "Host offline" },
-            },
-          ],
-        },
-      ],
-    });
-
-    const endpointUrl = `https://*.${domain}`;
-    const cloudEndpoint = await createCloudEndpoint(
-      apiKey,
-      endpointUrl,
-      trafficPolicy,
+  // Serialize concurrent register calls for the same user
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext('cu_' || ${orgId} || ':' || ${userId}))`,
     );
-    endpointId = cloudEndpoint.id;
 
-    // Create host row
-    const [hostRow] = await db
-      .insert(computerUseHosts)
-      .values({
-        orgId,
-        userId,
+    // If existing host found, partially clean up (keep domain and bot user)
+    const [existing] = await tx
+      .select()
+      .from(computerUseHosts)
+      .where(
+        and(
+          eq(computerUseHosts.orgId, orgId),
+          eq(computerUseHosts.userId, userId),
+        ),
+      )
+      .limit(1);
+
+    let reusableDomain: { domain: string; id: string } | null = null;
+
+    if (existing) {
+      log.debug("Cleaning up existing host registration", { orgId, userId });
+
+      // Delete credential and endpoint (need new token + routing), keep domain
+      if (existing.ngrokCredentialId) {
+        await safeDelete(
+          () => {
+            return deleteCredential(apiKey, existing.ngrokCredentialId!);
+          },
+          "Credential",
+          existing.ngrokCredentialId,
+        );
+      }
+      if (existing.ngrokEndpointId) {
+        await safeDelete(
+          () => {
+            return deleteCloudEndpoint(apiKey, existing.ngrokEndpointId!);
+          },
+          "Cloud endpoint",
+          existing.ngrokEndpointId,
+        );
+      }
+
+      // Preserve domain for reuse (same user = same deterministic slug)
+      if (existing.ngrokDomainId && existing.domain) {
+        reusableDomain = {
+          domain: existing.domain,
+          id: existing.ngrokDomainId,
+        };
+      }
+
+      await tx
+        .delete(computerUseHosts)
+        .where(eq(computerUseHosts.id, existing.id));
+    }
+
+    // Generate a DNS-safe slug from orgId+userId hash (hex chars only)
+    const slug = createHash("sha256")
+      .update(`${orgId}:${userId}`)
+      .digest("hex")
+      .substring(0, 12);
+    const subdomainName = `vm0-cu-${slug}`;
+    const endpointPrefix = `vm0-cu-${slug}`;
+    const botUserName = `vm0-cu-${slug}`;
+
+    // Provision ngrok resources — clean up on partial failure
+    let botUserId: string | undefined;
+    let credentialId: string | undefined;
+    let domainId: string | undefined;
+    let endpointId: string | undefined;
+
+    try {
+      const botUser = await findOrCreateBotUser(apiKey, botUserName);
+      botUserId = botUser.id;
+
+      const credential = await createCredential(apiKey, botUser.id, [
+        `bind:*.${endpointPrefix}.internal`,
+      ]);
+      credentialId = credential.id;
+
+      // Reuse existing domain or create new one
+      let domain: string;
+      if (reusableDomain) {
+        domain = reusableDomain.domain;
+        domainId = reusableDomain.id;
+        log.debug("Reusing existing reserved domain", { domain, domainId });
+      } else {
+        const reservedDomain = await findOrCreateReservedDomain(
+          apiKey,
+          subdomainName,
+          "us",
+        );
+        domain = reservedDomain.domain;
+        domainId = reservedDomain.id;
+      }
+
+      const bridgeToken = randomUUID();
+
+      // Traffic policy: verify bridge token and forward to internal endpoint
+      const trafficPolicy = JSON.stringify({
+        on_http_request: [
+          {
+            expressions: [
+              `!('x-vm0-token' in req.headers) || req.headers['x-vm0-token'][0] != '${bridgeToken}'`,
+            ],
+            actions: [{ type: "deny", config: { status_code: 403 } }],
+          },
+          {
+            actions: [
+              {
+                type: "forward-internal",
+                config: {
+                  url: `https://$\{conn.server_name.split('.${domain}')[0]}.${endpointPrefix}.internal`,
+                  on_error: "continue",
+                },
+              },
+              {
+                type: "custom-response",
+                config: { status_code: 502, body: "Host offline" },
+              },
+            ],
+          },
+        ],
+      });
+
+      const endpointUrl = `https://*.${domain}`;
+      const cloudEndpoint = await findOrCreateCloudEndpoint(
+        apiKey,
+        endpointUrl,
+        trafficPolicy,
+      );
+      endpointId = cloudEndpoint.id;
+
+      // Create host row
+      const [hostRow] = await tx
+        .insert(computerUseHosts)
+        .values({
+          orgId,
+          userId,
+          domain,
+          token: bridgeToken,
+          ngrokBotUserId: botUserId,
+          ngrokCredentialId: credentialId,
+          ngrokEndpointId: cloudEndpoint.id,
+          ngrokDomainId: domainId,
+          expiresAt: new Date(Date.now() + HOST_TTL_MS),
+        })
+        .returning();
+
+      if (!hostRow) {
+        throw new Error("Failed to create computer-use host");
+      }
+
+      log.debug("Computer-use host registered", {
+        hostId: hostRow.id,
+        botUserId,
+        domain,
+      });
+
+      return {
+        id: hostRow.id,
         domain,
         token: bridgeToken,
-        ngrokBotUserId: botUserId,
-        ngrokCredentialId: credentialId,
-        ngrokEndpointId: cloudEndpoint.id,
-        ngrokDomainId: domainId,
-        expiresAt: new Date(Date.now() + HOST_TTL_MS),
-      })
-      .returning();
-
-    if (!hostRow) {
-      throw new Error("Failed to create computer-use host");
+        ngrokToken: credential.token,
+        endpointPrefix,
+      };
+    } catch (error) {
+      log.error("Failed to register host, cleaning up", { orgId, userId });
+      const eid = endpointId;
+      const cid = credentialId;
+      const did = domainId;
+      const bid = botUserId;
+      if (eid) {
+        await safeDelete(
+          () => {
+            return deleteCloudEndpoint(apiKey, eid);
+          },
+          "Cloud endpoint",
+          eid,
+          true,
+        );
+      }
+      if (cid) {
+        await safeDelete(
+          () => {
+            return deleteCredential(apiKey, cid);
+          },
+          "Credential",
+          cid,
+          true,
+        );
+      }
+      if (did && !reusableDomain) {
+        await safeDelete(
+          () => {
+            return deleteReservedDomain(apiKey, did);
+          },
+          "Reserved domain",
+          did,
+          true,
+        );
+      }
+      if (bid) {
+        await safeDelete(
+          () => {
+            return deleteBotUser(apiKey, bid);
+          },
+          "Bot user",
+          bid,
+          true,
+        );
+      }
+      throw error;
     }
-
-    log.debug("Computer-use host registered", {
-      hostId: hostRow.id,
-      botUserId,
-      domain,
-    });
-
-    return {
-      id: hostRow.id,
-      domain,
-      token: bridgeToken,
-      ngrokToken: credential.token,
-      endpointPrefix,
-    };
-  } catch (error) {
-    log.error("Failed to register host, cleaning up", { orgId, userId });
-    const eid = endpointId;
-    const cid = credentialId;
-    const did = domainId;
-    const bid = botUserId;
-    if (eid) {
-      await safeDelete(
-        () => {
-          return deleteCloudEndpoint(apiKey, eid);
-        },
-        "Cloud endpoint",
-        eid,
-        true,
-      );
-    }
-    if (cid) {
-      await safeDelete(
-        () => {
-          return deleteCredential(apiKey, cid);
-        },
-        "Credential",
-        cid,
-        true,
-      );
-    }
-    if (did && !reusableDomain) {
-      await safeDelete(
-        () => {
-          return deleteReservedDomain(apiKey, did);
-        },
-        "Reserved domain",
-        did,
-        true,
-      );
-    }
-    if (bid) {
-      await safeDelete(
-        () => {
-          return deleteBotUser(apiKey, bid);
-        },
-        "Bot user",
-        bid,
-        true,
-      );
-    }
-    throw error;
-  }
+  });
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -52,7 +52,10 @@ export async function registerHost(
     throw new Error("NGROK_API_KEY is not configured");
   }
 
-  // Serialize concurrent register calls for the same user
+  // Serialize concurrent register calls for the same user.
+  // Note: this holds a DB connection for the duration of ngrok API calls (~1-5s).
+  // Acceptable while ComputerUse is staff-only (low concurrency). If opened to
+  // general users, refactor to two-phase: short lock transaction + external calls + update.
   return db.transaction(async (tx) => {
     await tx.execute(
       sql`SELECT pg_advisory_xact_lock(hashtext('cu_' || ${orgId} || ':' || ${userId}))`,


### PR DESCRIPTION
## Summary

Fixes the recurring ngrok API 400 errors on `/reserved_domains` and `/endpoints` during `zero-computer-use:register` (#8186).

**Root causes:**
- **Race condition (TOCTOU)**: Concurrent register calls for the same user both find no existing resource, then both try to create → second gets 400
- **Orphan endpoints**: Failed registrations can leave unreachable cloud endpoints on ngrok that block future registrations
- **Fragile lookups**: Pagination-based find was slow and increased the race window

**Fixes:**
- Add `pg_advisory_xact_lock` to serialize concurrent register calls per user (follows existing patterns in run-service, credit-service)
- Switch to optimistic create pattern: try POST first, fall back to lookup on 400 (duplicate)
- Use ngrok filter API for domain/bot-user lookups instead of paginating all results
- Add orphan endpoint detection and cleanup when endpoint creation fails with 400
- Include ngrok error response body (error_code + msg) in thrown errors for better observability

## Test plan

- [x] Existing 13 tests continue to pass
- [x] New test: reserved domain 400 recovery (optimistic create fallback)
- [x] New test: orphan endpoint 400 recovery (detect + delete + retry)
- [x] Lint, format, knip all pass

Closes #8186

🤖 Generated with [Claude Code](https://claude.com/claude-code)