### PR TITLE
refactor(platform): replace fetch-slack-org imperative command with reactive computed

### DIFF
--- a/turbo/apps/platform/src/signals/team-page/team-detail-page-setup.ts
+++ b/turbo/apps/platform/src/signals/team-page/team-detail-page-setup.ts
@@ -24,9 +24,9 @@ export const setupTeamDetailPage$ = command(
     const params = get(pathParams$) as { id?: string } | undefined;
     const agentId = params?.id ?? null;
     set(updateDocumentTitle$, "Team");
+    set(initSlackOrg$);
     await Promise.all([
       set(initZeroOnboarding$, signal),
-      set(initSlackOrg$, signal),
       agentId ? set(setActiveAgent$, agentId) : undefined,
     ]);
     signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
+++ b/turbo/apps/platform/src/signals/works-page/works-page-setup.ts
@@ -23,10 +23,8 @@ export const setupWorksPage$ = command(async ({ set }, signal: AbortSignal) => {
     createElement(SidebarLayout, null, createElement(ZeroWorksPage)),
   );
   set(updateDocumentTitle$, "Works");
-  await Promise.all([
-    set(initZeroOnboarding$, signal),
-    set(initSlackOrg$, signal),
-  ]);
+  set(initSlackOrg$);
+  await set(initZeroOnboarding$, signal);
   signal.throwIfAborted();
   await set(hideAppSkeleton$, signal);
   // pollSlackConnection$ is a long-running daemon loop — fire-and-forget so

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -265,8 +265,9 @@ export const onboardingAddToSlack$ = command(
     const isAdmin = await get(zeroNeedsOnboarding$);
     signal.throwIfAborted();
     if (isAdmin) {
-      const slackData = get(slackOrgData$);
-      if (slackData?.isAdmin && slackData.installUrl) {
+      const slackData = await get(slackOrgData$);
+      signal.throwIfAborted();
+      if (slackData.isAdmin && slackData.installUrl) {
         const url = new URL(slackData.installUrl, window.location.origin);
         url.searchParams.set("_t", String(Date.now()));
         window.open(url.toString(), "_blank");

--- a/turbo/apps/platform/src/signals/zero-page/zero-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-page.ts
@@ -20,8 +20,7 @@ export const loadInitialData$ = command(
     }
     await set(initZeroOnboarding$, signal);
     signal.throwIfAborted();
-    await set(initSlackOrg$, signal);
-    signal.throwIfAborted();
+    set(initSlackOrg$);
     set(initialDataLoaded$, true);
   },
 );

--- a/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-slack.ts
@@ -1,21 +1,29 @@
 import { command, computed, state } from "ccstate";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { delay } from "signal-timers";
-import { zeroIntegrationsSlackContract, type SlackOrgStatus } from "@vm0/core";
+import { zeroIntegrationsSlackContract } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
-import { throwIfAbort } from "../utils.ts";
 
-const slackOrgState$ = state<SlackOrgStatus | null>(null);
+const internalReload$ = state(0);
 
-export const slackOrgData$ = computed((get) => {
-  return get(slackOrgState$);
+export const slackOrgData$ = computed(async (get) => {
+  get(internalReload$);
+  const client = get(zeroClient$)(zeroIntegrationsSlackContract);
+  const result = await accept(client.getStatus(), [200], { toast: false });
+  return result.body;
+});
+
+const reloadSlackOrg$ = command(({ set }) => {
+  set(internalReload$, (prev) => {
+    return prev + 1;
+  });
 });
 
 /** True when the org-scoped Slack installation has outdated bot scopes (admin-only). */
-export const slackOrgScopeMismatch$ = computed((get) => {
-  const data = get(slackOrgState$);
-  return data?.scopeMismatch === true;
+export const slackOrgScopeMismatch$ = computed(async (get) => {
+  const data = await get(slackOrgData$);
+  return data.scopeMismatch === true;
 });
 
 // ---------------------------------------------------------------------------
@@ -34,24 +42,13 @@ export const setShowUninstallDialog$ = command(({ set }, show: boolean) => {
   set(showUninstallDialogState$, show);
 });
 
-const fetchSlackOrg$ = command(async ({ get, set }, signal: AbortSignal) => {
-  const client = get(zeroClient$)(zeroIntegrationsSlackContract);
-  try {
-    const result = await accept(client.getStatus(), [200], { toast: false });
-    signal.throwIfAborted();
-    set(slackOrgState$, result.body);
-  } catch (error) {
-    throwIfAbort(error);
-  }
-});
-
 export const disconnectSlackOrg$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroIntegrationsSlackContract);
     await accept(client.disconnect(), [200]);
     signal.throwIfAborted();
     toast.success("Disconnected from Slack");
-    await set(fetchSlackOrg$, signal);
+    set(reloadSlackOrg$);
   },
 );
 
@@ -61,7 +58,7 @@ export const uninstallSlackOrg$ = command(
     await accept(client.disconnect({ query: { action: "uninstall" } }), [200]);
     signal.throwIfAborted();
     toast.success("Slack workspace uninstalled");
-    await set(fetchSlackOrg$, signal);
+    set(reloadSlackOrg$);
   },
 );
 
@@ -79,36 +76,26 @@ export const setSlackPollIntervalMs$ = command(({ set }, ms: number) => {
 export const pollSlackConnection$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     // Already connected — nothing to poll.
-    const current = get(slackOrgState$);
-    if (current?.isConnected) {
+    const current = await get(slackOrgData$);
+    signal.throwIfAborted();
+    if (current.isConnected) {
       return;
     }
 
     while (!signal.aborted) {
       await delay(get(slackPollIntervalMs$), { signal });
-
-      const client = get(zeroClient$)(zeroIntegrationsSlackContract);
-      try {
-        const result = await accept(client.getStatus(), [200], {
-          toast: false,
-        });
-        signal.throwIfAborted();
-        set(slackOrgState$, result.body);
-
-        if (result.body.isConnected) {
-          toast.success("Slack connected successfully");
-          return;
-        }
-      } catch (error) {
-        throwIfAbort(error);
+      set(reloadSlackOrg$);
+      const result = await get(slackOrgData$);
+      signal.throwIfAborted();
+      if (result.isConnected) {
+        toast.success("Slack connected successfully");
+        return;
       }
     }
   },
 );
 
-export const initSlackOrg$ = command(async ({ set }, signal: AbortSignal) => {
-  await set(fetchSlackOrg$, signal);
-
+export const initSlackOrg$ = command((_ctx) => {
   const params = new URLSearchParams(window.location.search);
   if (params.get("updated") === "1") {
     toast.success("Permissions updated");

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -234,7 +234,7 @@ export function ZeroSidebar() {
   const setManagePinnedOpen = useSet(setManagePinnedDialogOpen$);
   // Feature gates
   const features = useLastResolved(featureSwitch$);
-  const slackScopeMismatch = useGet(slackOrgScopeMismatch$);
+  const slackScopeMismatch = useLastResolved(slackOrgScopeMismatch$) ?? false;
 
   // Compute selectedAgentIdFromChat for grey highlight
   const subagentIds = new Set(


### PR DESCRIPTION
## Summary

Closes #8280

- Replace `slackOrgState$` + `fetchSlackOrg$` imperative command with reactive `slackOrgData$ = computed(async ...)` pattern
- `initSlackOrg$` becomes a sync command handling only URL param toasts, eliminating the skeleton-blocking `await` in `loadInitialData$`
- `slackOrgScopeMismatch$` becomes async computed depending on `slackOrgData$`
- `zero-sidebar.tsx` uses `useLastResolved` instead of `useGet` for the async computed
- `zero-onboarding-actions.ts` now awaits `slackOrgData$` with proper `signal.throwIfAborted()` guard
- `pollSlackConnection$` uses `set(reloadSlackOrg$)` + `await get(slackOrgData$)` instead of direct HTTP calls

## Test plan

- [ ] All 3 `pollSlackConnection$` tests pass
- [ ] All 295 platform signal tests pass
- [ ] Type checks pass
- [ ] Lint passes (no ESLint or knip violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)