### PR TITLE
refactor: throw not-found for missing org metadata rows

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -9,7 +9,8 @@ import {
   DEFAULT_TEST_EMAIL,
 } from "../../../../../src/lib/auth/test-user";
 import { orgMembersCache } from "../../../../../src/db/schema/org-members-cache";
-import { getOrgDataOrNull } from "../../../../../src/lib/zero/org/resolve-org";
+import { getOrgMetadata } from "../../../../../src/lib/zero/org/org-metadata-service";
+import { isNotFound } from "../../../../../src/lib/shared/errors";
 import { env } from "../../../../../src/env";
 
 const bodySchema = z.object({
@@ -91,7 +92,14 @@ export async function POST(request: Request) {
     .orderBy(desc(orgMembersCache.cachedAt))
     .limit(1);
 
-  const org = cached ? await getOrgDataOrNull(cached.orgId) : null;
+  let org: { orgId: string; tier: string } | null = null;
+  if (cached) {
+    try {
+      org = await getOrgMetadata(cached.orgId);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+  }
   if (!org) {
     return NextResponse.json(
       { error: "Test user has no org — run test-token first" },

--- a/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/test-connector/route.ts
@@ -98,6 +98,8 @@ export async function POST(request: Request) {
       org = await getOrgMetadata(cached.orgId);
     } catch (error) {
       if (!isNotFound(error)) throw error;
+      // org_members_cache entry exists but org_metadata row doesn't yet — use defaults
+      org = { orgId: cached.orgId, tier: "free" };
     }
   }
   if (!org) {

--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../../../__tests__/api-test-helpers";
 import { reloadEnv } from "../../../env";
 import { createZeroRun } from "../zero-run-service";
-import { isInsufficientCredits } from "../../shared/errors";
+import { isInsufficientCredits, isNotFound } from "../../shared/errors";
 import { startRun, type CreateRunParams } from "../../infra/run/run-service";
 import {
   drainOrgQueue,
@@ -123,12 +123,12 @@ describe("credit check (zero layer)", () => {
       expect(result.status).toBe("pending");
     });
 
-    it("should allow when org_metadata row is missing", async () => {
+    it("should reject when org_metadata row is missing", async () => {
       await deleteOrgRow(user.orgId);
 
-      const result = await createZeroRun(baseParams({ modelProvider: "vm0" }));
-
-      expect(result.status).toBe("pending");
+      await expect(
+        createZeroRun(baseParams({ modelProvider: "vm0" })),
+      ).rejects.toSatisfy(isNotFound);
     });
 
     it("should not enqueue a rejected VM0 run", async () => {

--- a/turbo/apps/web/src/lib/zero/org/__tests__/org-metadata-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/org-metadata-service.test.ts
@@ -78,16 +78,12 @@ describe("getOrgMetadata", () => {
     expect(client.organizations.getOrganization).not.toHaveBeenCalled();
   });
 
-  it("returns free tier with zero credits when no row exists", async () => {
+  it("throws notFound when no row exists", async () => {
     const orgId = uniqueId("org-nonexistent");
 
-    const result = await getOrgMetadata(orgId);
-
-    expect(result).toEqual({
-      orgId,
-      tier: "free",
-      credits: 0,
-    });
+    await expect(getOrgMetadata(orgId)).rejects.toThrow(
+      `Organization ${orgId} not found`,
+    );
 
     // Clerk API should NOT have been called
     const client = await clerkClient();

--- a/turbo/apps/web/src/lib/zero/org/__tests__/resolve-org.test.ts
+++ b/turbo/apps/web/src/lib/zero/org/__tests__/resolve-org.test.ts
@@ -186,6 +186,16 @@ describe("resolveOrg", () => {
     expect(result2.org.tier).toBe("team");
   });
 
+  it("returns free tier defaults for brand-new org without org_metadata row", async () => {
+    const userId = uniqueId("test-user");
+    const orgId = uniqueId("brand-new-org");
+
+    const result = await resolveOrg(authCtx({ userId, orgId }));
+
+    expect(result.org.orgId).toBe(orgId);
+    expect(result.org.tier).toBe("free");
+  });
+
   it("returns member with correct role", async () => {
     const userId = uniqueId("test-user");
     const slug = uniqueId("org");

--- a/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
+++ b/turbo/apps/web/src/lib/zero/org/org-metadata-service.ts
@@ -1,11 +1,12 @@
 import { eq } from "drizzle-orm";
 import { orgMetadata } from "../../../db/schema/org-metadata";
+import { notFound } from "../../shared/errors";
 import { logger } from "../../shared/logger";
 import { getStripe } from "../stripe";
 
 const log = logger("service:org-metadata");
 
-interface OrgMetadata {
+export interface OrgMetadata {
   orgId: string;
   tier: string;
   credits: number;
@@ -39,10 +40,13 @@ export async function getOrgMetadata(orgId: string): Promise<OrgMetadata> {
     .from(orgMetadata)
     .where(eq(orgMetadata.orgId, orgId))
     .limit(1);
+  if (!row) {
+    throw notFound(`Organization ${orgId} not found`);
+  }
   return {
     orgId,
-    tier: row?.tier ?? "free",
-    credits: row?.credits ?? 0,
+    tier: row.tier,
+    credits: row.credits,
   };
 }
 

--- a/turbo/apps/web/src/lib/zero/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/zero/org/resolve-org.ts
@@ -5,52 +5,11 @@ import {
   isNotFound,
 } from "../../shared/errors";
 import { getOrgMetadata } from "./org-metadata-service";
+import type { OrgMetadata } from "./org-metadata-service";
 import { verifyMembershipCached } from "../../auth/org-membership-cache";
 import type { AuthContext } from "../../auth/get-auth-context";
 
 import type { OrgRole } from "@vm0/core";
-
-/**
- * Returns true when the error represents a "resource not found" condition
- * that should be treated as null rather than re-thrown.
- *
- * Covers:
- * - Our own NotFoundError (from errors.ts)
- * - Clerk API 404 responses (ClerkAPIResponseError with status 404)
- * - Missing-slug guard ("has no slug")
- */
-function isOrgNotFoundError(error: unknown): boolean {
-  if (isNotFound(error)) return true;
-  if (error instanceof Error) {
-    // Clerk API 404 responses (ClerkAPIResponseError with numeric status)
-    const statusHolder = error as { status?: unknown };
-    if (statusHolder.status === 404) return true;
-    // Clerk SDK org-not-found rejections: "Organization <id> not found"
-    // Also covers missing-slug guard: "Clerk organization <id> has no slug"
-    if (/organization\b.*\b(not found|has no slug)/i.test(error.message)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Wrapper around getOrgMetadata that returns null instead of throwing when the
- * org cannot be resolved.
- *
- * Only swallows not-found errors (our NotFoundError, Clerk API 404,
- * missing slug). Unexpected errors (DB failures, timeouts) propagate.
- */
-export async function getOrgDataOrNull(
-  orgId: string,
-): Promise<{ orgId: string; tier: string } | null> {
-  try {
-    return await getOrgMetadata(orgId);
-  } catch (error) {
-    if (isOrgNotFoundError(error)) return null;
-    throw error;
-  }
-}
 
 /**
  * Lightweight org type based on org_metadata data.
@@ -121,7 +80,14 @@ export async function resolveOrg(
     );
   }
 
-  const orgMeta = await getOrgMetadata(orgId);
+  let orgMeta: OrgMetadata;
+  try {
+    orgMeta = await getOrgMetadata(orgId);
+  } catch (error) {
+    if (!isNotFound(error)) throw error;
+    // Brand-new org: JWT proves existence, org_metadata row not yet created
+    orgMeta = { orgId, tier: "free", credits: 0 };
+  }
   const resolved: ResolvedOrg = { orgId: orgMeta.orgId, tier: orgMeta.tier };
   const member = await verifyMembership(resolved, authCtx);
   return { org: resolved, member };


### PR DESCRIPTION
## Summary

- `getOrgMetadata()` now throws `notFound` instead of silently returning defaults (`tier: "free"`, `credits: 0`) when the `org_metadata` row doesn't exist
- `resolveOrg()` catches `notFound` for brand-new orgs (JWT trusted, row not yet created) and applies free tier defaults
- `test-connector/route.ts` uses `getOrgMetadata` directly with inline try-catch
- Deleted dead code: `getOrgDataOrNull()` and `isOrgNotFoundError()` from `resolve-org.ts`
- `zero-run-service.ts` unchanged — `notFound` propagates correctly (run should fail for org without metadata)

## Test plan

- [x] `org-metadata-service.test.ts`: Updated test to expect `notFound` throw for missing row
- [x] `resolve-org.test.ts`: Added test for brand-new org without `org_metadata` row returning free tier defaults
- [x] All 17 existing tests pass
- [x] Lint clean
- [x] Type-check clean (`web` package)
- [x] Knip clean (no unused exports)

Closes #8384

🤖 Generated with [Claude Code](https://claude.com/claude-code)