### PR TITLE
ci(runner): enable keep-alive in all e2e test jobs

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -449,6 +449,7 @@ jobs:
             --name ${JOB_REF}-bench \
             --group vm0/development-${JOB_REF} \
             --runner-dirname ${JOB_REF}-bench \
+            --keep-alive \
             --api-url https://not-a-real-server.test \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
@@ -505,6 +506,7 @@ jobs:
             --group vm0/exec-${JOB_REF} \
             --runner-dirname ${JOB_REF}-exec \
             --max-concurrent 2 \
+            --keep-alive \
             --api-url https://not-a-real-server.test \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
@@ -718,6 +720,7 @@ jobs:
             --group vm0/cancel-${JOB_REF} \
             --runner-dirname ${JOB_REF}-cancel \
             --max-concurrent 2 \
+            --keep-alive \
             --api-url https://not-a-real-server.test \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
@@ -820,6 +823,7 @@ jobs:
             --group vm0/balloon-${JOB_REF} \
             --runner-dirname ${JOB_REF}-balloon \
             --max-concurrent 2 \
+            --keep-alive \
             --api-url https://not-a-real-server.test \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
@@ -1002,6 +1006,7 @@ jobs:
               --group ${GROUP} \
               --runner-dirname ${JOB_REF}-${SUFFIX} \
               --max-concurrent 2 \
+              --keep-alive \
               --api-url https://not-a-real-server.test \
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
           done

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1617,6 +1617,7 @@ jobs:
               --group vm0/development-${JOB_REF} \
               --runner-dirname ${JOB_REF} \
               --concurrency-factor 2.0 \
+              --keep-alive \
               --api-url ${PREVIEW_URL} \
               --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 


### PR DESCRIPTION
## Summary
- Add `--keep-alive` flag to `runner config` in all CI test jobs so VM keep-alive is exercised broadly
- Affected jobs: runner-benchmark, runner-exec, runner-cancel, runner-balloon, runner-upgrade-local (A+B), cli-e2e
- Production deployment (Ansible `deploy-runner.yml`) unchanged — keep-alive remains disabled

## Test plan
- [ ] All CI e2e jobs pass with keep-alive enabled
- [ ] runner-keep-alive job continues to pass (already had the flag)
- [ ] Production deploy config does not include --keep-alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)