### PR TITLE
feat(doctor): include agent id in missing-token connect url and auto-authorize after connect

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/missing-token.test.ts
@@ -99,7 +99,10 @@ describe("zero doctor missing-token command", () => {
       expect(logCalls).toContain("Sandbox env: not present");
       expect(logCalls).toContain("not connected");
       expect(logCalls).toContain(
-        "[Connect GitHub](https://app.vm0.ai/connectors/github/connect)",
+        "[Connect GitHub](https://app.vm0.ai/connectors/github/connect?agentId=agent-abc-123)",
+      );
+      expect(logCalls).toContain(
+        "run `zero doctor missing-token GH_TOKEN` again to re-diagnose",
       );
     });
   });
@@ -128,6 +131,9 @@ describe("zero doctor missing-token command", () => {
       expect(logCalls).toContain("not authorized");
       expect(logCalls).toContain(
         "[Authorize GitHub](https://app.vm0.ai/connectors/github/authorize?agentId=agent-abc-123)",
+      );
+      expect(logCalls).toContain(
+        "run `zero doctor missing-token GH_TOKEN` again to re-diagnose",
       );
     });
   });
@@ -162,6 +168,9 @@ describe("zero doctor missing-token command", () => {
         "[Reconnect GitHub](https://app.vm0.ai/connectors)",
       );
       expect(logCalls).not.toContain("not authorized");
+      expect(logCalls).toContain(
+        "run `zero doctor missing-token GH_TOKEN` again to re-diagnose",
+      );
     });
 
     it("should show both expired and not authorized when both issues exist", async () => {
@@ -194,6 +203,9 @@ describe("zero doctor missing-token command", () => {
       expect(logCalls).toContain(
         "[Authorize GitHub](https://app.vm0.ai/connectors/github/authorize?agentId=agent-abc-123)",
       );
+      expect(logCalls).toContain(
+        "run `zero doctor missing-token GH_TOKEN` again to re-diagnose",
+      );
     });
   });
 
@@ -223,6 +235,9 @@ describe("zero doctor missing-token command", () => {
       expect(logCalls).toContain(
         "[Check GitHub status](https://app.vm0.ai/connectors)",
       );
+      expect(logCalls).toContain(
+        "run `zero doctor missing-token GH_TOKEN` again to re-diagnose",
+      );
     });
   });
 
@@ -250,7 +265,7 @@ describe("zero doctor missing-token command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain(
-        "https://app.vm0.ai/connectors/github/connect",
+        "https://app.vm0.ai/connectors/github/connect?agentId=agent-1",
       );
     });
 
@@ -280,7 +295,7 @@ describe("zero doctor missing-token command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain(
-        "https://tunnel-yuma-vm0-app.vm7.ai/connectors/github/connect",
+        "https://tunnel-yuma-vm0-app.vm7.ai/connectors/github/connect?agentId=agent-1",
       );
     });
 
@@ -331,7 +346,7 @@ describe("zero doctor missing-token command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain(
-        "https://app.custom.example.com/connectors/github/connect",
+        "https://app.custom.example.com/connectors/github/connect?agentId=agent-1",
       );
     });
   });
@@ -357,7 +372,7 @@ describe("zero doctor missing-token command", () => {
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("not connected");
-      expect(logCalls).toContain("/connectors/github/connect");
+      expect(logCalls).toContain("/connectors/github/connect?agentId=agent-1");
     });
   });
 

--- a/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/missing-token.ts
@@ -65,11 +65,15 @@ Notes:
       const hasPermission =
         enabledTypes !== null && enabledTypes.includes(connectorType);
 
+      const rediagnoseHint = `Important: if ${tokenName} is still missing after the user takes action, run \`zero doctor missing-token ${tokenName}\` again to re-diagnose instead of assuming the status.`;
+
       if (!isConnected) {
         // Connector not connected — direct to the directed connect page
-        const url = `${platformUrl.origin}/connectors/${connectorType}/connect`;
+        const connectUrl = agentId
+          ? `${platformUrl.origin}/connectors/${connectorType}/connect?agentId=${agentId}`
+          : `${platformUrl.origin}/connectors/${connectorType}/connect`;
         console.log(
-          `The ${label} connector is not connected. Ask the user to connect it at: [Connect ${label}](${url})`,
+          `The ${label} connector is not connected. Ask the user to connect it at: [Connect ${label}](${connectUrl})\n${rediagnoseHint}`,
         );
         return;
       }
@@ -96,11 +100,12 @@ Notes:
         for (const issue of issues) {
           console.log(issue);
         }
