### PR TITLE
fix(ui): remove optimistic pin state to eliminate agent list dialog button blink

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-pinned-agents.ts
@@ -5,13 +5,9 @@ import { zeroClient$ } from "../api-client.ts";
 import { clerk$ } from "../auth.ts";
 import { zeroOnboardingStatus$ } from "./zero-onboarding.ts";
 import { agents$, defaultAgentId$ } from "../agent.ts";
+import { currentChatAgentId$ } from "../agent-chat.ts";
 
 const reloadPinned$ = state(0);
-
-/**
- * Optimistic override — when set, takes precedence over the server value.
- */
-const optimisticPinnedIds$ = state<string[] | null>(null);
 
 /**
  * Pinned agent IDs fetched from user preferences API.
@@ -25,35 +21,21 @@ const serverPinnedIds$ = computed(async (get) => {
 });
 
 /**
- * Effective pinned agent IDs — optimistic value if set, otherwise server value.
+ * Effective pinned agent IDs — always reads from server.
  */
 export const pinnedAgentIds$ = computed(async (get) => {
   const status = await get(zeroOnboardingStatus$);
   const defaultAgentId = status.defaultAgentId;
-  const optimistic = get(optimisticPinnedIds$);
-  if (optimistic !== null) {
-    return [
-      defaultAgentId,
-      ...optimistic.filter((id) => {
-        return id !== defaultAgentId;
-      }),
-    ].filter((a) => {
-      return a !== null;
-    });
-  }
   return [
     defaultAgentId,
     ...(await get(serverPinnedIds$)).filter((id) => {
       return id !== defaultAgentId;
     }),
-  ].filter((a) => {
+  ].filter((a): a is string => {
     return a !== null;
   });
 });
 
-/**
- * Update pinned agent IDs on the server with optimistic UI.
- */
 /** Pinned agent IDs resolved to full agent objects. */
 export const pinnedAgents$ = computed(async (get) => {
   const ids = await get(pinnedAgentIds$);
@@ -69,6 +51,18 @@ export const pinnedAgents$ = computed(async (get) => {
     });
 });
 
+/**
+ * Whether the current chat agent is pinned. Returns null if no agent is selected.
+ */
+export const currentChatAgentPinned$ = computed(async (get) => {
+  const agentId = await get(currentChatAgentId$);
+  if (!agentId) {
+    return null;
+  }
+  const ids = await get(pinnedAgentIds$);
+  return ids.includes(agentId);
+});
+
 export const updatePinnedAgentIds$ = command(
   async ({ get, set }, ids: string[], signal: AbortSignal) => {
     const defaultAgentId = await get(defaultAgentId$);
@@ -77,30 +71,25 @@ export const updatePinnedAgentIds$ = command(
       return id !== defaultAgentId;
     });
 
-    set(optimisticPinnedIds$, ids);
-    try {
-      const createClient = get(zeroClient$);
-      const client = createClient(zeroUserPreferencesContract);
-      await accept(
-        client.update({
-          body: { pinnedAgentIds: ids },
-          fetchOptions: { signal },
-        }),
-        [200],
-      );
-      signal.throwIfAborted();
+    const createClient = get(zeroClient$);
+    const client = createClient(zeroUserPreferencesContract);
+    await accept(
+      client.update({
+        body: { pinnedAgentIds: ids },
+        fetchOptions: { signal },
+      }),
+      [200],
+    );
+    signal.throwIfAborted();
 
-      const clerk = await get(clerk$);
-      signal.throwIfAborted();
+    const clerk = await get(clerk$);
+    signal.throwIfAborted();
 
-      await clerk.session?.getToken({ skipCache: true });
-      signal.throwIfAborted();
+    await clerk.session?.getToken({ skipCache: true });
+    signal.throwIfAborted();
 
-      set(reloadPinned$, (x) => {
-        return x + 1;
-      });
-    } finally {
-      set(optimisticPinnedIds$, null);
-    }
+    set(reloadPinned$, (x) => {
+      return x + 1;
+    });
   },
 );

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-dialogs.test.tsx
@@ -542,3 +542,64 @@ describe("managePinnedAgentsDialog - reorder handle is present (SIDEBAR-D-041)",
     });
   });
 });
