### PR TITLE
refactor(zero): unify pre-flight checks between zero-run-service and zero-run-queue-service

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -346,5 +346,139 @@ describe("credit check (infra queue path)", () => {
       const nonVm0 = await findTestRunRecord(nonVm0Run.runId);
       expect(nonVm0!.status).toBe("pending");
     });
+
+    it("should fail queued VM0 run when member creditEnabled is false at drain time", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+      reloadEnv();
+
+      // Org has plenty of credits but member cap is exhausted
+      await setOrgCredits(user.orgId, 10000);
+      await insertOrgDefaultModelProvider(user.orgId, "vm0");
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: false,
+      });
+
+      // Create a running run + a queued VM0 run
+      await startRun({
+        userId: user.userId,
+        agentComposeVersionId: versionId,
+        prompt: "Running",
+        orgTier: "free",
+      });
+      const queued = await enqueueRun(
+        queueBaseParams({
+          prompt: "Queued VM0 member cap",
+          modelProvider: "vm0",
+        }),
+      );
+      await insertTestZeroRun(queued.runId, { modelProvider: "vm0" });
+
+      // Mark running run as completed to free slot
+      await markRunningRunsAsCompleted(user.userId);
+
+      // Drain queue
+      await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
+
+      // Queued run should be marked as failed due to member credit cap
+      const run = await findTestRunRecord(queued.runId);
+      expect(run!.status).toBe("failed");
+      expect(run!.error).toContain("Insufficient credits");
+    });
+
+    it("should dequeue non-VM0 run when member creditEnabled is false", async () => {
+      vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+      reloadEnv();
+
+      await setOrgCredits(user.orgId, 10000);
+      await insertOrgMembersEntry({
+        orgId: user.orgId,
+        userId: user.userId,
+        creditCap: 100,
+        creditEnabled: false,
+      });
+
+      // Create a running run + a queued non-VM0 run
+      await startRun({
+        userId: user.userId,
+        agentComposeVersionId: versionId,
+        prompt: "Running",
+        orgTier: "free",
+      });
+      const queued = await enqueueRun(
+        queueBaseParams({
+          prompt: "Queued Anthropic member cap",
+          modelProvider: "anthropic",
+        }),
+      );
+      await insertTestZeroRun(queued.runId, { modelProvider: "anthropic" });
+
+      // Mark running run as completed
+      await markRunningRunsAsCompleted(user.userId);
+
+      // Drain queue
+      await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
+
+      // Non-VM0 run should be dequeued despite member cap
+      const run = await findTestRunRecord(queued.runId);
+      expect(run!.status).toBe("pending");
+    });
+  });
+});
+
+describe("model provider check (queue dispatch path)", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
+    reloadEnv();
+  });
+
+  it("should fail queued zero run when no model provider configured at dispatch time", async () => {
+    vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "1");
+    reloadEnv();
+
+    // Create compose WITHOUT default ANTHROPIC_API_KEY so model provider check applies
+    const agentName = uniqueId("agent");
+    const compose = await createTestCompose(agentName, {
+      skipDefaultApiKey: true,
+    });
+    const agentId = await getTestZeroAgentId(user.orgId, agentName);
+
+    // No org-level model provider configured — checkModelProviderConfigured will throw
+
+    // Create a running run to force the next one into the queue
+    await startRun({
+      userId: user.userId,
+      agentComposeVersionId: compose.versionId,
+      prompt: "Running",
+      orgTier: "free",
+    });
+
+    // Enqueue a zero run (no explicit modelProvider)
+    const queued = await enqueueRun({
+      userId: user.userId,
+      agentComposeVersionId: compose.versionId,
+      prompt: "Queued no provider",
+      orgId: user.orgId,
+      vars: { ZERO_AGENT_ID: agentId },
+      agentName,
+    });
+    await insertTestZeroRun(queued.runId);
+
+    // Mark running run as completed
+    await markRunningRunsAsCompleted(user.userId);
+
+    // Drain queue — dispatchQueuedZeroRun should fail with noModelProvider
+    await drainOrgQueue(user.orgId, dispatchQueuedZeroRun);
+
+    // Run should be marked as failed with model provider error
+    const run = await findTestRunRecord(queued.runId);
+    expect(run!.status).toBe("failed");
+    expect(run!.error).toContain("No model provider configured");
   });
 });

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -21,7 +21,6 @@ import {
 } from "../../db/schema/agent-compose";
 import { zeroAgents } from "../../db/schema/zero-agent";
 import { orgMetadata } from "../../db/schema/org-metadata";
