### PR TITLE
refactor: adopt ngrok find-or-update pattern for cloud endpoints and reserved domains

### DIFF
--- a/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
@@ -53,7 +53,9 @@ function setupNgrokMocks() {
   const calls = {
     createBotUser: [] as string[],
     listBotUsers: 0,
-    listReservedDomains: 0,
+    filterEndpoints: [] as string[],
+    patchEndpoint: [] as string[],
+    filterReservedDomains: [] as string[],
     createCredential: [] as string[],
     deleteCredential: [] as string[],
     createEndpoint: [] as string[],
@@ -94,8 +96,10 @@ function setupNgrokMocks() {
       calls.deleteCredential.push(params.id as string);
       return new HttpResponse(null, { status: 204 });
     }),
-    http.get("https://api.ngrok.com/reserved_domains", () => {
-      calls.listReservedDomains++;
+    http.get("https://api.ngrok.com/reserved_domains", ({ request }) => {
+      const url = new URL(request.url);
+      const filter = url.searchParams.get("filter");
+      calls.filterReservedDomains.push(filter ?? "");
       return HttpResponse.json({
         reserved_domains: [],
         next_page_uri: null,
@@ -117,6 +121,22 @@ function setupNgrokMocks() {
     http.delete("https://api.ngrok.com/reserved_domains/:id", ({ params }) => {
       calls.deleteReservedDomain.push(params.id as string);
       return new HttpResponse(null, { status: 204 });
+    }),
+    http.get("https://api.ngrok.com/endpoints", ({ request }) => {
+      const url = new URL(request.url);
+      const filter = url.searchParams.get("filter");
+      calls.filterEndpoints.push(filter ?? "");
+      return HttpResponse.json({
+        endpoints: [],
+        next_page_uri: null,
+      });
+    }),
+    http.patch("https://api.ngrok.com/endpoints/:id", async ({ params }) => {
+      calls.patchEndpoint.push(params.id as string);
+      return HttpResponse.json({
+        id: params.id as string,
+        url: "https://*.patched.ngrok-free.app",
+      });
     }),
     http.post("https://api.ngrok.com/endpoints", async ({ request }) => {
       const body = (await request.json()) as { url: string };
@@ -186,7 +206,9 @@ describe("POST /api/zero/computer-use/register", () => {
 
     expect(ngrokCalls.createBotUser.length).toBe(1);
     expect(ngrokCalls.createCredential.length).toBe(1);
+    expect(ngrokCalls.filterReservedDomains.length).toBe(1);
     expect(ngrokCalls.createReservedDomain.length).toBe(1);
+    expect(ngrokCalls.filterEndpoints.length).toBe(1);
     expect(ngrokCalls.createEndpoint.length).toBe(1);
   });
 
@@ -209,6 +231,37 @@ describe("POST /api/zero/computer-use/register", () => {
     expect(ngrokCalls.deleteBotUser).toEqual(["bot_test_cu_123"]);
     expect(ngrokCalls.deleteCredential).toEqual(["cr_test_cu_456"]);
     expect(ngrokCalls.deleteReservedDomain).toEqual(["rd_test_cu_abc"]);
+  });
+
+  it("should update existing orphaned endpoint instead of creating new one", async () => {
+    const userId = uniqueId("zcu-orphan");
+    await setupOrg(userId);
+    const ngrokCalls = setupNgrokMocks();
+
+    // Override GET /endpoints to return an orphaned endpoint
+    server.use(
+      http.get("https://api.ngrok.com/endpoints", ({ request }) => {
+        const url = new URL(request.url);
+        const filter = url.searchParams.get("filter");
+        ngrokCalls.filterEndpoints.push(filter ?? "");
+        return HttpResponse.json({
+          endpoints: [
+            { id: "ep_orphaned_123", url: "https://*.orphan.ngrok-free.app" },
+          ],
+          next_page_uri: null,
+        });
+      }),
+    );
+
+    const response = await POST(createPostRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.id).toBeDefined();
+
+    // Should PATCH the existing endpoint, not create a new one
+    expect(ngrokCalls.patchEndpoint).toEqual(["ep_orphaned_123"]);
+    expect(ngrokCalls.createEndpoint.length).toBe(0);
   });
 
   it("should return 200 on re-registration (idempotent)", async () => {

--- a/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/connectors/computer/__tests__/route.test.ts
@@ -30,11 +30,13 @@ function setupNgrokMocks() {
   const calls = {
     createBotUser: [] as string[],
     listBotUsers: 0,
+    filterEndpoints: [] as string[],
+    patchEndpoint: [] as string[],
+    filterReservedDomains: [] as string[],
     createCredential: [] as string[],
     deleteCredential: [] as string[],
     createEndpoint: [] as string[],
     deleteEndpoint: [] as string[],
-    listReservedDomains: 0,
     createReservedDomain: [] as string[],
     deleteReservedDomain: [] as string[],
     deleteBotUser: [] as string[],
@@ -71,8 +73,10 @@ function setupNgrokMocks() {
       calls.deleteCredential.push(params.id as string);
       return new HttpResponse(null, { status: 204 });
     }),
-    http.get("https://api.ngrok.com/reserved_domains", () => {
-      calls.listReservedDomains++;
+    http.get("https://api.ngrok.com/reserved_domains", ({ request }) => {
+      const url = new URL(request.url);
+      const filter = url.searchParams.get("filter");
+      calls.filterReservedDomains.push(filter ?? "");
       return HttpResponse.json({
         reserved_domains: [],
         next_page_uri: null,
@@ -94,6 +98,22 @@ function setupNgrokMocks() {
     http.delete("https://api.ngrok.com/reserved_domains/:id", ({ params }) => {
       calls.deleteReservedDomain.push(params.id as string);
       return new HttpResponse(null, { status: 204 });
+    }),
+    http.get("https://api.ngrok.com/endpoints", ({ request }) => {
+      const url = new URL(request.url);
+      const filter = url.searchParams.get("filter");
+      calls.filterEndpoints.push(filter ?? "");
+      return HttpResponse.json({
+        endpoints: [],
+        next_page_uri: null,
+      });
+    }),
+    http.patch("https://api.ngrok.com/endpoints/:id", async ({ params }) => {
+      calls.patchEndpoint.push(params.id as string);
+      return HttpResponse.json({
+        id: params.id as string,
+        url: "https://*.patched.ngrok-free.app",
+      });
     }),
     http.post("https://api.ngrok.com/endpoints", async ({ request }) => {
       const body = (await request.json()) as { url: string };

--- a/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/computer-connector-service.ts
@@ -17,7 +17,7 @@ import {
   findOrCreateBotUser,
   createCredential,
   deleteCredential,
-  createCloudEndpoint,
+  ensureCloudEndpoint,
   deleteCloudEndpoint,
   findOrCreateReservedDomain,
   deleteReservedDomain,
@@ -124,7 +124,7 @@ export async function createComputerConnector(
     });
 
     const endpointUrl = `https://*.${domain}`;
-    const cloudEndpoint = await createCloudEndpoint(
+    const cloudEndpoint = await ensureCloudEndpoint(
       apiKey,
       endpointUrl,
       trafficPolicy,

--- a/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
@@ -30,6 +30,11 @@ interface NgrokEndpoint {
   url: string;
 }
 
+interface NgrokEndpointsPage {
+  endpoints: NgrokEndpoint[];
+  next_page_uri: string | null;
+}
+
 interface NgrokDomain {
   id: string;
   domain: string;
@@ -155,18 +160,40 @@ export async function deleteCredential(
 }
 
 /**
- * Create a Cloud Endpoint with a traffic policy.
+ * Ensure a Cloud Endpoint exists with the given traffic policy.
+ *
+ * Uses CEL filter to find an existing endpoint by URL, then PATCH-updates
+ * the traffic policy if found. Creates a new endpoint if none exists.
+ * This is idempotent — safe to call when orphaned endpoints may exist.
  */
-export async function createCloudEndpoint(
+export async function ensureCloudEndpoint(
   apiKey: string,
   url: string,
   trafficPolicy: string,
 ): Promise<NgrokEndpoint> {
-  const response = await ngrokFetch(apiKey, "/endpoints", {
+  const filterQuery = encodeURIComponent(`obj.url == "${url}"`);
+  const response = await ngrokFetch(apiKey, `/endpoints?filter=${filterQuery}`);
+  const page = (await response.json()) as NgrokEndpointsPage;
+  const existing = page.endpoints[0];
+
+  if (existing) {
+    log.debug("Found existing cloud endpoint, updating traffic policy", {
+      id: existing.id,
+      url,
+    });
+    const updated = await ngrokFetch(apiKey, `/endpoints/${existing.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ traffic_policy: trafficPolicy }),
+    });
+    return (await updated.json()) as NgrokEndpoint;
+  }
+
+  log.debug("Creating new cloud endpoint", { url });
+  const created = await ngrokFetch(apiKey, "/endpoints", {
     method: "POST",
     body: JSON.stringify({ url, type: "cloud", traffic_policy: trafficPolicy }),
   });
-  return (await response.json()) as NgrokEndpoint;
+  return (await created.json()) as NgrokEndpoint;
 }
 
 /**
@@ -217,29 +244,21 @@ interface NgrokReservedDomainsPage {
 }
 
 /**
- * Find a reserved domain by name. Paginates through all results.
+ * Find a reserved domain by name using CEL filter.
+ * Matches the full domain name (e.g., "vm0-cu-abc123.ngrok-free.app").
  */
 async function findReservedDomainByName(
   apiKey: string,
   name: string,
 ): Promise<NgrokDomain | undefined> {
-  let nextPageUri: string | null = "/reserved_domains";
-
-  while (nextPageUri) {
-    const response = await ngrokFetch(apiKey, nextPageUri);
-    const page = (await response.json()) as NgrokReservedDomainsPage;
-
-    const found = page.reserved_domains.find((d) => {
-      return d.domain.startsWith(`${name}.`);
-    });
-    if (found) {
-      return found;
-    }
-
-    nextPageUri = page.next_page_uri;
-  }
-
-  return undefined;
+  const domainName = `${name}.ngrok-free.app`;
+  const filterQuery = encodeURIComponent(`obj.domain == "${domainName}"`);
+  const response = await ngrokFetch(
+    apiKey,
+    `/reserved_domains?filter=${filterQuery}`,
+  );
+  const page = (await response.json()) as NgrokReservedDomainsPage;
+  return page.reserved_domains[0];
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
+++ b/turbo/apps/web/src/lib/zero/computer-use/computer-use-service.ts
@@ -13,7 +13,7 @@ import {
   findOrCreateBotUser,
   createCredential,
   deleteCredential,
-  createCloudEndpoint,
+  ensureCloudEndpoint,
   deleteCloudEndpoint,
   findOrCreateReservedDomain,
   deleteReservedDomain,
@@ -169,7 +169,7 @@ export async function registerHost(
     });
 
     const endpointUrl = `https://*.${domain}`;
-    const cloudEndpoint = await createCloudEndpoint(
+    const cloudEndpoint = await ensureCloudEndpoint(
       apiKey,
       endpointUrl,
       trafficPolicy,


### PR DESCRIPTION
## Summary

- Replace `createCloudEndpoint` with idempotent `ensureCloudEndpoint` that uses CEL filter (`obj.url == "..."`) to find existing endpoints, PATCH to update traffic policy, or POST to create new — eliminates `ERR_NGROK_18017` errors from orphaned endpoints
- Optimize `findOrCreateReservedDomain` to use CEL filter (`obj.domain == "..."`) instead of manual pagination through all domains
- Update both computer-use and computer-connector services to use the new idempotent pattern

## Test plan

- [x] All 24 existing computer-use and computer-connector tests pass
- [x] New test: orphaned endpoint gets PATCH-updated instead of causing conflict
- [x] MSW mock handlers added for `GET /endpoints` (filter), `PATCH /endpoints/:id`, updated `GET /reserved_domains` (filter)
- [x] Type check passes
- [x] Lint passes
- [x] Knip passes (no unused exports)
- [ ] Verify no direct calls to old `createCloudEndpoint` remain: `grep -r "createCloudEndpoint" turbo/apps/web/src/` should return 0 results

Closes #8267

🤖 Generated with [Claude Code](https://claude.com/claude-code)