### PR TITLE
feat: add audit link feature switch to control audit link in slack messages

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 import {
   testContext,
@@ -16,6 +16,17 @@ import {
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import { computeHmacSignature } from "../../../../../../../src/lib/infra/callback/hmac";
 import { POST } from "../route";
+
+vi.mock("@vm0/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vm0/core")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(false),
+  };
+});
+
+const { isFeatureEnabled } = await import("@vm0/core");
+const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
 
 const context = testContext();
 
@@ -62,6 +73,7 @@ describe("POST /api/internal/callbacks/slack/org", () => {
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
+    mockIsFeatureEnabled.mockReturnValue(false);
   });
 
   async function setupOrgSlack() {
@@ -369,5 +381,88 @@ describe("POST /api/internal/callbacks/slack/org", () => {
       setStatusMock.mock.calls.length - 1
     ]![0] as { status: string };
     expect(lastCall.status).toBe("");
+  });
+
+  it("omits audit link block when AuditLink switch is off", async () => {
+    mockIsFeatureEnabled.mockReturnValue(false);
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createCallbackRequest(
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(blocksStr).not.toContain("Audit");
+    expect(blocksStr).not.toContain("clipboard");
+  });
+
+  it("includes audit link block when AuditLink switch is on", async () => {
+    mockIsFeatureEnabled.mockReturnValue(true);
+    const { workspaceId, connectionId } = await setupOrgSlack();
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createCallbackRequest(
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(blocksStr).toContain("Audit");
   });
 });

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -5,6 +5,7 @@ import { verifyCallback } from "../../../../../../src/lib/infra/callback";
 import { decryptSecretValue } from "../../../../../../src/lib/shared/crypto/secrets-encryption";
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
+import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
 import { findNewSessionId } from "../../../../../../src/lib/infra/session/find-new-session";
 import {
   createSlackClient,
@@ -177,6 +178,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const allOutputs = await extractAllRunOutputs(runId, error);
 
+  const [runContext] = await globalThis.services.db
+    .select({ userId: agentRuns.userId, orgId: agentRuns.orgId })
+    .from(agentRuns)
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+
+  const auditLinkEnabled = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
+    userId: runContext?.userId,
+    orgId: runContext?.orgId,
+  });
+
   // Resolve session
   await saveOrgThreadSession(payload, runId, status);
 
@@ -187,7 +199,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     if (!responseText) continue;
 
     const isLast = i === allOutputs.length - 1;
-    const logsUrl = isLast ? buildLogsUrl(runId) : undefined;
+    const logsUrl =
+      isLast && auditLinkEnabled ? buildLogsUrl(runId) : undefined;
 
     await postMessage(client, payload.channelId, responseText, {
       threadTs: payload.threadTs,

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/direct-message.ts
@@ -1,3 +1,4 @@
+import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
 import { decryptSecretValue } from "../../../shared/crypto/secrets-encryption";
 import { env } from "../../../../env";
 import {
@@ -223,7 +224,12 @@ export async function handleOrgDirectMessage(
     if (!runId) {
       const errorText =
         response ?? "Sorry, an error occurred. Please try again.";
-      const logsUrl = buildAgentLogsUrl();
+      const logsUrl = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
+        userId: connection.vm0UserId,
+        orgId,
+      })
+        ? buildAgentLogsUrl()
+        : undefined;
       await postMessage(client, context.channelId, errorText, {
         threadTs,
         blocks: buildAgentResponseMessage(errorText, logsUrl),

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/mention.ts
@@ -1,3 +1,4 @@
+import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
 import { decryptSecretValue } from "../../../shared/crypto/secrets-encryption";
 import { env } from "../../../../env";
 import { createSlackClient, setThreadStatus } from "../../slack/client";
@@ -227,7 +228,12 @@ export async function handleOrgMention(
     if (!runId) {
       const errorText =
         response ?? "Sorry, an error occurred. Please try again.";
-      const logsUrl = buildAgentLogsUrl();
+      const logsUrl = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
+        userId: connection.vm0UserId,
+        orgId,
+      })
+        ? buildAgentLogsUrl()
+        : undefined;
       await client.chat.postMessage({
         channel: context.channelId,
         thread_ts: threadTs,

--- a/turbo/apps/web/src/lib/zero/slack/__tests__/blocks.test.ts
+++ b/turbo/apps/web/src/lib/zero/slack/__tests__/blocks.test.ts
@@ -164,7 +164,7 @@ describe("buildAgentResponseMessage", () => {
       return b.type === "markdown";
     }) as MarkdownBlock;
     expect(markdownBlock.text.length).toBeLessThanOrEqual(12000);
-    expect(markdownBlock.text).toContain("truncated");
+    expect(markdownBlock.text).toContain("Message too long to view in Slack.");
   });
 
   it("should not truncate content under 12000 characters", () => {

--- a/turbo/apps/web/src/lib/zero/slack/blocks.ts
+++ b/turbo/apps/web/src/lib/zero/slack/blocks.ts
@@ -385,8 +385,7 @@ const MARKDOWN_BLOCK_MAX_LENGTH = 12000;
 function buildMarkdownMessage(content: string): (Block | KnownBlock)[] {
   // Markdown blocks have a cumulative 12,000 character limit per message.
   // If content exceeds that, truncate and indicate there is more.
-  const truncationSuffix =
-    "\n\n_(Response truncated. View the full output in audit logs.)_";
+  const truncationSuffix = "\n\n_(Message too long to view in Slack.)_";
   const truncated =
     content.length > MARKDOWN_BLOCK_MAX_LENGTH
       ? content.substring(

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -45,4 +45,5 @@ export enum FeatureSwitchKey {
   ComputerUse = "computerUse",
   MobileChatListPage = "mobileChatListPage",
   Lab = "lab",
+  AuditLink = "auditLink",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -207,6 +207,11 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.AuditLink]: {
+    maintainer: "ethan@vm0.ai",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary

- Adds `FeatureSwitchKey.AuditLink` feature switch (disabled by default, enabled for staff org only) to control whether the audit link appears in Slack messages
- Gates the `:clipboard: Audit` link in the Slack callback handler, mention handler, and DM handler behind this switch
- Changes the truncation message from "Response truncated. View the full output in audit logs." to "Message too long to view in Slack." (unconditional change)
- Adds 2 integration tests verifying audit link is omitted when switch is off and present when on

## Test plan

- [x] `FeatureSwitchKey.AuditLink` registered with `enabled: false, enabledOrgIdHashes: STAFF_ORG_ID_HASHES`
- [x] Slack callback route: audit link hidden when switch is off
- [x] Slack mention handler: audit link hidden when switch is off
- [x] Slack DM handler: audit link hidden when switch is off
- [x] Truncation message changed to "Message too long to view in Slack."
- [x] Integration test: audit link absent when switch is off (default)
- [x] Integration test: audit link present when switch is on
- [x] All 9 tests pass in route.test.ts
- [x] Lint, type-check, format, knip all pass

Closes #8296

🤖 Generated with [Claude Code](https://claude.com/claude-code)