### PR TITLE
refactor: remove 3-step existence check from resolve-org

### DIFF
--- a/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/status/__tests__/route.test.ts
@@ -32,9 +32,7 @@ describe("GET /api/zero/onboarding/status", () => {
 
   it("should return needsOnboarding=true when user has no org", async () => {
     const userId = `no-org-user-${Date.now()}`;
-    // Use a non-existent orgId so resolveOrg throws NotFoundError (caught by route)
-    // rather than BadRequestError (which would propagate as 500)
-    mockClerk({ userId, clerkOrgs: [], orgId: "org_nonexistent" });
+    mockClerk({ userId, clerkOrgs: [], orgId: null });
 
     const request = createTestRequest(
       "http://localhost:3000/api/zero/onboarding/status",

--- a/turbo/apps/web/app/api/zero/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/__tests__/route.test.ts
@@ -137,12 +137,11 @@ describe("PUT /api/zero/org", () => {
     expect(response.status).toBe(401);
   });
 
-  it("should return 404 when org not found", async () => {
+  it("should return 400 when no org in session", async () => {
     const userId = uniqueId("zorg-upd-nf");
     mockClerk({
       userId,
-      orgId: `org_mock_${userId}`,
-      orgRole: "org:admin",
+      orgId: null,
       clerkOrgs: [],
     });
 
@@ -153,7 +152,7 @@ describe("PUT /api/zero/org", () => {
         body: JSON.stringify({ name: "Test" }),
       }),
     );
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(400);
   });
 
   it("should reject zero token for PUT", async () => {

--- a/turbo/apps/web/app/api/zero/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/__tests__/route.test.ts
@@ -44,12 +44,11 @@ describe("GET /api/zero/org", () => {
     expect(data.name).toBeDefined();
   });
 
-  it("should return 404 when org not found", async () => {
+  it("should return 404 when no org in session", async () => {
     const userId = uniqueId("zorg-nf");
     mockClerk({
       userId,
-      orgId: `org_mock_${userId}`,
-      orgRole: "org:admin",
+      orgId: null,
       clerkOrgs: [],
     });
 

--- a/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/invite/__tests__/route.test.ts
@@ -161,12 +161,11 @@ describe("DELETE /api/zero/org/invite (revoke)", () => {
     expect(response.status).toBe(401);
   });
 
-  it("should return 404 when org not found", async () => {
+  it("should return 400 when no org in session", async () => {
     const userId = uniqueId("rev-nf");
     mockClerk({
       userId,
-      orgId: `org_mock_${userId}`,
-      orgRole: "org:admin",
+      orgId: null,
       clerkOrgs: [],
     });
 
@@ -178,6 +177,6 @@ describe("DELETE /api/zero/org/invite (revoke)", () => {
       }),
     );
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(400);
   });
 });

--- a/turbo/apps/web/app/api/zero/org/members/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/org/members/__tests__/route.test.ts
@@ -93,18 +93,17 @@ describe("GET /api/zero/org/members", () => {
     expect(response.status).toBe(401);
   });
 
-  it("should return 404 when org not found", async () => {
+  it("should return 400 when no org in session", async () => {
     const userId = uniqueId("mem-nf");
     mockClerk({
       userId,
-      orgId: `org_mock_${userId}`,
-      orgRole: "org:admin",
+      orgId: null,
       clerkOrgs: [],
     });
 
     const response = await GET(createTestRequest(membersUrl()));
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(400);
   });
 
   it("should not expose pendingInvitations or membershipRequests to non-admin members", async () => {

--- a/turbo/apps/web/src/lib/zero/org/__tests__/resolve-org.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/resolve-org.test.ts
@@ -70,31 +70,6 @@ describe("resolveOrg", () => {
     expect(result.org.orgId).toBe(orgId);
   });
 
-  it("explicit orgId parameter takes precedence over session", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-
-    // Set up Clerk org BEFORE creating org
-    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
-    const { id: orgId } = await createTestOrg(slug);
-
-    // Mock session with a different orgId (should NOT be used).
-    // Include created org in clerkOrgs so cross-org membership check passes.
-    mockClerk({
-      userId,
-      orgId: "org_session_different",
-      clerkOrgs: [{ id: orgId, slug, name: slug }],
-    });
-
-    // Pass explicit orgId matching the org
-    const result = await resolveOrg(
-      authCtx({ userId, orgId: "org_session_different" }),
-      orgId,
-    );
-
-    expect(result.org.orgId).toBe(orgId);
-  });
-
   it("throws 400 when no explicit org context available", async () => {
     const userId = uniqueId("test-user");
 
@@ -109,22 +84,6 @@ describe("resolveOrg", () => {
     await expect(resolveOrg(authCtx({ userId }))).rejects.toThrow(
       "Explicit org context required",
     );
-  });
-
-  it("throws when orgId has no matching org", async () => {
-    const userId = uniqueId("test-user");
-
-    // Mock session with an orgId that doesn't exist in org_metadata
-    mockClerk({
-      userId,
-      orgId: "org_nonexistent_xyz",
-      clerkOrgs: [],
-    });
-
-    // Should throw NotFoundError because org doesn't exist in org_metadata
-    await expect(
-      resolveOrg(authCtx({ userId, orgId: "org_nonexistent_xyz" })),
-    ).rejects.toThrow("not found");
   });
 
   it("resolves correct org when user has multiple orgs", async () => {
@@ -245,56 +204,5 @@ describe("resolveOrg", () => {
 
     expect(result.member.role).toBe("admin");
     expect(result.member.userId).toBe(userId);
-  });
-
-  it("throws when user is not a member of a cross-org", async () => {
-    const userId = uniqueId("test-user");
-    const otherUserId = uniqueId("other-user");
-    const slug = uniqueId("org");
-
-    // Set up Clerk org BEFORE creating org
-    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
-    const { id: orgId } = await createTestOrg(slug);
-
-    // Mock as different user whose session org differs from the target org.
-    // This forces the cache-backed membership check (not JWT fast path).
-    mockClerk({
-      userId: otherUserId,
-      orgId: "org_other_session",
-      clerkOrgs: [],
-    });
-
-    // Throws because the other user is not a member (cross-org path checks membership)
-    await expect(
-      resolveOrg(
-        authCtx({ userId: otherUserId, orgId: "org_other_session" }),
-        orgId,
-      ),
-    ).rejects.toThrow();
-  });
-
-  it("explicit orgId resolves org", async () => {
-    const userId = uniqueId("test-user");
-    const slug = uniqueId("org");
-
-    // Set up Clerk org BEFORE creating org
-    mockClerk({ userId, clerkOrgs: testOrgs(slug) });
-    const { id: orgId } = await createTestOrg(slug);
-
-    // Mock session — orgId is different from the explicit orgId.
-    // Include created org in clerkOrgs so cross-org membership check passes.
-    mockClerk({
-      userId,
-      orgId: "org_session_different",
-      clerkOrgs: [{ id: orgId, slug, name: slug }],
-    });
-
-    // Pass orgId directly
-    const result = await resolveOrg(
-      authCtx({ userId, orgId: "org_session_different" }),
-      orgId,
-    );
-
-    expect(result.org.orgId).toBe(orgId);
   });
 });

--- a/turbo/apps/web/src/lib/zero/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/zero/org/resolve-org.ts
@@ -1,15 +1,10 @@
-import { eq } from "drizzle-orm";
 import {
   forbidden,
-  notFound,
   badRequest,
   isBadRequest,
   isNotFound,
 } from "../../shared/errors";
-import { getOrgData } from "./org-cache-service";
 import { getOrgMetadata } from "./org-metadata-service";
-import { orgMetadata } from "../../../db/schema/org-metadata";
-import { orgCache } from "../../../db/schema/org-cache";
 import { verifyMembershipCached } from "../../auth/org-membership-cache";
 import type { AuthContext } from "../../auth/get-auth-context";
 
@@ -109,60 +104,27 @@ async function verifyMembership(
 }
 
 /**
- * Resolve org from request context using org_cache + org table.
+ * Resolve org from request context using org_metadata table.
  *
- * Requires explicit org context — either an explicit orgId or an
- * AuthContext with active org. Does NOT guess the user's org from
- * cache or Clerk API.
- *
+ * Requires explicit org context from AuthContext (active org in session).
  * Tier is always read from the org table (source of truth).
  *
  * @throws BadRequestError when no explicit org context is available
  */
 export async function resolveOrg(
   authCtx: AuthContext,
-  orgId?: string | null,
 ): Promise<{ org: ResolvedOrg; member: ResolvedMember }> {
-  const effectiveOrgId = orgId ?? authCtx.orgId ?? null;
-  if (effectiveOrgId) {
-    // Verify org is known to the system.
-    // Check org_metadata first (platform-owned), then org_cache (Clerk-validated).
-    // getOrgMetadata returns defaults for missing rows, so we need an explicit check.
-    const db = globalThis.services.db;
-    const [metaRow] = await db
-      .select({ orgId: orgMetadata.orgId })
-      .from(orgMetadata)
-      .where(eq(orgMetadata.orgId, effectiveOrgId))
-      .limit(1);
-    if (!metaRow) {
-      const [cacheRow] = await db
-        .select({ orgId: orgCache.orgId })
-        .from(orgCache)
-        .where(eq(orgCache.orgId, effectiveOrgId))
-        .limit(1);
-      if (!cacheRow) {
-        // Cold start: org not in our DB yet (e.g. new signup).
-        // Fall back to Clerk API to validate and populate org_cache.
-        try {
-          await getOrgData(effectiveOrgId);
-        } catch (error) {
-          if (isOrgNotFoundError(error)) {
-            throw notFound(`Organization ${effectiveOrgId} not found`);
-          }
-          throw error;
-        }
-      }
-    }
-
-    const orgMeta = await getOrgMetadata(effectiveOrgId);
-    const resolved: ResolvedOrg = { orgId: orgMeta.orgId, tier: orgMeta.tier };
-    const member = await verifyMembership(resolved, authCtx);
-    return { org: resolved, member };
+  const orgId = authCtx.orgId ?? null;
+  if (!orgId) {
+    throw badRequest(
+      "Explicit org context required — ensure active org in session",
+    );
   }
 
-  throw badRequest(
-    "Explicit org context required — ensure active org in session",
-  );
+  const orgMeta = await getOrgMetadata(orgId);
+  const resolved: ResolvedOrg = { orgId: orgMeta.orgId, tier: orgMeta.tier };
+  const member = await verifyMembership(resolved, authCtx);
+  return { org: resolved, member };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Remove `orgId?` parameter from `resolveOrg()` signature — always use `authCtx.orgId`
- Delete 3-step existence check (org_metadata → org_cache → Clerk API cold start) that produced no data used downstream
- Remove 5 unused imports (`eq`, `getOrgData`, `orgMetadata`, `orgCache`, `notFound`)
- Remove 4 test cases that tested cross-org parameter and cold-start behavior

## Performance Impact

| Path | Before | After |
|------|--------|-------|
| Web JWT, existing org | 2 DB + JWT fast path | **1 DB** + JWT fast path |
| Web JWT, cold start (new org) | 2 DB + Clerk API (500-700ms) + 1 DB | **1 DB** |
| CLI, same org | 2 DB + membership cache | **1 DB** + membership cache |

## Why it's safe

- Web JWT path: `authCtx.orgId` from Clerk JWT — org existence already proven by Clerk
- CLI path: `authCtx.orgId` validated by `verifyMembershipCached` in `getAuthContext`
- After #8341, no caller passes a second `orgId` parameter
- `getOrgMetadata()` returns safe defaults (tier="free") for missing rows

## Test plan

- [x] All 7 remaining resolve-org tests pass
- [x] All 16 slack connect route tests pass (downstream)
- [x] Lint passes
- [x] Type-check passes (web package)
- [x] Knip passes — no unused exports/imports
- [x] `rg "resolveOrg(.*," --type ts` confirms no cross-org callers remain

Closes #8342

🤖 Generated with [Claude Code](https://claude.com/claude-code)