### PR TITLE
fix: restore staff org access for computer-use feature switch

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -197,6 +197,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   [FeatureSwitchKey.ComputerUse]: {
     maintainer: "ethan@vm0.ai",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.MobileChatListPage]: {
     maintainer: "ethan@vm0.ai",


### PR DESCRIPTION
## Summary
- Restore `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` to the ComputerUse feature switch
- PR #8288 (lab page) accidentally removed the staff org hash, causing 403 "Computer use is not enabled" for all users including staff

## Test plan
- [ ] Verify staff org users can access computer-use register endpoint
- [ ] Verify non-staff users still get 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)