### PR TITLE
feat(e2e): add playwright infrastructure and auth/onboarding setup

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -4,3 +4,6 @@ node_modules/
 .env.local
 debug-*.png
 lighthouse/lighthouse-reports/
+playwright/.clerk/
+playwright-report/
+test-results/

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,11 +9,94 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@clerk/testing": "^2.0.11",
+        "@playwright/test": "^1.59.1",
         "@types/node": "^25.5.2",
         "dotenv": "^17.4.0"
       },
       "devDependencies": {
         "tsx": "^4.21.0"
+      }
+    },
+    "node_modules/@clerk/backend": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.7.tgz",
+      "integrity": "sha512-8IdAKqFpmWhaK0HkyheXv4kP5E3eE1KCCbTokNvVKA3xWh8Jk1CjrYCk+Uq1R/PA3b2h418qbsA21ZCFoSUY7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.5.0",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.5.0.tgz",
+      "integrity": "sha512-01xc2Mb6/srZa9kvk9apEFr98Zsoe3XZusTUrSzAQDaX0ltQn5W0r7V1cJiDGHKTYG5vv4ACeNfZ7sZgspKTbA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.16",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.0.11.tgz",
+      "integrity": "sha512-MIy6W6qlioroX6Xv2nXhesIKQBwzjIw9bn0e7NnxqTlbxvtqIQdWVnqNBLC/GC0C4OWKDQ1vzfAURa7u+oucOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.2.7",
+        "@clerk/shared": "^4.5.0",
+        "dotenv": "17.2.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1",
+        "cypress": "^13 || ^14"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "cypress": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing/node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -458,6 +541,37 @@
         "node": ">=18"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
+      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
@@ -465,6 +579,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/dotenv": {
@@ -521,6 +644,26 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
@@ -534,6 +677,51 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -543,6 +731,28 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -13,6 +13,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@clerk/testing": "^2.0.11",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^25.5.2",
     "dotenv": "^17.4.0"
   },

--- a/e2e/playwright/auth.setup.ts
+++ b/e2e/playwright/auth.setup.ts
@@ -1,4 +1,4 @@
-import { clerk, clerkSetup } from "@clerk/testing/playwright";
+import { clerk } from "@clerk/testing/playwright";
 import { expect, test as setup } from "@playwright/test";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
