### PR TITLE
fix: make skill volumes optional to handle removed skills gracefully

### DIFF
--- a/turbo/apps/web/src/lib/infra/storage/__tests__/system-skill-resolution.test.ts
+++ b/turbo/apps/web/src/lib/infra/storage/__tests__/system-skill-resolution.test.ts
@@ -124,17 +124,44 @@ describe("System Skill Resolution", () => {
     expect(manifest.storages[0]!.vasStorageName).toBe(storageName);
   });
 
-  it("should throw when skill not found in any org", async () => {
+  it("should skip skill volume when not found in any org", async () => {
     const { url } = uniqueSkillUrl();
 
-    await expect(
-      prepareStorageManifest(
-        skillAgentConfig(url),
-        {},
-        user.orgId,
-        user.orgId,
-        user.userId,
-      ),
-    ).rejects.toThrow("not found");
+    const manifest = await prepareStorageManifest(
+      skillAgentConfig(url),
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+    );
+
+    expect(manifest.storages).toHaveLength(0);
+  });
+
+  it("should resolve available skills and skip missing ones", async () => {
+    const found = uniqueSkillUrl();
+    const missing = uniqueSkillUrl();
+
+    // Only create storage for the first skill
+    await createTestVolumeForOrg(SYSTEM_ORG_ID, found.storageName);
+
+    const config: AgentVolumeConfig = {
+      agents: {
+        "test-agent": {
+          skills: [found.url, missing.url],
+        },
+      },
+    };
+
+    const manifest = await prepareStorageManifest(
+      config,
+      {},
+      user.orgId,
+      user.orgId,
+      user.userId,
+    );
+
+    expect(manifest.storages).toHaveLength(1);
+    expect(manifest.storages[0]!.vasStorageName).toBe(found.storageName);
   });
 });

--- a/turbo/apps/web/src/lib/infra/storage/storage-resolver.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-resolver.ts
@@ -274,6 +274,7 @@ function resolveInstructionsAndSkills(
           mountPath: `${skillsBasePath}/${parsed.skillName}`,
           vasStorageName: storageName,
           vasVersion: "latest",
+          optional: true,
         });
       }
     }

--- a/turbo/apps/web/src/lib/infra/storage/storage-service.ts
+++ b/turbo/apps/web/src/lib/infra/storage/storage-service.ts
@@ -399,12 +399,15 @@ export async function prepareStorageManifest(
 
         return manifestStorage;
       } catch (error) {
-        // For optional volumes, silently skip if not found
+        // For optional volumes, skip if not found
         if (
           volume.optional &&
           error instanceof Error &&
           error.message.includes("not found")
         ) {
+          log.warn(
+            `Optional volume "${volume.vasStorageName}" not found, skipping`,
+          );
           return null;
         }
         // Re-throw for required volumes


### PR DESCRIPTION
## Summary

- Mark skill volumes as `optional: true` in `storage-resolver.ts` so that missing skill storages are skipped instead of crashing the run
- Add `log.warn` when an optional volume is not found, for observability
- Update tests: removed the "should throw when skill not found" test, added "should skip missing skill" and "should resolve available skills while skipping missing ones" tests

## Root Cause

Skill storages are managed by the `sync-skills` cron, which removes orphaned skills when they're deleted from the source repo. However, existing agent compose versions (immutable, content-addressed) still reference deleted skills. When these stale composes are used for runs, the storage lookup fails fatally.

The infrastructure should naturally handle skill lifecycle changes (addition, removal, renaming) — a run should not crash because a platform-managed skill was removed.

## Test plan

- [x] Existing "resolve from system org" test passes
- [x] Existing "fallback to agent org" test passes
- [x] Existing "regular volumes from agent org" test passes
- [x] New: "skip skill volume when not found in any org" — verifies run succeeds with empty storages
- [x] New: "resolve available skills and skip missing ones" — verifies partial resolution (1 found, 1 missing → only found is mounted)

Closes #8108

🤖 Generated with [Claude Code](https://claude.com/claude-code)