### PR TITLE
feat: add --user flag to zero slack message send for direct messages

### DIFF
--- a/turbo/apps/cli/src/commands/zero/slack/__tests__/send.test.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/__tests__/send.test.ts
@@ -56,6 +56,38 @@ describe("zero slack message send command", () => {
       expect(logCalls).toContain("ts: 1234567890.123456");
     });
 
+    it("should send a DM with --user flag", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(SLACK_MESSAGE_URL, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            { ok: true, ts: "1234567890.123456", channel: "D-dm-channel" },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await sendCommand.parseAsync([
+        "node",
+        "cli",
+        "--user",
+        "U0A8V9X98QJ",
+        "--text",
+        "Hello DM!",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        user: "U0A8V9X98QJ",
+        text: "Hello DM!",
+      });
+      expect(capturedBody).not.toHaveProperty("channel");
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Message sent");
+    });
+
     it("should send a message with --text and --thread", async () => {
       let capturedBody: Record<string, unknown> | undefined;
 
@@ -121,6 +153,35 @@ describe("zero slack message send command", () => {
   });
 
   describe("validation errors", () => {
+    it("should error when both --channel and --user are provided", async () => {
+      await expect(async () => {
+        await sendCommand.parseAsync([
+          "node",
+          "cli",
+          "--channel",
+          "C1234567",
+          "--user",
+          "U0A8V9X98QJ",
+          "--text",
+          "hello",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("--channel and --user are mutually exclusive"),
+      );
+    });
+
+    it("should error when neither --channel nor --user is provided", async () => {
+      await expect(async () => {
+        await sendCommand.parseAsync(["node", "cli", "--text", "hello"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Either --channel or --user must be provided"),
+      );
+    });
+
     it("should error when neither --text nor --blocks is provided", async () => {
       await expect(async () => {
         await sendCommand.parseAsync(["node", "cli", "--channel", "C1234567"]);

--- a/turbo/apps/cli/src/commands/zero/slack/message/send.ts
+++ b/turbo/apps/cli/src/commands/zero/slack/message/send.ts
@@ -6,8 +6,9 @@ import { withErrorHandler } from "../../../../lib/command";
 
 export const sendCommand = new Command()
   .name("send")
-  .description("Send a message to a Slack channel")
-  .requiredOption("-c, --channel <id>", "Channel ID")
+  .description("Send a message to a Slack channel or DM a user")
+  .option("-c, --channel <id>", "Channel ID")
+  .option("-u, --user <id>", "Slack user ID for DM")
   .option("-t, --text <message>", "Message text")
   .option("--thread <ts>", "Thread timestamp for replies")
   .option("--blocks <json>", "Block Kit JSON string")
@@ -16,22 +17,41 @@ export const sendCommand = new Command()
     `
 Examples:
   Simple message:        zero slack message send -c C01234 -t "Hello!"
+  DM a user:             zero slack message send -u U0A8V9X98QJ -t "Hello!"
   Reply in thread:       zero slack message send -c C01234 --thread 1234567890.123456 -t "reply"
   Rich blocks:           zero slack message send -c C01234 --blocks '[{"type":"section","text":{"type":"mrkdwn","text":"*Bold*"}}]'
 
 Notes:
+  - Either --channel or --user is required; they are mutually exclusive
   - Either --text or --blocks is required; both can be used together`,
   )
   .action(
     withErrorHandler(
       async (options: {
-        channel: string;
+        channel?: string;
+        user?: string;
         text?: string;
         thread?: string;
         blocks?: string;
       }) => {
         let text = options.text;
-        const { channel, thread, blocks: blocksStr } = options;
+        const { channel, user, thread, blocks: blocksStr } = options;
+
+        // Validate mutual exclusion: exactly one of --channel or --user
+        if (!channel && !user) {
+          throw new Error("Either --channel or --user must be provided", {
+            cause: new Error(
+              'Usage: zero slack message send -c CHANNEL_ID -t "your message"\n       zero slack message send -u USER_ID -t "your message"',
+            ),
+          });
+        }
+        if (channel && user) {
+          throw new Error("--channel and --user are mutually exclusive", {
+            cause: new Error(
+              "Provide either --channel to send to a channel or --user to DM a user, not both",
+            ),
+          });
+        }
 
         // Read from stdin if text not provided and stdin is explicitly piped
         // (isTTY is false when piped, undefined when no TTY context e.g. tests)
@@ -66,7 +86,8 @@ Notes:
         }
 
         const result = await sendSlackMessage({
-          channel,
+          channel: channel || undefined,
+          user: user || undefined,
           text: text || undefined,
           threadTs: thread,
           blocks,

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -179,6 +179,81 @@ describe("POST /api/zero/integrations/slack/message", () => {
     expect(data.error.message).toContain("channel_not_found");
   });
 
+  it("sends DM via user field using conversations.open", async () => {
+    mockClerk({ userId: null });
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
+    const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+    await createTestSlackOrgInstallation({ orgId: user.orgId });
+
+    const request = createTestRequest(URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ user: "U0A8V9X98QJ", text: "Hello DM!" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.ok).toBe(true);
+
+    // Verify conversations.open was called with the user ID
+    const mockClient = vi.mocked(new WebClient(""));
+    expect(mockClient.conversations.open).toHaveBeenCalledWith({
+      users: "U0A8V9X98QJ",
+    });
+
+    // Verify postMessage was called with the resolved DM channel
+    expect(mockClient.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "D-mock-dm",
+        text: "Hello DM!",
+      }),
+    );
+  });
+
+  it("returns 404 when conversations.open fails with user_not_found", async () => {
+    mockClerk({ userId: null });
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
+    const token = await generateZeroToken(user.userId, "run-1", user.orgId);
+    await createTestSlackOrgInstallation({ orgId: user.orgId });
+
+    // Mock conversations.open to fail
+    const mockClient = vi.mocked(new WebClient(""));
+    vi.mocked(mockClient.conversations.open).mockRejectedValueOnce(
+      Object.assign(new Error("user_not_found"), {
+        data: { ok: false, error: "user_not_found" },
+      }),
+    );
+
+    const request = createTestRequest(URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ user: "U-invalid", text: "hello" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(404);
+
+    const data = await response.json();
+    expect(data.error.code).toBe("NOT_FOUND");
+    expect(data.error.message).toContain("user_not_found");
+  });
+
   it("appends 'Sent via' footer when agent is resolvable from run", async () => {
     const agentName = uniqueId("agent");
     const { composeId } = await createTestCompose(agentName);

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
@@ -8,6 +8,7 @@ import { zeroRuns } from "../../../../../../src/db/schema/zero-run";
 import { zeroAgentSchedules } from "../../../../../../src/db/schema/zero-agent-schedule";
 import {
   isSlackPlatformError,
+  openDMChannel,
   postMessage,
 } from "../../../../../../src/lib/zero/slack/client";
 import {
@@ -80,6 +81,29 @@ const router = tsr.router(integrationsSlackMessageContract, {
     if (scheduleLabel)
       footerParts.push(`Triggered by schedule "${scheduleLabel}"`);
 
+    // Resolve target channel: DM via user ID or direct channel ID
+    let targetChannel: string;
+    if (body.user) {
+      try {
+        targetChannel = await openDMChannel(slackCtx.client, body.user);
+      } catch (error) {
+        if (isSlackPlatformError(error)) {
+          return {
+            status: 404 as const,
+            body: {
+              error: {
+                message: `Cannot open DM: ${error.data.error}`,
+                code: "NOT_FOUND",
+              },
+            },
+          };
+        }
+        throw error;
+      }
+    } else {
+      targetChannel = body.channel!;
+    }
+
     let finalBlocks = body.blocks as (Block | KnownBlock)[] | undefined;
     if (footerParts.length > 0) {
       const footerBlocks = buildFooterBlocks(footerParts.join(" · "));
@@ -100,7 +124,7 @@ const router = tsr.router(integrationsSlackMessageContract, {
     try {
       const result = await postMessage(
         slackCtx.client,
-        body.channel,
+        targetChannel,
         body.text ?? "",
         {
           threadTs: body.threadTs,

--- a/turbo/apps/web/src/__tests__/setup.ts
+++ b/turbo/apps/web/src/__tests__/setup.ts
@@ -154,6 +154,9 @@ vi.mock("@slack/web-api", () => {
       replies: vi.fn().mockResolvedValue({ ok: true, messages: [] }),
       history: vi.fn().mockResolvedValue({ ok: true, messages: [] }),
       list: vi.fn().mockResolvedValue({ ok: true, channels: [] }),
+      open: vi
+        .fn()
+        .mockResolvedValue({ ok: true, channel: { id: "D-mock-dm" } }),
     },
     reactions: {
       add: vi.fn().mockResolvedValue({ ok: true }),

--- a/turbo/apps/web/src/lib/zero/slack/client.ts
+++ b/turbo/apps/web/src/lib/zero/slack/client.ts
@@ -15,6 +15,24 @@ export function createSlackClient(token: string): WebClient {
 }
 
 /**
+ * Open a DM channel with a Slack user
+ *
+ * @param client - Slack WebClient
+ * @param userId - Slack user ID
+ * @returns The DM channel ID
+ */
+export async function openDMChannel(
+  client: WebClient,
+  userId: string,
+): Promise<string> {
+  const result = await client.conversations.open({ users: userId });
+  if (!result.channel?.id) {
+    throw new Error("Failed to open DM channel");
+  }
+  return result.channel.id;
+}
+
+/**
  * Post a message to a Slack channel or thread
  *
  * @param client - Slack WebClient

--- a/turbo/packages/core/src/contracts/integrations.ts
+++ b/turbo/packages/core/src/contracts/integrations.ts
@@ -11,12 +11,20 @@ const c = initContract();
  * Sends a Slack message via the org's installed bot token.
  * Requires `slack:write` capability (via ZERO_TOKEN).
  */
-const sendSlackMessageBodySchema = z.object({
-  channel: z.string().min(1, "Channel ID is required"),
-  text: z.string().optional(),
-  threadTs: z.string().optional(),
-  blocks: z.array(z.object({ type: z.string() }).passthrough()).optional(),
-});
+const sendSlackMessageBodySchema = z
+  .object({
+    channel: z.string().min(1, "Channel ID is required").optional(),
+    user: z.string().min(1, "User ID is required").optional(),
+    text: z.string().optional(),
+    threadTs: z.string().optional(),
+    blocks: z.array(z.object({ type: z.string() }).passthrough()).optional(),
+  })
+  .refine(
+    (data) => {
+      return Boolean(data.channel) !== Boolean(data.user);
+    },
+    { message: "Exactly one of 'channel' or 'user' must be provided" },
+  );
 
 export type SendSlackMessageBody = z.infer<typeof sendSlackMessageBodySchema>;
 


### PR DESCRIPTION
## Summary

- Add `-u / --user` flag to `zero slack message send` that accepts a Slack user ID and sends a DM without requiring the caller to resolve the DM channel ID manually
- Server-side resolution: API route calls `conversations.open` to get the DM channel, then proceeds with `postMessage`
- Contract updated with mutual exclusion refinement — exactly one of `channel` or `user` must be provided

Closes #8394

## Changes

| File | Change |
|------|--------|
| `packages/core/src/contracts/integrations.ts` | Make `channel` optional, add `user` field, add `.refine()` for mutual exclusion |
| `apps/web/src/lib/zero/slack/client.ts` | Add `openDMChannel` helper wrapping `conversations.open` |
| `apps/web/.../slack/message/route.ts` | Resolve DM channel when `user` present, map errors to 404 |
| `apps/cli/.../slack/message/send.ts` | Add `-u` flag, mutual exclusion validation, updated help text |
| `apps/web/src/__tests__/setup.ts` | Add `conversations.open` to Slack mock |
| CLI + API test files | New tests for DM send, mutual exclusion, error mapping |

## Test plan

- [x] `zero slack message send -u U0A8V9X98QJ -t "Hello!"` sends a DM (CLI test)
- [x] `-c` and `-u` are mutually exclusive — error when both provided (CLI test)
- [x] Error when neither `-c` nor `-u` provided (CLI test)
- [x] API resolves DM channel via `conversations.open` and sends message (API test)
- [x] `conversations.open` failure maps to 404 (API test)
- [x] All 19 existing + new tests pass
- [x] Type check, lint, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)