### PR TITLE
feat(platform): display captured request headers and bodies in network logs

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -1,0 +1,173 @@
+import { IconChevronRight } from "@tabler/icons-react";
+import { CopyButton } from "@vm0/ui";
+import type { NetworkLogEntry } from "@vm0/core";
+import { InlineBadge } from "./network-badge.tsx";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+function formatBodyForDisplay(
+  body: string,
+  encoding: NetworkLogEntry["request_body_encoding"],
+): { text: string; isBinary: boolean } {
+  if (encoding === "base64") {
+    const sizeEstimate = Math.round((body.length * 3) / 4);
+    return {
+      text: `[Binary data, ${formatSize(sizeEstimate)} base64-encoded]`,
+      isBinary: true,
+    };
+  }
+  return { text: body, isBinary: false };
+}
+
+// ---------------------------------------------------------------------------
+// Components
+// ---------------------------------------------------------------------------
+
+function CollapsibleSection({
+  title,
+  badge,
+  truncated,
+  copyText,
+  children,
+}: {
+  title: string;
+  badge?: string;
+  truncated?: boolean;
+  copyText?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <details className="group">
+      <summary className="cursor-pointer list-none w-full text-left">
+        <div className="flex items-center gap-2">
+          <IconChevronRight
+            size={14}
+            stroke={2}
+            className="transition-transform group-open:rotate-90 text-muted-foreground shrink-0"
+          />
+          <span className="text-xs font-medium text-foreground">{title}</span>
+          {badge && <InlineBadge color="muted">{badge}</InlineBadge>}
+          {truncated && <InlineBadge color="warning">truncated</InlineBadge>}
+          {copyText && (
+            <span
+              className="ml-auto"
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              <CopyButton text={copyText} className="p-1" />
+            </span>
+          )}
+        </div>
+      </summary>
+      <div className="mt-2 ml-5">{children}</div>
+    </details>
+  );
+}
+
+function RequestHeaders({ headers }: { headers: Record<string, string> }) {
+  const entries = Object.entries(headers);
+  const copyText = entries
+    .map(([k, v]) => {
+      return `${k}: ${v}`;
+    })
+    .join("\n");
+
+  return (
+    <CollapsibleSection
+      title={`Request Headers (${entries.length})`}
+      copyText={copyText}
+    >
+      <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+        {entries.map(([name, value]) => {
+          return (
+            <div key={name} className="contents">
+              <span className="text-muted-foreground font-medium font-mono">
+                {name}
+              </span>
+              <span className="font-mono break-all">{value}</span>
+            </div>
+          );
+        })}
+      </div>
+    </CollapsibleSection>
+  );
+}
+
+function BodyBlock({
+  title,
+  body,
+  encoding,
+  truncated,
+}: {
+  title: string;
+  body: string;
+  encoding: NetworkLogEntry["request_body_encoding"];
+  truncated: boolean | undefined;
+}) {
+  const { text, isBinary } = formatBodyForDisplay(body, encoding);
+
+  return (
+    <CollapsibleSection
+      title={title}
+      badge={encoding}
+      truncated={truncated === true}
+      copyText={isBinary ? undefined : body}
+    >
+      <pre
+        className={`rounded-md border bg-muted/50 p-3 text-xs overflow-auto max-h-60 whitespace-pre-wrap break-words font-mono ${
+          isBinary ? "text-muted-foreground italic" : ""
+        }`}
+      >
+        {text}
+      </pre>
+    </CollapsibleSection>
+  );
+}
+
+export function CapturedBodySections({ entry }: { entry: NetworkLogEntry }) {
+  const requestHeaders =
+    entry.request_headers && Object.keys(entry.request_headers).length > 0
+      ? entry.request_headers
+      : null;
+  const requestBody = entry.request_body ?? null;
+  const responseBody = entry.response_body ?? null;
+
+  if (!requestHeaders && !requestBody && !responseBody) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      {requestHeaders && <RequestHeaders headers={requestHeaders} />}
+      {requestBody && (
+        <BodyBlock
+          title="Request Body"
+          body={requestBody}
+          encoding={entry.request_body_encoding}
+          truncated={entry.request_body_truncated}
+        />
+      )}
+      {responseBody && (
+        <BodyBlock
+          title="Response Body"
+          body={responseBody}
+          encoding={entry.response_body_encoding}
+          truncated={entry.response_body_truncated}
+        />
+      )}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -1,21 +1,11 @@
 import { IconChevronRight } from "@tabler/icons-react";
 import { CopyButton } from "@vm0/ui";
 import type { NetworkLogEntry } from "@vm0/core";
-import { InlineBadge } from "./network-badge.tsx";
+import { formatSize, InlineBadge } from "./network-badge.tsx";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) {
-    return `${bytes}B`;
-  }
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)}KB`;
-  }
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
-}
 
 function formatBodyForDisplay(
   body: string,

--- a/turbo/apps/platform/src/views/zero-page/components/network-badge.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-badge.tsx
@@ -1,3 +1,24 @@
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+export function formatSize(bytes: number | undefined | null): string {
+  if (bytes === null || bytes === undefined) {
+    return "—";
+  }
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+// ---------------------------------------------------------------------------
+// Badge component
+// ---------------------------------------------------------------------------
+
 const COLOR_MAP = {
   muted: "bg-muted text-muted-foreground",
   warning:

--- a/turbo/apps/platform/src/views/zero-page/components/network-badge.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-badge.tsx
@@ -1,0 +1,29 @@
+const COLOR_MAP = {
+  muted: "bg-muted text-muted-foreground",
+  warning:
+    "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  blue: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  violet:
+    "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400",
+  amber: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
+  teal: "bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400",
+  red: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+} as const;
+
+export type BadgeColor = keyof typeof COLOR_MAP;
+
+export function InlineBadge({
+  color,
+  children,
+}: {
+  color: BadgeColor;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold leading-none ${COLOR_MAP[color]}`}
+    >
+      {children}
+    </span>
+  );
+}

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -9,7 +9,7 @@ import {
   TableRow,
 } from "@vm0/ui";
 import type { NetworkLogEntry } from "@vm0/core";
