### PR TITLE
fix(platform): rename disapprove change button to deny change

### DIFF
--- a/turbo/apps/platform/src/views/firewall-allow/__tests__/firewall-allow-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/firewall-allow/__tests__/firewall-allow-page-interaction.test.tsx
@@ -244,7 +244,7 @@ describe("firewall allow page - admin request mode", () => {
     });
   });
 
-  it("fw-d-022: Disapprove change button rejects pending request", async () => {
+  it("fw-d-022: Deny change button rejects pending request", async () => {
     let requestStatus = "pending";
     server.use(
       http.put("*/api/zero/firewall-access-requests", () => {
@@ -270,11 +270,11 @@ describe("firewall allow page - admin request mode", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Disapprove change")).toBeInTheDocument();
+      expect(screen.getByText("Deny change")).toBeInTheDocument();
     });
 
     const user = userEvent.setup();
-    await user.click(screen.getByText("Disapprove change"));
+    await user.click(screen.getByText("Deny change"));
 
     await waitFor(() => {
       expect(screen.getByText("Permissions denied")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/firewall-allow/__tests__/firewall-allow-page.test.tsx
+++ b/turbo/apps/platform/src/views/firewall-allow/__tests__/firewall-allow-page.test.tsx
@@ -231,7 +231,7 @@ describe("firewall allow page", () => {
 
     expect(screen.getByText(/Need to read issues/)).toBeInTheDocument();
     expect(screen.getByText("Approve change")).toBeInTheDocument();
-    expect(screen.getByText("Disapprove change")).toBeInTheDocument();
+    expect(screen.getByText("Deny change")).toBeInTheDocument();
   });
 
   // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/firewall-allow/firewall-allow-page.tsx
+++ b/turbo/apps/platform/src/views/firewall-allow/firewall-allow-page.tsx
@@ -355,7 +355,7 @@ function AdminApprovalCard({
             disabled={resolving}
           >
             <IconX size={16} />
-            Disapprove change
+            Deny change
           </Button>
           <Button
             variant="outline"


### PR DESCRIPTION
## Summary

- Rename "Disapprove change" button to "Deny change" on the firewall allow page
- Update corresponding test assertions

## Test plan

- [x] Updated test text in `firewall-allow-page.test.tsx` and `firewall-allow-page-interaction.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)