### PR TITLE
refactor: extract concurrency control and business policy from infra to zero

### DIFF
--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -1,4 +1,4 @@
-import { eq, and, count, gt, or, sql } from "drizzle-orm";
+import { eq, and, or, sql } from "drizzle-orm";
 import { env } from "../../../env";
 import { checkpoints } from "../../../db/schema/checkpoint";
 import { agentRuns } from "../../../db/schema/agent-run";
@@ -8,16 +8,9 @@ import {
   agentComposes,
 } from "../../../db/schema/agent-compose";
 import { agentRunCallbacks } from "../../../db/schema/agent-run-callback";
-import {
-  notFound,
-  unauthorized,
-  badRequest,
-  forbidden,
-  concurrentRunLimit,
-} from "../../shared/errors";
+import { notFound, unauthorized, badRequest } from "../../shared/errors";
 
 import { logger } from "../../shared/logger";
-import type { Database } from "../../../types/global";
 import type { AgentComposeSnapshot } from "../checkpoint/types";
 import type { AgentComposeYaml } from "../agent-compose/types";
 import { getAgentSessionWithConversation } from "../agent-session";
@@ -29,7 +22,6 @@ import type { ExecutionContext, DispatchTimings, ResumeSession } from "./types";
 import type { ArtifactSnapshot } from "../checkpoint/types";
 import { buildInfraExecutionContext } from "./context/build-context";
 import { recordSandboxOperation } from "../metrics";
