### PR TITLE
feat(platform): paginate network logs with incremental loading

### DIFF
--- a/turbo/apps/platform/src/signals/activity-page/activity-download.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-download.ts
@@ -3,6 +3,7 @@ import { zeroRunContextContract, zeroRunNetworkLogsContract } from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { logger } from "../log.ts";
 import { accept } from "../../lib/accept.ts";
+import { fetchAllNetworkLogs } from "./activity-network-signals.ts";
 
 const L = logger("ActivityDownload");
 
@@ -31,16 +32,7 @@ export const fetchDownloadExtra$ = command(
       ).then((r) => {
         return r.body;
       }),
-      accept(
-        get(zeroClient$)(zeroRunNetworkLogsContract).getNetworkLogs({
-          params: { id: runId },
-          query: { limit: 500, order: "asc" },
-        }),
-        [200],
-        { toast: false },
-      ).then((r) => {
-        return r.body;
-      }),
+      fetchAllNetworkLogs(get(zeroClient$)(zeroRunNetworkLogsContract), runId),
     ]);
 
     if (contextResult.status === "fulfilled" && contextResult.value) {
@@ -50,7 +42,7 @@ export const fetchDownloadExtra$ = command(
     }
 
     if (networkResult.status === "fulfilled" && networkResult.value) {
-      extra.networkLogs = networkResult.value.networkLogs;
+      extra.networkLogs = networkResult.value;
     } else if (networkResult.status === "rejected") {
       L.debug("Failed to fetch network for download", networkResult.reason);
     }

--- a/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
@@ -1,27 +1,179 @@
-import { computed } from "ccstate";
-import { zeroRunNetworkLogsContract } from "@vm0/core";
+import { state, computed, command } from "ccstate";
+import { zeroRunNetworkLogsContract, type NetworkLogEntry } from "@vm0/core";
+import type { InitClientArgs, InitClientReturn } from "@ts-rest/core";
 import { zeroClient$ } from "../api-client.ts";
 import { currentRunId$ } from "./activity-signals.ts";
 import { accept } from "../../lib/accept.ts";
 
-/**
- * Network logs fetched from Axiom via the zero network API.
- * Returns null if network logs are not available.
- */
-export const zeroActivityNetworkLogs$ = computed(async (get) => {
-  const runId = get(currentRunId$);
-  if (!runId) {
-    return null;
-  }
+const PAGE_LIMIT = 500;
+const MAX_PAGES = 20;
 
-  const client = get(zeroClient$)(zeroRunNetworkLogsContract);
+type NetworkLogsClient = InitClientReturn<
+  typeof zeroRunNetworkLogsContract,
+  InitClientArgs
+>;
+
+/**
+ * Fetch a single page of network logs.
+ */
+async function fetchPage(
+  client: NetworkLogsClient,
+  runId: string,
+  since?: number,
+): Promise<{ logs: NetworkLogEntry[]; hasMore: boolean }> {
   const result = await accept(
     client.getNetworkLogs({
       params: { id: runId },
-      query: { limit: 500, order: "asc" },
+      query: {
+        limit: PAGE_LIMIT,
+        order: "asc",
+        ...(since !== undefined && { since }),
+      },
     }),
     [200],
     { toast: false },
   );
-  return result.body;
+  return { logs: result.body.networkLogs, hasMore: result.body.hasMore };
+}
+
+/**
+ * Paginate through all network log pages for a given run (used by download).
+ */
+export async function fetchAllNetworkLogs(
+  client: NetworkLogsClient,
+  runId: string,
+): Promise<NetworkLogEntry[]> {
+  const all: NetworkLogEntry[] = [];
+  let since: number | undefined;
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const { logs, hasMore } = await fetchPage(client, runId, since);
+    all.push(...logs);
+
+    if (!hasMore || logs.length === 0) {
+      break;
+    }
+
+    const lastEntry = logs[logs.length - 1];
+    since = new Date(lastEntry.timestamp).getTime();
+  }
+
+  return all;
+}
+
+// ---------------------------------------------------------------------------
+// Incremental page-loading signals (for UI display)
+// ---------------------------------------------------------------------------
+
+/**
+ * First page — auto-fetched via computed when runId changes.
+ */
+const firstPage$ = computed(async (get) => {
+  const runId = get(currentRunId$);
+  if (!runId) {
+    return null;
+  }
+  const client = get(zeroClient$)(zeroRunNetworkLogsContract);
+  return await fetchPage(client, runId);
 });
+
+/** Extra logs appended via "Load more". */
+const extraLogs$ = state<NetworkLogEntry[]>([]);
+
+/** Whether the last fetched page indicated more data. */
+const extraHasMore$ = state<boolean | null>(null);
+
+/** Cursor for the next page. */
+const nextSince$ = state<number | undefined>(undefined);
+
+/** Pages loaded so far (1 = first page only). */
+const pageCount$ = state(0);
+
+/** Whether a "load more" request is in flight. */
+const loadingMore$ = state(false);
+
+/** The runId that extra state belongs to (for stale detection). */
+const extraRunId$ = state<string | null>(null);
+
+/**
+ * Combined signal for the UI. Merges auto-loaded first page with
+ * any extra pages loaded via loadNetworkLogsNextPage$.
+ */
+export const zeroActivityNetworkLogs$ = computed(async (get) => {
+  const first = await get(firstPage$);
+  if (!first) {
+    return {
+      networkLogs: [] as NetworkLogEntry[],
+      hasMore: false,
+      loading: false,
+    };
+  }
+
+  const runId = get(currentRunId$);
+  const extraRunMatch = get(extraRunId$) === runId;
+  const extra = extraRunMatch ? get(extraLogs$) : [];
+  const hasMore =
+    extraRunMatch && get(extraHasMore$) !== null
+      ? get(extraHasMore$)
+      : first.hasMore;
+  const loading = get(loadingMore$);
+
+  return {
+    networkLogs: [...first.logs, ...extra],
+    hasMore: hasMore ?? false,
+    loading,
+  };
+});
+
+/**
+ * Load the next page. Called by "Load more" button.
+ */
+export const loadNetworkLogsNextPage$ = command(
+  async ({ get, set }, _signal: AbortSignal) => {
+    const runId = get(currentRunId$);
+    if (!runId) {
+      return;
+    }
+
+    // Initialise extra state on first "load more" for this run
+    if (get(extraRunId$) !== runId) {
+      const first = await get(firstPage$);
+      if (!first || !first.hasMore || first.logs.length === 0) {
+        return;
+      }
+      set(extraRunId$, runId);
+      set(extraLogs$, []);
+      set(extraHasMore$, first.hasMore);
+      set(pageCount$, 1);
+      const lastEntry = first.logs[first.logs.length - 1];
+      set(nextSince$, new Date(lastEntry.timestamp).getTime());
+    }
+
+    if (get(extraHasMore$) === false || get(loadingMore$)) {
+      return;
+    }
+
+    if (get(pageCount$) >= MAX_PAGES) {
+      return;
+    }
+
+    set(loadingMore$, true);
+
+    try {
+      const since = get(nextSince$);
+      const client = get(zeroClient$)(zeroRunNetworkLogsContract);
+      const { logs, hasMore } = await fetchPage(client, runId, since);
+
+      set(extraLogs$, [...get(extraLogs$), ...logs]);
+      set(extraHasMore$, hasMore);
+      set(pageCount$, get(pageCount$) + 1);
+
+      if (logs.length > 0) {
+        const lastEntry = logs[logs.length - 1];
+        set(nextSince$, new Date(lastEntry.timestamp).getTime());
+      }
+    } finally {
+      set(loadingMore$, false);
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
@@ -166,13 +166,17 @@ export const loadNetworkLogsNextPage$ = command(
       const { logs, hasMore } = await fetchPage(client, runId, pg.since);
 
       const lastEntry = logs.length > 0 ? logs[logs.length - 1] : undefined;
-      set(pagination$, {
-        ...pg,
-        logs: [...pg.logs, ...logs],
-        hasMore,
-        since: lastEntry ? new Date(lastEntry.timestamp).getTime() : pg.since,
-        pageCount: pg.pageCount + 1,
-        loading: false,
+      set(pagination$, (current) => {
+        return {
+          ...current,
+          logs: [...current.logs, ...logs],
+          hasMore,
+          since: lastEntry
+            ? new Date(lastEntry.timestamp).getTime()
+            : current.since,
+          pageCount: current.pageCount + 1,
+          loading: false,
+        };
       });
     } finally {
       set(pagination$, (current) => {

--- a/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
@@ -77,23 +77,24 @@ const firstPage$ = computed(async (get) => {
   return await fetchPage(client, runId);
 });
 
-/** Extra logs appended via "Load more". */
-const extraLogs$ = state<NetworkLogEntry[]>([]);
+interface PaginationState {
+  runId: string | null;
+  logs: NetworkLogEntry[];
+  hasMore: boolean;
+  since: number | undefined;
+  pageCount: number;
+  loading: boolean;
+}
 
-/** Whether the last fetched page indicated more data. */
-const extraHasMore$ = state<boolean | null>(null);
-
-/** Cursor for the next page. */
-const nextSince$ = state<number | undefined>(undefined);
-
-/** Pages loaded so far (1 = first page only). */
-const pageCount$ = state(0);
-
-/** Whether a "load more" request is in flight. */
-const loadingMore$ = state(false);
-
-/** The runId that extra state belongs to (for stale detection). */
-const extraRunId$ = state<string | null>(null);
+/** Extra-pages pagination state, managed by loadNetworkLogsNextPage$. */
+const pagination$ = state<PaginationState>({
+  runId: null,
+  logs: [],
+  hasMore: false,
+  since: undefined,
+  pageCount: 0,
+  loading: false,
+});
 
 /**
  * Combined signal for the UI. Merges auto-loaded first page with
@@ -110,17 +111,16 @@ export const zeroActivityNetworkLogs$ = computed(async (get) => {
   }
 
   const runId = get(currentRunId$);
-  const extraRunMatch = get(extraRunId$) === runId;
-  const extra = extraRunMatch ? get(extraLogs$) : [];
+  const pg = get(pagination$);
+  const extraRunMatch = pg.runId === runId;
+  const extra = extraRunMatch ? pg.logs : [];
   const hasMore =
-    extraRunMatch && get(extraHasMore$) !== null
-      ? get(extraHasMore$)
-      : first.hasMore;
-  const loading = get(loadingMore$);
+    extraRunMatch && pg.pageCount > 0 ? pg.hasMore : first.hasMore;
+  const loading = pg.loading;
 
   return {
     networkLogs: [...first.logs, ...extra],
-    hasMore: hasMore ?? false,
+    hasMore,
     loading,
   };
 });
@@ -135,45 +135,49 @@ export const loadNetworkLogsNextPage$ = command(
       return;
     }
 
-    // Initialise extra state on first "load more" for this run
-    if (get(extraRunId$) !== runId) {
+    let pg = get(pagination$);
+
+    // Initialise pagination state on first "load more" for this run
+    if (pg.runId !== runId) {
       const first = await get(firstPage$);
       if (!first || !first.hasMore || first.logs.length === 0) {
         return;
       }
-      set(extraRunId$, runId);
-      set(extraLogs$, []);
-      set(extraHasMore$, first.hasMore);
-      set(pageCount$, 1);
       const lastEntry = first.logs[first.logs.length - 1];
-      set(nextSince$, new Date(lastEntry.timestamp).getTime());
+      pg = {
+        runId,
+        logs: [],
+        hasMore: first.hasMore,
+        since: new Date(lastEntry.timestamp).getTime(),
+        pageCount: 1,
+        loading: false,
+      };
+      set(pagination$, pg);
     }
 
-    if (get(extraHasMore$) === false || get(loadingMore$)) {
+    if (!pg.hasMore || pg.loading || pg.pageCount >= MAX_PAGES) {
       return;
     }
 
-    if (get(pageCount$) >= MAX_PAGES) {
-      return;
-    }
-
-    set(loadingMore$, true);
+    set(pagination$, { ...pg, loading: true });
 
     try {
-      const since = get(nextSince$);
       const client = get(zeroClient$)(zeroRunNetworkLogsContract);
-      const { logs, hasMore } = await fetchPage(client, runId, since);
+      const { logs, hasMore } = await fetchPage(client, runId, pg.since);
 
-      set(extraLogs$, [...get(extraLogs$), ...logs]);
-      set(extraHasMore$, hasMore);
-      set(pageCount$, get(pageCount$) + 1);
-
-      if (logs.length > 0) {
-        const lastEntry = logs[logs.length - 1];
-        set(nextSince$, new Date(lastEntry.timestamp).getTime());
-      }
+      const lastEntry = logs.length > 0 ? logs[logs.length - 1] : undefined;
+      set(pagination$, {
+        ...pg,
+        logs: [...pg.logs, ...logs],
+        hasMore,
+        since: lastEntry ? new Date(lastEntry.timestamp).getTime() : pg.since,
+        pageCount: pg.pageCount + 1,
+        loading: false,
+      });
     } finally {
-      set(loadingMore$, false);
+      set(pagination$, (current) => {
+        return current.loading ? { ...current, loading: false } : current;
+      });
     }
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
@@ -581,4 +581,93 @@ describe("networkContent", () => {
       expect(screen.queryByText("Timestamp")).not.toBeInTheDocument();
     });
   });
+
+  it("should show Load more button and append next page on click (ACT-N-007)", async () => {
+    let requestCount = 0;
+    server.use(
+      http.get("*/api/zero/logs/:id", ({ params }) => {
+        if (params["id"] === LOG_ID) {
+          return HttpResponse.json(makeLogDetail());
+        }
+        return HttpResponse.json(
+          { error: { message: "Not found", code: "NOT_FOUND" } },
+          { status: 404 },
+        );
+      }),
+      http.get("*/api/zero/runs/:runId/telemetry/agent", () => {
+        return HttpResponse.json(makeEventsResponse());
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+      http.get("*/api/zero/runs/:id/network", () => {
+        requestCount++;
+        if (requestCount === 1) {
+          return HttpResponse.json({
+            networkLogs: [
+              makeNetworkEntry({
+                url: "https://page1.example.com",
+                timestamp: "2026-03-10T14:56:05Z",
+              }),
+            ],
+            hasMore: true,
+          });
+        }
+        return HttpResponse.json({
+          networkLogs: [
+            makeNetworkEntry({
+              url: "https://page2.example.com",
+              timestamp: "2026-03-10T14:56:06Z",
+            }),
+          ],
+          hasMore: false,
+        });
+      }),
+    );
+
+    const user = await setupAndNavigateToTab("Network");
+
+    // First page renders
+    await waitFor(() => {
+      expect(screen.getByText("https://page1.example.com")).toBeInTheDocument();
+    });
+
+    // "Load more" button visible
+    const loadMoreButton = screen.getByText("Load more");
+    expect(loadMoreButton).toBeInTheDocument();
+
+    // Click to load next page
+    await user.click(loadMoreButton);
+
+    // Second page appended
+    await waitFor(() => {
+      expect(screen.getByText("https://page2.example.com")).toBeInTheDocument();
+    });
+
+    // First page still visible
+    expect(screen.getByText("https://page1.example.com")).toBeInTheDocument();
+
+    // "Load more" gone since hasMore is false
+    expect(screen.queryByText("Load more")).not.toBeInTheDocument();
+  });
+
+  it("should not show Load more button when hasMore is false (ACT-N-008)", async () => {
+    setupMocks({
+      contextResponse: null,
+      networkResponse: {
+        networkLogs: [makeNetworkEntry()],
+        hasMore: false,
+      },
+    });
+
+    await setupAndNavigateToTab("Network");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("https://api.example.com/data"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Load more")).not.toBeInTheDocument();
+  });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
@@ -100,7 +100,7 @@ function setupMocks(options: {
   contextResponse?: RunContextResponse | null;
   networkResponse?: {
     networkLogs: NetworkLogEntry[];
-    hasMore?: boolean;
+    hasMore: boolean;
   } | null;
 }) {
   server.use(

--- a/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
@@ -100,7 +100,7 @@ function setupMocks(options: {
   contextResponse?: RunContextResponse | null;
   networkResponse?: {
     networkLogs: NetworkLogEntry[];
-    hasMore: boolean;
+    hasMore?: boolean;
   } | null;
 }) {
   server.use(
@@ -443,22 +443,6 @@ describe("networkContent", () => {
 
     // TCP entry renders host:port
     expect(screen.getByText("db.internal:5432")).toBeInTheDocument();
-  });
-
-  it("should render truncation indicator when hasMore is true (ACT-N-002)", async () => {
-    setupMocks({
-      contextResponse: null,
-      networkResponse: {
-        networkLogs: [makeNetworkEntry()],
-        hasMore: true,
-      },
-    });
-
-    await setupAndNavigateToTab("Network");
-
-    await waitFor(() => {
-      expect(screen.getByText(/truncated/i)).toBeInTheDocument();
-    });
   });
 
   it("should render formatted time, size, and latency (ACT-N-003)", async () => {

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -367,18 +367,16 @@ function NetworkLogRow({
 export function NetworkContent({
   networkLogs,
   hasMore,
+  loading,
+  onLoadMore,
 }: {
   networkLogs: NetworkLogEntry[];
   hasMore?: boolean;
+  loading?: boolean;
+  onLoadMore?: () => void;
 }) {
   return (
     <div className="pb-8">
-      {hasMore && (
-        <p className="text-xs text-muted-foreground mb-3">
-          Showing first {networkLogs.length} entries. Some entries may be
-          truncated.
-        </p>
-      )}
       <Table>
         <TableHeader>
           <TableRow>
@@ -398,6 +396,21 @@ export function NetworkContent({
           })}
         </TableBody>
       </Table>
+      {hasMore && onLoadMore && (
+        <div className="flex justify-center py-4">
+          {loading ? (
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+          ) : (
+            <button
+              type="button"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              onClick={onLoadMore}
+            >
+              Load more
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -1,3 +1,4 @@
+import { IconLoader2 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import {
   Table,
@@ -399,7 +400,7 @@ export function NetworkContent({
       {hasMore && onLoadMore && (
         <div className="flex justify-center py-4">
           {loading ? (
-            <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+            <IconLoader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           ) : (
             <button
               type="button"

--- a/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-activity-detail-page.tsx
@@ -58,7 +58,11 @@ import {
 import { GroupedMessageCard } from "./components/log-views/grouped-message-card.tsx";
 import { StatusDot } from "./components/log-views/status-dot.tsx";
 import { zeroActivityContext$ } from "../../signals/activity-page/activity-context-signals.ts";
-import { zeroActivityNetworkLogs$ } from "../../signals/activity-page/activity-network-signals.ts";
+import {
+  zeroActivityNetworkLogs$,
+  loadNetworkLogsNextPage$,
+} from "../../signals/activity-page/activity-network-signals.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { ContextContent } from "./components/context-content.tsx";
 import { NetworkContent } from "./components/network-content.tsx";
 import { Markdown } from "../components/markdown.tsx";
@@ -469,6 +473,8 @@ function ActivityContextTab() {
 
 function ActivityNetworkTab() {
   const logsLoadable = useLastLoadable(zeroActivityNetworkLogs$);
+  const loadNextPage = useSet(loadNetworkLogsNextPage$);
+  const pageSignal = useGet(pageSignal$);
 
   if (logsLoadable.state === "loading" || logsLoadable.state === "hasError") {
     return (
@@ -499,8 +505,17 @@ function ActivityNetworkTab() {
     );
   }
 
+  const handleLoadMore = () => {
+    detach(loadNextPage(pageSignal), Reason.DomCallback);
+  };
+
   return (
-    <NetworkContent networkLogs={data.networkLogs} hasMore={data.hasMore} />
+    <NetworkContent
+      networkLogs={data.networkLogs}
+      hasMore={data.hasMore}
+      loading={data.loading}
+      onLoadMore={handleLoadMore}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

- Network logs now load the first 500 entries on page open, with a **"Load more"** button to fetch subsequent pages incrementally
- JSON download path fetches all pages in one go (up to 10,000 entries / 20 pages)
- Shared `fetchPage` / `fetchAllNetworkLogs` helpers eliminate duplicated pagination logic between display and download paths

## Changes

- **`activity-network-signals.ts`** — `firstPage$` (auto-loaded computed) + `loadNetworkLogsNextPage$` (command for incremental loading) + `fetchAllNetworkLogs` (for download)
- **`activity-download.ts`** — uses shared `fetchAllNetworkLogs` instead of inline single-page fetch
- **`network-content.tsx`** — optional `hasMore`/`loading`/`onLoadMore` props with "Load more" button + spinner
- **`zero-activity-detail-page.tsx`** — wires up `loadNetworkLogsNextPage$` via `detach` + `pageSignal$`
- **`context-network-content.test.tsx`** — removed obsolete `hasMore` truncation test

## Test plan

- [ ] Open an activity run with >500 network log entries → first 500 shown, "Load more" button visible
- [ ] Click "Load more" → next 500 entries appended, spinner shown during fetch
- [ ] Run with ≤500 entries → no "Load more" button
- [ ] Download JSON → all network logs included (up to 10,000)
- [ ] Switch between runs → stale extra pages not shown
- [ ] Inspect page (local JSON) → unchanged behavior, no "Load more" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)