### PR TITLE
fix(onboarding): handle clerk 422 errors and unhandled promise rejection

### DIFF
--- a/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
@@ -37,6 +37,36 @@ function nameToSlug(name: string): string {
 }
 
 /**
+ * Check whether a Clerk API error indicates a slug conflict.
+ *
+ * ClerkAPIResponseError stores the HTTP statusText in `error.message`
+ * (e.g. "Unprocessable Entity"), while the actual error details live in
+ * the `error.errors` array.  We inspect that array for slug-specific
+ * codes / metadata so the retry logic works correctly.
+ */
+function isClerkSlugConflict(error: unknown): boolean {
+  if (error === null || typeof error !== "object" || !("errors" in error)) {
+    return false;
+  }
+  const { errors } = error as {
+    errors: Array<{
+      code?: string;
+      message?: string;
+      meta?: { paramName?: string };
+    }>;
+  };
+  if (!Array.isArray(errors)) return false;
+  return errors.some((e) => {
+    return (
+      e.code === "form_identifier_exists" ||
+      e.meta?.paramName === "slug" ||
+      (e.message &&
+        (e.message.includes("already exists") || e.message.includes("slug")))
+    );
+  });
+}
+
+/**
  * Update org name and slug via a single Clerk call.
  * Retries once with a random suffix if the slug conflicts.
  */
@@ -49,6 +79,13 @@ async function updateOrgNameAndSlug(
 
   const client = await clerkClient();
   const baseSlug = nameToSlug(name);
+
+  // Non-Latin names produce empty slugs — update name only, let Clerk keep existing slug
+  if (!baseSlug) {
+    await client.organizations.updateOrganization(orgId, { name });
+    return;
+  }
+
   const slugCandidates = [
     baseSlug,
     `${baseSlug.slice(0, 56)}-${Math.random().toString(36).slice(2, 8)}`,
@@ -61,10 +98,7 @@ async function updateOrgNameAndSlug(
       await client.organizations.updateOrganization(orgId, { name, slug });
       return;
     } catch (error: unknown) {
-      const msg = error instanceof Error ? error.message : String(error);
-      if (msg.includes("already exists") || msg.includes("slug")) {
-        continue;
-      }
+      if (isClerkSlugConflict(error)) continue;
       throw error;
     }
   }
@@ -124,12 +158,7 @@ const router = tsr.router(onboardingSetupContract, {
       }
     }
 
-    // Start org name + slug update in parallel (don't await yet)
-    const orgUpdatePromise = body.workspaceName?.trim()
-      ? updateOrgNameAndSlug(org.orgId, body.workspaceName)
-      : undefined;
-
-    // Parallel: model provider + compose (independent)
+    // Parallel: model provider + compose + org name/slug update
     const agentName = crypto.randomUUID();
     const content = buildComposeContent(agentName);
 
@@ -141,10 +170,10 @@ const router = tsr.router(onboardingSetupContract, {
         content,
         instructions: SEED_INSTRUCTIONS,
       }),
+      body.workspaceName?.trim()
+        ? updateOrgNameAndSlug(org.orgId, body.workspaceName)
+        : Promise.resolve(),
     ]);
