### PR TITLE
fix(platform): open queue drawer in-place and rename tab signals

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/__tests__/org-manage-dialog.test.ts
@@ -12,7 +12,7 @@ import {
   checkSettingsParam$,
   orgManageDialogOpen$,
 } from "../org-manage-dialog.ts";
-import { activeTab$, inviteMember$ } from "../org-manage-tabs-state.ts";
+import { orgManageTab$, inviteMember$ } from "../org-manage-tabs-state.ts";
 import { searchParams$ } from "../../../route.ts";
 
 const context = testContext();
@@ -37,7 +37,7 @@ describe("checkSettingsParam$", () => {
     await store.set(checkSettingsParam$, signal);
 
     expect(store.get(orgManageDialogOpen$)).toBeTruthy();
-    expect(store.get(activeTab$)).toBe("providers");
+    expect(store.get(orgManageTab$)).toBe("providers");
     // The param should be stripped from the URL
     expect(store.get(searchParams$).has("settings")).toBeFalsy();
   });
@@ -51,7 +51,7 @@ describe("checkSettingsParam$", () => {
     await store.set(checkSettingsParam$, signal);
 
     expect(store.get(orgManageDialogOpen$)).toBeTruthy();
-    expect(store.get(activeTab$)).toBe("billing");
+    expect(store.get(orgManageTab$)).toBe("billing");
   });
 
   it("should open dialog on usage tab when ?settings=usage is present", async () => {
@@ -63,7 +63,7 @@ describe("checkSettingsParam$", () => {
     await store.set(checkSettingsParam$, signal);
 
     expect(store.get(orgManageDialogOpen$)).toBeTruthy();
-    expect(store.get(activeTab$)).toBe("usage");
+    expect(store.get(orgManageTab$)).toBe("usage");
   });
 
   it("should map legacy ?settings=credits to usage tab", async () => {
@@ -75,7 +75,7 @@ describe("checkSettingsParam$", () => {
     await store.set(checkSettingsParam$, signal);
 
     expect(store.get(orgManageDialogOpen$)).toBeTruthy();
-    expect(store.get(activeTab$)).toBe("usage");
+    expect(store.get(orgManageTab$)).toBe("usage");
   });
 
   it("should not open dialog when no settings param is present", async () => {
@@ -119,7 +119,7 @@ describe("checkSettingsParam$", () => {
     await store.set(checkSettingsParam$, signal);
 
     expect(store.get(orgManageDialogOpen$)).toBeTruthy();
-    expect(store.get(activeTab$)).toBe("general");
+    expect(store.get(orgManageTab$)).toBe("general");
   });
 
   it("should preserve other search params when stripping settings", async () => {

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-dialog.ts
@@ -4,7 +4,7 @@ import { reloadBillingStatus$ } from "../billing.ts";
 import { isOrgAdmin$ } from "../../org.ts";
 import {
   initProfileName$,
-  setActiveTab$,
+  setActiveOrgManageTab$,
   type OrgManageTab,
 } from "./org-manage-tabs-state.ts";
 
@@ -59,7 +59,7 @@ export const checkSettingsParam$ = command(
       signal.throwIfAborted();
       const resolvedTab =
         !isAdmin && ADMIN_ONLY_TABS.has(tab) ? "general" : tab;
-      set(setActiveTab$, resolvedTab);
+      set(setActiveOrgManageTab$, resolvedTab);
       await set(setOrgManageDialogOpen$, true, signal);
     }
 

--- a/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/org-manage-tabs-state.ts
@@ -32,11 +32,11 @@ export type OrgManageTab =
 
 const internalActiveTab$ = state<OrgManageTab>("general");
 
-export const activeTab$ = computed((get) => {
+export const orgManageTab$ = computed((get) => {
   return get(internalActiveTab$);
 });
 
-export const setActiveTab$ = command(({ set }, tab: OrgManageTab) => {
+export const setActiveOrgManageTab$ = command(({ set }, tab: OrgManageTab) => {
   set(internalActiveTab$, tab);
 });
 

--- a/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
+++ b/turbo/apps/platform/src/views/queue-page/__tests__/queue-drawer.test.tsx
@@ -11,11 +11,17 @@
 
 import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
-import { setupPage } from "../../../__tests__/page-helper.ts";
+import {
+  setupPage,
+  detachedSetupPage,
+} from "../../../__tests__/page-helper.ts";
 import { openQueueDrawer$ } from "../../../signals/queue-page/queue-drawer-state.ts";
+import { pathname$ } from "../../../signals/route.ts";
+import { mockChatLifecycle } from "../../zero-page/__tests__/chat-test-helpers.ts";
 
 const context = testContext();
 
@@ -164,5 +170,52 @@ describe("queue drawer", () => {
     });
 
     expect(screen.queryByText(/Upgrade to/)).not.toBeInTheDocument();
+  });
+
+  it("clicking 'View queue' in chat should open drawer without navigating away", async () => {
+    const user = userEvent.setup();
+
+    const ctrl = mockChatLifecycle({
+      unsavedRuns: [
+        {
+          runId: "run-queue-1",
+          status: "queued",
+          prompt: "Do something",
+          error: null,
+          createdAt: "2026-03-10T00:00:00Z",
+        },
+      ],
+    });
+    ctrl.setRunStatus("queued");
+    ctrl.setQueuePosition(2);
+
+    server.use(
+      http.get("*/api/zero/runs/queue", () => {
+        return HttpResponse.json(
+          queueResponse({
+            concurrency: { tier: "free", limit: 1, active: 1, available: 0 },
+          }),
+        );
+      }),
+    );
+
+    detachedSetupPage({ context, path: "/chats/thread-test-1" });
+
+    const link = await waitFor(() => {
+      return screen.getByText("View queue");
+    });
+
+    expect(context.store.get(pathname$)).toBe("/chats/thread-test-1");
+
+    await user.click(link);
+
+    // Should stay on the chat page and open the queue drawer in-place
+    expect(context.store.get(pathname$)).toBe("/chats/thread-test-1");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: /waiting in line/ }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-manage-dialog.tsx
@@ -31,8 +31,8 @@ import { OrgUsageTab } from "./org-usage-tab.tsx";
 import { OrgInvoicesTab } from "./org-invoices-tab.tsx";
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
 import {
-  activeTab$,
-  setActiveTab$,
+  orgManageTab$,
+  setActiveOrgManageTab$,
   billingSubPage$,
   type OrgManageTab,
 } from "../../../../signals/zero-page/settings/org-manage-tabs-state.ts";
@@ -148,8 +148,8 @@ function TabContent({ tab }: { tab: OrgManageTab }) {
 }
 
 export function OrgManageDialog({ open, onOpenChange }: OrgManageDialogProps) {
-  const activeTab = useGet(activeTab$);
-  const setActiveTab = useSet(setActiveTab$);
+  const activeTab = useGet(orgManageTab$);
+  const setActiveTab = useSet(setActiveOrgManageTab$);
 
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =

--- a/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-layout.tsx
@@ -31,7 +31,7 @@ import { ZeroAboutPage } from "./zero-about-page.tsx";
 import { Link } from "../router/link.tsx";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
-  setActiveTab$,
+  setActiveOrgManageTab$,
   setBillingSubPage$,
 } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import {
@@ -73,7 +73,7 @@ function MobileTopBar() {
   const activeId = useGet(activeRoute$);
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin = isAdminLoadable.state === "hasData" && isAdminLoadable.data;
-  const setTab = useSet(setActiveTab$);
+  const setTab = useSet(setActiveOrgManageTab$);
   const setSubPage = useSet(setBillingSubPage$);
   const openManage = useSet(setOrgManageDialogOpen$);
   const pageSignal = useGet(pageSignal$);

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-page.tsx
@@ -32,7 +32,7 @@ import {
 import { detach, Reason } from "../../signals/utils.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import {
-  setActiveTab$,
+  setActiveOrgManageTab$,
   setBillingSubPage$,
 } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
@@ -157,7 +157,7 @@ function InviteButton({ pageSignal }: { pageSignal: AbortSignal }) {
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
-  const setTab = useSet(setActiveTab$);
+  const setTab = useSet(setActiveOrgManageTab$);
   const setSubPage = useSet(setBillingSubPage$);
   const openManage = useSet(setOrgManageDialogOpen$);
   const handleInvite = () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -28,6 +28,7 @@ import {
 import { RUN_ERROR_GUIDANCE } from "@vm0/core";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
+import { openQueueDrawer$ } from "../../signals/queue-page/queue-drawer-state.ts";
 import { FileAttachmentChip, ImageLightbox } from "./zero-attachment-chips.tsx";
 import {
   lightboxUrl$ as attachmentLightboxUrl$,
@@ -62,7 +63,7 @@ import {
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { Link } from "../router/link.tsx";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
-import { setActiveTab$ } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
+import { setActiveOrgManageTab$ } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import {
   timelineExpandedIds$,
   toggleTimelineExpanded$,
@@ -593,6 +594,7 @@ function RunActivityLineView({
   queuePosition: number;
   thinkingMsg: string;
 }) {
+  const openDrawer = useSet(openQueueDrawer$);
   if (isQueued) {
     return (
       <div className="flex items-center gap-2 min-w-0">
@@ -602,12 +604,13 @@ function RunActivityLineView({
         />
         <p className="text-muted-foreground text-xs truncate">
           {queueLabel(queuePosition)}{" "}
-          <Link
-            pathname="/queues"
+          <button
+            type="button"
+            onClick={openDrawer}
             className="underline hover:text-foreground transition-colors"
           >
             View queue
-          </Link>
+          </button>
         </p>
       </div>
     );
@@ -832,7 +835,7 @@ function StaticAssistantMessage({
 }) {
   const { avatarSrc } = useChatAgentIdentity();
   const setOrgManageOpen = useSet(setOrgManageDialogOpen$);
-  const setTab = useSet(setActiveTab$);
+  const setTab = useSet(setActiveOrgManageTab$);
   const pageSignal = useGet(pageSignal$);
   const content = useLastResolved(message.result$) ?? "";
   const avatar = (

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-upgrade.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-upgrade.tsx
@@ -5,7 +5,7 @@ import { billingStatusAsync$ } from "../../signals/zero-page/billing.ts";
 import planProImg from "./components/org-manage/assets/plan-pro.webp";
 import planTeamImg from "./components/org-manage/assets/plan-team.webp";
 import {
-  setActiveTab$,
+  setActiveOrgManageTab$,
   setBillingSubPage$,
 } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
@@ -29,7 +29,7 @@ export function SidebarUpgradeCard() {
   const isAdminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin =
     isAdminLoadable.state === "hasData" ? isAdminLoadable.data : false;
-  const setTab = useSet(setActiveTab$);
+  const setTab = useSet(setActiveOrgManageTab$);
   const setSubPage = useSet(setBillingSubPage$);
   const openManage = useSet(setOrgManageDialogOpen$);
 


### PR DESCRIPTION
## Summary
- **Fix:** "View queue" link in chat was navigating away from the current page. Now it opens the queue drawer in-place via `openQueueDrawer$` without leaving the chat thread.
- **Refactor:** Rename ambiguous `activeTab$`/`setActiveTab$` to `orgManageTab$`/`setActiveOrgManageTab$` for clarity across 6 files.
- **Test:** Add regression test verifying "View queue" click stays on chat page and opens the drawer.

## Test plan
- [x] New test: `queue-drawer.test.tsx` — "clicking 'View queue' in chat should open drawer without navigating away"
- [x] Existing `org-manage-dialog.test.ts` tests pass with renamed signals
- [ ] Manually verify "View queue" opens drawer without leaving chat
- [ ] Verify workspace settings dialog still works (tab switching, opening from sidebar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)