### PR TITLE
refactor: move cancel-run from infra to zero layer

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/cancel/route.ts
@@ -9,10 +9,8 @@ import { isSandboxAuth } from "../../../../../../src/lib/auth/capability-check";
 import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { eq, and } from "drizzle-orm";
-import {
-  cancelRun,
-  dispatchCancelSideEffects,
-} from "../../../../../../src/lib/infra/run/run-service";
+import { cancelRun } from "../../../../../../src/lib/zero/zero-run-cancel";
+import { dispatchCancelSideEffects } from "../../../../../../src/lib/infra/run/run-service";
 import {
   dispatchQueuedZeroRun,
   drainOrgQueue,

--- a/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/cancel/route.ts
@@ -10,10 +10,8 @@ import {
   isAuthError,
 } from "../../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
-import {
-  cancelRun,
-  dispatchCancelSideEffects,
-} from "../../../../../../src/lib/infra/run/run-service";
+import { cancelRun } from "../../../../../../src/lib/zero/zero-run-cancel";
+import { dispatchCancelSideEffects } from "../../../../../../src/lib/infra/run/run-service";
 import {
   dispatchQueuedZeroRun,
   drainOrgQueue,

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -40,8 +40,8 @@ import {
   type FirewallPolicies,
   type ConnectorType,
 } from "@vm0/core";
-import { agentRunQueue } from "../../../db/schema/agent-run-queue";
 import { publishCancelNotification } from "../realtime/client";
+import type { CancelRunResult } from "../../zero/zero-run-cancel";
 
 const log = logger("service:run");
 
@@ -1072,77 +1072,6 @@ export async function getRunById(
     createdAt: run.createdAt.toISOString(),
     startedAt: run.startedAt?.toISOString(),
     completedAt: run.completedAt?.toISOString(),
-  };
-}
-
-/**
- * Result of a successful run cancellation, used to dispatch side effects.
- */
-interface CancelRunResult {
-  runId: string;
-  previousStatus: string;
-  orgId: string;
-  sandboxId: string | null;
-  runnerGroup: string | null;
-}
-
-/**
- * Cancel a run. Atomically deletes queue entry and transitions status.
- * Throws NotFound if run doesn't exist, BadRequest if run can't be cancelled.
- */
-export async function cancelRun(
-  runId: string,
-  userId: string,
-  orgId: string,
-): Promise<CancelRunResult> {
-  const db = globalThis.services.db;
-
-  const [run] = await db
-    .select()
-    .from(agentRuns)
-    .where(
-      and(
-        eq(agentRuns.id, runId),
-        eq(agentRuns.userId, userId),
-        eq(agentRuns.orgId, orgId),
-      ),
-    )
-    .limit(1);
-
-  if (!run) {
-    throw notFound(`No such run: '${runId}'`);
-  }
-
-  if (
-    run.status !== "queued" &&
-    run.status !== "pending" &&
-    run.status !== "running"
-  ) {
-    throw badRequest(
-      `Run cannot be cancelled: current status is '${run.status}'`,
-    );
-  }
-
-  const cancelled = await db.transaction(async (tx) => {
-    await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, runId));
-    return transitionRunStatus(
-      runId,
-      { status: "cancelled", completedAt: new Date() },
-      ["queued", "pending", "running"],
-      tx,
-    );
-  });
-
-  if (!cancelled) {
-    throw badRequest(`Run cannot be cancelled: status has already changed`);
-  }
-
-  return {
-    runId,
-    previousStatus: run.status,
-    orgId: run.orgId,
-    sandboxId: run.sandboxId,
-    runnerGroup: run.runnerGroup,
   };
 }
 

--- a/turbo/apps/web/src/lib/zero/zero-run-cancel.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-cancel.ts
@@ -1,0 +1,76 @@
+import { eq, and } from "drizzle-orm";
+import { agentRuns } from "../../db/schema/agent-run";
+import { agentRunQueue } from "../../db/schema/agent-run-queue";
+import { transitionRunStatus } from "../infra/run/run-status";
+import { notFound, badRequest } from "../shared/errors";
+
+/**
+ * Result of a successful run cancellation, used to dispatch side effects.
+ */
+export interface CancelRunResult {
+  runId: string;
+  previousStatus: string;
+  orgId: string;
+  sandboxId: string | null;
+  runnerGroup: string | null;
+}
+
+/**
+ * Cancel a run. Atomically deletes queue entry and transitions status.
+ * Throws NotFound if run doesn't exist, BadRequest if run can't be cancelled.
+ */
+export async function cancelRun(
+  runId: string,
+  userId: string,
+  orgId: string,
+): Promise<CancelRunResult> {
+  const db = globalThis.services.db;
+
+  const [run] = await db
+    .select()
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.id, runId),
+        eq(agentRuns.userId, userId),
+        eq(agentRuns.orgId, orgId),
+      ),
+    )
+    .limit(1);
+
+  if (!run) {
+    throw notFound(`No such run: '${runId}'`);
+  }
+
+  if (
+    run.status !== "queued" &&
+    run.status !== "pending" &&
+    run.status !== "running"
+  ) {
+    throw badRequest(
+      `Run cannot be cancelled: current status is '${run.status}'`,
+    );
+  }
+
+  const cancelled = await db.transaction(async (tx) => {
+    await tx.delete(agentRunQueue).where(eq(agentRunQueue.runId, runId));
+    return transitionRunStatus(
+      runId,
+      { status: "cancelled", completedAt: new Date() },
+      ["queued", "pending", "running"],
+      tx,
+    );
+  });
+
+  if (!cancelled) {
+    throw badRequest(`Run cannot be cancelled: status has already changed`);
+  }
+
+  return {
+    runId,
+    previousStatus: run.status,
+    orgId: run.orgId,
+    sandboxId: run.sandboxId,
+    runnerGroup: run.runnerGroup,
+  };
+}


### PR DESCRIPTION
## Summary

- Move `cancelRun()` and `CancelRunResult` from `infra/run/run-service.ts` to new `zero/zero-run-cancel.ts`
- Update both cancel API routes (`/agent/runs/[id]/cancel`, `/zero/runs/[id]/cancel`) to import `cancelRun` from zero layer
- Keep `dispatchCancelSideEffects` in infra (Ably notification + terminal callbacks are execution concerns)

Pure code relocation — no behavioral changes. Part of Epic #8311 (refactor zero/infra layering).

Closes #8365

## Test plan

- [x] Type-check passes (`pnpm check-types` for web workspace)
- [x] Lint passes (0 warnings, 0 errors)
- [x] Knip passes (no unused exports/files)
- [x] Format passes (no changes needed)
- [ ] CI pipeline passes
- [ ] Existing cancel route tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)