### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -90,8 +90,8 @@ TMP_ROOTFS_PATH="${OUTPUT_DIR}/${TMP_ROOTFS}"
 ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
-GO_VERSION="1.26.1"
-CLAUDE_CODE_VERSION="2.1.92"
+GO_VERSION="1.26.2"
+CLAUDE_CODE_VERSION="2.1.94"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.25.3"


### PR DESCRIPTION
## Summary

Updates pinned package versions in `crates/runner/scripts/build-rootfs.sh`:

| Package | Old Version | New Version |
|---------|-------------|-------------|
| Go | 1.26.1 | 1.26.2 |
| Claude Code CLI | 2.1.92 | 2.1.94 |

Other pinned packages (`@googleworkspace/cli@0.22.5`, `@xdevplatform/xurl@1.0.3`, `agent-browser@0.25.3`) are already at their latest versions.

> Note: These version bumps will invalidate the rootfs cache, triggering a fresh build on next deploy.