### PR TITLE
feat: refetch insights data on page navigation

### DIFF
--- a/turbo/apps/platform/src/signals/network-insights/network-insights-page-setup.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-page-setup.ts
@@ -6,6 +6,7 @@ import { updateDocumentTitle$ } from "../document-title.ts";
 import { updatePage$ } from "../react-router.ts";
 import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { reloadChatThreads$ } from "../agent-chat.ts";
+import { reloadInsights$ } from "./network-insights-signals.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
 
 export const setupNetworkInsightsPage$ = command(
@@ -22,5 +23,6 @@ export const setupNetworkInsightsPage$ = command(
     }
 
     set(reloadChatThreads$);
+    set(reloadInsights$);
   },
 );

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -121,9 +121,12 @@ export const setInsightsHoveredAgent$ = command(
 // Data fetching
 // ---------------------------------------------------------------------------
 
+const internalReloadInsights$ = state(0);
+
 /** Always fetch 30 days; display filtering is handled by the UI. */
 export const networkInsightsData$ = computed(
   async (get): Promise<NetworkInsightsData> => {
+    get(internalReloadInsights$);
     const client = get(zeroClient$)(zeroInsightsContract);
     const result = await client.get({ query: { days: 30 } });
     if (result.status !== 200) {
@@ -132,3 +135,10 @@ export const networkInsightsData$ = computed(
     return result.body as NetworkInsightsData;
   },
 );
+
+/** Trigger a re-fetch of insights data. */
+export const reloadInsights$ = command(({ set }) => {
+  set(internalReloadInsights$, (x) => {
+    return x + 1;
+  });
+});

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -386,6 +386,53 @@ describe("network insights page - summary card", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Data refetch on navigation
+// ---------------------------------------------------------------------------
+
+describe("network insights page - data refetch", () => {
+  it("should fetch fresh data when navigating to insights page", async () => {
+    let callCount = 0;
+    server.use(
+      http.get("*/api/zero/insights", () => {
+        callCount++;
+        const agents =
+          callCount <= 1
+            ? [
+                {
+                  agentName: "InitialBot",
+                  agentId: "a-init",
+                  runs: 1,
+                  credits: 10,
+                },
+              ]
+            : [
+                {
+                  agentName: "RefreshedBot",
+                  agentId: "a-ref",
+                  runs: 2,
+                  credits: 20,
+                },
+              ];
+        return HttpResponse.json({
+          days: [sampleDay(day1Ago, { agents })],
+          totalCredits: 10,
+          totalRuns: 1,
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/insights" });
+
+    // The page setup calls reloadInsights$ which triggers a second fetch,
+    // so the UI should eventually show the refreshed data.
+    await waitFor(() => {
+      expect(screen.getByText("RefreshedBot")).toBeInTheDocument();
+    });
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Team usage in credits card
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `reloadInsights$` signal that invalidates cached insights data via a reload counter pattern (same as `reloadChatThreads$`)
- Call `reloadInsights$` in `setupNetworkInsightsPage$` so navigating to `/insights` always fetches fresh data
- Add integration test verifying the refetch behavior

## Test plan
- [x] New test: "should fetch fresh data when navigating to insights page" — verifies API is called multiple times and refreshed data renders
- [x] All 18 existing insights page tests pass
- [x] Type check, lint, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)