### PR TITLE
fix: use in-operator for ngrok domain lookup with known suffixes

### DIFF
--- a/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
@@ -262,9 +262,9 @@ async function findReservedDomainByName(
   apiKey: string,
   name: string,
 ): Promise<NgrokDomain | undefined> {
-  const candidates = NGROK_DOMAIN_SUFFIXES.map(
-    (suffix) => `"${name}.${suffix}"`,
-  ).join(", ");
+  const candidates = NGROK_DOMAIN_SUFFIXES.map((suffix) => {
+    return `"${name}.${suffix}"`;
+  }).join(", ");
   const filterQuery = encodeURIComponent(`obj.domain in [${candidates}]`);
   const response = await ngrokFetch(
     apiKey,

--- a/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
@@ -244,15 +244,28 @@ interface NgrokReservedDomainsPage {
 }
 
 /**
- * Find a reserved domain by name using CEL filter.
- * Uses prefix match to work with any ngrok domain suffix
- * (e.g., ".ngrok.app" for paid, ".ngrok-free.app" for free).
+ * Known ngrok domain suffixes. The actual suffix depends on the account
+ * plan (paid vs free) and era (legacy vs current).
+ */
+const NGROK_DOMAIN_SUFFIXES = [
+  "ngrok.app",
+  "ngrok-free.app",
+  "ngrok-free.dev",
+  "ngrok.io",
+];
+
+/**
+ * Find a reserved domain by name using CEL `in` filter.
+ * Queries all known ngrok suffixes in a single API call.
  */
 async function findReservedDomainByName(
   apiKey: string,
   name: string,
 ): Promise<NgrokDomain | undefined> {
-  const filterQuery = encodeURIComponent(`obj.domain.startsWith("${name}.")`);
+  const candidates = NGROK_DOMAIN_SUFFIXES.map(
+    (suffix) => `"${name}.${suffix}"`,
+  ).join(", ");
+  const filterQuery = encodeURIComponent(`obj.domain in [${candidates}]`);
   const response = await ngrokFetch(
     apiKey,
     `/reserved_domains?filter=${filterQuery}`,


### PR DESCRIPTION
## Summary
- Fix regression from #8285 where `startsWith()` CEL filter is rejected by ngrok API
- ngrok's `obj.domain` field only supports equality/comparison, NOT substring matching
- Use `obj.domain in [...]` with all known suffixes instead — single API call, O(1)

## POC Verification (against production ngrok API)

```
# startsWith → REJECTED
ERR_NGROK_250: field obj.domain does not support substring matching (startsWith)

# in-operator → WORKS ✅
obj.domain in ["name.ngrok.app", "name.ngrok-free.app", "name.ngrok-free.dev", "name.ngrok.io"]
→ Found: vm0-cu-66d4a49adace.ngrok.app
```

## Known ngrok suffixes
- `.ngrok.app` — paid accounts
- `.ngrok-free.app` — free accounts
- `.ngrok-free.dev` — free dev accounts
- `.ngrok.io` — legacy

## Test plan
- [x] 24 tests pass (computer-use + connector)
- [x] POC verified against production ngrok API with real API key
- [ ] Production host registration test after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)