-import { canAccessCompose } from "../agent/compose-access";
 
 import { encryptSecretValue } from "../../shared/crypto/secrets-encryption";
 import {
@@ -43,88 +35,13 @@ import {
 import { agentRunQueue } from "../../../db/schema/agent-run-queue";
 import { publishCancelNotification } from "../realtime/client";
 
+import {
+  checkRunConcurrencyLimit,
+  authorizeCompose,
+  validateComposeRequirements,
+} from "../../zero/zero-run-policy";
+
 const log = logger("service:run");
-
-// Defense-in-depth: exclude pending runs older than this from concurrency check.
-// The cleanup-sandboxes cron job already transitions pending runs to "timeout" after 5 minutes,
-// so this TTL only matters if the cron job fails to run.
-export const PENDING_RUN_TTL_MS = 15 * 60 * 1000; // 15 minutes
-
-/** Concurrent run limits by org tier */
-const TIER_CONCURRENCY_LIMITS: Record<OrgTier, number> = {
-  free: 1,
-  pro: 2,
-  team: 5,
-};
-
-function getConcurrencyLimitForTier(tier: OrgTier): number {
-  return TIER_CONCURRENCY_LIMITS[tier];
-}
-
-/**
- * Get the effective concurrency limit for an org tier.
- * Tier-based limit is the baseline; env var acts as a global cap.
- * Returns 0 for unlimited.
- */
-export function getEffectiveConcurrencyLimit(orgTier: OrgTier): number {
-  const tierLimit = getConcurrencyLimitForTier(orgTier);
-  const envCap = env().CONCURRENT_RUN_LIMIT_CAP;
-  if (envCap === 0) return 0;
-  if (envCap !== undefined && !isNaN(envCap))
-    return Math.min(tierLimit, envCap);
-  return tierLimit;
-}
-
-/**
- * Check if org has reached concurrent run limit
- *
- * @param orgId Clerk org ID to check
- * @param orgTier Org tier for tier-based limit (default: "free")
- * @param db Optional database instance (for use within transactions)
- * @throws ConcurrentRunLimitError if limit exceeded
- */
-export async function checkRunConcurrencyLimit(
-  orgId: string,
-  orgTier: OrgTier = "free",
-  db?: Database,
-): Promise<void> {
-  const effectiveLimit = getEffectiveConcurrencyLimit(orgTier);
-
-  // Skip check if limit is 0 (no limit)
-  if (effectiveLimit === 0) {
-    return;
-  }
-
-  const queryDb = db ?? globalThis.services.db;
-
-  // Count active runs: all "running" runs + "pending" runs within TTL
-  const staleThreshold = new Date(Date.now() - PENDING_RUN_TTL_MS);
-
-  const [result] = await queryDb
-    .select({ count: count() })
-    .from(agentRuns)
-    .where(
-      and(
-        eq(agentRuns.orgId, orgId),
-        or(
-          eq(agentRuns.status, "running"),
-          and(
-            eq(agentRuns.status, "pending"),
-            gt(agentRuns.createdAt, staleThreshold),
-          ),
-        ),
-      ),
-    );
-
-  const activeRunCount = Number(result?.count ?? 0);
-
-  if (activeRunCount >= effectiveLimit) {
-    log.debug(
-      `Org ${orgId} has ${activeRunCount} active runs, limit is ${effectiveLimit}`,
-    );
-    throw concurrentRunLimit();
-  }
-}
 
 /**
  * Validate a checkpoint for resume operation
@@ -476,30 +393,6 @@ export async function loadCompose(
       orgId: result.agentClerkOrgId,
     },
   };
-}
-
-export function authorizeCompose(
-  userId: string,
-  orgId: string,
-  compose: { id: string; userId: string; orgId: string },
-): void {
-  const hasAccess = canAccessCompose(userId, orgId, compose);
-  if (!hasAccess) {
-    throw forbidden("You do not have permission to access this agent");
-  }
-}
-
-/**
- * Validate image access for new runs.
- *
- * Skipped when resuming from checkpoint or continuing a session.
- */
-export async function validateComposeRequirements(
-  composeContent: AgentComposeYaml,
-): Promise<void> {
-  if (!composeContent?.agents) {
-    return;
-  }
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-policy.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-policy.ts
@@ -1,0 +1,117 @@
+import { eq, and, count, gt, or } from "drizzle-orm";
+import { env } from "../../env";
+import { agentRuns } from "../../db/schema/agent-run";
+import { concurrentRunLimit } from "../shared/errors";
+import { canAccessCompose } from "../infra/agent/compose-access";
+import { forbidden } from "../shared/errors";
+import { logger } from "../shared/logger";
+import type { Database } from "../../types/global";
+import type { OrgTier } from "@vm0/core";
+import type { AgentComposeYaml } from "../infra/agent-compose/types";
+
+const log = logger("zero:run-policy");
+
+// Defense-in-depth: exclude pending runs older than this from concurrency check.
+// The cleanup-sandboxes cron job already transitions pending runs to "timeout" after 5 minutes,
+// so this TTL only matters if the cron job fails to run.
+export const PENDING_RUN_TTL_MS = 15 * 60 * 1000; // 15 minutes
+
+/** Concurrent run limits by org tier */
+const TIER_CONCURRENCY_LIMITS: Record<OrgTier, number> = {
+  free: 1,
+  pro: 2,
+  team: 5,
+};
+
+function getConcurrencyLimitForTier(tier: OrgTier): number {
+  return TIER_CONCURRENCY_LIMITS[tier];
+}
+
+/**
+ * Get the effective concurrency limit for an org tier.
+ * Tier-based limit is the baseline; env var acts as a global cap.
+ * Returns 0 for unlimited.
+ */
+export function getEffectiveConcurrencyLimit(orgTier: OrgTier): number {
+  const tierLimit = getConcurrencyLimitForTier(orgTier);
+  const envCap = env().CONCURRENT_RUN_LIMIT_CAP;
+  if (envCap === 0) return 0;
+  if (envCap !== undefined && !isNaN(envCap))
+    return Math.min(tierLimit, envCap);
+  return tierLimit;
+}
+
+/**
+ * Check if org has reached concurrent run limit
+ *
+ * @param orgId Clerk org ID to check
+ * @param orgTier Org tier for tier-based limit (default: "free")
+ * @param db Optional database instance (for use within transactions)
+ * @throws ConcurrentRunLimitError if limit exceeded
+ */
+export async function checkRunConcurrencyLimit(
+  orgId: string,
+  orgTier: OrgTier = "free",
+  db?: Database,
+): Promise<void> {
+  const effectiveLimit = getEffectiveConcurrencyLimit(orgTier);
+
+  // Skip check if limit is 0 (no limit)
+  if (effectiveLimit === 0) {
+    return;
+  }
+
+  const queryDb = db ?? globalThis.services.db;
+
+  // Count active runs: all "running" runs + "pending" runs within TTL
+  const staleThreshold = new Date(Date.now() - PENDING_RUN_TTL_MS);
+
+  const [result] = await queryDb
+    .select({ count: count() })
+    .from(agentRuns)
+    .where(
+      and(
+        eq(agentRuns.orgId, orgId),
+        or(
+          eq(agentRuns.status, "running"),
+          and(
+            eq(agentRuns.status, "pending"),
+            gt(agentRuns.createdAt, staleThreshold),
+          ),
+        ),
+      ),
+    );
+
+  const activeRunCount = Number(result?.count ?? 0);
+
+  if (activeRunCount >= effectiveLimit) {
+    log.debug(
+      `Org ${orgId} has ${activeRunCount} active runs, limit is ${effectiveLimit}`,
+    );
+    throw concurrentRunLimit();
+  }
+}
+
+export function authorizeCompose(
+  userId: string,
+  orgId: string,
+  compose: { id: string; userId: string; orgId: string },
+): void {
+  const hasAccess = canAccessCompose(userId, orgId, compose);
+  if (!hasAccess) {
+    throw forbidden("You do not have permission to access this agent");
+  }
+}
+
+/**
+ * Validate image access for new runs.
+ *
+ * Skipped when resuming from checkpoint or continuing a session.
+ */
+export async function validateComposeRequirements(
+  composeContent: AgentComposeYaml,
+): Promise<void> {
+  if (!composeContent?.agents) {
+    return;
+  }
+}

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -28,10 +28,12 @@ import {
   PENDING_RUN_TTL_MS,
   getEffectiveConcurrencyLimit,
   checkRunConcurrencyLimit,
-  buildAndDispatchRun,
-  loadCompose,
   authorizeCompose,
   validateComposeRequirements,
+} from "./zero-run-policy";
+import {
+  buildAndDispatchRun,
+  loadCompose,
   registerCallbacks,
   markRunFailed,
 } from "../infra/run/run-service";


### PR DESCRIPTION
## Summary

- Move business policy functions (`checkRunConcurrencyLimit`, `getEffectiveConcurrencyLimit`, `PENDING_RUN_TTL_MS`, `authorizeCompose`, `validateComposeRequirements`) from `infra/run/run-service.ts` to new `zero/zero-run-policy.ts`
- Update `zero-run-queue-service.ts` to import business functions from `zero-run-policy` instead of infra
- `run-service.ts` imports from `zero-run-policy` internally for `createRunRecord()` and `startRun()`

Pure code relocation with no behavioral changes — foundational step for the transaction restructure (#8311).

Closes #8363

## Test plan

- [x] `pnpm check-types` passes (all 7 workspaces)
- [x] `pnpm turbo run lint` passes (all 6 workspaces, 0 warnings)
- [x] `pnpm knip` reports no unused exports
- [x] `grep -r "from.*infra/run.*checkRunConcurrencyLimit" turbo/apps/web/src/lib/zero/` returns zero results
- [x] `grep -r "checkRunConcurrencyLimit" turbo/apps/web/src/lib/zero/zero-run-policy.ts` confirms function exists in zero layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)