### PR TITLE
fix(schedule): handle pre-run failures to prevent stuck schedules

### DIFF
--- a/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/execute-schedules/__tests__/route.test.ts
@@ -11,6 +11,8 @@ import {
   getTestScheduleRuns,
   getTestRun,
   disableAllSchedules,
+  clearComposeHeadVersion,
+  setScheduleConsecutiveFailures,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -539,6 +541,114 @@ describe("GET /api/cron/execute-schedules", () => {
       expect(schedule.enabled).toBe(false);
       expect(schedule.nextRunAt).toBeNull();
       expect(schedule.retryStartedAt).toBeNull();
+    });
+  });
+
+  describe("Pre-Run Failure Handling", () => {
+    beforeEach(async () => {
+      vi.stubEnv("CRON_SECRET", "test-secret");
+      reloadEnv();
+      await disableAllSchedules(testOrgId);
+    });
+
+    it("should set nextRunAt to next cron occurrence on pre-run failure", async () => {
+      // 1. Mock time to 8:00 AM UTC
+      context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
+
+      // 2. Create and enable a cron schedule for 9 AM daily
+      await createTestSchedule(testComposeId, "cron-prerun-fail", {
+        cronExpression: "0 9 * * *",
+        prompt: "Daily task",
+        timezone: "UTC",
+      });
+      await enableTestSchedule(testComposeId, "cron-prerun-fail");
+
+      // 3. Clear headVersionId to cause pre-run failure in executeSchedule()
+      await clearComposeHeadVersion(testComposeId);
+
+      // 4. Advance time to 9:01 AM (schedule is due)
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+
+      // 5. Execute cron endpoint
+      await GET(authenticatedCronRequest());
+
+      // 6. Verify: consecutiveFailures incremented, nextRunAt set to next occurrence
+      const schedule = await getTestSchedule(testComposeId, "cron-prerun-fail");
+      expect(schedule.consecutiveFailures).toBe(1);
+      expect(schedule.enabled).toBe(true);
+      expect(schedule.nextRunAt).not.toBeNull();
+      // nextRunAt should be Jan 16 at 9:00 AM (next cron occurrence)
+      expect(new Date(schedule.nextRunAt!).getTime()).toBeGreaterThan(
+        new Date("2025-01-15T09:01:00Z").getTime(),
+      );
+    });
+
+    it("should set nextRunAt to now + interval on loop pre-run failure", async () => {
+      // 1. Mock time
+      context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
+
+      // 2. Create and enable a loop schedule
+      await createTestSchedule(testComposeId, "loop-prerun-fail", {
+        intervalSeconds: 300,
+        prompt: "Loop task",
+      });
+      await enableTestSchedule(testComposeId, "loop-prerun-fail");
+
+      // 3. Clear headVersionId to cause pre-run failure
+      await clearComposeHeadVersion(testComposeId);
+
+      // 4. Advance time slightly so schedule is due
+      context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:01Z"));
+
+      // 5. Execute cron endpoint
+      await GET(authenticatedCronRequest());
+
+      // 6. Verify: consecutiveFailures incremented, nextRunAt ≈ now + 300s
+      const schedule = await getTestSchedule(testComposeId, "loop-prerun-fail");
+      expect(schedule.consecutiveFailures).toBe(1);
+      expect(schedule.enabled).toBe(true);
+      expect(schedule.nextRunAt).not.toBeNull();
+      const expectedNextRun = new Date("2025-01-15T08:05:01Z"); // now + 300s
+      expect(
+        Math.abs(
+          new Date(schedule.nextRunAt!).getTime() - expectedNextRun.getTime(),
+        ),
+      ).toBeLessThan(2000);
+    });
+
+    it("should auto-disable schedule after 3 consecutive pre-run failures", async () => {
+      // 1. Mock time
+      context.mocks.date.setSystemTime(new Date("2025-01-15T08:00:00Z"));
+
+      // 2. Create and enable a cron schedule
+      await createTestSchedule(testComposeId, "cron-autodisable", {
+        cronExpression: "0 9 * * *",
+        prompt: "Daily task",
+        timezone: "UTC",
+      });
+      await enableTestSchedule(testComposeId, "cron-autodisable");
+
+      // 3. Set consecutiveFailures to 2 (simulate 2 prior failures)
+      await setScheduleConsecutiveFailures(
+        testComposeId,
+        "cron-autodisable",
+        2,
+      );
+
+      // 4. Clear headVersionId to cause pre-run failure
+      await clearComposeHeadVersion(testComposeId);
+
+      // 5. Advance time to 9:01 AM (schedule is due)
+      context.mocks.date.setSystemTime(new Date("2025-01-15T09:01:00Z"));
+
+      // 6. Execute cron endpoint
+      await GET(authenticatedCronRequest());
+
+      // 7. Verify: auto-disabled after 3rd failure
+      const schedule = await getTestSchedule(testComposeId, "cron-autodisable");
+      expect(schedule.consecutiveFailures).toBe(3);
+      expect(schedule.enabled).toBe(false);
+      expect(schedule.nextRunAt).toBeNull();
     });
   });
 });

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -5194,3 +5194,36 @@ export async function getAgentCustomSkills(agentId: string): Promise<string[]> {
   if (!agent) throw new Error(`Agent not found: ${agentId}`);
   return agent.customSkills;
 }
