### PR TITLE
fix: use prefix match for ngrok domain lookup instead of hardcoded suffix

### DIFF
--- a/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
@@ -245,14 +245,14 @@ interface NgrokReservedDomainsPage {
 
 /**
  * Find a reserved domain by name using CEL filter.
- * Matches the full domain name (e.g., "vm0-cu-abc123.ngrok-free.app").
+ * Uses prefix match to work with any ngrok domain suffix
+ * (e.g., ".ngrok.app" for paid, ".ngrok-free.app" for free).
  */
 async function findReservedDomainByName(
   apiKey: string,
   name: string,
 ): Promise<NgrokDomain | undefined> {
-  const domainName = `${name}.ngrok-free.app`;
-  const filterQuery = encodeURIComponent(`obj.domain == "${domainName}"`);
+  const filterQuery = encodeURIComponent(`obj.domain.startsWith("${name}.")`);
   const response = await ngrokFetch(
     apiKey,
     `/reserved_domains?filter=${filterQuery}`,


### PR DESCRIPTION
## Summary
- Fix regression from #8269 where `findReservedDomainByName` hardcoded `.ngrok-free.app` suffix
- Production uses `.ngrok.app` (paid plan), causing ERR_NGROK_413 on every host registration
- Changed CEL filter from exact match `obj.domain == "name.ngrok-free.app"` to prefix match `obj.domain.startsWith("name.")`

## Root Cause
PR #8269 refactored domain lookup from pagination to CEL filter, but assumed all domains end with `.ngrok-free.app`. Paid ngrok accounts use `.ngrok.app`.

## Test plan
- [x] All 24 computer-use + connector tests pass
- [ ] Verify host registration works in production after deploy

Fixes #8267

🤖 Generated with [Claude Code](https://claude.com/claude-code)