### PR TITLE
fix: align skeleton avatar with text placeholder in chat thread

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -387,7 +387,7 @@ function ChatSkeleton() {
       </div>
       {/* Assistant bubble skeleton */}
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
-        <Skeleton className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 rounded-xl" />
+        <Skeleton className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 shrink-0 @[900px]:mt-0.5 rounded-xl" />
         <div className="flex flex-col gap-2">
           <Skeleton className="h-4 w-[90%] rounded-lg" />
           <Skeleton className="h-4 w-[75%] rounded-lg" />
@@ -400,7 +400,7 @@ function ChatSkeleton() {
       </div>
       {/* Assistant bubble skeleton */}
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
-        <Skeleton className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 rounded-xl" />
+        <Skeleton className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 shrink-0 @[900px]:mt-0.5 rounded-xl" />
         <div className="flex flex-col gap-2">
           <Skeleton className="h-4 w-[85%] rounded-lg" />
           <Skeleton className="h-4 w-[60%] rounded-lg" />


### PR DESCRIPTION
## Summary

- Adds `shrink-0` and `@[900px]:mt-0.5` classes to skeleton avatar elements in `ChatSkeleton` to match the real avatar's styling
- Fixes vertical misalignment between skeleton text placeholder and avatar during loading state

Closes #7520

## Test plan

- [ ] Trigger chat loading skeleton state and verify avatar + text placeholders are vertically aligned
- [ ] Check alignment at both narrow (<900px) and wide (≥900px) viewport widths
- [ ] Confirm no visual shift when skeleton is replaced by real content

🤖 Generated with [Claude Code](https://claude.com/claude-code)