### PR TITLE
refactor: move cli run business logic from infra to api route

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -50,6 +50,21 @@ import { env } from "../../../../src/env";
 const log = logger("api:runs");
 
 /**
+ * Gate captureNetworkBodies to @vm0.ai accounts in production.
+ * Throws ForbiddenError for non-internal accounts.
+ */
+async function enforceCaptureNetworkBodiesGate(
+  userId: string,
+  captureNetworkBodies: boolean | undefined,
+): Promise<void> {
+  if (!captureNetworkBodies || env().VERCEL_ENV !== "production") return;
+  const { email } = await getCachedUser(userId);
+  if (!email.endsWith("@vm0.ai")) {
+    throw forbidden("captureNetworkBodies is restricted to internal accounts");
+  }
+}
+
+/**
  * Translate createRun() errors into API response format.
  *
  * Uses the generic isApiError() check so that new error types
@@ -241,15 +256,7 @@ const router = tsr.router(runsMainContract, {
     // Resolve zero-layer data (vars, secrets, connectors, firewalls, timezone)
     // before building the execution context.
     try {
-      // Gate captureNetworkBodies to @vm0.ai accounts in production
-      if (body.captureNetworkBodies && env().VERCEL_ENV === "production") {
-        const { email } = await getCachedUser(userId);
-        if (!email.endsWith("@vm0.ai")) {
-          throw forbidden(
-            "captureNetworkBodies is restricted to internal accounts",
-          );
-        }
-      }
+      await enforceCaptureNetworkBodiesGate(userId, body.captureNetworkBodies);
 
       const resolved = await resolveCliRunContext({
         orgId: org.orgId,

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -32,6 +32,7 @@ import {
   isApiError,
   notFound,
   badRequest,
+  forbidden,
 } from "../../../../src/lib/shared/errors";
 import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
 import { resolveCliRunContext } from "../../../../src/lib/zero/build-zero-context";
@@ -43,6 +44,8 @@ import {
 } from "../../../../src/lib/zero/zero-run-policy";
 import { generateSandboxToken } from "../../../../src/lib/auth/sandbox-token";
 import { buildInfraExecutionContext } from "../../../../src/lib/infra/run/context/build-context";
+import { getCachedUser } from "../../../../src/lib/auth/user-cache-service";
+import { env } from "../../../../src/env";
 
 const log = logger("api:runs");
 
@@ -238,6 +241,16 @@ const router = tsr.router(runsMainContract, {
     // Resolve zero-layer data (vars, secrets, connectors, firewalls, timezone)
     // before building the execution context.
     try {
+      // Gate captureNetworkBodies to @vm0.ai accounts in production
+      if (body.captureNetworkBodies && env().VERCEL_ENV === "production") {
+        const { email } = await getCachedUser(userId);
+        if (!email.endsWith("@vm0.ai")) {
+          throw forbidden(
+            "captureNetworkBodies is restricted to internal accounts",
+          );
+        }
+      }
+
       const resolved = await resolveCliRunContext({
         orgId: org.orgId,
         userId,

--- a/turbo/apps/web/app/api/agent/runs/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/route.ts
@@ -15,16 +15,34 @@ import {
   agentComposeVersions,
 } from "../../../../src/db/schema/agent-compose";
 import { agentRuns } from "../../../../src/db/schema/agent-run";
-import { and, eq, inArray, desc, gte, lte } from "drizzle-orm";
-import { startRun, type RunDispatchError } from "../../../../src/lib/infra/run";
+import { and, eq, inArray, desc, gte, lte, sql } from "drizzle-orm";
+import {
+  loadCompose,
+  insertRunRecord,
+  buildAndDispatchRun,
+  markRunFailed,
+  type RunDispatchError,
+} from "../../../../src/lib/infra/run";
 import {
   requireAuth,
   isAuthError,
 } from "../../../../src/lib/auth/require-auth";
 import { logger } from "../../../../src/lib/shared/logger";
-import { isApiError } from "../../../../src/lib/shared/errors";
+import {
+  isApiError,
+  notFound,
+  badRequest,
+} from "../../../../src/lib/shared/errors";
 import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
 import { resolveCliRunContext } from "../../../../src/lib/zero/build-zero-context";
+import { resolveStartRunCompose } from "../../../../src/lib/zero/zero-run-validation";
+import {
+  authorizeCompose,
+  validateComposeRequirements,
+  checkRunConcurrencyLimit,
+} from "../../../../src/lib/zero/zero-run-policy";
+import { generateSandboxToken } from "../../../../src/lib/auth/sandbox-token";
+import { buildInfraExecutionContext } from "../../../../src/lib/infra/run/context/build-context";
 
 const log = logger("api:runs");
 
@@ -218,7 +236,7 @@ const router = tsr.router(runsMainContract, {
     );
 
     // Resolve zero-layer data (vars, secrets, connectors, firewalls, timezone)
-    // before calling startRun(), which uses pure infra buildInfraExecutionContext.
+    // before building the execution context.
     try {
       const resolved = await resolveCliRunContext({
         orgId: org.orgId,
@@ -239,59 +257,139 @@ const router = tsr.router(runsMainContract, {
 
       const orgTier = orgTierSchema.parse(org.tier);
 
-      const result = await startRun({
+      // 1. Resolve compose version
+      const composeMeta = await resolveStartRunCompose({
         userId,
-        prompt: body.prompt,
-        appendSystemPrompt: body.appendSystemPrompt,
-        disallowedTools: body.disallowedTools,
-        tools: body.tools,
-        settings: body.settings,
         composeId: body.agentComposeId,
         agentComposeVersionId:
           resolved.agentComposeVersionId ?? body.agentComposeVersionId,
         checkpointId: body.checkpointId,
         sessionId: body.sessionId,
-        conversationId: body.conversationId,
-        vars: resolved.vars ?? body.vars,
-        secrets: resolved.secrets ?? body.secrets,
-        environment: resolved.environment,
-        secretConnectorMap: resolved.secretConnectorMap,
-        firewalls: resolved.firewalls,
-        userTimezone: resolved.userTimezone,
-        artifactName: resolved.artifactName ?? body.artifactName,
-        artifactVersion: resolved.artifactVersion ?? body.artifactVersion,
-        memoryName: resolved.memoryName ?? body.memoryName,
-        volumeVersions: resolved.volumeVersions ?? body.volumeVersions,
-        resumeSession: resolved.resumeSession,
-        resumeArtifact: resolved.resumeArtifact,
-        debugNoMockClaude: body.debugNoMockClaude,
-        captureNetworkBodies: body.captureNetworkBodies,
-        firewallPolicies: body.firewallPolicies,
-        callerOrgId: org.orgId,
-        orgTier,
-        resolveSourceDuration: resolved.timings.resolveSource,
-        resolveSecretsDuration: resolved.timings.resolveSecrets,
       });
 
-      log.debug(
-        `Run ${result.runId} dispatched successfully (status: ${result.status})`,
-      );
+      // 2. Cross-org check: ensure compose belongs to caller's org
+      if (composeMeta.orgId !== org.orgId) {
+        throw notFound("Resource not found");
+      }
 
-      return {
-        status: 201 as const,
-        body: {
-          runId: result.runId,
-          status: result.status as
-            | "queued"
-            | "pending"
-            | "running"
-            | "completed"
-            | "failed"
-            | "timeout",
-          sandboxId: result.sandboxId,
-          createdAt: result.createdAt.toISOString(),
-        },
-      };
+      // 3. Load compose and authorize
+      const apiStartTime = Date.now();
+      const { composeContent, compose } = await loadCompose(
+        composeMeta.agentComposeVersionId,
+        composeMeta.composeId,
+      );
+      authorizeCompose(userId, org.orgId, compose);
+      const authorizeTime = Date.now();
+
+      // 4. Validate compose requirements (new runs only)
+      if (!body.checkpointId && !body.sessionId) {
+        await validateComposeRequirements(composeContent);
+      }
+
+      // 5. Validate mutual exclusivity
+      if (body.checkpointId && body.sessionId) {
+        throw badRequest(
+          "Cannot specify both checkpointId and sessionId. Use checkpointId to resume from a checkpoint, or sessionId to continue a session.",
+        );
+      }
+
+      // 6. Concurrency check + INSERT (transaction with advisory lock)
+      const run = await globalThis.services.db.transaction(async (tx) => {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${org.orgId}))`,
+        );
+        await checkRunConcurrencyLimit(org.orgId, orgTier, tx);
+        return insertRunRecord(tx, {
+          userId,
+          orgId: org.orgId,
+          agentComposeVersionId: composeMeta.agentComposeVersionId,
+          prompt: body.prompt,
+          appendSystemPrompt: body.appendSystemPrompt,
+          vars: resolved.vars ?? body.vars,
+          secrets: resolved.secrets ?? body.secrets,
+          resumedFromCheckpointId: body.checkpointId,
+          sessionId: body.sessionId,
+        });
+      });
+      const transactionTime = Date.now();
+
+      // 7. Generate sandbox token
+      const sandboxToken = await generateSandboxToken(userId, run.id);
+      const tokenTime = Date.now();
+
+      try {
+        // 8. Build execution context (pure infra — all business data pre-resolved)
+        const { context } = buildInfraExecutionContext({
+          runId: run.id,
+          userId,
+          orgId: org.orgId,
+          agentComposeVersionId: composeMeta.agentComposeVersionId,
+          agentCompose: composeContent,
+          prompt: body.prompt,
+          sandboxToken,
+          appendSystemPrompt: body.appendSystemPrompt,
+          vars: resolved.vars ?? body.vars,
+          secrets: resolved.secrets ?? body.secrets,
+          secretConnectorMap: resolved.secretConnectorMap,
+          artifactName: resolved.artifactName ?? body.artifactName,
+          artifactVersion: resolved.artifactVersion ?? body.artifactVersion,
+          memoryName: resolved.memoryName ?? body.memoryName,
+          volumeVersions: resolved.volumeVersions ?? body.volumeVersions,
+          environment: resolved.environment,
+          userTimezone: resolved.userTimezone,
+          firewalls: resolved.firewalls,
+          disallowedTools: body.disallowedTools,
+          tools: body.tools,
+          settings: body.settings,
+          resumeSession: resolved.resumeSession,
+          resumeArtifact: resolved.resumeArtifact,
+          agentName: composeMeta.agentName,
+          resumedFromCheckpointId: body.checkpointId,
+          continuedFromSessionId: body.sessionId,
+          debugNoMockClaude: body.debugNoMockClaude,
+          captureNetworkBodies: body.captureNetworkBodies,
+        });
+
+        // 9. Dispatch
+        const dispatchResult = await buildAndDispatchRun({
+          runId: run.id,
+          context,
+          timings: {
+            apiStart: apiStartTime,
+            authorize: authorizeTime,
+            transaction: transactionTime,
+            token: tokenTime,
+            resolveSourceDuration: resolved.timings.resolveSource,
+            resolveSecretsDuration: resolved.timings.resolveSecrets,
+          },
+        });
+
+        log.debug(
+          `Run ${run.id} dispatched successfully (status: ${dispatchResult.status})`,
+        );
+
+        return {
+          status: 201 as const,
+          body: {
+            runId: run.id,
+            status: dispatchResult.status as
+              | "queued"
+              | "pending"
+              | "running"
+              | "completed"
+              | "failed"
+              | "timeout",
+            sandboxId: dispatchResult.sandboxId,
+            createdAt: run.createdAt.toISOString(),
+          },
+        };
+      } catch (error) {
+        // Post-INSERT failure: mark run as failed so client can track it.
+        // buildAndDispatchRun may have already called markRunFailed — the
+        // second call is a safe no-op (transitionRunStatus guards on status).
+        await markRunFailed(run.id, error);
+        throw error;
+      }
     } catch (error) {
       const errorResponse = handleCreateRunError(error);
       if (errorResponse) {

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -878,6 +878,140 @@ export async function createTestRun(
 }
 
 /**
+ * Test helper that mirrors the CLI API route pipeline (resolve → authorize →
+ * validate → concurrency check → insert → token → context → dispatch).
+ *
+ * Used by tests that need fine-grained control over run creation params
+ * (e.g., version pinning, concurrency testing) without going through HTTP.
+ */
+export interface CliRunParams {
+  userId: string;
+  agentComposeVersionId: string;
+  prompt: string;
+  orgTier: import("@vm0/core").OrgTier;
+  appendSystemPrompt?: string;
+  vars?: Record<string, string>;
+  secrets?: Record<string, string>;
+  checkpointId?: string;
+  sessionId?: string;
+  conversationId?: string;
+  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
+  memoryName?: string;
+  artifactName?: string;
+  artifactVersion?: string;
+  volumeVersions?: Record<string, string>;
+  debugNoMockClaude?: boolean;
+  captureNetworkBodies?: boolean;
+}
+
+export async function createCliRun(
+  params: CliRunParams,
+): Promise<import("../lib/infra/run/run-service").CreateRunResult> {
+  const { resolveStartRunCompose } =
+    await import("../lib/zero/zero-run-validation");
+  const {
+    authorizeCompose,
+    validateComposeRequirements,
+    checkRunConcurrencyLimit,
+  } = await import("../lib/zero/zero-run-policy");
+  const { generateSandboxToken: genToken } =
+    await import("../lib/auth/sandbox-token");
+  const { buildInfraExecutionContext } =
+    await import("../lib/infra/run/context/build-context");
+  const {
+    loadCompose,
+    insertRunRecord,
+    buildAndDispatchRun,
+    markRunFailed,
+    registerCallbacks,
+  } = await import("../lib/infra/run/run-service");
+
+  const composeMeta = await resolveStartRunCompose(params);
+
+  const apiStartTime = Date.now();
+  const { composeContent, compose } = await loadCompose(
+    composeMeta.agentComposeVersionId,
+    composeMeta.composeId,
+  );
+  authorizeCompose(params.userId, compose.orgId, compose);
+  const authorizeTime = Date.now();
+
+  if (!params.checkpointId && !params.sessionId) {
+    await validateComposeRequirements(composeContent);
+  }
+
+  const orgId = compose.orgId;
+  const run = await globalThis.services.db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
+    await checkRunConcurrencyLimit(orgId, params.orgTier, tx);
+    return insertRunRecord(tx, {
+      userId: params.userId,
+      orgId,
+      agentComposeVersionId: composeMeta.agentComposeVersionId,
+      prompt: params.prompt,
+      appendSystemPrompt: params.appendSystemPrompt,
+      vars: params.vars,
+      secrets: params.secrets,
+      resumedFromCheckpointId: params.checkpointId,
+      sessionId: params.sessionId,
+    });
+  });
+  const transactionTime = Date.now();
+
+  const sandboxToken = await genToken(params.userId, run.id);
+  const tokenTime = Date.now();
+
+  try {
+    if (params.callbacks && params.callbacks.length > 0) {
+      await registerCallbacks(run.id, params.callbacks);
+    }
+
+    const { context } = buildInfraExecutionContext({
+      runId: run.id,
+      userId: params.userId,
+      orgId,
+      agentComposeVersionId: composeMeta.agentComposeVersionId,
+      agentCompose: composeContent,
+      prompt: params.prompt,
+      sandboxToken,
+      appendSystemPrompt: params.appendSystemPrompt,
+      vars: params.vars,
+      secrets: params.secrets,
+      artifactName: params.artifactName,
+      artifactVersion: params.artifactVersion,
+      memoryName: params.memoryName,
+      volumeVersions: params.volumeVersions,
+      agentName: composeMeta.agentName,
+      resumedFromCheckpointId: params.checkpointId,
+      continuedFromSessionId: params.sessionId,
+      debugNoMockClaude: params.debugNoMockClaude,
+      captureNetworkBodies: params.captureNetworkBodies,
+    });
+
+    const result = await buildAndDispatchRun({
+      runId: run.id,
+      context,
+      timings: {
+        apiStart: apiStartTime,
+        authorize: authorizeTime,
+        transaction: transactionTime,
+        token: tokenTime,
+      },
+    });
+
+    return {
+      runId: run.id,
+      status: result.status,
+      sandboxId: result.sandboxId,
+      createdAt: run.createdAt,
+    };
+  } catch (error) {
+    await markRunFailed(run.id, error);
+    throw error;
+  }
+}
+
+/**
  * Get test run details via internal API route handler.
  *
  * @param runId - The run ID to fetch

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -63,6 +63,22 @@ import { creditPricing } from "../db/schema/credit-pricing";
 import { insightsDaily } from "../db/schema/insights-daily";
 import { users } from "../db/schema/user";
 import { and, eq, like, or, sql } from "drizzle-orm";
+import type { OrgTier } from "@vm0/core";
+import { resolveStartRunCompose } from "../lib/zero/zero-run-validation";
+import {
+  authorizeCompose,
+  validateComposeRequirements,
+  checkRunConcurrencyLimit,
+} from "../lib/zero/zero-run-policy";
+import { buildInfraExecutionContext } from "../lib/infra/run/context/build-context";
+import {
+  loadCompose,
+  insertRunRecord,
+  buildAndDispatchRun,
+  markRunFailed,
+  registerCallbacks,
+  type CreateRunResult,
+} from "../lib/infra/run/run-service";
 import { generateCallbackSecret } from "../lib/infra/callback/hmac";
 import { initServices } from "../lib/init-services";
 import { encryptSecretsMap } from "../lib/shared/crypto/secrets-encryption";
@@ -888,7 +904,7 @@ export interface CliRunParams {
   userId: string;
   agentComposeVersionId: string;
   prompt: string;
-  orgTier: import("@vm0/core").OrgTier;
+  orgTier: OrgTier;
   appendSystemPrompt?: string;
   vars?: Record<string, string>;
   secrets?: Record<string, string>;
@@ -906,26 +922,7 @@ export interface CliRunParams {
 
 export async function createCliRun(
   params: CliRunParams,
-): Promise<import("../lib/infra/run/run-service").CreateRunResult> {
-  const { resolveStartRunCompose } =
-    await import("../lib/zero/zero-run-validation");
-  const {
-    authorizeCompose,
-    validateComposeRequirements,
-    checkRunConcurrencyLimit,
-  } = await import("../lib/zero/zero-run-policy");
-  const { generateSandboxToken: genToken } =
-    await import("../lib/auth/sandbox-token");
-  const { buildInfraExecutionContext } =
-    await import("../lib/infra/run/context/build-context");
-  const {
-    loadCompose,
-    insertRunRecord,
-    buildAndDispatchRun,
-    markRunFailed,
-    registerCallbacks,
-  } = await import("../lib/infra/run/run-service");
-
+): Promise<CreateRunResult> {
   const composeMeta = await resolveStartRunCompose(params);
 
   const apiStartTime = Date.now();
@@ -958,7 +955,7 @@ export async function createCliRun(
   });
   const transactionTime = Date.now();
 
-  const sandboxToken = await genToken(params.userId, run.id);
+  const sandboxToken = await generateSandboxToken(params.userId, run.id);
   const tokenTime = Date.now();
 
   try {

--- a/turbo/apps/web/src/lib/infra/run/__tests__/create-run.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/create-run.test.ts
@@ -11,6 +11,8 @@ import {
   createTestRequest,
   createTestSandboxToken,
   createTestRun,
+  createCliRun,
+  type CliRunParams,
   insertStalePendingRun,
   findTestRunRecord,
   findTestRunCallbacks,
@@ -21,11 +23,7 @@ import {
 import { POST as checkpointWebhook } from "../../../../../app/api/webhooks/agent/checkpoints/route";
 import type { AgentComposeYaml } from "../../agent-compose/types";
 import { reloadEnv } from "../../../../env";
-import {
-  startRun,
-  type StartRunParams,
-  type CreateRunResult,
-} from "../run-service";
+import type { CreateRunResult } from "../run-service";
 import {
   isForbidden,
   isBadRequest,
@@ -37,7 +35,7 @@ import { mockClerk } from "../../../../__tests__/clerk-mock";
 
 const context = testContext();
 
-describe("startRun()", () => {
+describe("createCliRun()", () => {
   let user: UserContext;
   let composeId: string;
   let versionId: string;
@@ -50,7 +48,7 @@ describe("startRun()", () => {
     versionId = compose.versionId;
   });
 
-  function baseParams(overrides?: Partial<StartRunParams>): StartRunParams {
+  function baseParams(overrides?: Partial<CliRunParams>): CliRunParams {
     return {
       userId: user.userId,
       agentComposeVersionId: versionId,
@@ -62,7 +60,7 @@ describe("startRun()", () => {
 
   describe("Happy Path", () => {
     it("should create and dispatch a run successfully", async () => {
-      const result: CreateRunResult = await startRun(baseParams());
+      const result: CreateRunResult = await createCliRun(baseParams());
 
       expect(result.runId).toBeDefined();
       expect(result.status).toBe("pending");
@@ -79,7 +77,7 @@ describe("startRun()", () => {
     });
 
     it("should store appendSystemPrompt when provided", async () => {
-      const result = await startRun(
+      const result = await createCliRun(
         baseParams({ appendSystemPrompt: "Your name is Aria." }),
       );
 
@@ -89,7 +87,7 @@ describe("startRun()", () => {
     });
 
     it("should default appendSystemPrompt to null when not provided", async () => {
-      const result = await startRun(baseParams());
+      const result = await createCliRun(baseParams());
 
       const run = await findTestRunRecord(result.runId);
 
@@ -100,7 +98,7 @@ describe("startRun()", () => {
       vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
       reloadEnv();
 
-      const result = await startRun(
+      const result = await createCliRun(
         baseParams({ appendSystemPrompt: "Your name is Aria." }),
       );
 
@@ -112,7 +110,7 @@ describe("startRun()", () => {
     });
 
     it("should always set lastHeartbeatAt", async () => {
-      const result = await startRun(baseParams());
+      const result = await createCliRun(baseParams());
 
       const run = await findTestRunRecord(result.runId);
 
@@ -120,7 +118,7 @@ describe("startRun()", () => {
     });
 
     it("should refresh lastHeartbeatAt during pipeline", async () => {
-      const result = await startRun(baseParams());
+      const result = await createCliRun(baseParams());
 
       const run = await findTestRunRecord(result.runId);
 
@@ -134,7 +132,7 @@ describe("startRun()", () => {
 
     it("should store vars when provided", async () => {
       const vars = { MY_VAR: "value1", OTHER_VAR: "value2" };
-      const result = await startRun(baseParams({ vars }));
+      const result = await createCliRun(baseParams({ vars }));
 
       const run = await findTestRunRecord(result.runId);
 
@@ -143,7 +141,7 @@ describe("startRun()", () => {
 
     it("should store secretNames when secrets provided", async () => {
       const secrets = { API_KEY: "sk-123", DB_PASS: "pw" };
-      const result = await startRun(baseParams({ secrets }));
+      const result = await createCliRun(baseParams({ secrets }));
 
       const run = await findTestRunRecord(result.runId);
 
@@ -154,21 +152,21 @@ describe("startRun()", () => {
   describe("Concurrent Run Limit", () => {
     it("should reject when free tier limit reached", async () => {
       // Free tier (default) allows only 1 concurrent run
-      await startRun(baseParams({ prompt: "First run" }));
+      await createCliRun(baseParams({ prompt: "First run" }));
 
       // Second run should be rejected with concurrent run limit error
       await expect(
-        startRun(baseParams({ prompt: "Second run" })),
+        createCliRun(baseParams({ prompt: "Second run" })),
       ).rejects.toSatisfy(isConcurrentRunLimit);
     });
 
     it("should allow 2 concurrent runs for pro tier", async () => {
       await updateOrgTier(user.orgId, "pro");
 
-      const run1 = await startRun(
+      const run1 = await createCliRun(
         baseParams({ prompt: "Pro run 1", orgTier: "pro" }),
       );
-      const run2 = await startRun(
+      const run2 = await createCliRun(
         baseParams({ prompt: "Pro run 2", orgTier: "pro" }),
       );
 
@@ -179,11 +177,11 @@ describe("startRun()", () => {
     it("should reject 3rd concurrent run for pro tier", async () => {
       await updateOrgTier(user.orgId, "pro");
 
-      await startRun(baseParams({ prompt: "Pro run 1", orgTier: "pro" }));
-      await startRun(baseParams({ prompt: "Pro run 2", orgTier: "pro" }));
+      await createCliRun(baseParams({ prompt: "Pro run 1", orgTier: "pro" }));
+      await createCliRun(baseParams({ prompt: "Pro run 2", orgTier: "pro" }));
 
       await expect(
-        startRun(baseParams({ prompt: "Pro run 3", orgTier: "pro" })),
+        createCliRun(baseParams({ prompt: "Pro run 3", orgTier: "pro" })),
       ).rejects.toSatisfy(isConcurrentRunLimit);
     });
 
@@ -191,13 +189,13 @@ describe("startRun()", () => {
       await updateOrgTier(user.orgId, "team");
 
       // Create 3 concurrent runs to verify team tier allows more than pro tier (which allows 2)
-      const run1 = await startRun(
+      const run1 = await createCliRun(
         baseParams({ prompt: "Team run 1", orgTier: "team" }),
       );
-      const run2 = await startRun(
+      const run2 = await createCliRun(
         baseParams({ prompt: "Team run 2", orgTier: "team" }),
       );
-      const run3 = await startRun(
+      const run3 = await createCliRun(
         baseParams({ prompt: "Team run 3", orgTier: "team" }),
       );
 
@@ -210,8 +208,8 @@ describe("startRun()", () => {
       vi.stubEnv("CONCURRENT_RUN_LIMIT_CAP", "0");
       reloadEnv();
 
-      const run1 = await startRun(baseParams({ prompt: "Run 1" }));
-      const run2 = await startRun(baseParams({ prompt: "Run 2" }));
+      const run1 = await createCliRun(baseParams({ prompt: "Run 1" }));
+      const run2 = await createCliRun(baseParams({ prompt: "Run 2" }));
 
       expect(run1.status).toBe("pending");
       expect(run2.status).toBe("pending");
@@ -221,15 +219,15 @@ describe("startRun()", () => {
       // Free tier limit is 1; stale pending run should not count
       await insertStalePendingRun(user.userId, versionId);
 
-      const result = await startRun(baseParams());
+      const result = await createCliRun(baseParams());
       expect(result.status).toBe("pending");
     });
 
     it("should reject second run when concurrency limit reached", async () => {
       // Free tier limit is 1 — advisory lock should serialize them
       const results = await Promise.allSettled([
-        startRun(baseParams({ prompt: "Concurrent A" })),
-        startRun(baseParams({ prompt: "Concurrent B" })),
+        createCliRun(baseParams({ prompt: "Concurrent A" })),
+        createCliRun(baseParams({ prompt: "Concurrent B" })),
       ]);
 
       // One should succeed, one should be rejected
@@ -245,14 +243,14 @@ describe("startRun()", () => {
 
     it("should enforce limit per-org, not per-user", async () => {
       // Create a run in the default org (fills its free-tier slot)
-      await startRun(baseParams({ prompt: "Org 1 run" }));
+      await createCliRun(baseParams({ prompt: "Org 1 run" }));
 
       // Create a second user with a different org
       const otherUser = await context.setupUser({ prefix: "org-user" });
       const otherCompose = await createTestCompose(uniqueId("other-agent"));
 
       // Run in the other org should succeed (separate org, separate limit)
-      const result = await startRun({
+      const result = await createCliRun({
         userId: otherUser.userId,
         agentComposeVersionId: otherCompose.versionId,
         prompt: "Org 2 run",
@@ -265,7 +263,7 @@ describe("startRun()", () => {
   describe("Validation", () => {
     it("should reject mutually exclusive checkpointId and sessionId", async () => {
       await expect(
-        startRun(
+        createCliRun(
           baseParams({
             checkpointId: "some-checkpoint",
             sessionId: "some-session",
@@ -285,7 +283,7 @@ describe("startRun()", () => {
         },
       ];
 
-      const result = await startRun(baseParams({ callbacks }));
+      const result = await createCliRun(baseParams({ callbacks }));
 
       // Verify callback record in DB
       const callbackRecords = await findTestRunCallbacks(result.runId);
@@ -303,7 +301,7 @@ describe("startRun()", () => {
   describe("Memory", () => {
     it("should auto-create memory storage on first run", async () => {
       const memoryName = uniqueId("new-mem");
-      const result = await startRun(baseParams({ memoryName }));
+      const result = await createCliRun(baseParams({ memoryName }));
 
       expect(result.runId).toBeDefined();
       expect(result.status).toBe("pending");
@@ -316,10 +314,10 @@ describe("startRun()", () => {
 
       const memoryName = uniqueId("existing-mem");
       // First run creates the memory
-      await startRun(baseParams({ memoryName }));
+      await createCliRun(baseParams({ memoryName }));
 
       // Second run should also succeed (idempotent)
-      const result = await startRun(
+      const result = await createCliRun(
         baseParams({ memoryName, prompt: "second run" }),
       );
       expect(result.runId).toBeDefined();
@@ -327,7 +325,9 @@ describe("startRun()", () => {
     });
 
     it("should accept memoryName and dispatch successfully", async () => {
-      const result = await startRun(baseParams({ memoryName: "my-memory" }));
+      const result = await createCliRun(
+        baseParams({ memoryName: "my-memory" }),
+      );
 
       expect(result.runId).toBeDefined();
       expect(result.status).toBe("pending");
@@ -370,7 +370,7 @@ describe("startRun()", () => {
       };
 
       // Step 2: Continue from session WITHOUT specifying memoryName
-      const continueResult = await startRun(
+      const continueResult = await createCliRun(
         baseParams({
           sessionId: agentSessionId,
           prompt: "Continue prompt",
@@ -385,7 +385,7 @@ describe("startRun()", () => {
   describe("Auto-Create Artifact", () => {
     it("should succeed when artifact does not exist (auto-create)", async () => {
       const artifactName = uniqueId("new-art");
-      const result = await startRun(baseParams({ artifactName }));
+      const result = await createCliRun(baseParams({ artifactName }));
 
       expect(result.runId).toBeDefined();
       expect(result.status).toBe("pending");
@@ -395,7 +395,7 @@ describe("startRun()", () => {
       const artifactName = uniqueId("existing-art");
       await createTestArtifact(artifactName);
 
-      const result = await startRun(baseParams({ artifactName }));
+      const result = await createCliRun(baseParams({ artifactName }));
 
       expect(result.runId).toBeDefined();
       expect(result.status).toBe("pending");
@@ -462,7 +462,7 @@ describe("startRun()", () => {
         ["mydata:/data"],
       );
 
-      const result = await startRun(
+      const result = await createCliRun(
         baseParams({ agentComposeVersionId: compose.versionId }),
       );
 
@@ -484,7 +484,7 @@ describe("startRun()", () => {
       );
 
       // Should succeed - optional volume is silently skipped
-      const result = await startRun(
+      const result = await createCliRun(
         baseParams({ agentComposeVersionId: compose.versionId }),
       );
 
@@ -507,7 +507,7 @@ describe("startRun()", () => {
 
       // Should fail - required volume doesn't exist
       await expect(
-        startRun(baseParams({ agentComposeVersionId: compose.versionId })),
+        createCliRun(baseParams({ agentComposeVersionId: compose.versionId })),
       ).rejects.toThrow(/not found/);
     });
 
@@ -530,7 +530,7 @@ describe("startRun()", () => {
       // Simulate checkpoint resume scenario:
       // volumeVersions is provided but does NOT include the optional volume
       // (meaning it was skipped at checkpoint time)
-      const result = await startRun(
+      const result = await createCliRun(
         baseParams({
           agentComposeVersionId: compose.versionId,
           // Empty volumeVersions means no volumes were mounted at checkpoint
@@ -563,7 +563,7 @@ describe("startRun()", () => {
 
       // Session/Continue scenario: volumeVersions is NOT provided (undefined)
       // This means we should use current config and mount if volume exists
-      const result = await startRun(
+      const result = await createCliRun(
         baseParams({
           agentComposeVersionId: compose.versionId,
           // No volumeVersions - use latest state
@@ -597,7 +597,7 @@ describe("startRun()", () => {
       );
 
       // Should succeed - required volume exists, optional is skipped
-      const result = await startRun(
+      const result = await createCliRun(
         baseParams({ agentComposeVersionId: compose.versionId }),
       );
 
@@ -612,7 +612,7 @@ describe("startRun()", () => {
 
       mockClerk({ userId: user.userId, email: "user@example.com" });
 
-      const result = await startRun(baseParams());
+      const result = await createCliRun(baseParams());
 
       expect(result.status).toBe("pending");
     });
@@ -621,7 +621,7 @@ describe("startRun()", () => {
       // RUNNER_DEFAULT_GROUP is not set by default in test env
       mockClerk({ userId: user.userId, email: "team@vm0.ai" });
 
-      const result = await startRun(baseParams());
+      const result = await createCliRun(baseParams());
 
       expect(result.status).toBe("pending");
     });
@@ -634,7 +634,7 @@ describe("startRun()", () => {
 
       let caughtError: unknown;
       try {
-        await startRun(baseParams());
+        await createCliRun(baseParams());
       } catch (error: unknown) {
         caughtError = error;
       }
@@ -663,7 +663,7 @@ describe("startRun()", () => {
         overrides: { experimental_profile: "vm0/default" },
       });
 
-      const result = await startRun(
+      const result = await createCliRun(
         baseParams({ agentComposeVersionId: compose.versionId }),
       );
 
@@ -677,7 +677,7 @@ describe("startRun()", () => {
       vi.stubEnv("RUNNER_DEFAULT_GROUP", "vm0/production");
       reloadEnv();
 
-      const result = await startRun(baseParams());
+      const result = await createCliRun(baseParams());
 
       const job = await findTestRunnerJobEntry(result.runId);
       expect(job).toBeDefined();
@@ -695,8 +695,8 @@ describe("startRun()", () => {
         uniqueId("browser-agent"),
         { overrides: { experimental_profile: "vm0/default" } },
       );
-      await startRun(baseParams({ prompt: "default job" }));
-      await startRun(
+      await createCliRun(baseParams({ prompt: "default job" }));
+      await createCliRun(
         baseParams({
           prompt: "browser job",
           agentComposeVersionId: browserCompose.versionId,
@@ -746,14 +746,14 @@ describe("startRun()", () => {
       });
 
       await expect(
-        startRun(baseParams({ agentComposeVersionId: compose.versionId })),
+        createCliRun(baseParams({ agentComposeVersionId: compose.versionId })),
       ).rejects.toSatisfy(isBadRequest);
     });
   });
 
   describe("Org Resolution for Storage", () => {
     it("should use compose org for artifact/memory storage", async () => {
-      const result = await startRun(
+      const result = await createCliRun(
         baseParams({
           artifactName: "artifact",
           memoryName: "memory",

--- a/turbo/apps/web/src/lib/infra/run/index.ts
+++ b/turbo/apps/web/src/lib/infra/run/index.ts
@@ -4,7 +4,6 @@
  */
 
 export {
-  startRun,
   insertRunRecord,
   buildAndDispatchRun,
   loadCompose,

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -1,4 +1,4 @@
-import { eq, and, or, sql } from "drizzle-orm";
+import { eq, and, or } from "drizzle-orm";
 import { env } from "../../../env";
 import { agentRuns } from "../../../db/schema/agent-run";
 import { transitionRunStatus, dispatchTerminalSideEffects } from "./run-status";
@@ -7,8 +7,7 @@ import {
   agentComposes,
 } from "../../../db/schema/agent-compose";
 import { agentRunCallbacks } from "../../../db/schema/agent-run-callback";
-import { notFound, badRequest, forbidden } from "../../shared/errors";
-import { getCachedUser } from "../../auth/user-cache-service";
+import { notFound } from "../../shared/errors";
 
 import { logger } from "../../shared/logger";
 import type { Database } from "../../../types/global";
@@ -16,10 +15,7 @@ import type { AgentComposeYaml } from "../agent-compose/types";
 import { prepareForExecution } from "./context/execution-preparer";
 import { executeRunnerJob } from "./executors/runner-executor";
 import type { ExecutorResult, PreparedContext } from "./executors/types";
-import { generateSandboxToken } from "../../auth/sandbox-token";
-import type { ExecutionContext, DispatchTimings, ResumeSession } from "./types";
-import type { ArtifactSnapshot } from "../checkpoint/types";
-import { buildInfraExecutionContext } from "./context/build-context";
+import type { ExecutionContext, DispatchTimings } from "./types";
 import { recordSandboxOperation } from "../metrics";
 
 import { encryptSecretValue } from "../../shared/crypto/secrets-encryption";
@@ -27,19 +23,11 @@ import {
   type OrgTier,
   type RunStatus,
   type GetRunResponse,
-  type Firewalls,
   type FirewallPolicies,
   type ConnectorType,
 } from "@vm0/core";
 import { publishCancelNotification } from "../realtime/client";
 import type { CancelRunResult } from "../../zero/zero-run-cancel";
-
-import {
-  checkRunConcurrencyLimit,
-  authorizeCompose,
-  validateComposeRequirements,
-} from "../../zero/zero-run-policy";
-import { resolveStartRunCompose } from "../../zero/zero-run-validation";
 
 const log = logger("service:run");
 
@@ -132,66 +120,6 @@ export interface CreateRunParams {
     composeContent: AgentComposeYaml;
     compose: { id: string; userId: string; orgId: string };
   };
-}
-
-/**
- * High-level run params — callers provide a compose identifier and startRun()
- * resolves version + org internally.
- *
- * Compose resolution modes (mutually exclusive):
- * - composeId: new run from compose (resolves headVersionId)
- * - agentComposeVersionId: new run from pinned version (SDK/CLI)
- * - checkpointId: resume from checkpoint (resolves version from checkpoint)
- * - sessionId: continue session (resolves version from session's compose)
- */
-export interface StartRunParams {
-  userId: string;
-  prompt: string;
-
-  // --- Compose resolution (mutually exclusive) ---
-  composeId?: string;
-  agentComposeVersionId?: string;
-  checkpointId?: string;
-  sessionId?: string;
-
-  // --- Caller-validated org (optional, for API routes with org membership) ---
-  // When provided, startRun() verifies the compose belongs to this org
-  // and uses it for authorization. When omitted, org is auto-resolved
-  // from the compose (used by integration callers that verify access upstream).
-  callerOrgId?: string;
-
-  // --- Optional params (forwarded to createRun) ---
-  appendSystemPrompt?: string;
-  disallowedTools?: string[];
-  tools?: string[];
-  settings?: string;
-  conversationId?: string;
-  vars?: Record<string, string>;
-  secrets?: Record<string, string>;
-  artifactName?: string;
-  artifactVersion?: string;
-  memoryName?: string;
-  volumeVersions?: Record<string, string>;
-  callbacks?: Array<{ url: string; secret: string; payload: unknown }>;
-  debugNoMockClaude?: boolean;
-  captureNetworkBodies?: boolean;
-  firewallPolicies?: FirewallPolicies;
-  allowedConnectorTypes?: ConnectorType[];
-
-  // --- Pre-resolved context data (from resolveCliRunContext or caller) ---
-  environment?: Record<string, string>;
-  secretConnectorMap?: Record<string, string>;
-  userTimezone?: string;
-  firewalls?: Firewalls;
-  resumeSession?: ResumeSession;
-  resumeArtifact?: ArtifactSnapshot;
-
-  // --- Pre-resolved org tier (callers resolve via getOrgData + orgTierSchema) ---
-  orgTier: OrgTier;
-
-  // --- Pre-resolved timing data (passed through to dispatch timings) ---
-  resolveSourceDuration?: number;
-  resolveSecretsDuration?: number;
 }
 
 export interface CreateRunResult {
@@ -342,7 +270,7 @@ export async function markRunFailed(
 
 /**
  * Shared dispatch pipeline for steps 6-10 of the run creation flow.
- * Used by startRun (new runs) and dispatchQueuedZeroRun (dequeued runs).
+ * Used by the CLI API route (new runs) and dispatchQueuedZeroRun (dequeued runs).
  */
 export async function buildAndDispatchRun(opts: {
   runId: string;
@@ -442,146 +370,6 @@ export async function buildAndDispatchRun(opts: {
 }
 
 /**
- * High-level run entry point — the single public API for CLI run creation.
- *
- * Resolves compose version + org context, creates a run record, builds an
- * infra execution context, and dispatches. Uses infra primitives directly
- * (no zero layer dependency). Callers only need a compose identifier
- * (composeId, versionId, checkpointId, or sessionId).
- *
- * @throws NotFoundError - compose/version/checkpoint/session not found
- * @throws BadRequestError - compose has no versions, or missing identifier
- * @throws ForbiddenError - user cannot access compose
- * @throws Error - dispatch failure
- */
-export async function startRun(
-  params: StartRunParams,
-): Promise<CreateRunResult> {
-  // 0. Gate captureNetworkBodies to @vm0.ai accounts in production
-  if (params.captureNetworkBodies && env().VERCEL_ENV === "production") {
-    const { email } = await getCachedUser(params.userId);
-    if (!email.endsWith("@vm0.ai")) {
-      throw forbidden(
-        "captureNetworkBodies is restricted to internal accounts",
-      );
-    }
-  }
-
-  // 1. Resolve compose version
-  const resolved = await resolveStartRunCompose(params);
-
-  // 2. Cross-org check: if caller provides a validated orgId, ensure
-  //    the compose belongs to that org. This prevents users from accessing
-  //    composes in orgs they don't belong to (used by API routes).
-  if (params.callerOrgId && resolved.orgId !== params.callerOrgId) {
-    throw notFound("Resource not found");
-  }
-
-  // 3. Resolve org context (use callerOrgId for authorization when available)
-  const authOrgId = params.callerOrgId ?? resolved.orgId;
-
-  // 4. Create run record — ConcurrentRunLimitError propagates to API route (returns 429)
-  const record = await createRunRecord({
-    userId: params.userId,
-    agentComposeVersionId: resolved.agentComposeVersionId,
-    prompt: params.prompt,
-    appendSystemPrompt: params.appendSystemPrompt,
-    disallowedTools: params.disallowedTools,
-    tools: params.tools,
-    settings: params.settings,
-    composeId: resolved.composeId,
-    checkpointId: params.checkpointId,
-    sessionId: params.sessionId,
-    conversationId: params.conversationId,
-    vars: params.vars,
-    secrets: params.secrets,
-    artifactName: params.artifactName,
-    artifactVersion: params.artifactVersion,
-    memoryName: params.memoryName,
-    volumeVersions: params.volumeVersions,
-    callbacks: params.callbacks,
-    resumedFromCheckpointId: params.checkpointId,
-    agentName: resolved.agentName,
-    debugNoMockClaude: params.debugNoMockClaude,
-    captureNetworkBodies: params.captureNetworkBodies,
-    firewallPolicies: params.firewallPolicies,
-    allowedConnectorTypes: params.allowedConnectorTypes,
-    orgId: authOrgId,
-    orgTier: params.orgTier,
-  });
-
-  // 5. Generate sandbox token
-  const sandboxToken = await generateSandboxToken(params.userId, record.run.id);
-  const tokenTime = Date.now();
-
-  try {
-    // 6. Register callbacks early so they persist even if context building fails
-    if (params.callbacks && params.callbacks.length > 0) {
-      await registerCallbacks(record.run.id, params.callbacks);
-    }
-
-    // 7. Build execution context (pure infra — all business data pre-resolved by caller)
-    const { context } = buildInfraExecutionContext({
-      runId: record.run.id,
-      userId: params.userId,
-      orgId: authOrgId,
-      agentComposeVersionId: resolved.agentComposeVersionId,
-      agentCompose: record.composeContent,
-      prompt: params.prompt,
-      sandboxToken,
-      appendSystemPrompt: params.appendSystemPrompt,
-      vars: params.vars,
-      secrets: params.secrets,
-      secretConnectorMap: params.secretConnectorMap,
-      artifactName: params.artifactName,
-      artifactVersion: params.artifactVersion,
-      memoryName: params.memoryName,
-      volumeVersions: params.volumeVersions,
-      environment: params.environment,
-      userTimezone: params.userTimezone,
-      firewalls: params.firewalls,
-      disallowedTools: params.disallowedTools,
-      tools: params.tools,
-      settings: params.settings,
-      resumeSession: params.resumeSession,
-      resumeArtifact: params.resumeArtifact,
-      agentName: resolved.agentName,
-      resumedFromCheckpointId: params.checkpointId,
-      continuedFromSessionId: params.sessionId,
-      debugNoMockClaude: params.debugNoMockClaude,
-      captureNetworkBodies: params.captureNetworkBodies,
-    });
-
-    // 8. Dispatch
-    const result = await buildAndDispatchRun({
-      runId: record.run.id,
-      context,
-      timings: {
-        apiStart: record.apiStartTime,
-        authorize: record.authorizeTime,
-        transaction: record.transactionTime,
-        token: tokenTime,
-        resolveSourceDuration: params.resolveSourceDuration,
-        resolveSecretsDuration: params.resolveSecretsDuration,
-      },
-    });
-
-    return {
-      runId: record.run.id,
-      status: result.status,
-      sandboxId: result.sandboxId,
-      createdAt: record.run.createdAt,
-    };
-  } catch (error) {
-    // Mark run as failed when context building or dispatch fails.
-    // buildAndDispatchRun may have already called markRunFailed — the
-    // second call is a safe no-op (transitionRunStatus guards on status).
-    await markRunFailed(record.run.id, error);
-    throw error;
-  }
-}
-
-/**
  * Result of createRunRecord — contains the run record and all metadata
  * needed by buildAndDispatchRun to complete the dispatch pipeline.
  */
@@ -641,73 +429,6 @@ export async function insertRunRecord(
   }
 
   return newRun;
-}
-
-/**
- * Create a run record without dispatching.
- *
- * Handles steps 1-5 of the run creation pipeline:
- * 1. Load compose version content + compose metadata
- * 2. Permission check (canAccessCompose)
- * 3. Validate template vars and image access
- * 4. Validate mutual exclusivity (checkpointId vs sessionId)
- * 5. Acquire per-org advisory lock, check concurrent run limit, INSERT agentRuns (atomic transaction)
- *
- * Returns the run record and compose content needed by buildAndDispatchRun().
- * Does NOT handle the enqueueRun() fallback — callers decide how to handle
- * ConcurrentRunLimitError.
- *
- * Used by startRun() for the legacy CLI path.
- *
- * @throws ForbiddenError - user cannot access compose
- * @throws BadRequestError - validation failure (missing vars, mutual exclusivity)
- * @throws NotFoundError - compose version not found
- * @throws ConcurrentRunLimitError - org has reached concurrent run limit
- */
-async function createRunRecord(
-  params: CreateRunParams,
-): Promise<CreateRunRecordResult> {
-  const apiStartTime = Date.now();
-
-  // Steps 1-2: Load compose and authorize
-  const { composeContent, compose } =
-    params.preloadedCompose ??
-    (await loadCompose(params.agentComposeVersionId, params.composeId));
-  authorizeCompose(params.userId, params.orgId, compose);
-  const authorizeTime = Date.now();
-
-  // Step 3: Validate template vars and image access (for new runs only)
-  if (!params.checkpointId && !params.sessionId) {
-    await validateComposeRequirements(composeContent);
-  }
-
-  // Step 4: Validate mutual exclusivity
-  if (params.checkpointId && params.sessionId) {
-    throw badRequest(
-      "Cannot specify both checkpointId and sessionId. Use checkpointId to resume from a checkpoint, or sessionId to continue a session.",
-    );
-  }
-
-  const orgId = params.orgId;
-
-  // Step 5: Concurrency check + INSERT in a transaction with advisory lock
-  const run = await globalThis.services.db.transaction(async (tx) => {
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${orgId}))`);
-    await checkRunConcurrencyLimit(orgId, params.orgTier ?? "free", tx);
-    return insertRunRecord(tx, params);
-  });
-
-  const transactionTime = Date.now();
-  log.debug(`Created run ${run.id} for user ${params.userId}`);
-
-  return {
-    run: { id: run.id, createdAt: run.createdAt },
-    composeContent,
-    orgId,
-    apiStartTime,
-    authorizeTime,
-    transactionTime,
-  };
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/credit-check.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../__tests__/test-helpers";
 import {
   createTestCompose,
+  createTestRunInDb,
   getTestZeroAgentId,
   findTestRunsByUserAndPrompt,
   findTestRunRecord,
@@ -20,7 +21,7 @@ import {
 import { reloadEnv } from "../../../env";
 import { createZeroRun } from "../zero-run-service";
 import { isInsufficientCredits, isNotFound } from "../../shared/errors";
-import { startRun, type CreateRunParams } from "../../infra/run/run-service";
+import type { CreateRunParams } from "../../infra/run/run-service";
 import {
   drainOrgQueue,
   enqueueRun,
@@ -213,12 +214,14 @@ describe("credit check (zero layer)", () => {
 
 describe("credit check (infra queue path)", () => {
   let user: UserContext;
+  let composeId: string;
   let versionId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
     const compose = await createTestCompose(uniqueId("agent"));
+    composeId = compose.composeId;
     versionId = compose.versionId;
   });
 
@@ -240,12 +243,7 @@ describe("credit check (infra queue path)", () => {
       reloadEnv();
 
       // Create a running run + a queued VM0 run
-      await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
-        prompt: "Running",
-        orgTier: "free",
-      });
+      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(
         queueBaseParams({ prompt: "Queued VM0", modelProvider: "vm0" }),
       );
@@ -275,12 +273,7 @@ describe("credit check (infra queue path)", () => {
       reloadEnv();
 
       // Create a running run + a queued non-VM0 run
-      await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
-        prompt: "Running",
-        orgTier: "free",
-      });
+      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(
         queueBaseParams({
           prompt: "Queued Anthropic",
@@ -308,12 +301,7 @@ describe("credit check (infra queue path)", () => {
       reloadEnv();
 
       // Create a running run
-      await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
-        prompt: "Running",
-        orgTier: "free",
-      });
+      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
 
       // Enqueue two runs: first VM0, then non-VM0
       const vm0Run = await enqueueRun(
@@ -362,12 +350,7 @@ describe("credit check (infra queue path)", () => {
       });
 
       // Create a running run + a queued VM0 run
-      await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
-        prompt: "Running",
-        orgTier: "free",
-      });
+      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(
         queueBaseParams({
           prompt: "Queued VM0 member cap",
@@ -401,12 +384,7 @@ describe("credit check (infra queue path)", () => {
       });
 
       // Create a running run + a queued non-VM0 run
-      await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
-        prompt: "Running",
-        orgTier: "free",
-      });
+      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(
         queueBaseParams({
           prompt: "Queued Anthropic member cap",
@@ -452,11 +430,8 @@ describe("model provider check (queue dispatch path)", () => {
     // No org-level model provider configured — checkModelProviderConfigured will throw
 
     // Create a running run to force the next one into the queue
-    await startRun({
-      userId: user.userId,
-      agentComposeVersionId: compose.versionId,
+    await createTestRunInDb(user.userId, compose.composeId, {
       prompt: "Running",
-      orgTier: "free",
     });
 
     // Enqueue a zero run (no explicit modelProvider)

--- a/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../__tests__/test-helpers";
 import {
   createTestCompose,
+  createTestRunInDb,
   findTestRunRecord,
   findTestQueueEntry,
   markRunningRunsAsCompleted,
@@ -14,7 +15,7 @@ import {
   updateOrgTier,
 } from "../../../__tests__/api-test-helpers";
 import { reloadEnv } from "../../../env";
-import { startRun, type CreateRunParams } from "../../infra/run/run-service";
+import type { CreateRunParams } from "../../infra/run/run-service";
 import {
   enqueueRun,
   drainOrgQueue,
@@ -27,12 +28,14 @@ const context = testContext();
 
 describe("run-queue-service", () => {
   let user: UserContext;
+  let composeId: string;
   let versionId: string;
 
   beforeEach(async () => {
     context.setupMocks();
     user = await context.setupUser();
     const compose = await createTestCompose(uniqueId("agent"));
+    composeId = compose.composeId;
     versionId = compose.versionId;
   });
 
@@ -95,12 +98,7 @@ describe("run-queue-service", () => {
       reloadEnv();
 
       // Create a running run and a queued run
-      await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
-        prompt: "Running",
-        orgTier: "free",
-      });
+      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(baseParams({ prompt: "Queued" }));
       expect(queued.status).toBe("queued");
 
@@ -124,12 +122,7 @@ describe("run-queue-service", () => {
       reloadEnv();
 
       // Alice creates a run → pending
-      await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
-        prompt: "Alice run",
-        orgTier: "free",
-      });
+      await createTestRunInDb(user.userId, composeId, { prompt: "Alice run" });
 
       // Bob is a different user in the same org
       const bob = await context.setupUser({ prefix: "test-bob" });
@@ -169,12 +162,7 @@ describe("run-queue-service", () => {
       reloadEnv();
 
       // Create a running run and a queued run
-      await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
-        prompt: "Running",
-        orgTier: "free",
-      });
+      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(baseParams({ prompt: "Queued" }));
       expect(queued.status).toBe("queued");
 
@@ -249,12 +237,7 @@ describe("run-queue-service", () => {
       await updateOrgTier(user.orgId, "pro");
 
       // Create 1 running run — fills free limit but not pro limit
-      await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
-        prompt: "Running",
-        orgTier: "free",
-      });
+      await createTestRunInDb(user.userId, composeId, { prompt: "Running" });
       const queued = await enqueueRun(baseParams({ prompt: "Queued" }));
 
       // With pro tier (limit=2), drain should succeed despite 1 active run
@@ -338,13 +321,9 @@ describe("run-queue-service", () => {
       reloadEnv();
 
       // user1 creates a run first (before changing Clerk mock)
-      const run1 = await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
+      await createTestRunInDb(user.userId, composeId, {
         prompt: "User1 running",
-        orgTier: "free",
       });
-      expect(run1.status).toBe("pending");
 
       // Create second user sharing user1's org
       const user2 = await context.setupUser({ prefix: "test-user-2" });
@@ -376,11 +355,8 @@ describe("run-queue-service", () => {
       reloadEnv();
 
       // user1 creates a run first (before changing Clerk mock)
-      await startRun({
-        userId: user.userId,
-        agentComposeVersionId: versionId,
+      await createTestRunInDb(user.userId, composeId, {
         prompt: "User1 running",
-        orgTier: "free",
       });
 
       // Create second user sharing user1's org


### PR DESCRIPTION
## Summary

Closes #8391

- Move authorization, validation, and concurrency control from `startRun()`/`createRunRecord()` in `run-service.ts` into the CLI API route handler (`app/api/agent/runs/route.ts`)
- Delete `startRun()`, `createRunRecord()`, and `StartRunParams` from `run-service.ts` — it now contains zero business logic
- Update tests to use `createCliRun()` helper (mirrors route pipeline) and `createTestRunInDb()` for setup-only run creation

## Key Changes

**`route.ts`** — Inline orchestration replaces single `startRun()` call:
1. `resolveStartRunCompose()` — compose version resolution
2. Cross-org check
3. `loadCompose()` + `authorizeCompose()` — load and authorize
4. `validateComposeRequirements()` — validate (new runs only)
5. Advisory lock + `checkRunConcurrencyLimit()` + `insertRunRecord()` — atomic transaction
6. `generateSandboxToken()` + `buildInfraExecutionContext()` + `buildAndDispatchRun()` — dispatch

**`run-service.ts`** — Only pure infra functions remain:
- `loadCompose`, `insertRunRecord`, `buildAndDispatchRun`, `markRunFailed`, `registerCallbacks`
- `CreateRunParams` kept (used by queue system)

## Test plan

- [x] All 38 `create-run.test.ts` tests pass with new `createCliRun()` helper
- [x] All 68 `route.test.ts` + `run-queue-service.test.ts` tests pass
- [x] `credit-check.test.ts` infra queue path tests pass (zero layer failures are pre-existing DB migration issue)
- [x] TypeScript type-check passes
- [x] Lint passes (zero errors)
- [x] Knip passes (no unused exports)
- [x] `grep -r "startRun" turbo/apps/web/src/lib/infra/` returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)