### PR TITLE
feat: navigate to first empty thread when clicking "+"

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -17,6 +17,7 @@ import {
   zeroChatAttachments$,
   uploadZeroAttachment$,
   removeZeroAttachment$,
+  createNewChatThread$,
 } from "../zero-chat.ts";
 import { chatThreadId$ } from "../zero-nav.ts";
 
@@ -503,6 +504,152 @@ describe("zero-chat signals", () => {
       // Second call skips because messages are already present
       await context.store.set(loadSessionFromSnapshot$, context.signal);
       expect(loadCount).toBe(countAfterSetup);
+    });
+  });
+
+  describe("createNewChatThread$", () => {
+    it("should navigate to first thread when it has no title and matches agent", async () => {
+      server.use(
+        http.get("*/api/zero/chat-threads", () => {
+          return HttpResponse.json({
+            threads: [
+              {
+                id: "empty-thread-1",
+                title: null,
+                agentId: "c0000000-0000-4000-a000-000000000001",
+                createdAt: "2026-03-10T00:00:00Z",
+                updatedAt: "2026-03-10T00:00:00Z",
+              },
+              {
+                id: "other-thread",
+                title: null,
+                agentId: "c0000000-0000-4000-a000-000000000001",
+                createdAt: "2026-03-09T00:00:00Z",
+                updatedAt: "2026-03-09T00:00:00Z",
+              },
+            ],
+          });
+        }),
+      );
+
+      await setup();
+
+      await context.store.set(createNewChatThread$, null, context.signal);
+
+      // Should navigate to the first empty thread, not the second
+      expect(context.store.get(chatThreadId$)).toBe("empty-thread-1");
+    });
+
+    it("should create new thread when first thread has a title", async () => {
+      let createCalled = false;
+      server.use(
+        http.get("*/api/zero/chat-threads", () => {
+          return HttpResponse.json({
+            threads: [
+              {
+                id: "titled-thread",
+                title: "Existing chat",
+                agentId: "c0000000-0000-4000-a000-000000000001",
+                createdAt: "2026-03-10T00:00:00Z",
+                updatedAt: "2026-03-10T00:00:00Z",
+              },
+            ],
+          });
+        }),
+        http.post("*/api/zero/chat-threads", () => {
+          createCalled = true;
+          return HttpResponse.json(
+            {
+              id: "new-thread-created",
+              title: null,
+              agentId: "c0000000-0000-4000-a000-000000000001",
+              createdAt: "2026-03-10T01:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setup();
+
+      await context.store.set(createNewChatThread$, null, context.signal);
+
+      expect(createCalled).toBeTruthy();
+      expect(context.store.get(chatThreadId$)).toBe("new-thread-created");
+    });
+
+    it("should create new thread when thread list is empty", async () => {
+      let createCalled = false;
+      server.use(
+        http.get("*/api/zero/chat-threads", () => {
+          return HttpResponse.json({ threads: [] });
+        }),
+        http.post("*/api/zero/chat-threads", () => {
+          createCalled = true;
+          return HttpResponse.json(
+            {
+              id: "new-thread-empty-list",
+              title: null,
+              agentId: "c0000000-0000-4000-a000-000000000001",
+              createdAt: "2026-03-10T01:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setup();
+
+      await context.store.set(createNewChatThread$, null, context.signal);
+
+      expect(createCalled).toBeTruthy();
+      expect(context.store.get(chatThreadId$)).toBe("new-thread-empty-list");
+    });
+
+    it("should not navigate to second thread when first has a title", async () => {
+      let createCalled = false;
+      server.use(
+        http.get("*/api/zero/chat-threads", () => {
+          return HttpResponse.json({
+            threads: [
+              {
+                id: "titled-thread",
+                title: "Has messages",
+                agentId: "c0000000-0000-4000-a000-000000000001",
+                createdAt: "2026-03-10T01:00:00Z",
+                updatedAt: "2026-03-10T01:00:00Z",
+              },
+              {
+                id: "empty-second-thread",
+                title: null,
+                agentId: "c0000000-0000-4000-a000-000000000001",
+                createdAt: "2026-03-10T00:00:00Z",
+                updatedAt: "2026-03-10T00:00:00Z",
+              },
+            ],
+          });
+        }),
+        http.post("*/api/zero/chat-threads", () => {
+          createCalled = true;
+          return HttpResponse.json(
+            {
+              id: "brand-new-thread",
+              title: null,
+              agentId: "c0000000-0000-4000-a000-000000000001",
+              createdAt: "2026-03-10T02:00:00Z",
+            },
+            { status: 201 },
+          );
+        }),
+      );
+
+      await setup();
+
+      await context.store.set(createNewChatThread$, null, context.signal);
+
+      // Should NOT navigate to empty-second-thread; should create brand new
+      expect(createCalled).toBeTruthy();
+      expect(context.store.get(chatThreadId$)).toBe("brand-new-thread");
     });
   });
 

--- a/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/__tests__/zero-chat.test.ts
@@ -541,7 +541,6 @@ describe("zero-chat signals", () => {
     });
 
     it("should create new thread when first thread has a title", async () => {
-      let createCalled = false;
       server.use(
         http.get("*/api/zero/chat-threads", () => {
           return HttpResponse.json({
@@ -557,7 +556,6 @@ describe("zero-chat signals", () => {
           });
         }),
         http.post("*/api/zero/chat-threads", () => {
-          createCalled = true;
           return HttpResponse.json(
             {
               id: "new-thread-created",
@@ -574,18 +572,15 @@ describe("zero-chat signals", () => {
 
       await context.store.set(createNewChatThread$, null, context.signal);
 
-      expect(createCalled).toBeTruthy();
       expect(context.store.get(chatThreadId$)).toBe("new-thread-created");
     });
 
     it("should create new thread when thread list is empty", async () => {
-      let createCalled = false;
       server.use(
         http.get("*/api/zero/chat-threads", () => {
           return HttpResponse.json({ threads: [] });
         }),
         http.post("*/api/zero/chat-threads", () => {
-          createCalled = true;
           return HttpResponse.json(
             {
               id: "new-thread-empty-list",
@@ -602,12 +597,10 @@ describe("zero-chat signals", () => {
 
       await context.store.set(createNewChatThread$, null, context.signal);
 
-      expect(createCalled).toBeTruthy();
       expect(context.store.get(chatThreadId$)).toBe("new-thread-empty-list");
     });
 
     it("should not navigate to second thread when first has a title", async () => {
-      let createCalled = false;
       server.use(
         http.get("*/api/zero/chat-threads", () => {
           return HttpResponse.json({
@@ -630,7 +623,6 @@ describe("zero-chat signals", () => {
           });
         }),
         http.post("*/api/zero/chat-threads", () => {
-          createCalled = true;
           return HttpResponse.json(
             {
               id: "brand-new-thread",
@@ -648,7 +640,6 @@ describe("zero-chat signals", () => {
       await context.store.set(createNewChatThread$, null, context.signal);
 
       // Should NOT navigate to empty-second-thread; should create brand new
-      expect(createCalled).toBeTruthy();
       expect(context.store.get(chatThreadId$)).toBe("brand-new-thread");
     });
   });

--- a/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-chat.ts
@@ -846,14 +846,15 @@ const internalCreateNewChatSession$ = command(
       return;
     }
 
-    // A2: If an empty thread already exists in the list, navigate to it
+    // A2: If the first thread in the list is empty, navigate to it
     const threads = await get(chatThreads$);
-    const emptyThread = threads.find((t) => {
-      return t.title === null && t.agentId === resolvedComposeId;
-    });
-    if (emptyThread) {
+    const firstThread = threads[0];
+    if (
+      firstThread?.title === null &&
+      firstThread.agentId === resolvedComposeId
+    ) {
       set(startNewZeroSession$);
-      set(navigateToChat$, emptyThread.id);
+      set(navigateToChat$, firstThread.id);
       return;
     }
 


### PR DESCRIPTION
## Summary

- Changes A2 in `internalCreateNewChatSession$` to check only `threads[0]` (the first/most-recently-updated thread) instead of scanning all threads with `.find()`
- Clicking "+" now navigates to the first thread only if it has no title (empty/new chat), preventing duplicate empty threads
- Adds 4 integration tests covering: navigate to first empty thread, create new when first has title, create new when list is empty, and don't navigate to second thread when first has a title

Fixes #8171

## Test plan

- [x] Tests pass: `createNewChatThread$` navigates to first thread when `title === null` and matches agent
- [x] Tests pass: creates new thread when first thread has a title
- [x] Tests pass: creates new thread when thread list is empty
- [x] Tests pass: does not navigate to second empty thread when first has a title
- [x] Lint passes
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)