### PR TITLE
fix(cli): key command cannot send modifier+letter combinations

### DIFF
--- a/turbo/apps/cli/src/lib/computer-use/cliclick.ts
+++ b/turbo/apps/cli/src/lib/computer-use/cliclick.ts
@@ -173,6 +173,14 @@ function parseKeyCombo(keys: string): {
 }
 
 /**
+ * Build the cliclick command to press or type a key.
+ * Special keys (return, tab, arrow-up, etc.) use `kp:`, regular characters use `t:`.
+ */
+function keyAction(key: string): string {
+  return VALID_SPECIAL_KEYS.has(key) ? `kp:${key}` : `t:${key}`;
+}
+
+/**
  * Press a key combination using cliclick.
  * Accepts combo strings like "cmd+c", "ctrl+shift+s", or single keys like "return".
  */
@@ -180,7 +188,7 @@ export async function pressKey(keys: string): Promise<void> {
   const { modifiers, mainKey } = parseKeyCombo(keys);
 
   if (modifiers.length === 0) {
-    await execFileAsync("cliclick", [`kp:${mainKey}`]);
+    await execFileAsync("cliclick", [keyAction(mainKey)]);
     return;
   }
 
@@ -188,7 +196,7 @@ export async function pressKey(keys: string): Promise<void> {
   for (const mod of modifiers) {
     args.push(`kd:${mod}`);
   }
-  args.push(`kp:${mainKey}`);
+  args.push(keyAction(mainKey));
   for (let i = modifiers.length - 1; i >= 0; i--) {
     args.push(`ku:${modifiers[i]}`);
   }


### PR DESCRIPTION
## Summary
- Fix `pressKey` in cliclick.ts to use `t:` (type) for regular character keys instead of `kp:` (key press)
- cliclick's `kp` command only supports special keys (return, tab, arrow-up, etc.), not regular letters
- Modifier+letter combos like `cmd+s` now correctly generate `kd:cmd t:s ku:cmd` instead of `kd:cmd kp:s ku:cmd`

Closes #8360

## Test plan
- [x] All 44 existing desktop-server tests pass
- [x] Lint passes
- [x] Type check passes
- [x] Knip passes
- [ ] Manual verification: `zero computer-use client key cmd+s` sends correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)