### PR TITLE
fix(billing): refresh stale billing period from stripe when cached date expires

### DIFF
--- a/turbo/apps/web/src/lib/zero/billing/billing-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/billing-service.ts
@@ -245,7 +245,7 @@ export async function handleInvoicePaid(invoice: InvoiceInput): Promise<void> {
     : undefined;
 
   if (!subscriptionId) {
-    log.debug("invoice.paid without subscription — skipping", {
+    log.warn("invoice.paid without subscription — skipping", {
       invoiceId: invoice.id,
     });
     return;
@@ -307,7 +307,11 @@ export async function handleInvoicePaid(invoice: InvoiceInput): Promise<void> {
   const credits = TIER_MONTHLY_CREDITS[tier];
 
   if (credits <= 0) {
-    log.debug("no credits to grant for tier", { tier, invoiceId: invoice.id });
+    log.warn("no credits to grant for tier", {
+      tier,
+      invoiceId: invoice.id,
+      orgId: org.orgId,
+    });
     return;
   }
 

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/member-credit-cap-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/member-credit-cap-service.test.ts
@@ -98,8 +98,8 @@ describe("evaluateMemberCaps", () => {
     mockClerk({ userId });
     const { id: orgId } = await createTestOrg(slug);
 
-    // Set up billing period
-    const periodEnd = new Date("2026-04-01T00:00:00Z");
+    // Set up billing period (future date to avoid stale-period Stripe refresh)
+    const periodEnd = new Date("2099-04-01T00:00:00Z");
     await updateOrgStripeFields(orgId, {
       stripeSubscriptionId: uniqueId("sub"),
       stripeCustomerId: uniqueId("cus"),
@@ -120,7 +120,7 @@ describe("evaluateMemberCaps", () => {
       userId,
       status: "processed",
       creditsCharged: 75,
-      processedAt: new Date("2026-03-15T00:00:00Z"),
+      processedAt: new Date("2099-03-15T00:00:00Z"),
     });
 
     await evaluateMemberCaps(orgId, [userId]);
@@ -135,8 +135,8 @@ describe("evaluateMemberCaps", () => {
     mockClerk({ userId });
     const { id: orgId } = await createTestOrg(slug);
 
-    // Set up billing period
-    const periodEnd = new Date("2026-04-01T00:00:00Z");
+    // Set up billing period (future date to avoid stale-period Stripe refresh)
+    const periodEnd = new Date("2099-04-01T00:00:00Z");
     await updateOrgStripeFields(orgId, {
       stripeSubscriptionId: uniqueId("sub"),
       stripeCustomerId: uniqueId("cus"),
@@ -157,7 +157,7 @@ describe("evaluateMemberCaps", () => {
       userId,
       status: "processed",
       creditsCharged: 25,
-      processedAt: new Date("2026-03-15T00:00:00Z"),
+      processedAt: new Date("2099-03-15T00:00:00Z"),
     });
 
     await evaluateMemberCaps(orgId, [userId]);
@@ -173,8 +173,8 @@ describe("evaluateMemberCaps", () => {
     mockClerk({ userId: userId1 });
     const { id: orgId } = await createTestOrg(slug);
 
-    // Set up billing period
-    const periodEnd = new Date("2026-04-01T00:00:00Z");
+    // Set up billing period (future date to avoid stale-period Stripe refresh)
+    const periodEnd = new Date("2099-04-01T00:00:00Z");
     await updateOrgStripeFields(orgId, {
       stripeSubscriptionId: uniqueId("sub"),
       stripeCustomerId: uniqueId("cus"),
@@ -193,7 +193,7 @@ describe("evaluateMemberCaps", () => {
       userId: userId1,
       status: "processed",
       creditsCharged: 75,
-      processedAt: new Date("2026-03-15T00:00:00Z"),
+      processedAt: new Date("2099-03-15T00:00:00Z"),
     });
 
     // User2: cap 100, usage 30 (under cap -> should remain enabled)
@@ -207,7 +207,7 @@ describe("evaluateMemberCaps", () => {
       userId: userId2,
       status: "processed",
       creditsCharged: 30,
-      processedAt: new Date("2026-03-15T00:00:00Z"),
+      processedAt: new Date("2099-03-15T00:00:00Z"),
     });
 
     await evaluateMemberCaps(orgId, [userId1, userId2]);
@@ -225,8 +225,8 @@ describe("evaluateMemberCaps", () => {
     mockClerk({ userId });
     const { id: orgId } = await createTestOrg(slug);
 
-    // Set up billing period
-    const periodEnd = new Date("2026-04-01T00:00:00Z");
+    // Set up billing period (future date to avoid stale-period Stripe refresh)
+    const periodEnd = new Date("2099-04-01T00:00:00Z");
     await updateOrgStripeFields(orgId, {
       stripeSubscriptionId: uniqueId("sub"),
       stripeCustomerId: uniqueId("cus"),
@@ -247,7 +247,7 @@ describe("evaluateMemberCaps", () => {
       userId,
       status: "processed",
       creditsCharged: 999,
-      processedAt: new Date("2026-03-15T00:00:00Z"),
+      processedAt: new Date("2099-03-15T00:00:00Z"),
     });
 
     await evaluateMemberCaps(orgId, [userId]);
@@ -262,8 +262,8 @@ describe("evaluateMemberCaps", () => {
     mockClerk({ userId });
     const { id: orgId } = await createTestOrg(slug);
 
-    // Set up billing period
-    const periodEnd = new Date("2026-04-01T00:00:00Z");
+    // Set up billing period (future date to avoid stale-period Stripe refresh)
+    const periodEnd = new Date("2099-04-01T00:00:00Z");
     await updateOrgStripeFields(orgId, {
       stripeSubscriptionId: uniqueId("sub"),
       stripeCustomerId: uniqueId("cus"),
@@ -284,7 +284,7 @@ describe("evaluateMemberCaps", () => {
       userId,
       status: "processed",
       creditsCharged: 10,
-      processedAt: new Date("2026-03-15T00:00:00Z"),
+      processedAt: new Date("2099-03-15T00:00:00Z"),
     });
 
     await evaluateMemberCaps(orgId, [userId]);

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-metadata-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-metadata-service.test.ts
@@ -191,4 +191,62 @@ describe("getOrgBillingPeriod", () => {
 
     expect(result).toBeNull();
   });
+
+  it("refreshes from Stripe when currentPeriodEnd is in the past", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    const subId = uniqueId("sub");
+    const stalePeriodEnd = new Date("2026-03-01T00:00:00Z"); // past date
+
+    await updateOrgStripeFields(orgId, {
+      stripeSubscriptionId: subId,
+      stripeCustomerId: uniqueId("cus"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: stalePeriodEnd,
+    });
+
+    const newPeriodEndUnix = Math.floor(
+      new Date("2026-04-01T00:00:00Z").getTime() / 1000,
+    );
+
+    stripeMocks.subscriptionsRetrieve.mockResolvedValueOnce({
+      latest_invoice: "inv_fresh123",
+    });
+    stripeMocks.invoicesRetrieve.mockResolvedValueOnce({
+      period_end: newPeriodEndUnix,
+    });
+
+    const result = await getOrgBillingPeriod(orgId);
+
+    expect(result).not.toBeNull();
+    expect(result!.end).toEqual(new Date("2026-04-01T00:00:00Z"));
+    expect(stripeMocks.subscriptionsRetrieve).toHaveBeenCalledWith(subId);
+    expect(stripeMocks.invoicesRetrieve).toHaveBeenCalledWith("inv_fresh123");
+  });
+
+  it("uses cached value when currentPeriodEnd is in the future", async () => {
+    const userId = uniqueId("test-user");
+    const slug = uniqueId("org");
+    mockClerk({ userId });
+    const { id: orgId } = await createTestOrg(slug);
+
+    const futurePeriodEnd = new Date("2026-05-01T00:00:00Z"); // future date
+
+    await updateOrgStripeFields(orgId, {
+      stripeSubscriptionId: uniqueId("sub"),
+      stripeCustomerId: uniqueId("cus"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: futurePeriodEnd,
+    });
+
+    const result = await getOrgBillingPeriod(orgId);
+
+    expect(result).not.toBeNull();
+    expect(result!.end).toEqual(futurePeriodEnd);
+    // Stripe should NOT have been called — we used the cached value
+    expect(stripeMocks.subscriptionsRetrieve).not.toHaveBeenCalled();
+  });
 });

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-metadata-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-metadata-service.test.ts
@@ -221,8 +221,8 @@ describe("getOrgBillingPeriod", () => {
 
     const result = await getOrgBillingPeriod(orgId);
 
-    expect(result).not.toBeNull();
-    expect(result!.end).toEqual(new Date("2026-04-01T00:00:00Z"));
+    if (!result) throw new Error("expected result to be non-null");
+    expect(result.end).toEqual(new Date("2026-04-01T00:00:00Z"));
     expect(stripeMocks.subscriptionsRetrieve).toHaveBeenCalledWith(subId);
     expect(stripeMocks.invoicesRetrieve).toHaveBeenCalledWith("inv_fresh123");
   });
@@ -244,8 +244,8 @@ describe("getOrgBillingPeriod", () => {
 
     const result = await getOrgBillingPeriod(orgId);
 
-    expect(result).not.toBeNull();
-    expect(result!.end).toEqual(futurePeriodEnd);
+    if (!result) throw new Error("expected result to be non-null");
+    expect(result.end).toEqual(futurePeriodEnd);
     // Stripe should NOT have been called — we used the cached value
     expect(stripeMocks.subscriptionsRetrieve).not.toHaveBeenCalled();
   });

--- a/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
+++ b/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
@@ -69,10 +69,16 @@ export async function getOrgBillingPeriod(
 
   let periodEnd = orgRow?.currentPeriodEnd ?? null;
 
-  if (!periodEnd && orgRow?.stripeSubscriptionId) {
-    // Has subscription but no period cached in metadata — fetch from Stripe.
+  if ((!periodEnd || periodEnd < new Date()) && orgRow?.stripeSubscriptionId) {
+    // Has subscription but period is missing or expired — fetch from Stripe.
     // In Stripe v2025 API, current_period_end was removed from Subscription.
     // Use the latest_invoice.period_end instead.
+    if (periodEnd && periodEnd < new Date()) {
+      log.warn("currentPeriodEnd is stale, refreshing from Stripe", {
+        orgId,
+        currentPeriodEnd: periodEnd,
+      });
+    }
     const stripe = getStripe();
     const subscription = await stripe.subscriptions.retrieve(
       orgRow.stripeSubscriptionId,


### PR DESCRIPTION
## Summary

- Fixes `getOrgBillingPeriod()` to fall back to Stripe not only when `currentPeriodEnd` is `null`, but also when it is expired (in the past), providing self-healing when webhooks fail or are delayed
- Adds `log.warn` when a stale `currentPeriodEnd` is detected, improving observability
- Promotes two `log.debug` calls in `handleInvoicePaid()` to `log.warn` for unexpected early-return paths (no behavioral change)
- Adds integration tests for the new staleness check behavior

## Test plan

- [ ] "refreshes from Stripe when currentPeriodEnd is in the past" — verifies Stripe is called and fresh period is returned
- [ ] "uses cached value when currentPeriodEnd is in the future" — verifies Stripe is NOT called when cache is valid
- [ ] Existing tests continue to pass (null case, free-tier case, no-latest-invoice case)

Closes #8119

🤖 Generated with [Claude Code](https://claude.com/claude-code)