### PR TITLE
fix(sentry): ignore clerk session auth error from mobile safari itp

### DIFF
--- a/turbo/apps/platform/src/lib/sentry.ts
+++ b/turbo/apps/platform/src/lib/sentry.ts
@@ -47,6 +47,8 @@ export function initSentry(): void {
       "AbortError",
       // Browser extensions
       "ResizeObserver loop",
+      // Clerk SDK - session cleared by Mobile Safari ITP (third-party noise)
+      "Unable to authenticate the request",
     ],
   });
 }


### PR DESCRIPTION
## Summary

- Adds `"Unable to authenticate the request"` to the `ignoreErrors` array in `turbo/apps/platform/src/lib/sentry.ts`
- Filters out Clerk SDK noise caused by Mobile Safari ITP clearing session cookies on iOS devices
- The error originates from Clerk's internal `_baseFetch` method and is not actionable by our team

Closes #8222

## Test plan

- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes (`pnpm check-types`)
- [x] Format unchanged (`pnpm format`)
- [x] Knip finds no issues
- No tests needed — this is a Sentry configuration string addition