+
+/**
+ * Clear the headVersionId of a compose to simulate a compose with no versions.
+ * Useful for triggering pre-run failures in executeSchedule().
+ */
+export async function clearComposeHeadVersion(
+  composeId: string,
+): Promise<void> {
+  await globalThis.services.db
+    .update(agentComposes)
+    .set({ headVersionId: null })
+    .where(eq(agentComposes.id, composeId));
+}
+
+/**
+ * Set the consecutiveFailures count on a schedule.
+ * Useful for testing auto-disable after N failures.
+ */
+export async function setScheduleConsecutiveFailures(
+  composeId: string,
+  name: string,
+  failures: number,
+): Promise<void> {
+  await globalThis.services.db
+    .update(zeroAgentSchedules)
+    .set({ consecutiveFailures: failures })
+    .where(
+      and(
+        eq(zeroAgentSchedules.agentId, composeId),
+        eq(zeroAgentSchedules.name, name),
+      ),
+    );
+}

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -18,6 +18,9 @@ import type {
 
 const log = logger("service:schedule");
 
+// Auto-disable after this many consecutive pre-run failures
+const MAX_CONSECUTIVE_FAILURES = 3;
+
 /**
  * Schedule data for API responses
  */
@@ -767,6 +770,47 @@ export async function executeDueSchedules(): Promise<{
       executed++;
     } catch (error) {
       log.error(`Failed to execute schedule ${schedule.name}:`, error);
+
+      // Pre-run failure: increment consecutive failures and schedule next attempt
+      // (mirrors callback failure handling from #8430)
+      const now = new Date();
+      const newFailureCount = schedule.consecutiveFailures + 1;
+      const shouldDisable = newFailureCount >= MAX_CONSECUTIVE_FAILURES;
+
+      let nextRunAt: Date | null = null;
+      if (!shouldDisable) {
+        if (schedule.triggerType === "cron" && schedule.cronExpression) {
+          nextRunAt = calculateNextRun(
+            schedule.cronExpression,
+            schedule.timezone,
+          );
+        } else if (
+          schedule.triggerType === "loop" &&
+          schedule.intervalSeconds
+        ) {
+          nextRunAt = new Date(now.getTime() + schedule.intervalSeconds * 1000);
+        }
+        // "once" triggers: CAS claim already set enabled=false, no recovery needed
+      }
+
+      await globalThis.services.db
+        .update(zeroAgentSchedules)
+        .set({
+          consecutiveFailures: newFailureCount,
+          ...(shouldDisable && { enabled: false }),
+          nextRunAt,
+          updatedAt: now,
+        })
+        .where(eq(zeroAgentSchedules.id, schedule.id));
+
+      if (shouldDisable) {
+        log.warn("Schedule auto-disabled after consecutive pre-run failures", {
+          scheduleId: schedule.id,
+          scheduleName: schedule.name,
+          consecutiveFailures: newFailureCount,
+        });
+      }
+
       skipped++;
     }
   }


### PR DESCRIPTION
## Summary

- When `executeSchedule()` fails before run creation (e.g., `INSUFFICIENT_CREDITS`), the schedule becomes permanently stuck (`enabled = true`, `nextRunAt = null`) because no callback fires to restore `nextRunAt`
- The catch block in `executeDueSchedules()` now increments `consecutiveFailures` and sets `nextRunAt` to the next occurrence (cron/loop), mirroring the post-run failure handling from callbacks (#8430)
- Auto-disables the schedule after 3 consecutive pre-run failures, consistent with callback behavior

Closes #8106

## Test plan

- [x] Cron schedule with pre-run failure gets `nextRunAt` set to next cron occurrence
- [x] Loop schedule with pre-run failure gets `nextRunAt` set to `now + intervalSeconds`
- [x] Schedule auto-disabled after 3 consecutive pre-run failures (`consecutiveFailures = 3`, `enabled = false`)
- [x] All 20 integration tests pass (17 existing + 3 new)
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)