### PR TITLE
fix: use 403 instead of 401 for authorization errors

### DIFF
--- a/turbo/apps/web/app/api/zero/ask-user/answer/route.ts
+++ b/turbo/apps/web/app/api/zero/ask-user/answer/route.ts
@@ -24,9 +24,9 @@ const router = tsr.router(zeroAskUserAnswerContract, {
     const { runId } = authCtx;
     if (!runId) {
       return {
-        status: 401 as const,
+        status: 403 as const,
         body: {
-          error: { message: "No run context available", code: "UNAUTHORIZED" },
+          error: { message: "No run context available", code: "FORBIDDEN" },
         },
       };
     }

--- a/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
@@ -384,7 +384,7 @@ describe("POST /api/zero/developer-support", () => {
     expect((await step2.json()).reference).toBeDefined();
   });
 
-  it("returns 401 when no auth header is provided", async () => {
+  it("returns 403 when token lacks runId and orgId", async () => {
     const response = await POST(
       createTestRequest(URL, {
         method: "POST",
@@ -396,6 +396,6 @@ describe("POST /api/zero/developer-support", () => {
       }),
     );
 
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(403);
   });
 });

--- a/turbo/apps/web/app/api/zero/developer-support/route.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/route.ts
@@ -98,11 +98,11 @@ const router = tsr.router(zeroDeveloperSupportContract, {
     const { userId, orgId, runId } = authCtx;
     if (!runId || !orgId) {
       return {
-        status: 401 as const,
+        status: 403 as const,
         body: {
           error: {
             message: "This endpoint requires a zero token with runId and orgId",
-            code: "UNAUTHORIZED",
+            code: "FORBIDDEN",
           },
         },
       };

--- a/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
@@ -85,11 +85,11 @@ const router = tsr.router(onboardingSetupContract, {
 
     if (member.role !== "admin") {
       return {
-        status: 401 as const,
+        status: 403 as const,
         body: {
           error: {
             message: "Only org admins can run onboarding setup",
-            code: "UNAUTHORIZED",
+            code: "FORBIDDEN",
           },
         },
       };

--- a/turbo/apps/web/src/__tests__/onboarding-setup.test.ts
+++ b/turbo/apps/web/src/__tests__/onboarding-setup.test.ts
@@ -137,11 +137,11 @@ describe("POST /api/zero/onboarding/setup", () => {
     expect(response.status).toBe(401);
   });
 
-  it("should return 401 for non-admin members", async () => {
+  it("should return 403 for non-admin members", async () => {
     const { userId, orgId } = await context.setupUser();
     mockClerk({ userId, orgId, orgRole: "org:member" });
 
     const response = await postSetup({ displayName: "Zero" });
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(403);
   });
 });

--- a/turbo/packages/core/src/contracts/onboarding.ts
+++ b/turbo/packages/core/src/contracts/onboarding.ts
@@ -72,6 +72,7 @@ export const onboardingSetupContract = c.router({
     responses: {
       200: z.object({ agentId: z.string() }),
       401: apiErrorSchema,
+      403: apiErrorSchema,
       409: z.object({ agentId: z.string() }),
       422: apiErrorSchema,
     },

--- a/turbo/packages/core/src/contracts/zero-ask-user.ts
+++ b/turbo/packages/core/src/contracts/zero-ask-user.ts
@@ -86,6 +86,7 @@ export const zeroAskUserAnswerContract = c.router({
     responses: {
       200: askUserAnswerResponseSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
       404: apiErrorSchema,
     },
     summary: "Poll for the user's answer to a pending question",

--- a/turbo/packages/core/src/contracts/zero-developer-support.ts
+++ b/turbo/packages/core/src/contracts/zero-developer-support.ts
@@ -28,6 +28,7 @@ export const zeroDeveloperSupportContract = c.router({
       200: z.union([consentCodeResponseSchema, submitResponseSchema]),
       400: apiErrorSchema,
       401: apiErrorSchema,
+      403: apiErrorSchema,
     },
     summary:
       "Developer support: consent code generation or diagnostic submission",


### PR DESCRIPTION
## Summary

- Fix 3 routes that incorrectly returned HTTP 401 (Unauthorized) for **authorization** failures — cases where the user is authenticated but lacks sufficient permissions or token claims
- Change to HTTP 403 (Forbidden), which is the correct semantic for "authenticated but not authorized"
- Update corresponding ts-rest contracts to declare `403: apiErrorSchema`

### Routes fixed

| Route | Condition | Before | After |
|-------|-----------|--------|-------|
| `POST /api/zero/onboarding/setup` | Non-admin role | 401 | 403 |
| `POST /api/zero/developer-support` | Token missing `runId`/`orgId` claims | 401 | 403 |
| `GET /api/zero/ask-user/answer` | Token missing `runId` claim | 401 | 403 |

## Test plan

- [x] Updated developer-support test expectation from 401 to 403
- [x] All existing tests pass (20/20 for affected routes)
- [x] Type check passes
- [x] Lint and knip pass (verified by pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)