### PR TITLE
chore: update stale comments referencing deleted startRun/createRunRecord

### DIFF
--- a/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/runs/__tests__/route.test.ts
@@ -93,7 +93,7 @@ describe("POST /api/agent/runs - Internal Runs API", () => {
       const data = await createTestRun(composeId, "Hello");
       const run = await getTestRun(data.runId);
 
-      // CLI path (startRun) does not inject agent identity — that's done by createZeroRun
+      // CLI path does not inject agent identity — that's done by createZeroRun
       expect(run.appendSystemPrompt).toBeNull();
     });
 

--- a/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/slack/events/__tests__/route.test.ts
@@ -327,7 +327,7 @@ describe("POST /api/zero/slack/events", () => {
     });
 
     it("posts error when run was not created (no callback)", async () => {
-      // Set up a compose WITHOUT a version → startRun fails before creating the run
+      // Set up a compose WITHOUT a version → createZeroRun fails before creating the run
       const { agentId } = await seedTestCompose({
         userId: user.userId,
         name: uniqueId("agent"),
@@ -356,7 +356,7 @@ describe("POST /api/zero/slack/events", () => {
 
       await context.mocks.flushAfter();
 
-      // startRun failed before creating a run → no callback → handler posts error
+      // createZeroRun failed before creating a run → no callback → handler posts error
       const { WebClient } = await import("@slack/web-api");
       const mockClient = new WebClient();
       expect(mockClient.chat.postMessage).toHaveBeenCalledOnce();

--- a/turbo/apps/web/src/lib/infra/run/run-service.ts
+++ b/turbo/apps/web/src/lib/infra/run/run-service.ts
@@ -370,7 +370,7 @@ export async function buildAndDispatchRun(opts: {
 }
 
 /**
- * Result of createRunRecord — contains the run record and all metadata
+ * Run record result — contains the run record and all metadata
  * needed by buildAndDispatchRun to complete the dispatch pipeline.
  */
 export interface CreateRunRecordResult {

--- a/turbo/apps/web/src/lib/zero/build-zero-context.ts
+++ b/turbo/apps/web/src/lib/zero/build-zero-context.ts
@@ -285,7 +285,7 @@ interface ResolveCliRunContextParams {
 
 /**
  * Pre-resolved context data for CLI runs.
- * Returned by resolveCliRunContext() for the CLI route to pass to startRun().
+ * Returned by resolveCliRunContext() for the CLI route to use inline.
  */
 interface ResolvedCliContext {
   // Session/checkpoint resolution
@@ -323,7 +323,7 @@ interface ResolvedCliContext {
  * This is the CLI counterpart to buildZeroExecutionContext — it performs the
  * same resolution (vars, secrets, connectors, firewalls, timezone, model
  * provider) but returns pre-resolved data instead of a built ExecutionContext.
- * The CLI route calls this before startRun(), which then uses the pure
+ * The CLI route calls this to get resolved context, then directly uses
  * buildInfraExecutionContext to assemble the context.
  */
 export async function resolveCliRunContext(

--- a/turbo/apps/web/src/lib/zero/github/handlers/issue-event.ts
+++ b/turbo/apps/web/src/lib/zero/github/handlers/issue-event.ts
@@ -426,7 +426,7 @@ async function dispatchAgentRun(params: DispatchParams): Promise<void> {
 
   const vm0UserId = userLink.vm0UserId;
 
-  // 3. Resolve agent compose (version + org resolved by startRun)
+  // 3. Resolve agent compose (version + org resolved by createZeroRun)
   const [compose] = await globalThis.services.db
     .select({
       id: agentComposes.id,

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -856,7 +856,7 @@ export async function executeSchedule(
     });
   }
 
-  // Delegate run creation, validation, and dispatch to startRun()
+  // Delegate run creation, validation, and dispatch to createZeroRun()
   let runId: string;
   try {
     const result = await createZeroRun({

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/run-agent.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/run-agent.ts
@@ -35,12 +35,12 @@ interface RunAgentResult {
 /**
  * Execute an agent run for org-aware Slack integration.
  *
- * Uses the unified startRun() entry point which handles compose/org resolution.
+ * Uses createZeroRun() which handles compose/org resolution.
  * This function only handles Slack-specific concerns: prompt construction and callbacks.
  *
  * Context (integration header, thread history, user metadata) is passed via
  * appendSystemPrompt so Claude sees it as system-level instructions rather than
- * user input. startRun() prepends agent identity to appendSystemPrompt.
+ * user input. createZeroRun() prepends agent identity to appendSystemPrompt.
  */
 export async function runAgentForSlackOrg(
   params: RunAgentParams,
@@ -62,7 +62,7 @@ export async function runAgentForSlackOrg(
   } = params;
 
   try {
-    // Build system prompt from context parts (agent identity is prepended by startRun)
+    // Build system prompt from context parts (agent identity is prepended by createZeroRun)
     const contextParts = [
       buildIntegrationContext("Slack", {
         botUserId,


### PR DESCRIPTION
## Summary
- Update stale comments across 7 files that referenced deleted `startRun()` and `createRunRecord()` functions
- Comments now reflect current code which uses `createZeroRun()` and inline CLI route logic

## Files changed
- `build-zero-context.ts` — updated 2 JSDoc blocks referencing `startRun()`
- `schedule-service.ts` — updated inline comment to reference `createZeroRun()`
- `run-agent.ts` — updated JSDoc and inline comment (3 references)
- `issue-event.ts` — updated inline comment
- `route.test.ts` (runs) — updated test comment
- `route.test.ts` (slack events) — updated 2 test comments
- `run-service.ts` — updated `CreateRunRecordResult` JSDoc

## Test plan
- [ ] Comment-only changes, no functional impact
- [ ] CI passes (lint, types, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)