### PR TITLE
refactor: extract shared AxiomNetworkEvent type from duplicate route definitions

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/__tests__/route.test.ts
@@ -12,21 +12,23 @@ import {
 } from "../../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
+import type { AxiomNetworkEvent } from "@vm0/core";
 
 const context = testContext();
 
-// [NETWORK_LOG_FIELDS] — subset for testing; see route.ts for full definition
-interface AxiomNetworkEvent {
-  _time: string;
-  runId: string;
-  userId: string;
-  method: string;
-  url: string;
-  status: number;
-  latency_ms: number;
-  request_size: number;
-  response_size: number;
-}
+// Subset of AxiomNetworkEvent fields used in tests
+type TestAxiomNetworkEvent = Pick<
+  AxiomNetworkEvent,
+  | "_time"
+  | "runId"
+  | "userId"
+  | "method"
+  | "url"
+  | "status"
+  | "latency_ms"
+  | "request_size"
+  | "response_size"
+>;
 
 function createAxiomNetworkEvent(
   timestamp: string,
@@ -35,7 +37,7 @@ function createAxiomNetworkEvent(
   status: number,
   runId: string,
   userId: string,
-): AxiomNetworkEvent {
+): TestAxiomNetworkEvent {
   return {
     _time: timestamp,
     runId,

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -3,7 +3,7 @@ import {
   tsr,
   TsRestResponse,
 } from "../../../../../../../src/lib/ts-rest-handler";
-import { runNetworkLogsContract } from "@vm0/core";
+import { runNetworkLogsContract, type AxiomNetworkEvent } from "@vm0/core";
 import { initServices } from "../../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../../src/db/schema/agent-run";
 import { eq, and } from "drizzle-orm";
@@ -14,38 +14,6 @@ import {
   getDatasetName,
   DATASETS,
 } from "../../../../../../../src/lib/shared/axiom";
-/**
- * Axiom network event (MITM proxy)
- * [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
- */
-interface AxiomNetworkEvent {
-  _time: string;
-  runId: string;
-  userId: string;
-  type?: string;
-  action?: "ALLOW" | "DENY";
-  host?: string;
-  port?: number;
-  method?: string;
-  url?: string;
-  status?: number;
-  latency_ms?: number;
-  request_size?: number;
-  response_size?: number;
-  firewall_base?: string;
-  firewall_name?: string;
-  firewall_ref?: string;
-  firewall_permission?: string;
-  firewall_rule_match?: string;
-  firewall_params?: Record<string, string>;
-  firewall_error?: string;
-  auth_resolved_secrets?: string[];
-  auth_refreshed_connectors?: string[];
-  auth_refreshed_secrets?: string[];
-  auth_cache_hit?: boolean;
-  auth_url_rewrite?: boolean;
-  error?: string;
-}
 
 const router = tsr.router(runNetworkLogsContract, {
   getNetworkLogs: async ({ params, query, headers }) => {

--- a/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
@@ -3,7 +3,7 @@ import {
   createSafeErrorHandler,
   tsr,
 } from "../../../../../../src/lib/ts-rest-handler";
-import { zeroRunNetworkLogsContract } from "@vm0/core";
+import { zeroRunNetworkLogsContract, type AxiomNetworkEvent } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import {
   requireAuth,
@@ -16,39 +16,6 @@ import {
   getDatasetName,
   DATASETS,
 } from "../../../../../../src/lib/shared/axiom";
-
-/**
- * Axiom network event (MITM proxy)
- * [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
- */
-interface AxiomNetworkEvent {
-  _time: string;
-  runId: string;
-  userId: string;
-  type?: string;
-  action?: "ALLOW" | "DENY";
-  host?: string;
-  port?: number;
-  method?: string;
-  url?: string;
-  status?: number;
-  latency_ms?: number;
-  request_size?: number;
-  response_size?: number;
-  firewall_base?: string;
-  firewall_name?: string;
-  firewall_ref?: string;
-  firewall_permission?: string;
-  firewall_rule_match?: string;
-  firewall_params?: Record<string, string>;
-  firewall_error?: string;
-  auth_resolved_secrets?: string[];
-  auth_refreshed_connectors?: string[];
-  auth_refreshed_secrets?: string[];
-  auth_cache_hit?: boolean;
-  auth_url_rewrite?: boolean;
-  error?: string;
-}
 
 const router = tsr.router(zeroRunNetworkLogsContract, {
   getNetworkLogs: async ({ params, query, headers }) => {

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -110,6 +110,7 @@ export {
   type MetricsResponse,
   type AgentEventsResponse,
   type NetworkLogEntry,
+  type AxiomNetworkEvent,
   type NetworkLogsResponse,
   type SearchResult,
   type LogsSearchResponse,

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -716,6 +716,17 @@ export type MetricsResponse = z.infer<typeof metricsResponseSchema>;
 export type AgentEventsResponse = z.infer<typeof agentEventsResponseSchema>;
 export type NetworkLogEntry = z.infer<typeof networkLogEntrySchema>;
 export type NetworkLogsResponse = z.infer<typeof networkLogsResponseSchema>;
+/**
+ * Axiom raw network event — the shape returned by `queryAxiom` for MITM logs.
+ * Uses `_time` (Axiom's timestamp field) instead of `timestamp`, and includes
+ * `runId`/`userId` used for Axiom filtering.
+ * [NETWORK_LOG_FIELDS]
+ */
+export type AxiomNetworkEvent = Omit<NetworkLogEntry, "timestamp"> & {
+  _time: string;
+  runId: string;
+  userId: string;
+};
 export type SearchResult = z.infer<typeof searchResultSchema>;
 export type LogsSearchResponse = z.infer<typeof logsSearchResponseSchema>;
 export type QueueEntry = z.infer<typeof queueEntrySchema>;

--- a/turbo/packages/core/src/contracts/webhooks.ts
+++ b/turbo/packages/core/src/contracts/webhooks.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { authHeadersSchema, initContract } from "./base";
 import { apiErrorSchema } from "./errors";
+import { networkLogEntrySchema } from "./runs";
 import {
   storageTypeSchema,
   fileEntryWithHashSchema,
@@ -286,36 +287,8 @@ const sandboxOperationSchema = z.object({
   error: z.string().optional(),
 });
 
-/**
- * Network log entry schema (from mitmproxy addon)
- * [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
- */
-const networkLogSchema = z.object({
-  timestamp: z.string(),
-  type: z.string().optional(),
-  action: z.enum(["ALLOW", "DENY"]).optional(),
-  host: z.string().optional(),
-  port: z.number().optional(),
-  method: z.string().optional(),
-  url: z.string().optional(),
-  status: z.number().optional(),
-  latency_ms: z.number().optional(),
-  request_size: z.number().optional(),
-  response_size: z.number().optional(),
-  firewall_base: z.string().optional(),
-  firewall_name: z.string().optional(),
-  firewall_ref: z.string().optional(),
-  firewall_permission: z.string().optional(),
-  firewall_rule_match: z.string().optional(),
-  firewall_params: z.record(z.string(), z.string()).optional(),
-  firewall_error: z.string().optional(),
-  auth_resolved_secrets: z.array(z.string()).optional(),
-  auth_refreshed_connectors: z.array(z.string()).optional(),
-  auth_refreshed_secrets: z.array(z.string()).optional(),
-  auth_cache_hit: z.boolean().optional(),
-  auth_url_rewrite: z.boolean().optional(),
-  error: z.string().optional(),
-});
+// Network log schema — uses the shared definition from runs.ts.
+// [NETWORK_LOG_FIELDS]
 
 /**
  * Webhook telemetry contract for /api/webhooks/agent/telemetry
@@ -333,7 +306,7 @@ export const webhookTelemetryContract = c.router({
       runId: z.string().min(1, "runId is required"),
       systemLog: z.string().optional(),
       metrics: z.array(metricDataSchema).optional(),
-      networkLogs: z.array(networkLogSchema).optional(),
+      networkLogs: z.array(networkLogEntrySchema).optional(),
       sandboxOperations: z.array(sandboxOperationSchema).optional(),
     }),
     responses: {


### PR DESCRIPTION
## Summary
- Extract `AxiomNetworkEvent` type into `@vm0/core` (derived from `NetworkLogEntry` via `Omit` + intersection), eliminating duplicate interface definitions in two route files
- Replace duplicate `networkLogSchema` in `webhooks.ts` with the existing `networkLogEntrySchema` from `runs.ts`
- Update test file to import shared type and use `Pick` for the subset

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/runs.ts` | Add `AxiomNetworkEvent` type (+11 lines) |
| `packages/core/src/contracts/index.ts` | Export `AxiomNetworkEvent` |
| `packages/core/src/contracts/webhooks.ts` | Replace 26-line duplicate schema with import of `networkLogEntrySchema` |
| `apps/web/.../zero/runs/[id]/network/route.ts` | Remove local interface, import from `@vm0/core` |
| `apps/web/.../agent/runs/[id]/telemetry/network/route.ts` | Same |
| `apps/web/.../__tests__/route.test.ts` | Import shared type, use `Pick<AxiomNetworkEvent, ...>` |

**Net: -78 lines** (33 added, 111 removed)

## Test plan
- [x] `pnpm check-types` passes for `web` and `@vm0/core`
- [x] `knip` finds no unused exports
- [ ] CI passes

Closes #7656

🤖 Generated with [Claude Code](https://claude.com/claude-code)