### PR TITLE
fix(a11y): add sheet descriptions to queue drawer and firewall permissions sheet

### DIFF
--- a/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
+++ b/turbo/apps/platform/src/views/queue-page/queue-drawer.tsx
@@ -1,6 +1,13 @@
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, Button } from "@vm0/ui";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  Button,
+} from "@vm0/ui";
 import { IconCrown } from "@tabler/icons-react";
 import {
   queueDrawerOpen$,
@@ -229,6 +236,9 @@ export function QueueDrawer() {
       >
         <SheetHeader className="shrink-0">
           <SheetTitle>Your agent is waiting in line</SheetTitle>
+          <SheetDescription>
+            View your position in the queue and upgrade to skip the wait.
+          </SheetDescription>
         </SheetHeader>
 
         <div className="flex-1 min-h-0 overflow-y-auto -mx-6 px-6 -mb-6 pb-6">

--- a/turbo/apps/platform/src/views/zero-page/components/settings/firewall-permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/firewall-permissions-dialog.tsx
@@ -3,6 +3,7 @@ import { useLoadableSet } from "ccstate-react/experimental";
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
   SheetFooter,
@@ -260,7 +261,7 @@ export function FirewallPermissionsDrawer({
         return !open && onClose();
       }}
     >
-      <SheetContent side="right" aria-describedby={undefined}>
+      <SheetContent side="right">
         <SheetHeader>
           <div className="flex items-center gap-3">
             <ConnectorIcon type={connectorType} size={24} />
@@ -271,6 +272,10 @@ export function FirewallPermissionsDrawer({
               </span>
             </SheetTitle>
           </div>
+          <SheetDescription>
+            Configure which actions this agent is allowed to perform via this
+            connector.
+          </SheetDescription>
         </SheetHeader>
 
         {!config ? (


### PR DESCRIPTION
## Summary

Follow-up to #8379 — two `SheetContent` instances were missing accessible descriptions (Radix `Sheet` is built on `DialogContent` and generates the same warning).

- `queue-drawer.tsx`: Added `SheetDescription "View your position in the queue and upgrade to skip the wait."`
- `firewall-permissions-dialog.tsx`: Replaced `aria-describedby={undefined}` with `SheetDescription "Configure which actions this agent is allowed to perform via this connector."`

## Test plan
- [ ] CI passes — no more `Warning: Missing Description or aria-describedby={undefined} for {DialogContent}` from these components