### PR TITLE
docs(test): clarify os boundary mocks in desktop-server test

### DIFF
--- a/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
+++ b/turbo/apps/cli/src/lib/computer-use/__tests__/desktop-server.test.ts
@@ -2,14 +2,21 @@
  * Tests for the desktop HTTP server.
  *
  * Entry point: startDesktopServer()
- * Mock (external): screencapture module (macOS system commands)
- * Real (internal): HTTP server, token validation, routing
+ * Real: HTTP server, token validation, routing, JSON serialization
+ * Mocked: OS boundary adapters (see below)
+ *
+ * The 5 mocked modules (screencapture, cliclick, scroll, clipboard, application)
+ * are thin wrappers around macOS system commands (screencapture, cliclick, pbpaste,
+ * osascript, open) that are unavailable in the Linux test environment and contain
+ * no business logic. These relative vi.mock() paths are intentional — they mock at
+ * the OS boundary, not internal application code.
  */
 
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { http, passthrough } from "msw";
 import { server as mswServer } from "../../../mocks/server";
 
+// OS boundary adapters — macOS system command wrappers
 vi.mock("../screencapture", () => {
   return {
     captureScreenshot: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary

- Document why the 5 relative `vi.mock()` paths in `desktop-server.test.ts` are intentional — they mock macOS system command wrappers (OS boundary adapters), not internal application logic
- After deep research, concluded these mocks don't violate the spirit of AP-4: the mocked modules are thin wrappers around unavailable macOS commands with zero business logic

## Test plan

- [ ] Verify CI passes (comment-only change, no logic affected)

Closes #8303

🤖 Generated with [Claude Code](https://claude.com/claude-code)