+        console.log(rediagnoseHint);
       } else {
         // Both connected and authorized — something else is wrong
         const url = `${platformUrl.origin}/connectors`;
         console.log(
-          `The ${label} connector is connected and authorized, but the token is still missing. Ask VM0 developer to resolve this issue. Connector status: [Check ${label} status](${url})`,
+          `The ${label} connector is connected and authorized, but the token is still missing. Ask VM0 developer to resolve this issue. Connector status: [Check ${label} status](${url})\n${rediagnoseHint}`,
         );
       }
     }),

--- a/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
+++ b/turbo/apps/platform/src/signals/connectors-page/directed-connect-type.ts
@@ -1,5 +1,5 @@
 import { command, computed, state } from "ccstate";
-import { pathParams$ } from "../route.ts";
+import { pathParams$, searchParams$ } from "../route.ts";
 
 /**
  * Connector type extracted from `/connectors/:type/connect` route params.
@@ -8,6 +8,14 @@ export const directedConnectType$ = computed((get): string | null => {
   const params = get(pathParams$);
   const type = params?.type;
   return typeof type === "string" ? type.toLowerCase() : null;
+});
+
+/**
+ * Agent ID extracted from `?agentId=` query parameter on the connect page.
+ * When present, the connect page will auto-authorize the agent after connecting.
+ */
+export const directedConnectAgentId$ = computed((get): string | null => {
+  return get(searchParams$).get("agentId");
 });
 
 const internalTokenDialogOpen$ = state(false);

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-directed-connect-page.test.tsx
@@ -44,6 +44,19 @@ function mockConnectors(
   );
 }
 
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+
+function mockUserConnectors(agentId: string, enabledTypes: string[] = []) {
+  server.use(
+    http.get(`*/api/zero/agents/${agentId}/user-connectors`, () => {
+      return HttpResponse.json({ enabledTypes });
+    }),
+    http.put(`*/api/zero/agents/${agentId}/user-connectors`, () => {
+      return HttpResponse.json({ enabledTypes });
+    }),
+  );
+}
+
 describe("directed connect page", () => {
   it("renders connect card for an oauth connector", async () => {
     await setupPage({ context, path: "/connectors/gmail/connect" });
@@ -277,5 +290,133 @@ describe("directed connect page", () => {
       expect(capturedBody?.name).toBe("AXIOM_TOKEN");
       expect(capturedBody?.value).toBe("test-token-value");
     });
+  });
+
+  it("auto-authorizes agent after API token connect when agentId is present", async () => {
+    const user = userEvent.setup();
+    mockUserConnectors(AGENT_ID);
+
+    let authorizeCalled = false;
+    server.use(
+      http.post("*/api/zero/secrets", () => {
+        return HttpResponse.json(
+          {
+            id: crypto.randomUUID(),
+            name: "AXIOM_TOKEN",
+            type: "user",
+            description: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          { status: 201 },
+        );
+      }),
+      http.put(`*/api/zero/agents/${AGENT_ID}/user-connectors`, () => {
+        authorizeCalled = true;
+        return HttpResponse.json({ enabledTypes: ["axiom"] });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: `/connectors/axiom/connect?agentId=${AGENT_ID}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button").find((el) => {
+          return el.textContent?.trim() === "Connect";
+        }),
+      ).toBeDefined();
+    });
+
+    const connectBtn = screen.getAllByRole("button").find((el) => {
+      return el.textContent?.trim() === "Connect";
+    });
+    expect(connectBtn).toBeDefined();
+    await user.click(connectBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("xaat-...")).toBeInTheDocument();
+    });
+
+    await user.type(
+      screen.getByPlaceholderText("xaat-..."),
+      "test-token-value",
+    );
+    const saveBtn = screen.getAllByRole("button").find((el) => {
+      return el.textContent?.trim() === "Save";
+    });
+    expect(saveBtn).toBeDefined();
+    await user.click(saveBtn!);
+
+    await waitFor(() => {
+      expect(authorizeCalled).toBeTruthy();
+    });
+  });
+
+  it("does not call authorize after API token connect when agentId is absent", async () => {
+    const user = userEvent.setup();
+
+    let authorizeCalled = false;
+    server.use(
+      http.post("*/api/zero/secrets", () => {
+        return HttpResponse.json(
+          {
+            id: crypto.randomUUID(),
+            name: "AXIOM_TOKEN",
+            type: "user",
+            description: null,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          },
+          { status: 201 },
+        );
+      }),
+      http.put(`*/api/zero/agents/*/user-connectors`, () => {
+        authorizeCalled = true;
+        return HttpResponse.json({ enabledTypes: [] });
+      }),
+    );
+
+    await setupPage({
+      context,
+      path: "/connectors/axiom/connect",
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button").find((el) => {
+          return el.textContent?.trim() === "Connect";
+        }),
+      ).toBeDefined();
+    });
+
+    const connectBtn = screen.getAllByRole("button").find((el) => {
+      return el.textContent?.trim() === "Connect";
+    });
+    expect(connectBtn).toBeDefined();
+    await user.click(connectBtn!);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("xaat-...")).toBeInTheDocument();
+    });
+
+    await user.type(
+      screen.getByPlaceholderText("xaat-..."),
+      "test-token-value",
+    );
+    const saveBtn = screen.getAllByRole("button").find((el) => {
+      return el.textContent?.trim() === "Save";
+    });
+    expect(saveBtn).toBeDefined();
+    await user.click(saveBtn!);
+
+    // Wait for the token to be submitted
+    await waitFor(() => {
+      expect(screen.getByText("Axiom connected")).toBeInTheDocument();
+    });
+
+    expect(authorizeCalled).toBeFalsy();
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-directed-connect-page.tsx
@@ -24,9 +24,11 @@ import {
 import { detach, Reason } from "../../signals/utils.ts";
 import {
   directedConnectType$,
+  directedConnectAgentId$,
   tokenDialogOpen$,
   setTokenDialogOpen$,
 } from "../../signals/connectors-page/directed-connect-type.ts";
+import { authorizeConnector$ } from "../../signals/connectors-page/directed-authorize-type.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { handleZeroAccountAction$ } from "../../signals/zero-page/zero-nav.ts";
 import {
@@ -215,10 +217,12 @@ function ApiTokenDialog({
   type,
   open,
   onOpenChange,
+  onConnected,
 }: {
   type: ConnectorType;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onConnected?: () => void;
 }) {
   const config = CONNECTOR_TYPES[type];
   return (
@@ -234,6 +238,7 @@ function ApiTokenDialog({
           type={type}
           onSuccess={() => {
             onOpenChange(false);
+            onConnected?.();
           }}
         />
       </DialogContent>
@@ -243,8 +248,10 @@ function ApiTokenDialog({
 
 function DirectedConnectCard() {
   const type = useGet(directedConnectType$);
+  const agentId = useGet(directedConnectAgentId$);
   const pollingType = useGet(pollingConnectorType$);
   const connect = useSet(connectConnector$);
+  const authorize = useSet(authorizeConnector$);
   const signal = useGet(pageSignal$);
   const justConnected = useGet(justConnectedTypes$);
   const allLoadable = useLastLoadable(allConnectorTypes$);
@@ -280,7 +287,17 @@ function DirectedConnectCard() {
 
   const handleConnect = () => {
     if (hasOAuth) {
-      detach(connect(connectorType, signal), Reason.DomCallback);
+      if (agentId) {
+        detach(
+          (async () => {
+            await connect(connectorType, signal);
+            await authorize(connectorType, agentId, signal);
+          })(),
+          Reason.DomCallback,
+        );
+      } else {
+        detach(connect(connectorType, signal), Reason.DomCallback);
+      }
     } else {
       setTokenDialogOpen(true);
     }
@@ -345,6 +362,16 @@ function DirectedConnectCard() {
         type={connectorType}
         open={tokenDialogOpen}
         onOpenChange={setTokenDialogOpen}
+        onConnected={
+          agentId
+            ? () => {
+                detach(
+                  authorize(connectorType, agentId, signal),
+                  Reason.DomCallback,
+                );
+              }
+            : undefined
+        }
       />
     </>
   );


### PR DESCRIPTION
## Summary

- Include `?agentId=xxx` in the doctor `missing-token` connect URL when `ZERO_AGENT_ID` is set, so the platform connect page can auto-authorize the agent after successful connection
- Add `directedConnectAgentId$` signal to extract agentId from the connect page query params
- Chain `authorizeConnector$` after connect in the directed connect page (both OAuth and API token paths)
- Add re-diagnose hint to all doctor output messages, instructing the AI agent to re-run `zero doctor missing-token` instead of self-judging status

## Test plan

- [x] CLI tests: connect URL includes `?agentId=xxx` when agent ID is set
- [x] CLI tests: connect URL omits agentId when `ZERO_AGENT_ID` is empty
- [x] CLI tests: all output paths include re-diagnose hint
- [x] Platform tests: API token connect with agentId triggers auto-authorize
- [x] Platform tests: API token connect without agentId does not trigger authorize
- [x] Authorize page tests: no regressions (8 tests passing)

Closes #8396

🤖 Generated with [Claude Code](https://claude.com/claude-code)