### PR TITLE
feat: display last updated timestamp and refetch insights on navigation

### DIFF
--- a/turbo/apps/platform/src/signals/network-insights/network-insights-page-setup.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-page-setup.ts
@@ -1,6 +1,5 @@
 import { command } from "ccstate";
 import { createElement } from "react";
-import { delay } from "signal-timers";
 import { SidebarLayout } from "../../views/zero-page/sidebar-layout.tsx";
 import { NetworkInsightsPage } from "../../views/network-insights/network-insights-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -9,7 +8,6 @@ import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { reloadChatThreads$ } from "../agent-chat.ts";
 import { reloadInsights$ } from "./network-insights-signals.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
-import { tickInsightsRelativeTime$ } from "./network-insights-signals.ts";
 
 export const setupNetworkInsightsPage$ = command(
   async ({ set }, signal: AbortSignal) => {
@@ -26,11 +24,5 @@ export const setupNetworkInsightsPage$ = command(
 
     set(reloadChatThreads$);
     set(reloadInsights$);
-
-    // Tick relative timestamps every 60 s until page is unmounted.
-    while (!signal.aborted) {
-      await delay(60_000, { signal });
-      set(tickInsightsRelativeTime$);
-    }
   },
 );

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-page-setup.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-page-setup.ts
@@ -1,5 +1,6 @@
 import { command } from "ccstate";
 import { createElement } from "react";
+import { delay } from "signal-timers";
 import { SidebarLayout } from "../../views/zero-page/sidebar-layout.tsx";
 import { NetworkInsightsPage } from "../../views/network-insights/network-insights-page.tsx";
 import { updateDocumentTitle$ } from "../document-title.ts";
@@ -8,6 +9,7 @@ import { onboardGuard$ } from "../zero-page/onboard-guard.ts";
 import { reloadChatThreads$ } from "../agent-chat.ts";
 import { reloadInsights$ } from "./network-insights-signals.ts";
 import { hideAppSkeleton$ } from "../app-skeleton.ts";
+import { tickInsightsRelativeTime$ } from "./network-insights-signals.ts";
 
 export const setupNetworkInsightsPage$ = command(
   async ({ set }, signal: AbortSignal) => {
@@ -24,5 +26,11 @@ export const setupNetworkInsightsPage$ = command(
 
     set(reloadChatThreads$);
     set(reloadInsights$);
+
+    // Tick relative timestamps every 60 s until page is unmounted.
+    while (!signal.aborted) {
+      await delay(60_000, { signal });
+      set(tickInsightsRelativeTime$);
+    }
   },
 );

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -57,6 +57,7 @@ export interface NetworkInsightsData {
   days: DayInsight[];
   totalCredits: number;
   totalRuns: number;
+  lastUpdated: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -118,6 +118,19 @@ export const setInsightsHoveredAgent$ = command(
   },
 );
 
+/** Tick counter incremented every 60 s to refresh relative timestamps. */
+const internalRelativeTimeTick$ = state(0);
+
+export const insightsRelativeTimeTick$ = computed((get) => {
+  return get(internalRelativeTimeTick$);
+});
+
+export const tickInsightsRelativeTime$ = command(({ set }) => {
+  set(internalRelativeTimeTick$, (n) => {
+    return n + 1;
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Data fetching
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -118,19 +118,6 @@ export const setInsightsHoveredAgent$ = command(
   },
 );
 
-/** Tick counter incremented every 60 s to refresh relative timestamps. */
-const internalRelativeTimeTick$ = state(0);
-
-export const insightsRelativeTimeTick$ = computed((get) => {
-  return get(internalRelativeTimeTick$);
-});
-
-export const tickInsightsRelativeTime$ = command(({ set }) => {
-  set(internalRelativeTimeTick$, (n) => {
-    return n + 1;
-  });
-});
-
 // ---------------------------------------------------------------------------
 // Data fetching
 // ---------------------------------------------------------------------------

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -137,7 +137,7 @@ describe("network insights page - data rendering", () => {
   });
 
   it("should display last updated timestamp", async () => {
-    mockInsightsAPI([sampleDay(daysAgoIso(1))]);
+    mockInsightsAPI([sampleDay(day1Ago)]);
 
     await setupPage({ context, path: "/insights" });
 

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -41,7 +41,8 @@ function mockInsightsAPI(days: Record<string, unknown>[] = []) {
           }, 0)
         );
       }, 0);
-      return HttpResponse.json({ days, totalCredits, totalRuns });
+      const lastUpdated = days.length > 0 ? new Date().toISOString() : null;
+      return HttpResponse.json({ days, totalCredits, totalRuns, lastUpdated });
     }),
   );
 }