+
+describe("chatListDialog - pin buttons disabled during save (SIDEBAR-D-042)", () => {
+  it("disables pin and reorder buttons while save is in progress and re-enables after completion", async () => {
+    const user = userEvent.setup();
+    let resolvePost: (() => void) | undefined;
+    const postPromise = new Promise<void>((resolve) => {
+      resolvePost = resolve;
+    });
+
+    mockAPIsWithSubagents({ pinnedAgentIds: ["pinned-agent-id"] });
+    server.use(
+      http.post("*/api/zero/user-preferences", async () => {
+        await postPromise;
+        return HttpResponse.json({
+          timezone: null,
+          pinnedAgentIds: ["pinned-agent-id", "unpinned-agent-id"],
+          sendMode: "enter" as const,
+          captureNetworkBodiesRemaining: 0,
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/agents" });
+    await openChatListDialog(user);
+
+    const dialog = screen.getByRole("dialog");
+
+    // Wait for both pinned and unpinned agents to load
+    await waitFor(() => {
+      expect(within(dialog).getByText("Pinned")).toBeInTheDocument();
+      expect(within(dialog).getByText("Others")).toBeInTheDocument();
+    });
+
+    // Click the pin button for the unpinned agent to trigger a save
+    const pinButton = within(dialog).getByLabelText("Pin to sidebar");
+    await user.click(pinButton);
+
+    // While save is pending, existing pin/unpin/reorder buttons should be disabled
+    await waitFor(() => {
+      expect(
+        within(dialog).getByLabelText("Unpin Pinned Agent"),
+      ).toBeDisabled();
+      expect(
+        within(dialog).getByLabelText("Reorder Pinned Agent"),
+      ).toBeDisabled();
+    });
+
+    // Resolve the pending request
+    resolvePost!();
+
+    // After save completes, buttons should be re-enabled
+    await waitFor(() => {
+      expect(
+        within(dialog).getByLabelText("Unpin Pinned Agent"),
+      ).not.toBeDisabled();
+      expect(
+        within(dialog).getByLabelText("Reorder Pinned Agent"),
+      ).not.toBeDisabled();
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -6,6 +6,7 @@ import {
   useLastResolved,
   useResolved,
 } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { user$ } from "../../signals/auth.ts";
 import { IconArrowUpRight, IconPin, IconUserPlus } from "@tabler/icons-react";
@@ -24,6 +25,7 @@ import {
 import {
   pinnedAgentIds$,
   updatePinnedAgentIds$,
+  currentChatAgentPinned$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
 
 import { detach, Reason } from "../../signals/utils.ts";
@@ -209,11 +211,11 @@ export function AgentChatPage() {
   const navigate = useSet(detachedNavigateTo$);
 
   const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
-  const savePinnedIds = useSet(updatePinnedAgentIds$);
+  const pinnedStatus = useLastResolved(currentChatAgentPinned$);
+  const showPinPill = pinnedStatus === false;
+  const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
+  const pinSaving = pinLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
-
-  const showPinPill =
-    currentChatAgentId && !pinnedIds.includes(currentChatAgentId);
 
   const handlePin = () => {
     if (currentChatAgentId) {
@@ -293,7 +295,8 @@ export function AgentChatPage() {
                       <button
                         type="button"
                         onClick={handlePin}
-                        className="absolute -top-0.5 -right-0.5 flex h-6 w-6 items-center justify-center rounded-full zero-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground hover:shadow-md cursor-pointer"
+                        disabled={pinSaving}
+                        className="absolute -top-0.5 -right-0.5 flex h-6 w-6 items-center justify-center rounded-full zero-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground hover:shadow-md cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
                         aria-label="Pin to sidebar"
                       >
                         <IconPin size={12} stroke={2} />

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -6,6 +6,7 @@ import {
   useLastResolved,
   useResolved,
 } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import {
   IconAlertCircle,
@@ -45,6 +46,7 @@ import avatar1Img from "./assets/avatar_1.webp";
 import {
   pinnedAgentIds$,
   updatePinnedAgentIds$,
+  currentChatAgentPinned$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
 
 import {
@@ -134,16 +136,11 @@ function ChatThreadHeader() {
   const pageSignal = useGet(pageSignal$);
 
   // Pin pill
-  const pinnedLoadable = useLastLoadable(pinnedAgentIds$);
-  const pinnedIds = (
-    pinnedLoadable.state === "hasData" ? pinnedLoadable.data : []
-  ).filter((id): id is string => {
-    return id !== null;
-  });
-  const savePinnedIds = useSet(updatePinnedAgentIds$);
-  const showPinPill =
-    typeof currentChatAgentId === "string" &&
-    !pinnedIds.includes(currentChatAgentId);
+  const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
+  const pinnedStatus = useLastResolved(currentChatAgentPinned$);
+  const showPinPill = pinnedStatus === false;
+  const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
+  const pinSaving = pinLoadable.state === "loading";
   const handlePin = () => {
     if (currentChatAgentId) {
       detach(
@@ -195,7 +192,8 @@ function ChatThreadHeader() {
                   <button
                     type="button"
                     onClick={handlePin}
-                    className="absolute -top-0.5 -right-0.5 flex h-5 w-5 items-center justify-center rounded-full zero-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground hover:shadow-md cursor-pointer"
+                    disabled={pinSaving}
+                    className="absolute -top-0.5 -right-0.5 flex h-5 w-5 items-center justify-center rounded-full zero-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground hover:shadow-md cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
                     aria-label="Pin to sidebar"
                   >
                     <IconPin size={10} stroke={2} />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-dialogs.tsx
@@ -1,4 +1,5 @@
 import { useGet, useSet, useLastResolved } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import {
   IconSearch,
   IconX,
@@ -43,16 +44,24 @@ import {
   setDraftPinnedIds$,
 } from "../../signals/zero-page/zero-sidebar-state.ts";
 import { leadAgentAvatar$, type SubagentInfo } from "../../signals/agent.ts";
+import {
+  pinnedAgentIds$,
+  updatePinnedAgentIds$,
+} from "../../signals/zero-page/zero-pinned-agents.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 
 function SortablePinnedAgent({
   agent,
   onUnpin,
   onChat,
+  disabled,
 }: {
   agent: SubagentInfo;
   onUnpin: () => void;
   onChat?: () => void;
+  disabled?: boolean;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: agent.id });
@@ -97,8 +106,9 @@ function SortablePinnedAgent({
       <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
         <button
           type="button"
-          className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg cursor-grab active:cursor-grabbing touch-none text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18"
+          className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg cursor-grab active:cursor-grabbing touch-none text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
           aria-label={`Reorder ${agent.displayName ?? agent.id}`}
+          disabled={disabled}
           {...attributes}
           {...listeners}
         >
@@ -106,9 +116,10 @@ function SortablePinnedAgent({
         </button>
         <button
           type="button"
-          className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18"
+          className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
           onClick={onUnpin}
           aria-label={`Unpin ${agent.displayName ?? agent.id}`}
+          disabled={disabled}
         >
           <IconX size={16} stroke={2} />
         </button>
@@ -346,26 +357,26 @@ export function ManagePinnedAgentsDialog({
   );
 }
 
-export function ChatListDialog({
+export function AgentListDialog({
   open,
   onOpenChange,
   displayName,
   subagents,
-  pinnedIds,
-  onPinnedIdsChange,
   onNewChat,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   displayName: string;
   subagents: SubagentInfo[];
-  pinnedIds: string[];
-  onPinnedIdsChange: (ids: string[]) => void;
   onNewChat?: (agentId: string | null) => void;
 }) {
   const zeroAvatarSrc = useLastResolved(leadAgentAvatar$) ?? null;
   const query = useGet(chatListQuery$);
   const setQuery = useSet(setChatListQuery$);
+  const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
+  const pageSignal = useGet(pageSignal$);
+  const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
+  const saving = pinLoadable.state === "loading";
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -409,15 +420,12 @@ export function ChatListDialog({
     !trimmedQuery || displayName.toLowerCase().includes(trimmedQuery);
 
   const togglePin = (agentId: string) => {
-    if (pinnedIds.includes(agentId)) {
-      onPinnedIdsChange(
-        pinnedIds.filter((id) => {
+    const next = pinnedIds.includes(agentId)
+      ? pinnedIds.filter((id) => {
           return id !== agentId;
-        }),
-      );
-    } else {
-      onPinnedIdsChange([...pinnedIds, agentId]);
-    }
+        })
+      : [...pinnedIds, agentId];
+    detach(savePinnedIds(next, pageSignal), Reason.DomCallback);
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -433,7 +441,7 @@ export function ChatListDialog({
     const next = [...pinnedIds];
     next.splice(oldIndex, 1);
     next.splice(newIndex, 0, pinnedIds[oldIndex]!);
-    onPinnedIdsChange(next);
+    detach(savePinnedIds(next, pageSignal), Reason.DomCallback);
   };
 
   const handleChat = (agentId: string | null) => {
@@ -551,6 +559,7 @@ export function ChatListDialog({
                           onChat={() => {
                             return handleChat(agent.id);
                           }}
+                          disabled={saving}
                         />
                       );
                     })}
@@ -594,11 +603,12 @@ export function ChatListDialog({
                           <TooltipTrigger asChild>
                             <button
                               type="button"
-                              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18"
+                              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-all duration-150 group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted-foreground/12 hover:text-foreground dark:hover:bg-muted-foreground/18 disabled:cursor-not-allowed disabled:opacity-50"
                               onClick={() => {
                                 return togglePin(agent.id);
                               }}
                               aria-label="Pin to sidebar"
+                              disabled={saving}
                             >
                               <IconPin size={16} stroke={2} />
                             </button>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -4,6 +4,7 @@ import {
   useLastResolved,
   useLastLoadable,
 } from "ccstate-react";
+import { useLoadableSet } from "ccstate-react/experimental";
 import { IconPlus, IconChevronRight, IconX } from "@tabler/icons-react";
 import {
   Tooltip,
@@ -42,7 +43,7 @@ import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
-import { ChatListDialog } from "./zero-sidebar-dialogs.tsx";
+import { AgentListDialog } from "./zero-sidebar-dialogs.tsx";
 
 export function PinnedAgentListSection() {
   const activeRoute = useGet(activeRoute$);
@@ -66,7 +67,8 @@ export function PinnedAgentListSection() {
   const collapsed = useGet(agentCardCollapsed$);
   const setCollapsed = useSet(setAgentCardCollapsed$);
   const reloadAgents = useSet(reloadAgents$);
-  const savePinnedIds = useSet(updatePinnedAgentIds$);
+  const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
+  const savingPinned = pinLoadable.state === "loading";
   const createNewChat = useSet(createNewChatThread$);
   const setExpanded = useSet(setSidebarExpanded$);
   const pageSignal = useGet(pageSignal$);
@@ -184,7 +186,8 @@ export function PinnedAgentListSection() {
                                   }),
                                 );
                               }}
-                              className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 ${
+                              disabled={savingPinned}
+                              className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 disabled:cursor-not-allowed disabled:opacity-50 ${
                                 isPrimarySelected
                                   ? "text-slate-500 hover:text-slate-900 hover:bg-slate-300"
                                   : "text-sidebar-foreground/80 hover:text-foreground hover:bg-sidebar-foreground/10"
@@ -207,13 +210,11 @@ export function PinnedAgentListSection() {
         </div>
       )}
 
-      <ChatListDialog
+      <AgentListDialog
         open={chatListOpen}
         onOpenChange={setChatListOpenFn}
         displayName={displayName}
         subagents={subagents}
-        pinnedIds={pinnedIds}
-        onPinnedIdsChange={onPinnedIdsChange}
         onNewChat={onNewChat}
       />
     </div>


### PR DESCRIPTION
## Summary

- Removes the shared `optimisticPinnedIds$` atom that caused pin button blinking when concurrent `updatePinnedAgentIds$` commands cleared each other's optimistic state
- Simplifies `pinnedAgentIds$` to always read from the server, eliminates the `try/finally` clear pattern
- Renames `ChatListDialog` to `AgentListDialog` and makes it self-contained (reads signals internally instead of accepting `pinnedIds`/`onPinnedIdsChange` props)
- Adds `currentChatAgentPinned$` computed signal for clean pin pill visibility in thread/chat pages
- Disables pin/unpin/reorder buttons during save operations via `useLoadableSet` loading state

## Test plan

- [x] All existing pin-related tests pass (`zero-sidebar-dialogs`, `zero-chat-thread-page-interaction`, `zero-chat-page-interaction`, `zero-chat-thread-page-display`, `pinned-agent-switch`) — 41 tests total
- [x] TypeScript types pass
- [x] Lint passes
- [x] Knip finds no unused exports

Closes #8461

🤖 Generated with [Claude Code](https://claude.com/claude-code)