### PR TITLE
refactor: remove unnecessary org data lookup from storages/commit webhook

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/storages/commit/route.ts
@@ -13,7 +13,6 @@ import {
 import { storageVersionLineage } from "../../../../../../src/db/schema/storage-version-lineage";
 import { eq, and } from "drizzle-orm";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
-import { getOrgData } from "../../../../../../src/lib/zero/org/org-cache-service";
 import {
   s3ObjectExists,
   verifyS3FilesExist,
@@ -74,9 +73,6 @@ const router = tsr.router(webhookStoragesCommitContract, {
       };
     }
 
-    // Use the org from the run record (set at run creation time)
-    const runtimeOrg = await getOrgData(run.orgId);
-
     // Volumes use sentinel userId; artifacts/memory use real userId
     const storageUserId =
       storageType === "volume" ? VOLUME_ORG_USER_ID : userId;
@@ -87,7 +83,7 @@ const router = tsr.router(webhookStoragesCommitContract, {
       .from(storages)
       .where(
         and(
-          eq(storages.orgId, runtimeOrg.orgId),
+          eq(storages.orgId, run.orgId),
           eq(storages.userId, storageUserId),
           eq(storages.name, storageName),
           eq(storages.type, storageType),


### PR DESCRIPTION
## Summary

- Remove unnecessary `getOrgData(run.orgId)` call from `POST /api/webhooks/agent/storages/commit` that triggered a DB query + potential Clerk API call (500-700ms) only to return the same `orgId` already available from the run record
- Replace `runtimeOrg.orgId` with `run.orgId` directly

Closes #8313

## Test plan

- [x] All 8 existing `webhooks/agent/storages/commit` integration tests pass
- [x] TypeScript type check passes (`pnpm check-types --filter=web`)
- [x] Lint passes (`pnpm turbo run lint --filter=web`)
- [x] Knip reports no unused exports/imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)