### PR TITLE
fix(sandbox): recover leaked resources when sandbox is dropped without destroy

### DIFF
--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -8,7 +8,10 @@ use tracing::{info, warn};
 use nbd_cow::NbdCowDevice;
 
 use crate::config::FirecrackerConfig;
-use crate::network::PooledNetns;
+use crate::network::{GUEST_NETWORK, NetnsPool, NetnsPoolConfig, PooledNetns, generate_boot_args};
+use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
+use crate::prerequisites;
+use crate::sandbox::FirecrackerSandbox;
 
 /// Maximum attempts to destroy a COW device after killing Firecracker.
 /// After kill_process_group + child.wait(), the kernel may still be
@@ -17,7 +20,6 @@ pub(crate) const DESTROY_RETRIES: u32 = 5;
 
 /// Delay between COW device destroy retries.
 pub(crate) const DESTROY_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
-use crate::network::{GUEST_NETWORK, NetnsPool, NetnsPoolConfig, generate_boot_args};
 
 /// Resources that require async cleanup when a sandbox is dropped without
 /// going through `factory.destroy()` (e.g. executor task panic).
@@ -25,15 +27,12 @@ use crate::network::{GUEST_NETWORK, NetnsPool, NetnsPoolConfig, generate_boot_ar
 /// The `FirecrackerSandbox::Drop` impl sends these to a cleanup channel
 /// owned by the factory, which drains them asynchronously.
 pub(crate) struct LeakedResources {
-    pub sandbox_id: String,
-    pub device_index: u32,
-    pub network: PooledNetns,
-    pub sock_dir: PathBuf,
-    pub workspace: PathBuf,
+    pub(crate) sandbox_id: String,
+    pub(crate) device_index: u32,
+    pub(crate) network: PooledNetns,
+    pub(crate) sock_dir: PathBuf,
+    pub(crate) workspace: PathBuf,
 }
-use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
-use crate::prerequisites;
-use crate::sandbox::FirecrackerSandbox;
 
 /// Shell command executed during snapshot creation to pre-warm guest state.
 /// Changing this invalidates all cached snapshots (included in [`config_hash`]).

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -21,6 +21,11 @@ pub(crate) const DESTROY_RETRIES: u32 = 5;
 /// Delay between COW device destroy retries.
 pub(crate) const DESTROY_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 
+/// Channel capacity for leaked sandbox resource cleanup.
+/// 32 is generous — the channel only receives messages when an executor task
+/// panics after sandbox creation, which is an exceptional path.
+const LEAK_CHANNEL_CAPACITY: usize = 32;
+
 /// Resources that require async cleanup when a sandbox is dropped without
 /// going through `factory.destroy()` (e.g. executor task panic).
 ///
@@ -302,7 +307,7 @@ impl SandboxFactory for FirecrackerFactory {
 
         // Spawn background task to clean up resources leaked by sandbox Drop
         // impls that fire without going through factory.destroy().
-        let (leak_tx, leak_rx) = tokio::sync::mpsc::channel(32);
+        let (leak_tx, leak_rx) = tokio::sync::mpsc::channel(LEAK_CHANNEL_CAPACITY);
         self.leak_tx = Some(leak_tx);
         self.leak_cleanup_handle = Some(tokio::spawn(Self::drain_leaked_resources(
             leak_rx,

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use async_trait::async_trait;
 use sandbox::{Sandbox, SandboxConfig, SandboxError, SandboxFactory};
 use sha2::{Digest, Sha256};
@@ -6,6 +8,7 @@ use tracing::{info, warn};
 use nbd_cow::NbdCowDevice;
 
 use crate::config::FirecrackerConfig;
+use crate::network::PooledNetns;
 
 /// Maximum attempts to destroy a COW device after killing Firecracker.
 /// After kill_process_group + child.wait(), the kernel may still be
@@ -15,6 +18,19 @@ pub(crate) const DESTROY_RETRIES: u32 = 5;
 /// Delay between COW device destroy retries.
 pub(crate) const DESTROY_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 use crate::network::{GUEST_NETWORK, NetnsPool, NetnsPoolConfig, generate_boot_args};
+
+/// Resources that require async cleanup when a sandbox is dropped without
+/// going through `factory.destroy()` (e.g. executor task panic).
+///
+/// The `FirecrackerSandbox::Drop` impl sends these to a cleanup channel
+/// owned by the factory, which drains them asynchronously.
+pub(crate) struct LeakedResources {
+    pub sandbox_id: String,
+    pub device_index: u32,
+    pub network: PooledNetns,
+    pub sock_dir: PathBuf,
+    pub workspace: PathBuf,
+}
 use crate::paths::{FactoryPaths, RuntimePaths, SandboxPaths, SockPaths};
 use crate::prerequisites;
 use crate::sandbox::FirecrackerSandbox;
@@ -127,6 +143,11 @@ pub struct FirecrackerFactory {
     /// Pre-warming pool for COW files.
     cow_pool: Option<tokio::sync::Mutex<crate::cow_pool::CowPool>>,
     started: bool,
+    /// Channel for receiving leaked sandbox resources from `Drop` impls.
+    /// Created during `startup()`, cloned into each sandbox at `create()`.
+    leak_tx: Option<tokio::sync::mpsc::Sender<LeakedResources>>,
+    /// Background task that drains `leak_tx` and releases pool resources.
+    leak_cleanup_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl FirecrackerFactory {
@@ -166,6 +187,8 @@ impl FirecrackerFactory {
             base_image_size: 0,
             cow_pool: None,
             started: false,
+            leak_tx: None,
+            leak_cleanup_handle: None,
         })
     }
 
@@ -186,6 +209,33 @@ impl FirecrackerFactory {
     #[allow(clippy::expect_used)]
     fn cow_pool(&self) -> &tokio::sync::Mutex<crate::cow_pool::CowPool> {
         self.cow_pool.as_ref().expect("factory not started")
+    }
+
+    /// Background task that receives leaked sandbox resources from `Drop`
+    /// impls and releases them asynchronously (pool indices, namespaces, dirs).
+    async fn drain_leaked_resources(
+        mut rx: tokio::sync::mpsc::Receiver<LeakedResources>,
+        device_pool: std::sync::Arc<tokio::sync::Mutex<nbd_cow::pool::DevicePool>>,
+        netns_pool: std::sync::Arc<tokio::sync::Mutex<NetnsPool>>,
+    ) {
+        while let Some(leaked) = rx.recv().await {
+            warn!(
+                id = %leaked.sandbox_id,
+                device_index = leaked.device_index,
+                "cleaning up leaked sandbox resources"
+            );
+            device_pool.lock().await.release(leaked.device_index);
+            if let Err(e) = netns_pool.lock().await.release(leaked.network).await {
+                warn!(id = %leaked.sandbox_id, error = %e, "failed to release leaked netns");
+            }
+            if let Err(e) = tokio::fs::remove_dir_all(&leaked.sock_dir).await {
+                warn!(id = %leaked.sandbox_id, error = %e, "failed to delete leaked sock dir");
+            }
+            if let Err(e) = tokio::fs::remove_dir_all(&leaked.workspace).await {
+                warn!(id = %leaked.sandbox_id, error = %e, "failed to delete leaked workspace");
+            }
+            info!(id = %leaked.sandbox_id, "leaked sandbox resources cleaned up");
+        }
     }
 }
 
@@ -247,6 +297,16 @@ impl SandboxFactory for FirecrackerFactory {
         let mut cow_pool = crate::cow_pool::CowPool::new(cow_pool_config);
         cow_pool.warmup().await;
         self.cow_pool = Some(tokio::sync::Mutex::new(cow_pool));
+
+        // Spawn background task to clean up resources leaked by sandbox Drop
+        // impls that fire without going through factory.destroy().
+        let (leak_tx, leak_rx) = tokio::sync::mpsc::channel(32);
+        self.leak_tx = Some(leak_tx);
+        self.leak_cleanup_handle = Some(tokio::spawn(Self::drain_leaked_resources(
+            leak_rx,
+            std::sync::Arc::clone(&self.device_pool),
+            self.netns_pool().clone(),
+        )));
 
         self.started = true;
 
@@ -359,6 +419,7 @@ impl SandboxFactory for FirecrackerFactory {
             sock_paths,
             network,
             cow_device,
+            self.leak_tx.clone(),
         );
 
         Ok(Box::new(sandbox))
@@ -373,6 +434,9 @@ impl SandboxFactory for FirecrackerFactory {
                 return;
             }
         };
+
+        // Mark as destroyed so Drop doesn't send to leak cleanup channel.
+        sandbox.destroyed = true;
 
         // Ensure the sandbox is killed before releasing pool resources.
         // After kill(), `sandbox.process` is `None`, so the Drop impl's
@@ -442,6 +506,12 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn shutdown(&mut self) {
+        // Stop accepting leaked resources and abort the cleanup task.
+        self.leak_tx.take();
+        if let Some(h) = self.leak_cleanup_handle.take() {
+            h.abort();
+        }
+
         // Clean up COW pool (delete pre-warmed COW files).
         if let Some(pool_mutex) = self.cow_pool.take() {
             let mut pool = pool_mutex.into_inner();
@@ -511,5 +581,74 @@ mod tests {
         let trait_hash = sandbox::SnapshotProvider::config_hash(&provider);
         let direct_hash = config_hash();
         assert_eq!(trait_hash, direct_hash);
+    }
+
+    fn test_network() -> PooledNetns {
+        PooledNetns {
+            name: "test-ns".into(),
+            host_device: "test-ve".into(),
+            peer_ip: "10.200.0.2".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn leaked_resources_channel_receives_on_send() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+
+        tx.send(LeakedResources {
+            sandbox_id: "test-sandbox".into(),
+            device_index: 42,
+            network: test_network(),
+            sock_dir: PathBuf::from("/tmp/nonexistent-sock"),
+            workspace: PathBuf::from("/tmp/nonexistent-ws"),
+        })
+        .await
+        .unwrap();
+
+        let leaked = rx.recv().await.unwrap();
+        assert_eq!(leaked.sandbox_id, "test-sandbox");
+        assert_eq!(leaked.device_index, 42);
+    }
+
+    #[test]
+    fn leaked_resources_try_send_does_not_panic_on_closed_channel() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<LeakedResources>(1);
+        drop(rx);
+
+        let resources = LeakedResources {
+            sandbox_id: "test".into(),
+            device_index: 0,
+            network: test_network(),
+            sock_dir: PathBuf::from("/nonexistent"),
+            workspace: PathBuf::from("/nonexistent"),
+        };
+
+        // Should not panic — just returns Err.
+        assert!(tx.try_send(resources).is_err());
+    }
+
+    #[test]
+    fn leaked_resources_try_send_does_not_panic_on_full_channel() {
+        let (tx, _rx) = tokio::sync::mpsc::channel::<LeakedResources>(1);
+
+        // Fill the channel.
+        tx.try_send(LeakedResources {
+            sandbox_id: "first".into(),
+            device_index: 0,
+            network: test_network(),
+            sock_dir: PathBuf::from("/nonexistent"),
+            workspace: PathBuf::from("/nonexistent"),
+        })
+        .unwrap();
+
+        // Second send should fail gracefully.
+        let result = tx.try_send(LeakedResources {
+            sandbox_id: "second".into(),
+            device_index: 1,
+            network: test_network(),
+            sock_dir: PathBuf::from("/nonexistent"),
+            workspace: PathBuf::from("/nonexistent"),
+        });
+        assert!(result.is_err());
     }
 }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -225,8 +225,11 @@ impl FirecrackerFactory {
                 "cleaning up leaked sandbox resources"
             );
             device_pool.lock().await.release(leaked.device_index);
-            if let Err(e) = netns_pool.lock().await.release(leaked.network).await {
-                warn!(id = %leaked.sandbox_id, error = %e, "failed to release leaked netns");
+            {
+                let mut pool = netns_pool.lock().await;
+                if let Err(e) = pool.release(leaked.network).await {
+                    warn!(id = %leaked.sandbox_id, error = %e, "failed to release leaked netns");
+                }
             }
             if let Err(e) = tokio::fs::remove_dir_all(&leaked.sock_dir).await {
                 warn!(id = %leaked.sandbox_id, error = %e, "failed to delete leaked sock dir");
@@ -506,10 +509,15 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn shutdown(&mut self) {
-        // Stop accepting leaked resources and abort the cleanup task.
+        // Drop the sender so no new leaked resources are accepted, then
+        // wait for the drain task to finish processing any queued items.
+        // This ensures resources queued during the final job drain are
+        // cleaned up before pool shutdown.
         self.leak_tx.take();
         if let Some(h) = self.leak_cleanup_handle.take() {
-            h.abort();
+            // The drain loop exits when all senders are dropped (channel closed).
+            // Use a timeout to avoid blocking shutdown indefinitely.
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), h).await;
         }
 
         // Clean up COW pool (delete pre-warmed COW files).

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -509,15 +509,13 @@ impl SandboxFactory for FirecrackerFactory {
     }
 
     async fn shutdown(&mut self) {
-        // Drop the sender so no new leaked resources are accepted, then
-        // wait for the drain task to finish processing any queued items.
-        // This ensures resources queued during the final job drain are
-        // cleaned up before pool shutdown.
+        // Close the leak channel and abort the drain task.  Any in-flight
+        // leaked resources will be cleaned by `runner gc` on the next start.
+        // We abort (rather than await) so the task immediately releases its
+        // Arc refs to the pools — required for Arc::try_unwrap below.
         self.leak_tx.take();
         if let Some(h) = self.leak_cleanup_handle.take() {
-            // The drain loop exits when all senders are dropped (channel closed).
-            // Use a timeout to avoid blocking shutdown indefinitely.
-            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), h).await;
+            h.abort();
         }
 
         // Clean up COW pool (delete pre-warmed COW files).

--- a/crates/sandbox-fc/src/sandbox.rs
+++ b/crates/sandbox-fc/src/sandbox.rs
@@ -94,6 +94,11 @@ pub struct FirecrackerSandbox {
     control_server: Option<tokio::task::JoinHandle<()>>,
     /// Balloon memory reclaim controller.
     balloon_controller: Option<tokio::task::JoinHandle<()>>,
+    /// Sender for leaked resource cleanup. When Drop fires without prior
+    /// `factory.destroy()`, pool resources are sent here for async cleanup.
+    leak_tx: Option<tokio::sync::mpsc::Sender<crate::factory::LeakedResources>>,
+    /// Set to `true` by `factory.destroy()` to suppress Drop-based leak recovery.
+    pub(crate) destroyed: bool,
 }
 
 impl FirecrackerSandbox {
@@ -104,6 +109,7 @@ impl FirecrackerSandbox {
         sock_paths: SockPaths,
         network: PooledNetns,
         cow_device: NbdCowDevice,
+        leak_tx: Option<tokio::sync::mpsc::Sender<crate::factory::LeakedResources>>,
     ) -> Self {
         let id = config.id.to_string();
         Self {
@@ -121,6 +127,8 @@ impl FirecrackerSandbox {
             crash_notify: Arc::new(Notify::new()),
             control_server: None,
             balloon_controller: None,
+            leak_tx,
+            destroyed: false,
         }
     }
 
@@ -396,6 +404,28 @@ impl Drop for FirecrackerSandbox {
         }
         // Dropping `self.process` (Option<Child>) will trigger kill_on_drop as
         // a secondary safety net.
+
+        // If factory.destroy() was not called, send pool resources to the
+        // async cleanup channel so they can be released without blocking.
+        // NbdCowDevice::Drop handles the kernel-level NBD disconnect; this
+        // covers the pool index, network namespace, and directories.
+        if !self.destroyed
+            && let Some(tx) = self.leak_tx.take()
+        {
+            let resources = crate::factory::LeakedResources {
+                sandbox_id: self.id.clone(),
+                device_index: self.cow_device.device_index(),
+                network: self.network.clone(),
+                sock_dir: self.sock_paths.dir().to_owned(),
+                workspace: self.sandbox_paths.workspace().to_owned(),
+            };
+            if tx.try_send(resources).is_err() {
+                tracing::warn!(
+                    id = %self.id,
+                    "leak cleanup channel full or closed — resources will require runner gc"
+                );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- When an executor task panics after sandbox creation, `FirecrackerSandbox::Drop` only kills the process group — pool resources (NBD device index, network namespace) and directories leak
- Add an `mpsc` cleanup channel: `Drop` sends leaked resources to a background task owned by the factory, which releases pool indices, network namespaces, and deletes directories asynchronously
- `factory.destroy()` sets a `destroyed` flag so the `Drop` impl skips the leak channel on the normal cleanup path
- Degrades gracefully: if the channel is full (32 concurrent panics), falls back to `runner gc` cleanup

Closes #8286

## Changes
- `sandbox-fc/src/factory.rs`: Add `LeakedResources` struct, cleanup channel + background drain task, wire into startup/shutdown/create/destroy
- `sandbox-fc/src/sandbox.rs`: Add `leak_tx` sender and `destroyed` flag to `FirecrackerSandbox`, update `Drop` to send leaked resources

## Test plan
- [x] 3 new unit tests: channel receive, closed channel graceful failure, full channel graceful failure
- [x] All existing workspace tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy -p sandbox-fc -p runner`)
- [ ] E2E: existing runner-exec/cancel/balloon tests cover the normal destroy path (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)