### PR TITLE
refactor(firewalls): disable fine-grained connector permissions

### DIFF
--- a/turbo/packages/core/src/firewalls/index.ts
+++ b/turbo/packages/core/src/firewalls/index.ts
@@ -334,10 +334,35 @@ function expandPlaceholders(
   return { ...firewall, placeholders: expanded };
 }
 
+/**
+ * Connectors whose fine-grained permissions are stripped at load time.
+ * These connectors allow any request matching the base URL through the proxy.
+ */
+const STRIP_PERMISSIONS_CONNECTORS = new Set<ConnectorType>(["github"]);
+
+function stripPermissions(firewall: FirewallConfig): FirewallConfig {
+  return {
+    ...firewall,
+    apis: firewall.apis.map((api) => {
+      return {
+        ...api,
+        permissions: [],
+      };
+    }),
+  };
+}
+
 // Pre-compute expanded placeholders at module load time.
+// Connectors outside the fine-grained whitelist have permissions stripped.
 const EXPANDED_CONNECTOR_FIREWALLS = Object.fromEntries(
   Object.entries(CONNECTOR_FIREWALLS).map(([type, firewall]) => {
-    return [type, expandPlaceholders(firewall, type as ConnectorType)];
+    const expanded = expandPlaceholders(firewall, type as ConnectorType);
+    return [
+      type,
+      STRIP_PERMISSIONS_CONNECTORS.has(type as ConnectorType)
+        ? stripPermissions(expanded)
+        : expanded,
+    ];
   }),
 ) as typeof CONNECTOR_FIREWALLS;
 

--- a/turbo/packages/core/src/firewalls/index.ts
+++ b/turbo/packages/core/src/firewalls/index.ts
@@ -334,12 +334,6 @@ function expandPlaceholders(
   return { ...firewall, placeholders: expanded };
 }
 
-/**
- * Connectors whose fine-grained permissions are stripped at load time.
- * These connectors allow any request matching the base URL through the proxy.
- */
-const STRIP_PERMISSIONS_CONNECTORS = new Set<ConnectorType>(["github"]);
-
 function stripPermissions(firewall: FirewallConfig): FirewallConfig {
   return {
     ...firewall,
@@ -352,17 +346,15 @@ function stripPermissions(firewall: FirewallConfig): FirewallConfig {
   };
 }
 
-// Pre-compute expanded placeholders at module load time.
-// Connectors outside the fine-grained whitelist have permissions stripped.
+// Pre-compute expanded placeholders and strip fine-grained permissions
+// at module load time. Fine-grained permission rules are not yet stable
+// enough for production use — strip them globally for now and gradually
+// re-enable per connector as rules are validated and DEFAULT_ALLOWED
+// policies are configured.
 const EXPANDED_CONNECTOR_FIREWALLS = Object.fromEntries(
   Object.entries(CONNECTOR_FIREWALLS).map(([type, firewall]) => {
     const expanded = expandPlaceholders(firewall, type as ConnectorType);
-    return [
-      type,
-      STRIP_PERMISSIONS_CONNECTORS.has(type as ConnectorType)
-        ? stripPermissions(expanded)
-        : expanded,
-    ];
+    return [type, stripPermissions(expanded)];
   }),
 ) as typeof CONNECTOR_FIREWALLS;
 


### PR DESCRIPTION
## Summary

Fine-grained firewall permission rules are not yet stable enough for production use:
- Some connectors (e.g., GitHub) use both REST and GraphQL APIs, but GraphQL has no public permission mapping data, making it impossible to generate equivalent fine-grained rules
- Existing REST permission rules lack validated DEFAULT_ALLOWED policies

Disable fine-grained permission filtering globally for now. Re-enable per connector gradually as rules are validated and DEFAULT_ALLOWED policies are configured.

## Changes

- Add `stripPermissions()` helper to clear permissions from firewall configs
- Strip all connector permissions at module load time in `EXPANDED_CONNECTOR_FIREWALLS`
- Proxy will allow any request matching the base URL (via `UNRESTRICTED_PERMISSION` in resolve-firewalls)

## Test plan
- [ ] Verify all connector requests pass through proxy without permission-level filtering
- [ ] Run existing firewall tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)