### PR TITLE
fix(firewall): include all permissions when no policies are configured

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
@@ -21,16 +21,18 @@ function makeFirewall(
 }
 
 describe("applyConnectorPolicies", () => {
-  it("returns unrestricted when no policies are provided", () => {
+  it("includes all permissions when no policies are provided", () => {
+    const permissions = [
+      { name: "repo-read", rules: ["GET /repos/{owner}/{repo}"] },
+      { name: "repo-write", rules: ["PUT /repos/{owner}/{repo}"] },
+    ];
     const fw = makeFirewall({
       ref: "github",
       apis: [
         {
           base: "https://api.github.com",
           auth: { headers: { Authorization: "Bearer token" } },
-          permissions: [
-            { name: "repo-read", rules: ["GET /repos/{owner}/{repo}"] },
-          ],
+          permissions,
         },
       ],
     });
@@ -40,7 +42,7 @@ describe("applyConnectorPolicies", () => {
     expect(result).toHaveLength(1);
     const entry = result[0];
     expect(entry).toBeDefined();
-    expect(entry?.apis[0]?.permissions).toEqual([UNRESTRICTED_PERMISSION]);
+    expect(entry?.apis[0]?.permissions).toEqual(permissions);
   });
 
   it("filters permissions by policy when permissions are defined", () => {

--- a/turbo/apps/web/src/lib/zero/context/resolve-firewalls.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-firewalls.ts
@@ -62,7 +62,8 @@ export const UNRESTRICTED_PERMISSION = {
  *
  * For each connector firewall:
  * - If the ref has explicit policies, only "allow" permissions are included.
- * - If the ref has no policies (or firewallPolicies is null), an "unrestricted"
+ * - If the ref has no policies, all defined permissions are included as-is
+ *   (treated as all-allow). If no permissions are defined, an "unrestricted"
  *   permission is added to allow all endpoints through the proxy.
  * - If all permissions are denied, the entry is excluded entirely.
  */
@@ -75,18 +76,27 @@ export function applyConnectorPolicies(
   for (const fw of connectorFirewalls) {
     const refPolicies = policies?.[fw.ref];
 
-    // If no policies or the firewall defines no permissions on any api,
-    // treat all apis as unrestricted (no granular permission control).
+    // If the firewall defines no permissions on any api, treat as
+    // unrestricted (no granular permission control).
     const hasPermissions = fw.apis.some((api) => {
       return api.permissions && api.permissions.length > 0;
     });
 
     const apis = fw.apis.map((api) => {
-      if (!refPolicies || !hasPermissions) {
+      if (!hasPermissions) {
         return {
           base: api.base,
           auth: api.auth,
           permissions: [UNRESTRICTED_PERMISSION],
+        };
+      }
+
+      if (!refPolicies) {
+        // No policies configured — include all defined permissions.
+        return {
+          base: api.base,
+          auth: api.auth,
+          permissions: api.permissions ?? [],
         };
       }
 


### PR DESCRIPTION
## Summary
- When a connector firewall has defined permissions but no explicit policies, all permissions are now included as-is instead of being replaced with `UNRESTRICTED_PERMISSION`
- `UNRESTRICTED_PERMISSION` (`ANY /{path*}`) is now only used when the firewall defines **no permissions at all**

## Root Cause
`applyConnectorPolicies()` treated `!refPolicies || !hasPermissions` as a single condition, replacing all permissions with the unrestricted wildcard. This meant that connectors with granular permissions (e.g., Xero with `accounting.contacts`, `connections`, etc.) would bypass all path restrictions when no explicit policy was configured — the proxy would allow **any** request to the base URL.

## Fix
Split the condition:
- `!hasPermissions` → UNRESTRICTED (no granular control available)
- `!refPolicies` + has permissions → pass through all defined permissions (all-allow)
- Has policies → filter by `allow` (existing behavior, unchanged)

## Test plan
- [x] Existing test updated: "includes all permissions when no policies are provided"
- [x] All 4 `apply-connector-policies.test.ts` tests pass
- [x] Type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)