### PR TITLE
fix(checkpoint): extract blob pre-registration into session-history service

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/checkpoints/prepare-history/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/checkpoints/prepare-history/route.ts
@@ -7,7 +7,8 @@ import { webhookCheckpointsPrepareHistoryContract } from "@vm0/core";
 import { initServices } from "../../../../../../src/lib/init-services";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { blobs } from "../../../../../../src/db/schema/blob";
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
+import { preRegisterSessionHistoryBlob } from "../../../../../../src/lib/infra/session-history";
 import { getSandboxAuthForRun } from "../../../../../../src/lib/auth/get-sandbox-auth";
 import {
   generatePresignedPutUrl,
@@ -96,13 +97,7 @@ const router = tsr.router(webhookCheckpointsPrepareHistoryContract, {
 
     // Pre-register the blob record with the correct size.
     // The subsequent checkpoint call will increment refCount via registerSessionHistoryBlob.
-    await globalThis.services.db
-      .insert(blobs)
-      .values({ hash, size, refCount: 0 })
-      .onConflictDoUpdate({
-        target: blobs.hash,
-        set: { size },
-      });
+    await preRegisterSessionHistoryBlob(hash, size);
 
     log.debug(`Presigned URL generated for session history: hash=${hash}`);
 

--- a/turbo/apps/web/src/lib/infra/session-history/index.ts
+++ b/turbo/apps/web/src/lib/infra/session-history/index.ts
@@ -1,4 +1,5 @@
 export {
+  preRegisterSessionHistoryBlob,
   registerSessionHistoryBlob,
   resolveSessionHistory,
 } from "./session-history-service";

--- a/turbo/apps/web/src/lib/infra/session-history/session-history-service.ts
+++ b/turbo/apps/web/src/lib/infra/session-history/session-history-service.ts
@@ -12,6 +12,31 @@ import { logger } from "../../shared/logger";
 const log = logger("session-history");
 
 /**
+ * Pre-register a session history blob with correct size before S3 upload.
+ * Creates the blob record with refCount 0; the subsequent checkpoint call
+ * will increment refCount via registerSessionHistoryBlob.
+ *
+ * On conflict (blob already exists), updates size to the correct value.
+ *
+ * @param hash SHA-256 hash of the content
+ * @param size File size in bytes
+ */
+export async function preRegisterSessionHistoryBlob(
+  hash: string,
+  size: number,
+): Promise<void> {
+  log.debug(`Pre-registering session history blob, hash=${hash}, size=${size}`);
+
+  await globalThis.services.db
+    .insert(blobs)
+    .values({ hash, size, refCount: 0 })
+    .onConflictDoUpdate({
+      target: blobs.hash,
+      set: { size },
+    });
+}
+
+/**
  * Register a session history blob that was uploaded directly to S3 via presigned URL.
  * The blob record (with correct size) is pre-created by the prepare-history endpoint;
  * this function increments refCount to track usage.


### PR DESCRIPTION
## Summary

- Extract inline blob DB insert from `prepare-history/route.ts` into `preRegisterSessionHistoryBlob()` in `session-history-service.ts`
- Consolidate all blob registration logic (pre-registration + registration) in the session-history service layer
- Remove unused `sql` import from `prepare-history/route.ts`

Follow-up from #8445. Addresses #8454.

## Context

The `prepare-history` endpoint was doing a raw DB insert to pre-register blobs with the correct `size` and `refCount: 0`. This logic was duplicated outside the service layer. Now both `preRegisterSessionHistoryBlob` (sets correct size, refCount 0) and `registerSessionHistoryBlob` (increments refCount) live in the same service module.

## Test plan

- [ ] Existing `prepare-history` integration tests pass (1 pre-existing failure unrelated to this change)
- [ ] TypeScript type check passes
- [ ] Lint and knip checks pass
- [ ] No behavioral change — same SQL operations, just extracted into a function

🤖 Generated with [Claude Code](https://claude.com/claude-code)