@@ -8,15 +8,15 @@ const CREDENTIALS_PATH = path.join(__dirname, ".clerk", "credentials.json");
 const STORAGE_STATE = path.join(__dirname, ".clerk", "user.json");
 
 setup("authenticate and complete onboarding", async ({ page }) => {
-  await clerkSetup();
-
   const raw = await readFile(CREDENTIALS_PATH, "utf-8");
   const { email, password } = JSON.parse(raw) as {
     email: string;
     password: string;
   };
 
-  const appUrl = deriveAppUrl(process.env.VM0_API_URL ?? "");
+  const apiUrl = process.env.VM0_API_URL;
+  if (!apiUrl) throw new Error("VM0_API_URL environment variable is required");
+  const appUrl = deriveAppUrl(apiUrl);
 
   await page.goto(appUrl);
 

--- a/e2e/playwright/auth.setup.ts
+++ b/e2e/playwright/auth.setup.ts
@@ -2,10 +2,9 @@ import { clerk } from "@clerk/testing/playwright";
 import { expect, test as setup } from "@playwright/test";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { STORAGE_STATE } from "./playwright.config";
 
 const CREDENTIALS_PATH = path.join(__dirname, ".clerk", "credentials.json");
-
-const STORAGE_STATE = path.join(__dirname, ".clerk", "user.json");
 
 setup("authenticate and complete onboarding", async ({ page }) => {
   const raw = await readFile(CREDENTIALS_PATH, "utf-8");
@@ -55,26 +54,26 @@ async function completeOnboarding(
 
   // Step 1: Name your workspace
   const workspaceInput = page.getByPlaceholder("e.g. Acme Corp");
-  if (await workspaceInput.isVisible({ timeout: 5_000 }).catch(() => false)) {
+  if (await workspaceInput.isVisible({ timeout: 5_000 })) {
     await workspaceInput.fill("E2E Test Workspace");
     await page.getByRole("button", { name: "Next" }).click();
   }
 
   // Step 2: Choose your tools — skip
   const chooseTools = page.getByTestId("onboarding-step-select-connectors");
-  if (await chooseTools.isVisible({ timeout: 5_000 }).catch(() => false)) {
+  if (await chooseTools.isVisible({ timeout: 5_000 })) {
     await page.getByRole("button", { name: "Next" }).click();
   }
 
   // Step 3: Connect your apps — skip
   const connectApps = page.getByText("Connect your apps");
-  if (await connectApps.isVisible({ timeout: 5_000 }).catch(() => false)) {
+  if (await connectApps.isVisible({ timeout: 5_000 })) {
     await page.getByRole("button", { name: "Next" }).click();
   }
 
   // Step 4: Where to work — continue in web
   const continueWeb = page.getByRole("button", { name: "Continue in web" });
-  if (await continueWeb.isVisible({ timeout: 5_000 }).catch(() => false)) {
+  if (await continueWeb.isVisible({ timeout: 5_000 })) {
     await continueWeb.click();
   }
 }

--- a/e2e/playwright/auth.setup.ts
+++ b/e2e/playwright/auth.setup.ts
@@ -1,0 +1,80 @@
+import { clerk, clerkSetup } from "@clerk/testing/playwright";
+import { expect, test as setup } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const CREDENTIALS_PATH = path.join(__dirname, ".clerk", "credentials.json");
+
+const STORAGE_STATE = path.join(__dirname, ".clerk", "user.json");
+
+setup("authenticate and complete onboarding", async ({ page }) => {
+  await clerkSetup();
+
+  const raw = await readFile(CREDENTIALS_PATH, "utf-8");
+  const { email, password } = JSON.parse(raw) as {
+    email: string;
+    password: string;
+  };
+
+  const appUrl = deriveAppUrl(process.env.VM0_API_URL ?? "");
+
+  await page.goto(appUrl);
+
+  await clerk.signIn({
+    page,
+    signInParams: {
+      strategy: "password",
+      identifier: email,
+      password,
+    },
+  });
+
+  // Complete onboarding if present
+  await completeOnboarding(page);
+
+  // Wait for chat page
+  await page.waitForURL("**/agents/*/chat", { timeout: 90_000 });
+  await expect(page.getByText("Ask me to automate workflows")).toBeVisible({
+    timeout: 90_000,
+  });
+
+  await page.context().storageState({ path: STORAGE_STATE });
+});
+
+function deriveAppUrl(webUrl: string): string {
+  return webUrl.replace(/^(https?:\/\/)www\./, "$1app.");
+}
+
+async function completeOnboarding(
+  page: import("@playwright/test").Page
+): Promise<void> {
+  // Check if already on chat page (already onboarded)
+  if (page.url().includes("/agents/") && page.url().includes("/chat")) {
+    return;
+  }
+
+  // Step 1: Name your workspace
+  const workspaceInput = page.getByPlaceholder("e.g. Acme Corp");
+  if (await workspaceInput.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await workspaceInput.fill("E2E Test Workspace");
+    await page.getByRole("button", { name: "Next" }).click();
+  }
+
+  // Step 2: Choose your tools — skip
+  const chooseTools = page.getByTestId("onboarding-step-select-connectors");
+  if (await chooseTools.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await page.getByRole("button", { name: "Next" }).click();
+  }
+
+  // Step 3: Connect your apps — skip
+  const connectApps = page.getByText("Connect your apps");
+  if (await connectApps.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await page.getByRole("button", { name: "Next" }).click();
+  }
+
+  // Step 4: Where to work — continue in web
+  const continueWeb = page.getByRole("button", { name: "Continue in web" });
+  if (await continueWeb.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await continueWeb.click();
+  }
+}

--- a/e2e/playwright/global-setup.ts
+++ b/e2e/playwright/global-setup.ts
@@ -1,0 +1,31 @@
+import { clerkSetup } from "@clerk/testing/playwright";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  createUser,
+  deleteUserByEmail,
+  generatePassword,
+  generateTestEmail,
+} from "./lib/clerk-api";
+
+const CREDENTIALS_PATH = path.join(
+  __dirname,
+  ".clerk",
+  "credentials.json"
+);
+
+export default async function globalSetup(): Promise<void> {
+  await clerkSetup();
+
+  const email = generateTestEmail();
+  const password = generatePassword();
+
+  await deleteUserByEmail(email);
+  await createUser(email, password);
+
+  await mkdir(path.dirname(CREDENTIALS_PATH), { recursive: true });
+  await writeFile(
+    CREDENTIALS_PATH,
+    JSON.stringify({ email, password }, null, 2)
+  );
+}

--- a/e2e/playwright/global-teardown.ts
+++ b/e2e/playwright/global-teardown.ts
@@ -1,0 +1,15 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { deleteUserByEmail } from "./lib/clerk-api";
+
+const CREDENTIALS_PATH = path.join(
+  __dirname,
+  ".clerk",
+  "credentials.json"
+);
+
+export default async function globalTeardown(): Promise<void> {
+  const raw = await readFile(CREDENTIALS_PATH, "utf-8");
+  const { email } = JSON.parse(raw) as { email: string; password: string };
+  await deleteUserByEmail(email);
+}

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -1,3 +1,5 @@
+import { randomBytes, randomInt } from "node:crypto";
+
 const CLERK_API_BASE = "https://api.clerk.com/v1";
 
 function getClerkHeaders(): Record<string, string> {
@@ -13,19 +15,15 @@ function getClerkHeaders(): Record<string, string> {
 
 export function generateTestEmail(): string {
   const jobRef = process.env.JOB_REF ?? "local";
-  const randHex = Array.from(
-    { length: 8 },
-    () => Math.floor(Math.random() * 16).toString(16)
-  ).join("");
+  const randHex = randomBytes(4).toString("hex");
   return `${jobRef}+clerk_test@${randHex}.ai`;
 }
 
 export function generatePassword(): string {
   const chars =
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  const rand = Array.from(
-    { length: 16 },
-    () => chars[Math.floor(Math.random() * chars.length)]
+  const rand = Array.from({ length: 16 }, () =>
+    chars[randomInt(chars.length)]
   ).join("");
   return `${rand}!Aa1`;
 }

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -1,0 +1,72 @@
+const CLERK_API_BASE = "https://api.clerk.com/v1";
+
+function getClerkHeaders(): Record<string, string> {
+  const secretKey = process.env.CLERK_SECRET_KEY;
+  if (!secretKey) {
+    throw new Error("CLERK_SECRET_KEY environment variable is required");
+  }
+  return {
+    Authorization: `Bearer ${secretKey}`,
+    "Content-Type": "application/json",
+  };
+}
+
+export function generateTestEmail(): string {
+  const jobRef = process.env.JOB_REF ?? "local";
+  const randHex = Array.from(
+    { length: 8 },
+    () => Math.floor(Math.random() * 16).toString(16)
+  ).join("");
+  return `${jobRef}+clerk_test@${randHex}.ai`;
+}
+
+export function generatePassword(): string {
+  const chars =
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const rand = Array.from(
+    { length: 16 },
+    () => chars[Math.floor(Math.random() * chars.length)]
+  ).join("");
+  return `${rand}!Aa1`;
+}
+
+export async function createUser(
+  email: string,
+  password: string
+): Promise<string> {
+  const response = await fetch(`${CLERK_API_BASE}/users`, {
+    method: "POST",
+    headers: getClerkHeaders(),
+    body: JSON.stringify({
+      email_address: [email],
+      password,
+    }),
+  });
+  const data = (await response.json()) as { id?: string; errors?: unknown[] };
+  if (!response.ok || !data.id) {
+    throw new Error(`Failed to create Clerk user: ${JSON.stringify(data)}`);
+  }
+  return data.id;
+}
+
+export async function deleteUserByEmail(email: string): Promise<void> {
+  const searchResponse = await fetch(
+    `${CLERK_API_BASE}/users?query=${encodeURIComponent(email)}&limit=10`,
+    { headers: getClerkHeaders() }
+  );
+  const users = (await searchResponse.json()) as Array<{
+    id: string;
+    email_addresses: Array<{ email_address: string }>;
+  }>;
+
+  for (const user of users) {
+    const userEmail = user.email_addresses[0]?.email_address;
+    if (userEmail === email) {
+      await fetch(`${CLERK_API_BASE}/users/${user.id}`, {
+        method: "DELETE",
+        headers: getClerkHeaders(),
+      });
+      return;
+    }
+  }
+}

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -62,10 +62,15 @@ export async function deleteUserByEmail(email: string): Promise<void> {
   for (const user of users) {
     const userEmail = user.email_addresses[0]?.email_address;
     if (userEmail === email) {
-      await fetch(`${CLERK_API_BASE}/users/${user.id}`, {
+      const deleteResponse = await fetch(`${CLERK_API_BASE}/users/${user.id}`, {
         method: "DELETE",
         headers: getClerkHeaders(),
       });
+      if (!deleteResponse.ok) {
+        throw new Error(
+          `Failed to delete Clerk user ${user.id}: ${deleteResponse.status}`
+        );
+      }
       return;
     }
   }

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+
+const STORAGE_STATE = path.join(__dirname, ".clerk", "user.json");
+
+export default defineConfig({
+  testDir: ".",
+  globalSetup: "./global-setup",
+  globalTeardown: "./global-teardown",
+  use: {
+    baseURL: process.env.VM0_API_URL,
+    ignoreHTTPSErrors: true,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "setup",
+      testMatch: /auth\.setup\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+    {
+      name: "features",
+      testMatch: /.*\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: STORAGE_STATE,
+      },
+      dependencies: ["setup"],
+    },
+  ],
+});

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
 import path from "node:path";
 
-const STORAGE_STATE = path.join(__dirname, ".clerk", "user.json");
+if (!process.env.VM0_API_URL) {
+  throw new Error("VM0_API_URL environment variable is required");
+}
+
+export const STORAGE_STATE = path.join(__dirname, ".clerk", "user.json");
 
 export default defineConfig({
   testDir: ".",


### PR DESCRIPTION
## Summary

- Add `@playwright/test@^1.59.1` and `@clerk/testing@^2.0.11` to `e2e/package.json`
- Create `e2e/playwright/` directory with Playwright config (setup + features projects), Clerk API helpers, global setup/teardown, and auth setup test
- Update `e2e/.gitignore` with playwright-specific entries

## Details

This is PR 1 of 4 in the migration from `agent-browser` to Playwright for browser E2E tests (see issue #8434, parent issue #8320).

### New files
| File | Purpose |
|------|---------|
| `e2e/playwright/playwright.config.ts` | Playwright config with 2 projects: `setup` (serial) + `features` (parallel, uses storageState) |
| `e2e/playwright/lib/clerk-api.ts` | Clerk Backend API helpers: `createUser`, `deleteUserByEmail`, `generateTestEmail`, `generatePassword` |
| `e2e/playwright/global-setup.ts` | `clerkSetup()` + create test user via Clerk API + write credentials to `.clerk/credentials.json` |
| `e2e/playwright/global-teardown.ts` | Delete test user via Clerk API |
| `e2e/playwright/auth.setup.ts` | `clerk.signIn()` → complete 4-step onboarding → save storageState to `.clerk/user.json` |

### Modified files
| File | Change |
|------|--------|
| `e2e/package.json` | Add `@playwright/test`, `@clerk/testing` |
| `e2e/.gitignore` | Add `playwright/.clerk/`, `playwright-report/`, `test-results/` |

## Test plan
- [ ] `cd e2e && npm install` succeeds
- [ ] `npx playwright test --config playwright/playwright.config.ts --list` shows `auth.setup.ts` setup test
- [ ] With `VM0_API_URL`, `CLERK_SECRET_KEY`, `CLERK_PUBLISHABLE_KEY` set: `npx playwright test --config playwright/playwright.config.ts --project=setup` creates user, signs in, completes onboarding, saves storageState, then deletes user in teardown

Closes #8434

🤖 Generated with [Claude Code](https://claude.com/claude-code)