### PR TITLE
feat(slack): add ffmpeg frame extraction hint for video attachments

### DIFF
--- a/turbo/apps/web/src/lib/zero/slack/__tests__/context.test.ts
+++ b/turbo/apps/web/src/lib/zero/slack/__tests__/context.test.ts
@@ -230,6 +230,149 @@ describe("Feature: Format Context With Image Upload", () => {
     });
   });
 
+  describe("Scenario: Upload video files with ffmpeg hint", () => {
+    it("should include ffmpeg frame extraction instructions for MP4 video", async () => {
+      const videoContent = Buffer.from("fake-mp4-content");
+
+      const downloadHandler = http.get(
+        "https://files.slack.com/download/recording.mp4",
+        () => {
+          return new HttpResponse(videoContent, {
+            headers: { "content-type": "video/mp4" },
+          });
+        },
+      );
+      server.use(downloadHandler.handler);
+
+      const messages = [
+        {
+          user: "U123",
+          text: "Check this recording",
+          ts: "1234567890.001",
+          files: [
+            {
+              id: "FVID1",
+              name: "recording.mp4",
+              mimetype: "video/mp4",
+              filetype: "mp4",
+              original_w: "1920",
+              original_h: "1080",
+              url_private_download:
+                "https://files.slack.com/download/recording.mp4",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+        "test-session-123",
+        "BBOT123",
+        "thread",
+      );
+
+      expect(context.mocks.s3.uploadS3Buffer).toHaveBeenCalledWith(
+        "test-bucket",
+        expect.stringContaining("slack-files/test-session-123/"),
+        expect.any(Buffer),
+        "video/mp4",
+      );
+      expect(result).toContain("[file]: recording.mp4 (video/mp4)");
+      expect(result).toContain("Dimensions: 1920x1080");
+      expect(result).toContain(
+        'Download: curl -sS -o /tmp/FVID1.mp4 "https://mock-presigned-url"',
+      );
+      expect(result).toContain("Video: To analyze this video");
+      expect(result).toContain(
+        'ffmpeg -i /tmp/FVID1.mp4 -vf "fps=1" -q:v 2 /tmp/FVID1_frame_%03d.jpg',
+      );
+    });
+
+    it("should include ffmpeg hint for QuickTime MOV files", async () => {
+      const videoContent = Buffer.from("fake-mov-content");
+
+      const downloadHandler = http.get(
+        "https://files.slack.com/download/screen.mov",
+        () => {
+          return new HttpResponse(videoContent, {
+            headers: { "content-type": "video/quicktime" },
+          });
+        },
+      );
+      server.use(downloadHandler.handler);
+
+      const messages = [
+        {
+          user: "U123",
+          text: "Screen recording",
+          ts: "1234567890.001",
+          files: [
+            {
+              id: "FVID2",
+              name: "screen.mov",
+              mimetype: "video/quicktime",
+              filetype: "mov",
+              url_private_download:
+                "https://files.slack.com/download/screen.mov",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+        "test-session-123",
+      );
+
+      expect(result).toContain("[file]: screen.mov (video/quicktime)");
+      expect(result).toContain("Video: To analyze this video");
+      expect(result).toContain("ffmpeg -i /tmp/FVID2.mov");
+    });
+
+    it("should not include ffmpeg hint for non-video files", async () => {
+      const pdfContent = Buffer.from("%PDF-1.4 fake pdf content");
+
+      const downloadHandler = http.get(
+        "https://files.slack.com/download/doc.pdf",
+        () => {
+          return new HttpResponse(pdfContent, {
+            headers: { "content-type": "application/pdf" },
+          });
+        },
+      );
+      server.use(downloadHandler.handler);
+
+      const messages = [
+        {
+          user: "U123",
+          text: "Document",
+          ts: "1234567890.001",
+          files: [
+            {
+              id: "FDOC1",
+              name: "doc.pdf",
+              mimetype: "application/pdf",
+              filetype: "pdf",
+              url_private_download: "https://files.slack.com/download/doc.pdf",
+            },
+          ],
+        },
+      ];
+
+      const result = await formatContextForAgentWithImages(
+        messages,
+        "xoxb-test-token",
+        "test-session-123",
+      );
+
+      expect(result).toContain("[file]: doc.pdf (application/pdf)");
+      expect(result).not.toContain("ffmpeg");
+      expect(result).not.toContain("Video:");
+    });
+  });
+
   describe("Scenario: Handle download failures gracefully", () => {
     it("should fall back to URL when download fails", async () => {
       const downloadHandler = http.get(

--- a/turbo/apps/web/src/lib/zero/slack/context.ts
+++ b/turbo/apps/web/src/lib/zero/slack/context.ts
@@ -356,14 +356,9 @@ async function downloadAndUploadSlackFile(
   }
 }
 
-/** MIME types that represent video files. */
-const VIDEO_MIME_PREFIXES = ["video/"];
-
 function isVideoMimeType(mimetype: string | undefined): boolean {
   if (!mimetype) return false;
-  return VIDEO_MIME_PREFIXES.some((prefix) => {
-    return mimetype.startsWith(prefix);
-  });
+  return mimetype.startsWith("video/");
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/slack/context.ts
+++ b/turbo/apps/web/src/lib/zero/slack/context.ts
@@ -356,6 +356,16 @@ async function downloadAndUploadSlackFile(
   }
 }
 
+/** MIME types that represent video files. */
+const VIDEO_MIME_PREFIXES = ["video/"];
+
+function isVideoMimeType(mimetype: string | undefined): boolean {
+  if (!mimetype) return false;
+  return VIDEO_MIME_PREFIXES.some((prefix) => {
+    return mimetype.startsWith(prefix);
+  });
+}
+
 /**
  * Format file information for context with file upload to R2
  * Uploads files to R2 and provides presigned URLs for agent access
@@ -385,6 +395,19 @@ async function formatFileInfoWithUpload(
     if (presignedUrl) {
       const filename = `${file.id || "file"}.${file.filetype || "bin"}`;
       parts.push(`   Download: curl -sS -o /tmp/${filename} "${presignedUrl}"`);
+
+      if (isVideoMimeType(file.mimetype)) {
+        parts.push(
+          `   Video: To analyze this video, extract key frames with ffmpeg:`,
+        );
+        parts.push(
+          `     ffmpeg -i /tmp/${filename} -vf "fps=1" -q:v 2 /tmp/${file.id || "video"}_frame_%03d.jpg`,
+        );
+        parts.push(
+          `     Then view the extracted frames to understand the video content.`,
+        );
+      }
+
       return parts.join("\n");
     }
   }


### PR DESCRIPTION
## Summary

- When a video file (mp4, mov, etc.) is shared in Slack, the context now includes ffmpeg instructions so the agent can extract key frames and analyze video content visually
- Detects video files by `video/*` MIME type prefix
- Adds download + ffmpeg extraction command in the formatted file context

Closes #8410

## Test plan

- [x] New tests: MP4 video includes ffmpeg hint
- [x] New tests: QuickTime MOV video includes ffmpeg hint  
- [x] New tests: Non-video files (PDF) do NOT include ffmpeg hint
- [x] Existing tests all pass (58 tests)
- [x] Pre-commit hooks pass (lint, format, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)