### PR TITLE
fix(firewall): include xero connections endpoint in firewall config

### DIFF
--- a/turbo/packages/core/src/firewalls/xero.generated.ts
+++ b/turbo/packages/core/src/firewalls/xero.generated.ts
@@ -14,6 +14,20 @@ export const xeroFirewall = {
   },
   apis: [
     {
+      base: "https://api.xero.com",
+      auth: {
+        headers: {
+          Authorization: "Bearer ${{ secrets.XERO_TOKEN }}",
+        },
+      },
+      permissions: [
+        {
+          name: "connections",
+          rules: ["GET /Connections", "DELETE /Connections/{id}"],
+        },
+      ],
+    },
+    {
       base: "https://api.xero.com/api.xro/2.0",
       auth: {
         headers: {

--- a/turbo/packages/firewalls-generator/src/xero.ts
+++ b/turbo/packages/firewalls-generator/src/xero.ts
@@ -59,13 +59,19 @@ interface XeroSpec {
 }
 
 // ── Scopeless endpoints ──────────────────────────────────────────────────
-// Endpoints without OAuth scopes that are intentionally denied.
-// Unknown scopeless endpoints cause a build error.
+// Endpoints without OAuth2 scopes that should still be included in the
+// firewall config. Map key = "METHOD /path", value = permission group name.
+// The proxy needs these registered so it can inject the Bearer token.
+//
+// Unknown scopeless endpoints cause a build error — add them here or
+// investigate why they lack scopes.
 
-const SCOPELESS_ENDPOINTS = new Set<string>([
-  // Identity endpoints use different auth (BasicAuth / openid scopes)
-  "GET /Connections",
-  "DELETE /Connections/{id}",
+const INCLUDED_SCOPELESS = new Map<string, string>([
+  // Identity endpoints use openid scopes (not OAuth2) but still need
+  // Bearer token auth. Required to retrieve tenant IDs before any
+  // accounting API call.
+  ["GET /Connections", "connections"],
+  ["DELETE /Connections/{id}", "connections"],
 ]);
 
 // ── Grouping ─────────────────────────────────────────────────────────────
@@ -105,7 +111,21 @@ function buildGroups(specs: ParsedSpec[]): {
         }
 
         if (scopes.length === 0) {
-          if (!SCOPELESS_ENDPOINTS.has(rule)) {
+          const permName = INCLUDED_SCOPELESS.get(rule);
+          if (permName) {
+            // Scopeless-but-needed: add under its named permission group
+            let baseMap = groups.get(permName);
+            if (!baseMap) {
+              baseMap = new Map();
+              groups.set(permName, baseMap);
+            }
+            let ruleSet = baseMap.get(spec.baseUrl);
+            if (!ruleSet) {
+              ruleSet = new Set();
+              baseMap.set(spec.baseUrl, ruleSet);
+            }
+            ruleSet.add(rule);
+          } else {
             unknownScopeless.push(`${rule} (${spec.baseUrl})`);
           }
           continue;

--- a/turbo/packages/firewalls-generator/src/xero.ts
+++ b/turbo/packages/firewalls-generator/src/xero.ts
@@ -10,7 +10,7 @@
  * Each spec has its own base URL (e.g. api.xro/2.0, assets.xro/1.0),
  * so we generate one `apis` entry per unique base URL.
  *
- * Endpoints without scopes are tracked in SCOPELESS_ENDPOINTS — unknown
+ * Endpoints without scopes are tracked in INCLUDED_SCOPELESS — unknown
  * scopeless endpoints cause a build error.
  */
 
@@ -81,6 +81,25 @@ interface ParsedSpec {
   paths: Record<string, Record<string, XeroOperation>>;
 }
 
+function addRule(
+  groups: Map<string, Map<string, Set<string>>>,
+  scope: string,
+  baseUrl: string,
+  rule: string,
+): void {
+  let baseMap = groups.get(scope);
+  if (!baseMap) {
+    baseMap = new Map();
+    groups.set(scope, baseMap);
+  }
+  let ruleSet = baseMap.get(baseUrl);
+  if (!ruleSet) {
+    ruleSet = new Set();
+    baseMap.set(baseUrl, ruleSet);
+  }
+  ruleSet.add(rule);
+}
+
 function buildGroups(specs: ParsedSpec[]): {
   /** Map: baseUrl -> permission groups */
   hostGroups: Map<string, PermissionGroup[]>;
@@ -113,18 +132,7 @@ function buildGroups(specs: ParsedSpec[]): {
         if (scopes.length === 0) {
           const permName = INCLUDED_SCOPELESS.get(rule);
           if (permName) {
-            // Scopeless-but-needed: add under its named permission group
-            let baseMap = groups.get(permName);
-            if (!baseMap) {
-              baseMap = new Map();
-              groups.set(permName, baseMap);
-            }
-            let ruleSet = baseMap.get(spec.baseUrl);
-            if (!ruleSet) {
-              ruleSet = new Set();
-              baseMap.set(spec.baseUrl, ruleSet);
-            }
-            ruleSet.add(rule);
+            addRule(groups, permName, spec.baseUrl, rule);
           } else {
             unknownScopeless.push(`${rule} (${spec.baseUrl})`);
           }
@@ -135,17 +143,7 @@ function buildGroups(specs: ParsedSpec[]): {
         // and read-only scopes for read endpoints (OR semantics), so the
         // rule must appear in both groups.
         for (const scope of scopes) {
-          let baseMap = groups.get(scope);
-          if (!baseMap) {
-            baseMap = new Map();
-            groups.set(scope, baseMap);
-          }
-          let ruleSet = baseMap.get(spec.baseUrl);
-          if (!ruleSet) {
-            ruleSet = new Set();
-            baseMap.set(spec.baseUrl, ruleSet);
-          }
-          ruleSet.add(rule);
+          addRule(groups, scope, spec.baseUrl, rule);
         }
       }
     }
@@ -273,14 +271,14 @@ export async function generate(): Promise<void> {
 
   if (scopeless.length > 0) {
     console.error(
-      `\n  ${scopeless.length} endpoints without scopes (add to SCOPELESS_ENDPOINTS):`,
+      `\n  ${scopeless.length} endpoints without scopes (add to INCLUDED_SCOPELESS):`,
     );
     for (const ep of scopeless.sort()) {
       console.error(`    "${ep}",`);
     }
     throw new Error(
       `${scopeless.length} unknown scopeless endpoints found.\n` +
-        "Add them to SCOPELESS_ENDPOINTS in xero.ts to fix this error.",
+        "Add them to INCLUDED_SCOPELESS in xero.ts to fix this error.",
     );
   }
 


### PR DESCRIPTION
## Summary
- Xero `/Connections` endpoint was missing from firewall config, causing proxy to never inject Bearer token → 401 errors
- Changed generator to include scopeless-but-needed identity endpoints under a `connections` permission group
- Regenerated `xero.generated.ts` with new `https://api.xero.com` base URL

## Root Cause
The firewall generator (`xero.ts`) had a `SCOPELESS_ENDPOINTS` set that silently **skipped** identity endpoints (`GET /Connections`, `DELETE /Connections/{id}`) because they use OpenID scopes instead of standard OAuth2 scopes. Since no scoped endpoints referenced the identity base URL (`https://api.xero.com`), that base never appeared in the generated config. The proxy only injects tokens for registered bases → Xero returned `401 AuthenticationUnsuccessful`.

## Fix
Replace `SCOPELESS_ENDPOINTS` (Set — skip) with `INCLUDED_SCOPELESS` (Map — include under named permission group). Unknown scopeless endpoints still cause a build error.

## Verified
- Base URL `https://api.xero.com` matches [Xero OpenAPI spec](https://github.com/XeroAPI/Xero-OpenAPI/blob/master/xero-identity.yaml) `servers[0].url`
- Auth: Bearer token (same `XERO_TOKEN` as all other Xero APIs)
- Paths: `GET /Connections`, `DELETE /Connections/{id}` — exact casing matches spec

## Test plan
- [ ] Verify type check and lint pass in CI
- [ ] Test Xero connector: agent calling `/connections` to retrieve tenant IDs should succeed (no more 401)

Closes #8331

🤖 Generated with [Claude Code](https://claude.com/claude-code)