### PR TITLE
feat(schedule): add consecutive failure tracking and auto-disable for cron schedules

### DIFF
--- a/turbo/apps/cli/src/commands/zero/schedule/status.ts
+++ b/turbo/apps/cli/src/commands/zero/schedule/status.ts
@@ -84,7 +84,7 @@ function printTimeSchedule(schedule: ScheduleResponse): void {
     );
   }
 
-  if (schedule.triggerType === "loop") {
+  if (schedule.triggerType === "loop" || schedule.triggerType === "cron") {
     const failureText =
       schedule.consecutiveFailures > 0
         ? chalk.yellow(`${schedule.consecutiveFailures}/3`)

--- a/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
@@ -313,7 +313,8 @@ describe("GET /api/cron/execute-schedules", () => {
       const after = await getTestSchedule(testComposeId, "cron-stays-enabled");
       expect(after.enabled).toBe(true);
       expect(after.lastRunAt).not.toBeNull();
-      expect(after.nextRunAt).not.toBeNull();
+      // nextRunAt is null after execution — cron callback sets it on completion
+      expect(after.nextRunAt).toBeNull();
     });
   });
 
@@ -456,14 +457,14 @@ describe("GET /api/cron/execute-schedules", () => {
       context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
       await GET(authenticatedCronRequest());
 
-      // 5. Verify schedule advanced to next day (no retry state)
+      // 5. Verify schedule state after execution (no retry state)
+      //    nextRunAt is null — cron callback sets it on completion
       const schedule = await getTestSchedule(
         testComposeId,
         "queue-advance-test",
       );
       expect(schedule.retryStartedAt).toBeNull();
-      const nextRunAt = new Date(schedule.nextRunAt!);
-      expect(nextRunAt.toISOString()).toBe("2025-01-16T09:00:00.000Z");
+      expect(schedule.nextRunAt).toBeNull();
     });
 
     it("should disable one-time schedule after queued run", async () => {

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/cron/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/cron/__tests__/route.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import {
+  createTestCompose,
+  createTestRunInDb,
+  createTestCallback,
+  createTestRequest,
+  createTestSchedule,
+  createTestZeroAgent,
+  enableTestSchedule,
+  disableTestSchedule,
+  deleteTestSchedule,
+  updateTestScheduleState,
+  findTestScheduleById,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import { computeHmacSignature } from "../../../../../../../src/lib/infra/callback/hmac";
+
+const context = testContext();
+
+interface CronCallbackPayload {
+  scheduleId: string;
+  cronExpression: string;
+  timezone: string;
+}
+
+function createCallbackRequest(
+  body: {
+    callbackId?: string;
+    runId: string;
+    status: "completed" | "failed";
+    error?: string;
+    payload: CronCallbackPayload;
+  },
+  secret: string,
+  options?: { invalidSignature?: boolean },
+): NextRequest {
+  const bodyString = JSON.stringify(body);
+  const timestamp = Math.floor(Date.now() / 1000);
+
+  const signature = options?.invalidSignature
+    ? "invalid-signature"
+    : computeHmacSignature(bodyString, secret, timestamp);
+
+  return createTestRequest(
+    "http://localhost/api/internal/callbacks/schedule/cron",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-VM0-Signature": signature,
+        "X-VM0-Timestamp": timestamp.toString(),
+      },
+      body: bodyString,
+    },
+  );
+}
+
+describe("POST /api/internal/callbacks/schedule/cron", () => {
+  let composeId: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    userId = user.userId;
+    const agentName = uniqueId("agent");
+    composeId = (await createTestCompose(agentName)).composeId;
+    await createTestZeroAgent(user.orgId, agentName, {});
+  });
+
+  async function setupCronSchedule() {
+    const schedule = await createTestSchedule(composeId, uniqueId("cron"), {
+      cronExpression: "0 9 * * *",
+      timezone: "UTC",
+    });
+    await enableTestSchedule(composeId, schedule.name);
+    const { runId } = await createTestRunInDb(userId, composeId, {
+      prompt: "Cron task",
+    });
+    const { callbackId, secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/schedule/cron",
+      payload: {
+        scheduleId: schedule.id,
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+      },
+    });
+    return { schedule, runId, callbackId, secret };
+  }
+
+  describe("Signature Verification", () => {
+    it("should reject request with invalid signature", async () => {
+      const { schedule, runId, secret } = await setupCronSchedule();
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            scheduleId: schedule.id,
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+          },
+        },
+        secret,
+        { invalidSignature: true },
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should reject request with unknown runId", async () => {
+      const request = createCallbackRequest(
+        {
+          runId: "00000000-0000-0000-0000-000000000000",
+          status: "completed",
+          payload: {
+            scheduleId: "00000000-0000-0000-0000-000000000000",
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+          },
+        },
+        "fake-secret",
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("Success Callback", () => {
+    it("should reset failure counter and schedule next run", async () => {
+      const { schedule, runId, secret } = await setupCronSchedule();
+
+      // Simulate prior consecutive failures
+      await updateTestScheduleState(schedule.id, { consecutiveFailures: 2 });
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            scheduleId: schedule.id,
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // Verify DB state
+      const updated = await findTestScheduleById(schedule.id);
+      expect(updated!.consecutiveFailures).toBe(0);
+      expect(updated!.nextRunAt).not.toBeNull();
+      expect(updated!.enabled).toBe(true);
+    });
+  });
+
+  describe("Failure Callback", () => {
+    it("should increment failure counter on first failure", async () => {
+      const { schedule, runId, secret } = await setupCronSchedule();
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "failed",
+          error: "Agent crashed",
+          payload: {
+            scheduleId: schedule.id,
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      const updated = await findTestScheduleById(schedule.id);
+      expect(updated!.consecutiveFailures).toBe(1);
+      expect(updated!.enabled).toBe(true);
+      // Should still schedule next run
+      expect(updated!.nextRunAt).not.toBeNull();
+    });
+
+    it("should auto-disable after 3 consecutive failures", async () => {
+      const { schedule, runId, secret } = await setupCronSchedule();
+
+      // Set to 2 consecutive failures already
+      await updateTestScheduleState(schedule.id, { consecutiveFailures: 2 });
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "failed",
+          error: "Third failure",
+          payload: {
+            scheduleId: schedule.id,
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+
+      const updated = await findTestScheduleById(schedule.id);
+      expect(updated!.consecutiveFailures).toBe(3);
+      expect(updated!.enabled).toBe(false);
+      expect(updated!.nextRunAt).toBeNull();
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should skip callback for deleted schedule", async () => {
+      const { schedule, runId, secret } = await setupCronSchedule();
+
+      // Delete the schedule via API helper
+      await deleteTestSchedule(composeId, schedule.name);
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            scheduleId: schedule.id,
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.skipped).toBe(true);
+    });
+
+    it("should skip callback for disabled schedule", async () => {
+      const { schedule, runId, secret } = await setupCronSchedule();
+
+      // Disable the schedule via API helper
+      await disableTestSchedule(composeId, schedule.name);
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "completed",
+          payload: {
+            scheduleId: schedule.id,
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.skipped).toBe(true);
+    });
+  });
+});

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/cron/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/cron/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { initServices } from "../../../../../../src/lib/init-services";
+import { verifyCallback } from "../../../../../../src/lib/infra/callback";
+import { zeroAgentSchedules } from "../../../../../../src/db/schema/zero-agent-schedule";
+import type { ScheduleCronCallbackPayload } from "../../../../../../src/lib/infra/callback/callback-payloads";
+import { calculateNextRun } from "../../../../../../src/lib/zero/schedule/schedule-service";
+import { logger } from "../../../../../../src/lib/shared/logger";
+
+const log = logger("callback:schedule:cron");
+
+// Auto-disable after this many consecutive failures
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+function parsePayload(payload: unknown): ScheduleCronCallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  if (
+    typeof p.scheduleId !== "string" ||
+    typeof p.cronExpression !== "string" ||
+    typeof p.timezone !== "string"
+  ) {
+    return null;
+  }
+  return p as unknown as ScheduleCronCallbackPayload;
+}
+
+function errorResponse(message: string, status: number): NextResponse {
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+
+  const result = await verifyCallback<ScheduleCronCallbackPayload>(
+    request,
+    log,
+  );
+  if (!result.ok) return result.response;
+
+  const { status, payload: rawPayload } = result.data;
+
+  const payload = parsePayload(rawPayload);
+  if (!payload) {
+    return errorResponse("Invalid or missing payload", 400);
+  }
+
+  const { scheduleId, cronExpression, timezone } = payload;
+
+  log.debug("Processing cron schedule callback", {
+    runId: result.data.runId,
+    status,
+    scheduleId,
+  });
+
+  // Load schedule
+  const [schedule] = await globalThis.services.db
+    .select()
+    .from(zeroAgentSchedules)
+    .where(eq(zeroAgentSchedules.id, scheduleId))
+    .limit(1);
+
+  if (!schedule) {
+    // Schedule deleted — gracefully ignore
+    log.debug("Schedule not found, ignoring callback", { scheduleId });
+    return NextResponse.json({ success: true, skipped: true });
+  }
+
+  if (!schedule.enabled) {
+    // Schedule disabled — don't advance
+    log.debug("Schedule disabled, ignoring callback", { scheduleId });
+    return NextResponse.json({ success: true, skipped: true });
+  }
+
+  const now = new Date();
+  const newFailureCount =
+    status === "completed" ? 0 : schedule.consecutiveFailures + 1;
+  const shouldDisable = newFailureCount >= MAX_CONSECUTIVE_FAILURES;
+  const nextRunAt = shouldDisable
+    ? null
+    : calculateNextRun(cronExpression, timezone);
+
+  await globalThis.services.db
+    .update(zeroAgentSchedules)
+    .set({
+      consecutiveFailures: newFailureCount,
+      ...(shouldDisable && { enabled: false }),
+      nextRunAt,
+      updatedAt: now,
+    })
+    .where(eq(zeroAgentSchedules.id, scheduleId));
+
+  if (shouldDisable) {
+    log.warn("Cron schedule auto-disabled after consecutive failures", {
+      scheduleId,
+      scheduleName: schedule.name,
+      consecutiveFailures: newFailureCount,
+    });
+  } else {
+    log.info(`Cron schedule advanced after ${status}`, {
+      scheduleId,
+      scheduleName: schedule.name,
+      consecutiveFailures: newFailureCount,
+      nextRunAt: nextRunAt?.toISOString(),
+    });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
+++ b/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
@@ -56,6 +56,12 @@ export interface ScheduleLoopCallbackPayload {
   intervalSeconds: number;
 }
 
+export interface ScheduleCronCallbackPayload {
+  scheduleId: string;
+  cronExpression: string;
+  timezone: string;
+}
+
 export interface GitHubIssuesCallbackPayload {
   installationId: string;
   repo: string;
@@ -78,5 +84,6 @@ export type CallbackPayload =
   | EmailTriggerCallbackPayload
   | EmailReplyCallbackPayload
   | ScheduleLoopCallbackPayload
+  | ScheduleCronCallbackPayload
   | GitHubIssuesCallbackPayload
   | ChatCallbackPayload;

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -11,7 +11,10 @@ import { logger } from "../../shared/logger";
 import { createZeroRun } from "../zero-run-service";
 import { generateCallbackSecret, getApiUrl } from "../../infra/callback";
 import { generateScheduleDescription } from "../ai/lightweight-model";
-import type { ScheduleLoopCallbackPayload } from "../../infra/callback/callback-payloads";
+import type {
+  ScheduleLoopCallbackPayload,
+  ScheduleCronCallbackPayload,
+} from "../../infra/callback/callback-payloads";
 
 const log = logger("service:schedule");
 
@@ -89,7 +92,7 @@ function isValidTimezone(timezone: string): boolean {
 /**
  * Calculate next run time from cron expression and timezone
  */
-function calculateNextRun(
+export function calculateNextRun(
   cronExpression: string,
   timezone: string,
 ): Date | null {
@@ -769,22 +772,14 @@ async function advanceScheduleState(
       })
       .where(eq(zeroAgentSchedules.id, schedule.id));
   } else if (schedule.triggerType === "cron") {
-    if (!schedule.cronExpression) {
-      throw new Error(
-        `Cron schedule ${schedule.name} (${schedule.id}) missing cronExpression`,
-      );
-    }
-    const nextRunAt = calculateNextRun(
-      schedule.cronExpression,
-      schedule.timezone,
-    );
+    // Cron: don't advance nextRunAt here — the cron callback handles it on completion
     await globalThis.services.db
       .update(zeroAgentSchedules)
       .set({
         ...(lastRunId !== undefined && { lastRunId }),
         lastRunAt: now,
         retryStartedAt: null,
-        nextRunAt,
+        nextRunAt: null, // Will be set by cron callback on run completion
       })
       .where(eq(zeroAgentSchedules.id, schedule.id));
   } else {
@@ -840,7 +835,7 @@ export async function executeSchedule(
   const callbacks: Array<{
     url: string;
     secret: string;
-    payload: ScheduleLoopCallbackPayload;
+    payload: ScheduleLoopCallbackPayload | ScheduleCronCallbackPayload;
   }> = [];
 
   // Loop schedule advancement callback (triggers next iteration on completion)
@@ -853,6 +848,20 @@ export async function executeSchedule(
       url: `${getApiUrl()}/api/internal/callbacks/schedule/loop`,
       secret: generateCallbackSecret(),
       payload: loopPayload,
+    });
+  }
+
+  // Cron schedule completion callback (tracks failures and advances next run)
+  if (schedule.triggerType === "cron") {
+    const cronPayload: ScheduleCronCallbackPayload = {
+      scheduleId: schedule.id,
+      cronExpression: schedule.cronExpression!,
+      timezone: schedule.timezone,
+    };
+    callbacks.push({
+      url: `${getApiUrl()}/api/internal/callbacks/schedule/cron`,
+      secret: generateCallbackSecret(),
+      payload: cronPayload,
     });
   }
 


### PR DESCRIPTION
## Summary

- Add cron completion callback route mirroring the existing loop callback pattern
- Cron schedules now track consecutive failures and auto-disable after 3 consecutive failures
- Update `advanceScheduleState()` to defer cron `nextRunAt` to the callback (same as loop)
- Show failure count in CLI `schedule status` for cron schedules

## Changes

| File | Description |
|------|-------------|
| `callback-payloads.ts` | Add `ScheduleCronCallbackPayload` type |
| `schedule/cron/route.ts` | New cron callback handler |
| `schedule/cron/__tests__/route.test.ts` | Integration tests (7 tests) |
| `schedule-service.ts` | Register cron callback, update `advanceScheduleState()`, export `calculateNextRun()` |
| `schedule/status.ts` | Show failure count for cron schedules |

## Test plan

- [x] All 7 new cron callback tests pass (signature verification, success/failure callbacks, edge cases)
- [x] All 9 existing loop callback tests still pass (no regression)
- [x] TypeScript type check passes for web and CLI packages
- [x] Lint passes with 0 errors
- [x] Knip finds no unused exports
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

Closes #8426

🤖 Generated with [Claude Code](https://claude.com/claude-code)