### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -94,7 +94,7 @@ GO_VERSION="1.26.1"
 CLAUDE_CODE_VERSION="2.1.92"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.24.1"
+AGENT_BROWSER_VERSION="0.25.3"
 
 # ---------------------------------------------------------------------------
 # Dependency checks


### PR DESCRIPTION
## Summary

Updated pinned package versions in `crates/runner/scripts/build-rootfs.sh`:

| Package | Old Version | New Version |
|---------|-------------|-------------|
| `agent-browser` (npm) | `0.24.1` | `0.25.3` |

All other pinned versions are already up to date:
- Go: `1.26.1` ✓
- Claude Code: `2.1.92` ✓
- `@googleworkspace/cli`: `0.22.5` ✓
- `@xdevplatform/xurl`: `1.0.3` ✓

## Test plan

- [ ] Verify rootfs build completes with updated `agent-browser@0.25.3`
- [ ] Confirm sandbox CI passes