### PR TITLE
fix(developer-support): include user prompts in download bundle

### DIFF
--- a/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/__tests__/route.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import AdmZip from "adm-zip";
 import { POST } from "../route";
 import {
   createTestRequest,
@@ -382,6 +383,182 @@ describe("POST /api/zero/developer-support", () => {
     );
     expect(step2.status).toBe(200);
     expect((await step2.json()).reference).toBeDefined();
+  });
+
+  it("includes user prompts as user_prompt events in chat-history.jsonl", async () => {
+    const prompt = "test prompt"; // default prompt from createTestRunInDb
+    const { token } = await setupRunContext(user);
+
+    // Step 1: Get consent code
+    const step1 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc" },
+      token,
+    );
+    const { consentCode } = await step1.json();
+
+    // Mock Axiom to return an assistant event
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      {
+        runId: "r1",
+        eventType: "assistant",
+        eventData: { message: "I'll fix the bug" },
+        _time: "2024-01-01T00:01:00Z",
+        sequenceNumber: 1,
+      },
+    ]);
+
+    // Step 2: Submit
+    const step2 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc", consentCode },
+      token,
+    );
+    expect(step2.status).toBe(200);
+
+    // Extract ZIP and parse chat-history.jsonl
+    const zipBuffer = context.mocks.s3.uploadS3Buffer.mock
+      .calls[0]![2] as Buffer;
+    const zip = new AdmZip(zipBuffer);
+    const chatHistoryEntry = zip.getEntry("chat-history.jsonl");
+    expect(chatHistoryEntry).toBeDefined();
+
+    const lines = chatHistoryEntry!
+      .getData()
+      .toString("utf-8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        return JSON.parse(line);
+      });
+
+    // Verify a user_prompt event exists with the run's prompt
+    const promptEvent = lines.find((e: Record<string, unknown>) => {
+      return e.eventType === "user_prompt";
+    });
+    expect(promptEvent).toBeDefined();
+    expect(promptEvent.eventData.role).toBe("user");
+    expect(promptEvent.eventData.content).toBe(prompt);
+    expect(promptEvent.sequenceNumber).toBe(-1);
+
+    // Verify agent-events.jsonl no longer exists
+    expect(zip.getEntry("agent-events.jsonl")).toBeNull();
+  });
+
+  it("includes prompts from all runs in multi-run session ordered chronologically", async () => {
+    const sessionId = crypto.randomUUID();
+    const firstPrompt = "Deploy the new feature";
+    const secondPrompt = "Now fix the failing test";
+
+    // Create first run (completed, earlier createdAt)
+    const { composeId: composeId1 } = await createTestCompose(
+      uniqueId("agent"),
+    );
+    const { runId: firstRunId } = await createTestRunInDb(
+      user.userId,
+      composeId1,
+      {
+        status: "completed",
+        prompt: firstPrompt,
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+        result: {
+          agentSessionId: sessionId,
+          checkpointId: "cp-1",
+          conversationId: "cv-1",
+        },
+      },
+    );
+
+    // Create continuation run (current, later createdAt)
+    const { composeId: composeId2 } = await createTestCompose(
+      uniqueId("agent"),
+    );
+    const { runId: currentRunId } = await createTestRunInDb(
+      user.userId,
+      composeId2,
+      {
+        status: "running",
+        prompt: secondPrompt,
+        createdAt: new Date("2024-01-01T01:00:00Z"),
+        continuedFromSessionId: sessionId,
+      },
+    );
+
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
+    mockClerk({ userId: null });
+    const token = await generateZeroToken(
+      user.userId,
+      currentRunId,
+      user.orgId,
+    );
+
+    // Get consent code
+    const step1 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc" },
+      token,
+    );
+    const { consentCode } = await step1.json();
+
+    // Mock Axiom events for both runs
+    context.mocks.axiom.queryAxiom.mockResolvedValueOnce([
+      {
+        runId: firstRunId,
+        eventType: "assistant",
+        _time: "2024-01-01T00:00:30Z",
+        sequenceNumber: 1,
+        eventData: {},
+      },
+      {
+        runId: currentRunId,
+        eventType: "assistant",
+        _time: "2024-01-01T01:00:30Z",
+        sequenceNumber: 1,
+        eventData: {},
+      },
+    ]);
+
+    const step2 = await postDeveloperSupport(
+      { title: "Bug", description: "Desc", consentCode },
+      token,
+    );
+    expect(step2.status).toBe(200);
+
+    // Extract ZIP and parse chat-history.jsonl
+    const zipBuffer = context.mocks.s3.uploadS3Buffer.mock
+      .calls[0]![2] as Buffer;
+    const zip = new AdmZip(zipBuffer);
+    const lines = zip
+      .getEntry("chat-history.jsonl")!
+      .getData()
+      .toString("utf-8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        return JSON.parse(line);
+      });
+
+    // Find prompt events
+    const promptEvents = lines.filter((e: Record<string, unknown>) => {
+      return e.eventType === "user_prompt";
+    });
+    expect(promptEvents).toHaveLength(2);
+
+    // First prompt should come before second prompt (chronological)
+    expect(promptEvents[0].eventData.content).toBe(firstPrompt);
+    expect(promptEvents[0].runId).toBe(firstRunId);
+    expect(promptEvents[1].eventData.content).toBe(secondPrompt);
+    expect(promptEvents[1].runId).toBe(currentRunId);
+
+    // Verify each prompt appears before its run's assistant events
+    const firstPromptIdx = lines.findIndex((e: Record<string, unknown>) => {
+      return e.eventType === "user_prompt" && e.runId === firstRunId;
+    });
+    const firstAssistantIdx = lines.findIndex((e: Record<string, unknown>) => {
+      return e.eventType === "assistant" && e.runId === firstRunId;
+    });
+    expect(firstPromptIdx).toBeLessThan(firstAssistantIdx);
   });
 
   it("returns 403 when token lacks runId and orgId", async () => {

--- a/turbo/apps/web/app/api/zero/developer-support/route.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/route.ts
@@ -204,26 +204,38 @@ const router = tsr.router(zeroDeveloperSupportContract, {
       }
     }
 
-    // Collect all run IDs for agent events.
+    // Collect all runs for agent events (with prompt + createdAt for chat history).
     // With a session: find continuation runs + first run (via result->>'agentSessionId').
-    // Without a session (first run): fall back to just the current runId.
-    const sessionRunIds: string[] = sessionId
-      ? (
-          await db
-            .select({ id: agentRuns.id })
-            .from(agentRuns)
-            .where(
-              or(
-                eq(agentRuns.continuedFromSessionId, sessionId),
-                sql`${agentRuns.result}->>'agentSessionId' = ${sessionId}`,
-              ),
-            )
-        ).map((r) => {
-          return r.id;
-        })
-      : [runId];
+    // Without a session (first run): fall back to just the current run.
+    const sessionRuns = sessionId
+      ? await db
+          .select({
+            id: agentRuns.id,
+            prompt: agentRuns.prompt,
+            createdAt: agentRuns.createdAt,
+          })
+          .from(agentRuns)
+          .where(
+            or(
+              eq(agentRuns.continuedFromSessionId, sessionId),
+              sql`${agentRuns.result}->>'agentSessionId' = ${sessionId}`,
+            ),
+          )
+          .orderBy(agentRuns.createdAt)
+      : await db
+          .select({
+            id: agentRuns.id,
+            prompt: agentRuns.prompt,
+            createdAt: agentRuns.createdAt,
+          })
+          .from(agentRuns)
+          .where(eq(agentRuns.id, runId))
+          .limit(1);
 
     // Query Axiom for agent events from all session runs
+    const sessionRunIds = sessionRuns.map((r) => {
+      return r.id;
+    });
     const agentEvents = await (async () => {
       if (sessionRunIds.length === 0) return [];
       const runIdList = sessionRunIds
@@ -244,10 +256,36 @@ const router = tsr.router(zeroDeveloperSupportContract, {
       return [];
     });
 
-    log.info("Collected agent events for diagnostic bundle", {
+    // Synthesize user_prompt events from agent_runs.prompt and merge with Axiom events
+    const promptEvents = sessionRuns.map((r) => {
+      return {
+        runId: r.id,
+        eventType: "user_prompt",
+        sequenceNumber: -1,
+        eventData: {
+          type: "user_prompt",
+          sequenceNumber: -1,
+          role: "user",
+          content: r.prompt,
+        },
+        _time: r.createdAt.toISOString(),
+      };
+    });
+
+    const chatHistory = [...promptEvents, ...agentEvents].sort((a, b) => {
+      const timeA = (a as Record<string, unknown>)._time as string;
+      const timeB = (b as Record<string, unknown>)._time as string;
+      if (timeA !== timeB) return timeA < timeB ? -1 : 1;
+      const seqA = (a as Record<string, unknown>).sequenceNumber as number;
+      const seqB = (b as Record<string, unknown>).sequenceNumber as number;
+      return seqA - seqB;
+    });
+
+    log.info("Collected chat history for diagnostic bundle", {
       reference,
       runCount: sessionRunIds.length,
       eventCount: agentEvents.length,
+      promptCount: promptEvents.length,
     });
 
     // Safe connector subset (no tokens)
@@ -282,8 +320,8 @@ const router = tsr.router(zeroDeveloperSupportContract, {
         content: `# ${body.title}\n\n${body.description}`,
       },
       {
-        path: "agent-events.jsonl",
-        content: agentEvents
+        path: "chat-history.jsonl",
+        content: chatHistory
           .map((e) => {
             return JSON.stringify(e);
           })

--- a/turbo/apps/web/app/api/zero/developer-support/route.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/route.ts
@@ -63,6 +63,14 @@ interface ZipEntry {
   content: string;
 }
 
+interface ChatHistoryEvent {
+  runId: string;
+  eventType: string;
+  sequenceNumber: number;
+  eventData: Record<string, unknown>;
+  _time: string;
+}
+
 async function assembleZip(entries: ZipEntry[]): Promise<Buffer> {
   const archive = archiver("zip", { zlib: { level: 6 } });
   const chunks: Buffer[] = [];
@@ -248,16 +256,16 @@ const router = tsr.router(zeroDeveloperSupportContract, {
 | where runId in (${runIdList})
 | order by _time asc, sequenceNumber asc
 | limit 2000`;
-      return queryAxiom(apl);
+      return queryAxiom<ChatHistoryEvent>(apl);
     })().catch((err) => {
       log.warn("Failed to collect agent events from Axiom", {
         error: String(err),
       });
-      return [];
+      return [] as ChatHistoryEvent[];
     });
 
     // Synthesize user_prompt events from agent_runs.prompt and merge with Axiom events
-    const promptEvents = sessionRuns.map((r) => {
+    const promptEvents: ChatHistoryEvent[] = sessionRuns.map((r) => {
       return {
         runId: r.id,
         eventType: "user_prompt",
@@ -273,12 +281,8 @@ const router = tsr.router(zeroDeveloperSupportContract, {
     });
 
     const chatHistory = [...promptEvents, ...agentEvents].sort((a, b) => {
-      const timeA = (a as Record<string, unknown>)._time as string;
-      const timeB = (b as Record<string, unknown>)._time as string;
-      if (timeA !== timeB) return timeA < timeB ? -1 : 1;
-      const seqA = (a as Record<string, unknown>).sequenceNumber as number;
-      const seqB = (b as Record<string, unknown>).sequenceNumber as number;
-      return seqA - seqB;
+      if (a._time !== b._time) return a._time < b._time ? -1 : 1;
+      return a.sequenceNumber - b.sequenceNumber;
     });
 
     log.info("Collected chat history for diagnostic bundle", {

--- a/turbo/apps/web/package.json
+++ b/turbo/apps/web/package.json
@@ -18,7 +18,6 @@
     "db:reset": "tsx scripts/reset-db.ts"
   },
   "dependencies": {
-    "@vm0/ui": "workspace:*",
     "@aws-sdk/client-s3": "^3.1024.0",
     "@aws-sdk/s3-request-presigner": "^3.1024.0",
     "@axiomhq/js": "^1.3.1",
@@ -35,6 +34,7 @@
     "@ts-rest/core": "3.53.0-rc.1",
     "@ts-rest/serverless": "3.53.0-rc.1",
     "@vm0/core": "workspace:*",
+    "@vm0/ui": "workspace:*",
     "ably": "^2.17.0",
     "archiver": "^7.0.1",
     "cpu-features": "0.0.10",
@@ -64,6 +64,7 @@
     "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/adm-zip": "^0.5.8",
     "@types/archiver": "^7.0.0",
     "@types/html-to-text": "^9.0.4",
     "@types/node": "^24.3.0",
@@ -74,6 +75,7 @@
     "@typescript-eslint/utils": "^8.58.0",
     "@vm0/eslint-config": "workspace:*",
     "@vm0/typescript-config": "workspace:*",
+    "adm-zip": "^0.5.17",
     "drizzle-kit": "^0.31.9",
     "e2b": "^2.10.3",
     "eslint": "^9.34.0",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -485,6 +485,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/adm-zip':
+        specifier: ^0.5.8
+        version: 0.5.8
       '@types/archiver':
         specifier: ^7.0.0
         version: 7.0.0
@@ -515,6 +518,9 @@ importers:
       '@vm0/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
+      adm-zip:
+        specifier: ^0.5.17
+        version: 0.5.17
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.10
@@ -4475,6 +4481,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/adm-zip@0.5.8':
+    resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
+
   '@types/archiver@7.0.0':
     resolution: {integrity: sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==}
 
@@ -4910,6 +4919,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.17:
+    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -13151,6 +13164,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/adm-zip@0.5.8':
+    dependencies:
+      '@types/node': 24.3.0
+
   '@types/archiver@7.0.0':
     dependencies:
       '@types/readdir-glob': 1.1.5
@@ -13689,6 +13706,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  adm-zip@0.5.17: {}
 
   agent-base@6.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

- Extend the `sessionRunIds` query in the developer-support route to also select `prompt` and `createdAt` from `agent_runs`
- Synthesize `user_prompt` events (with `sequenceNumber: -1`) for each run's prompt and merge them chronologically with Axiom agent events
- Rename the ZIP entry from `agent-events.jsonl` to `chat-history.jsonl` for full conversation reconstruction

## Test plan

- [x] Existing 11 tests pass unchanged
- [x] New test: verifies `chat-history.jsonl` contains `user_prompt` events with correct prompt content, role, and sequenceNumber
- [x] New test: verifies multi-run sessions include all prompts ordered chronologically, each appearing before its run's assistant events
- [x] Lint, type-check, format, and knip all pass

Closes #8460

🤖 Generated with [Claude Code](https://claude.com/claude-code)