### PR TITLE
fix(e2e): re-enable browser tests 5-11

### DIFF
--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -307,7 +307,6 @@ teardown_file() {
 }
 
 @test "verify chat page is displayed" {
-  skip "Temporarily disabled — post-onboarding agent provisioning is too slow for this timeout (tracked: github.com/vm0-ai/vm0)"
   echo "# Verifying chat page..." >&3
 
   local chat_loaded=false
@@ -342,7 +341,6 @@ teardown_file() {
 # ===========================================================================
 
 @test "navigate to team page and verify zero agent" {
-  skip "Temporarily disabled — post-onboarding agent provisioning is too slow for this timeout (tracked: github.com/vm0-ai/vm0)"
   echo "# Navigating to /team page..." >&3
   navigate_to_app_page "/team"
   step_screenshot "team-page-initial"
@@ -362,7 +360,6 @@ teardown_file() {
 }
 
 @test "create new agent via dialog" {
-  skip "Temporarily disabled — post-onboarding agent provisioning is too slow for this timeout (tracked: github.com/vm0-ai/vm0)"
   echo "# Clicking New agent..." >&3
   agent-browser find role button click --name "New agent"
   agent-browser wait 1000
@@ -397,7 +394,6 @@ teardown_file() {
 }
 
 @test "verify new agent appears on team page" {
-  skip "Temporarily disabled — post-onboarding agent provisioning is too slow for this timeout (tracked: github.com/vm0-ai/vm0)"
   echo "# Verifying agent appears on team page..." >&3
   wait_for_text "$AGENT_NAME" 20
   step_screenshot "agent-visible"
@@ -420,7 +416,6 @@ teardown_file() {
 # ===========================================================================
 
 @test "navigate to schedule page and open creation dialog" {
-  skip "Temporarily disabled — post-onboarding agent provisioning is too slow for this timeout (tracked: github.com/vm0-ai/vm0)"
   echo "# Navigating to schedule page..." >&3
   agent-browser open "${APP_URL}/schedule" --ignore-https-errors
   agent-browser wait 3000
@@ -449,7 +444,6 @@ teardown_file() {
 }
 
 @test "fill and submit schedule creation form" {
-  skip "Temporarily disabled — post-onboarding agent provisioning is too slow for this timeout (tracked: github.com/vm0-ai/vm0)"
   # Fill the prompt textarea
   echo "# Filling schedule prompt: $SCHEDULE_PROMPT" >&3
   agent-browser find label "Prompt" fill "$SCHEDULE_PROMPT"
@@ -470,7 +464,6 @@ teardown_file() {
 }
 
 @test "verify schedule list page still loads after creation" {
-  skip "Temporarily disabled — post-onboarding agent provisioning is too slow for this timeout (tracked: github.com/vm0-ai/vm0)"
   # After form submission, verify the schedule list page is still functional.
   echo "# Verifying schedule list page loads..." >&3
   agent-browser open "${APP_URL}/schedule" --ignore-https-errors


### PR DESCRIPTION
## Summary

Restores tests 5–11 in `brw-t01-platform-e2e.bats` that were temporarily skipped in #8310.

**Do not merge until the root cause is fixed.** These tests were skipped because post-onboarding agent provisioning in fresh PR environments takes longer than the 20–30s test timeouts, causing 100% failure rate.

## Tests restored

- Test 5: verify chat page is displayed
- Test 6: navigate to team page and verify zero agent
- Test 7: create new agent via dialog
- Test 8: verify new agent appears on team page
- Test 9: navigate to schedule page and open creation dialog
- Test 10: fill and submit schedule creation form
- Test 11: verify schedule list page still loads after creation

## Merge criteria

Merge this PR once the provisioning timing issue is resolved — either by:
- Adding a post-onboarding readiness poll before tests 5–11 run, or
- Fixing backend provisioning to complete within the test timeout window

🤖 Generated with [Claude Code](https://claude.com/claude-code)