### PR TITLE
refactor: remove cross-org resolve-org calls from slack connect routes

### DIFF
--- a/turbo/apps/web/app/api/zero/integrations/slack/connect/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/connect/route.ts
@@ -193,21 +193,14 @@ export async function POST(request: Request) {
 
   // Already bound — verify org match
   if (installation.orgId !== org.orgId) {
-    // Check if user is a member of the workspace's org but has the wrong active org
-    let isMemberOfTargetOrg = false;
-    try {
-      await resolveOrg(authCtx, installation.orgId);
-      isMemberOfTargetOrg = true;
-    } catch {
-      // Not a member
-    }
-
-    const message = isMemberOfTargetOrg
-      ? "Your active organization doesn't match this Slack workspace. Please switch to the correct organization in the platform sidebar before connecting."
-      : "You don't have access to the organization this Slack workspace belongs to. Contact the organization admin for an invite.";
-
     return NextResponse.json(
-      { error: { message, code: "FORBIDDEN" } },
+      {
+        error: {
+          message:
+            "Your active organization doesn't match this Slack workspace. Please switch to the correct organization in the platform sidebar before connecting.",
+          code: "FORBIDDEN",
+        },
+      },
       { status: 403 },
     );
   }

--- a/turbo/apps/web/app/api/zero/slack/connect/route.ts
+++ b/turbo/apps/web/app/api/zero/slack/connect/route.ts
@@ -105,25 +105,12 @@ export async function GET(request: Request) {
     userId,
   });
   if (!effectiveOrgId || effectiveOrgId !== installation.orgId) {
-    // Distinguish: is the user a member of the workspace's org at all?
-    let isMember = false;
-    try {
-      await resolveOrg(authCtx, installation.orgId);
-      isMember = true;
-    } catch {
-      // Not a member
-    }
-
-    const message = isMember
-      ? "Your active organization doesn't match this Slack workspace. Please switch to the correct organization in the platform sidebar before connecting."
-      : "You don't have access to the organization this Slack workspace belongs to. Contact the organization admin for an invite.";
-
     return NextResponse.redirect(
-      `${appUrl}/slack/connect?error=${encodeURIComponent(message)}`,
+      `${appUrl}/slack/connect?error=${encodeURIComponent("Your active organization doesn't match this Slack workspace. Please switch to the correct organization in the platform sidebar before connecting.")}`,
     );
   }
 
-  const { org, member } = await resolveOrg(authCtx, installation.orgId);
+  const { org, member } = await resolveOrg(authCtx);
 
   if (member.role === "admin") {
     await adminConnect({


### PR DESCRIPTION
## Summary

- Remove 3 cross-org `resolveOrg(authCtx, installation.orgId)` calls from Slack connect routes as part of org resolution audit (#8274)
- Simplify membership check blocks to use a single error message instead of distinguishing between member/non-member of target org
- Replace `resolveOrg(authCtx, installation.orgId)` with `resolveOrg(authCtx)` for the actual org resolve call

## Changes

### `turbo/apps/web/app/api/zero/slack/connect/route.ts`
- Removed try/catch cross-org membership check (lines 108-119), replaced with single error redirect
- Changed `resolveOrg(authCtx, installation.orgId)` → `resolveOrg(authCtx)` since org match is already verified

### `turbo/apps/web/app/api/zero/integrations/slack/connect/route.ts`
- Removed try/catch cross-org membership check (lines 196-207), replaced with single error JSON response

## Test plan

- [x] All 16 existing tests pass (integrations/slack/connect route)
- [x] No `resolveOrg(authCtx, installation.orgId)` calls remain (verified via grep)
- [x] Lint passes
- [x] Type-check passes (web package)
- [x] Knip passes

Closes #8341

🤖 Generated with [Claude Code](https://claude.com/claude-code)