@@ -132,6 +133,16 @@ describe("network insights page - data rendering", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Insights")).toBeInTheDocument();
+    });
+  });
+
+  it("should display last updated timestamp", async () => {
+    mockInsightsAPI([sampleDay(daysAgoIso(1))]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Updated/)).toBeInTheDocument();
     });
   });
 

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -142,7 +142,7 @@ describe("network insights page - data rendering", () => {
     await setupPage({ context, path: "/insights" });
 
     await waitFor(() => {
-      expect(screen.getByText(/Updated/)).toBeInTheDocument();
+      expect(screen.getByText(/Last updated/)).toBeInTheDocument();
     });
   });
 
@@ -428,6 +428,7 @@ describe("network insights page - data refetch", () => {
           days: [sampleDay(day1Ago, { agents })],
           totalCredits: 10,
           totalRuns: 1,
+          lastUpdated: new Date().toISOString(),
         });
       }),
     );

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -934,6 +934,42 @@ function DaySection({ day }: { day: DayInsight }) {
 }
 
 // ---------------------------------------------------------------------------
+// Last updated label
+// ---------------------------------------------------------------------------
+
+/** Format an ISO timestamp as a relative duration, e.g. "2 hours ago". */
+function formatRelativeTime(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const diffMs = now - then;
+  const seconds = Math.floor(diffMs / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    return `${days}d ago`;
+  }
+  if (hours > 0) {
+    return `${hours}h ago`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ago`;
+  }
+  return "just now";
+}
+
+/** Format an ISO timestamp as a locale-aware absolute time for the tooltip. */
+function formatAbsoluteTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Main content
 // ---------------------------------------------------------------------------
 
@@ -953,7 +989,17 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
         {/* Header */}
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h1 className="text-xl font-semibold">Insights</h1>
+            <div className="flex items-baseline gap-2">
+              <h1 className="text-xl font-semibold">Insights</h1>
+              {data.lastUpdated && (
+                <span
+                  className="text-xs text-muted-foreground"
+                  title={formatAbsoluteTime(data.lastUpdated)}
+                >
+                  Updated {formatRelativeTime(data.lastUpdated)}
+                </span>
+              )}
+            </div>
             <p className="text-sm text-muted-foreground mt-1">
               Monitor what your agents access, which permissions they use, and
               spot anything unusual.

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useReducer } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   IconNetwork,
@@ -969,6 +970,19 @@ function formatAbsoluteTime(iso: string): string {
   });
 }
 
+/** Re-compute relative time every 60 s so it stays fresh while the page is open. */
+function useRelativeTime(iso: string | null): string | null {
+  const [, tick] = useReducer((n: number) => n + 1, 0);
+  useEffect(() => {
+    if (!iso) return;
+    const id = setInterval(tick, 60_000);
+    return () => {
+      clearInterval(id);
+    };
+  }, [iso]);
+  return iso ? formatRelativeTime(iso) : null;
+}
+
 // ---------------------------------------------------------------------------
 // Main content
 // ---------------------------------------------------------------------------
@@ -982,6 +996,7 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
       ? prefsLoadable.data.timezone
       : new Intl.DateTimeFormat().resolvedOptions().timeZone;
   const filtered = filterDays(data.days, dateRange, timezone);
+  const relativeTime = useRelativeTime(data.lastUpdated);
 
   return (
     <div className="h-full overflow-auto">
@@ -991,12 +1006,12 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
           <div>
             <div className="flex items-baseline gap-2">
               <h1 className="text-xl font-semibold">Insights</h1>
-              {data.lastUpdated && (
+              {data.lastUpdated && relativeTime && (
                 <span
                   className="text-xs text-muted-foreground"
                   title={formatAbsoluteTime(data.lastUpdated)}
                 >
-                  Updated {formatRelativeTime(data.lastUpdated)}
+                  Updated {relativeTime}
                 </span>
               )}
             </div>

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useReducer } from "react";
 import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   IconNetwork,
@@ -29,6 +28,7 @@ import {
   setInsightsCalendarMonth$,
   insightsHoveredAgent$,
   setInsightsHoveredAgent$,
+  insightsRelativeTimeTick$,
   type DayInsight,
   type NetworkInsightsData,
 } from "../../signals/network-insights/network-insights-signals.ts";
@@ -970,19 +970,6 @@ function formatAbsoluteTime(iso: string): string {
   });
 }
 
-/** Re-compute relative time every 60 s so it stays fresh while the page is open. */
-function useRelativeTime(iso: string | null): string | null {
-  const [, tick] = useReducer((n: number) => n + 1, 0);
-  useEffect(() => {
-    if (!iso) return;
-    const id = setInterval(tick, 60_000);
-    return () => {
-      clearInterval(id);
-    };
-  }, [iso]);
-  return iso ? formatRelativeTime(iso) : null;
-}
-
 // ---------------------------------------------------------------------------
 // Main content
 // ---------------------------------------------------------------------------
@@ -996,7 +983,8 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
       ? prefsLoadable.data.timezone
       : new Intl.DateTimeFormat().resolvedOptions().timeZone;
   const filtered = filterDays(data.days, dateRange, timezone);
-  const relativeTime = useRelativeTime(data.lastUpdated);
+  // Reading the tick signal triggers a re-render every 60 s (driven by page setup).
+  useGet(insightsRelativeTimeTick$);
 
   return (
     <div className="h-full overflow-auto">
@@ -1006,12 +994,12 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
           <div>
             <div className="flex items-baseline gap-2">
               <h1 className="text-xl font-semibold">Insights</h1>
-              {data.lastUpdated && relativeTime && (
+              {data.lastUpdated && (
                 <span
                   className="text-xs text-muted-foreground"
                   title={formatAbsoluteTime(data.lastUpdated)}
                 >
-                  Updated {relativeTime}
+                  Updated {formatRelativeTime(data.lastUpdated)}
                 </span>
               )}
             </div>

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -28,7 +28,6 @@ import {
   setInsightsCalendarMonth$,
   insightsHoveredAgent$,
   setInsightsHoveredAgent$,
-  insightsRelativeTimeTick$,
   type DayInsight,
   type NetworkInsightsData,
 } from "../../signals/network-insights/network-insights-signals.ts";
@@ -938,29 +937,7 @@ function DaySection({ day }: { day: DayInsight }) {
 // Last updated label
 // ---------------------------------------------------------------------------
 
-/** Format an ISO timestamp as a relative duration, e.g. "2 hours ago". */
-function formatRelativeTime(iso: string): string {
-  const now = Date.now();
-  const then = new Date(iso).getTime();
-  const diffMs = now - then;
-  const seconds = Math.floor(diffMs / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-  const days = Math.floor(hours / 24);
-
-  if (days > 0) {
-    return `${days}d ago`;
-  }
-  if (hours > 0) {
-    return `${hours}h ago`;
-  }
-  if (minutes > 0) {
-    return `${minutes}m ago`;
-  }
-  return "just now";
-}
-
-/** Format an ISO timestamp as a locale-aware absolute time for the tooltip. */
+/** Format an ISO timestamp as a locale-aware absolute time. */
 function formatAbsoluteTime(iso: string): string {
   return new Date(iso).toLocaleString(undefined, {
     month: "short",
@@ -983,8 +960,6 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
       ? prefsLoadable.data.timezone
       : new Intl.DateTimeFormat().resolvedOptions().timeZone;
   const filtered = filterDays(data.days, dateRange, timezone);
-  // Reading the tick signal triggers a re-render every 60 s (driven by page setup).
-  useGet(insightsRelativeTimeTick$);
 
   return (
     <div className="h-full overflow-auto">
@@ -995,11 +970,8 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
             <div className="flex items-baseline gap-2">
               <h1 className="text-xl font-semibold">Insights</h1>
               {data.lastUpdated && (
-                <span
-                  className="text-xs text-muted-foreground"
-                  title={formatAbsoluteTime(data.lastUpdated)}
-                >
-                  Updated {formatRelativeTime(data.lastUpdated)}
+                <span className="text-xs text-muted-foreground">
+                  Last updated {formatAbsoluteTime(data.lastUpdated)}
                 </span>
               )}
             </div>

--- a/turbo/apps/web/app/api/zero/insights/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/insights/__tests__/route.test.ts
@@ -82,6 +82,7 @@ describe("GET /api/zero/insights", () => {
     expect(data.days).toEqual([]);
     expect(data.totalCredits).toBe(0);
     expect(data.totalRuns).toBe(0);
+    expect(data.lastUpdated).toBeNull();
   });
 
   it("should return insights with correct structure", async () => {
@@ -107,6 +108,8 @@ describe("GET /api/zero/insights", () => {
     expect(data.days[0].creditsUsed).toBe(100);
     expect(data.totalCredits).toBe(100);
     expect(data.totalRuns).toBe(5);
+    expect(data.lastUpdated).toBeTruthy();
+    expect(new Date(data.lastUpdated).getTime()).not.toBeNaN();
   });
 
   it("should aggregate totals across multiple days", async () => {

--- a/turbo/apps/web/app/api/zero/insights/route.ts
+++ b/turbo/apps/web/app/api/zero/insights/route.ts
@@ -36,7 +36,11 @@ export async function GET(request: Request) {
   const cutoffIso = cutoff.toISOString().split("T")[0]!;
 
   const rows = await globalThis.services.db
-    .select({ date: insightsDaily.date, data: insightsDaily.data })
+    .select({
+      date: insightsDaily.date,
+      data: insightsDaily.data,
+      updatedAt: insightsDaily.updatedAt,
+    })
     .from(insightsDaily)
     .where(
       and(
@@ -74,9 +78,21 @@ export async function GET(request: Request) {
     );
   }, 0);
 
+  let lastUpdated: string | null = null;
+  if (rows.length > 0) {
+    let latest = rows[0]!.updatedAt;
+    for (const row of rows) {
+      if (row.updatedAt > latest) {
+        latest = row.updatedAt;
+      }
+    }
+    lastUpdated = latest.toISOString();
+  }
+
   return NextResponse.json({
     days: daysData,
     totalCredits,
     totalRuns,
+    lastUpdated,
   });
 }

--- a/turbo/packages/core/src/contracts/zero-insights.ts
+++ b/turbo/packages/core/src/contracts/zero-insights.ts
@@ -52,6 +52,7 @@ const insightsResponseSchema = z.object({
   days: z.array(dayInsightSchema),
   totalCredits: z.number(),
   totalRuns: z.number(),
+  lastUpdated: z.string().nullable(),
 });
 
 const insightsRangeResponseSchema = z.object({


### PR DESCRIPTION
## Summary
- Display absolute "Last updated" timestamp on insights page header (e.g. "Last updated Apr 8, 10:30 AM")
- Add `reloadInsights$` signal to refetch data on each navigation to `/insights`
- Add `lastUpdated` field to insights API response and contract
- Add integration test for data refetch behavior

Replaces #8427 (closed due to stale merge base).

## Test plan
- [x] 22 insights page interaction tests pass (including new refetch test)
- [x] Type check, lint, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)