### PR TITLE
fix: add validation error logging and client-side skill name checks

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/create.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/create.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { readFileSync } from "node:fs";
 import chalk from "chalk";
+import { zeroAgentCustomSkillNameSchema } from "@vm0/core";
 import { createZeroAgent, updateZeroAgentInstructions } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 
@@ -40,6 +41,17 @@ Examples:
               return s.trim();
             })
           : undefined;
+
+        if (customSkills) {
+          for (const name of customSkills) {
+            const result = zeroAgentCustomSkillNameSchema.safeParse(name);
+            if (!result.success) {
+              throw new Error(
+                `Invalid skill name "${name}": must be 2-64 characters, lowercase alphanumeric and hyphens only (e.g. my-skill)`,
+              );
+            }
+          }
+        }
 
         const agent = await createZeroAgent({
           displayName: options.displayName,

--- a/turbo/apps/cli/src/commands/zero/agent/edit.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/edit.ts
@@ -1,12 +1,22 @@
 import { Command } from "commander";
 import { readFileSync } from "node:fs";
 import chalk from "chalk";
+import { zeroAgentCustomSkillNameSchema } from "@vm0/core";
 import {
   getZeroAgent,
   updateZeroAgent,
   updateZeroAgentInstructions,
 } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
+
+function validateSkillName(name: string): void {
+  const result = zeroAgentCustomSkillNameSchema.safeParse(name);
+  if (!result.success) {
+    throw new Error(
+      `Invalid skill name "${name}": must be 2-64 characters, lowercase alphanumeric and hyphens only (e.g. my-skill)`,
+    );
+  }
+}
 
 function resolveCustomSkills(
   options: { skills?: string; addSkill?: string; removeSkill?: string },
@@ -17,12 +27,17 @@ function resolveCustomSkills(
   }
 
   if (options.skills) {
-    return options.skills.split(",").map((s) => {
+    const names = options.skills.split(",").map((s) => {
       return s.trim();
     });
+    for (const name of names) {
+      validateSkillName(name);
+    }
+    return names;
   }
 
   if (options.addSkill) {
+    validateSkillName(options.addSkill);
     if (existing.includes(options.addSkill)) {
       throw new Error(
         `Skill "${options.addSkill}" is already attached to this agent`,

--- a/turbo/apps/web/src/lib/ts-rest-handler.ts
+++ b/turbo/apps/web/src/lib/ts-rest-handler.ts
@@ -66,11 +66,17 @@ export function createSafeErrorHandler(
           validationError.pathParamsError ??
           validationError.bodyError ??
           validationError.queryError;
+        const sourceLabel = validationError.pathParamsError
+          ? "pathParams"
+          : validationError.bodyError
+            ? "body"
+            : "query";
         if (source) {
           const issue = source.issues[0];
           if (issue) {
             const path = issue.path.join(".");
             const message = path ? `${path}: ${issue.message}` : issue.message;
+            log.warn(`validation error (${sourceLabel}): ${message}`);
             return TsRestResponse.fromJson(
               { error: { message, code: "BAD_REQUEST" } },
               { status: 400 },


### PR DESCRIPTION
## Summary

- Add `log.warn` for ts-rest validation errors in `createSafeErrorHandler` so BAD_REQUEST details (field path, error message, source type) are visible in Axiom logs
- Add client-side custom skill name validation in CLI `agent create` and `agent edit` commands using `zeroAgentCustomSkillNameSchema` before sending API requests

## Context

Closes #8109 — Production BAD_REQUEST errors on `zero-agents`, `zero-connectors:type`, and `zero-agents:user-connectors` APIs could not be diagnosed because validation errors were returned to clients without any server-side logging.

## Test plan

- [x] CLI tests pass (create + edit commands, 9 tests)
- [x] TypeScript type check passes (web + cli)
- [x] Lint passes (web + cli)
- [x] Knip passes (no unused exports)
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)