-import { type BadgeColor, InlineBadge } from "./network-badge.tsx";
+import { type BadgeColor, formatSize, InlineBadge } from "./network-badge.tsx";
 import { CapturedBodySections } from "./captured-body-sections.tsx";
 import {
   networkLogExpandedRows$,
@@ -27,19 +27,6 @@ function formatTime(timestamp: string): string {
   const s = String(d.getSeconds()).padStart(2, "0");
   const ms = String(d.getMilliseconds()).padStart(3, "0");
   return `${h}:${m}:${s}.${ms}`;
-}
-
-function formatSize(bytes: number | undefined | null): string {
-  if (bytes === null || bytes === undefined) {
-    return "—";
-  }
-  if (bytes < 1024) {
-    return `${bytes}B`;
-  }
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)}KB`;
-  }
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
 function formatLatency(ms: number | undefined | null): string {

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -180,6 +180,8 @@ function addField(
 }
 
 // [NETWORK_LOG_FIELDS] — keep in sync with all network log schemas
+// Note: request_headers, request/response body fields are rendered
+// separately by CapturedBodySections below.
 function collectDetails(entry: NetworkLogEntry): [string, string][] {
   const out: [string, string][] = [];
   addField(out, "Timestamp", entry.timestamp, entry.timestamp);

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -1,6 +1,7 @@
-import { IconLoader2 } from "@tabler/icons-react";
+import { IconChevronRight, IconLoader2 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import {
+  CopyButton,
   Table,
   TableBody,
   TableCell,
@@ -278,6 +279,179 @@ function collectDetails(entry: NetworkLogEntry): [string, string][] {
   return out;
 }
 
+// ---------------------------------------------------------------------------
+// Captured headers / body components
+// ---------------------------------------------------------------------------
+
+function EncodingBadge({ encoding }: { encoding: string }) {
+  return (
+    <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold leading-none bg-muted text-muted-foreground">
+      {encoding}
+    </span>
+  );
+}
+
+function TruncatedBadge() {
+  return (
+    <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold leading-none bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400">
+      truncated
+    </span>
+  );
+}
+
+function formatBodyForDisplay(
+  body: string,
+  encoding: NetworkLogEntry["request_body_encoding"],
+): { text: string; isBinary: boolean } {
+  if (encoding === "base64") {
+    const sizeEstimate = Math.round((body.length * 3) / 4);
+    return {
+      text: `[Binary data, ${formatSize(sizeEstimate)} base64-encoded]`,
+      isBinary: true,
+    };
+  }
+  return { text: body, isBinary: false };
+}
+
+function CollapsibleSection({
+  title,
+  badge,
+  truncated,
+  copyText,
+  children,
+}: {
+  title: string;
+  badge?: string;
+  truncated?: boolean;
+  copyText?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <details className="group">
+      <summary className="cursor-pointer list-none w-full text-left">
+        <div className="flex items-center gap-2">
+          <IconChevronRight
+            size={14}
+            stroke={2}
+            className="transition-transform group-open:rotate-90 text-muted-foreground shrink-0"
+          />
+          <span className="text-xs font-medium text-foreground">{title}</span>
+          {badge && <EncodingBadge encoding={badge} />}
+          {truncated && <TruncatedBadge />}
+          {copyText && (
+            <span
+              className="ml-auto"
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              <CopyButton text={copyText} className="p-1" />
+            </span>
+          )}
+        </div>
+      </summary>
+      <div className="mt-2 ml-5">{children}</div>
+    </details>
+  );
+}
+
+function RequestHeaders({ headers }: { headers: Record<string, string> }) {
+  const entries = Object.entries(headers);
+  const copyText = entries
+    .map(([k, v]) => {
+      return `${k}: ${v}`;
+    })
+    .join("\n");
+
+  return (
+    <CollapsibleSection
+      title={`Request Headers (${entries.length})`}
+      copyText={copyText}
+    >
+      <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+        {entries.map(([name, value]) => {
+          return (
+            <div key={name} className="contents">
+              <span className="text-muted-foreground font-medium font-mono">
+                {name}
+              </span>
+              <span className="font-mono break-all">{value}</span>
+            </div>
+          );
+        })}
+      </div>
+    </CollapsibleSection>
+  );
+}
+
+function BodyBlock({
+  title,
+  body,
+  encoding,
+  truncated,
+}: {
+  title: string;
+  body: string;
+  encoding: NetworkLogEntry["request_body_encoding"];
+  truncated: boolean | undefined;
+}) {
+  const { text, isBinary } = formatBodyForDisplay(body, encoding);
+
+  return (
+    <CollapsibleSection
+      title={title}
+      badge={encoding}
+      truncated={truncated === true}
+      copyText={isBinary ? undefined : body}
+    >
+      <pre
+        className={`rounded-md border bg-muted/50 p-3 text-xs overflow-auto max-h-60 whitespace-pre-wrap break-words font-mono ${
+          isBinary ? "text-muted-foreground italic" : ""
+        }`}
+      >
+        {text}
+      </pre>
+    </CollapsibleSection>
+  );
+}
+
+function CapturedBodySections({ entry }: { entry: NetworkLogEntry }) {
+  const hasHeaders =
+    entry.request_headers && Object.keys(entry.request_headers).length > 0;
+  const hasRequestBody = entry.request_body;
+  const hasResponseBody = entry.response_body;
+
+  if (!hasHeaders && !hasRequestBody && !hasResponseBody) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      {hasHeaders && <RequestHeaders headers={entry.request_headers!} />}
+      {hasRequestBody && (
+        <BodyBlock
+          title="Request Body"
+          body={entry.request_body!}
+          encoding={entry.request_body_encoding}
+          truncated={entry.request_body_truncated}
+        />
+      )}
+      {hasResponseBody && (
+        <BodyBlock
+          title="Response Body"
+          body={entry.response_body!}
+          encoding={entry.response_body_encoding}
+          truncated={entry.response_body_truncated}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Detail row
+// ---------------------------------------------------------------------------
+
 function NetworkLogRowDetail({ entry }: { entry: NetworkLogEntry }) {
   const details = collectDetails(entry);
 
@@ -300,6 +474,7 @@ function NetworkLogRowDetail({ entry }: { entry: NetworkLogEntry }) {
             );
           })}
         </div>
+        <CapturedBodySections entry={entry} />
       </td>
     </TableRow>
   );

--- a/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/network-content.tsx
@@ -1,7 +1,6 @@
-import { IconChevronRight, IconLoader2 } from "@tabler/icons-react";
+import { IconLoader2 } from "@tabler/icons-react";
 import { useGet, useSet } from "ccstate-react";
 import {
-  CopyButton,
   Table,
   TableBody,
   TableCell,
@@ -10,6 +9,8 @@ import {
   TableRow,
 } from "@vm0/ui";
 import type { NetworkLogEntry } from "@vm0/core";
+import { type BadgeColor, InlineBadge } from "./network-badge.tsx";
+import { CapturedBodySections } from "./captured-body-sections.tsx";
 import {
   networkLogExpandedRows$,
   toggleNetworkLogRowExpanded$,
@@ -64,23 +65,23 @@ function entryType(entry: NetworkLogEntry): string {
   return "HTTP";
 }
 
-function typeColor(type: string): string {
+function typeBadgeColor(type: string): BadgeColor {
   if (type === "HTTP") {
-    return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400";
+    return "blue";
   }
   if (type === "TCP") {
-    return "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400";
+    return "violet";
   }
   if (type === "UDP" || type === "ICMP") {
-    return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400";
+    return "amber";
   }
   if (type === "DNS") {
-    return "bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400";
+    return "teal";
   }
   if (type === "DENY") {
-    return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400";
+    return "red";
   }
-  return "bg-muted text-muted-foreground";
+  return "muted";
 }
 
 function statusColor(status: number | undefined): string {
@@ -114,14 +115,7 @@ function latencyColor(ms: number | undefined | null): string {
 // ---------------------------------------------------------------------------
 
 function TypeBadge({ type }: { type: string }) {
-  const color = typeColor(type);
-  return (
-    <span
-      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold leading-none ${color}`}
-    >
-      {type}
-    </span>
-  );
+  return <InlineBadge color={typeBadgeColor(type)}>{type}</InlineBadge>;
 }
 
 function formatValue(value: unknown): string {
@@ -279,175 +273,6 @@ function collectDetails(entry: NetworkLogEntry): [string, string][] {
   );
   addField(out, "Error", entry.error, formatValue(entry.error));
   return out;
-}
-
-// ---------------------------------------------------------------------------
-// Captured headers / body components
-// ---------------------------------------------------------------------------
-
-function EncodingBadge({ encoding }: { encoding: string }) {
-  return (
-    <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold leading-none bg-muted text-muted-foreground">
-      {encoding}
-    </span>
-  );
-}
-
-function TruncatedBadge() {
-  return (
-    <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-semibold leading-none bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400">
-      truncated
-    </span>
-  );
-}
-
-function formatBodyForDisplay(
-  body: string,
-  encoding: NetworkLogEntry["request_body_encoding"],
-): { text: string; isBinary: boolean } {
-  if (encoding === "base64") {
-    const sizeEstimate = Math.round((body.length * 3) / 4);
-    return {
-      text: `[Binary data, ${formatSize(sizeEstimate)} base64-encoded]`,
-      isBinary: true,
-    };
-  }
-  return { text: body, isBinary: false };
-}
-
-function CollapsibleSection({
-  title,
-  badge,
-  truncated,
-  copyText,
-  children,
-}: {
-  title: string;
-  badge?: string;
-  truncated?: boolean;
-  copyText?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <details className="group">
-      <summary className="cursor-pointer list-none w-full text-left">
-        <div className="flex items-center gap-2">
-          <IconChevronRight
-            size={14}
-            stroke={2}
-            className="transition-transform group-open:rotate-90 text-muted-foreground shrink-0"
-          />
-          <span className="text-xs font-medium text-foreground">{title}</span>
-          {badge && <EncodingBadge encoding={badge} />}
-          {truncated && <TruncatedBadge />}
-          {copyText && (
-            <span
-              className="ml-auto"
-              onClick={(e) => {
-                e.stopPropagation();
-              }}
-            >
-              <CopyButton text={copyText} className="p-1" />
-            </span>
-          )}
-        </div>
-      </summary>
-      <div className="mt-2 ml-5">{children}</div>
-    </details>
-  );
-}
-
-function RequestHeaders({ headers }: { headers: Record<string, string> }) {
-  const entries = Object.entries(headers);
-  const copyText = entries
-    .map(([k, v]) => {
-      return `${k}: ${v}`;
-    })
-    .join("\n");
-
-  return (
-    <CollapsibleSection
-      title={`Request Headers (${entries.length})`}
-      copyText={copyText}
-    >
-      <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
-        {entries.map(([name, value]) => {
-          return (
-            <div key={name} className="contents">
-              <span className="text-muted-foreground font-medium font-mono">
-                {name}
-              </span>
-              <span className="font-mono break-all">{value}</span>
-            </div>
-          );
-        })}
-      </div>
-    </CollapsibleSection>
-  );
-}
-
-function BodyBlock({
-  title,
-  body,
-  encoding,
-  truncated,
-}: {
-  title: string;
-  body: string;
-  encoding: NetworkLogEntry["request_body_encoding"];
-  truncated: boolean | undefined;
-}) {
-  const { text, isBinary } = formatBodyForDisplay(body, encoding);
-
-  return (
-    <CollapsibleSection
-      title={title}
-      badge={encoding}
-      truncated={truncated === true}
-      copyText={isBinary ? undefined : body}
-    >
-      <pre
-        className={`rounded-md border bg-muted/50 p-3 text-xs overflow-auto max-h-60 whitespace-pre-wrap break-words font-mono ${
-          isBinary ? "text-muted-foreground italic" : ""
-        }`}
-      >
-        {text}
-      </pre>
-    </CollapsibleSection>
-  );
-}
-
-function CapturedBodySections({ entry }: { entry: NetworkLogEntry }) {
-  const hasHeaders =
-    entry.request_headers && Object.keys(entry.request_headers).length > 0;
-  const hasRequestBody = entry.request_body;
-  const hasResponseBody = entry.response_body;
-
-  if (!hasHeaders && !hasRequestBody && !hasResponseBody) {
-    return null;
-  }
-
-  return (
-    <div className="mt-3 space-y-2">
-      {hasHeaders && <RequestHeaders headers={entry.request_headers!} />}
-      {hasRequestBody && (
-        <BodyBlock
-          title="Request Body"
-          body={entry.request_body!}
-          encoding={entry.request_body_encoding}
-          truncated={entry.request_body_truncated}
-        />
-      )}
-      {hasResponseBody && (
-        <BodyBlock
-          title="Response Body"
-          body={entry.response_body!}
-          encoding={entry.response_body_encoding}
-          truncated={entry.response_body_truncated}
-        />
-      )}
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add collapsible sections to network log detail rows for request headers, request body, and response body
- Headers shown in key-value grid with count in title; bodies in scrollable code blocks (max-h-60)
- Encoding badge (utf-8/base64) and truncated warning badge when applicable
- Base64 bodies show binary data indicator instead of decoding; UTF-8 bodies have copy button
- Entries without capture data render exactly as before (no visual change)

Closes #8358

## Test plan
- [ ] Expand a network log entry with captured headers — verify collapsible header section shows key-value pairs
- [ ] Expand an entry with UTF-8 request/response body — verify code block renders with copy button
- [ ] Expand an entry with base64 body — verify binary indicator shown, no copy button
- [ ] Expand an entry with truncated body — verify yellow "truncated" badge appears
- [ ] Expand an entry without capture data — verify no new sections appear
- [ ] CI passes (build, lint, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)