### PR TITLE
fix: use pagination instead of cel filter for cloud endpoint lookup

### DIFF
--- a/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/__tests__/route.test.ts
@@ -238,8 +238,26 @@ describe("POST /api/zero/computer-use/register", () => {
     await setupOrg(userId);
     const ngrokCalls = setupNgrokMocks();
 
-    // Override GET /endpoints to return an orphaned endpoint
+    // Override reserved domain lookup to return "orphan.ngrok-free.app" so the
+    // endpoint URL built by the service (`https://*.orphan.ngrok-free.app`)
+    // matches the orphaned endpoint below.
     server.use(
+      http.get("https://api.ngrok.com/reserved_domains", ({ request }) => {
+        const url = new URL(request.url);
+        const filter = url.searchParams.get("filter");
+        ngrokCalls.filterReservedDomains.push(filter ?? "");
+        return HttpResponse.json({
+          reserved_domains: [
+            {
+              id: "rd_orphan_123",
+              domain: "orphan.ngrok-free.app",
+              region: "us",
+              cname_target: null,
+            },
+          ],
+          next_page_uri: null,
+        });
+      }),
       http.get("https://api.ngrok.com/endpoints", ({ request }) => {
         const url = new URL(request.url);
         const filter = url.searchParams.get("filter");

--- a/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
+++ b/turbo/apps/web/src/lib/zero/computer-connector/ngrok-client.ts
@@ -160,9 +160,40 @@ export async function deleteCredential(
 }
 
 /**
+ * Find an existing cloud endpoint by URL.
+ *
+ * The CEL filter `obj.url == "..."` does not reliably match wildcard URLs
+ * (e.g., `https://*.domain`), so we paginate through all endpoints and
+ * match client-side. Cloud endpoint counts are small (one per user), so
+ * this is not a scalability concern.
+ */
+async function findEndpointByUrl(
+  apiKey: string,
+  url: string,
+): Promise<NgrokEndpoint | undefined> {
+  let nextPageUri: string | null = "/endpoints";
+
+  while (nextPageUri) {
+    const response = await ngrokFetch(apiKey, nextPageUri);
+    const page = (await response.json()) as NgrokEndpointsPage;
+
+    const found = page.endpoints.find((ep) => {
+      return ep.url === url;
+    });
+    if (found) {
+      return found;
+    }
+
+    nextPageUri = page.next_page_uri;
+  }
+
+  return undefined;
+}
+
+/**
  * Ensure a Cloud Endpoint exists with the given traffic policy.
  *
- * Uses CEL filter to find an existing endpoint by URL, then PATCH-updates
+ * Finds an existing endpoint by URL (client-side match), then PATCH-updates
  * the traffic policy if found. Creates a new endpoint if none exists.
  * This is idempotent — safe to call when orphaned endpoints may exist.
  */
@@ -171,10 +202,7 @@ export async function ensureCloudEndpoint(
   url: string,
   trafficPolicy: string,
 ): Promise<NgrokEndpoint> {
-  const filterQuery = encodeURIComponent(`obj.url == "${url}"`);
-  const response = await ngrokFetch(apiKey, `/endpoints?filter=${filterQuery}`);
-  const page = (await response.json()) as NgrokEndpointsPage;
-  const existing = page.endpoints[0];
+  const existing = await findEndpointByUrl(apiKey, url);
 
   if (existing) {
     log.debug("Found existing cloud endpoint, updating traffic policy", {


### PR DESCRIPTION
## Summary
- Replace CEL filter `obj.url == "https://*.domain"` with paginated list + client-side match in `ensureCloudEndpoint`
- The CEL filter never matched wildcard URLs, causing every `host start` to fail on first attempt with ERR_NGROK_18017 (pooling conflict)
- Pagination is appropriate here since endpoint count is small (one per user)

## Test plan
- [x] Existing computer connector tests pass (10/10)
- [ ] `zero computer-use host start` succeeds on first attempt (no more retry needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)