### PR TITLE
fix(cli): return logical-resolution screenshots and fix scale factor detection

### DIFF
--- a/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
+++ b/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
@@ -14,8 +14,8 @@ vi.mock("../screencapture", () => {
   return {
     captureScreenshot: vi.fn().mockResolvedValue({
       image: "dGVzdC1pbWFnZQ==",
-      width: 1920,
-      height: 1080,
+      width: 960,
+      height: 540,
       scaleFactor: 2,
       format: "jpg",
     }),
@@ -23,12 +23,12 @@ vi.mock("../screencapture", () => {
       image: "em9vbS1pbWFnZQ==",
       width: 400,
       height: 300,
-      scaleFactor: 1,
+      scaleFactor: 2,
       format: "jpg",
     }),
     getScreenInfo: vi.fn().mockResolvedValue({
-      width: 1920,
-      height: 1080,
+      width: 960,
+      height: 540,
       scaleFactor: 2,
     }),
   };
@@ -189,8 +189,8 @@ describe("desktop-server", () => {
       const data = await res.json();
       expect(data).toEqual({
         image: "dGVzdC1pbWFnZQ==",
-        width: 1920,
-        height: 1080,
+        width: 960,
+        height: 540,
         scaleFactor: 2,
         format: "jpg",
       });
@@ -208,8 +208,8 @@ describe("desktop-server", () => {
 
       const data = await res.json();
       expect(data).toEqual({
-        width: 1920,
-        height: 1080,
+        width: 960,
+        height: 540,
         scaleFactor: 2,
       });
       expect(getScreenInfo).toHaveBeenCalledOnce();
@@ -246,7 +246,7 @@ describe("desktop-server", () => {
         image: "em9vbS1pbWFnZQ==",
         width: 400,
         height: 300,
-        scaleFactor: 1,
+        scaleFactor: 2,
         format: "jpg",
       });
       expect(captureRegionScreenshot).toHaveBeenCalledWith({
@@ -350,7 +350,7 @@ describe("desktop-server", () => {
       const { server, port } = await setup();
       testServer = server;
 
-      // Screen is 1920x1080 with scaleFactor 2, so max is 960x540 points
+      // Screen returns logical dimensions 960x540 directly
       const res = await fetch(`http://127.0.0.1:${port}/mouse`, {
         method: "POST",
         headers: {

--- a/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
+++ b/turbo/apps/cli/src/lib/computer-use/desktop-server.ts
@@ -185,12 +185,10 @@ async function handleMouseRequest(
     }
 
     const info = await getScreenInfo();
-    const maxX = Math.floor(info.width / info.scaleFactor);
-    const maxY = Math.floor(info.height / info.scaleFactor);
-    if (x < 0 || x >= maxX || y < 0 || y >= maxY) {
+    if (x < 0 || x >= info.width || y < 0 || y >= info.height) {
       res.writeHead(400, { "Content-Type": "text/plain" });
       res.end(
-        `Coordinates out of bounds. Screen size: ${maxX}x${maxY} (points)`,
+        `Coordinates out of bounds. Screen size: ${info.width}x${info.height} (points)`,
       );
       return;
     }

--- a/turbo/apps/cli/src/lib/computer-use/screencapture.ts
+++ b/turbo/apps/cli/src/lib/computer-use/screencapture.ts
@@ -27,15 +27,28 @@ interface RegionParams {
 
 /**
  * Capture a screenshot on macOS using the screencapture command.
- * Returns the image as a base64 string along with screen metadata.
+ * Returns the image as a base64 string at logical resolution along with screen metadata.
  */
 export async function captureScreenshot(): Promise<ScreenshotResult> {
   const tmpPath = join(tmpdir(), `vm0-screenshot-${randomUUID()}.jpg`);
 
   try {
     await execFileAsync("screencapture", ["-x", "-t", "jpg", tmpPath]);
-    const buffer = await readFile(tmpPath);
     const info = await getScreenInfo();
+
+    if (info.scaleFactor > 1) {
+      await execFileAsync("sips", [
+        "-z",
+        String(info.height),
+        String(info.width),
+        "-s",
+        "formatOptions",
+        "80",
+        tmpPath,
+      ]);
+    }
+
+    const buffer = await readFile(tmpPath);
 
     return {
       image: buffer.toString("base64"),
@@ -51,7 +64,8 @@ export async function captureScreenshot(): Promise<ScreenshotResult> {
 
 /**
  * Capture a screenshot of a specific screen region on macOS.
- * Uses screencapture -R x,y,w,h to crop to the given rectangle.
+ * Uses screencapture -R x,y,w,h to crop to the given rectangle (logical coordinates).
+ * Returns the image at logical resolution to match the coordinate space.
  */
 export async function captureRegionScreenshot(
   region: RegionParams,
@@ -68,13 +82,28 @@ export async function captureRegionScreenshot(
       regionArg,
       tmpPath,
     ]);
+
+    const info = await getScreenInfo();
+
+    if (info.scaleFactor > 1) {
+      await execFileAsync("sips", [
+        "-z",
+        String(region.height),
+        String(region.width),
+        "-s",
+        "formatOptions",
+        "80",
+        tmpPath,
+      ]);
+    }
+
     const buffer = await readFile(tmpPath);
 
     return {
       image: buffer.toString("base64"),
       width: region.width,
       height: region.height,
-      scaleFactor: 1,
+      scaleFactor: info.scaleFactor,
       format: "jpg",
     };
   } finally {
@@ -93,7 +122,8 @@ interface DisplayData {
 }
 
 /**
- * Get screen resolution and scale factor on macOS using system_profiler.
+ * Get screen logical resolution and scale factor on macOS using system_profiler.
+ * Returns logical (point) dimensions that match the coordinate space used by all operations.
  */
 export async function getScreenInfo(): Promise<ScreenInfo> {
   const { stdout } = await execFileAsync("system_profiler", [
@@ -109,17 +139,35 @@ export async function getScreenInfo(): Promise<ScreenInfo> {
     for (const screen of screens) {
       const pixelStr = screen._spdisplays_pixels;
       if (pixelStr) {
-        const match = pixelStr.match(/(\d+)\s*x\s*(\d+)/);
-        if (match?.[1] && match[2]) {
-          const width = parseInt(match[1], 10);
-          const height = parseInt(match[2], 10);
+        const pixelMatch = pixelStr.match(/(\d+)\s*x\s*(\d+)/);
+        if (pixelMatch?.[1] && pixelMatch[2]) {
+          const physicalWidth = parseInt(pixelMatch[1], 10);
+          const physicalHeight = parseInt(pixelMatch[2], 10);
 
           const resStr =
             screen._spdisplays_resolution ?? screen.spdisplays_resolution ?? "";
-          const isRetina = /retina/i.test(resStr);
-          const scaleFactor = isRetina ? 2 : 1;
+          const resMatch = resStr.match(/(\d+)\s*x\s*(\d+)/);
 
-          return { width, height, scaleFactor };
+          let scaleFactor: number;
+          let logicalWidth: number;
+          let logicalHeight: number;
+
+          if (resMatch?.[1] && resMatch[2]) {
+            logicalWidth = parseInt(resMatch[1], 10);
+            logicalHeight = parseInt(resMatch[2], 10);
+            scaleFactor = Math.round(physicalWidth / logicalWidth);
+          } else {
+            const isRetina = /retina/i.test(resStr);
+            scaleFactor = isRetina ? 2 : 1;
+            logicalWidth = Math.floor(physicalWidth / scaleFactor);
+            logicalHeight = Math.floor(physicalHeight / scaleFactor);
+          }
+
+          return {
+            width: logicalWidth,
+            height: logicalHeight,
+            scaleFactor,
+          };
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fix scaleFactor detection on Retina Macs by computing from physical/logical dimension ratio instead of relying on "retina" string in `system_profiler` output
- Downscale screenshots to logical resolution using `sips` so image pixel coordinates match the operation coordinate space (1:1 mapping)
- Simplify coordinate validation in desktop-server since `getScreenInfo()` now returns logical dimensions directly

Closes #8355

## Test plan
- [x] All 44 existing desktop-server tests pass with updated mocks/assertions
- [x] Lint clean (0 warnings, 0 errors)
- [x] Type check clean
- [ ] Manual verification on Retina Mac: `zero computer-use client info` returns correct scaleFactor and logical dimensions
- [ ] Manual verification: screenshot pixel dimensions match logical coordinate space

🤖 Generated with [Claude Code](https://claude.com/claude-code)