### PR TITLE
refactor(zero): remove redundant slug parameter from org members query

### DIFF
--- a/turbo/apps/web/app/api/zero/org/members/route.ts
+++ b/turbo/apps/web/app/api/zero/org/members/route.ts
@@ -15,7 +15,6 @@ import {
   updateMemberRole,
   removeMember,
 } from "../../../../../src/lib/zero/org/org-member-service";
-import { getOrgData } from "../../../../../src/lib/zero/org/org-cache-service";
 import {
   isBadRequest,
   isForbidden,
@@ -31,12 +30,7 @@ const router = tsr.router(zeroOrgMembersContract, {
 
     try {
       const { org } = await resolveOrg(authCtx);
-      const orgData = await getOrgData(org.orgId);
-      const status = await getOrgMembers(
-        authCtx.userId,
-        org.orgId,
-        orgData.slug,
-      );
+      const status = await getOrgMembers(authCtx.userId, org.orgId);
       return { status: 200 as const, body: status };
     } catch (error) {
       if (isBadRequest(error)) {

--- a/turbo/apps/web/src/lib/zero/org/org-member-service.ts
+++ b/turbo/apps/web/src/lib/zero/org/org-member-service.ts
@@ -120,11 +120,7 @@ function mapClerkRole(clerkRole: string): OrgRole {
  * Get org members list.
  * Reads membership data directly from Clerk API.
  */
-export async function getOrgMembers(
-  userId: string,
-  orgId: string,
-  orgSlug: string,
-) {
+export async function getOrgMembers(userId: string, orgId: string) {
   const client = await clerkClient();
 
   // Parallel: org info + memberships + invitations
@@ -277,7 +273,7 @@ export async function getOrgMembers(
   }
 
   return {
-    slug: orgSlug,
+    slug: org.slug,
     role: callerRole,
     members,
     pendingInvitations,


### PR DESCRIPTION
## Summary

- Remove redundant `orgSlug` parameter from `getOrgMembers()` — use `org.slug` from the Clerk API response already fetched inside the function
- Remove unnecessary `getOrgData()` call in the members route handler, eliminating one DB/Clerk API lookup per request

Closes #8309

## Test plan

- [x] Existing 5 tests in `route.test.ts` all pass without modification
- [x] Type check passes (no errors in changed files)
- [x] Lint passes
- [x] Knip passes (no unused imports/exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)