### PR TITLE
fix(schedule): prevent duplicate execution via atomic claim

### DIFF
--- a/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
@@ -198,6 +198,47 @@ describe("GET /api/cron/execute-schedules", () => {
       expect(schedule.lastRunAt).not.toBeNull();
     });
 
+    it("should not create duplicate runs on concurrent cron invocations", async () => {
+      // 1. Mock time to 8:00 AM UTC
+      context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
+
+      // 2. Create and enable a cron schedule due at 9 AM
+      await createTestSchedule(testComposeId, "concurrent-test", {
+        cronExpression: "0 9 * * *",
+        prompt: "Daily 9 AM task",
+        timezone: "UTC",
+      });
+      await enableTestSchedule(testComposeId, "concurrent-test");
+
+      // 3. Advance time to 9:01 AM (schedule is now due)
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+
+      // 4. Invoke cron endpoint twice concurrently (simulates Vercel double-fire)
+      const [response1, response2] = await Promise.all([
+        GET(authenticatedCronRequest()),
+        GET(authenticatedCronRequest()),
+      ]);
+      const [data1, data2] = await Promise.all([
+        response1.json(),
+        response2.json(),
+      ]);
+
+      expect(response1.status).toBe(200);
+      expect(response2.status).toBe(200);
+
+      // 5. Exactly one invocation should have executed, the other should have skipped
+      const totalExecuted = data1.executed + data2.executed;
+      expect(totalExecuted).toBe(1);
+
+      // 6. Verify only 1 run was created
+      const { runs } = await getTestScheduleRuns(
+        testComposeId,
+        "concurrent-test",
+        10,
+      );
+      expect(runs.length).toBe(1);
+    });
+
     it("should execute due one-time (atTime) schedule", async () => {
       // 1. Mock time to 8:00 AM UTC
       context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -735,6 +735,33 @@ export async function executeDueSchedules(): Promise<{
       }
     }
 
+    // Atomic CAS claim: advance schedule state to prevent duplicate execution.
+    // If another invocation already claimed this schedule (changed nextRunAt),
+    // the WHERE condition won't match and we skip it.
+    const [claimed] = await globalThis.services.db
+      .update(zeroAgentSchedules)
+      .set({
+        nextRunAt: null,
+        lastRunAt: now,
+        retryStartedAt: null,
+        ...(schedule.triggerType === "once" && { enabled: false }),
+      })
+      .where(
+        and(
+          eq(zeroAgentSchedules.id, schedule.id),
+          eq(zeroAgentSchedules.nextRunAt, schedule.nextRunAt!),
+        ),
+      )
+      .returning();
+
+    if (!claimed) {
+      log.debug(
+        `Skipping schedule ${schedule.name}: already claimed by another invocation`,
+      );
+      skipped++;
+      continue;
+    }
+
     try {
       await executeSchedule(schedule);
       executed++;
@@ -746,60 +773,6 @@ export async function executeDueSchedules(): Promise<{
 
   log.debug(`Executed ${executed} schedules, skipped ${skipped}`);
   return { executed, skipped };
-}
-
-/**
- * Advance schedule to next occurrence (cron), disable (one-time), or wait for callback (loop).
- * Shared by retry-window-expired, failure, and success paths.
- *
- * Loop schedules do NOT set nextRunAt here — their next run is scheduled
- * by the completion callback, which provides completion-based timing.
- */
-async function advanceScheduleState(
-  schedule: typeof zeroAgentSchedules.$inferSelect,
-  lastRunId?: string,
-): Promise<void> {
-  const now = new Date();
-  if (schedule.triggerType === "loop") {
-    // Loop: don't advance nextRunAt here — the loop callback handles it on completion
-    await globalThis.services.db
-      .update(zeroAgentSchedules)
-      .set({
-        ...(lastRunId !== undefined && { lastRunId }),
-        lastRunAt: now,
-        retryStartedAt: null,
-        nextRunAt: null, // Will be set by loop callback on run completion
-      })
-      .where(eq(zeroAgentSchedules.id, schedule.id));
-  } else if (schedule.triggerType === "cron") {
-    // Cron: don't advance nextRunAt here — the cron callback handles it on completion
-    await globalThis.services.db
-      .update(zeroAgentSchedules)
-      .set({
-        ...(lastRunId !== undefined && { lastRunId }),
-        lastRunAt: now,
-        retryStartedAt: null,
-        nextRunAt: null, // Will be set by cron callback on run completion
-      })
-      .where(eq(zeroAgentSchedules.id, schedule.id));
-  } else {
-    // One-time (once): disable after execution
-    if (schedule.triggerType !== "once") {
-      log.warn(
-        `advanceScheduleState reached one-time branch for schedule ${schedule.name} (${schedule.id}) with triggerType=${schedule.triggerType}`,
-      );
-    }
-    await globalThis.services.db
-      .update(zeroAgentSchedules)
-      .set({
-        enabled: false,
-        ...(lastRunId !== undefined && { lastRunId }),
-        lastRunAt: now,
-        retryStartedAt: null,
-        nextRunAt: null,
-      })
-      .where(eq(zeroAgentSchedules.id, schedule.id));
-  }
 }
 
 /**
@@ -866,31 +839,25 @@ export async function executeSchedule(
   }
 
   // Delegate run creation, validation, and dispatch to createZeroRun()
-  let runId: string;
-  try {
-    const result = await createZeroRun({
-      userId: schedule.userId,
-      prompt: schedule.prompt,
-      appendSystemPrompt: schedule.appendSystemPrompt ?? undefined,
-      agentId: schedule.agentId,
-      scheduleId: schedule.id,
-      triggerSource: "schedule",
-      callbacks,
-    });
-    runId = result.runId;
-  } catch (error) {
-    // Update schedule state (disable one-time, advance cron) on any failure
-    await advanceScheduleState(schedule);
-    log.debug(`Schedule ${schedule.name} (${schedule.triggerType}) failed`);
+  // Note: schedule state (nextRunAt, lastRunAt, enabled) is already advanced
+  // by the atomic CAS claim in executeDueSchedules(). We only need to persist
+  // lastRunId after successful run creation.
+  const result = await createZeroRun({
+    userId: schedule.userId,
+    prompt: schedule.prompt,
+    appendSystemPrompt: schedule.appendSystemPrompt ?? undefined,
+    agentId: schedule.agentId,
+    scheduleId: schedule.id,
+    triggerSource: "schedule",
+    callbacks,
+  });
 
-    throw error; // Re-throw so executeDueSchedules counts it as skipped
-  }
+  // Persist lastRunId so the active-run check in executeDueSchedules works
+  await globalThis.services.db
+    .update(zeroAgentSchedules)
+    .set({ lastRunId: result.runId })
+    .where(eq(zeroAgentSchedules.id, schedule.id));
 
-  // Advance schedule state (also persists lastRunId):
-  // - cron: clear nextRunAt (callback will set it on completion)
-  // - once: disable
-  // - loop: clear nextRunAt (callback will set it on completion)
-  await advanceScheduleState(schedule, runId);
   log.debug(`Schedule ${schedule.name} (${schedule.triggerType}) executed`);
-  return runId;
+  return result.runId;
 }


### PR DESCRIPTION
## Summary

- Replace the non-atomic SELECT → execute → UPDATE pattern in `executeDueSchedules()` with an atomic Compare-And-Swap (CAS) UPDATE that claims the schedule before execution
- The CAS WHERE condition (`nextRunAt = :old_value`) ensures only one concurrent invocation can claim a given schedule, preventing duplicate runs when Vercel cron fires twice in the same minute
- Remove the now-unused `advanceScheduleState()` function; `executeSchedule()` now only persists `lastRunId` after successful run creation
- Add concurrent invocation deduplication test

Closes #8446

## Test plan

- [x] Existing tests pass (11/11 same as main — 5 pre-existing failures due to missing `user_connectors` table are unrelated)
- [x] Lint passes (0 errors)
- [x] Type check passes
- [x] New test: `should not create duplicate runs on concurrent cron invocations` — calls endpoint twice via `Promise.all`, verifies exactly 1 execution
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)