-
-    // Await org name + slug update (already running in parallel)
-    if (orgUpdatePromise) await orgUpdatePromise;
 
     if (!composeResult) {
       return {

--- a/turbo/apps/web/src/__tests__/onboarding-setup.test.ts
+++ b/turbo/apps/web/src/__tests__/onboarding-setup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { POST } from "../../app/api/zero/onboarding/setup/route";
 import { GET as getOnboardingStatus } from "../../app/api/zero/onboarding/status/route";
 import { GET as listAgents } from "../../app/api/zero/agents/route";
@@ -7,6 +7,7 @@ import { GET as listModelProviders } from "../../app/api/zero/model-providers/ro
 import { createTestRequest, getOrgDefaultAgent } from "./api-test-helpers";
 import { testContext } from "./test-helpers";
 import { mockClerk } from "./clerk-mock";
+import { clerkClient } from "@clerk/nextjs/server";
 
 const context = testContext();
 
@@ -143,5 +144,117 @@ describe("POST /api/zero/onboarding/setup", () => {
 
     const response = await postSetup({ displayName: "Zero" });
     expect(response.status).toBe(403);
+  });
+
+  it("should retry with suffixed slug on Clerk slug conflict", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const client = await clerkClient();
+    let callCount = 0;
+    const slugConflictMock = vi.fn(
+      (_orgId: string, data: { slug?: string }) => {
+        callCount++;
+        if (data.slug && callCount === 1) {
+          const err = Object.assign(new Error("Unprocessable Entity"), {
+            status: 422,
+            errors: [
+              {
+                code: "form_identifier_exists",
+                message: "That slug is already in use",
+                meta: { paramName: "slug" },
+              },
+            ],
+          });
+          return Promise.reject(err);
+        }
+        return Promise.resolve({});
+      },
+    );
+    client.organizations.updateOrganization =
+      slugConflictMock as unknown as typeof client.organizations.updateOrganization;
+
+    const response = await postSetup({
+      displayName: "Zero",
+      workspaceName: "My Workspace",
+    });
+    expect(response.status).toBe(200);
+    expect(slugConflictMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("should update name only for non-Latin workspace names", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const client = await clerkClient();
+    const updateOrg = vi.mocked(client.organizations.updateOrganization);
+
+    const response = await postSetup({
+      displayName: "Zero",
+      workspaceName: "我的工作区",
+    });
+    expect(response.status).toBe(200);
+
+    // Should be called once with name only (no slug)
+    expect(updateOrg).toHaveBeenCalledTimes(1);
+    expect(updateOrg).toHaveBeenCalledWith(expect.any(String), {
+      name: "我的工作区",
+    });
+  });
+
+  it("should fall back to name-only update when all slug candidates conflict", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const client = await clerkClient();
+    const allConflictMock = vi.fn((_orgId: string, data: { slug?: string }) => {
+      if (data.slug) {
+        const err = Object.assign(new Error("Unprocessable Entity"), {
+          status: 422,
+          errors: [
+            {
+              code: "form_identifier_exists",
+              message: "That slug is already in use",
+              meta: { paramName: "slug" },
+            },
+          ],
+        });
+        return Promise.reject(err);
+      }
+      return Promise.resolve({});
+    });
+    client.organizations.updateOrganization =
+      allConflictMock as unknown as typeof client.organizations.updateOrganization;
+
+    const response = await postSetup({
+      displayName: "Zero",
+      workspaceName: "My Workspace",
+    });
+    expect(response.status).toBe(200);
+
+    // 2 slug attempts + 1 name-only fallback = 3 calls
+    expect(allConflictMock).toHaveBeenCalledTimes(3);
+    const lastCall = allConflictMock.mock.calls[2];
+    expect(lastCall![1]).toEqual({ name: "My Workspace" });
+  });
+
+  it("should update name and slug for valid Latin workspace names", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const client = await clerkClient();
+    const updateOrg = vi.mocked(client.organizations.updateOrganization);
+
+    const response = await postSetup({
+      displayName: "Zero",
+      workspaceName: "My Workspace",
+    });
+    expect(response.status).toBe(200);
+
+    expect(updateOrg).toHaveBeenCalledTimes(1);
+    expect(updateOrg).toHaveBeenCalledWith(expect.any(String), {
+      name: "My Workspace",
+      slug: "my-workspace",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fix broken Clerk error matching that checked `error.message` (HTTP statusText) instead of `error.errors[].code` for slug conflicts — the slug-conflict retry logic never worked
- Fix unhandled promise rejection by including `orgUpdatePromise` in the main `Promise.all` instead of awaiting it separately after
- Fix `nameToSlug` producing empty/invalid slugs for non-Latin workspace names (CJK, emoji, etc.) — now falls back to name-only update

Closes #8439

## Test plan

- [x] Clerk slug conflict triggers retry with suffixed slug
- [x] Non-Latin workspace names update name only (no invalid slug sent)
- [x] All slug candidates conflicting falls back to name-only update
- [x] Valid Latin workspace names set both name and slug
- [x] All existing tests still pass (11/11)
- [x] Lint, type check, and knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)