### PR TITLE
refactor: remove unnecessary org data lookup from storages/prepare webhook

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/prepare/route.ts
@@ -16,7 +16,6 @@ import {
 } from "../../../../../../src/db/schema/storage";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
-import { getOrgData } from "../../../../../../src/lib/zero/org/org-cache-service";
 import {
   generatePresignedPutUrl,
   downloadManifest,
@@ -97,9 +96,6 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       };
     }
 
-    // Use the org from the run record (set at run creation time)
-    const resolvedOrg = await getOrgData(run.orgId);
-
     // Volumes use sentinel userId (org-level shared); artifacts/memory use real userId
     const storageUserId =
       storageType === "volume" ? VOLUME_ORG_USER_ID : userId;
@@ -109,10 +105,10 @@ const router = tsr.router(webhookStoragesPrepareContract, {
       .insert(storages)
       .values({
         userId: storageUserId,
-        orgId: resolvedOrg.orgId,
+        orgId: run.orgId,
         name: storageName,
         type: storageType,
-        s3Prefix: `${resolvedOrg.orgId}/${storageType}/${storageName}`,
+        s3Prefix: `${run.orgId}/${storageType}/${storageName}`,
         size: 0,
         fileCount: 0,
       })


### PR DESCRIPTION
## Summary
- Remove redundant `getOrgData(run.orgId)` call from `POST /api/webhooks/agent/storages/prepare`
- Use `run.orgId` directly instead of resolving it through org-cache-service
- Eliminates unnecessary DB query + potential Clerk API call (500-700ms on cache miss) per request

Closes #8312

## Test plan
- [x] All 6 existing integration tests pass without modification
- [x] Lint, type check, format, and knip all pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)