### PR TITLE
fix: restore org slug update in onboarding setup

### DIFF
--- a/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
@@ -24,6 +24,55 @@ import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("api:onboarding-setup");
 
+/**
+ * Generate a URL-safe slug from a workspace name.
+ */
+function nameToSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 64);
+}
+
+/**
+ * Update org name and slug via a single Clerk call.
+ * Retries once with a random suffix if the slug conflicts.
+ */
+async function updateOrgNameAndSlug(
+  orgId: string,
+  workspaceName: string,
+): Promise<void> {
+  const name = workspaceName.trim();
+  if (!name) return;
+
+  const client = await clerkClient();
+  const baseSlug = nameToSlug(name);
+  const slugCandidates = [
+    baseSlug,
+    `${baseSlug.slice(0, 56)}-${Math.random().toString(36).slice(2, 8)}`,
+  ].filter((s) => {
+    return s.length >= 3;
+  });
+
+  for (const slug of slugCandidates) {
+    try {
+      await client.organizations.updateOrganization(orgId, { name, slug });
+      return;
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (msg.includes("already exists") || msg.includes("slug")) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  // Both slug attempts conflicted — update name only
+  await client.organizations.updateOrganization(orgId, { name });
+}
+
 const router = tsr.router(onboardingSetupContract, {
   setup: async ({ body, headers }) => {
     initServices();
@@ -75,13 +124,9 @@ const router = tsr.router(onboardingSetupContract, {
       }
     }
 
-    // Start org name update in parallel (don't await yet)
-    const orgNamePromise = body.workspaceName?.trim()
-      ? clerkClient().then((client) => {
-          return client.organizations.updateOrganization(org.orgId, {
-            name: body.workspaceName!.trim(),
-          });
-        })
+    // Start org name + slug update in parallel (don't await yet)
+    const orgUpdatePromise = body.workspaceName?.trim()
+      ? updateOrgNameAndSlug(org.orgId, body.workspaceName)
       : undefined;
 
     // Parallel: model provider + compose (independent)
@@ -98,8 +143,8 @@ const router = tsr.router(onboardingSetupContract, {
       }),
     ]);
 
-    // Await org name update (already running in parallel)
-    if (orgNamePromise) await orgNamePromise;
+    // Await org name + slug update (already running in parallel)
+    if (orgUpdatePromise) await orgUpdatePromise;
 
     if (!composeResult) {
       return {


### PR DESCRIPTION
## Summary

- Restores org slug update that was dropped in #8275 (which only replaced `tryUpdateOrgNameSlug` with a name-only Clerk update)
- New `updateOrgNameAndSlug` calls `updateOrganization({ name, slug })` in a single Clerk call with conflict retry
- Runs in parallel with `serverSideCompose` and `upsertOrgNoSecretModelProvider` — zero extra latency

## What changed

**Before (#8275)**: `clerkClient().organizations.updateOrganization(orgId, { name })` — name only, slug dropped

**After**: `updateOrgNameAndSlug(orgId, workspaceName)` which:
1. Generates slug from workspace name (same logic as original `tryUpdateOrgNameSlug`)
2. Calls `updateOrganization(orgId, { name, slug })` — 1 Clerk call for both
3. On slug conflict, retries with random suffix
4. Falls back to name-only if both slug attempts fail

| Metric | Original (pre-#8275) | #8275 | This PR |
|--------|---------------------|-------|---------|
| Clerk API calls | 4 sequential | 1 | 1-3 (with retry) |
| Slug updated | Yes | No | Yes |
| Parallel with compose | No | Yes | Yes |

## Test plan

- [x] 7 backend integration tests pass
- [x] Lint passes (0 warnings, 0 errors)
- [x] Knip passes (no unused exports)
- [x] Web type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)