### PR TITLE
chore(schedule): update stale comment for cron in advance-schedule-state

### DIFF
--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -887,7 +887,7 @@ export async function executeSchedule(
   }
 
   // Advance schedule state (also persists lastRunId):
-  // - cron: calculate next cron time
+  // - cron: clear nextRunAt (callback will set it on completion)
   // - once: disable
   // - loop: clear nextRunAt (callback will set it on completion)
   await advanceScheduleState(schedule, runId);


### PR DESCRIPTION
## Summary
- Update stale comment in `advanceScheduleState` call site (line 890 of `schedule-service.ts`)
- Since PR #8430, cron no longer calculates next cron time in `advanceScheduleState` — the cron callback handles it
- Changed comment from `// - cron: calculate next cron time` to `// - cron: clear nextRunAt (callback will set it on completion)` to match actual behavior

## Test plan
- [ ] Comment-only change, no functional impact
- [ ] Verify comment matches behavior at line 775

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>