### PR TITLE
feat(runner): keep-alive sandbox across conversation turns

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1081,6 +1081,101 @@ jobs:
           echo "=== Upgrade test passed ==="
           REMOTE_SCRIPT
 
+  runner-keep-alive:
+    runs-on: ubuntu-latest
+    needs: [runner-build]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup SSH via Cloudflare Tunnel
+        uses: ./.github/actions/setup-ssh-tunnel
+        with:
+          ssh-key: ${{ secrets.AWS_METAL_RUNNER_SSH_KEY }}
+          cf-access-client-id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+
+      - name: Test VM keep-alive across conversation turns
+        env:
+          METAL_USER: ${{ vars.AWS_METAL_RUNNER_USER }}
+          OFFICIAL_RUNNER_SECRET: ${{ secrets.OFFICIAL_RUNNER_SECRET }}
+          HOST: ${{ needs.runner-build.outputs.host }}
+          JOB_REF: ${{ needs.runner-build.outputs.job-ref }}
+          DEFAULT_ROOTFS_HASH: ${{ needs.runner-build.outputs.default-rootfs-hash }}
+          DEFAULT_SNAPSHOT_HASH: ${{ needs.runner-build.outputs.default-snapshot-hash }}
+        run: |
+          REMOTE="${METAL_USER}@${HOST}"
+          # shellcheck disable=SC2088
+          BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"
+
+          echo "=== Generating config (keep-alive enabled) ==="
+          # shellcheck disable=SC2029
+          ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
+            --profile vm0/default \
+            --rootfs-hash ${DEFAULT_ROOTFS_HASH} \
+            --snapshot-hash ${DEFAULT_SNAPSHOT_HASH} \
+            --name ${JOB_REF}-keepalive \
+            --group vm0/keepalive-${JOB_REF} \
+            --runner-dirname ${JOB_REF}-keepalive \
+            --max-concurrent 2 \
+            --keep-alive \
+            --api-url https://not-a-real-server.test \
+            --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
+
+          echo "=== Running keep-alive test ==="
+          ssh "$REMOTE" bash -s -- "${BIN_DIR}" "${JOB_REF}" <<'REMOTE_SCRIPT'
+          BIN_DIR=$1; JOB_REF=$2
+          RUNNER_DIR="/var/lib/vm0-runner/runners/${JOB_REF}-keepalive"
+          SVC="${JOB_REF}-keepalive"
+          GROUP="vm0/keepalive-${JOB_REF}"
+          SESSION_ID="e2e-keepalive-test-session"
+
+          fail() { echo "FAIL: $1"; exit 1; }
+
+          cleanup() {
+            echo "--- Cleanup ---"
+            sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          # Start transient runner service with keep-alive
+          echo "--- Starting runner (keep-alive enabled) ---"
+          sudo "$BIN_DIR/runner" service start --name "$SVC" \
+            --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true
+
+          # Turn 1: submit job with session ID — creates a marker file in guest
+          echo "--- Turn 1: create marker file ---"
+          sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+            --session-id "$SESSION_ID" \
+            --prompt 'touch /tmp/keepalive-marker && echo turn1-done' \
+            || fail "Turn 1 failed"
+
+          # Turn 2: submit job with same session ID — should reuse the VM.
+          # If VM was reused, the marker file from turn 1 still exists (exit 0).
+          # If a new VM was created, the file is missing and test exits non-zero.
+          echo "--- Turn 2: verify marker file persists (VM reused) ---"
+          sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+            --session-id "$SESSION_ID" \
+            --prompt 'test -f /tmp/keepalive-marker' \
+            || fail "Turn 2: marker file not found — VM was not reused"
+          echo "PASS: Turn 2 completed (VM reused, filesystem persisted)"
+
+          # Turn 3: submit with a DIFFERENT session — should create a new VM.
+          # The marker file must NOT exist in the new VM (session isolation).
+          echo "--- Turn 3: different session creates new VM ---"
+          sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
+            --session-id "different-session" \
+            --prompt 'test ! -f /tmp/keepalive-marker' \
+            || fail "Turn 3: marker file found — session isolation broken"
+          echo "PASS: Turn 3 completed (new VM for different session)"
+
+          # Stop transient service (drains idle pool)
+          sudo "$BIN_DIR/runner" service stop --name "$SVC"
+          trap - EXIT
+
+          echo "=== Keep-alive test passed ==="
+          REMOTE_SCRIPT
+
   ci-gate-crates:
     runs-on: ubuntu-latest
     needs:
@@ -1093,6 +1188,7 @@ jobs:
       - runner-exec
       - runner-balloon
       - runner-upgrade-local
+      - runner-keep-alive
       - nbd-cow-test
     # Always run so the gate reports an explicit result (not "skipped").
     if: always()
@@ -1138,6 +1234,7 @@ jobs:
           check_result "runner-exec" "${{ needs.runner-exec.result }}" "true"
           check_result "runner-balloon" "${{ needs.runner-balloon.result }}" "true"
           check_result "runner-upgrade-local" "${{ needs.runner-upgrade-local.result }}" "true"
+          check_result "runner-keep-alive" "${{ needs.runner-keep-alive.result }}" "true"
           check_result "nbd-cow-test" "${{ needs.nbd-cow-test.result }}" "true"
 
           echo "::endgroup::"
@@ -1146,7 +1243,7 @@ jobs:
   runner-cleanup:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [runner-build, runner-benchmark, runner-exec, runner-cancel, runner-balloon, runner-upgrade-local]
+    needs: [runner-build, runner-benchmark, runner-exec, runner-cancel, runner-balloon, runner-upgrade-local, runner-keep-alive]
     if: ${{ always() && needs.runner-build.result != 'skipped' }}
     steps:
       - uses: actions/checkout@v6

--- a/ansible/playbooks/cleanup-crates-runner.yml
+++ b/ansible/playbooks/cleanup-crates-runner.yml
@@ -64,6 +64,10 @@
       command: systemctl stop vm0-runner-{{ job_ref }}-cancel.service
       ignore_errors: true
 
+    - name: Stop transient service keepalive
+      command: systemctl stop vm0-runner-{{ job_ref }}-keepalive.service
+      ignore_errors: true
+
     - name: Reload systemd daemon
       command: systemctl daemon-reload
       ignore_errors: true
@@ -80,7 +84,9 @@
         - "{{ base_dir }}/runners/{{ job_ref }}-balloon"
         - "{{ base_dir }}/runners/{{ job_ref }}-upgrade-a"
         - "{{ base_dir }}/runners/{{ job_ref }}-upgrade-b"
+        - "{{ base_dir }}/runners/{{ job_ref }}-keepalive"
         - "{{ base_dir }}/groups/vm0/cancel-{{ job_ref }}"
         - "{{ base_dir }}/groups/vm0/exec-{{ job_ref }}"
         - "{{ base_dir }}/groups/vm0/balloon-{{ job_ref }}"
         - "{{ base_dir }}/groups/vm0/upgrade-{{ job_ref }}"
+        - "{{ base_dir }}/groups/vm0/keepalive-{{ job_ref }}"

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -41,6 +41,10 @@ pub struct ConfigArgs {
     #[arg(long, default_value_t = DEFAULT_CONCURRENCY_FACTOR)]
     concurrency_factor: f64,
 
+    /// Keep VMs alive between conversation turns for session reuse
+    #[arg(long)]
+    keep_alive: bool,
+
     /// vm0 API URL
     #[arg(long, env = "VM0_API_URL")]
     api_url: String,
@@ -128,6 +132,8 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
         sandbox: SandboxConfig {
             max_concurrent: args.max_concurrent,
             concurrency_factor: args.concurrency_factor,
+            keep_alive: args.keep_alive,
+            ..SandboxConfig::default()
         },
         server: Some(ServerConfig {
             url: args.api_url,

--- a/crates/runner/src/cmd/doctor.rs
+++ b/crates/runner/src/cmd/doctor.rs
@@ -269,6 +269,8 @@ struct StatusInfo {
     active_run_ids: Vec<String>,
     proxy_port: Option<u16>,
     dns_port: Option<u16>,
+    idle_vms: usize,
+    idle_sessions: Vec<String>,
 }
 
 struct InstalledService {
@@ -640,6 +642,10 @@ struct StatusFile {
     proxy_port: Option<u16>,
     #[serde(default)]
     dns_port: Option<u16>,
+    #[serde(default)]
+    idle_vms: usize,
+    #[serde(default)]
+    idle_sessions: Vec<String>,
 }
 
 /// Returns `true` for modes where proxy absence is expected (not a warning).
@@ -657,6 +663,8 @@ async fn read_status(base_dir: &Path) -> Option<StatusInfo> {
         active_run_ids: file.active_run_ids,
         proxy_port: file.proxy_port,
         dns_port: file.dns_port,
+        idle_vms: file.idle_vms,
+        idle_sessions: file.idle_sessions,
     })
 }
 
@@ -974,6 +982,16 @@ fn print_report(
             println!("    Jobs:    0 active");
         }
 
+        // Idle VMs (keep-alive)
+        if let Some(st) = &r.status
+            && st.idle_vms > 0
+        {
+            println!("    Idle:    {} VMs", st.idle_vms);
+            for session in &st.idle_sessions {
+                println!("      - session {session}");
+            }
+        }
+
         // Per-runner warnings
         if !r.warnings.is_empty() {
             for w in &r.warnings {
@@ -1090,6 +1108,8 @@ mod tests {
             active_run_ids: vec!["abc".into(), "def".into()],
             proxy_port: None,
             dns_port: None,
+            idle_vms: 0,
+            idle_sessions: vec![],
         };
         let fc = vec![
             process::FirecrackerProcessInfo {
@@ -1122,6 +1142,8 @@ mod tests {
             active_run_ids: vec!["abc".into()],
             proxy_port: None,
             dns_port: None,
+            idle_vms: 0,
+            idle_sessions: vec![],
         };
         let fc: Vec<process::FirecrackerProcessInfo> = vec![];
         let (jobs, warnings) = correlate_jobs(&status, Path::new("/data/r1"), &fc);
@@ -1138,6 +1160,8 @@ mod tests {
             active_run_ids: vec![],
             proxy_port: None,
             dns_port: None,
+            idle_vms: 0,
+            idle_sessions: vec![],
         };
         let fc = vec![process::FirecrackerProcessInfo {
             pid: 200,
@@ -1159,6 +1183,8 @@ mod tests {
             active_run_ids: vec!["abc".into()],
             proxy_port: None,
             dns_port: None,
+            idle_vms: 0,
+            idle_sessions: vec![],
         };
         // This firecracker belongs to a different runner (different base_dir)
         let fc = vec![process::FirecrackerProcessInfo {

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -36,6 +36,9 @@ pub struct SubmitArgs {
     /// VM profile to use (e.g. "vm0/default")
     #[arg(long)]
     profile: Option<String>,
+    /// Session ID for keep-alive VM reuse across conversation turns
+    #[arg(long)]
+    session_id: Option<String>,
     /// Timeout in seconds waiting for a runner to complete the job
     #[arg(long, default_value_t = 300)]
     timeout: u64,
@@ -103,6 +106,7 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
         environment: None,
         user_timezone: detect_system_timezone(),
         profile: args.profile,
+        session_id: args.session_id,
     };
 
     let json = serde_json::to_vec(&request)
@@ -273,6 +277,7 @@ mod tests {
             working_dir: "/workspace".into(),
             cli_agent_type: "claude-code".into(),
             profile: Some("bad-name".into()),
+            session_id: None,
             timeout: 1,
         };
         let err = run_submit(args).await.unwrap_err();
@@ -290,6 +295,7 @@ mod tests {
             working_dir: "/workspace".into(),
             cli_agent_type: "claude-code".into(),
             profile: Some("vm0/default".into()),
+            session_id: None,
             timeout: 1,
         };
         // Should pass validation and fail later (HomePaths or timeout), not on profile.

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -17,6 +17,7 @@ use crate::error::{RunnerError, RunnerResult};
 use crate::executor::{self, ExecutorConfig};
 use crate::host;
 use crate::http::HttpClient;
+use crate::idle_pool::{IdleEntry, IdlePool, IdlePoolConfig, ParkResult};
 use crate::kmsg_log;
 use crate::lock;
 use crate::paths::{HomePaths, LogPaths, RunnerPaths, touch_mtime};
@@ -201,6 +202,9 @@ pub async fn run_start(
     let config::SandboxConfig {
         max_concurrent,
         concurrency_factor,
+        keep_alive,
+        keep_alive_timeout_secs,
+        keep_alive_max_idle,
     } = runner_config.sandbox;
     let host_cpus = host::cpu_count()?;
     let host_memory_mb = host::memory_mb()?;
@@ -220,6 +224,19 @@ pub async fn run_start(
         profiles = runner_config.profiles.len(),
         "resource budget initialized"
     );
+
+    // Idle sandbox pool for VM keep-alive across conversation turns.
+    let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+        enabled: keep_alive,
+        default_timeout: Duration::from_secs(keep_alive_timeout_secs),
+        max_idle: keep_alive_max_idle,
+    })));
+    if keep_alive {
+        info!(
+            keep_alive_timeout_secs,
+            keep_alive_max_idle, "VM keep-alive enabled"
+        );
+    }
 
     // Estimated capacity for status reporting.
     // Derived from the smallest profile to cover the worst case.
@@ -295,6 +312,7 @@ pub async fn run_start(
         runtime,
         home,
         budget,
+        idle_pool,
         status,
         mitm,
         mitm_crash_rx,
@@ -320,6 +338,7 @@ struct RunConfig {
     runtime: Box<dyn SandboxRuntime>,
     home: HomePaths,
     budget: Arc<ResourceBudget>,
+    idle_pool: SharedIdlePool,
     status: Arc<StatusTracker>,
     mitm: proxy::MitmProxy,
     mitm_crash_rx: tokio::sync::mpsc::Receiver<()>,
@@ -347,6 +366,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         mut runtime,
         home,
         budget,
+        idle_pool,
         status,
         mut mitm,
         mut mitm_crash_rx,
@@ -386,6 +406,10 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     }
 
     let mut jobs: JoinSet<Option<Uuid>> = JoinSet::new();
+    // Tracked destroy tasks — JoinSet ensures we can await all in-flight
+    // destroys at shutdown, preventing factory Arc leaks that cause
+    // "factory still referenced" warnings from Arc::try_unwrap.
+    let mut destroy_tasks: JoinSet<()> = JoinSet::new();
 
     status.write_initial().await;
     info!(
@@ -435,6 +459,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     });
 
     // -----------------------------------------------------------------------
+    // Idle pool cleanup interval (every 10 seconds)
+    // -----------------------------------------------------------------------
+    let mut idle_cleanup = tokio::time::interval(Duration::from_secs(10));
+    idle_cleanup.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    // -----------------------------------------------------------------------
     // Main loop
     // -----------------------------------------------------------------------
     let mut current_mode = RunnerMode::Running;
@@ -452,12 +482,43 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         // Spawn background restart task when timer fires
         maybe_spawn_mitm_restart(&mut mitm, &mut mitm_crash_rx, &mut mitm_retry).await;
 
-        // If budget is exhausted for all profiles, wait for a job to finish
+        // If budget is exhausted for all profiles, try evicting an idle VM
+        // before waiting for a running job to finish.
+        //
+        // NOTE: evict_oldest is session-blind — it may destroy the very VM
+        // that the next job wants to reuse. A proper fix requires knowing
+        // session_id before claim, which is tracked for Phase 2.
         if !budget.can_afford(min_vcpu, min_memory_mb) {
+            if let Some(evicted) = idle_pool.lock().await.evict_oldest() {
+                info!(
+                    session_id = %evicted.session_id,
+                    profile = %evicted.profile_name,
+                    "evicting idle VM for resource pressure"
+                );
+                // Inline destroy so budget.release() happens synchronously
+                // before the `continue` re-checks can_afford(). Using
+                // tokio::spawn here would cause a cascade: the async release
+                // hasn't fired yet → can_afford still false → evict another →
+                // repeat until the entire pool is drained unnecessarily.
+                let vcpu = evicted.vcpu;
+                let memory_mb = evicted.memory_mb;
+                let mut sandbox = evicted.sandbox;
+                if let Err(e) = sandbox.stop().await {
+                    warn!(error = %e, "failed to stop idle sandbox during eviction");
+                }
+                evicted.factory.destroy(sandbox).await;
+                budget.release(vcpu, memory_mb);
+                continue; // retry budget check — budget is now actually freed
+            }
             tokio::select! {
                 _ = mode_rx.changed() => {}
                 result = jobs.join_next() => {
                     handle_job_result(result, &cancel_tokens).await;
+                }
+                Some(result) = destroy_tasks.join_next() => {
+                    if let Err(e) = result {
+                        warn!(error = %e, "destroy task panicked");
+                    }
                 }
                 _ = mitm_crash_rx.recv() => {
                     warn!("mitmproxy exited unexpectedly, scheduling restart");
@@ -516,7 +577,42 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 };
                 info!(run_id = %run_id, profile = %profile_name, "job claimed, spawning executor");
                 status.add_run(run_id).await;
+
+                // Check idle pool for a reusable VM (same session + same profile).
+                let reuse_entry = if let Some(session_id) = context.session_id() {
+                    let mut pool = idle_pool.lock().await;
+                    match pool.take(session_id) {
+                        Some(entry) if entry.profile_name == profile_name => {
+                            info!(
+                                run_id = %run_id,
+                                session_id,
+                                "reusing idle VM for session"
+                            );
+                            // Idle entry already holds budget — release the new reservation.
+                            budget.release(job_vcpu, job_memory);
+                            Some(entry)
+                        }
+                        Some(stale) => {
+                            // Profile mismatch — destroy the stale VM.
+                            info!(
+                                run_id = %run_id,
+                                session_id,
+                                old_profile = %stale.profile_name,
+                                new_profile = %profile_name,
+                                "idle VM profile mismatch, destroying"
+                            );
+                            let b = Arc::clone(&budget);
+                            destroy_tasks.spawn(destroy_idle_entry(stale, b));
+                            None
+                        }
+                        None => None,
+                    }
+                } else {
+                    None
+                };
+
                 let job_profile = JobProfile {
+                    profile_name: profile_name.clone(),
                     vcpu: job_vcpu,
                     memory_mb: job_memory,
                     use_snapshot: *use_snapshot,
@@ -524,8 +620,9 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     cancel: job_cancel,
                 };
                 spawn_job(
-                    context, job_profile, &provider, &exec_config,
-                    &budget, &mut jobs, &status,
+                    context, job_profile, reuse_entry, &provider, &exec_config,
+                    &budget, &idle_pool, &mut jobs, &status,
+                    current_mode,
                 );
             }
             // Mitmproxy crash detection
@@ -541,12 +638,55 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             () = sleep_until_retry(&mitm_retry.restart_at) => {}
             // Mode changes (signals)
             _ = mode_rx.changed() => {}
+            // Reap completed destroy tasks
+            Some(result) = destroy_tasks.join_next() => {
+                if let Err(e) = result {
+                    warn!(error = %e, "destroy task panicked");
+                }
+            }
+            // Idle pool cleanup: evict expired VMs and update status
+            _ = idle_cleanup.tick() => {
+                let mut pool = idle_pool.lock().await;
+                let expired = pool.evict_expired();
+                for entry in &expired {
+                    info!(
+                        profile = %entry.profile_name,
+                        "idle VM expired, destroying"
+                    );
+                }
+                // Update status with current idle pool state
+                let idle_count = pool.len();
+                let idle_sessions = pool.held_sessions();
+                drop(pool);
+                status.set_idle_info(idle_count, idle_sessions).await;
+                for entry in expired {
+                    let b = Arc::clone(&budget);
+                    destroy_tasks.spawn(destroy_idle_entry(entry, b));
+                }
+            }
         }
     }
 
     // -----------------------------------------------------------------------
-    // Shutdown — release discovery resources, then drain running jobs
+    // Shutdown — drain idle pool, release discovery resources, then drain running jobs
     // -----------------------------------------------------------------------
+
+    // Drain idle pool first — these VMs hold budget reservations.
+    let idle_entries = idle_pool.lock().await.drain();
+    if !idle_entries.is_empty() {
+        info!(count = idle_entries.len(), "draining idle VMs");
+        for entry in idle_entries {
+            let vcpu = entry.vcpu;
+            let memory_mb = entry.memory_mb;
+            let mut sandbox = entry.sandbox;
+            if let Err(e) = sandbox.stop().await {
+                warn!(error = %e, "failed to stop idle sandbox");
+            }
+            entry.factory.destroy(sandbox).await;
+            budget.release(vcpu, memory_mb);
+        }
+    }
+
     provider.shutdown().await;
 
     let remaining = jobs.len();
@@ -559,6 +699,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 result = jobs.join_next() => {
                     handle_job_result(result, &cancel_tokens).await;
                 }
+                Some(result) = destroy_tasks.join_next() => {
+                    if let Err(e) = result {
+                        warn!(error = %e, "destroy task panicked");
+                    }
+                }
                 _ = mitm_crash_rx.recv() => {
                     warn!("mitmproxy exited unexpectedly, scheduling restart");
                     mitm_retry.schedule();
@@ -568,6 +713,14 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 }
                 () = sleep_until_retry(&mitm_retry.restart_at) => {}
             }
+        }
+    }
+    // Wait for any in-flight destroy tasks (from cleanup tick, profile
+    // mismatch eviction, etc.) so their factory Arcs are dropped before
+    // shutdown_factories calls Arc::try_unwrap.
+    while let Some(result) = destroy_tasks.join_next().await {
+        if let Err(e) = result {
+            warn!(error = %e, "destroy task panicked during shutdown");
         }
     }
     if let Some(h) = mitm_retry.handle {
@@ -602,6 +755,7 @@ type SharedFactory = Arc<Box<dyn SandboxFactory>>;
 
 /// Per-job profile parameters resolved from the profile config.
 struct JobProfile {
+    profile_name: String,
     vcpu: u32,
     memory_mb: u32,
     use_snapshot: bool,
@@ -624,26 +778,37 @@ async fn shutdown_factories(
     runtime.shutdown().await;
 }
 
+type SharedIdlePool = Arc<tokio::sync::Mutex<IdlePool>>;
+
 /// Spawn a job executor task.
 ///
 /// The provider has already claimed the job and the caller has reserved
 /// resources in the budget — this function spawns the executor, reports
 /// completion via the provider, and releases the budget when done.
 ///
-/// Returns the run_id via the JoinSet so the main loop can clean up
-/// the cancel token.
+/// If `reuse_entry` is `Some`, the job reuses an existing idle sandbox.
+/// Otherwise it creates a new one via the factory.
+///
+/// After execution, if keep-alive is enabled and the job succeeded,
+/// the sandbox is parked in the idle pool instead of being destroyed.
+#[allow(clippy::too_many_arguments)]
 fn spawn_job(
     context: ExecutionContext,
     job_profile: JobProfile,
+    reuse_entry: Option<IdleEntry>,
     provider: &Arc<dyn JobProvider>,
     exec_config: &Arc<ExecutorConfig>,
     budget: &Arc<ResourceBudget>,
+    idle_pool: &SharedIdlePool,
     jobs: &mut JoinSet<Option<Uuid>>,
     status: &Arc<StatusTracker>,
+    mode: RunnerMode,
 ) {
     let run_id = context.run_id;
+    let session_id = context.session_id().map(String::from);
     let vcpu = job_profile.vcpu;
     let memory_mb = job_profile.memory_mb;
+    let profile_name = job_profile.profile_name;
     let factory = job_profile.factory;
     let job_cancel = job_profile.cancel;
     let params = executor::JobParams {
@@ -656,35 +821,144 @@ fn spawn_job(
     let exec_config = Arc::clone(exec_config);
     let budget = Arc::clone(budget);
     let status = Arc::clone(status);
+    let idle_pool = Arc::clone(idle_pool);
+    let factory_for_cleanup = Arc::clone(&factory);
 
     jobs.spawn(async move {
         // Inner spawn isolates panics: if execute_job panics, the outer task
         // still reports completion and releases budget.
         let cancel = job_cancel.clone();
+
         let inner = tokio::spawn(async move {
-            executor::execute_job(&**factory, context, &exec_config, &params, cancel).await
+            if let Some(idle_entry) = reuse_entry {
+                executor::execute_job_reuse(idle_entry, context, &exec_config, &params, cancel)
+                    .await
+            } else {
+                executor::execute_job(&**factory, context, &exec_config, &params, cancel).await
+            }
         });
 
-        let (exit_code, err) = match inner.await {
-            Ok((code, err)) => {
-                if job_cancel.is_cancelled() {
-                    (code, Some("cancelled by user".to_string()))
+        let (exit_code, err, sandbox, source_ip) = match inner.await {
+            Ok(outcome) => {
+                let err = if job_cancel.is_cancelled() {
+                    Some("cancelled by user".to_string())
                 } else {
-                    (code, err)
-                }
+                    outcome.error
+                };
+                (outcome.exit_code, err, outcome.sandbox, outcome.source_ip)
             }
             Err(e) => {
                 error!(run_id = %run_id, error = %e, "executor task panicked");
-                (1, Some(format!("internal error: {e}")))
+                (1, Some(format!("internal error: {e}")), None, String::new())
             }
+        };
+
+        // Decide: park sandbox for keep-alive, or stop + destroy.
+        let parked = if let Some(sandbox) = sandbox {
+            let parkable_session =
+                if exit_code == 0 && !job_cancel.is_cancelled() && mode == RunnerMode::Running {
+                    session_id.as_deref()
+                } else {
+                    None
+                };
+
+            if let Some(session_id) = parkable_session {
+                // Single lock: check enabled, get timeout, and park.
+                let mut pool = idle_pool.lock().await;
+                if !pool.is_enabled() {
+                    drop(pool);
+                    let mut sb = sandbox;
+                    if let Err(e) = sb.stop().await {
+                        warn!(run_id = %run_id, error = %e, "sandbox stop failed");
+                    }
+                    factory_for_cleanup.destroy(sb).await;
+                    false
+                } else {
+                    let idle_timeout = pool.default_timeout();
+                    let entry = IdleEntry {
+                        sandbox,
+                        factory: factory_for_cleanup,
+                        session_id: session_id.to_string(),
+                        profile_name,
+                        vcpu,
+                        memory_mb,
+                        source_ip,
+                        parked_at: std::time::Instant::now(),
+                        idle_timeout,
+                    };
+                    match pool.park(session_id.to_string(), entry) {
+                        ParkResult::Parked => {
+                            info!(run_id = %run_id, session_id, "VM parked for keep-alive");
+                            true
+                        }
+                        ParkResult::Evicted(evicted) => {
+                            info!(run_id = %run_id, session_id, "VM parked, evicting previous");
+                            drop(pool);
+                            // Inline destroy: this code runs inside a tokio task
+                            // (jobs.spawn), so awaiting here does not block the
+                            // main loop. Inline ensures the factory Arc is dropped
+                            // before shutdown_factories runs.
+                            let evict_vcpu = evicted.vcpu;
+                            let evict_mem = evicted.memory_mb;
+                            let mut sb = evicted.sandbox;
+                            if let Err(e) = sb.stop().await {
+                                warn!(run_id = %run_id, error = %e, "evicted sandbox stop failed");
+                            }
+                            evicted.factory.destroy(sb).await;
+                            budget.release(evict_vcpu, evict_mem);
+                            true
+                        }
+                        ParkResult::PoolFull(rejected) => {
+                            info!(run_id = %run_id, session_id, "idle pool full, destroying VM");
+                            drop(pool);
+                            // Inline stop+destroy — budget will be released
+                            // by the `!parked` path below, not by destroy_idle_entry,
+                            // to avoid double-releasing the same budget.
+                            let mut sb = rejected.sandbox;
+                            if let Err(e) = sb.stop().await {
+                                warn!(run_id = %run_id, error = %e, "sandbox stop failed");
+                            }
+                            rejected.factory.destroy(sb).await;
+                            false
+                        }
+                    }
+                }
+            } else {
+                // No parkable session — stop + destroy
+                let mut sb = sandbox;
+                if let Err(e) = sb.stop().await {
+                    warn!(run_id = %run_id, error = %e, "sandbox stop failed");
+                }
+                factory_for_cleanup.destroy(sb).await;
+                false
+            }
+        } else {
+            false
         };
 
         // Structural guarantee: claim (in provider) is always paired with complete.
         provider.complete(run_id, exit_code, err.as_deref()).await;
         status.remove_run(run_id).await;
-        budget.release(vcpu, memory_mb);
+
+        // Release budget only if sandbox was NOT parked (parked VMs hold their budget).
+        if !parked {
+            budget.release(vcpu, memory_mb);
+        }
+
         Some(run_id)
     });
+}
+
+/// Destroy an idle sandbox entry and release its budget.
+async fn destroy_idle_entry(entry: IdleEntry, budget: Arc<ResourceBudget>) {
+    let vcpu = entry.vcpu;
+    let memory_mb = entry.memory_mb;
+    let mut sandbox = entry.sandbox;
+    if let Err(e) = sandbox.stop().await {
+        warn!(error = %e, "failed to stop idle sandbox");
+    }
+    entry.factory.destroy(sandbox).await;
+    budget.release(vcpu, memory_mb);
 }
 
 /// Handle a completed job from the JoinSet, cleaning up cancel tokens.

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Args;
-use sandbox::{RuntimeProvider, SandboxFactory, SandboxRuntime};
+use sandbox::{RuntimeProvider, Sandbox, SandboxFactory, SandboxRuntime};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
@@ -468,10 +468,19 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Main loop
     // -----------------------------------------------------------------------
     let mut current_mode = RunnerMode::Running;
+    let mut spawn_ctx = SpawnContext {
+        provider: Arc::clone(&provider),
+        exec_config: Arc::clone(&exec_config),
+        budget: Arc::clone(&budget),
+        idle_pool: Arc::clone(&idle_pool),
+        status: Arc::clone(&status),
+        mode: current_mode,
+    };
     loop {
         let mode = *mode_rx.borrow_and_update();
         if mode != current_mode {
             current_mode = mode;
+            spawn_ctx.mode = mode;
             status.set_mode(mode).await;
         }
         match mode {
@@ -502,11 +511,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 // repeat until the entire pool is drained unnecessarily.
                 let vcpu = evicted.vcpu;
                 let memory_mb = evicted.memory_mb;
-                let mut sandbox = evicted.sandbox;
-                if let Err(e) = sandbox.stop().await {
-                    warn!(error = %e, "failed to stop idle sandbox during eviction");
-                }
-                evicted.factory.destroy(sandbox).await;
+                evicted.stop_and_destroy().await;
                 budget.release(vcpu, memory_mb);
                 continue; // retry budget check — budget is now actually freed
             }
@@ -620,9 +625,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     cancel: job_cancel,
                 };
                 spawn_job(
-                    context, job_profile, reuse_entry, &provider, &exec_config,
-                    &budget, &idle_pool, &mut jobs, &status,
-                    current_mode,
+                    context, job_profile, reuse_entry, &spawn_ctx, &mut jobs,
                 );
             }
             // Mitmproxy crash detection
@@ -678,11 +681,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         for entry in idle_entries {
             let vcpu = entry.vcpu;
             let memory_mb = entry.memory_mb;
-            let mut sandbox = entry.sandbox;
-            if let Err(e) = sandbox.stop().await {
-                warn!(error = %e, "failed to stop idle sandbox");
-            }
-            entry.factory.destroy(sandbox).await;
+            entry.stop_and_destroy().await;
             budget.release(vcpu, memory_mb);
         }
     }
@@ -780,6 +779,16 @@ async fn shutdown_factories(
 
 type SharedIdlePool = Arc<tokio::sync::Mutex<IdlePool>>;
 
+/// Shared state passed to each spawned job task.
+struct SpawnContext {
+    provider: Arc<dyn JobProvider>,
+    exec_config: Arc<ExecutorConfig>,
+    budget: Arc<ResourceBudget>,
+    idle_pool: SharedIdlePool,
+    status: Arc<StatusTracker>,
+    mode: RunnerMode,
+}
+
 /// Spawn a job executor task.
 ///
 /// The provider has already claimed the job and the caller has reserved
@@ -791,18 +800,12 @@ type SharedIdlePool = Arc<tokio::sync::Mutex<IdlePool>>;
 ///
 /// After execution, if keep-alive is enabled and the job succeeded,
 /// the sandbox is parked in the idle pool instead of being destroyed.
-#[allow(clippy::too_many_arguments)]
 fn spawn_job(
     context: ExecutionContext,
     job_profile: JobProfile,
     reuse_entry: Option<IdleEntry>,
-    provider: &Arc<dyn JobProvider>,
-    exec_config: &Arc<ExecutorConfig>,
-    budget: &Arc<ResourceBudget>,
-    idle_pool: &SharedIdlePool,
+    ctx: &SpawnContext,
     jobs: &mut JoinSet<Option<Uuid>>,
-    status: &Arc<StatusTracker>,
-    mode: RunnerMode,
 ) {
     let run_id = context.run_id;
     let session_id = context.session_id().map(String::from);
@@ -817,11 +820,12 @@ fn spawn_job(
         use_snapshot: job_profile.use_snapshot,
     };
 
-    let provider = Arc::clone(provider);
-    let exec_config = Arc::clone(exec_config);
-    let budget = Arc::clone(budget);
-    let status = Arc::clone(status);
-    let idle_pool = Arc::clone(idle_pool);
+    let provider = Arc::clone(&ctx.provider);
+    let exec_config = Arc::clone(&ctx.exec_config);
+    let budget = Arc::clone(&ctx.budget);
+    let status = Arc::clone(&ctx.status);
+    let idle_pool = Arc::clone(&ctx.idle_pool);
+    let mode = ctx.mode;
     let factory_for_cleanup = Arc::clone(&factory);
 
     jobs.spawn(async move {
@@ -831,8 +835,7 @@ fn spawn_job(
 
         let inner = tokio::spawn(async move {
             if let Some(idle_entry) = reuse_entry {
-                executor::execute_job_reuse(idle_entry, context, &exec_config, &params, cancel)
-                    .await
+                executor::execute_job_reuse(idle_entry, context, &exec_config, cancel).await
             } else {
                 executor::execute_job(&**factory, context, &exec_config, &params, cancel).await
             }
@@ -863,73 +866,43 @@ fn spawn_job(
                 };
 
             if let Some(session_id) = parkable_session {
-                // Single lock: check enabled, get timeout, and park.
                 let mut pool = idle_pool.lock().await;
-                if !pool.is_enabled() {
-                    drop(pool);
-                    let mut sb = sandbox;
-                    if let Err(e) = sb.stop().await {
-                        warn!(run_id = %run_id, error = %e, "sandbox stop failed");
+                let idle_timeout = pool.default_timeout();
+                let entry = IdleEntry {
+                    sandbox,
+                    factory: factory_for_cleanup,
+                    session_id: session_id.to_string(),
+                    profile_name,
+                    vcpu,
+                    memory_mb,
+                    source_ip,
+                    parked_at: std::time::Instant::now(),
+                    idle_timeout,
+                };
+                match pool.park(session_id.to_string(), entry) {
+                    ParkResult::Parked => {
+                        info!(run_id = %run_id, session_id, "VM parked for keep-alive");
+                        true
                     }
-                    factory_for_cleanup.destroy(sb).await;
-                    false
-                } else {
-                    let idle_timeout = pool.default_timeout();
-                    let entry = IdleEntry {
-                        sandbox,
-                        factory: factory_for_cleanup,
-                        session_id: session_id.to_string(),
-                        profile_name,
-                        vcpu,
-                        memory_mb,
-                        source_ip,
-                        parked_at: std::time::Instant::now(),
-                        idle_timeout,
-                    };
-                    match pool.park(session_id.to_string(), entry) {
-                        ParkResult::Parked => {
-                            info!(run_id = %run_id, session_id, "VM parked for keep-alive");
-                            true
-                        }
-                        ParkResult::Evicted(evicted) => {
-                            info!(run_id = %run_id, session_id, "VM parked, evicting previous");
-                            drop(pool);
-                            // Inline destroy: this code runs inside a tokio task
-                            // (jobs.spawn), so awaiting here does not block the
-                            // main loop. Inline ensures the factory Arc is dropped
-                            // before shutdown_factories runs.
-                            let evict_vcpu = evicted.vcpu;
-                            let evict_mem = evicted.memory_mb;
-                            let mut sb = evicted.sandbox;
-                            if let Err(e) = sb.stop().await {
-                                warn!(run_id = %run_id, error = %e, "evicted sandbox stop failed");
-                            }
-                            evicted.factory.destroy(sb).await;
-                            budget.release(evict_vcpu, evict_mem);
-                            true
-                        }
-                        ParkResult::PoolFull(rejected) => {
-                            info!(run_id = %run_id, session_id, "idle pool full, destroying VM");
-                            drop(pool);
-                            // Inline stop+destroy — budget will be released
-                            // by the `!parked` path below, not by destroy_idle_entry,
-                            // to avoid double-releasing the same budget.
-                            let mut sb = rejected.sandbox;
-                            if let Err(e) = sb.stop().await {
-                                warn!(run_id = %run_id, error = %e, "sandbox stop failed");
-                            }
-                            rejected.factory.destroy(sb).await;
-                            false
-                        }
+                    ParkResult::Evicted(evicted) => {
+                        info!(run_id = %run_id, session_id, "VM parked, evicting previous");
+                        drop(pool);
+                        let evict_vcpu = evicted.vcpu;
+                        let evict_mem = evicted.memory_mb;
+                        evicted.stop_and_destroy().await;
+                        budget.release(evict_vcpu, evict_mem);
+                        true
+                    }
+                    ParkResult::PoolFull(rejected) => {
+                        info!(run_id = %run_id, session_id, "idle pool full, destroying VM");
+                        drop(pool);
+                        rejected.stop_and_destroy().await;
+                        false
                     }
                 }
             } else {
                 // No parkable session — stop + destroy
-                let mut sb = sandbox;
-                if let Err(e) = sb.stop().await {
-                    warn!(run_id = %run_id, error = %e, "sandbox stop failed");
-                }
-                factory_for_cleanup.destroy(sb).await;
+                stop_and_destroy_sandbox(sandbox, &**factory_for_cleanup).await;
                 false
             }
         } else {
@@ -953,12 +926,16 @@ fn spawn_job(
 async fn destroy_idle_entry(entry: IdleEntry, budget: Arc<ResourceBudget>) {
     let vcpu = entry.vcpu;
     let memory_mb = entry.memory_mb;
-    let mut sandbox = entry.sandbox;
-    if let Err(e) = sandbox.stop().await {
-        warn!(error = %e, "failed to stop idle sandbox");
-    }
-    entry.factory.destroy(sandbox).await;
+    entry.stop_and_destroy().await;
     budget.release(vcpu, memory_mb);
+}
+
+/// Stop a sandbox and destroy it via its factory.
+async fn stop_and_destroy_sandbox(mut sandbox: Box<dyn Sandbox>, factory: &dyn SandboxFactory) {
+    if let Err(e) = sandbox.stop().await {
+        warn!(error = %e, "sandbox stop failed");
+    }
+    factory.destroy(sandbox).await;
 }
 
 /// Handle a completed job from the JoinSet, cleaning up cancel tokens.

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -46,6 +46,12 @@ pub struct SandboxConfig {
     pub max_concurrent: usize,
     /// Overcommit factor applied to both CPU and memory budgets (default: 1.0).
     pub concurrency_factor: f64,
+    /// Keep VMs alive between conversation turns for session reuse (default: false).
+    pub keep_alive: bool,
+    /// Idle timeout in seconds for kept-alive VMs (default: 300).
+    pub keep_alive_timeout_secs: u64,
+    /// Maximum number of idle VMs to keep (0 = no limit, default: 0).
+    pub keep_alive_max_idle: usize,
 }
 
 impl Default for SandboxConfig {
@@ -53,6 +59,9 @@ impl Default for SandboxConfig {
         Self {
             max_concurrent: DEFAULT_MAX_CONCURRENT,
             concurrency_factor: DEFAULT_CONCURRENCY_FACTOR,
+            keep_alive: false,
+            keep_alive_timeout_secs: 300,
+            keep_alive_max_idle: 0,
         }
     }
 }
@@ -595,6 +604,7 @@ sandbox:
             sandbox: SandboxConfig {
                 max_concurrent: 8,
                 concurrency_factor: 2.0,
+                ..SandboxConfig::default()
             },
             server: Some(ServerConfig {
                 url: "https://api.example.com".into(),
@@ -681,5 +691,86 @@ profiles:
         let snap = fc.snapshot.unwrap();
         assert_eq!(snap.hash, "def456");
         assert_eq!(snap.output_dir, home.snapshots_dir().join("def456"));
+    }
+
+    #[tokio::test]
+    async fn keep_alive_config_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        for f in [&fc, &kernel] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+        let home = test_home_with_artifacts(dir.path(), &[("abc123", Some("def456"))]).await;
+
+        let runner_dir = dir.path().join("my-runner");
+        let config = RunnerConfig {
+            name: "test-runner".into(),
+            group: "vm0/prod".into(),
+            base_dir: runner_dir.clone(),
+            ca_dir: dir.path().to_path_buf(),
+            firecracker: FirecrackerConfig { binary: fc, kernel },
+            profiles: make_profiles(),
+            sandbox: SandboxConfig {
+                max_concurrent: 4,
+                concurrency_factor: 1.5,
+                keep_alive: true,
+                keep_alive_timeout_secs: 600,
+                keep_alive_max_idle: 10,
+            },
+            server: None,
+        };
+
+        generate(&config).await.unwrap();
+
+        let loaded = load_with_home(&runner_dir.join("runner.yaml"), &home)
+            .await
+            .unwrap();
+        assert!(loaded.sandbox.keep_alive);
+        assert_eq!(loaded.sandbox.keep_alive_timeout_secs, 600);
+        assert_eq!(loaded.sandbox.keep_alive_max_idle, 10);
+        assert_eq!(loaded, config);
+    }
+
+    #[tokio::test]
+    async fn keep_alive_defaults_when_omitted() {
+        let dir = tempfile::tempdir().unwrap();
+        let fc = dir.path().join("firecracker");
+        let kernel = dir.path().join("vmlinux");
+        for f in [&fc, &kernel] {
+            tokio::fs::write(f, b"").await.unwrap();
+        }
+        let home = test_home_with_artifacts(dir.path(), &[("abc", None)]).await;
+
+        // YAML without any keep_alive fields
+        let yaml = format!(
+            r#"
+name: test
+group: test/group
+base_dir: {base_dir}
+ca_dir: {ca_dir}
+firecracker:
+  binary: {fc}
+  kernel: {kernel}
+profiles:
+  vm0/default:
+    rootfs_hash: abc
+    vcpu: 2
+    memory_mb: 4096
+    disk_mb: 16384
+"#,
+            base_dir = dir.path().display(),
+            ca_dir = dir.path().display(),
+            fc = fc.display(),
+            kernel = kernel.display(),
+        );
+
+        let config_path = dir.path().join("runner.yaml");
+        tokio::fs::write(&config_path, &yaml).await.unwrap();
+
+        let config = load_with_home(&config_path, &home).await.unwrap();
+        assert!(!config.sandbox.keep_alive);
+        assert_eq!(config.sandbox.keep_alive_timeout_secs, 300);
+        assert_eq!(config.sandbox.keep_alive_max_idle, 0);
     }
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -105,7 +105,6 @@ pub async fn execute_job_reuse(
     idle_entry: IdleEntry,
     context: ExecutionContext,
     config: &ExecutorConfig,
-    params: &JobParams,
     cancel: CancellationToken,
 ) -> ExecuteOutcome {
     let run_id = context.run_id;
@@ -125,7 +124,6 @@ pub async fn execute_job_reuse(
         &source_ip,
         &context,
         config,
-        params,
         &mut telemetry,
         cancel,
     )
@@ -230,7 +228,6 @@ async fn execute_reused_sandbox(
     source_ip: &str,
     context: &ExecutionContext,
     config: &ExecutorConfig,
-    _params: &JobParams,
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
 ) -> ExecuteOutcome {
@@ -2219,14 +2216,7 @@ mod tests {
 
         // Reuse the sandbox for a second turn
         let cancel = tokio_util::sync::CancellationToken::new();
-        let reuse_outcome = execute_job_reuse(
-            idle_entry,
-            minimal_context(),
-            &config,
-            &default_params(),
-            cancel,
-        )
-        .await;
+        let reuse_outcome = execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
         assert!(reuse_outcome.error.is_none());
         assert!(reuse_outcome.sandbox.is_some());
@@ -2278,8 +2268,7 @@ mod tests {
         });
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let reuse_outcome =
-            execute_job_reuse(idle_entry, ctx2, &config, &default_params(), cancel).await;
+        let reuse_outcome = execute_job_reuse(idle_entry, ctx2, &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
         assert!(reuse_outcome.sandbox.is_some());
     }
@@ -2338,14 +2327,8 @@ mod tests {
 
         // Execute reuse
         let cancel = tokio_util::sync::CancellationToken::new();
-        let reuse_outcome = execute_job_reuse(
-            reuse_entry,
-            minimal_context(),
-            &config,
-            &default_params(),
-            cancel,
-        )
-        .await;
+        let reuse_outcome =
+            execute_job_reuse(reuse_entry, minimal_context(), &config, cancel).await;
         assert_eq!(reuse_outcome.exit_code, 0);
         assert!(reuse_outcome.sandbox.is_some());
     }
@@ -2374,7 +2357,7 @@ mod tests {
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
         };
-        pool.park("session-1".into(), entry);
+        let _ = pool.park("session-1".into(), entry);
 
         // Take and verify profile
         let taken = pool.take("session-1").expect("should find");
@@ -2409,14 +2392,7 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job_reuse(
-            idle_entry,
-            minimal_context(),
-            &config,
-            &default_params(),
-            cancel,
-        )
-        .await;
+        let outcome = execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
 
         assert_eq!(outcome.exit_code, 1);
         assert!(outcome.error.unwrap().contains("vsock broken"));
@@ -2456,14 +2432,7 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job_reuse(
-            idle_entry,
-            minimal_context(),
-            &config,
-            &default_params(),
-            cancel,
-        )
-        .await;
+        let outcome = execute_job_reuse(idle_entry, minimal_context(), &config, cancel).await;
 
         assert_eq!(outcome.exit_code, 1);
         assert!(outcome.error.unwrap().contains("reseed timeout"));
@@ -2513,7 +2482,7 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job_reuse(idle_entry, ctx, &config, &default_params(), cancel).await;
+        let outcome = execute_job_reuse(idle_entry, ctx, &config, cancel).await;
 
         // If storage download was NOT skipped, write_file would have been called
         // with the poisoned error, causing the job to fail with "download should
@@ -2555,7 +2524,7 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job_reuse(idle_entry, ctx, &config, &default_params(), cancel).await;
+        let outcome = execute_job_reuse(idle_entry, ctx, &config, cancel).await;
 
         assert_eq!(outcome.exit_code, 1);
         assert!(outcome.error.unwrap().contains("disk full"));
@@ -2614,7 +2583,7 @@ mod tests {
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job_reuse(idle_entry, ctx, &config, &default_params(), cancel).await;
+        let outcome = execute_job_reuse(idle_entry, ctx, &config, cancel).await;
 
         // If storage download was NOT skipped, write_file would be called for
         // the manifest, consuming the error. Session restore's write_file would

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -17,6 +17,7 @@ const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(300);
 
 use crate::error::{RunnerError, RunnerResult};
 use crate::http::HttpClient;
+use crate::idle_pool::IdleEntry;
 use crate::kmsg_log;
 use crate::network_logs;
 use crate::paths::{LogPaths, guest};
@@ -40,24 +41,103 @@ pub struct JobParams {
     pub use_snapshot: bool,
 }
 
-/// Execute a single job inside a Firecracker VM.
+/// Outcome of a job execution, including the sandbox for possible reuse.
+pub struct ExecuteOutcome {
+    pub exit_code: i32,
+    pub error: Option<String>,
+    /// The sandbox after execution. `Some` when the sandbox is still alive
+    /// and eligible for keep-alive parking. `None` when execution failed
+    /// during create/start (sandbox was destroyed inline).
+    pub sandbox: Option<Box<dyn Sandbox>>,
+    pub source_ip: String,
+}
+
+/// Execute a single job inside a **new** Firecracker VM.
 ///
-/// Returns `(exit_code, error_message)`. The caller is responsible for
-/// reporting completion to the API — this keeps `claim` and `complete`
-/// in the same function for structural pairing.
+/// Returns [`ExecuteOutcome`] with the sandbox still alive (not stopped/destroyed).
+/// The caller decides whether to park it in the idle pool or destroy it.
 pub async fn execute_job(
     factory: &dyn SandboxFactory,
     context: ExecutionContext,
     config: &ExecutorConfig,
     params: &JobParams,
     cancel: CancellationToken,
-) -> (i32, Option<String>) {
+) -> ExecuteOutcome {
     let run_id = context.run_id;
     let mut telemetry =
         JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
 
-    // Record api_to_vm_start: elapsed time from the API-side timestamp to now.
-    // api_start_time is milliseconds since Unix epoch (Date.now() in TS).
+    record_api_latency(&context, &mut telemetry);
+
+    let outcome = match execute_new_sandbox(
+        factory,
+        &context,
+        config,
+        params,
+        &mut telemetry,
+        cancel,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            error!(run_id = %run_id, error = %e, "job execution failed");
+            ExecuteOutcome {
+                exit_code: 1,
+                error: Some(e.to_string()),
+                sandbox: None,
+                source_ip: String::new(),
+            }
+        }
+    };
+
+    info!(run_id = %run_id, exit_code = outcome.exit_code, "job finished");
+    telemetry.flush().await;
+
+    outcome
+}
+
+/// Execute a single job inside a **reused** (kept-alive) VM.
+///
+/// Skips create + start. Re-registers proxy, fixes clock, then runs the agent.
+/// Returns [`ExecuteOutcome`] with the sandbox still alive.
+pub async fn execute_job_reuse(
+    idle_entry: IdleEntry,
+    context: ExecutionContext,
+    config: &ExecutorConfig,
+    params: &JobParams,
+    cancel: CancellationToken,
+) -> ExecuteOutcome {
+    let run_id = context.run_id;
+    let mut telemetry =
+        JobTelemetry::new(config.http.clone(), run_id, context.sandbox_token.clone());
+
+    record_api_latency(&context, &mut telemetry);
+    telemetry.record("vm_reuse", Duration::ZERO, true, None);
+
+    let source_ip = idle_entry.source_ip.clone();
+    let sandbox = idle_entry.sandbox;
+
+    // execute_reused_sandbox never returns Err — it always returns the sandbox
+    // in the outcome so the caller can stop + destroy it on failure.
+    let outcome = execute_reused_sandbox(
+        sandbox,
+        &source_ip,
+        &context,
+        config,
+        params,
+        &mut telemetry,
+        cancel,
+    )
+    .await;
+
+    info!(run_id = %run_id, exit_code = outcome.exit_code, reused = true, "job finished");
+    telemetry.flush().await;
+
+    outcome
+}
+
+fn record_api_latency(context: &ExecutionContext, telemetry: &mut JobTelemetry) {
     if let Some(api_start_ms) = context.api_start_time {
         let now_ms = chrono::Utc::now().timestamp_millis() as f64;
         let elapsed_ms = (now_ms - api_start_ms).max(0.0);
@@ -68,30 +148,19 @@ pub async fn execute_job(
             None,
         );
     }
-
-    let (exit_code, err) =
-        match execute_inner(factory, &context, config, params, &mut telemetry, cancel).await {
-            Ok((code, stderr)) => (code, stderr),
-            Err(e) => {
-                error!(run_id = %run_id, error = %e, "job execution failed");
-                (1, Some(e.to_string()))
-            }
-        };
-
-    info!(run_id = %run_id, exit_code, "job finished");
-    telemetry.flush().await;
-
-    (exit_code, err)
 }
 
-async fn execute_inner(
+/// Create a new sandbox, run the job, and return the sandbox for possible reuse.
+///
+/// The caller is responsible for stop + destroy (or parking in the idle pool).
+async fn execute_new_sandbox(
     factory: &dyn SandboxFactory,
     context: &ExecutionContext,
     config: &ExecutorConfig,
     params: &JobParams,
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
-) -> RunnerResult<(i32, Option<String>)> {
+) -> RunnerResult<ExecuteOutcome> {
     let sandbox_id = context.run_id;
     let sandbox_config = SandboxConfig {
         id: sandbox_id,
@@ -112,13 +181,122 @@ async fn execute_inner(
         }
     };
 
-    // Register VM in proxy registry BEFORE starting the sandbox so that
-    // mitmproxy can intercept traffic from the very first request.
-    // source_ip is available after create() — it's assigned during network
-    // namespace allocation, before the VM boots.
     let source_ip = sandbox.source_ip().to_string();
-    let network_log_path = config.log_paths.network_log(context.run_id);
 
+    // Register VM in proxy registry BEFORE starting the sandbox.
+    register_proxy(config, context, &source_ip).await;
+
+    if let Err(e) = sandbox.start().await {
+        telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
+        unregister_proxy(config, context, &source_ip).await;
+        factory.destroy(sandbox).await;
+        return Err(e.into());
+    }
+    telemetry.record("vm_create", t.elapsed(), true, None);
+
+    // Run job inside sandbox
+    let result = run_in_sandbox(
+        sandbox.as_ref(),
+        context,
+        config,
+        params.use_snapshot,
+        false, // new sandbox — download storages normally
+        telemetry,
+        cancel,
+    )
+    .await;
+
+    // Post-job: copy logs + unregister proxy (sandbox stays alive for possible reuse)
+    post_job_cleanup(sandbox.as_ref(), config, context, &source_ip).await;
+
+    let (exit_code, error) = match result {
+        Ok((code, err)) => (code, err),
+        Err(e) => (1, Some(e.to_string())),
+    };
+
+    Ok(ExecuteOutcome {
+        exit_code,
+        error,
+        sandbox: Some(sandbox),
+        source_ip,
+    })
+}
+
+/// Run a job inside a reused (kept-alive) sandbox.
+///
+/// Skips create + start. Re-registers proxy, fixes clock/entropy, then runs.
+async fn execute_reused_sandbox(
+    sandbox: Box<dyn Sandbox>,
+    source_ip: &str,
+    context: &ExecutionContext,
+    config: &ExecutorConfig,
+    _params: &JobParams,
+    telemetry: &mut JobTelemetry,
+    cancel: CancellationToken,
+) -> ExecuteOutcome {
+    info!(
+        run_id = %context.run_id,
+        sandbox_id = %sandbox.id(),
+        "reusing kept-alive sandbox"
+    );
+
+    // Re-register proxy with new run credentials
+    register_proxy(config, context, source_ip).await;
+
+    // Fix clock drift and reseed entropy (always needed after idle period).
+    // On failure, return the sandbox so the caller can still stop + destroy it.
+    if let Err(e) = fix_guest_clock(sandbox.as_ref()).await {
+        warn!(run_id = %context.run_id, error = %e, "fix_guest_clock failed on reused sandbox");
+        unregister_proxy(config, context, source_ip).await;
+        return ExecuteOutcome {
+            exit_code: 1,
+            error: Some(e.to_string()),
+            sandbox: Some(sandbox),
+            source_ip: source_ip.to_string(),
+        };
+    }
+    if let Err(e) = reseed_guest_entropy(sandbox.as_ref()).await {
+        warn!(run_id = %context.run_id, error = %e, "reseed_guest_entropy failed on reused sandbox");
+        unregister_proxy(config, context, source_ip).await;
+        return ExecuteOutcome {
+            exit_code: 1,
+            error: Some(e.to_string()),
+            sandbox: Some(sandbox),
+            source_ip: source_ip.to_string(),
+        };
+    }
+
+    // Run job — clock/entropy already handled, storage persists from previous turn
+    let result = run_in_sandbox(
+        sandbox.as_ref(),
+        context,
+        config,
+        false, // clock/entropy already handled
+        true,  // skip storage download — filesystem persists across turns
+        telemetry,
+        cancel,
+    )
+    .await;
+
+    // Post-job cleanup
+    post_job_cleanup(sandbox.as_ref(), config, context, source_ip).await;
+
+    let (exit_code, error) = match result {
+        Ok((code, err)) => (code, err),
+        Err(e) => (1, Some(e.to_string())),
+    };
+
+    ExecuteOutcome {
+        exit_code,
+        error,
+        sandbox: Some(sandbox),
+        source_ip: source_ip.to_string(),
+    }
+}
+
+/// Register a VM in the proxy registry and IP log map.
+async fn register_proxy(config: &ExecutorConfig, context: &ExecutionContext, source_ip: &str) {
+    let network_log_path = config.log_paths.network_log(context.run_id);
     let run_id_str = context.run_id.to_string();
     let registration = proxy::VmRegistration {
         run_id: &run_id_str,
@@ -129,48 +307,39 @@ async fn execute_inner(
         secret_connector_map: context.secret_connector_map.as_ref(),
         vars: context.vars.as_ref(),
     };
-    if let Err(e) = config.registry.register_vm(&source_ip, &registration).await {
+    if let Err(e) = config.registry.register_vm(source_ip, &registration).await {
         warn!(run_id = %context.run_id, error = %e, "failed to register VM in proxy");
     }
-    // Register source IP in log map so non-TCP and DNS traffic is logged.
     config
         .ip_log_map
         .lock()
         .await
-        .insert(source_ip.clone(), network_log_path.clone());
+        .insert(source_ip.to_string(), network_log_path);
+}
 
-    if let Err(e) = sandbox.start().await {
-        telemetry.record("vm_create", t.elapsed(), false, Some(&e.to_string()));
-        // Unregister on start failure
-        if let Err(e) = config.registry.unregister_vm(&source_ip).await {
-            warn!(run_id = %context.run_id, error = %e, "failed to unregister VM from proxy");
-        }
-        config.ip_log_map.lock().await.remove(&source_ip);
-        factory.destroy(sandbox).await;
-        return Err(e.into());
-    }
-    telemetry.record("vm_create", t.elapsed(), true, None);
-
-    // Run job inside sandbox, then destroy regardless of outcome
-    let result = run_in_sandbox(
-        sandbox.as_ref(),
-        context,
-        config,
-        params.use_snapshot,
-        telemetry,
-        cancel,
-    )
-    .await;
-
-    // Copy guest logs to host log directory (best-effort).
-    copy_guest_logs(sandbox.as_ref(), context, &config.log_paths).await;
-
-    // Unregister VM from proxy + kmsg map + upload network logs before cleanup timer.
-    // Unregister first ensures no more log entries are written.
-    if let Err(e) = config.registry.unregister_vm(&source_ip).await {
+/// Unregister a VM from the proxy registry and IP log map.
+async fn unregister_proxy(config: &ExecutorConfig, context: &ExecutionContext, source_ip: &str) {
+    if let Err(e) = config.registry.unregister_vm(source_ip).await {
         warn!(run_id = %context.run_id, error = %e, "failed to unregister VM from proxy");
     }
-    config.ip_log_map.lock().await.remove(&source_ip);
+    config.ip_log_map.lock().await.remove(source_ip);
+}
+
+/// Post-job cleanup: copy logs, unregister proxy, upload network logs.
+///
+/// Called after `run_in_sandbox` completes, whether the sandbox will be
+/// parked (keep-alive) or destroyed.
+async fn post_job_cleanup(
+    sandbox: &dyn Sandbox,
+    config: &ExecutorConfig,
+    context: &ExecutionContext,
+    source_ip: &str,
+) {
+    copy_guest_logs(sandbox, context, &config.log_paths).await;
+
+    unregister_proxy(config, context, source_ip).await;
+
+    let network_log_path = config.log_paths.network_log(context.run_id);
     network_logs::upload_network_logs(
         &config.http,
         context.run_id,
@@ -178,28 +347,6 @@ async fn execute_inner(
         &network_log_path,
     )
     .await;
-
-    // Cleanup: stop + destroy
-    let t = Instant::now();
-
-    // Best-effort stop
-    let stop_err = match sandbox.stop().await {
-        Ok(()) => None,
-        Err(e) => {
-            warn!(sandbox_id = %sandbox_id, error = %e, "sandbox stop failed");
-            Some(e.to_string())
-        }
-    };
-    factory.destroy(sandbox).await;
-
-    telemetry.record(
-        "cleanup",
-        t.elapsed(),
-        stop_err.is_none(),
-        stop_err.as_deref(),
-    );
-
-    result
 }
 
 async fn run_in_sandbox(
@@ -207,6 +354,7 @@ async fn run_in_sandbox(
     context: &ExecutionContext,
     config: &ExecutorConfig,
     use_snapshot: bool,
+    skip_storage_download: bool,
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
 ) -> RunnerResult<(i32, Option<String>)> {
@@ -222,8 +370,8 @@ async fn run_in_sandbox(
     // 2. Set guest timezone from user preference (best-effort, never fails).
     sync_guest_timezone(sandbox, context).await;
 
-    // 3. Download storages
-    if let Some(manifest) = &context.storage_manifest {
+    // 3. Download storages (skipped for reused VMs — filesystem persists)
+    if !skip_storage_download && let Some(manifest) = &context.storage_manifest {
         let t = Instant::now();
         let result = download_storages(sandbox, context, manifest, &log_file).await;
         let err = result.as_ref().err().map(|e| e.to_string());
@@ -296,7 +444,7 @@ async fn run_in_sandbox(
         .map(|stdout_rx| tokio::spawn(drain_stdout_to_file(stdout_rx, host_log_path)));
 
     // 6. Wait for exit (or cancellation).
-    // On cancel we return immediately — the caller (execute_inner) will
+    // On cancel we return immediately — the caller (execute_new_sandbox) will
     // call sandbox.stop() + factory.destroy() in its cleanup path.
     let result = tokio::select! {
         result = sandbox.wait_exit(handle, JOB_TIMEOUT) => result,
@@ -1850,7 +1998,7 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // execute_inner integration tests (MockSandboxFactory + real filesystem)
+    // execute_new_sandbox integration tests (MockSandboxFactory + real filesystem)
     // -----------------------------------------------------------------------
 
     /// Build a real `ExecutorConfig` backed by tempdir files.
@@ -1896,7 +2044,9 @@ mod tests {
     ) -> RunnerResult<(i32, Option<String>)> {
         let mut telemetry = test_telemetry(config, ctx);
         let cancel = tokio_util::sync::CancellationToken::new();
-        execute_inner(factory, ctx, config, params, &mut telemetry, cancel).await
+        let outcome =
+            execute_new_sandbox(factory, ctx, config, params, &mut telemetry, cancel).await?;
+        Ok((outcome.exit_code, outcome.error))
     }
 
     #[tokio::test]
@@ -1993,7 +2143,7 @@ mod tests {
         factory.startup().await.unwrap();
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let (exit_code, error_msg) = execute_job(
+        let outcome = execute_job(
             &factory,
             minimal_context(),
             &config,
@@ -2001,8 +2151,9 @@ mod tests {
             cancel,
         )
         .await;
-        assert_eq!(exit_code, 0);
-        assert!(error_msg.is_none());
+        assert_eq!(outcome.exit_code, 0);
+        assert!(outcome.error.is_none());
+        assert!(outcome.sandbox.is_some());
     }
 
     #[tokio::test]
@@ -2014,7 +2165,7 @@ mod tests {
         factory.push_create_result(Err(SandboxError::CreationFailed("boom".into())));
 
         let cancel = tokio_util::sync::CancellationToken::new();
-        let (exit_code, error_msg) = execute_job(
+        let outcome = execute_job(
             &factory,
             minimal_context(),
             &config,
@@ -2022,7 +2173,491 @@ mod tests {
             cancel,
         )
         .await;
-        assert_eq!(exit_code, 1);
-        assert!(error_msg.unwrap().contains("boom"));
+        assert_eq!(outcome.exit_code, 1);
+        assert!(outcome.error.unwrap().contains("boom"));
+        assert!(outcome.sandbox.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Keep-alive VM reuse integration tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn execute_job_reuse_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory::new();
+        factory.startup().await.unwrap();
+
+        // First: create a sandbox via normal execute_job
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let outcome = execute_job(
+            &factory,
+            minimal_context(),
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+        assert_eq!(outcome.exit_code, 0);
+        let sandbox = outcome.sandbox.expect("sandbox should be alive");
+
+        // Build an idle entry from the outcome
+        let idle_entry = crate::idle_pool::IdleEntry {
+            sandbox,
+            factory: std::sync::Arc::new(
+                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: "test-session".into(),
+            profile_name: "vm0/default".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+            source_ip: outcome.source_ip,
+            parked_at: std::time::Instant::now(),
+            idle_timeout: std::time::Duration::from_secs(300),
+        };
+
+        // Reuse the sandbox for a second turn
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let reuse_outcome = execute_job_reuse(
+            idle_entry,
+            minimal_context(),
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+        assert_eq!(reuse_outcome.exit_code, 0);
+        assert!(reuse_outcome.error.is_none());
+        assert!(reuse_outcome.sandbox.is_some());
+    }
+
+    #[tokio::test]
+    async fn execute_job_reuse_with_session_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory::new();
+        factory.startup().await.unwrap();
+
+        // First turn: execute with resume_session
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: "test-session-abc".into(),
+            session_history: r#"{"type":"human","text":"hello"}"#.into(),
+        });
+        assert_eq!(ctx.session_id(), Some("test-session-abc"));
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let outcome = execute_job(&factory, ctx, &config, &default_params(), cancel).await;
+        assert_eq!(outcome.exit_code, 0);
+        let sandbox = outcome.sandbox.expect("sandbox should be alive");
+
+        // Build idle entry
+        let idle_entry = crate::idle_pool::IdleEntry {
+            sandbox,
+            factory: std::sync::Arc::new(
+                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: "test-session".into(),
+            profile_name: "vm0/default".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+            source_ip: outcome.source_ip,
+            parked_at: std::time::Instant::now(),
+            idle_timeout: std::time::Duration::from_secs(300),
+        };
+
+        // Second turn: reuse with new session history
+        let mut ctx2 = minimal_context();
+        ctx2.resume_session = Some(ResumeSession {
+            session_id: "test-session-abc".into(),
+            session_history: r#"{"type":"human","text":"hello"}
+{"type":"assistant","text":"hi"}
+{"type":"human","text":"do something"}"#
+                .into(),
+        });
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let reuse_outcome =
+            execute_job_reuse(idle_entry, ctx2, &config, &default_params(), cancel).await;
+        assert_eq!(reuse_outcome.exit_code, 0);
+        assert!(reuse_outcome.sandbox.is_some());
+    }
+
+    #[tokio::test]
+    async fn idle_pool_park_and_reuse_cycle() {
+        use crate::idle_pool::{IdlePool, IdlePoolConfig, ParkResult};
+
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory::new();
+        factory.startup().await.unwrap();
+
+        // Execute first job
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let outcome = execute_job(
+            &factory,
+            minimal_context(),
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+        assert_eq!(outcome.exit_code, 0);
+        let sandbox = outcome.sandbox.expect("sandbox alive");
+
+        // Park in idle pool
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            enabled: true,
+            default_timeout: std::time::Duration::from_secs(300),
+            max_idle: 0,
+        });
+
+        let entry = crate::idle_pool::IdleEntry {
+            sandbox,
+            factory: std::sync::Arc::new(
+                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: "test-session".into(),
+            profile_name: "vm0/default".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+            source_ip: outcome.source_ip,
+            parked_at: std::time::Instant::now(),
+            idle_timeout: std::time::Duration::from_secs(300),
+        };
+
+        let result = pool.park("session-1".into(), entry);
+        assert!(matches!(result, ParkResult::Parked));
+        assert_eq!(pool.len(), 1);
+
+        // Take from pool for reuse
+        let reuse_entry = pool.take("session-1").expect("should find session");
+        assert_eq!(pool.len(), 0);
+        assert_eq!(reuse_entry.profile_name, "vm0/default");
+
+        // Execute reuse
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let reuse_outcome = execute_job_reuse(
+            reuse_entry,
+            minimal_context(),
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+        assert_eq!(reuse_outcome.exit_code, 0);
+        assert!(reuse_outcome.sandbox.is_some());
+    }
+
+    #[tokio::test]
+    async fn idle_pool_profile_mismatch_returns_none() {
+        use crate::idle_pool::{IdlePool, IdlePoolConfig};
+
+        let mut pool = IdlePool::new(IdlePoolConfig {
+            enabled: true,
+            default_timeout: std::time::Duration::from_secs(300),
+            max_idle: 0,
+        });
+
+        // Park with profile "vm0/default"
+        let entry = crate::idle_pool::IdleEntry {
+            sandbox: Box::new(sandbox_mock::MockSandbox::new("test")),
+            factory: std::sync::Arc::new(
+                Box::new(sandbox_mock::MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: "test-session".into(),
+            profile_name: "vm0/default".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+            source_ip: "10.0.0.1".into(),
+            parked_at: std::time::Instant::now(),
+            idle_timeout: std::time::Duration::from_secs(300),
+        };
+        pool.park("session-1".into(), entry);
+
+        // Take and verify profile
+        let taken = pool.take("session-1").expect("should find");
+        assert_eq!(taken.profile_name, "vm0/default");
+
+        // Simulate caller checking profile mismatch
+        let matches_browser = taken.profile_name == "vm0/browser";
+        assert!(!matches_browser, "should not match different profile");
+    }
+
+    #[tokio::test]
+    async fn execute_job_reuse_clock_fix_failure_returns_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+
+        // Build a MockSandbox that fails on the first exec (fix_guest_clock)
+        let sandbox = MockSandbox::new("reuse-clock-fail");
+        sandbox.push_exec_result(Err(SandboxError::ExecFailed("vsock broken".into())));
+
+        let idle_entry = crate::idle_pool::IdleEntry {
+            sandbox: Box::new(sandbox),
+            factory: std::sync::Arc::new(
+                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: "sess-1".into(),
+            profile_name: "vm0/default".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+            source_ip: "10.0.0.1".into(),
+            parked_at: std::time::Instant::now(),
+            idle_timeout: std::time::Duration::from_secs(300),
+        };
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let outcome = execute_job_reuse(
+            idle_entry,
+            minimal_context(),
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code, 1);
+        assert!(outcome.error.unwrap().contains("vsock broken"));
+        // Critical: sandbox must be returned so caller can stop + destroy it
+        assert!(
+            outcome.sandbox.is_some(),
+            "sandbox must be returned on clock fix failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_job_reuse_reseed_failure_returns_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+
+        // First exec (fix_guest_clock) succeeds, second (reseed_guest_entropy) fails
+        let sandbox = MockSandbox::new("reuse-reseed-fail");
+        sandbox.push_exec_result(Ok(ExecResult {
+            exit_code: 0,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        }));
+        sandbox.push_exec_result(Err(SandboxError::ExecFailed("reseed timeout".into())));
+
+        let idle_entry = crate::idle_pool::IdleEntry {
+            sandbox: Box::new(sandbox),
+            factory: std::sync::Arc::new(
+                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: "sess-1".into(),
+            profile_name: "vm0/default".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+            source_ip: "10.0.0.1".into(),
+            parked_at: std::time::Instant::now(),
+            idle_timeout: std::time::Duration::from_secs(300),
+        };
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let outcome = execute_job_reuse(
+            idle_entry,
+            minimal_context(),
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+
+        assert_eq!(outcome.exit_code, 1);
+        assert!(outcome.error.unwrap().contains("reseed timeout"));
+        assert!(
+            outcome.sandbox.is_some(),
+            "sandbox must be returned on reseed failure"
+        );
+    }
+
+    /// Verify that the reuse path skips storage download even when context
+    /// has a storage_manifest. Strategy: push a write_file error — if download
+    /// ran, it would call write_file (consuming the error and failing).
+    /// Since download is skipped, write_file is never called and the test passes.
+    #[tokio::test]
+    async fn execute_job_reuse_skips_storage_download() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+
+        let sandbox = MockSandbox::new("reuse-skip-download");
+        // Poison write_file: if called, it would fail with this error.
+        sandbox.push_write_file_result(Err(SandboxError::ExecFailed(
+            "download should be skipped".into(),
+        )));
+
+        let mut ctx = minimal_context();
+        ctx.storage_manifest = Some(StorageManifest {
+            storages: vec![StorageEntry {
+                mount_path: "/data".into(),
+                archive_url: Some("https://s3/archive.tar.gz".into()),
+            }],
+            artifact: None,
+            memory: None,
+        });
+
+        let idle_entry = crate::idle_pool::IdleEntry {
+            sandbox: Box::new(sandbox),
+            factory: std::sync::Arc::new(
+                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: "sess-1".into(),
+            profile_name: "vm0/default".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+            source_ip: "10.0.0.1".into(),
+            parked_at: std::time::Instant::now(),
+            idle_timeout: std::time::Duration::from_secs(300),
+        };
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let outcome = execute_job_reuse(idle_entry, ctx, &config, &default_params(), cancel).await;
+
+        // If storage download was NOT skipped, write_file would have been called
+        // with the poisoned error, causing the job to fail with "download should
+        // be skipped". Success here proves download was truly skipped.
+        assert_eq!(outcome.exit_code, 0, "reuse should skip storage download");
+        assert!(outcome.error.is_none());
+        assert!(outcome.sandbox.is_some());
+    }
+
+    /// Verify that session restore failure during reuse still returns the sandbox.
+    #[tokio::test]
+    async fn execute_job_reuse_session_restore_failure_returns_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+
+        let sandbox = MockSandbox::new("reuse-session-fail");
+        // clock fix and reseed succeed (default), then mkdir exec succeeds,
+        // but write_file for session history fails.
+        sandbox.push_write_file_result(Err(SandboxError::ExecFailed("disk full".into())));
+
+        let mut ctx = minimal_context();
+        ctx.resume_session = Some(ResumeSession {
+            session_id: "sess-abc".into(),
+            session_history: r#"{"type":"init"}"#.into(),
+        });
+
+        let idle_entry = crate::idle_pool::IdleEntry {
+            sandbox: Box::new(sandbox),
+            factory: std::sync::Arc::new(
+                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: "sess-abc".into(),
+            profile_name: "vm0/default".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+            source_ip: "10.0.0.1".into(),
+            parked_at: std::time::Instant::now(),
+            idle_timeout: std::time::Duration::from_secs(300),
+        };
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let outcome = execute_job_reuse(idle_entry, ctx, &config, &default_params(), cancel).await;
+
+        assert_eq!(outcome.exit_code, 1);
+        assert!(outcome.error.unwrap().contains("disk full"));
+        assert!(
+            outcome.sandbox.is_some(),
+            "sandbox must be returned on session restore failure"
+        );
+    }
+
+    /// Verify that reuse skips storage download but still runs session restore
+    /// when both storage_manifest and resume_session are present.
+    ///
+    /// Strategy: push a write_file error. If storage download ran, it would
+    /// call write_file first (for the manifest), consuming the error and
+    /// failing with "storage should be skipped". Since download IS skipped,
+    /// the first write_file call is for restore_session (session history),
+    /// which consumes the error and fails with "storage should be skipped"
+    /// — proving both that download was skipped AND session restore ran.
+    #[tokio::test]
+    async fn execute_job_reuse_skips_storage_but_runs_session_restore() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+
+        let sandbox = MockSandbox::new("reuse-combined");
+        // Poison write_file: consumed by whichever calls write_file first.
+        sandbox.push_write_file_result(Err(SandboxError::ExecFailed(
+            "storage should be skipped".into(),
+        )));
+
+        let mut ctx = minimal_context();
+        ctx.storage_manifest = Some(StorageManifest {
+            storages: vec![StorageEntry {
+                mount_path: "/data".into(),
+                archive_url: Some("https://s3/archive.tar.gz".into()),
+            }],
+            artifact: None,
+            memory: None,
+        });
+        ctx.resume_session = Some(ResumeSession {
+            session_id: "sess-combined".into(),
+            session_history: r#"{"type":"init"}"#.into(),
+        });
+
+        let idle_entry = crate::idle_pool::IdleEntry {
+            sandbox: Box::new(sandbox),
+            factory: std::sync::Arc::new(
+                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
+            ),
+            session_id: "sess-combined".into(),
+            profile_name: "vm0/default".into(),
+            vcpu: 2,
+            memory_mb: 2048,
+            source_ip: "10.0.0.1".into(),
+            parked_at: std::time::Instant::now(),
+            idle_timeout: std::time::Duration::from_secs(300),
+        };
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let outcome = execute_job_reuse(idle_entry, ctx, &config, &default_params(), cancel).await;
+
+        // If storage download was NOT skipped, write_file would be called for
+        // the manifest, consuming the error. Session restore's write_file would
+        // then succeed (default), and the download exec would fail — the error
+        // message would NOT contain "storage should be skipped".
+        //
+        // Since storage IS skipped, session restore is the first write_file
+        // caller, it consumes the error, and we see it in the outcome.
+        assert_eq!(outcome.exit_code, 1);
+        assert!(
+            outcome
+                .error
+                .as_ref()
+                .unwrap()
+                .contains("storage should be skipped"),
+            "session restore should have consumed the write_file error, \
+             proving it ran while storage download was skipped. Got: {:?}",
+            outcome.error,
+        );
+        assert!(outcome.sandbox.is_some());
+    }
+
+    #[tokio::test]
+    async fn execute_job_nonzero_exit_still_returns_sandbox() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let mut factory = MockSandboxFactory::new();
+        factory.startup().await.unwrap();
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let outcome = execute_job(
+            &factory,
+            minimal_context(),
+            &config,
+            &default_params(),
+            cancel,
+        )
+        .await;
+
+        // Sandbox should be alive regardless of exit code (caller decides fate)
+        assert!(
+            outcome.sandbox.is_some(),
+            "sandbox must be returned for caller to stop+destroy or park"
+        );
     }
 }

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -1,0 +1,468 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use sandbox::{Sandbox, SandboxFactory};
+
+/// Default idle timeout for kept-alive VMs (5 minutes).
+const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 300;
+
+/// Configuration for the idle sandbox pool.
+#[derive(Debug, Clone)]
+pub struct IdlePoolConfig {
+    /// Whether VM keep-alive is enabled.
+    pub enabled: bool,
+    /// Default idle timeout for parked VMs.
+    pub default_timeout: Duration,
+    /// Maximum number of idle VMs (0 = unlimited).
+    pub max_idle: usize,
+}
+
+impl Default for IdlePoolConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            default_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
+            max_idle: 0,
+        }
+    }
+}
+
+/// A sandbox parked in the idle pool, waiting for reuse.
+pub struct IdleEntry {
+    pub sandbox: Box<dyn Sandbox>,
+    pub factory: Arc<Box<dyn SandboxFactory>>,
+    pub session_id: String,
+    pub profile_name: String,
+    pub vcpu: u32,
+    pub memory_mb: u32,
+    pub source_ip: String,
+    pub parked_at: Instant,
+    pub idle_timeout: Duration,
+}
+
+/// Pool of idle sandboxes keyed by session ID.
+///
+/// After a job completes successfully, its sandbox can be parked here
+/// instead of being destroyed. A subsequent job for the same session
+/// can reuse the parked sandbox, skipping VM creation and startup.
+pub struct IdlePool {
+    entries: HashMap<String, IdleEntry>,
+    config: IdlePoolConfig,
+}
+
+impl IdlePool {
+    pub fn new(config: IdlePoolConfig) -> Self {
+        Self {
+            entries: HashMap::new(),
+            config,
+        }
+    }
+
+    /// Park a sandbox in the pool. Returns the previously parked entry
+    /// for this session if one existed (caller must destroy it).
+    ///
+    /// If the pool is at capacity (`max_idle`), returns `PoolFull(entry)`
+    /// so the caller can destroy the entry that couldn't be parked.
+    pub fn park(&mut self, session_id: String, entry: IdleEntry) -> ParkResult {
+        if self.config.max_idle > 0 && self.entries.len() >= self.config.max_idle {
+            // At capacity and this session has no existing entry to replace.
+            if !self.entries.contains_key(&session_id) {
+                return ParkResult::PoolFull(entry);
+            }
+        }
+        match self.entries.insert(session_id, entry) {
+            Some(evicted) => ParkResult::Evicted(evicted),
+            None => ParkResult::Parked,
+        }
+    }
+
+    /// Take a sandbox from the pool for reuse. Returns `None` if no
+    /// sandbox is parked for this session.
+    pub fn take(&mut self, session_id: &str) -> Option<IdleEntry> {
+        self.entries.remove(session_id)
+    }
+
+    /// Remove and return all entries that have exceeded their idle timeout.
+    pub fn evict_expired(&mut self) -> Vec<IdleEntry> {
+        let now = Instant::now();
+        let expired_keys: Vec<String> = self
+            .entries
+            .iter()
+            .filter(|(_, e)| now.duration_since(e.parked_at) >= e.idle_timeout)
+            .map(|(k, _)| k.clone())
+            .collect();
+
+        expired_keys
+            .into_iter()
+            .filter_map(|k| self.entries.remove(&k))
+            .collect()
+    }
+
+    /// Evict the oldest idle entry (by park time). Used for resource
+    /// pressure relief.
+    pub fn evict_oldest(&mut self) -> Option<IdleEntry> {
+        let oldest_key = self
+            .entries
+            .iter()
+            .min_by_key(|(_, e)| e.parked_at)
+            .map(|(k, _)| k.clone())?;
+        self.entries.remove(&oldest_key)
+    }
+
+    /// Return the list of session IDs currently held in the pool.
+    pub fn held_sessions(&self) -> Vec<String> {
+        self.entries.keys().cloned().collect()
+    }
+
+    /// Number of idle VMs in the pool.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether keep-alive is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    /// The default idle timeout.
+    pub fn default_timeout(&self) -> Duration {
+        self.config.default_timeout
+    }
+
+    /// Drain all entries from the pool (for shutdown).
+    ///
+    /// Also disables the pool so that concurrent job tasks that still hold
+    /// a stale `mode == Running` snapshot cannot park new entries after drain.
+    pub fn drain(&mut self) -> Vec<IdleEntry> {
+        self.config.enabled = false;
+        self.entries.drain().map(|(_, v)| v).collect()
+    }
+}
+
+/// Result of a `park` operation.
+pub enum ParkResult {
+    /// Successfully parked; no previous entry for this session.
+    Parked,
+    /// Successfully parked; the returned entry was evicted (same session).
+    Evicted(IdleEntry),
+    /// Pool is at max capacity; the entry could not be parked.
+    PoolFull(IdleEntry),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::time::Duration;
+
+    use sandbox_mock::{MockSandbox, MockSandboxFactory};
+
+    fn make_entry(vcpu: u32, memory_mb: u32) -> IdleEntry {
+        IdleEntry {
+            sandbox: Box::new(MockSandbox::new("test")),
+            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            session_id: "test-session".into(),
+            profile_name: "vm0/default".into(),
+            vcpu,
+            memory_mb,
+            source_ip: "10.0.0.1".into(),
+            parked_at: Instant::now(),
+            idle_timeout: Duration::from_secs(300),
+        }
+    }
+
+    fn make_entry_with_park_time(
+        vcpu: u32,
+        memory_mb: u32,
+        parked_at: Instant,
+        idle_timeout: Duration,
+    ) -> IdleEntry {
+        IdleEntry {
+            sandbox: Box::new(MockSandbox::new("test")),
+            factory: Arc::new(Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>),
+            session_id: "test-session".into(),
+            profile_name: "vm0/default".into(),
+            vcpu,
+            memory_mb,
+            source_ip: "10.0.0.1".into(),
+            parked_at,
+            idle_timeout,
+        }
+    }
+
+    fn pool_config(max_idle: usize) -> IdlePoolConfig {
+        IdlePoolConfig {
+            enabled: true,
+            default_timeout: Duration::from_secs(300),
+            max_idle,
+        }
+    }
+
+    #[test]
+    fn park_and_take() {
+        let mut pool = IdlePool::new(pool_config(0));
+        assert_eq!(pool.len(), 0);
+
+        let result = pool.park("session-1".into(), make_entry(2, 2048));
+        assert!(matches!(result, ParkResult::Parked));
+        assert_eq!(pool.len(), 1);
+
+        let entry = pool.take("session-1").unwrap();
+        assert_eq!(entry.vcpu, 2);
+        assert_eq!(entry.memory_mb, 2048);
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn take_missing_returns_none() {
+        let mut pool = IdlePool::new(pool_config(0));
+        assert!(pool.take("nonexistent").is_none());
+    }
+
+    #[test]
+    fn park_same_session_evicts_previous() {
+        let mut pool = IdlePool::new(pool_config(0));
+
+        pool.park("session-1".into(), make_entry(2, 2048));
+        let result = pool.park("session-1".into(), make_entry(4, 4096));
+
+        match result {
+            ParkResult::Evicted(evicted) => {
+                assert_eq!(evicted.vcpu, 2);
+                assert_eq!(evicted.memory_mb, 2048);
+            }
+            _ => panic!("expected Evicted"),
+        }
+
+        assert_eq!(pool.len(), 1);
+        let entry = pool.take("session-1").unwrap();
+        assert_eq!(entry.vcpu, 4);
+    }
+
+    #[test]
+    fn park_respects_max_idle() {
+        let mut pool = IdlePool::new(pool_config(2));
+
+        pool.park("s1".into(), make_entry(2, 2048));
+        pool.park("s2".into(), make_entry(2, 2048));
+
+        // Third session should fail
+        let result = pool.park("s3".into(), make_entry(2, 2048));
+        assert!(matches!(result, ParkResult::PoolFull(_)));
+        assert_eq!(pool.len(), 2);
+
+        // But replacing existing session should work
+        let result = pool.park("s1".into(), make_entry(4, 4096));
+        assert!(matches!(result, ParkResult::Evicted(_)));
+        assert_eq!(pool.len(), 2);
+    }
+
+    #[test]
+    fn evict_expired() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let now = Instant::now();
+
+        // Entry expired 10s ago
+        pool.park(
+            "expired".into(),
+            make_entry_with_park_time(
+                2,
+                2048,
+                now - Duration::from_secs(310),
+                Duration::from_secs(300),
+            ),
+        );
+        // Entry still fresh
+        pool.park(
+            "fresh".into(),
+            make_entry_with_park_time(2, 2048, now, Duration::from_secs(300)),
+        );
+
+        let evicted = pool.evict_expired();
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(pool.len(), 1);
+        assert!(pool.take("fresh").is_some());
+    }
+
+    #[test]
+    fn evict_oldest() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let now = Instant::now();
+
+        pool.park(
+            "old".into(),
+            make_entry_with_park_time(
+                2,
+                2048,
+                now - Duration::from_secs(100),
+                Duration::from_secs(300),
+            ),
+        );
+        pool.park(
+            "new".into(),
+            make_entry_with_park_time(4, 4096, now, Duration::from_secs(300)),
+        );
+
+        let evicted = pool.evict_oldest().unwrap();
+        assert_eq!(evicted.vcpu, 2); // the old one
+        assert_eq!(pool.len(), 1);
+        assert!(pool.take("new").is_some());
+    }
+
+    #[test]
+    fn evict_oldest_empty_returns_none() {
+        let mut pool = IdlePool::new(pool_config(0));
+        assert!(pool.evict_oldest().is_none());
+    }
+
+    #[test]
+    fn held_sessions() {
+        let mut pool = IdlePool::new(pool_config(0));
+        pool.park("s1".into(), make_entry(2, 2048));
+        pool.park("s2".into(), make_entry(2, 2048));
+
+        let mut sessions = pool.held_sessions();
+        sessions.sort();
+        assert_eq!(sessions, vec!["s1", "s2"]);
+    }
+
+    #[test]
+    fn drain() {
+        let mut pool = IdlePool::new(pool_config(0));
+        pool.park("s1".into(), make_entry(2, 2048));
+        pool.park("s2".into(), make_entry(4, 4096));
+
+        let drained = pool.drain();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(pool.len(), 0);
+        // drain disables the pool to prevent post-shutdown parking
+        assert!(!pool.is_enabled());
+    }
+
+    #[test]
+    fn disabled_pool() {
+        let pool = IdlePool::new(IdlePoolConfig::default());
+        assert!(!pool.is_enabled());
+    }
+
+    #[test]
+    fn park_after_drain_still_inserts() {
+        // drain() disables the pool, but park() itself does not check enabled —
+        // the caller (spawn_job) is responsible for checking is_enabled() first.
+        // This test documents the current behaviour.
+        let mut pool = IdlePool::new(pool_config(0));
+        pool.park("s1".into(), make_entry(2, 2048));
+        pool.drain();
+        assert!(!pool.is_enabled());
+
+        // park still succeeds at the data-structure level
+        let result = pool.park("s2".into(), make_entry(4, 4096));
+        assert!(matches!(result, ParkResult::Parked));
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn evict_expired_none_expired() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let now = Instant::now();
+        pool.park(
+            "fresh".into(),
+            make_entry_with_park_time(2, 2048, now, Duration::from_secs(300)),
+        );
+        let evicted = pool.evict_expired();
+        assert!(evicted.is_empty());
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn drain_empty_pool() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let drained = pool.drain();
+        assert!(drained.is_empty());
+        assert!(!pool.is_enabled());
+    }
+
+    #[test]
+    fn evict_expired_all_entries() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let now = Instant::now();
+
+        pool.park(
+            "s1".into(),
+            make_entry_with_park_time(
+                2,
+                2048,
+                now - Duration::from_secs(400),
+                Duration::from_secs(300),
+            ),
+        );
+        pool.park(
+            "s2".into(),
+            make_entry_with_park_time(
+                4,
+                4096,
+                now - Duration::from_secs(310),
+                Duration::from_secs(300),
+            ),
+        );
+        assert_eq!(pool.len(), 2);
+
+        let evicted = pool.evict_expired();
+        assert_eq!(evicted.len(), 2);
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn evict_expired_respects_per_entry_timeout() {
+        let mut pool = IdlePool::new(pool_config(0));
+        let now = Instant::now();
+
+        // Short timeout (60s), parked 70s ago → expired
+        pool.park(
+            "short".into(),
+            make_entry_with_park_time(
+                2,
+                2048,
+                now - Duration::from_secs(70),
+                Duration::from_secs(60),
+            ),
+        );
+        // Long timeout (300s), parked 70s ago → NOT expired
+        pool.park(
+            "long".into(),
+            make_entry_with_park_time(
+                4,
+                4096,
+                now - Duration::from_secs(70),
+                Duration::from_secs(300),
+            ),
+        );
+
+        let evicted = pool.evict_expired();
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].vcpu, 2); // only the short-timeout entry
+        assert_eq!(pool.len(), 1);
+        assert!(pool.take("long").is_some());
+    }
+
+    #[test]
+    fn park_max_idle_one() {
+        let mut pool = IdlePool::new(pool_config(1));
+
+        let result = pool.park("s1".into(), make_entry(2, 2048));
+        assert!(matches!(result, ParkResult::Parked));
+
+        // Second different session rejected
+        let result = pool.park("s2".into(), make_entry(4, 4096));
+        assert!(matches!(result, ParkResult::PoolFull(_)));
+        assert_eq!(pool.len(), 1);
+
+        // Same session replacement still works
+        let result = pool.park("s1".into(), make_entry(8, 8192));
+        assert!(matches!(result, ParkResult::Evicted(_)));
+        assert_eq!(pool.len(), 1);
+        let entry = pool.take("s1").unwrap();
+        assert_eq!(entry.vcpu, 8);
+    }
+}

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -41,6 +41,17 @@ pub struct IdleEntry {
     pub idle_timeout: Duration,
 }
 
+impl IdleEntry {
+    /// Stop the sandbox and destroy it via its factory.
+    pub async fn stop_and_destroy(self) {
+        let mut sandbox = self.sandbox;
+        if let Err(e) = sandbox.stop().await {
+            tracing::warn!(error = %e, "failed to stop idle sandbox");
+        }
+        self.factory.destroy(sandbox).await;
+    }
+}
+
 /// Pool of idle sandboxes keyed by session ID.
 ///
 /// After a job completes successfully, its sandbox can be parked here
@@ -62,9 +73,11 @@ impl IdlePool {
     /// Park a sandbox in the pool. Returns the previously parked entry
     /// for this session if one existed (caller must destroy it).
     ///
-    /// If the pool is at capacity (`max_idle`), returns `PoolFull(entry)`
-    /// so the caller can destroy the entry that couldn't be parked.
+    /// Returns `PoolFull(entry)` if the pool is disabled or at capacity.
     pub fn park(&mut self, session_id: String, entry: IdleEntry) -> ParkResult {
+        if !self.config.enabled {
+            return ParkResult::PoolFull(entry);
+        }
         if self.config.max_idle > 0 && self.entries.len() >= self.config.max_idle {
             // At capacity and this session has no existing entry to replace.
             if !self.entries.contains_key(&session_id) {
@@ -121,6 +134,7 @@ impl IdlePool {
     }
 
     /// Whether keep-alive is enabled.
+    #[cfg(test)]
     pub fn is_enabled(&self) -> bool {
         self.config.enabled
     }
@@ -141,12 +155,13 @@ impl IdlePool {
 }
 
 /// Result of a `park` operation.
+#[must_use]
 pub enum ParkResult {
     /// Successfully parked; no previous entry for this session.
     Parked,
     /// Successfully parked; the returned entry was evicted (same session).
     Evicted(IdleEntry),
-    /// Pool is at max capacity; the entry could not be parked.
+    /// Pool is at max capacity or disabled; the entry could not be parked.
     PoolFull(IdleEntry),
 }
 
@@ -224,7 +239,7 @@ mod tests {
     fn park_same_session_evicts_previous() {
         let mut pool = IdlePool::new(pool_config(0));
 
-        pool.park("session-1".into(), make_entry(2, 2048));
+        let _ = pool.park("session-1".into(), make_entry(2, 2048));
         let result = pool.park("session-1".into(), make_entry(4, 4096));
 
         match result {
@@ -244,8 +259,8 @@ mod tests {
     fn park_respects_max_idle() {
         let mut pool = IdlePool::new(pool_config(2));
 
-        pool.park("s1".into(), make_entry(2, 2048));
-        pool.park("s2".into(), make_entry(2, 2048));
+        let _ = pool.park("s1".into(), make_entry(2, 2048));
+        let _ = pool.park("s2".into(), make_entry(2, 2048));
 
         // Third session should fail
         let result = pool.park("s3".into(), make_entry(2, 2048));
@@ -264,7 +279,7 @@ mod tests {
         let now = Instant::now();
 
         // Entry expired 10s ago
-        pool.park(
+        let _ = pool.park(
             "expired".into(),
             make_entry_with_park_time(
                 2,
@@ -274,7 +289,7 @@ mod tests {
             ),
         );
         // Entry still fresh
-        pool.park(
+        let _ = pool.park(
             "fresh".into(),
             make_entry_with_park_time(2, 2048, now, Duration::from_secs(300)),
         );
@@ -290,7 +305,7 @@ mod tests {
         let mut pool = IdlePool::new(pool_config(0));
         let now = Instant::now();
 
-        pool.park(
+        let _ = pool.park(
             "old".into(),
             make_entry_with_park_time(
                 2,
@@ -299,7 +314,7 @@ mod tests {
                 Duration::from_secs(300),
             ),
         );
-        pool.park(
+        let _ = pool.park(
             "new".into(),
             make_entry_with_park_time(4, 4096, now, Duration::from_secs(300)),
         );
@@ -319,8 +334,8 @@ mod tests {
     #[test]
     fn held_sessions() {
         let mut pool = IdlePool::new(pool_config(0));
-        pool.park("s1".into(), make_entry(2, 2048));
-        pool.park("s2".into(), make_entry(2, 2048));
+        let _ = pool.park("s1".into(), make_entry(2, 2048));
+        let _ = pool.park("s2".into(), make_entry(2, 2048));
 
         let mut sessions = pool.held_sessions();
         sessions.sort();
@@ -330,8 +345,8 @@ mod tests {
     #[test]
     fn drain() {
         let mut pool = IdlePool::new(pool_config(0));
-        pool.park("s1".into(), make_entry(2, 2048));
-        pool.park("s2".into(), make_entry(4, 4096));
+        let _ = pool.park("s1".into(), make_entry(2, 2048));
+        let _ = pool.park("s2".into(), make_entry(4, 4096));
 
         let drained = pool.drain();
         assert_eq!(drained.len(), 2);
@@ -347,26 +362,31 @@ mod tests {
     }
 
     #[test]
-    fn park_after_drain_still_inserts() {
-        // drain() disables the pool, but park() itself does not check enabled —
-        // the caller (spawn_job) is responsible for checking is_enabled() first.
-        // This test documents the current behaviour.
+    fn disabled_pool_rejects_park() {
+        let mut pool = IdlePool::new(IdlePoolConfig::default());
+        let result = pool.park("s1".into(), make_entry(2, 2048));
+        assert!(matches!(result, ParkResult::PoolFull(_)));
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn park_after_drain_rejected() {
+        // drain() disables the pool — subsequent park() calls are rejected.
         let mut pool = IdlePool::new(pool_config(0));
-        pool.park("s1".into(), make_entry(2, 2048));
+        let _ = pool.park("s1".into(), make_entry(2, 2048));
         pool.drain();
         assert!(!pool.is_enabled());
 
-        // park still succeeds at the data-structure level
         let result = pool.park("s2".into(), make_entry(4, 4096));
-        assert!(matches!(result, ParkResult::Parked));
-        assert_eq!(pool.len(), 1);
+        assert!(matches!(result, ParkResult::PoolFull(_)));
+        assert_eq!(pool.len(), 0);
     }
 
     #[test]
     fn evict_expired_none_expired() {
         let mut pool = IdlePool::new(pool_config(0));
         let now = Instant::now();
-        pool.park(
+        let _ = pool.park(
             "fresh".into(),
             make_entry_with_park_time(2, 2048, now, Duration::from_secs(300)),
         );
@@ -388,7 +408,7 @@ mod tests {
         let mut pool = IdlePool::new(pool_config(0));
         let now = Instant::now();
 
-        pool.park(
+        let _ = pool.park(
             "s1".into(),
             make_entry_with_park_time(
                 2,
@@ -397,7 +417,7 @@ mod tests {
                 Duration::from_secs(300),
             ),
         );
-        pool.park(
+        let _ = pool.park(
             "s2".into(),
             make_entry_with_park_time(
                 4,
@@ -419,7 +439,7 @@ mod tests {
         let now = Instant::now();
 
         // Short timeout (60s), parked 70s ago → expired
-        pool.park(
+        let _ = pool.park(
             "short".into(),
             make_entry_with_park_time(
                 2,
@@ -429,7 +449,7 @@ mod tests {
             ),
         );
         // Long timeout (300s), parked 70s ago → NOT expired
-        pool.park(
+        let _ = pool.park(
             "long".into(),
             make_entry_with_park_time(
                 4,

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -7,6 +7,7 @@ mod error;
 mod executor;
 mod host;
 mod http;
+mod idle_pool;
 mod kmsg_log;
 mod lock;
 mod network_logs;

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -35,6 +35,9 @@ pub(crate) struct JobRequest {
     pub(crate) user_timezone: Option<String>,
     #[serde(default)]
     pub(crate) profile: Option<String>,
+    /// Session ID for keep-alive VM reuse across conversation turns.
+    #[serde(default)]
+    pub(crate) session_id: Option<String>,
 }
 
 /// Job response written by the runner as a `{job_id}.result` file.
@@ -232,7 +235,10 @@ impl JobProvider for LocalProvider {
             working_dir: req.working_dir,
             storage_manifest: None,
             environment: req.environment,
-            resume_session: None,
+            resume_session: req.session_id.map(|id| crate::types::ResumeSession {
+                session_id: id,
+                session_history: String::new(),
+            }),
             secret_values: None,
             encrypted_secrets: None,
             secret_connector_map: None,
@@ -311,6 +317,7 @@ mod tests {
             environment: None,
             user_timezone: None,
             profile: profile.map(String::from),
+            session_id: None,
         };
         let json = serde_json::to_vec(&req).unwrap();
         std::fs::write(dir.join(format!("{job_id}.job")), &json).unwrap();

--- a/crates/runner/src/status.rs
+++ b/crates/runner/src/status.rs
@@ -21,6 +21,9 @@ struct RunnerStatus {
     max_concurrent: usize,
     active_runs: usize,
     active_run_ids: Vec<Uuid>,
+    idle_vms: usize,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    idle_sessions: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     proxy_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -51,6 +54,8 @@ pub struct StatusTracker {
 struct MutableState {
     mode: RunnerMode,
     active_run_ids: BTreeSet<Uuid>,
+    idle_vms: usize,
+    idle_sessions: Vec<String>,
 }
 
 impl StatusTracker {
@@ -64,6 +69,8 @@ impl StatusTracker {
             state: Mutex::new(MutableState {
                 mode: RunnerMode::Running,
                 active_run_ids: BTreeSet::new(),
+                idle_vms: 0,
+                idle_sessions: Vec::new(),
             }),
         }
     }
@@ -98,6 +105,14 @@ impl StatusTracker {
         self.write_status(&state).await;
     }
 
+    /// Update idle VM count and session list in the status file.
+    pub async fn set_idle_info(&self, idle_vms: usize, idle_sessions: Vec<String>) {
+        let mut state = self.state.lock().await;
+        state.idle_vms = idle_vms;
+        state.idle_sessions = idle_sessions;
+        self.write_status(&state).await;
+    }
+
     /// Write the initial status file.
     pub async fn write_initial(&self) {
         let state = self.state.lock().await;
@@ -111,6 +126,8 @@ impl StatusTracker {
             max_concurrent: self.max_concurrent,
             active_runs: state.active_run_ids.len(),
             active_run_ids: state.active_run_ids.iter().copied().collect(),
+            idle_vms: state.idle_vms,
+            idle_sessions: state.idle_sessions.clone(),
             proxy_port: self.proxy_port,
             dns_port: self.dns_port,
             started_at: self.started_at,
@@ -244,5 +261,48 @@ mod tests {
         assert!(started.ends_with('Z'));
         assert!(started.contains('T'));
         assert_eq!(started.len(), 24); // "2026-02-10T12:34:56.789Z"
+    }
+
+    #[tokio::test]
+    async fn set_idle_info_updates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4);
+
+        tracker.write_initial().await;
+
+        let status = read_status(&path);
+        assert_eq!(status["idle_vms"], 0);
+        assert!(status.get("idle_sessions").is_none()); // empty vec omitted
+
+        tracker
+            .set_idle_info(2, vec!["sess-1".into(), "sess-2".into()])
+            .await;
+
+        let status = read_status(&path);
+        assert_eq!(status["idle_vms"], 2);
+        let sessions: Vec<String> = status["idle_sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(sessions, vec!["sess-1", "sess-2"]);
+    }
+
+    #[tokio::test]
+    async fn set_idle_info_empty_sessions_omitted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("status.json");
+        let tracker = StatusTracker::new(path.clone(), 4);
+
+        tracker.set_idle_info(0, vec![]).await;
+
+        let status = read_status(&path);
+        assert_eq!(status["idle_vms"], 0);
+        assert!(
+            status.get("idle_sessions").is_none(),
+            "empty idle_sessions should be omitted from JSON"
+        );
     }
 }

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -163,6 +163,16 @@ pub struct ResumeSession {
     pub session_history: String,
 }
 
+impl ExecutionContext {
+    /// Extract the session ID for keep-alive VM reuse.
+    ///
+    /// Phase 1: only continued sessions (with `resume_session`) benefit.
+    /// Phase 2: a top-level `session_id` field will enable first-turn reuse.
+    pub fn session_id(&self) -> Option<&str> {
+        self.resume_session.as_ref().map(|r| r.session_id.as_str())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Complete
 // ---------------------------------------------------------------------------
@@ -362,6 +372,36 @@ mod tests {
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["error"], "timeout");
+    }
+
+    #[test]
+    fn session_id_returns_none_without_resume() {
+        let json = json!({
+            "runId": "550e8400-e29b-41d4-a716-446655440000",
+            "prompt": "hello",
+            "sandboxToken": "tok",
+            "workingDir": "/home/user",
+            "cliAgentType": "claude_code"
+        });
+        let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
+        assert!(ctx.session_id().is_none());
+    }
+
+    #[test]
+    fn session_id_returns_id_from_resume_session() {
+        let json = json!({
+            "runId": "550e8400-e29b-41d4-a716-446655440000",
+            "prompt": "hello",
+            "sandboxToken": "tok",
+            "workingDir": "/home/user",
+            "cliAgentType": "claude_code",
+            "resumeSession": {
+                "sessionId": "sess-abc-123",
+                "sessionHistory": "{}"
+            }
+        });
+        let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
+        assert_eq!(ctx.session_id(), Some("sess-abc-123"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #8233 — Phase 1 (runner-side only, no API changes).

- **Idle pool**: After a job completes successfully, park the running VM in an `IdlePool` keyed by `session_id` instead of destroying it. Next job for the same session reuses the parked VM — skips create, start, snapshot restore, and storage download.
- **Executor refactor**: Split `execute_job` into new-sandbox and reuse-sandbox paths. Reuse path re-registers proxy, fixes guest clock, reseeds entropy, then runs the agent.
- **Main loop integration**: Park on success, evict on timeout (default 5min) or resource pressure, drain all idle VMs on shutdown.
- **Config**: `keep_alive`, `keep_alive_timeout_secs`, `keep_alive_max_idle` fields in `SandboxConfig`. Disabled by default — opt in with `--keep-alive`.
- **CLI**: `runner config --keep-alive` flag, `runner local submit --session-id` flag for local testing.
- **Observability**: `status.json` reports `idle_vms`/`idle_sessions`, `runner doctor` displays idle VM info.
- **CI**: E2E test in `crates.yml` — 3 turns verifying reuse and session isolation.
- **Cleanup**: Ansible playbook updated with keepalive service/directory entries.

### Known limitations (tracked for Phase 2)
- `evict_oldest` is session-blind — may evict the target VM (#8305)
- Guest log files accumulate across turns (#8308)

## Test plan

- [x] 14 unit tests for `IdlePool` (park/take/evict/drain/max_idle/per-entry-timeout)
- [x] 8+ integration tests for `execute_job_reuse` (success, failure, clock fix, reseed, session restore, skip storage)
- [x] `StatusTracker::set_idle_info` tests
- [x] `ExecutionContext::session_id()` tests
- [x] E2E test: Turn 1 creates marker → Turn 2 same session verifies marker exists (reuse) → Turn 3 different session verifies marker absent (isolation)
- [x] All 411 existing tests pass, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)