### PR TITLE
refactor: restructure run record creation — zero owns transaction

### DIFF
--- a/turbo/apps/web/src/lib/infra/run/index.ts
+++ b/turbo/apps/web/src/lib/infra/run/index.ts
@@ -5,7 +5,7 @@
 
 export {
   startRun,
-  createRunRecord,
+  insertRunRecord,
   buildAndDispatchRun,
   loadCompose,
   markRunFailed,

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -10,6 +10,7 @@ import { agentRunCallbacks } from "../../../db/schema/agent-run-callback";
 import { notFound, badRequest } from "../../shared/errors";
 
 import { logger } from "../../shared/logger";
+import type { Database } from "../../../types/global";
 import type { AgentComposeYaml } from "../agent-compose/types";
 import { prepareForExecution } from "./context/execution-preparer";
 import { executeRunnerJob } from "./executors/runner-executor";
@@ -579,6 +580,55 @@ export interface CreateRunRecordResult {
 }
 
 /**
+ * Parameters for the pure INSERT into agent_runs.
+ * Subset of CreateRunParams — only the fields needed for the INSERT.
+ */
+interface InsertRunParams {
+  userId: string;
+  orgId: string;
+  agentComposeVersionId: string;
+  prompt: string;
+  appendSystemPrompt?: string;
+  vars?: Record<string, string>;
+  secrets?: Record<string, string>;
+  resumedFromCheckpointId?: string;
+  sessionId?: string;
+}
+
+/**
+ * Pure INSERT into agent_runs within an existing transaction.
+ * No business logic — caller is responsible for authorization,
+ * validation, and concurrency checks.
+ */
+export async function insertRunRecord(
+  tx: Database,
+  params: InsertRunParams,
+): Promise<{ id: string; createdAt: Date }> {
+  const [newRun] = await tx
+    .insert(agentRuns)
+    .values({
+      userId: params.userId,
+      orgId: params.orgId,
+      agentComposeVersionId: params.agentComposeVersionId,
+      status: "pending",
+      prompt: params.prompt,
+      appendSystemPrompt: params.appendSystemPrompt ?? null,
+      vars: params.vars ?? null,
+      secretNames: params.secrets ? Object.keys(params.secrets) : null,
+      resumedFromCheckpointId: params.resumedFromCheckpointId ?? null,
+      continuedFromSessionId: params.sessionId ?? null,
+      lastHeartbeatAt: new Date(),
+    })
+    .returning();
+
+  if (!newRun) {
+    throw new Error("Failed to create run record");
+  }
+
+  return newRun;
+}
+
+/**
  * Create a run record without dispatching.
  *
  * Handles steps 1-5 of the run creation pipeline:
@@ -592,22 +642,23 @@ export interface CreateRunRecordResult {
  * Does NOT handle the enqueueRun() fallback — callers decide how to handle
  * ConcurrentRunLimitError.
  *
+ * Used by startRun() for the legacy CLI path.
+ *
  * @throws ForbiddenError - user cannot access compose
  * @throws BadRequestError - validation failure (missing vars, mutual exclusivity)
  * @throws NotFoundError - compose version not found
  * @throws ConcurrentRunLimitError - org has reached concurrent run limit
  */
-export async function createRunRecord(
+async function createRunRecord(
   params: CreateRunParams,
 ): Promise<CreateRunRecordResult> {
   const apiStartTime = Date.now();
-  const { userId, agentComposeVersionId, prompt } = params;
 
   // Steps 1-2: Load compose and authorize
   const { composeContent, compose } =
     params.preloadedCompose ??
-    (await loadCompose(agentComposeVersionId, params.composeId));
-  authorizeCompose(userId, params.orgId, compose);
+    (await loadCompose(params.agentComposeVersionId, params.composeId));
+  authorizeCompose(params.userId, params.orgId, compose);
   const authorizeTime = Date.now();
 
   // Step 3: Validate template vars and image access (for new runs only)
@@ -622,46 +673,17 @@ export async function createRunRecord(
     );
   }
 
-  // Org context for the run record and storage (required from caller)
   const orgId = params.orgId;
 
   // Step 5: Concurrency check + INSERT in a transaction with advisory lock
-  // to prevent TOCTOU race where two concurrent requests both pass the
-  // concurrency check before either inserts.
   const run = await globalThis.services.db.transaction(async (tx) => {
-    // Acquire per-org advisory lock (released when transaction ends)
     await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
-
-    // Check concurrent run limit within the serialized transaction
     await checkRunConcurrencyLimit(orgId, params.orgTier ?? "free", tx);
-
-    // INSERT within the same transaction
-    const [newRun] = await tx
-      .insert(agentRuns)
-      .values({
-        userId,
-        orgId,
-        agentComposeVersionId,
-        status: "pending",
-        prompt,
-        appendSystemPrompt: params.appendSystemPrompt ?? null,
-        vars: params.vars ?? null,
-        secretNames: params.secrets ? Object.keys(params.secrets) : null,
-        resumedFromCheckpointId: params.resumedFromCheckpointId ?? null,
-        continuedFromSessionId: params.sessionId ?? null,
-        lastHeartbeatAt: new Date(),
-      })
-      .returning();
-
-    if (!newRun) {
-      throw new Error("Failed to create run record");
-    }
-
-    return newRun;
+    return insertRunRecord(tx, params);
   });
 
   const transactionTime = Date.now();
-  log.debug(`Created run ${run.id} for user ${userId}`);
+  log.debug(`Created run ${run.id} for user ${params.userId}`);
 
   return {
     run: { id: run.id, createdAt: run.createdAt },

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -1,4 +1,4 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import {
   resolveFirewallPolicies,
   orgTierSchema,
@@ -9,7 +9,7 @@ import {
   connectorTypeSchema,
 } from "@vm0/core";
 import {
-  createRunRecord,
+  insertRunRecord,
   buildAndDispatchRun,
   loadCompose,
   markRunFailed,
@@ -19,6 +19,11 @@ import {
   type CreateRunRecordResult,
 } from "../infra/run";
 import { resolveStartRunCompose } from "./zero-run-validation";
+import {
+  checkRunConcurrencyLimit,
+  authorizeCompose,
+  validateComposeRequirements,
+} from "./zero-run-policy";
 import {
   enqueueRun,
   drainOrgQueue,
@@ -328,11 +333,19 @@ export async function createZeroRunRecord(
     orgTier,
   };
 
-  // 3. Pre-flight checks: credits + model provider (before createRunRecord)
+  // 3. Pre-flight checks: load compose, authorize, validate, credits, model provider
+  const apiStartTime = Date.now();
   const preloadedCompose = await loadCompose(
     resolved.agentComposeVersionId,
     resolved.composeId,
   );
+  authorizeCompose(params.userId, resolved.orgId, preloadedCompose.compose);
+  const authorizeTime = Date.now();
+
+  if (!params.sessionId) {
+    await validateComposeRequirements(preloadedCompose.composeContent);
+  }
+
   await Promise.all([
     checkOrgCredits(resolved.orgId, params.userId, params.modelProvider),
     checkModelProviderConfigured(
@@ -342,10 +355,16 @@ export async function createZeroRunRecord(
     ),
   ]);
 
-  // 4. Create run record (may throw ConcurrentRunLimitError)
-  let record;
+  // 4. Advisory lock + concurrency check + INSERT (zero owns the transaction)
+  let run;
   try {
-    record = await createRunRecord({ ...runParams, preloadedCompose });
+    run = await globalThis.services.db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext(${resolved.orgId}))`,
+      );
+      await checkRunConcurrencyLimit(resolved.orgId, orgTier, tx);
+      return insertRunRecord(tx, runParams);
+    });
   } catch (error) {
     if (isConcurrentRunLimit(error)) {
       // Enqueue without token — dispatchQueuedZeroRun generates a fresh
@@ -364,10 +383,21 @@ export async function createZeroRunRecord(
     throw error;
   }
 
+  const transactionTime = Date.now();
+
+  const record: CreateRunRecordResult = {
+    run: { id: run.id, createdAt: run.createdAt },
+    composeContent: preloadedCompose.composeContent,
+    orgId: resolved.orgId,
+    apiStartTime,
+    authorizeTime,
+    transactionTime,
+  };
+
   return {
-    runId: record.run.id,
+    runId: run.id,
     status: "pending",
-    createdAt: record.run.createdAt,
+    createdAt: run.createdAt,
     record,
     runParams,
     orgId: resolved.orgId,


### PR DESCRIPTION
## Summary

- Extract `insertRunRecord(tx, params)` as a pure INSERT function in infra — no business logic, accepts a transaction
- Restructure `createZeroRunRecord()` to own the full transaction: advisory lock → concurrency check → `insertRunRecord()`
- `createRunRecord()` becomes an internal function used only by the legacy `startRun()` CLI path
- Zero layer now fully owns all business policy decisions (authorize, validate, concurrency) for run creation

This is the core architectural change from Epic #8311 that makes infra a pure execution layer.

Closes #8366

## Test plan

- [x] `pnpm check-types` passes (all 7 workspaces)
- [x] `pnpm turbo run lint` passes (0 warnings)
- [x] `pnpm knip` clean — no unused exports
- [x] `grep advisory_xact_lock zero-run-service.ts` confirms zero owns the advisory lock
- [x] `grep checkRunConcurrencyLimit infra/run/run-service.ts` only in internal `createRunRecord()` wrapper
- [x] All pre-commit hooks pass (prettier, knip, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)