### PR TITLE
feat: gate capture-network-bodies to internal accounts in production

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -1394,4 +1394,80 @@ describe("GET /api/agent/runs - List Runs", () => {
     });
     expect(prompts).toContain("Target org run");
   });
+
+  describe("captureNetworkBodies gate", () => {
+    it("should reject non-vm0.ai accounts in production", async () => {
+      // Use a fresh user so user_cache is empty for this email
+      const freshUser = await context.setupUser({ prefix: "capture-ext" });
+      mockClerk({ userId: freshUser.userId, email: "external@gmail.com" });
+      const { composeId } = await createTestCompose(uniqueId("cap-agent"));
+
+      vi.stubEnv("VERCEL_ENV", "production");
+      reloadEnv();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentComposeId: composeId,
+            prompt: "Test capture",
+            captureNetworkBodies: true,
+          }),
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(403);
+    });
+
+    it("should allow vm0.ai accounts in production", async () => {
+      const freshUser = await context.setupUser({ prefix: "capture-int" });
+      mockClerk({ userId: freshUser.userId, email: "team@vm0.ai" });
+      const { composeId } = await createTestCompose(uniqueId("cap-agent"));
+
+      vi.stubEnv("VERCEL_ENV", "production");
+      reloadEnv();
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentComposeId: composeId,
+            prompt: "Test capture",
+            captureNetworkBodies: true,
+          }),
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+    });
+
+    it("should allow any account in non-production", async () => {
+      // Default VERCEL_ENV is not "production" in test env
+      const freshUser = await context.setupUser({ prefix: "capture-dev" });
+      mockClerk({ userId: freshUser.userId, email: "external@gmail.com" });
+      const { composeId } = await createTestCompose(uniqueId("cap-agent"));
+
+      const request = createTestRequest(
+        "http://localhost:3000/api/agent/runs",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentComposeId: composeId,
+            prompt: "Test capture",
+            captureNetworkBodies: true,
+          }),
+        },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+    });
+  });
 });

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -7,7 +7,8 @@ import {
   agentComposes,
 } from "../../../db/schema/agent-compose";
 import { agentRunCallbacks } from "../../../db/schema/agent-run-callback";
-import { notFound, badRequest } from "../../shared/errors";
+import { notFound, badRequest, forbidden } from "../../shared/errors";
+import { getCachedUser } from "../../auth/user-cache-service";
 
 import { logger } from "../../shared/logger";
 import type { AgentComposeYaml } from "../agent-compose/types";
@@ -455,6 +456,16 @@ export async function buildAndDispatchRun(opts: {
 export async function startRun(
   params: StartRunParams,
 ): Promise<CreateRunResult> {
+  // 0. Gate captureNetworkBodies to @vm0.ai accounts in production
+  if (params.captureNetworkBodies && env().VERCEL_ENV === "production") {
+    const { email } = await getCachedUser(params.userId);
+    if (!email.endsWith("@vm0.ai")) {
+      throw forbidden(
+        "captureNetworkBodies is restricted to internal accounts",
+      );
+    }
+  }
+
   // 1. Resolve compose version
   const resolved = await resolveStartRunCompose(params);
 


### PR DESCRIPTION
## Summary

- Restricts `captureNetworkBodies` to `@vm0.ai` email accounts in production (`VERCEL_ENV=production`)
- Check is in `startRun()` (run-service), covers all run creation paths (CLI, API, zero)
- Non-production environments (dev, preview, local) are unrestricted, so e2e tests are unaffected

## Test plan

- [ ] Verify non-vm0.ai account gets 403 when using `--capture-network-bodies` in production
- [ ] Verify vm0.ai account can use the feature in production
- [ ] Verify any account can use the feature in non-production environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)