-import { modelProviders } from "../../db/schema/model-provider";
 import { env } from "../../env";
 import { getCachedUser } from "../auth/user-cache-service";
 import { transitionRunStatus } from "../infra/run/run-status";
@@ -47,8 +46,11 @@ import {
   encryptSecretsMap,
   decryptSecretsMap,
 } from "../shared/crypto/secrets-encryption";
-import { isConcurrentRunLimit, insufficientCredits } from "../shared/errors";
-import { ORG_SENTINEL_USER_ID } from "./org/org-sentinel";
+import { isConcurrentRunLimit, isInsufficientCredits } from "../shared/errors";
+import {
+  checkOrgCredits,
+  checkModelProviderConfigured,
+} from "./zero-run-service";
 import { logger } from "../shared/logger";
 import type { OrgTier, QueueResponse, TriggerSource } from "@vm0/core";
 
@@ -230,15 +232,15 @@ async function dequeueNextAtomic(
       // Serialize all queue operations for this org
       await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
 
-      // Look up org tier and credits from org table (source of truth).
+      // Look up org tier from org table (source of truth).
       // Falls back to "free" (most conservative limit) if row is missing.
+      // Credits are checked by checkOrgCredits() within this transaction.
       const [orgRow] = await tx
-        .select({ tier: orgMetadata.tier, credits: orgMetadata.credits })
+        .select({ tier: orgMetadata.tier })
         .from(orgMetadata)
         .where(eq(orgMetadata.orgId, orgId))
         .limit(1);
       const orgTier = parseOrgTier(orgRow?.tier);
-      const orgCredits = orgRow?.credits ?? null;
 
       // Check concurrency FIRST — don't dequeue if no slot available
       await checkRunConcurrencyLimit(orgId, orgTier, tx);
@@ -249,10 +251,11 @@ async function dequeueNextAtomic(
       // LEFT JOIN zeroRuns to read modelProvider for credit check.
       const rows = await tx.execute<{
         run_id: string;
+        user_id: string;
         encrypted_params: string | null;
         model_provider: string | null;
       }>(
-        sql`SELECT q.run_id, q.encrypted_params, zr.model_provider
+        sql`SELECT q.run_id, q.user_id, q.encrypted_params, zr.model_provider
          FROM agent_run_queue q
          JOIN agent_runs r ON r.id = q.run_id
          LEFT JOIN zero_runs zr ON zr.id = r.id
@@ -266,19 +269,16 @@ async function dequeueNextAtomic(
           .delete(agentRunQueue)
           .where(eq(agentRunQueue.runId, row.run_id));
 
-        // Check credits for VM0 provider runs
-        if (orgCredits !== null && orgCredits <= 0) {
-          const isVm0 = await resolveIsVm0Provider(
-            row.model_provider,
-            orgId,
-            tx,
-          );
-          if (isVm0) {
+        // Unified pre-flight credit check (org-level + per-member cap)
+        try {
+          await checkOrgCredits(orgId, row.user_id, row.model_provider, tx);
+        } catch (error) {
+          if (isInsufficientCredits(error)) {
             await transitionRunStatus(
               row.run_id,
               {
                 status: "failed",
-                error: insufficientCredits().message,
+                error: error.message,
                 completedAt: new Date(),
               },
               ["queued"],
@@ -287,6 +287,7 @@ async function dequeueNextAtomic(
             log.debug(`Run ${row.run_id} failed credit check, skipping`);
             continue;
           }
+          throw error;
         }
 
         // Update run status — fails silently if run was already cancelled/failed
@@ -320,33 +321,6 @@ async function dequeueNextAtomic(
     }
     throw error;
   }
-}
-
-/**
- * Resolve whether the effective model provider is VM0.
- * Queries the model_providers table within the provided transaction
- * to maintain advisory lock guarantees.
- */
-async function resolveIsVm0Provider(
-  modelProvider: string | null,
-  orgId: string,
-  db: typeof globalThis.services.db,
-): Promise<boolean> {
-  if (modelProvider === "vm0") return true;
-  if (modelProvider && modelProvider !== "vm0") return false;
-  // null → check org default within the transaction
-  const [defaultProvider] = await db
-    .select({ type: modelProviders.type })
-    .from(modelProviders)
-    .where(
-      and(
-        eq(modelProviders.orgId, orgId),
-        eq(modelProviders.userId, ORG_SENTINEL_USER_ID),
-        eq(modelProviders.isDefault, true),
-      ),
-    )
-    .limit(1);
-  return defaultProvider?.type === "vm0";
 }
 
 /**
@@ -487,6 +461,15 @@ export async function dispatchQueuedZeroRun(
     );
     authorizeCompose(params.userId, params.orgId, compose);
     const authorizeTime = Date.now();
+
+    // Pre-flight: ensure model provider is still configured (may have been
+    // removed after enqueue). Throws noModelProvider() on failure — caught by
+    // drainOrgQueue() which marks the run as failed.
+    await checkModelProviderConfigured(
+      params.orgId,
+      params.modelProvider,
+      composeContent,
+    );
 
     // Validate compose requirements for new runs only
     if (!params.checkpointId && !params.sessionId) {

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -70,14 +70,17 @@ interface ZeroRunParams {
 /**
  * Pre-flight check: ensure the org has sufficient credits for VM0 runs.
  * Skips for non-VM0 provider runs. Queries orgMetadata + orgMembersMetadata.
+ *
+ * Accepts an optional `db` parameter so callers running inside a transaction
+ * (e.g. dequeueNextAtomic with pg_advisory_xact_lock) can pass the transaction
+ * object and keep all reads within the same isolation boundary.
  */
-async function checkOrgCredits(
+export async function checkOrgCredits(
   orgId: string,
   userId: string,
   modelProvider: string | null | undefined,
+  db: typeof globalThis.services.db = globalThis.services.db,
 ): Promise<void> {
-  const db = globalThis.services.db;
-
   // Explicit non-VM0 provider — skip check entirely
   if (modelProvider && modelProvider !== "vm0") {
     return;
@@ -150,7 +153,7 @@ async function checkOrgCredits(
  * Skips when compose has explicit env vars, an explicit modelProvider param
  * is provided, or the framework doesn't use model providers.
  */
-async function checkModelProviderConfigured(
+export async function checkModelProviderConfigured(
   orgId: string,
   modelProvider: string | null | undefined,
   composeContent: AgentComposeYaml,


### PR DESCRIPTION
## Summary

- Refactor `checkOrgCredits()` to accept an optional `db | tx` parameter (default: `globalThis.services.db`) so it can be reused inside advisory-locked transactions
- Replace inline credit check in `dequeueNextAtomic()` with unified `checkOrgCredits()` call, adding the previously missing **per-member credit cap** check
- Add `checkModelProviderConfigured()` to `dispatchQueuedZeroRun()` so queued runs validate model provider configuration before dispatch
- Remove duplicated `resolveIsVm0Provider()` helper (logic subsumed by `checkOrgCredits()`)

Closes #8281

## Test plan

- [x] Existing 16 credit-check tests pass (no regression)
- [x] New test: queued VM0 run fails when member `creditEnabled: false` at drain time
- [x] New test: queued non-VM0 run dequeues despite member `creditEnabled: false`
- [x] New test: queued zero run fails when no model provider configured at dispatch time
- [x] Type check passes
- [x] Lint passes (0 errors)
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)