### PR TITLE
feat: add insights dashboard with cron pre-aggregation pipeline

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -37,6 +37,7 @@ import { setupSignInTokenPage$ } from "./sign-in-token-setup.ts";
 import { setupFirewallAllowPage$ } from "./firewall-allow/firewall-allow-page-setup.ts";
 import { setupChatListPage$ } from "./zero-page/chat-list-page-setup.ts";
 import { setupLabPage$ } from "./lab-page/lab-page-setup.ts";
+import { setupNetworkInsightsPage$ } from "./network-insights/network-insights-page-setup.ts";
 
 /**
  * Catch-all fallback — redirects unknown paths to /.
@@ -80,6 +81,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.chatList,
     setup: setupAuthPageWrapper(setupChatListPage$),
+  },
+  {
+    path: ROUTES.insights,
+    setup: setupAuthPageWrapper(setupNetworkInsightsPage$),
   },
   {
     path: ROUTES.chat,

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-page-setup.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-page-setup.ts
@@ -1,0 +1,29 @@
+import { command } from "ccstate";
+import { createElement } from "react";
+import { SidebarLayout } from "../../views/zero-page/sidebar-layout.tsx";
+import { NetworkInsightsPage } from "../../views/network-insights/network-insights-page.tsx";
+import { updateDocumentTitle$ } from "../document-title.ts";
+import { updatePage$ } from "../react-router.ts";
+import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
+import { initZeroOnboarding$ } from "../zero-page/zero-onboarding.ts";
+import { reloadChatThreads$ } from "../zero-page/zero-chat.ts";
+import { hideAppSkeleton$ } from "../app-skeleton.ts";
+
+export const setupNetworkInsightsPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(
+      updatePage$,
+      createElement(SidebarLayout, null, createElement(NetworkInsightsPage)),
+    );
+    set(updateDocumentTitle$, "Insights");
+    await set(initZeroOnboarding$, signal);
+    signal.throwIfAborted();
+    await set(hideAppSkeleton$, signal);
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+
+    set(reloadChatThreads$);
+  },
+);

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -1,0 +1,134 @@
+import { command, computed, state } from "ccstate";
+import { zeroInsightsContract } from "@vm0/core";
+import { zeroClient$ } from "../api-client.ts";
+
+// ---------------------------------------------------------------------------
+// Data model
+// ---------------------------------------------------------------------------
+
+export interface AgentUsage {
+  agentName: string;
+  agentId: string | null;
+  runs: number;
+  credits: number;
+}
+
+export interface ServiceUsage {
+  name: string;
+  domain: string;
+  calls: number;
+  /** Which agents used this service */
+  agentNames: string[];
+}
+
+export interface PermissionEntry {
+  label: string;
+  allowed: number;
+  denied: number;
+  /** Which agents triggered this permission */
+  agentNames: string[];
+}
+
+export interface TopTask {
+  name: string;
+  count: number;
+}
+
+export interface MemberCredits {
+  name: string;
+  credits: number;
+  agentNames: string[];
+  agentCredits?: Record<string, number>;
+}
+
+/** A single day's insight snapshot */
+export interface DayInsight {
+  date: string; // ISO date, e.g. "2026-04-03"
+  agents: AgentUsage[];
+  creditsUsed: number;
+  creditBalance: number;
+  teamUsage: MemberCredits[];
+  topTask: TopTask | null;
+  services: ServiceUsage[];
+  permissions: PermissionEntry[];
+}
+
+export interface NetworkInsightsData {
+  days: DayInsight[];
+  totalCredits: number;
+  totalRuns: number;
+}
+
+// ---------------------------------------------------------------------------
+// UI state signals
+// ---------------------------------------------------------------------------
+
+/** Page-level date range filter */
+const internalDateRange$ = state<string>("last7");
+
+export const insightsDateRange$ = computed((get) => {
+  return get(internalDateRange$);
+});
+
+export const setInsightsDateRange$ = command(({ set }, range: string) => {
+  set(internalDateRange$, range);
+});
+
+/** Calendar popover state */
+const internalCalendarOpen$ = state(false);
+
+export const insightsCalendarOpen$ = computed((get) => {
+  return get(internalCalendarOpen$);
+});
+
+export const setInsightsCalendarOpen$ = command(({ set }, open: boolean) => {
+  set(internalCalendarOpen$, open);
+});
+
+const internalCalendarYear$ = state(new Date().getFullYear());
+const internalCalendarMonth$ = state(new Date().getMonth());
+
+export const insightsCalendarYear$ = computed((get) => {
+  return get(internalCalendarYear$);
+});
+
+export const insightsCalendarMonth$ = computed((get) => {
+  return get(internalCalendarMonth$);
+});
+
+export const setInsightsCalendarYear$ = command(({ set }, year: number) => {
+  set(internalCalendarYear$, year);
+});
+
+export const setInsightsCalendarMonth$ = command(({ set }, month: number) => {
+  set(internalCalendarMonth$, month);
+});
+
+/** Hovered agent name in the insights page (for highlighting). */
+const internalHoveredAgent$ = state<string | null>(null);
+
+export const insightsHoveredAgent$ = computed((get) => {
+  return get(internalHoveredAgent$);
+});
+
+export const setInsightsHoveredAgent$ = command(
+  ({ set }, agent: string | null) => {
+    set(internalHoveredAgent$, agent);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+
+/** Always fetch 30 days; display filtering is handled by the UI. */
+export const networkInsightsData$ = computed(
+  async (get): Promise<NetworkInsightsData> => {
+    const client = get(zeroClient$)(zeroInsightsContract);
+    const result = await client.get({ query: { days: 30 } });
+    if (result.status !== 200) {
+      throw new Error(`Failed to fetch insights: ${result.status}`);
+    }
+    return result.body as NetworkInsightsData;
+  },
+);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -25,6 +25,7 @@ export const ROUTES = {
   onboarding: "/onboarding",
   signInToken: "/sign-in-token",
   lab: "/_/lab",
+  insights: "/insights",
   internalConnectorLogos: "/__internal-connector-logos",
 } as const;
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -121,6 +121,7 @@ export type SidebarNavId =
   | "connectors"
   | "schedules"
   | "activities"
+  | "insights"
   | "works"
   | "settings"
   | "settingsUsage"
@@ -149,6 +150,8 @@ export const handleZeroNavSelect$ = command(({ set }, id: SidebarNavId) => {
     set(detachedNavigateTo$, ROUTES.schedules);
   } else if (id === "activities") {
     set(detachedNavigateTo$, ROUTES.activities);
+  } else if (id === "insights") {
+    set(detachedNavigateTo$, ROUTES.insights);
   } else if (id === "works") {
     set(detachedNavigateTo$, ROUTES.works);
   } else if (id === "settings") {

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -1,0 +1,374 @@
+/**
+ * Interaction tests for the Network Insights page.
+ *
+ * Covers rendering insight cards, date range filtering, empty states,
+ * and agent hover interactions.
+ */
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { setupPage } from "../../../__tests__/page-helper.ts";
+
+const context = testContext();
+
+function daysAgoIso(n: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+// Pre-compute at package scope to satisfy ccstate/computed-const-args-package-scope
+const day1Ago = daysAgoIso(1);
+const day2Ago = daysAgoIso(2);
+const day20Ago = daysAgoIso(20);
+const day25Ago = daysAgoIso(25);
+
+function mockInsightsAPI(days: Record<string, unknown>[] = []) {
+  server.use(
+    http.get("*/api/zero/insights", () => {
+      const totalCredits = days.reduce((s, d) => {
+        return s + ((d.creditsUsed as number) ?? 0);
+      }, 0);
+      const totalRuns = days.reduce((s, d) => {
+        const agents = (d.agents as { runs: number }[]) ?? [];
+        return (
+          s +
+          agents.reduce((rs, a) => {
+            return rs + (a.runs ?? 0);
+          }, 0)
+        );
+      }, 0);
+      return HttpResponse.json({ days, totalCredits, totalRuns });
+    }),
+  );
+}
+
+function sampleDay(date: string, overrides?: Record<string, unknown>) {
+  return {
+    date,
+    agents: [
+      { agentName: "Alpha Bot", agentId: "a-1", runs: 5, credits: 120 },
+      { agentName: "Beta Bot", agentId: "a-2", runs: 3, credits: 80 },
+    ],
+    creditsUsed: 200,
+    creditBalance: 9800,
+    teamUsage: [
+      {
+        name: "alice",
+        credits: 120,
+        agentNames: ["Alpha Bot"],
+        agentCredits: { "Alpha Bot": 120 },
+      },
+      {
+        name: "bob",
+        credits: 80,
+        agentNames: ["Beta Bot"],
+        agentCredits: { "Beta Bot": 80 },
+      },
+    ],
+    topTask: { name: "chat:write", count: 15 },
+    services: [
+      {
+        name: "Slack",
+        domain: "slack",
+        calls: 10,
+        agentNames: ["Alpha Bot"],
+      },
+      {
+        name: "GitHub",
+        domain: "github",
+        calls: 5,
+        agentNames: ["Beta Bot"],
+      },
+    ],
+    permissions: [
+      {
+        label: "chat:write",
+        allowed: 8,
+        denied: 2,
+        agentNames: ["Alpha Bot"],
+      },
+      {
+        label: "contents:read",
+        allowed: 5,
+        denied: 0,
+        agentNames: ["Beta Bot"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+describe("network insights page - empty state", () => {
+  it("should show empty message when no data", async () => {
+    mockInsightsAPI([]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Run an agent to see insights here."),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Data rendering
+// ---------------------------------------------------------------------------
+
+describe("network insights page - data rendering", () => {
+  it("should render the Insights heading", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Insights")).toBeInTheDocument();
+    });
+  });
+
+  it("should display agent names from the data", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha Bot")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Beta Bot")).toBeInTheDocument();
+  });
+
+  it("should display credit amount", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("200")).toBeInTheDocument();
+    });
+  });
+
+  it("should display most-used service name", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Most used:/)).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("Slack").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should display blocked permissions card when denied > 0", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Blocked")).toBeInTheDocument();
+    });
+  });
+
+  it("should not display blocked card when no denials", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        permissions: [
+          {
+            label: "chat:write",
+            allowed: 10,
+            denied: 0,
+            agentNames: ["Alpha Bot"],
+          },
+        ],
+      }),
+    ]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Allowed")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Blocked")).not.toBeInTheDocument();
+  });
+
+  it("should show Yesterday header for yesterday's data", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Yesterday")).toBeInTheDocument();
+    });
+  });
+
+  it("should render multiple days", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago),
+      sampleDay(day2Ago, {
+        agents: [
+          { agentName: "Gamma Bot", agentId: "a-3", runs: 1, credits: 10 },
+        ],
+      }),
+    ]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha Bot")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Gamma Bot")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Date range filter
+// ---------------------------------------------------------------------------
+
+describe("network insights page - date range filter", () => {
+  it("should show date range dropdown when data exists", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Last 7 Days")).toBeInTheDocument();
+    });
+  });
+
+  it("should not show date range dropdown when no data", async () => {
+    mockInsightsAPI([]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Run an agent to see insights here."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Last 7 Days")).not.toBeInTheDocument();
+  });
+
+  it("should show no-activity message when filter excludes all days", async () => {
+    // Only data from 20 days ago, but default range is "last7"
+    mockInsightsAPI([sampleDay(day20Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No activity in this time range."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should switch to Last 30 Days range", async () => {
+    const user = userEvent.setup();
+    mockInsightsAPI([
+      sampleDay(day1Ago),
+      sampleDay(day25Ago, {
+        agents: [
+          { agentName: "OldBot", agentId: "a-old", runs: 1, credits: 5 },
+        ],
+      }),
+    ]);
+
+    await setupPage({ context, path: "/insights" });
+
+    // Default is "Last 7 Days" — OldBot not visible
+    await waitFor(() => {
+      expect(screen.getByText("Last 7 Days")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("OldBot")).not.toBeInTheDocument();
+
+    // Open dropdown and select "Last 30 Days"
+    await user.click(screen.getByText("Last 7 Days"));
+    await waitFor(() => {
+      expect(screen.getByText("Last 30 Days")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Last 30 Days"));
+
+    await waitFor(() => {
+      expect(screen.getByText("OldBot")).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Summary card
+// ---------------------------------------------------------------------------
+
+describe("network insights page - summary card", () => {
+  it("should show blocked summary when denials exist", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        permissions: [
+          {
+            label: "chat:write",
+            allowed: 8,
+            denied: 5,
+            agentNames: ["Alpha Bot"],
+          },
+        ],
+      }),
+    ]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText(/5 requests were blocked/)).toBeInTheDocument();
+    });
+  });
+
+  it("should show busy day summary for high run count", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        agents: [
+          { agentName: "A1", agentId: "a-1", runs: 5, credits: 50 },
+          { agentName: "A2", agentId: "a-2", runs: 5, credits: 50 },
+        ],
+        permissions: [],
+      }),
+    ]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText(/busy day/i)).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Team usage in credits card
+// ---------------------------------------------------------------------------
+
+describe("network insights page - credits card", () => {
+  it("should display team member names", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeInTheDocument();
+    });
+    expect(screen.getByText("bob")).toBeInTheDocument();
+  });
+
+  it("should display credit balance", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("9,800")).toBeInTheDocument();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -1,0 +1,1035 @@
+import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import {
+  IconNetwork,
+  IconChevronDown,
+  IconChevronLeft,
+  IconChevronRight,
+} from "@tabler/icons-react";
+import {
+  Skeleton,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@vm0/ui";
+import {
+  networkInsightsData$,
+  insightsDateRange$,
+  setInsightsDateRange$,
+  insightsCalendarOpen$,
+  setInsightsCalendarOpen$,
+  insightsCalendarYear$,
+  setInsightsCalendarYear$,
+  insightsCalendarMonth$,
+  setInsightsCalendarMonth$,
+  insightsHoveredAgent$,
+  setInsightsHoveredAgent$,
+  type DayInsight,
+  type NetworkInsightsData,
+} from "../../signals/network-insights/network-insights-signals.ts";
+import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
+
+// ---------------------------------------------------------------------------
+// Date range filter
+// ---------------------------------------------------------------------------
+
+/** A preset range or a specific ISO date string like "2026-04-03". */
+type DateRange = "last7" | "last28" | "last30" | (string & {});
+
+/** Get yesterday's date string (YYYY-MM-DD) in the given IANA timezone. */
+function yesterdayIso(tz: string): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}
+
+/** Get a date string N days ago (YYYY-MM-DD) in the given IANA timezone. */
+function daysAgoIso(n: number, tz: string): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(d);
+}
+
+function dateRangeLabel(range: DateRange): string {
+  switch (range) {
+    case "last7": {
+      return "Last 7 Days";
+    }
+    case "last28": {
+      return "Last 28 Days";
+    }
+    case "last30": {
+      return "Last 30 Days";
+    }
+    default: {
+      return formatDateShort(range);
+    }
+  }
+}
+
+/** Short date label for dropdown items, e.g. "Apr 3" or "Today". */
+function formatDateShort(iso: string): string {
+  const d = new Date(iso + "T00:00:00");
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const diff = now.getTime() - d.getTime();
+  const dayMs = 86_400_000;
+  if (diff < dayMs) {
+    return "Today";
+  }
+  if (diff < dayMs * 2) {
+    return "Yesterday";
+  }
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/** Filter days that fall within the selected range or match a specific date. */
+function filterDays(
+  days: DayInsight[],
+  range: DateRange,
+  tz: string,
+): DayInsight[] {
+  if (range !== "last7" && range !== "last28" && range !== "last30") {
+    return days.filter((d) => {
+      return d.date === range;
+    });
+  }
+
+  const n = range === "last7" ? 7 : range === "last28" ? 28 : 30;
+  const cutoff = daysAgoIso(n, tz);
+
+  return days.filter((d) => {
+    return d.date >= cutoff;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Calendar popover for custom date selection
+// ---------------------------------------------------------------------------
+
+function CalendarMonth({
+  year,
+  month,
+  selected,
+  hasData,
+  onSelect,
+}: {
+  year: number;
+  month: number;
+  selected: string | null;
+  hasData: Set<string>;
+  onSelect: (iso: string) => void;
+}) {
+  const weekdays = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+  const first = new Date(year, month, 1);
+  const startDay = first.getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  // Compute padding keys from previous month's trailing days
+  const padKeys = Array.from({ length: startDay }, (_, n) => {
+    const prevDate = new Date(year, month, -(startDay - 1 - n));
+    return `pad-${prevDate.getFullYear()}-${prevDate.getMonth()}-${prevDate.getDate()}`;
+  });
+
+  return (
+    <div className="grid grid-cols-7 gap-0.5 text-center">
+      {weekdays.map((d) => {
+        return (
+          <span
+            key={d}
+            className="text-[10px] text-muted-foreground font-medium py-1"
+          >
+            {d}
+          </span>
+        );
+      })}
+      {padKeys.map((k) => {
+        return <span key={k} />;
+      })}
+      {Array.from({ length: daysInMonth }, (_, n) => {
+        const day = n + 1;
+        const iso = `${year}-${String(month + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+        const active = hasData.has(iso);
+        const isSelected = selected === iso;
+        return (
+          <button
+            key={iso}
+            type="button"
+            disabled={!active}
+            onClick={() => {
+              onSelect(iso);
+            }}
+            className={`text-xs h-7 w-7 mx-auto rounded-full transition-colors ${
+              isSelected
+                ? "bg-foreground text-background font-semibold"
+                : active
+                  ? "hover:bg-muted font-medium text-foreground"
+                  : "text-muted-foreground/30"
+            }`}
+          >
+            {day}
+            {active && !isSelected && (
+              <span className="block mx-auto w-1 h-1 rounded-full bg-foreground/40 -mt-0.5" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function CustomRangePicker({
+  value,
+  onChange,
+  availableDates,
+}: {
+  value: DateRange;
+  onChange: (v: DateRange) => void;
+  availableDates: string[];
+}) {
+  const open = useGet(insightsCalendarOpen$);
+  const setOpen = useSet(setInsightsCalendarOpen$);
+  const hasData = new Set(availableDates);
+
+  const viewYear = useGet(insightsCalendarYear$);
+  const setViewYear = useSet(setInsightsCalendarYear$);
+  const viewMonth = useGet(insightsCalendarMonth$);
+  const setViewMonth = useSet(setInsightsCalendarMonth$);
+
+  const monthLabel = new Date(viewYear, viewMonth, 1).toLocaleDateString(
+    "en-US",
+    { month: "long", year: "numeric" },
+  );
+
+  const prevMonth = () => {
+    if (viewMonth === 0) {
+      setViewYear(viewYear - 1);
+      setViewMonth(11);
+    } else {
+      setViewMonth(viewMonth - 1);
+    }
+  };
+  const nextMonth = () => {
+    if (viewMonth === 11) {
+      setViewYear(viewYear + 1);
+      setViewMonth(0);
+    } else {
+      setViewMonth(viewMonth + 1);
+    }
+  };
+
+  const selectedDate = isPreset(value) ? null : value;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left hover:bg-accent transition-colors ${
+            !isPreset(value) ? "font-semibold" : ""
+          }`}
+        >
+          Custom Range
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="left"
+        align="start"
+        sideOffset={12}
+        className="w-auto p-3"
+      >
+        <div className="flex items-center justify-between mb-2">
+          <button
+            type="button"
+            onClick={prevMonth}
+            className="h-7 w-7 inline-flex items-center justify-center rounded-md hover:bg-muted transition-colors"
+          >
+            <IconChevronLeft size={14} stroke={1.5} />
+          </button>
+          <p className="text-sm font-semibold">{monthLabel}</p>
+          <button
+            type="button"
+            onClick={nextMonth}
+            className="h-7 w-7 inline-flex items-center justify-center rounded-md hover:bg-muted transition-colors"
+          >
+            <IconChevronRight size={14} stroke={1.5} />
+          </button>
+        </div>
+        <CalendarMonth
+          year={viewYear}
+          month={viewMonth}
+          selected={selectedDate}
+          hasData={hasData}
+          onSelect={(iso) => {
+            onChange(iso);
+            setOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Date range dropdown
+// ---------------------------------------------------------------------------
+
+function isPreset(v: DateRange): v is "last7" | "last28" | "last30" {
+  return v === "last7" || v === "last28" || v === "last30";
+}
+
+const PRESETS = ["last7", "last28", "last30"] as const;
+
+function DateRangeFilter({
+  value,
+  onChange,
+  availableDates,
+  timezone,
+}: {
+  value: DateRange;
+  onChange: (v: DateRange) => void;
+  availableDates: string[];
+  timezone: string;
+}) {
+  const yesterday = yesterdayIso(timezone);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-2 rounded-lg border bg-background px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+        >
+          {dateRangeLabel(value)}
+          <IconChevronDown
+            size={14}
+            stroke={1.5}
+            className="text-muted-foreground"
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        {availableDates.includes(yesterday) && (
+          <DropdownMenuItem
+            onClick={() => {
+              onChange(yesterday);
+            }}
+            className={
+              !isPreset(value) && value === yesterday ? "font-semibold" : ""
+            }
+          >
+            Yesterday
+          </DropdownMenuItem>
+        )}
+        {availableDates.includes(yesterday) && <DropdownMenuSeparator />}
+        {PRESETS.map((preset) => {
+          return (
+            <DropdownMenuItem
+              key={preset}
+              onClick={() => {
+                onChange(preset);
+              }}
+              className={value === preset ? "font-semibold" : ""}
+            >
+              {dateRangeLabel(preset)}
+            </DropdownMenuItem>
+          );
+        })}
+        <DropdownMenuSeparator />
+        <CustomRangePicker
+          value={value}
+          onChange={onChange}
+          availableDates={availableDates}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary card — fun one-liner based on today's data
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick a deterministic "random" index from a pool based on the day string,
+ * so the same day always gets the same quote but different days vary.
+ */
+function dayHash(date: string, poolSize: number): number {
+  let h = 0;
+  for (let i = 0; i < date.length; i++) {
+    h = (h * 31 + date.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h) % poolSize;
+}
+
+function buildSummaryQuote(day: DayInsight): {
+  quote: string;
+  caption: string;
+} {
+  const totalRuns = day.agents.reduce((s, a) => {
+    return s + a.runs;
+  }, 0);
+  const totalCalls = day.services.reduce((s, svc) => {
+    return s + svc.calls;
+  }, 0);
+  const blocked = day.permissions.reduce((s, p) => {
+    return s + p.denied;
+  }, 0);
+  let quote: string;
+  let caption: string;
+
+  if (blocked > 0) {
+    quote = `${blocked} requests were blocked by your permission rules. Review them to make sure nothing important is being held back.`;
+    caption = `${totalCalls} calls · ${blocked} blocked`;
+  } else if (totalRuns > 8) {
+    quote = `A busy day — ${day.agents.length} agents completed ${totalRuns} runs. Your network is working hard.`;
+    caption = `${totalRuns} runs · ${day.agents.length} agents`;
+  } else if (totalCalls > 100) {
+    quote = `${totalCalls} service calls across ${day.services.length} services. High traffic day.`;
+    caption = `${totalCalls} calls · ${day.services.length} services`;
+  } else if (day.agents.length >= 4) {
+    quote = `${day.agents.length} agents active, using ${day.creditsUsed} credits total. A well-distributed workload.`;
+    caption = `${day.agents.length} agents · ${day.creditsUsed} credits`;
+  } else if (totalRuns <= 2 && totalCalls < 30) {
+    quote = `Light activity — ${totalRuns === 0 ? "no runs" : `only ${totalRuns} ${totalRuns === 1 ? "run" : "runs"}`} and ${totalCalls} calls. A quiet day.`;
+    caption = `${totalRuns} ${totalRuns === 1 ? "run" : "runs"} · a quiet day`;
+  } else {
+    quote = `${totalRuns} runs and ${totalCalls} service calls today. Everything running smoothly.`;
+    caption = `${totalRuns} runs · ${totalCalls} calls`;
+  }
+
+  return { quote, caption };
+}
+
+function SummaryCard({ day }: { day: DayInsight }) {
+  const { quote, caption } = buildSummaryQuote(day);
+  const variants: { bg: string; dark: boolean }[] = [
+    { bg: "bg-[#98928B]", dark: true }, // taupe
+    { bg: "bg-[#EFC184]", dark: false }, // sandy orange
+    { bg: "bg-[#F3B8B1]", dark: false }, // rose pink
+    { bg: "bg-[#EC70A5]", dark: true }, // hot pink
+    { bg: "bg-[#358A8E]", dark: true }, // teal
+    { bg: "bg-[#E1C43C]", dark: false }, // mustard gold
+  ];
+  const v = variants[dayHash(day.date, variants.length)] ?? variants[0];
+  const textMain = v.dark ? "text-white/90" : "text-foreground/90";
+  const textSub = v.dark ? "text-white/50" : "text-foreground/50";
+
+  return (
+    <div
+      className={`${v.bg} rounded-[20px] p-7 flex flex-col justify-between min-h-[180px] mb-3 break-inside-avoid`}
+    >
+      <div>
+        <p className={`${textSub} text-3xl leading-none mb-3 font-serif`}>
+          &ldquo;
+        </p>
+        <p
+          className={`text-xl font-medium leading-relaxed italic font-serif ${textMain}`}
+        >
+          {quote}
+        </p>
+      </div>
+      <p className={`text-xs ${textSub} mt-4 tracking-wide uppercase`}>
+        {caption}
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+interface CardPalette {
+  bg: string;
+  accent: string;
+}
+
+function getCardPalette(colorIndex: number): CardPalette {
+  const palette: CardPalette[] = [
+    { bg: "bg-[#EFC184]/20", accent: "#D4956A" }, // sandy orange — brand original
+    { bg: "bg-[#F3B8B1]/20", accent: "#E24B6A" }, // rose → brand vibrant rose
+    { bg: "bg-[#E1C43C]/15", accent: "#E1C43C" }, // mustard gold — brand original
+    { bg: "bg-gray-50", accent: "#98928B" }, // grey-50 → taupe
+    { bg: "bg-[#EC70A5]/15", accent: "#EC70A5" }, // hot pink — brand original
+    { bg: "bg-[#358A8E]/15", accent: "#358A8E" }, // teal — brand original
+    { bg: "bg-[#98928B]/15", accent: "#98928B" }, // taupe — brand original
+  ];
+  return palette[colorIndex % palette.length] ?? palette[0];
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="bg-gray-50 text-foreground rounded-[20px] p-6 border border-border/40 relative overflow-hidden mb-3 break-inside-avoid">
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card: Agents used
+// ---------------------------------------------------------------------------
+
+function AgentsCard({
+  day,
+  colorIndex,
+  hoveredAgent,
+  onHoverAgent,
+}: {
+  day: DayInsight;
+  colorIndex: number;
+  hoveredAgent: string | null;
+  onHoverAgent: (name: string | null) => void;
+}) {
+  const totalRuns = day.agents.reduce((s, a) => {
+    return s + a.runs;
+  }, 0);
+  const { accent } = getCardPalette(colorIndex);
+  return (
+    <Card>
+      <p
+        className="text-xs font-semibold uppercase tracking-widest mb-3"
+        style={{ color: accent }}
+      >
+        Agents
+      </p>
+      <div className="flex items-center mb-3">
+        <span className="text-3xl font-black tabular-nums font-serif">
+          {day.agents.length}
+        </span>
+      </div>
+      <p className="text-sm opacity-60">
+        {day.agents.length === 1 ? "agent" : "agents"} ran {totalRuns}{" "}
+        {totalRuns === 1 ? "time" : "times"}
+      </p>
+      <div className="flex flex-col gap-2 mt-3">
+        {day.agents.map((a) => {
+          const isActive =
+            hoveredAgent === null || hoveredAgent === a.agentName;
+          return (
+            <div
+              key={a.agentName}
+              className={`flex items-center gap-2 rounded-md px-1.5 py-0.5 -mx-1.5 cursor-default transition-all duration-150 ${
+                hoveredAgent === a.agentName ? "bg-foreground/5" : ""
+              } ${isActive ? "opacity-100" : "opacity-30"}`}
+              onMouseEnter={() => {
+                onHoverAgent(a.agentName);
+              }}
+              onMouseLeave={() => {
+                onHoverAgent(null);
+              }}
+            >
+              <span className="text-sm font-medium flex-1 truncate decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-2">
+                {a.agentName}
+              </span>
+              <span className="text-xs opacity-60 tabular-nums shrink-0">
+                {a.runs} {a.runs === 1 ? "run" : "runs"}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card: Credits consumed
+// ---------------------------------------------------------------------------
+
+function CreditsCard({
+  day,
+  colorIndex,
+  hoveredAgent,
+}: {
+  day: DayInsight;
+  colorIndex: number;
+  hoveredAgent: string | null;
+}) {
+  const hoveredAgentData = hoveredAgent
+    ? day.agents.find((a) => {
+        return a.agentName === hoveredAgent;
+      })
+    : null;
+  const displayCredits = hoveredAgentData
+    ? hoveredAgentData.credits
+    : day.creditsUsed;
+
+  const sorted = [...day.teamUsage].sort((a, b) => {
+    return b.credits - a.credits;
+  });
+  const maxCredits = Math.max(
+    1,
+    ...sorted.map((m) => {
+      return m.credits;
+    }),
+  );
+  const { accent } = getCardPalette(colorIndex);
+
+  return (
+    <Card>
+      <p
+        className="text-xs font-semibold uppercase tracking-widest mb-3"
+        style={{ color: accent }}
+      >
+        Credits
+      </p>
+      <p className="text-5xl font-black leading-none tabular-nums font-serif transition-all duration-150">
+        {displayCredits.toLocaleString()}
+      </p>
+      <p className="text-sm opacity-60 mt-2">
+        {hoveredAgentData
+          ? `by ${hoveredAgentData.agentName}`
+          : "consumed today"}
+      </p>
+
+      <div>
+        <div className="flex items-center justify-between mt-4">
+          <span className="text-sm opacity-60">Balance</span>
+          <span className="text-sm font-semibold tabular-nums">
+            {day.creditBalance.toLocaleString()}
+          </span>
+        </div>
+
+        {sorted.length > 0 && (
+          <div className="mt-4">
+            <p
+              className="text-xs font-semibold uppercase tracking-widest mb-3"
+              style={{ color: accent }}
+            >
+              Team
+            </p>
+            <div className="flex flex-col gap-2">
+              {sorted.map((m) => {
+                const isActive =
+                  hoveredAgent === null || m.agentNames?.includes(hoveredAgent);
+                const memberCredits =
+                  hoveredAgent &&
+                  m.agentCredits?.[hoveredAgent] !== null &&
+                  m.agentCredits?.[hoveredAgent] !== undefined
+                    ? m.agentCredits[hoveredAgent]
+                    : m.credits;
+                const pct = (memberCredits / maxCredits) * 100;
+                return (
+                  <div
+                    key={m.name}
+                    className={`flex items-center gap-3 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
+                  >
+                    <span className="text-sm w-20 truncate shrink-0">
+                      {m.name}
+                    </span>
+                    <div className="flex-1 h-1.5 rounded-full bg-current/10 overflow-hidden">
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          width: `${pct}%`,
+                          backgroundColor: accent,
+                        }}
+                      />
+                    </div>
+                    <span className="text-xs opacity-60 w-10 text-right shrink-0 tabular-nums">
+                      {memberCredits}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card: Top task
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Card: Services accessed
+// ---------------------------------------------------------------------------
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function ServicesCard({
+  day,
+  colorIndex,
+  hoveredAgent,
+}: {
+  day: DayInsight;
+  colorIndex: number;
+  hoveredAgent: string | null;
+}) {
+  const maxCalls = Math.max(
+    1,
+    ...day.services.map((s) => {
+      return s.calls;
+    }),
+  );
+  const sorted = [...day.services].sort((a, b) => {
+    return b.calls - a.calls;
+  });
+  const top = sorted[0];
+  const { accent } = getCardPalette(colorIndex);
+
+  return (
+    <Card>
+      <p
+        className="text-xs font-semibold uppercase tracking-widest mb-3"
+        style={{ color: accent }}
+      >
+        Services
+      </p>
+      <p className="text-5xl font-black leading-none tabular-nums font-serif">
+        {day.services.length}
+      </p>
+      {top && (
+        <p className="text-sm opacity-60 mt-2">
+          Most used:{" "}
+          <span className="font-semibold opacity-100">
+            {capitalize(top.name)}
+          </span>{" "}
+          ({top.calls} calls)
+        </p>
+      )}
+      <div className="flex flex-col gap-2.5 mt-4">
+        {sorted.map((s) => {
+          const isActive =
+            hoveredAgent === null || s.agentNames.includes(hoveredAgent);
+          const pct = (s.calls / maxCalls) * 100;
+          return (
+            <div
+              key={s.name}
+              className={`flex items-center gap-3 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
+            >
+              <span className="text-sm font-medium w-20 truncate shrink-0 capitalize">
+                {s.name}
+              </span>
+              <div className="flex-1 h-1.5 rounded-full bg-current/10 overflow-hidden">
+                <div
+                  className="h-full rounded-full"
+                  style={{ width: `${pct}%`, backgroundColor: accent }}
+                />
+              </div>
+              <span className="text-xs opacity-60 w-8 text-right shrink-0 tabular-nums">
+                {s.calls}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card: Permissions
+// ---------------------------------------------------------------------------
+
+function PermissionsAllowedCard({
+  day,
+  colorIndex,
+  hoveredAgent,
+}: {
+  day: DayInsight;
+  colorIndex: number;
+  hoveredAgent: string | null;
+}) {
+  const allowed = day.permissions.filter((p) => {
+    return p.allowed > 0;
+  });
+
+  if (allowed.length === 0) {
+    return null;
+  }
+
+  const totalAllowed = allowed.reduce((s, p) => {
+    return s + p.allowed;
+  }, 0);
+  const { accent } = getCardPalette(colorIndex);
+
+  return (
+    <Card>
+      <p
+        className="text-xs font-semibold uppercase tracking-widest mb-3"
+        style={{ color: accent }}
+      >
+        Allowed
+      </p>
+      <p className="text-5xl font-black leading-none tabular-nums font-serif">
+        {totalAllowed}
+      </p>
+      <p className="text-sm opacity-60 mt-2">
+        calls passed across {allowed.length}{" "}
+        {allowed.length === 1 ? "permission" : "permissions"}
+      </p>
+      <div className="flex flex-col gap-2 mt-4">
+        {allowed.map((p) => {
+          const isActive =
+            hoveredAgent === null || p.agentNames.includes(hoveredAgent);
+          return (
+            <div
+              key={p.label}
+              className={`flex items-center justify-between gap-2 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
+            >
+              <span className="text-sm">{p.label}</span>
+              <span className="text-xs opacity-60 tabular-nums shrink-0">
+                {p.allowed}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+function PermissionsBlockedCard({
+  day,
+  hoveredAgent,
+}: {
+  day: DayInsight;
+  hoveredAgent: string | null;
+}) {
+  const blocked = day.permissions.filter((p) => {
+    return p.denied > 0;
+  });
+
+  if (blocked.length === 0) {
+    return null;
+  }
+
+  const totalBlocked = blocked.reduce((s, p) => {
+    return s + p.denied;
+  }, 0);
+
+  const { accent } = getCardPalette(4);
+
+  return (
+    <Card>
+      <p
+        className="text-xs font-semibold uppercase tracking-widest mb-3"
+        style={{ color: accent }}
+      >
+        Blocked
+      </p>
+      <p className="text-5xl font-black leading-none tabular-nums font-serif">
+        {totalBlocked}
+      </p>
+      <p className="text-sm opacity-60 mt-2">
+        calls blocked across {blocked.length}{" "}
+        {blocked.length === 1 ? "permission" : "permissions"}
+      </p>
+      <div className="flex flex-col gap-2 mt-4">
+        {blocked.map((p) => {
+          const isActive =
+            hoveredAgent === null || p.agentNames.includes(hoveredAgent);
+          const fullyBlocked = p.allowed === 0;
+          return (
+            <div
+              key={p.label}
+              className={`flex items-center justify-between gap-2 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
+            >
+              <span className="text-sm font-medium">{p.label}</span>
+              <span className="text-xs tabular-nums shrink-0 opacity-70">
+                {fullyBlocked
+                  ? `${p.denied} rejected`
+                  : `${p.denied} of ${p.allowed + p.denied} rejected`}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Date header
+// ---------------------------------------------------------------------------
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + "T00:00:00");
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const diff = today.getTime() - d.getTime();
+  const dayMs = 86_400_000;
+
+  if (diff < dayMs) {
+    return "Today";
+  }
+  if (diff < dayMs * 2) {
+    return "Yesterday";
+  }
+
+  return d.toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Day section — masonry of cards (dim approach for hover)
+// ---------------------------------------------------------------------------
+
+function DaySection({ day }: { day: DayInsight }) {
+  const hoveredAgent = useGet(insightsHoveredAgent$);
+  const setHoveredAgent = useSet(setInsightsHoveredAgent$);
+
+  const handleHoverAgent = (name: string | null) => {
+    setHoveredAgent(name);
+  };
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h2 className="text-lg font-semibold text-foreground sticky top-0 bg-background/80 backdrop-blur-sm py-2 z-10">
+        {formatDate(day.date)}
+      </h2>
+      <div className="columns-1 sm:columns-2 lg:columns-3 gap-3">
+        <SummaryCard day={day} />
+        <CreditsCard day={day} colorIndex={1} hoveredAgent={hoveredAgent} />
+        <AgentsCard
+          day={day}
+          colorIndex={0}
+          hoveredAgent={hoveredAgent}
+          onHoverAgent={handleHoverAgent}
+        />
+        <ServicesCard day={day} colorIndex={2} hoveredAgent={hoveredAgent} />
+        <PermissionsAllowedCard
+          day={day}
+          colorIndex={5}
+          hoveredAgent={hoveredAgent}
+        />
+        <PermissionsBlockedCard day={day} hoveredAgent={hoveredAgent} />
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main content
+// ---------------------------------------------------------------------------
+
+function InsightsContent({ data }: { data: NetworkInsightsData }) {
+  const dateRange = useGet(insightsDateRange$);
+  const setRange = useSet(setInsightsDateRange$);
+  const prefsLoadable = useLastLoadable(userPreferences$);
+  const timezone =
+    prefsLoadable.state === "hasData" && prefsLoadable.data?.timezone
+      ? prefsLoadable.data.timezone
+      : new Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const filtered = filterDays(data.days, dateRange, timezone);
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="mx-auto w-full max-w-[960px] px-4 sm:px-8 py-8 flex flex-col gap-10">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold">Insights</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Monitor what your agents access, which permissions they use, and
+              spot anything unusual.
+            </p>
+          </div>
+          {data.days.length > 0 && (
+            <DateRangeFilter
+              value={dateRange}
+              onChange={setRange}
+              availableDates={data.days.map((d) => {
+                return d.date;
+              })}
+              timezone={timezone}
+            />
+          )}
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
+            <div className="w-14 h-14 rounded-2xl bg-muted flex items-center justify-center">
+              <IconNetwork
+                size={28}
+                stroke={1}
+                className="text-muted-foreground"
+              />
+            </div>
+            <p className="text-sm text-muted-foreground max-w-xs">
+              {data.days.length === 0
+                ? "Run an agent to see insights here."
+                : "No activity in this time range."}
+            </p>
+          </div>
+        ) : (
+          filtered.map((day) => {
+            return <DaySection key={day.date} day={day} />;
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function InsightsSkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-[960px] px-4 sm:px-8 py-8 flex flex-col gap-8">
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-4 w-52" />
+      </div>
+      <div className="columns-1 sm:columns-2 lg:columns-3 gap-3">
+        <Skeleton className="h-44 rounded-[20px] mb-3 break-inside-avoid" />
+        <Skeleton className="h-56 rounded-[20px] mb-3 break-inside-avoid" />
+        <Skeleton className="h-36 rounded-[20px] mb-3 break-inside-avoid" />
+        <Skeleton className="h-28 rounded-[20px] mb-3 break-inside-avoid" />
+        <Skeleton className="h-48 rounded-[20px] mb-3 break-inside-avoid" />
+        <Skeleton className="h-64 rounded-[20px] mb-3 break-inside-avoid" />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page entry point
+// ---------------------------------------------------------------------------
+
+export function NetworkInsightsPage() {
+  const dataLoadable = useLastLoadable(networkInsightsData$);
+
+  if (dataLoadable.state === "loading" || dataLoadable.state === "hasError") {
+    return (
+      <div className="h-full overflow-auto">
+        <InsightsSkeleton />
+      </div>
+    );
+  }
+
+  const data = dataLoadable.data;
+  if (!data) {
+    return (
+      <div className="h-full flex items-center justify-center text-muted-foreground">
+        <p className="text-sm">Could not load network activity.</p>
+      </div>
+    );
+  }
+
+  return <InsightsContent data={data} />;
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   IconLayoutSidebarLeftCollapse,
   IconPlug,
   IconFlask,
+  IconSparkles,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/core";
 import {
@@ -382,7 +383,33 @@ export function ZeroSidebar() {
           </TooltipProvider>
         </nav>
 
-        <div className="flex w-full shrink-0 justify-center pb-2 pt-1">
+        <div className="flex w-full shrink-0 flex-col items-center gap-1 pb-2 pt-1">
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Link
+                  pathname="/insights"
+                  onPointerDown={(e) => {
+                    if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                      return;
+                    }
+                    e.preventDefault();
+                    onSelect("insights");
+                  }}
+                  className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
+                    activeId === "insights"
+                      ? "bg-gray-200 text-gray-900"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent"
+                  }`}
+                >
+                  <IconSparkles size={16} className="shrink-0" />
+                </Link>
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                <p className="text-xs">Insights</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           <AccountDropdown onAccountAction={onAccountAction} collapsed />
         </div>
       </aside>
@@ -588,8 +615,38 @@ export function ZeroSidebar() {
               },
             )}
             <div className="h-px bg-border/30 mx-1 my-1" />
-            {/* Account dropdown */}
-            <AccountDropdown onAccountAction={onAccountAction} />
+            {/* Insights + Account */}
+            <div className="flex items-center gap-1">
+              <div className="flex-1 min-w-0">
+                <AccountDropdown onAccountAction={onAccountAction} />
+              </div>
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Link
+                      pathname="/insights"
+                      onPointerDown={(e) => {
+                        if (e.metaKey || e.ctrlKey || e.shiftKey) {
+                          return;
+                        }
+                        e.preventDefault();
+                        onSelect("insights");
+                      }}
+                      className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
+                        activeId === "insights"
+                          ? "bg-gray-200 text-gray-900"
+                          : "text-sidebar-foreground hover:bg-sidebar-accent"
+                      }`}
+                    >
+                      <IconSparkles size={16} className="shrink-0" />
+                    </Link>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    <p className="text-xs">Insights</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
           </div>
         </div>
       </aside>

--- a/turbo/apps/web/app/api/cron/aggregate-insights/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/__tests__/route.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GET } from "../route";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../src/__tests__/test-helpers";
+import {
+  createTestCompose,
+  createCompletedTestRun,
+  ensureOrgRow,
+  findInsightsDaily,
+  seedCreditUsageRecord,
+  seedUserCacheEntry,
+} from "../../../../../src/__tests__/api-test-helpers";
+import { reloadEnv } from "../../../../../src/env";
+
+vi.hoisted(() => {
+  vi.stubEnv("CRON_SECRET", "test-cron-secret");
+});
+
+const context = testContext();
+
+function cronRequest(secret?: string) {
+  return new Request("http://localhost:3000/api/cron/aggregate-insights", {
+    method: "GET",
+    headers: secret ? { authorization: `Bearer ${secret}` } : {},
+  });
+}
+
+/**
+ * Returns a recent timestamp within today's UTC window.
+ * The cron aggregates runs from today's local-day start to now,
+ * so test runs must fall within this window.
+ */
+function recentDate(): { date: Date; dateStr: string } {
+  const now = new Date();
+  const date = new Date(now.getTime() - 60_000); // 1 minute ago
+  return { date, dateStr: todayDateStr() };
+}
+
+/** The cron stores insights under today's date (the current local date). */
+function todayDateStr(): string {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  )
+    .toISOString()
+    .split("T")[0]!;
+}
+
+describe("GET /api/cron/aggregate-insights", () => {
+  let composeVersionId: string;
+  let userId: string;
+  let orgId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    vi.stubEnv("CRON_SECRET", "test-cron-secret");
+    reloadEnv();
+    const user = await context.setupUser();
+    userId = user.userId;
+    orgId = user.orgId;
+    const { versionId } = await createTestCompose(uniqueId("insights-agent"));
+    composeVersionId = versionId;
+
+    // Ensure org has metadata row for credit balance lookup
+    await ensureOrgRow(orgId);
+  });
+
+  it("should return 401 with invalid cron secret", async () => {
+    const response = await GET(cronRequest("wrong-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 401 with missing authorization header", async () => {
+    const response = await GET(cronRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 200 with no runs for this org", async () => {
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+
+    // This org had no runs, so no insights row should exist
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeUndefined();
+  });
+
+  it("should aggregate previous day agent runs", async () => {
+    const { date, dateStr } = recentDate();
+
+    await createCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: new Date(date.getTime() + 5000),
+    });
+
+    // Second run
+    const run2Start = new Date(date.getTime() + 60000);
+    await createCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: run2Start,
+      startedAt: run2Start,
+      completedAt: new Date(run2Start.getTime() + 8000),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+
+    const data = row!.data;
+    const agents = data.agents as Array<{
+      agentName: string;
+      runs: number;
+      credits: number;
+    }>;
+    expect(agents).toHaveLength(1);
+    expect(agents[0]!.runs).toBe(2);
+  });
+
+  it("should aggregate credit usage per member", async () => {
+    const { date, dateStr } = recentDate();
+
+    const runId = await createCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: new Date(date.getTime() + 5000),
+    });
+
+    await seedUserCacheEntry(userId, "test@example.com");
+
+    await seedCreditUsageRecord({
+      runId,
+      orgId,
+      userId,
+      creditsCharged: 500,
+      createdAt: date,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+
+    const data = row!.data;
+    expect(data.creditsUsed).toBe(500);
+
+    const teamUsage = data.teamUsage as Array<{
+      name: string;
+      credits: number;
+    }>;
+    expect(teamUsage).toHaveLength(1);
+    expect(teamUsage[0]!.credits).toBe(500);
+  });
+
+  it("should include credit balance from org metadata", async () => {
+    const { date, dateStr } = recentDate();
+
+    await createCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: new Date(date.getTime() + 5000),
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+    // ensureOrgRow inserts with default 10000 credits
+    expect(row!.data.creditBalance).toBe(10000);
+  });
+
+  it("should include Axiom network data when available", async () => {
+    const { date, dateStr } = recentDate();
+
+    const runId = await createCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: new Date(date.getTime() + 5000),
+    });
+
+    // Mock Axiom to return network logs referencing this run
+    context.mocks.axiom.queryAxiom.mockResolvedValue([
+      {
+        _time: date.toISOString(),
+        runId,
+        host: "api.slack.com",
+        firewall_ref: "slack",
+        firewall_permission: "send_message",
+        action: "ALLOW",
+      },
+      {
+        _time: date.toISOString(),
+        runId,
+        host: "api.slack.com",
+        firewall_ref: "slack",
+        firewall_permission: "send_message",
+        action: "DENY",
+      },
+      {
+        _time: date.toISOString(),
+        runId,
+        host: "api.linear.app",
+        firewall_ref: "linear",
+        firewall_permission: "read_issues",
+        action: "ALLOW",
+      },
+    ]);
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+
+    const data = row!.data;
+    const services = data.services as Array<{
+      domain: string;
+      calls: number;
+    }>;
+    expect(services).toHaveLength(2);
+
+    const slackService = services.find((s) => {
+      return s.domain === "slack";
+    });
+    expect(slackService).toBeDefined();
+    expect(slackService!.calls).toBe(2);
+
+    const linearService = services.find((s) => {
+      return s.domain === "linear";
+    });
+    expect(linearService).toBeDefined();
+    expect(linearService!.calls).toBe(1);
+
+    const permissions = data.permissions as Array<{
+      label: string;
+      allowed: number;
+      denied: number;
+    }>;
+    expect(permissions).toHaveLength(2);
+
+    // Permission labels are either human-readable descriptions or "ref:permission" fallbacks
+    const slackPerm = permissions.find((p) => {
+      return p.label.includes("slack") && p.label.includes("send_message");
+    });
+    expect(slackPerm).toBeDefined();
+    expect(slackPerm!.allowed).toBe(1);
+    expect(slackPerm!.denied).toBe(1);
+  });
+
+  it("should continue without network data when Axiom fails", async () => {
+    const { date, dateStr } = recentDate();
+
+    await createCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: new Date(date.getTime() + 5000),
+    });
+
+    context.mocks.axiom.queryAxiom.mockRejectedValue(
+      new Error("Axiom unavailable"),
+    );
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+
+    // Agent data should still be present even without Axiom
+    const agents = row!.data.agents as Array<{ runs: number }>;
+    expect(agents).toHaveLength(1);
+    expect(agents[0]!.runs).toBe(1);
+
+    // No services or permissions since Axiom failed
+    expect(row!.data.services).toEqual([]);
+    expect(row!.data.permissions).toEqual([]);
+  });
+
+  it("should be idempotent on rerun", async () => {
+    const { date, dateStr } = recentDate();
+
+    await createCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: new Date(date.getTime() + 5000),
+    });
+
+    // First run
+    await GET(cronRequest("test-cron-secret"));
+
+    // Second run
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    const agents = row!.data.agents as Array<{ runs: number }>;
+    expect(agents).toHaveLength(1);
+    expect(agents[0]!.runs).toBe(1);
+  });
+});

--- a/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
@@ -1,0 +1,864 @@
+import { NextResponse } from "next/server";
+import { sql, and, eq, gte, lt, inArray, isNotNull } from "drizzle-orm";
+import { initServices } from "../../../../src/lib/init-services";
+import { env } from "../../../../src/env";
+import { logger } from "../../../../src/lib/shared/logger";
+import { agentRuns } from "../../../../src/db/schema/agent-run";
+import { agentComposeVersions } from "../../../../src/db/schema/agent-compose";
+import { zeroAgents } from "../../../../src/db/schema/zero-agent";
+import { creditUsage } from "../../../../src/db/schema/credit-usage";
+import { orgMetadata } from "../../../../src/db/schema/org-metadata";
+import { orgMembersMetadata } from "../../../../src/db/schema/org-members-metadata";
+import { userCache } from "../../../../src/db/schema/user-cache";
+import { insightsDaily } from "../../../../src/db/schema/insights-daily";
+import {
+  queryAxiom,
+  getDatasetName,
+  DATASETS,
+} from "../../../../src/lib/shared/axiom";
+import { getConnectorFirewall, isFirewallConnectorType } from "@vm0/core";
+import { clerkClient } from "@clerk/nextjs/server";
+
+const log = logger("cron:aggregate-insights");
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AgentInfo {
+  agentId: string;
+  agentName: string;
+  runs: number;
+  credits: number;
+}
+
+interface AxiomNetworkRow {
+  _time: string;
+  runId: string;
+  host: string;
+  firewall_ref: string;
+  firewall_permission: string;
+  action: string;
+}
+
+// ---------------------------------------------------------------------------
+// Timezone helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve per-user timezones from org_members_metadata. */
+async function resolveUserTimezones(
+  orgUserPairs: Array<{ orgId: string; userId: string }>,
+): Promise<Map<string, string>> {
+  if (orgUserPairs.length === 0) return new Map();
+
+  const db = globalThis.services.db;
+  const userIds = [
+    ...new Set(
+      orgUserPairs.map((p) => {
+        return p.userId;
+      }),
+    ),
+  ];
+
+  const rows = await db
+    .select({
+      orgId: orgMembersMetadata.orgId,
+      userId: orgMembersMetadata.userId,
+      timezone: orgMembersMetadata.timezone,
+    })
+    .from(orgMembersMetadata)
+    .where(
+      and(
+        inArray(orgMembersMetadata.userId, userIds),
+        isNotNull(orgMembersMetadata.timezone),
+      ),
+    );
+
+  // key: `orgId:userId` → timezone
+  const tzMap = new Map<string, string>();
+  for (const row of rows) {
+    if (row.timezone) {
+      tzMap.set(`${row.orgId}:${row.userId}`, row.timezone);
+    }
+  }
+
+  return tzMap;
+}
+
+function getLocalDayStartUtc(timezone: string, now: Date): Date {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+  const localMidnight = new Date(`${parts}T00:00:00`);
+  const utcStr = localMidnight.toLocaleString("en-US", { timeZone: "UTC" });
+  const tzStr = localMidnight.toLocaleString("en-US", { timeZone: timezone });
+  const utcDate = new Date(utcStr);
+  const tzDate = new Date(tzStr);
+  const offsetMs = utcDate.getTime() - tzDate.getTime();
+  return new Date(localMidnight.getTime() + offsetMs);
+}
+
+/** Get "today" window in a given timezone: from local midnight to now. */
+function getLocalToday(
+  timezone: string,
+  now: Date,
+): { targetDate: string; dayStart: Date; dayEnd: Date } {
+  const dayStart = getLocalDayStartUtc(timezone, now);
+  const dayEnd = now;
+  const targetDate = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+  return { targetDate, dayStart, dayEnd };
+}
+
+// ---------------------------------------------------------------------------
+// Permission label resolution
+// ---------------------------------------------------------------------------
+
+const permissionLabelCache = new Map<string, string>();
+
+function getPermissionLabel(
+  firewallRef: string,
+  permissionName: string,
+): string {
+  const key = `${firewallRef}:${permissionName}`;
+  const cached = permissionLabelCache.get(key);
+  if (cached) return cached;
+
+  if (isFirewallConnectorType(firewallRef)) {
+    const config = getConnectorFirewall(firewallRef);
+    for (const api of config.apis) {
+      if (!api.permissions) continue;
+      for (const perm of api.permissions) {
+        if (perm.name === permissionName) {
+          const label = perm.description ?? key;
+          permissionLabelCache.set(key, label);
+          return label;
+        }
+      }
+    }
+  }
+
+  permissionLabelCache.set(key, key);
+  return key;
+}
+
+// ---------------------------------------------------------------------------
+// User name resolution
+// ---------------------------------------------------------------------------
+
+async function resolveUserNames(
+  userIds: string[],
+): Promise<Map<string, string>> {
+  if (userIds.length === 0) return new Map();
+
+  const db = globalThis.services.db;
+
+  const cachedUsers = await db
+    .select({ userId: userCache.userId, email: userCache.email })
+    .from(userCache)
+    .where(inArray(userCache.userId, userIds));
+
+  const nameMap = new Map(
+    cachedUsers.map((u) => {
+      return [u.userId, u.email.split("@")[0] ?? u.email];
+    }),
+  );
+
+  const missingIds = userIds.filter((id) => {
+    return !nameMap.has(id);
+  });
+  if (missingIds.length > 0) {
+    const client = await clerkClient();
+    const clerkUsers = await client.users.getUserList({
+      userId: missingIds,
+      limit: missingIds.length,
+    });
+
+    const now = new Date();
+    for (const user of clerkUsers.data) {
+      const primaryEmail = user.emailAddresses.find((e) => {
+        return e.id === user.primaryEmailAddressId;
+      });
+      const email = primaryEmail?.emailAddress ?? "unknown";
+      const name =
+        user.firstName ?? user.username ?? email.split("@")[0] ?? "unknown";
+      nameMap.set(user.id, name);
+
+      await db
+        .insert(userCache)
+        .values({ userId: user.id, email, cachedAt: now })
+        .onConflictDoUpdate({
+          target: userCache.userId,
+          set: { email, cachedAt: now },
+        });
+    }
+  }
+
+  return nameMap;
+}
+
+// ---------------------------------------------------------------------------
+// Network data aggregation (per-user)
+// ---------------------------------------------------------------------------
+
+interface UserNetworkData {
+  serviceMap: Map<string, { calls: number; agentNames: Set<string> }>;
+  permMap: Map<
+    string,
+    {
+      label: string;
+      allowed: number;
+      denied: number;
+      agentNames: Set<string>;
+    }
+  >;
+}
+
+function aggregateNetworkDataPerUser(
+  networkRows: AxiomNetworkRow[],
+  runIdToInfo: Map<
+    string,
+    { orgId: string; userId: string; agentName: string }
+  >,
+): Map<string, UserNetworkData> {
+  const userNetworkMap = new Map<string, UserNetworkData>();
+
+  for (const row of networkRows) {
+    if (!isFirewallConnectorType(row.firewall_ref)) continue;
+
+    const info = runIdToInfo.get(row.runId);
+    if (!info) continue;
+
+    const key = `${info.orgId}:${info.userId}`;
+
+    if (!userNetworkMap.has(key)) {
+      userNetworkMap.set(key, {
+        serviceMap: new Map(),
+        permMap: new Map(),
+      });
+    }
+    const userData = userNetworkMap.get(key)!;
+
+    const connectorKey = row.firewall_ref;
+    const svc = userData.serviceMap.get(connectorKey) ?? {
+      calls: 0,
+      agentNames: new Set<string>(),
+    };
+    svc.calls++;
+    svc.agentNames.add(info.agentName);
+    userData.serviceMap.set(connectorKey, svc);
+
+    if (row.firewall_permission) {
+      const isUnrestricted = row.firewall_permission === "unrestricted";
+      const permKey = isUnrestricted
+        ? row.firewall_ref
+        : `${row.firewall_ref}:${row.firewall_permission}`;
+      const label = isUnrestricted
+        ? row.firewall_ref
+        : getPermissionLabel(row.firewall_ref, row.firewall_permission);
+      const perm = userData.permMap.get(permKey) ?? {
+        label,
+        allowed: 0,
+        denied: 0,
+        agentNames: new Set<string>(),
+      };
+      if (row.action === "ALLOW") {
+        perm.allowed++;
+      } else if (row.action === "DENY") {
+        perm.denied++;
+      }
+      perm.agentNames.add(info.agentName);
+      userData.permMap.set(permKey, perm);
+    }
+  }
+
+  return userNetworkMap;
+}
+
+// ---------------------------------------------------------------------------
+// Per-user insight assembly
+// ---------------------------------------------------------------------------
+
+interface InsightData {
+  agents: {
+    agentName: string;
+    agentId: string;
+    runs: number;
+    credits: number;
+  }[];
+  creditsUsed: number;
+  creditBalance: number;
+  teamUsage: {
+    name: string;
+    credits: number;
+    agentNames: string[];
+    agentCredits: Record<string, number>;
+  }[];
+  topTask: { name: string; count: number } | null;
+  services: {
+    name: string;
+    domain: string;
+    calls: number;
+    agentNames: string[];
+  }[];
+  permissions: {
+    label: string;
+    allowed: number;
+    denied: number;
+    agentNames: string[];
+  }[];
+  axiomDegraded?: boolean;
+}
+
+function buildUserInsight(
+  networkData: UserNetworkData | undefined,
+  agents: AgentInfo[],
+  orgCreditsUsed: number,
+  orgCreditBalance: number,
+  orgTeamUsage: Array<{
+    name: string;
+    credits: number;
+    agentNames: string[];
+    agentCredits: Record<string, number>;
+  }>,
+  axiomDegraded?: boolean,
+): InsightData {
+  const services = networkData
+    ? [...networkData.serviceMap.entries()]
+        .map(([connectorKey, svc]) => {
+          const config = isFirewallConnectorType(connectorKey)
+            ? getConnectorFirewall(connectorKey)
+            : null;
+          return {
+            name: config?.name ?? connectorKey,
+            domain: connectorKey,
+            calls: svc.calls,
+            agentNames: [...svc.agentNames],
+          };
+        })
+        .sort((a, b) => {
+          return b.calls - a.calls;
+        })
+    : [];
+
+  const permissions = networkData
+    ? [...networkData.permMap.values()]
+        .map((p) => {
+          return {
+            label: p.label,
+            allowed: p.allowed,
+            denied: p.denied,
+            agentNames: [...p.agentNames],
+          };
+        })
+        .sort((a, b) => {
+          return b.allowed + b.denied - (a.allowed + a.denied);
+        })
+    : [];
+
+  const topPerm = permissions[0];
+  const topTask = topPerm
+    ? { name: topPerm.label, count: topPerm.allowed + topPerm.denied }
+    : null;
+
+  return {
+    agents: agents.map((a) => {
+      return {
+        agentName: a.agentName,
+        agentId: a.agentId,
+        runs: a.runs,
+        credits: a.credits,
+      };
+    }),
+    creditsUsed: orgCreditsUsed,
+    creditBalance: orgCreditBalance,
+    teamUsage: orgTeamUsage,
+    topTask,
+    services,
+    permissions,
+    ...(axiomDegraded ? { axiomDegraded: true } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Credit aggregation
+// ---------------------------------------------------------------------------
+
+interface TeamUsageEntry {
+  name: string;
+  credits: number;
+  agentNames: string[];
+  agentCredits: Record<string, number>;
+}
+
+interface OrgCreditsInfo {
+  creditsUsed: number;
+  teamUsage: TeamUsageEntry[];
+}
+
+function aggregateOrgCredits(
+  memberRows: {
+    orgId: string;
+    userId: string;
+    agentName: string;
+    credits: number;
+  }[],
+  userNameMap: Map<string, string>,
+): Map<string, OrgCreditsInfo> {
+  const memberAgg = new Map<
+    string,
+    Map<
+      string,
+      {
+        credits: number;
+        agentNames: Set<string>;
+        agentCredits: Map<string, number>;
+      }
+    >
+  >();
+
+  for (const row of memberRows) {
+    if (!memberAgg.has(row.orgId)) {
+      memberAgg.set(row.orgId, new Map());
+    }
+    const orgMembers = memberAgg.get(row.orgId)!;
+    const existing = orgMembers.get(row.userId) ?? {
+      credits: 0,
+      agentNames: new Set<string>(),
+      agentCredits: new Map<string, number>(),
+    };
+    const amt = Number(row.credits);
+    existing.credits += amt;
+    existing.agentNames.add(row.agentName);
+    existing.agentCredits.set(
+      row.agentName,
+      (existing.agentCredits.get(row.agentName) ?? 0) + amt,
+    );
+    orgMembers.set(row.userId, existing);
+  }
+
+  const orgCreditsMap = new Map<string, OrgCreditsInfo>();
+  for (const [orgId, members] of memberAgg) {
+    let creditsUsed = 0;
+    const teamUsage: TeamUsageEntry[] = [];
+    for (const [userId, data] of members) {
+      creditsUsed += data.credits;
+      teamUsage.push({
+        name: userNameMap.get(userId) ?? userId,
+        credits: data.credits,
+        agentNames: [...data.agentNames],
+        agentCredits: Object.fromEntries(data.agentCredits),
+      });
+    }
+    teamUsage.sort((a, b) => {
+      return b.credits - a.credits;
+    });
+    orgCreditsMap.set(orgId, { creditsUsed, teamUsage });
+  }
+
+  return orgCreditsMap;
+}
+
+// ---------------------------------------------------------------------------
+// Window group processing
+// ---------------------------------------------------------------------------
+
+interface WindowGroup {
+  dayStart: Date;
+  dayEnd: Date;
+  targetDate: string;
+  users: Array<{ orgId: string; userId: string }>;
+}
+
+async function processWindowGroup(
+  db: typeof globalThis.services.db,
+  group: WindowGroup,
+): Promise<{ upserted: number; networkRows: number }> {
+  const { dayStart, dayEnd, targetDate, users } = group;
+  const orgIds = [
+    ...new Set(
+      users.map((u) => {
+        return u.orgId;
+      }),
+    ),
+  ];
+  const userIds = [
+    ...new Set(
+      users.map((u) => {
+        return u.userId;
+      }),
+    ),
+  ];
+
+  // ── Agent runs per user ────────────────────────────────────────────
+
+  const agentRows = await db
+    .select({
+      orgId: agentRuns.orgId,
+      userId: agentRuns.userId,
+      agentId: zeroAgents.id,
+      agentName:
+        sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
+          "agent_name",
+        ),
+      runCount: sql<number>`COUNT(DISTINCT ${agentRuns.id})::int`.as(
+        "run_count",
+      ),
+      credits:
+        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
+          "credits",
+        ),
+    })
+    .from(agentRuns)
+    .innerJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .leftJoin(
+      creditUsage,
+      and(
+        eq(creditUsage.runId, agentRuns.id),
+        eq(creditUsage.status, "processed"),
+      ),
+    )
+    .where(
+      and(
+        inArray(agentRuns.orgId, orgIds),
+        inArray(agentRuns.userId, userIds),
+        gte(agentRuns.createdAt, dayStart),
+        lt(agentRuns.createdAt, dayEnd),
+        isNotNull(agentRuns.completedAt),
+      ),
+    )
+    .groupBy(
+      agentRuns.orgId,
+      agentRuns.userId,
+      zeroAgents.id,
+      zeroAgents.displayName,
+      zeroAgents.name,
+    );
+
+  // key: `orgId:userId`
+  const userAgentMap = new Map<string, AgentInfo[]>();
+  for (const row of agentRows) {
+    const key = `${row.orgId}:${row.userId}`;
+    const list = userAgentMap.get(key) ?? [];
+    list.push({
+      agentId: row.agentId,
+      agentName: row.agentName,
+      runs: row.runCount,
+      credits: Number(row.credits),
+    });
+    userAgentMap.set(key, list);
+  }
+
+  // ── runId → user mapping for Axiom cross-reference ─────────────────
+
+  const runAgentRows = await db
+    .select({
+      runId: agentRuns.id,
+      orgId: agentRuns.orgId,
+      userId: agentRuns.userId,
+      agentName:
+        sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
+          "agent_name",
+        ),
+    })
+    .from(agentRuns)
+    .innerJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .where(
+      and(
+        inArray(agentRuns.orgId, orgIds),
+        inArray(agentRuns.userId, userIds),
+        gte(agentRuns.createdAt, dayStart),
+        lt(agentRuns.createdAt, dayEnd),
+      ),
+    );
+
+  const runIdToInfo = new Map<
+    string,
+    { orgId: string; userId: string; agentName: string }
+  >();
+  for (const row of runAgentRows) {
+    runIdToInfo.set(row.runId, {
+      orgId: row.orgId,
+      userId: row.userId,
+      agentName: row.agentName,
+    });
+  }
+
+  // ── Org-wide credits with agent breakdown ────────────────────────────
+
+  const memberRows = await db
+    .select({
+      orgId: creditUsage.orgId,
+      userId: creditUsage.userId,
+      agentName:
+        sql<string>`COALESCE(${zeroAgents.displayName}, ${zeroAgents.name})`.as(
+          "agent_name",
+        ),
+      credits:
+        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
+          "credits",
+        ),
+    })
+    .from(creditUsage)
+    .innerJoin(agentRuns, eq(creditUsage.runId, agentRuns.id))
+    .innerJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .innerJoin(zeroAgents, eq(agentComposeVersions.composeId, zeroAgents.id))
+    .where(
+      and(
+        inArray(creditUsage.orgId, orgIds),
+        eq(creditUsage.status, "processed"),
+        gte(creditUsage.createdAt, dayStart),
+        lt(creditUsage.createdAt, dayEnd),
+      ),
+    )
+    .groupBy(
+      creditUsage.orgId,
+      creditUsage.userId,
+      zeroAgents.displayName,
+      zeroAgents.name,
+    );
+
+  const allCreditUserIds = [
+    ...new Set(
+      memberRows.map((r) => {
+        return r.userId;
+      }),
+    ),
+  ];
+  const userNameMap = await resolveUserNames(allCreditUserIds);
+  const orgCreditsMap = aggregateOrgCredits(memberRows, userNameMap);
+
+  // ── Credit balances ────────────────────────────────────────────────
+
+  const balanceRows =
+    orgIds.length > 0
+      ? await db
+          .select({ orgId: orgMetadata.orgId, credits: orgMetadata.credits })
+          .from(orgMetadata)
+          .where(inArray(orgMetadata.orgId, orgIds))
+      : [];
+
+  const orgBalanceMap = new Map(
+    balanceRows.map((r) => {
+      return [r.orgId, Number(r.credits)];
+    }),
+  );
+
+  // ── Axiom network logs ─────────────────────────────────────────────
+
+  const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_NETWORK);
+  const startIso = dayStart.toISOString();
+  const endIso = dayEnd.toISOString();
+
+  const apl = `['${dataset}']
+| where _time >= datetime("${startIso}") and _time < datetime("${endIso}")
+| where isnotnull(firewall_ref) and firewall_ref != ""
+| project runId, host, firewall_ref, firewall_permission, action
+| limit 100000`;
+
+  let networkRows: AxiomNetworkRow[] = [];
+  let axiomDegraded = false;
+  try {
+    networkRows = await queryAxiom<AxiomNetworkRow>(apl);
+  } catch (error) {
+    axiomDegraded = true;
+    log.error("Failed to query Axiom for network logs", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const userNetworkMap = aggregateNetworkDataPerUser(networkRows, runIdToInfo);
+
+  // ── Upsert per user ────────────────────────────────────────────────
+
+  let upserted = 0;
+  for (const { orgId, userId } of users) {
+    const key = `${orgId}:${userId}`;
+    const agents = userAgentMap.get(key) ?? [];
+    const orgCredits = orgCreditsMap.get(orgId);
+    const networkData = userNetworkMap.get(key);
+
+    const data = buildUserInsight(
+      networkData,
+      agents,
+      orgCredits?.creditsUsed ?? 0,
+      orgBalanceMap.get(orgId) ?? 0,
+      orgCredits?.teamUsage ?? [],
+      axiomDegraded,
+    );
+
+    await db
+      .insert(insightsDaily)
+      .values({ orgId, userId, date: targetDate, data })
+      .onConflictDoUpdate({
+        target: [insightsDaily.orgId, insightsDaily.userId, insightsDaily.date],
+        set: { data, updatedAt: new Date() },
+      });
+
+    upserted++;
+  }
+
+  return { upserted, networkRows: networkRows.length };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function GET(request: Request): Promise<Response> {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = env().CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { error: { message: "Invalid cron secret", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const db = globalThis.services.db;
+  const now = new Date();
+
+  // ── Step 1: Find (org, user) pairs with new completed runs ─────────────
+  // 25h lookback covers "today" in all timezones (UTC-12 to UTC+14)
+
+  const lookbackStart = new Date(now.getTime() - 25 * 3600_000);
+
+  const activeUsers = await db
+    .select({
+      orgId: agentRuns.orgId,
+      userId: agentRuns.userId,
+      lastCompleted: sql<Date>`MAX(${agentRuns.completedAt})`.as(
+        "last_completed",
+      ),
+    })
+    .from(agentRuns)
+    .where(
+      and(
+        gte(agentRuns.completedAt, lookbackStart),
+        isNotNull(agentRuns.completedAt),
+      ),
+    )
+    .groupBy(agentRuns.orgId, agentRuns.userId);
+
+  if (activeUsers.length === 0) {
+    log.info("No users with new runs, skipping aggregation");
+    return NextResponse.json({ users: 0, skipped: true });
+  }
+
+  // ── Step 1b: Filter out users whose last run is older than last aggregation
+
+  const activeOrgIds = [
+    ...new Set(
+      activeUsers.map((u) => {
+        return u.orgId;
+      }),
+    ),
+  ];
+  const activeUserIds = [
+    ...new Set(
+      activeUsers.map((u) => {
+        return u.userId;
+      }),
+    ),
+  ];
+
+  const lastAggRows = await db
+    .select({
+      orgId: insightsDaily.orgId,
+      userId: insightsDaily.userId,
+      lastUpdated: sql<Date>`MAX(${insightsDaily.updatedAt})`.as(
+        "last_updated",
+      ),
+    })
+    .from(insightsDaily)
+    .where(
+      and(
+        inArray(insightsDaily.orgId, activeOrgIds),
+        inArray(insightsDaily.userId, activeUserIds),
+      ),
+    )
+    .groupBy(insightsDaily.orgId, insightsDaily.userId);
+
+  const lastAggMap = new Map(
+    lastAggRows.map((r) => {
+      return [`${r.orgId}:${r.userId}`, r.lastUpdated];
+    }),
+  );
+
+  const usersToAggregate = activeUsers.filter((u) => {
+    const lastAgg = lastAggMap.get(`${u.orgId}:${u.userId}`);
+    if (!lastAgg) return true;
+    return u.lastCompleted > lastAgg;
+  });
+
+  if (usersToAggregate.length === 0) {
+    log.info("All active users are up to date");
+    return NextResponse.json({ users: 0, skipped: true });
+  }
+
+  // ── Step 2: Resolve per-user timezones ─────────────────────────────────
+
+  const userTzMap = await resolveUserTimezones(usersToAggregate);
+
+  // Group users by their "today" time window
+  const windowGroups = new Map<string, WindowGroup>();
+
+  for (const { orgId, userId } of usersToAggregate) {
+    const tz = userTzMap.get(`${orgId}:${userId}`) ?? "UTC";
+    const { targetDate, dayStart, dayEnd } = getLocalToday(tz, now);
+    const windowKey = `${dayStart.toISOString()}|${dayEnd.toISOString()}`;
+
+    const group = windowGroups.get(windowKey) ?? {
+      dayStart,
+      dayEnd,
+      targetDate,
+      users: [],
+    };
+    group.users.push({ orgId, userId });
+    windowGroups.set(windowKey, group);
+  }
+
+  // ── Step 3: Process each time window ───────────────────────────────────
+
+  let upserted = 0;
+  let totalNetworkRows = 0;
+
+  for (const group of windowGroups.values()) {
+    const result = await processWindowGroup(db, group);
+    upserted += result.upserted;
+    totalNetworkRows += result.networkRows;
+  }
+
+  log.info("Aggregated insights", {
+    users: upserted,
+    windows: windowGroups.size,
+    networkRows: totalNetworkRows,
+  });
+
+  return NextResponse.json({
+    users: upserted,
+    windows: windowGroups.size,
+    networkRows: totalNetworkRows,
+  });
+}

--- a/turbo/apps/web/app/api/zero/insights/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/insights/__tests__/route.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  ensureOrgRow,
+  seedInsightsDaily,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+/** Return an ISO date string N days ago from today. */
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+function defaultInsightData(overrides?: Record<string, unknown>) {
+  return {
+    agents: [
+      { agentName: "Test Agent", agentId: "agent-1", runs: 5, credits: 100 },
+    ],
+    creditsUsed: 100,
+    creditBalance: 9900,
+    teamUsage: [{ name: "alice", credits: 100 }],
+    topTask: { name: "Send message", count: 10 },
+    services: [
+      {
+        name: "api.slack.com",
+        domain: "api.slack.com",
+        calls: 10,
+        agentNames: ["Test Agent"],
+      },
+    ],
+    permissions: [
+      {
+        label: "chat:write",
+        allowed: 8,
+        denied: 2,
+        agentNames: ["Test Agent"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("GET /api/zero/insights", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    await ensureOrgRow(user.orgId);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return empty days when no insights exist", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.days).toEqual([]);
+    expect(data.totalCredits).toBe(0);
+    expect(data.totalRuns).toBe(0);
+  });
+
+  it("should return insights with correct structure", async () => {
+    const yesterday = daysAgo(1);
+    await seedInsightsDaily(
+      user.orgId,
+      yesterday,
+      defaultInsightData(),
+      user.userId,
+    );
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.days).toHaveLength(1);
+    expect(data.days[0].date).toBe(yesterday);
+    expect(data.days[0].agents).toHaveLength(1);
+    expect(data.days[0].agents[0].agentName).toBe("Test Agent");
+    expect(data.days[0].creditsUsed).toBe(100);
+    expect(data.totalCredits).toBe(100);
+    expect(data.totalRuns).toBe(5);
+  });
+
+  it("should aggregate totals across multiple days", async () => {
+    await seedInsightsDaily(
+      user.orgId,
+      daysAgo(1),
+      defaultInsightData(),
+      user.userId,
+    );
+    await seedInsightsDaily(
+      user.orgId,
+      daysAgo(2),
+      defaultInsightData({
+        agents: [
+          {
+            agentName: "Agent B",
+            agentId: "agent-2",
+            runs: 3,
+            credits: 200,
+          },
+        ],
+        creditsUsed: 200,
+      }),
+      user.userId,
+    );
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.days).toHaveLength(2);
+    expect(data.totalCredits).toBe(300);
+    expect(data.totalRuns).toBe(8);
+  });
+
+  it("should respect days query parameter", async () => {
+    await seedInsightsDaily(
+      user.orgId,
+      daysAgo(1),
+      defaultInsightData(),
+      user.userId,
+    );
+    await seedInsightsDaily(
+      user.orgId,
+      daysAgo(2),
+      defaultInsightData({ creditsUsed: 50 }),
+      user.userId,
+    );
+    await seedInsightsDaily(
+      user.orgId,
+      daysAgo(5),
+      defaultInsightData({ creditsUsed: 75 }),
+      user.userId,
+    );
+
+    // days=3 covers daysAgo(1) and daysAgo(2) but not daysAgo(5)
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights?days=3",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.days).toHaveLength(2);
+  });
+
+  it("should clamp days parameter between 1 and 90", async () => {
+    await seedInsightsDaily(
+      user.orgId,
+      daysAgo(0),
+      defaultInsightData(),
+      user.userId,
+    );
+
+    // days=0 should clamp to 1
+    const request1 = createTestRequest(
+      "http://localhost:3000/api/zero/insights?days=0",
+    );
+    const response1 = await GET(request1);
+    const data1 = await response1.json();
+    expect(response1.status).toBe(200);
+    expect(data1.days).toHaveLength(1);
+
+    // days=200 should clamp to 90
+    const request2 = createTestRequest(
+      "http://localhost:3000/api/zero/insights?days=200",
+    );
+    const response2 = await GET(request2);
+    expect(response2.status).toBe(200);
+  });
+
+  it("should not return insights from other orgs", async () => {
+    await seedInsightsDaily(
+      uniqueId("org_other"),
+      daysAgo(1),
+      defaultInsightData(),
+      user.userId,
+    );
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.days).toEqual([]);
+  });
+
+  it("should not return insights from other users", async () => {
+    await seedInsightsDaily(
+      user.orgId,
+      daysAgo(1),
+      defaultInsightData(),
+      "user_other",
+    );
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.days).toEqual([]);
+  });
+
+  it("should order days by date descending", async () => {
+    const day1 = daysAgo(3);
+    const day2 = daysAgo(1);
+    const day3 = daysAgo(2);
+    await seedInsightsDaily(
+      user.orgId,
+      day1,
+      defaultInsightData(),
+      user.userId,
+    );
+    await seedInsightsDaily(
+      user.orgId,
+      day2,
+      defaultInsightData(),
+      user.userId,
+    );
+    await seedInsightsDaily(
+      user.orgId,
+      day3,
+      defaultInsightData(),
+      user.userId,
+    );
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.days).toHaveLength(3);
+    expect(data.days[0].date).toBe(day2);
+    expect(data.days[1].date).toBe(day3);
+    expect(data.days[2].date).toBe(day1);
+  });
+});

--- a/turbo/apps/web/app/api/zero/insights/range/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/insights/range/__tests__/route.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  ensureOrgRow,
+  seedInsightsDaily,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+function defaultInsightData(overrides?: Record<string, unknown>) {
+  return {
+    agents: [
+      { agentName: "Test Agent", agentId: "agent-1", runs: 3, credits: 50 },
+    ],
+    creditsUsed: 50,
+    creditBalance: 9950,
+    teamUsage: [{ name: "alice", credits: 50 }],
+    topTask: null,
+    services: [],
+    permissions: [],
+    ...overrides,
+  };
+}
+
+describe("GET /api/zero/insights/range", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+    await ensureOrgRow(user.orgId);
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights/range",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return nulls when no insights exist", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights/range",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.minDate).toBeNull();
+    expect(data.maxDate).toBeNull();
+    expect(data.totalDays).toBe(0);
+  });
+
+  it("should return correct range for a single day", async () => {
+    const date = daysAgo(1);
+    await seedInsightsDaily(
+      user.orgId,
+      date,
+      defaultInsightData(),
+      user.userId,
+    );
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights/range",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.minDate).toBe(date);
+    expect(data.maxDate).toBe(date);
+    expect(data.totalDays).toBe(1);
+  });
+
+  it("should return correct range for multiple days", async () => {
+    const day1 = daysAgo(5);
+    const day2 = daysAgo(3);
+    const day3 = daysAgo(1);
+    await seedInsightsDaily(
+      user.orgId,
+      day1,
+      defaultInsightData(),
+      user.userId,
+    );
+    await seedInsightsDaily(
+      user.orgId,
+      day2,
+      defaultInsightData(),
+      user.userId,
+    );
+    await seedInsightsDaily(
+      user.orgId,
+      day3,
+      defaultInsightData(),
+      user.userId,
+    );
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights/range",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.minDate).toBe(day1);
+    expect(data.maxDate).toBe(day3);
+    expect(data.totalDays).toBe(3);
+  });
+
+  it("should not include insights from other orgs", async () => {
+    const otherOrg = uniqueId("org_other");
+    await seedInsightsDaily(
+      otherOrg,
+      daysAgo(1),
+      defaultInsightData(),
+      user.userId,
+    );
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights/range",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.minDate).toBeNull();
+    expect(data.maxDate).toBeNull();
+    expect(data.totalDays).toBe(0);
+  });
+
+  it("should not include insights from other users", async () => {
+    await seedInsightsDaily(
+      user.orgId,
+      daysAgo(1),
+      defaultInsightData(),
+      "user_other",
+    );
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/insights/range",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.minDate).toBeNull();
+    expect(data.maxDate).toBeNull();
+    expect(data.totalDays).toBe(0);
+  });
+});

--- a/turbo/apps/web/app/api/zero/insights/range/route.ts
+++ b/turbo/apps/web/app/api/zero/insights/range/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { sql, eq, and } from "drizzle-orm";
+import { initServices } from "../../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
+import { insightsDaily } from "../../../../../src/db/schema/insights-daily";
+
+/**
+ * GET /api/zero/insights/range
+ *
+ * Returns the date range of available insights for the authenticated org.
+ * Used by the frontend to determine which date filter options to display.
+ */
+export async function GET(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { org } = await resolveOrg(authCtx);
+
+  const [row] = await globalThis.services.db
+    .select({
+      minDate: sql<string>`MIN(${insightsDaily.date})`.as("min_date"),
+      maxDate: sql<string>`MAX(${insightsDaily.date})`.as("max_date"),
+      totalDays: sql<number>`COUNT(*)::int`.as("total_days"),
+    })
+    .from(insightsDaily)
+    .where(
+      and(
+        eq(insightsDaily.orgId, org.orgId),
+        eq(insightsDaily.userId, authCtx.userId),
+      ),
+    );
+
+  if (!row || row.totalDays === 0) {
+    return NextResponse.json({ minDate: null, maxDate: null, totalDays: 0 });
+  }
+
+  return NextResponse.json({
+    minDate: row.minDate,
+    maxDate: row.maxDate,
+    totalDays: row.totalDays,
+  });
+}

--- a/turbo/apps/web/app/api/zero/insights/route.ts
+++ b/turbo/apps/web/app/api/zero/insights/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { sql, desc, eq, and, gte } from "drizzle-orm";
+import { initServices } from "../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
+import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
+import { insightsDaily } from "../../../../src/db/schema/insights-daily";
+
+/**
+ * GET /api/zero/insights
+ *
+ * Returns pre-aggregated daily insights for the authenticated org.
+ * Query params:
+ *   - days: number of days to look back from today (default 30, max 90)
+ */
+export async function GET(request: Request) {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const { org } = await resolveOrg(authCtx);
+
+  const url = new URL(request.url);
+  const daysParam = url.searchParams.get("days");
+  const days = Math.min(Math.max(parseInt(daysParam ?? "30", 10) || 30, 1), 90);
+
+  const cutoff = new Date();
+  cutoff.setUTCHours(0, 0, 0, 0);
+  cutoff.setUTCDate(cutoff.getUTCDate() - days);
+  const cutoffIso = cutoff.toISOString().split("T")[0]!;
+
+  const rows = await globalThis.services.db
+    .select({ date: insightsDaily.date, data: insightsDaily.data })
+    .from(insightsDaily)
+    .where(
+      and(
+        eq(insightsDaily.orgId, org.orgId),
+        eq(insightsDaily.userId, authCtx.userId),
+        gte(insightsDaily.date, sql`${cutoffIso}::date`),
+      ),
+    )
+    .orderBy(desc(insightsDaily.date));
+
+  interface DayData {
+    agents?: { runs?: number }[];
+    creditsUsed?: number;
+    [key: string]: unknown;
+  }
+
+  const daysData = rows.map((row) => {
+    const data = row.data as DayData;
+    return { date: row.date, ...data };
+  });
+
+  const totalCredits = rows.reduce((sum, row) => {
+    const data = row.data as DayData;
+    return sum + (data.creditsUsed ?? 0);
+  }, 0);
+
+  const totalRuns = rows.reduce((sum, row) => {
+    const data = row.data as DayData;
+    const agents = data.agents ?? [];
+    return (
+      sum +
+      agents.reduce((s, a) => {
+        return s + (a.runs ?? 0);
+      }, 0)
+    );
+  }, 0);
+
+  return NextResponse.json({
+    days: daysData,
+    totalCredits,
+    totalRuns,
+  });
+}

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -60,6 +60,7 @@ import { userCache } from "../db/schema/user-cache";
 import { creditUsage } from "../db/schema/credit-usage";
 import { sandboxTelemetry } from "../db/schema/sandbox-telemetry";
 import { creditPricing } from "../db/schema/credit-pricing";
+import { insightsDaily } from "../db/schema/insights-daily";
 import { users } from "../db/schema/user";
 import { and, eq, like, or, sql } from "drizzle-orm";
 import { generateCallbackSecret } from "../lib/infra/callback/hmac";
@@ -2058,6 +2059,86 @@ export async function findUsageDaily(
       ),
     );
   return row;
+}
+
+/**
+ * Look up an insights_daily record for verification in tests.
+ */
+export async function findInsightsDaily(
+  orgId: string,
+  date: string,
+  userId?: string,
+): Promise<{ data: Record<string, unknown> } | undefined> {
+  const conditions = [
+    eq(insightsDaily.orgId, orgId),
+    eq(insightsDaily.date, date),
+  ];
+  if (userId) {
+    conditions.push(eq(insightsDaily.userId, userId));
+  }
+  const [row] = await globalThis.services.db
+    .select({ data: insightsDaily.data })
+    .from(insightsDaily)
+    .where(and(...conditions));
+  return row as { data: Record<string, unknown> } | undefined;
+}
+
+/**
+ * Seed a credit_usage record for testing insights aggregation.
+ */
+export async function seedCreditUsageRecord(options: {
+  runId: string;
+  orgId: string;
+  userId: string;
+  creditsCharged: number;
+  createdAt: Date;
+}): Promise<void> {
+  await globalThis.services.db.insert(creditUsage).values({
+    runId: options.runId,
+    orgId: options.orgId,
+    userId: options.userId,
+    model: "claude-sonnet-4-20250514",
+    modelProvider: "anthropic",
+    inputTokens: 100,
+    outputTokens: 50,
+    creditsCharged: options.creditsCharged,
+    status: "processed",
+    createdAt: options.createdAt,
+  });
+}
+
+/**
+ * Seed or update a user_cache entry for testing.
+ */
+export async function seedUserCacheEntry(
+  userId: string,
+  email: string,
+): Promise<void> {
+  await globalThis.services.db
+    .insert(userCache)
+    .values({ userId, email, cachedAt: new Date() })
+    .onConflictDoUpdate({
+      target: userCache.userId,
+      set: { email, cachedAt: new Date() },
+    });
+}
+
+/**
+ * Seed an insights_daily record for testing the insights API.
+ */
+export async function seedInsightsDaily(
+  orgId: string,
+  date: string,
+  data: Record<string, unknown>,
+  userId?: string,
+): Promise<void> {
+  await globalThis.services.db
+    .insert(insightsDaily)
+    .values({ orgId, userId: userId ?? "user_test_default", date, data })
+    .onConflictDoUpdate({
+      target: [insightsDaily.orgId, insightsDaily.userId, insightsDaily.date],
+      set: { data, updatedAt: new Date() },
+    });
 }
 
 /**

--- a/turbo/apps/web/src/db/db.ts
+++ b/turbo/apps/web/src/db/db.ts
@@ -50,6 +50,7 @@ import * as storageVersionLineageSchema from "./schema/storage-version-lineage";
 import * as vm0ApiKeySchema from "./schema/vm0-api-key";
 import * as zeroSkillSchema from "./schema/zero-skill";
 import * as computerUseHostSchema from "./schema/computer-use-host";
+import * as insightsDailySchema from "./schema/insights-daily";
 
 export const schema = {
   ...userSchema,
@@ -104,4 +105,5 @@ export const schema = {
   ...vm0ApiKeySchema,
   ...zeroSkillSchema,
   ...computerUseHostSchema,
+  ...insightsDailySchema,
 };

--- a/turbo/apps/web/src/db/migrations/0225_open_ben_urich.sql
+++ b/turbo/apps/web/src/db/migrations/0225_open_ben_urich.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "insights_daily" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" text NOT NULL,
+	"user_id" text,
+	"date" date NOT NULL,
+	"data" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_insights_daily_org_user_date" ON "insights_daily" USING btree ("org_id","user_id","date");--> statement-breakpoint
+CREATE INDEX "idx_insights_daily_org_user_date_desc" ON "insights_daily" USING btree ("org_id","user_id","date" DESC NULLS LAST);

--- a/turbo/apps/web/src/db/migrations/meta/0225_snapshot.json
+++ b/turbo/apps/web/src/db/migrations/meta/0225_snapshot.json
@@ -1,0 +1,6858 @@
+{
+  "id": "49c7f96e-96b6-4e3e-8934-b2fdd2b18ed7",
+  "prevId": "77a8b662-57f8-4992-817e-b5559258d2fe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_compose_versions": {
+      "name": "agent_compose_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_compose_versions_compose_id": {
+          "name": "idx_agent_compose_versions_compose_id",
+          "columns": [
+            {
+              "expression": "compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_compose_versions_compose_id_agent_composes_id_fk": {
+          "name": "agent_compose_versions_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_compose_versions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_composes": {
+      "name": "agent_composes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_composes_org": {
+          "name": "idx_agent_composes_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_composes_org_name": {
+          "name": "idx_agent_composes_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_callbacks": {
+      "name": "agent_run_callbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret": {
+          "name": "encrypted_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_run_callbacks_run_id": {
+          "name": "idx_agent_run_callbacks_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_run_callbacks_pending": {
+          "name": "idx_agent_run_callbacks_pending",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_callbacks_run_id_agent_runs_id_fk": {
+          "name": "agent_run_callbacks_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_callbacks",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_events": {
+      "name": "agent_run_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sequence_number": {
+          "name": "sequence_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_run_events_run_id_agent_runs_id_fk": {
+          "name": "agent_run_events_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_events",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_run_queue": {
+      "name": "agent_run_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_params": {
+          "name": "encrypted_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_run_queue_user_created_idx": {
+          "name": "agent_run_queue_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_org_created_idx": {
+          "name": "agent_run_queue_org_created_idx",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_run_queue_expires_at_idx": {
+          "name": "agent_run_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_run_queue_run_id_agent_runs_id_fk": {
+          "name": "agent_run_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "agent_run_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_runs": {
+      "name": "agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_version_id": {
+          "name": "agent_compose_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resumed_from_checkpoint_id": {
+          "name": "resumed_from_checkpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continued_from_session_id": {
+          "name": "continued_from_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_names": {
+          "name": "secret_names",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_runs_user_created": {
+          "name": "idx_agent_runs_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org": {
+          "name": "idx_agent_runs_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_status_heartbeat": {
+          "name": "idx_agent_runs_status_heartbeat",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_running_heartbeat": {
+          "name": "idx_agent_runs_running_heartbeat",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_runs_org_status_created": {
+          "name": "idx_agent_runs_org_status_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk": {
+          "name": "agent_runs_agent_compose_version_id_agent_compose_versions_id_fk",
+          "tableFrom": "agent_runs",
+          "tableTo": "agent_compose_versions",
+          "columnsFrom": ["agent_compose_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_name": {
+          "name": "memory_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_sessions_user_compose_artifact": {
+          "name": "idx_agent_sessions_user_compose_artifact",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artifact_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_sessions_org": {
+          "name": "idx_agent_sessions_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_sessions_agent_compose_id_agent_composes_id_fk": {
+          "name": "agent_sessions_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_sessions_conversation_id_conversations_id_fk": {
+          "name": "agent_sessions_conversation_id_conversations_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blobs": {
+      "name": "blobs",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref_count": {
+          "name": "ref_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blobs_ref_count": {
+          "name": "idx_blobs_ref_count",
+          "columns": [
+            {
+              "expression": "ref_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_thread_runs": {
+      "name": "chat_thread_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "chat_thread_id": {
+          "name": "chat_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_thread_runs_unique": {
+          "name": "idx_chat_thread_runs_unique",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_thread_runs_thread": {
+          "name": "idx_chat_thread_runs_thread",
+          "columns": [
+            {
+              "expression": "chat_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_thread_runs_chat_thread_id_chat_threads_id_fk": {
+          "name": "chat_thread_runs_chat_thread_id_chat_threads_id_fk",
+          "tableFrom": "chat_thread_runs",
+          "tableTo": "chat_threads",
+          "columnsFrom": ["chat_thread_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_thread_runs_run_id_agent_runs_id_fk": {
+          "name": "chat_thread_runs_run_id_agent_runs_id_fk",
+          "tableFrom": "chat_thread_runs",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_threads": {
+      "name": "chat_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_id": {
+          "name": "agent_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_threads_user_compose_updated": {
+          "name": "idx_chat_threads_user_compose_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_compose_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_threads_agent_compose_id_agent_composes_id_fk": {
+          "name": "chat_threads_agent_compose_id_agent_composes_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_threads_session_id_agent_sessions_id_fk": {
+          "name": "chat_threads_session_id_agent_sessions_id_fk",
+          "tableFrom": "chat_threads",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checkpoints": {
+      "name": "checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_compose_snapshot": {
+          "name": "agent_compose_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_snapshot": {
+          "name": "artifact_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_snapshot": {
+          "name": "memory_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions_snapshot": {
+          "name": "volume_versions_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checkpoints_run_id_agent_runs_id_fk": {
+          "name": "checkpoints_run_id_agent_runs_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "checkpoints_conversation_id_conversations_id_fk": {
+          "name": "checkpoints_conversation_id_conversations_id_fk",
+          "tableFrom": "checkpoints",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "checkpoints_run_id_unique": {
+          "name": "checkpoints_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cli_tokens": {
+      "name": "cli_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_tokens_token_unique": {
+          "name": "cli_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compose_jobs": {
+      "name": "compose_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_url": {
+          "name": "github_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "overwrite": {
+          "name": "overwrite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'github'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_compose_jobs_user_status": {
+          "name": "idx_compose_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_created": {
+          "name": "idx_compose_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_compose_jobs_user_active": {
+          "name": "idx_compose_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.computer_use_hosts": {
+      "name": "computer_use_hosts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ngrok_bot_user_id": {
+          "name": "ngrok_bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ngrok_credential_id": {
+          "name": "ngrok_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ngrok_endpoint_id": {
+          "name": "ngrok_endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ngrok_domain_id": {
+          "name": "ngrok_domain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_computer_use_hosts_org_user": {
+          "name": "idx_computer_use_hosts_org_user",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_computer_use_hosts_org": {
+          "name": "idx_computer_use_hosts_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_sessions": {
+      "name": "connector_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "connector_session_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_connector_sessions_code": {
+          "name": "idx_connector_sessions_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connector_sessions_user_status": {
+          "name": "idx_connector_sessions_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_username": {
+          "name": "external_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_email": {
+          "name": "external_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "needs_reconnect": {
+          "name": "needs_reconnect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connectors_org": {
+          "name": "idx_connectors_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connectors_org_user_type": {
+          "name": "idx_connectors_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_type": {
+          "name": "cli_agent_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_id": {
+          "name": "cli_agent_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_agent_session_history": {
+          "name": "cli_agent_session_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cli_agent_session_history_hash": {
+          "name": "cli_agent_session_history_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_run_id_agent_runs_id_fk": {
+          "name": "conversations_run_id_agent_runs_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_run_id_unique": {
+          "name": "conversations_run_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["run_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_expires_record": {
+      "name": "credit_expires_record",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credit_expires_org_active": {
+          "name": "idx_credit_expires_org_active",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "remaining > 0",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_credit_expires_invoice": {
+          "name": "uq_credit_expires_invoice",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "stripe_invoice_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_pricing": {
+      "name": "credit_pricing",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "input_token_price": {
+          "name": "input_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_token_price": {
+          "name": "output_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_token_price": {
+          "name": "cache_read_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_token_price": {
+          "name": "cache_creation_token_price",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_credit_pricing_model_provider": {
+          "name": "uq_credit_pricing_model_provider",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_usage": {
+      "name": "credit_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_uuid": {
+          "name": "result_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "web_search_requests": {
+          "name": "web_search_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(12, 8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_charged": {
+          "name": "credits_charged",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_credit_usage_run_result": {
+          "name": "uq_credit_usage_run_result",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_run_id": {
+          "name": "idx_credit_usage_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_org_status": {
+          "name": "idx_credit_usage_org_status",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_org_created": {
+          "name": "idx_credit_usage_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credit_usage_org_user_status_processed": {
+          "name": "idx_credit_usage_org_user_status_processed",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_usage_run_id_agent_runs_id_fk": {
+          "name": "credit_usage_run_id_agent_runs_id_fk",
+          "tableFrom": "credit_usage",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_code_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_outbox": {
+      "name": "email_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_addresses": {
+          "name": "to_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc_addresses": {
+          "name": "cc_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_send_action": {
+          "name": "post_send_action",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_id": {
+          "name": "resend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_outbox_drain_idx": {
+          "name": "email_outbox_drain_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_retry_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_outbox_created_at_idx": {
+          "name": "email_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_reply_requests": {
+      "name": "email_reply_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_thread_session_id": {
+          "name": "email_thread_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_email_id": {
+          "name": "inbound_email_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inbound_message_id": {
+          "name": "inbound_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_reply_requests_run": {
+          "name": "idx_email_reply_requests_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_reply_requests_run_id_agent_runs_id_fk": {
+          "name": "email_reply_requests_run_id_agent_runs_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk": {
+          "name": "email_reply_requests_email_thread_session_id_email_thread_sessions_id_fk",
+          "tableFrom": "email_reply_requests",
+          "tableTo": "email_thread_sessions",
+          "columnsFrom": ["email_thread_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resend_email_id": {
+          "name": "resend_email_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_suppressions_email_lower_idx": {
+          "name": "email_suppressions_email_lower_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email_address\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_thread_sessions": {
+      "name": "email_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_email_message_id": {
+          "name": "last_email_message_id",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_token": {
+          "name": "reply_to_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_thread_sessions_reply_token": {
+          "name": "idx_email_thread_sessions_reply_token",
+          "columns": [
+            {
+              "expression": "reply_to_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_thread_sessions_user": {
+          "name": "idx_email_thread_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_thread_sessions_agent_id_agent_composes_id_fk": {
+          "name": "email_thread_sessions_agent_id_agent_composes_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "email_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "email_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.export_jobs": {
+      "name": "export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_urls": {
+          "name": "artifact_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_export_jobs_user_status": {
+          "name": "idx_export_jobs_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_created": {
+          "name": "idx_export_jobs_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_export_jobs_user_active": {
+          "name": "idx_export_jobs_user_active",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.firewall_access_requests": {
+      "name": "firewall_access_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_user_id": {
+          "name": "requester_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firewall_ref": {
+          "name": "firewall_ref",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allow'"
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_firewall_access_requests_agent_status": {
+          "name": "idx_firewall_access_requests_agent_status",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_firewall_access_requests_org": {
+          "name": "idx_firewall_access_requests_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "firewall_access_requests_agent_id_zero_agents_id_fk": {
+          "name": "firewall_access_requests_agent_id_zero_agents_id_fk",
+          "tableFrom": "firewall_access_requests",
+          "tableTo": "zero_agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_github_user_id": {
+          "name": "admin_github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_configs": {
+          "name": "repo_configs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_installations_installation_id_unique": {
+          "name": "github_installations_installation_id_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "installation_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "github_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "github_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_issue_sessions": {
+      "name": "github_issue_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo": {
+          "name": "repo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_number": {
+          "name": "issue_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_comment_id": {
+          "name": "last_comment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_issue_sessions_installation_repo_issue": {
+          "name": "idx_github_issue_sessions_installation_repo_issue",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_issue_sessions_installation": {
+          "name": "idx_github_issue_sessions_installation",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_issue_sessions_installation_id_github_installations_id_fk": {
+          "name": "github_issue_sessions_installation_id_github_installations_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_issue_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "github_issue_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "github_issue_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_user_links": {
+      "name": "github_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_github_user_links_user_installation": {
+          "name": "idx_github_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_user_links_installation_id_github_installations_id_fk": {
+          "name": "github_user_links_installation_id_github_installations_id_fk",
+          "tableFrom": "github_user_links",
+          "tableTo": "github_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insights_daily": {
+      "name": "insights_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_insights_daily_org_user_date": {
+          "name": "uq_insights_daily_org_user_date",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_insights_daily_org_user_date_desc": {
+          "name": "idx_insights_daily_org_user_date_desc",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_providers": {
+      "name": "model_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_id": {
+          "name": "secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_providers_secret": {
+          "name": "idx_model_providers_secret",
+          "columns": [
+            {
+              "expression": "secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org": {
+          "name": "idx_model_providers_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_providers_org_user_type": {
+          "name": "idx_model_providers_org_user_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_providers_secret_id_secrets_id_fk": {
+          "name": "model_providers_secret_id_secrets_id_fk",
+          "tableFrom": "model_providers",
+          "tableTo": "secrets",
+          "columnsFrom": ["secret_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_cache": {
+      "name": "org_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_cache_slug": {
+          "name": "idx_org_cache_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_cache": {
+      "name": "org_members_cache",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_cache_org_id_user_id_pk": {
+          "name": "org_members_cache_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members_metadata": {
+      "name": "org_members_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned_agent_ids": {
+          "name": "pinned_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "send_mode": {
+          "name": "send_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enter'"
+        },
+        "onboarding_done": {
+          "name": "onboarding_done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "credit_cap": {
+          "name": "credit_cap",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit_enabled": {
+          "name": "credit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "org_members_metadata_org_id_user_id_pk": {
+          "name": "org_members_metadata_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_metadata": {
+      "name": "org_metadata",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "default_agent_id": {
+          "name": "default_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_processed_invoice_id": {
+          "name": "last_processed_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_enabled": {
+          "name": "auto_recharge_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_recharge_threshold": {
+          "name": "auto_recharge_threshold",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_amount": {
+          "name": "auto_recharge_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_recharge_pending_at": {
+          "name": "auto_recharge_pending_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_org_stripe_customer": {
+          "name": "uq_org_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_metadata_default_agent_id_agent_composes_id_fk": {
+          "name": "org_metadata_default_agent_id_agent_composes_id_fk",
+          "tableFrom": "org_metadata",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runner_job_queue": {
+      "name": "runner_job_queue",
+      "schema": "",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "runner_group": {
+          "name": "runner_group",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile": {
+          "name": "profile",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vm0/default'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_context": {
+          "name": "execution_context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runner_job_queue_group_profile_unclaimed_idx": {
+          "name": "runner_job_queue_group_profile_unclaimed_idx",
+          "columns": [
+            {
+              "expression": "runner_group",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "claimed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runner_job_queue_expires_at_idx": {
+          "name": "runner_job_queue_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runner_job_queue_run_id_agent_runs_id_fk": {
+          "name": "runner_job_queue_run_id_agent_runs_id_fk",
+          "tableFrom": "runner_job_queue",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_telemetry": {
+      "name": "sandbox_telemetry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_telemetry_run_id": {
+          "name": "idx_sandbox_telemetry_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_telemetry_run_id_agent_runs_id_fk": {
+          "name": "sandbox_telemetry_run_id_agent_runs_id_fk",
+          "tableFrom": "sandbox_telemetry",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_secrets_type": {
+          "name": "idx_secrets_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org": {
+          "name": "idx_secrets_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_secrets_org_user_name_type": {
+          "name": "idx_secrets_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skills": {
+      "name": "skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_path": {
+          "name": "full_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_hash": {
+          "name": "version_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skills_name": {
+          "name": "idx_skills_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skills_storage_id": {
+          "name": "idx_skills_storage_id",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skills_storage_id_storages_id_fk": {
+          "name": "skills_storage_id_storages_id_fk",
+          "tableFrom": "skills",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "skills_url_unique": {
+          "name": "skills_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_connections": {
+      "name": "slack_org_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slack_user_id": {
+          "name": "slack_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_connections_user_workspace": {
+          "name": "idx_slack_org_connections_user_workspace",
+          "columns": [
+            {
+              "expression": "slack_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_workspace": {
+          "name": "idx_slack_org_connections_workspace",
+          "columns": [
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_connections_vm0_user_workspace": {
+          "name": "idx_slack_org_connections_vm0_user_workspace",
+          "columns": [
+            {
+              "expression": "vm0_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk": {
+          "name": "slack_org_connections_slack_workspace_id_slack_org_installations_slack_workspace_id_fk",
+          "tableFrom": "slack_org_connections",
+          "tableTo": "slack_org_installations",
+          "columnsFrom": ["slack_workspace_id"],
+          "columnsTo": ["slack_workspace_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_installations": {
+      "name": "slack_org_installations",
+      "schema": "",
+      "columns": {
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slack_workspace_name": {
+          "name": "slack_workspace_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_by_user_id": {
+          "name": "installed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bot_scopes": {
+          "name": "bot_scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_installations_org": {
+          "name": "idx_slack_org_installations_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_installations_org_unique": {
+          "name": "idx_slack_org_installations_org_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "org_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_pending_questions": {
+      "name": "slack_org_pending_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_workspace_id": {
+          "name": "slack_workspace_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_message_ts": {
+          "name": "slack_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compose_id": {
+          "name": "compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_slack_org_pending_questions_run_id": {
+          "name": "idx_slack_org_pending_questions_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_pending_questions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_pending_questions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slack_org_pending_questions_compose_id_agent_composes_id_fk": {
+          "name": "slack_org_pending_questions_compose_id_agent_composes_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_pending_questions_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_pending_questions_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_pending_questions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.slack_org_thread_sessions": {
+      "name": "slack_org_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slack_thread_ts": {
+          "name": "slack_thread_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_processed_message_ts": {
+          "name": "last_processed_message_ts",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_slack_org_thread_sessions_conn_channel_thread": {
+          "name": "idx_slack_org_thread_sessions_conn_channel_thread",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slack_thread_ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_slack_org_thread_sessions_connection": {
+          "name": "idx_slack_org_thread_sessions_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk": {
+          "name": "slack_org_thread_sessions_connection_id_slack_org_connections_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "slack_org_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "slack_org_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "slack_org_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_version_lineage": {
+      "name": "storage_version_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_version_id": {
+          "name": "parent_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_type": {
+          "name": "storage_type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storage_version_lineage_storage_version": {
+          "name": "idx_storage_version_lineage_storage_version",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_storage_parent": {
+          "name": "idx_storage_version_lineage_storage_parent",
+          "columns": [
+            {
+              "expression": "storage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storage_version_lineage_run": {
+          "name": "idx_storage_version_lineage_run",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_version_lineage_storage_id_storages_id_fk": {
+          "name": "storage_version_lineage_storage_id_storages_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_version_lineage_run_id_agent_runs_id_fk": {
+          "name": "storage_version_lineage_run_id_agent_runs_id_fk",
+          "tableFrom": "storage_version_lineage",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_versions": {
+      "name": "storage_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "storage_id": {
+          "name": "storage_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_versions_storage_id_storages_id_fk": {
+          "name": "storage_versions_storage_id_storages_id_fk",
+          "tableFrom": "storage_versions",
+          "tableTo": "storages",
+          "columnsFrom": ["storage_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storages": {
+      "name": "storages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'volume'"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_prefix": {
+          "name": "s3_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "head_version_id": {
+          "name": "head_version_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_storages_org": {
+          "name": "idx_storages_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_storages_org_user_name_type": {
+          "name": "idx_storages_org_user_name_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storages_head_version_id_storage_versions_id_fk": {
+          "name": "storages_head_version_id_storage_versions_id_fk",
+          "tableFrom": "storages",
+          "tableTo": "storage_versions",
+          "columnsFrom": ["head_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_installations": {
+      "name": "telegram_installations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_bot_id": {
+          "name": "telegram_bot_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bot_username": {
+          "name": "bot_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_bot_token": {
+          "name": "encrypted_bot_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_compose_id": {
+          "name": "default_compose_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "telegram_installations_default_compose_id_agent_composes_id_fk": {
+          "name": "telegram_installations_default_compose_id_agent_composes_id_fk",
+          "tableFrom": "telegram_installations",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["default_compose_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "telegram_installations_telegram_bot_id_unique": {
+          "name": "telegram_installations_telegram_bot_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["telegram_bot_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_messages": {
+      "name": "telegram_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_username": {
+          "name": "from_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_messages_unique": {
+          "name": "idx_telegram_messages_unique",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_chat": {
+          "name": "idx_telegram_messages_chat",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_messages_created_at": {
+          "name": "idx_telegram_messages_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_messages_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_messages_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_messages",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_thread_sessions": {
+      "name": "telegram_thread_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_link_id": {
+          "name": "telegram_user_link_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_message_id": {
+          "name": "root_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_session_id": {
+          "name": "agent_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_processed_message_id": {
+          "name": "last_processed_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_thread_sessions_chat_user_link": {
+          "name": "idx_telegram_thread_sessions_chat_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "root_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_telegram_thread_sessions_user_link": {
+          "name": "idx_telegram_thread_sessions_user_link",
+          "columns": [
+            {
+              "expression": "telegram_user_link_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk": {
+          "name": "telegram_thread_sessions_telegram_user_link_id_telegram_user_links_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "telegram_user_links",
+          "columnsFrom": ["telegram_user_link_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk": {
+          "name": "telegram_thread_sessions_agent_session_id_agent_sessions_id_fk",
+          "tableFrom": "telegram_thread_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["agent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_user_links": {
+      "name": "telegram_user_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vm0_user_id": {
+          "name": "vm0_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dm_welcome_sent": {
+          "name": "dm_welcome_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_telegram_user_links_user_installation": {
+          "name": "idx_telegram_user_links_user_installation",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "telegram_user_links_installation_id_telegram_installations_id_fk": {
+          "name": "telegram_user_links_installation_id_telegram_installations_id_fk",
+          "tableFrom": "telegram_user_links",
+          "tableTo": "telegram_installations",
+          "columnsFrom": ["installation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_daily": {
+      "name": "usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "run_time_ms": {
+          "name": "run_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_usage_daily_user_org_date": {
+          "name": "uq_usage_daily_user_org_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_cache": {
+      "name": "user_cache",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_list_cached_at": {
+          "name": "org_list_cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_connectors": {
+      "name": "user_connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_connectors_unique": {
+          "name": "idx_user_connectors_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_connectors_agent_user": {
+          "name": "idx_user_connectors_agent_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_connectors_agent_id_zero_agents_id_fk": {
+          "name": "user_connectors_agent_id_zero_agents_id_fk",
+          "tableFrom": "user_connectors",
+          "tableTo": "zero_agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_unsubscribed": {
+          "name": "email_unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.variables": {
+      "name": "variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_variables_org": {
+          "name": "idx_variables_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_variables_org_user_name": {
+          "name": "idx_variables_org_user_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vm0_api_keys": {
+      "name": "vm0_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_vm0_api_keys_vendor": {
+          "name": "idx_vm0_api_keys_vendor",
+          "columns": [
+            {
+              "expression": "vendor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agent_schedules": {
+      "name": "zero_agent_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_type": {
+          "name": "trigger_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at_time": {
+          "name": "at_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "append_system_prompt": {
+          "name": "append_system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_secrets": {
+          "name": "encrypted_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume_versions": {
+          "name": "volume_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_started_at": {
+          "name": "retry_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agent_schedules_zero_agent": {
+          "name": "idx_zero_agent_schedules_zero_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_org": {
+          "name": "idx_zero_agent_schedules_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_agent_name_org_user": {
+          "name": "idx_zero_agent_schedules_agent_name_org_user",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_next_run": {
+          "name": "idx_zero_agent_schedules_next_run",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "enabled = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agent_schedules_user_org": {
+          "name": "idx_zero_agent_schedules_user_org",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agent_schedules_agent_id_agent_composes_id_fk": {
+          "name": "zero_agent_schedules_agent_id_agent_composes_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_agent_schedules_last_run_id_agent_runs_id_fk": {
+          "name": "zero_agent_schedules_last_run_id_agent_runs_id_fk",
+          "tableFrom": "zero_agent_schedules",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["last_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agent_sessions": {
+      "name": "zero_agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_messages": {
+          "name": "chat_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zero_agent_sessions_id_agent_sessions_id_fk": {
+          "name": "zero_agent_sessions_id_agent_sessions_id_fk",
+          "tableFrom": "zero_agent_sessions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_agents": {
+      "name": "zero_agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sound": {
+          "name": "sound",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firewall_policies": {
+          "name": "firewall_policies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_skills": {
+          "name": "custom_skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_agents_org_name": {
+          "name": "idx_zero_agents_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_agents_org": {
+          "name": "idx_zero_agents_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_agents_id_agent_composes_id_fk": {
+          "name": "zero_agents_id_agent_composes_id_fk",
+          "tableFrom": "zero_agents",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_runs": {
+      "name": "zero_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_agent_id": {
+          "name": "trigger_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_provider": {
+          "name": "model_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selected_model": {
+          "name": "selected_model",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_zero_runs_schedule": {
+          "name": "idx_zero_runs_schedule",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "schedule_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zero_runs_id_agent_runs_id_fk": {
+          "name": "zero_runs_id_agent_runs_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "agent_runs",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zero_runs_schedule_id_zero_agent_schedules_id_fk": {
+          "name": "zero_runs_schedule_id_zero_agent_schedules_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "zero_agent_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "zero_runs_trigger_agent_id_agent_composes_id_fk": {
+          "name": "zero_runs_trigger_agent_id_agent_composes_id_fk",
+          "tableFrom": "zero_runs",
+          "tableTo": "agent_composes",
+          "columnsFrom": ["trigger_agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zero_skills": {
+      "name": "zero_skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_zero_skills_org_name": {
+          "name": "idx_zero_skills_org_name",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_zero_skills_org": {
+          "name": "idx_zero_skills_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.connector_session_status": {
+      "name": "connector_session_status",
+      "schema": "public",
+      "values": ["pending", "complete", "expired", "error"]
+    },
+    "public.device_code_status": {
+      "name": "device_code_status",
+      "schema": "public",
+      "values": ["pending", "authenticated", "expired", "denied"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/turbo/apps/web/src/db/migrations/meta/_journal.json
+++ b/turbo/apps/web/src/db/migrations/meta/_journal.json
@@ -1576,6 +1576,13 @@
       "when": 1775300000000,
       "tag": "0224_add_firewall_access_request_action",
       "breakpoints": true
+    },
+    {
+      "idx": 225,
+      "version": "7",
+      "when": 1775558858000,
+      "tag": "0225_open_ben_urich",
+      "breakpoints": true
     }
   ]
 }

--- a/turbo/apps/web/src/db/schema/insights-daily.ts
+++ b/turbo/apps/web/src/db/schema/insights-daily.ts
@@ -1,0 +1,48 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  date,
+  jsonb,
+  timestamp,
+  uniqueIndex,
+  index,
+} from "drizzle-orm/pg-core";
+
+/**
+ * Pre-aggregated daily insights per user within an org.
+ * Populated by /api/cron/aggregate-insights from PostgreSQL (runs, credits)
+ * and Axiom (network logs, permissions) data sources.
+ *
+ * Agent runs, services, and permissions are per-user.
+ * Credits data (creditsUsed, creditBalance, teamUsage) is org-wide.
+ *
+ * The `data` column stores a full DayInsight snapshot as JSONB,
+ * keeping the schema flexible as new card types are added.
+ */
+export const insightsDaily = pgTable(
+  "insights_daily",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    orgId: text("org_id").notNull(),
+    userId: text("user_id"),
+    date: date("date").notNull(),
+    data: jsonb("data").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => {
+    return [
+      uniqueIndex("uq_insights_daily_org_user_date").on(
+        table.orgId,
+        table.userId,
+        table.date,
+      ),
+      index("idx_insights_daily_org_user_date_desc").on(
+        table.orgId,
+        table.userId,
+        table.date.desc(),
+      ),
+    ];
+  },
+);

--- a/turbo/apps/web/vercel.json
+++ b/turbo/apps/web/vercel.json
@@ -16,6 +16,10 @@
       "schedule": "5 0 * * *"
     },
     {
+      "path": "/api/cron/aggregate-insights",
+      "schedule": "0 * * * *"
+    },
+    {
       "path": "/api/cron/telegram-cleanup",
       "schedule": "0 1 * * *"
     },

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -756,3 +756,12 @@ export {
   type ZeroComputerUseUnregisterContract,
   type ZeroComputerUseHostContract,
 } from "./zero-computer-use";
+export {
+  zeroInsightsContract,
+  zeroInsightsRangeContract,
+  type ZeroInsightsContract,
+  type ZeroInsightsRangeContract,
+  type InsightsResponse,
+  type InsightsRangeResponse,
+  type DayInsight,
+} from "./zero-insights";

--- a/turbo/packages/core/src/contracts/zero-insights.ts
+++ b/turbo/packages/core/src/contracts/zero-insights.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const insightAgentSchema = z.object({
+  agentName: z.string(),
+  agentId: z.string().nullable(),
+  runs: z.number(),
+  credits: z.number(),
+});
+
+const insightServiceSchema = z.object({
+  name: z.string(),
+  domain: z.string(),
+  calls: z.number(),
+  agentNames: z.array(z.string()),
+});
+
+const insightPermissionSchema = z.object({
+  label: z.string(),
+  allowed: z.number(),
+  denied: z.number(),
+  agentNames: z.array(z.string()),
+});
+
+const insightTopTaskSchema = z.object({
+  name: z.string(),
+  count: z.number(),
+});
+
+const insightMemberCreditsSchema = z.object({
+  name: z.string(),
+  credits: z.number(),
+  agentNames: z.array(z.string()).optional(),
+  agentCredits: z.record(z.string(), z.number()).optional(),
+});
+
+const dayInsightSchema = z.object({
+  date: z.string(),
+  agents: z.array(insightAgentSchema).default([]),
+  creditsUsed: z.number().default(0),
+  creditBalance: z.number().default(0),
+  teamUsage: z.array(insightMemberCreditsSchema).default([]),
+  topTask: insightTopTaskSchema.nullable().default(null),
+  services: z.array(insightServiceSchema).default([]),
+  permissions: z.array(insightPermissionSchema).default([]),
+});
+
+const insightsResponseSchema = z.object({
+  days: z.array(dayInsightSchema),
+  totalCredits: z.number(),
+  totalRuns: z.number(),
+});
+
+const insightsRangeResponseSchema = z.object({
+  minDate: z.string().nullable(),
+  maxDate: z.string().nullable(),
+  totalDays: z.number(),
+});
+
+export const zeroInsightsContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/insights",
+    headers: authHeadersSchema,
+    query: z.object({
+      days: z.coerce.number().optional(),
+    }),
+    responses: {
+      200: insightsResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Get daily insights for the authenticated org",
+  },
+});
+
+export const zeroInsightsRangeContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/insights/range",
+    headers: authHeadersSchema,
+    responses: {
+      200: insightsRangeResponseSchema,
+      401: apiErrorSchema,
+    },
+    summary: "Get available date range for org insights",
+  },
+});
+
+export type ZeroInsightsContract = typeof zeroInsightsContract;
+export type ZeroInsightsRangeContract = typeof zeroInsightsRangeContract;
+export type InsightsResponse = z.infer<typeof insightsResponseSchema>;
+export type InsightsRangeResponse = z.infer<typeof insightsRangeResponseSchema>;
+export type DayInsight = z.infer<typeof dayInsightSchema>;


### PR DESCRIPTION
## Summary
- Add network insights page with interactive agent activity cards (platform frontend)
- Add cron-based daily aggregation pipeline with per-user timezone-aware data collection
- Add `insights_daily` table with JSONB data column for flexible insight snapshots
- Add `/api/zero/insights` and `/api/zero/insights/range` API endpoints with ts-rest contracts

## What's included
- **Frontend**: Interactive insights page with agent usage, credit breakdown, service/permission cards, date range filtering
- **Backend**: Hourly cron job aggregating data from PostgreSQL (runs, credits) and Axiom (network logs, permissions)
- **Tests**: 41 tests across 4 test files (cron, insights API, range API, frontend interactions)

## Test plan
- [x] `pnpm vitest` — 41 tests passing (cron, API, frontend)
- [x] `pnpm turbo run lint` — 0 errors
- [x] `pnpm check-types` — passes
- [x] `pnpm knip` — no unused exports
- [x] Migration consistency — 226 SQL files, 226 snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)