### PR TITLE
fix(firewalls): add docusign oauth endpoints to firewall config

### DIFF
--- a/turbo/packages/core/src/firewalls/docusign.generated.ts
+++ b/turbo/packages/core/src/firewalls/docusign.generated.ts
@@ -86,5 +86,23 @@ export const docusignFirewall = {
       },
       permissions: [],
     },
+    {
+      base: "https://account.docusign.com",
+      auth: {
+        headers: {
+          Authorization: "Bearer ${{ secrets.DOCUSIGN_TOKEN }}",
+        },
+      },
+      permissions: [],
+    },
+    {
+      base: "https://account-d.docusign.com",
+      auth: {
+        headers: {
+          Authorization: "Bearer ${{ secrets.DOCUSIGN_TOKEN }}",
+        },
+      },
+      permissions: [],
+    },
   ],
 } as const satisfies FirewallConfig;

--- a/turbo/packages/firewalls-generator/src/docusign.ts
+++ b/turbo/packages/firewalls-generator/src/docusign.ts
@@ -31,9 +31,18 @@ const DOCUSIGN_DOMAINS = [
   "demo.docusign.net",
 ];
 
+// OAuth/userinfo endpoints — required to discover the correct regional
+// API base URI before making any eSignature API calls.
+// See: https://developers.docusign.com/platform/auth/reference/user-info/
+const DOCUSIGN_OAUTH_DOMAINS = [
+  "account.docusign.com", // production
+  "account-d.docusign.com", // demo/development
+];
+
 function generateTypeScript(): string {
-  const apiEntries = DOCUSIGN_DOMAINS.map(
-    (domain) => `    {
+  const apiEntries = [...DOCUSIGN_DOMAINS, ...DOCUSIGN_OAUTH_DOMAINS]
+    .map(
+      (domain) => `    {
       base: "https://${domain}",
       auth: {
         headers: {
@@ -42,7 +51,8 @@ function generateTypeScript(): string {
       },
       permissions: [],
     }`,
-  ).join(",\n");
+    )
+    .join(",\n");
 
   const lines: string[] = [
     "// Auto-generated from DocuSign API docs.",


### PR DESCRIPTION
## Summary
- Add `account.docusign.com` (production) and `account-d.docusign.com` (demo) to DocuSign firewall
- The `/oauth/userinfo` endpoint on these domains is required to discover the correct regional API base URI before making eSignature API calls
- Uses same Bearer token auth as other DocuSign endpoints

## Test plan
- [x] `firewall-secret-consistency` test passes (129 tests)
- [x] `check-types` passes