### PR TITLE
fix(slack): skip channel context fetch for dm conversations

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -228,7 +228,7 @@ install_packages() {
   export DEBIAN_FRONTEND=noninteractive
   apt-get update
   apt-get install -y \
-    procps wget git ripgrep jq file iproute2 sudo \
+    procps wget git ripgrep jq file iproute2 sudo ffmpeg \
     libnss3 p11-kit-modules unzip \
     nodejs \
     python3 python3-pip \

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
@@ -29,7 +29,7 @@ export const STATUS_LABELS: Readonly<Record<LogStatus, string>> = {
 
 /** With source column (activity page) */
 const GRID_WITH_SOURCE =
-  "grid grid-cols-[minmax(6rem,1fr)_minmax(8rem,1.5fr)_6rem_8rem_5rem_2.5rem] gap-x-6 items-center";
+  "grid grid-cols-[minmax(6rem,1fr)_minmax(8rem,1.5fr)_minmax(4rem,0.8fr)_6rem_8rem_5rem_2.5rem] gap-x-6 items-center";
 
 /** Without source column (schedule history) */
 const GRID_WITHOUT_SOURCE =
@@ -69,6 +69,14 @@ function LogRow({
                   entry.triggerAgentName,
                 )
               : "\u2014"}
+          </div>
+        )}
+        {showSource && (
+          <div
+            className="min-w-0 truncate text-left text-sm text-muted-foreground font-mono"
+            title={entry.sessionId ?? undefined}
+          >
+            {entry.sessionId ? entry.sessionId.slice(0, 8) : "\u2014"}
           </div>
         )}
         <div className="text-left">
@@ -133,6 +141,9 @@ function SkeletonRows({
             {showSource && (
               <div className="h-4 w-12 rounded bg-muted/50 animate-pulse" />
             )}
+            {showSource && (
+              <div className="h-4 w-14 rounded bg-muted/50 animate-pulse" />
+            )}
             <div className="h-5 w-16 rounded-full bg-muted/50 animate-pulse" />
             <div className="h-4 w-24 rounded bg-muted/50 animate-pulse" />
             <div className="h-4 w-14 rounded bg-muted/50 animate-pulse" />
@@ -192,6 +203,7 @@ export function LogTable({
           >
             <div className="text-left">Agent</div>
             {showSource && <div className="text-left">Source</div>}
+            {showSource && <div className="text-left">Session</div>}
             <div className="text-left">Status</div>
             <div className="text-left">Start Time</div>
             <div className="text-left">Duration</div>

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/__tests__/shared.test.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/__tests__/shared.test.ts
@@ -345,6 +345,55 @@ describe("fetchConversationContexts", () => {
     expect(client.conversations.history).toHaveBeenCalledTimes(1);
   });
 
+  it("should NOT fetch channel context for DM without thread", async () => {
+    const client = createMockConversationClient({
+      channelMessages: [{ user: "U100", text: "Should not appear", ts: "1.0" }],
+    });
+
+    const { executionContext } = await fetchConversationContexts(
+      client,
+      "D-dm-channel", // DM channel ID starts with "D"
+      undefined, // no threadTs
+      "BBOT",
+      "xoxb-token",
+      undefined,
+      undefined,
+    );
+
+    expect(executionContext).toBe("");
+    expect(client.conversations.history).not.toHaveBeenCalled();
+  });
+
+  it("should NOT fetch channel context for DM first thread session", async () => {
+    const client = createMockConversationClient({
+      threadMessages: [
+        { user: "U100", text: "DM thread parent", ts: "100.0" },
+        { user: "U200", text: "DM reply", ts: "100.1" },
+      ],
+      channelMessages: [
+        { user: "U300", text: "Should not appear", ts: "99.0" },
+      ],
+    });
+
+    const { executionContext } = await fetchConversationContexts(
+      client,
+      "D-dm-channel", // DM channel ID
+      "100.0", // threadTs
+      "BBOT",
+      "xoxb-token",
+      undefined, // lastProcessedMessageTs
+      "100.1", // currentMessageTs
+      undefined, // no existingSessionId → first session
+    );
+
+    // Thread context should be present, but no channel context
+    expect(executionContext).toContain("# Slack Thread Context");
+    expect(executionContext).not.toContain("# Recent Channel Messages");
+    expect(executionContext).toContain("DM thread parent");
+    expect(executionContext).not.toContain("Should not appear");
+    expect(client.conversations.history).not.toHaveBeenCalled();
+  });
+
   describe("image upload in channel context prefix", () => {
     const context = testContext();
 

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/shared.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/shared.ts
@@ -242,6 +242,7 @@ export async function fetchConversationContexts(
   existingSessionId?: string,
 ): Promise<{ executionContext: string }> {
   const imageSessionId = `${channelId}-${threadTs ?? "channel"}`;
+  const isDm = channelId.startsWith("D");
   const contextType = threadTs ? "thread" : "channel";
 
   // First session in a thread (no existing session) — fetch channel messages
@@ -249,14 +250,21 @@ export async function fetchConversationContexts(
   const isFirstThreadSession = Boolean(threadTs && !existingSessionId);
 
   // Fetch all messages once (single Slack API call)
+  // DMs without a thread don't need channel context — the current message is
+  // already the full conversation context.
   const allMessages = threadTs
     ? await fetchThreadContext(client, channelId, threadTs)
-    : await fetchChannelContext(client, channelId, 10);
+    : isDm
+      ? []
+      : await fetchChannelContext(client, channelId, 10);
 
-  // For first thread mention, fetch the 10 channel messages before the thread
-  const channelMessages = isFirstThreadSession
-    ? await fetchChannelContext(client, channelId, 10, threadTs)
-    : [];
+  // For first thread mention in a non-DM channel, fetch the 10 channel messages
+  // before the thread so the agent has background context.
+  // DMs don't need channel history — the thread already contains the full conversation.
+  const channelMessages =
+    isFirstThreadSession && !isDm
+      ? await fetchChannelContext(client, channelId, 10, threadTs)
+      : [];
 
   // Exclude the current message (it's already sent as the prompt)
   const contextMessages = currentMessageTs


### PR DESCRIPTION
## Summary
- **Slack DM context**: Skip `fetchChannelContext` calls for DM conversations (channel IDs starting with "D") — both non-thread DMs and first thread sessions no longer fetch channel history
- **Runner rootfs**: Add `ffmpeg` to VM rootfs image for video frame extraction
- **Activity table**: Add Session ID column to the activity list page

## Test plan
- [x] Added test: DM without thread does not call `conversations.history`
- [x] Added test: DM first thread session skips channel context, only includes thread replies
- [x] Existing 17 tests pass without regression (19 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)