### PR TITLE
feat(firewalls): add graphql field modifier for rule matching

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -218,12 +218,12 @@ class FirewallBlock(NamedTuple):
     path: str
 
 
-def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None] | None:
-    """Parse a rule's path+suffix into (path, type_filter, op_filter).
+def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None, str | None] | None:
+    """Parse a rule's path+suffix into (path, type_filter, op_filter, field_filter).
 
     If the rule contains the ``GraphQL`` keyword, returns the path portion
-    and optional ``type:`` / ``operationName:`` filters.  Returns None when
-    the ``GraphQL`` keyword is absent (plain REST rule).
+    and optional ``type:`` / ``operationName:`` / ``field:`` filters.
+    Returns None when the ``GraphQL`` keyword is absent (plain REST rule).
     """
     gql_idx = rest.find(" GraphQL")
     if gql_idx == -1:
@@ -234,22 +234,134 @@ def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None] | None:
 
     type_filter: str | None = None
     op_filter: str | None = None
+    field_filter: str | None = None
 
     for part in suffix_parts[1:]:  # skip "GraphQL" itself
         if part.startswith("type:"):
             type_filter = part[5:]
         elif part.startswith("operationName:"):
             op_filter = part[14:]
+        elif part.startswith("field:"):
+            field_filter = part[6:]
 
-    return path, type_filter, op_filter
+    return path, type_filter, op_filter, field_filter
+
+
+def _extract_top_level_fields(query_str: str) -> list[str]:
+    """Extract top-level selection field names from a GraphQL query string.
+
+    Parses just enough to find the operation body's opening brace and then
+    extracts identifiers at depth 1.  Handles aliases (``alias: fieldName``)
+    by returning the field name, not the alias.
+    """
+    s = query_str.lstrip()
+    if not s:
+        return []
+
+    i = 0
+
+    # Skip operation keyword (query/mutation/subscription)
+    if s[0].isalpha():
+        while i < len(s) and s[i].isalpha():
+            i += 1
+        # Skip optional operation name
+        while i < len(s) and s[i].isspace():
+            i += 1
+        if i < len(s) and (s[i].isalpha() or s[i] == "_"):
+            while i < len(s) and (s[i].isalnum() or s[i] == "_"):
+                i += 1
+            while i < len(s) and s[i].isspace():
+                i += 1
+        # Skip optional variable definitions: ($var: Type, ...)
+        if i < len(s) and s[i] == "(":
+            depth = 1
+            i += 1
+            while i < len(s) and depth > 0:
+                if s[i] == "(":
+                    depth += 1
+                elif s[i] == ")":
+                    depth -= 1
+                i += 1
+            while i < len(s) and s[i].isspace():
+                i += 1
+
+    # Skip optional directives (@skip, @include, etc.) before opening brace
+    while i < len(s) and s[i] == "@":
+        while i < len(s) and not s[i].isspace() and s[i] != "{":
+            i += 1
+        # Directive might have arguments
+        if i < len(s) and s[i] == "(":
+            depth = 1
+            i += 1
+            while i < len(s) and depth > 0:
+                if s[i] == "(":
+                    depth += 1
+                elif s[i] == ")":
+                    depth -= 1
+                i += 1
+        while i < len(s) and s[i].isspace():
+            i += 1
+
+    # Find opening brace of selection set
+    if i >= len(s) or s[i] != "{":
+        return []
+    i += 1  # skip '{'
+
+    fields: list[str] = []
+    depth = 1
+
+    while i < len(s) and depth > 0:
+        c = s[i]
+        if c == "{":
+            depth += 1
+            i += 1
+        elif c == "}":
+            depth -= 1
+            i += 1
+        elif depth == 1 and (c.isalpha() or c == "_"):
+            # Read identifier
+            j = i
+            while j < len(s) and (s[j].isalnum() or s[j] == "_"):
+                j += 1
+            ident = s[i:j]
+            i = j
+            # Skip whitespace
+            while i < len(s) and s[i].isspace():
+                i += 1
+            # Check if this is an alias (followed by ':')
+            if i < len(s) and s[i] == ":":
+                i += 1  # skip ':'
+                while i < len(s) and s[i].isspace():
+                    i += 1
+                # Read the actual field name
+                j = i
+                while j < len(s) and (s[j].isalnum() or s[j] == "_"):
+                    j += 1
+                if j > i:
+                    fields.append(s[i:j])
+                i = j
+            else:
+                fields.append(ident)
+        else:
+            i += 1
+
+    return fields
+
+
+def _match_wildcard(value: str, pattern: str) -> bool:
+    """Match a value against a pattern with optional trailing wildcard."""
+    if pattern.endswith("*"):
+        return value.startswith(pattern[:-1])
+    return value == pattern
 
 
 def match_graphql_body(
     body: bytes | None,
     type_filter: str | None,
     op_filter: str | None,
+    field_filter: str | None = None,
 ) -> bool:
-    """Match a GraphQL request body against type and operationName filters.
+    """Match a GraphQL request body against type, operationName, and field filters.
 
     Fail-closed: returns False if the body cannot be parsed or required
     fields are missing.
@@ -265,13 +377,18 @@ def match_graphql_body(
     if not isinstance(data, dict):
         return False
 
+    query_str: str | None = None
+    needs_query = type_filter is not None or field_filter is not None
+    if needs_query:
+        query_str = data.get("query")
+        if not isinstance(query_str, str):
+            return False
+
     # Extract operation type from the query string.
     # GraphQL allows compact forms like `mutation{`, `query($id: ID!)`,
     # so we extract only leading alpha characters as the keyword.
     if type_filter is not None:
-        query_str = data.get("query")
-        if not isinstance(query_str, str):
-            return False
+        assert query_str is not None
         stripped = query_str.lstrip()
         if not stripped:
             return False
@@ -288,11 +405,16 @@ def match_graphql_body(
         op_name = data.get("operationName")
         if not isinstance(op_name, str) or not op_name:
             return False
-        if op_filter.endswith("*"):
-            prefix = op_filter[:-1]
-            if not op_name.startswith(prefix):
-                return False
-        elif op_name != op_filter:
+        if not _match_wildcard(op_name, op_filter):
+            return False
+
+    # Match field name
+    if field_filter is not None:
+        assert query_str is not None
+        fields = _extract_top_level_fields(query_str)
+        if not fields:
+            return False
+        if not any(_match_wildcard(f, field_filter) for f in fields):
             return False
 
     return True
@@ -366,16 +488,22 @@ def match_firewall_request(
                     # Check for GraphQL suffix
                     gql = parse_graphql_rule(rest)
                     if gql is not None:
-                        rule_pattern, type_filter, op_filter = gql
+                        rule_pattern, type_filter, op_filter, field_filter = gql
                     else:
                         rule_pattern = rest
-                        type_filter, op_filter = None, None
+                        type_filter, op_filter, field_filter = None, None, None
 
                     params = match_path(rel_path, rule_pattern)
                     if params is not None:
                         # If GraphQL rule, also check body
-                        has_gql_filter = type_filter is not None or op_filter is not None
-                        if has_gql_filter and not match_graphql_body(body, type_filter, op_filter):
+                        has_gql_filter = (
+                            type_filter is not None
+                            or op_filter is not None
+                            or field_filter is not None
+                        )
+                        if has_gql_filter and not match_graphql_body(
+                            body, type_filter, op_filter, field_filter
+                        ):
                             continue
                         # Merge base params with rule params
                         all_params = {**base_params, **params}

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -247,12 +247,48 @@ def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None, str | No
     return path, type_filter, op_filter, field_filter
 
 
+def _skip_string(s: str, i: int) -> int:
+    """Advance past a quoted string (handles escape sequences)."""
+    quote = s[i]
+    i += 1
+    while i < len(s):
+        if s[i] == "\\":
+            i += 2  # skip escaped character
+        elif s[i] == quote:
+            return i + 1
+        else:
+            i += 1
+    return i
+
+
+def _skip_parens(s: str, i: int) -> int:
+    """Advance past balanced parentheses, respecting strings."""
+    depth = 1
+    i += 1  # skip opening '('
+    while i < len(s) and depth > 0:
+        c = s[i]
+        if c == "(":
+            depth += 1
+            i += 1
+        elif c == ")":
+            depth -= 1
+            i += 1
+        elif c in ('"', "'"):
+            i = _skip_string(s, i)
+        else:
+            i += 1
+    return i
+
+
 def _extract_top_level_fields(query_str: str) -> list[str]:
     """Extract top-level selection field names from a GraphQL query string.
 
     Parses just enough to find the operation body's opening brace and then
-    extracts identifiers at depth 1.  Handles aliases (``alias: fieldName``)
-    by returning the field name, not the alias.
+    extracts identifiers at brace-depth 1.  Handles aliases
+    (``alias: fieldName``) by returning the field name, not the alias.
+
+    Properly skips string literals and parenthesized argument lists so that
+    values inside arguments cannot be mistaken for field names.
     """
     s = query_str.lstrip()
     if not s:
@@ -274,31 +310,16 @@ def _extract_top_level_fields(query_str: str) -> list[str]:
                 i += 1
         # Skip optional variable definitions: ($var: Type, ...)
         if i < len(s) and s[i] == "(":
-            depth = 1
-            i += 1
-            while i < len(s) and depth > 0:
-                if s[i] == "(":
-                    depth += 1
-                elif s[i] == ")":
-                    depth -= 1
-                i += 1
+            i = _skip_parens(s, i)
             while i < len(s) and s[i].isspace():
                 i += 1
 
     # Skip optional directives (@skip, @include, etc.) before opening brace
     while i < len(s) and s[i] == "@":
-        while i < len(s) and not s[i].isspace() and s[i] != "{":
+        while i < len(s) and not s[i].isspace() and s[i] not in ("{", "("):
             i += 1
-        # Directive might have arguments
         if i < len(s) and s[i] == "(":
-            depth = 1
-            i += 1
-            while i < len(s) and depth > 0:
-                if s[i] == "(":
-                    depth += 1
-                elif s[i] == ")":
-                    depth -= 1
-                i += 1
+            i = _skip_parens(s, i)
         while i < len(s) and s[i].isspace():
             i += 1
 
@@ -318,6 +339,10 @@ def _extract_top_level_fields(query_str: str) -> list[str]:
         elif c == "}":
             depth -= 1
             i += 1
+        elif c in ('"', "'"):
+            i = _skip_string(s, i)
+        elif c == "(":
+            i = _skip_parens(s, i)
         elif depth == 1 and (c.isalpha() or c == "_"):
             # Read identifier
             j = i
@@ -388,8 +413,7 @@ def match_graphql_body(
     # GraphQL allows compact forms like `mutation{`, `query($id: ID!)`,
     # so we extract only leading alpha characters as the keyword.
     if type_filter is not None:
-        assert query_str is not None
-        stripped = query_str.lstrip()
+        stripped = query_str.lstrip()  # type: ignore[union-attr]
         if not stripped:
             return False
         # Extract leading alphabetic chars: "mutation(" → "mutation"
@@ -410,8 +434,7 @@ def match_graphql_body(
 
     # Match field name
     if field_filter is not None:
-        assert query_str is not None
-        fields = _extract_top_level_fields(query_str)
+        fields = _extract_top_level_fields(query_str)  # type: ignore[arg-type]
         if not fields:
             return False
         if not any(_match_wildcard(f, field_filter) for f in fields):

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -248,7 +248,16 @@ def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None, str | No
 
 
 def _skip_string(s: str, i: int) -> int:
-    """Advance past a quoted string (handles escape sequences)."""
+    """Advance past a quoted string (handles escape sequences and block strings)."""
+    # Block string: """..."""
+    if s[i : i + 3] == '"""':
+        i += 3
+        while i < len(s):
+            if s[i : i + 3] == '"""':
+                return i + 3
+            i += 1
+        return i
+    # Regular string: "..."
     quote = s[i]
     i += 1
     while i < len(s):
@@ -261,8 +270,35 @@ def _skip_string(s: str, i: int) -> int:
     return i
 
 
+def _skip_comment(s: str, i: int) -> int:
+    """Advance past a line comment (# to end of line)."""
+    while i < len(s) and s[i] != "\n":
+        i += 1
+    return i
+
+
+def _skip_spread(s: str, i: int) -> int:
+    """Advance past a fragment spread (...Name) or inline fragment (... on Type)."""
+    i += 3  # skip "..."
+    while i < len(s) and s[i].isspace():
+        i += 1
+    # Read first identifier (fragment name, or "on" for inline fragments)
+    j = i
+    while j < len(s) and (s[j].isalnum() or s[j] == "_"):
+        j += 1
+    ident = s[i:j]
+    i = j
+    # If it was "on", also skip the type name
+    if ident == "on":
+        while i < len(s) and s[i].isspace():
+            i += 1
+        while i < len(s) and (s[i].isalnum() or s[i] == "_"):
+            i += 1
+    return i
+
+
 def _skip_parens(s: str, i: int) -> int:
-    """Advance past balanced parentheses, respecting strings."""
+    """Advance past balanced parentheses, respecting strings and comments."""
     depth = 1
     i += 1  # skip opening '('
     while i < len(s) and depth > 0:
@@ -273,8 +309,10 @@ def _skip_parens(s: str, i: int) -> int:
         elif c == ")":
             depth -= 1
             i += 1
-        elif c in ('"', "'"):
+        elif c == '"':
             i = _skip_string(s, i)
+        elif c == "#":
+            i = _skip_comment(s, i)
         else:
             i += 1
     return i
@@ -339,10 +377,14 @@ def _extract_top_level_fields(query_str: str) -> list[str]:
         elif c == "}":
             depth -= 1
             i += 1
-        elif c in ('"', "'"):
+        elif c == '"':
             i = _skip_string(s, i)
+        elif c == "#":
+            i = _skip_comment(s, i)
         elif c == "(":
             i = _skip_parens(s, i)
+        elif c == "." and i + 2 < len(s) and s[i + 1] == "." and s[i + 2] == ".":
+            i = _skip_spread(s, i)
         elif depth == 1 and (c.isalpha() or c == "_"):
             # Read identifier
             j = i

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -444,18 +444,19 @@ def match_graphql_body(
     if not isinstance(data, dict):
         return False
 
+    # Extract query string early if any filter needs it.
     query_str: str | None = None
-    needs_query = type_filter is not None or field_filter is not None
-    if needs_query:
-        query_str = data.get("query")
-        if not isinstance(query_str, str):
+    if type_filter is not None or field_filter is not None:
+        raw = data.get("query")
+        if not isinstance(raw, str):
             return False
+        query_str = raw
 
     # Extract operation type from the query string.
     # GraphQL allows compact forms like `mutation{`, `query($id: ID!)`,
     # so we extract only leading alpha characters as the keyword.
-    if type_filter is not None:
-        stripped = query_str.lstrip()  # type: ignore[union-attr]
+    if type_filter is not None and query_str is not None:
+        stripped = query_str.lstrip()
         if not stripped:
             return False
         # Extract leading alphabetic chars: "mutation(" → "mutation"
@@ -475,8 +476,8 @@ def match_graphql_body(
             return False
 
     # Match field name
-    if field_filter is not None:
-        fields = _extract_top_level_fields(query_str)  # type: ignore[arg-type]
+    if field_filter is not None and query_str is not None:
+        fields = _extract_top_level_fields(query_str)
         if not fields:
             return False
         if not any(_match_wildcard(f, field_filter) for f in fields):

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -2421,3 +2421,73 @@ class TestGraphQLFieldMatching:
             body=body,
         )
         assert isinstance(result, FirewallBlock)
+
+    def test_field_comment_not_extracted(self):
+        """Field names inside comments must NOT be extracted."""
+        body = _gql_body(
+            'mutation {\n  deleteRepo(id: "1") { id }\n  # createIssue\n}',
+            "DeleteRepo",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_block_string_not_extracted(self):
+        """Field names inside block strings must NOT be extracted."""
+        body = _gql_body(
+            'mutation { deleteRepo(desc: """createIssue""") { id } }',
+            "DeleteRepo",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_fragment_spread_not_extracted(self):
+        """Fragment spread names must NOT be extracted as field names."""
+        body = _gql_body(
+            "mutation { ...MutationFields }",
+            "BatchOp",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:MutationFields"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_inline_fragment_not_extracted(self):
+        """Inline fragment type names must NOT be extracted as field names."""
+        body = _gql_body(
+            "mutation { ... on Mutation { createIssue(input: {}) { id } } }",
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:Mutation"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_comment_in_args_not_extracted(self):
+        """Comments inside arguments must not leak field names."""
+        body = _gql_body(
+            'mutation {\n  deleteRepo(\n    # createIssue\n    id: "1"\n  ) { id }\n}',
+            "DeleteRepo",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -2366,3 +2366,58 @@ class TestGraphQLFieldMatching:
             body=body,
         )
         assert isinstance(result, FirewallBlock)
+
+    def test_field_string_arg_not_extracted(self):
+        """Field names inside string arguments must NOT be extracted."""
+        body = _gql_body(
+            'mutation { deleteRepository(name: "createIssue") { id } }',
+            "DeleteRepo",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_string_arg_with_escape(self):
+        """Escaped quotes inside string arguments are handled."""
+        body = _gql_body(
+            r'mutation { deleteRepository(name: "foo\"createIssue") { id } }',
+            "DeleteRepo",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_with_all_three_modifiers(self):
+        """type: + operationName: + field: all apply together."""
+        body = _gql_body(
+            "mutation IssueCreate { createIssue(input: {}) { id } }",
+            "IssueCreate",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(
+                ["POST /graphql GraphQL type:mutation operationName:IssueCreate field:createIssue"]
+            ),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_catch_all_blocks_empty_query(self):
+        """field:* blocks when query has no selection fields."""
+        body = json.dumps({"query": ""}).encode()
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL field:*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -2491,3 +2491,176 @@ class TestGraphQLFieldMatching:
             body=body,
         )
         assert isinstance(result, FirewallBlock)
+
+    def test_field_underscore_prefix(self):
+        """Fields starting with underscore (e.g., __typename) are extracted."""
+        body = _gql_body("mutation { __typename createIssue(input: {}) { id } }", "Op")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:__typename"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_multiple_aliases(self):
+        """Multiple aliased fields are all extracted correctly."""
+        body = _gql_body(
+            'mutation { a: createIssue(input: {}) { id } b: closeIssue(id: "1") { id } }',
+            "BatchOp",
+        )
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.linear.app",
+                    "auth": {"headers": {}},
+                    "permissions": [
+                        {
+                            "name": "create",
+                            "rules": ["POST /graphql GraphQL type:mutation field:createIssue"],
+                        },
+                        {
+                            "name": "close",
+                            "rules": ["POST /graphql GraphQL type:mutation field:closeIssue"],
+                        },
+                    ],
+                }
+            ]
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql", "POST", fws, body=body
+        )
+        assert isinstance(result, FirewallAllow)
+        # First matching permission wins (order-dependent)
+        assert result.match_info["permission"] == "create"
+
+    def test_field_nested_object_arg_not_extracted(self):
+        """Field names inside nested object arguments must NOT be extracted."""
+        body = _gql_body(
+            "mutation { createIssue(input: { nested: { closeIssue: true } }) { id } }",
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:closeIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_with_directive(self):
+        """Fields with directives are still extracted."""
+        body = _gql_body(
+            "mutation { createIssue(input: {}) @skip(if: false) { id } }",
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_no_selection_set(self):
+        """Field without selection set or arguments (unusual but valid)."""
+        body = _gql_body("mutation { createIssue }", "Op")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_empty_selection_set(self):
+        """Empty selection set has no fields."""
+        body = _gql_body("mutation { }", "Op")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_multiline_with_tabs(self):
+        """Multiline query with tabs and varied whitespace."""
+        body = _gql_body(
+            "mutation Op {\n\tcreateIssue(\n\t\tinput: {}\n\t) {\n\t\tid\n\t}\n}",
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_and_operation_name_without_type(self):
+        """field: + operationName: without type: — both must match."""
+        body = _gql_body("mutation { createIssue(input: {}) { id } }", "IssueCreate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL operationName:IssueCreate field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_and_operation_name_mismatch(self):
+        """field matches but operationName doesn't — blocked."""
+        body = _gql_body("mutation { createIssue(input: {}) { id } }", "WrongName")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL operationName:IssueCreate field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_multiple_permissions_correct_match(self):
+        """With multiple permissions, the correct one is matched by field."""
+        body = _gql_body('mutation { closeIssue(id: "1") { id } }', "CloseIssue")
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.linear.app",
+                    "auth": {"headers": {}},
+                    "permissions": [
+                        {
+                            "name": "create",
+                            "rules": ["POST /graphql GraphQL type:mutation field:createIssue"],
+                        },
+                        {
+                            "name": "close",
+                            "rules": ["POST /graphql GraphQL type:mutation field:closeIssue"],
+                        },
+                        {
+                            "name": "update",
+                            "rules": ["POST /graphql GraphQL type:mutation field:updateIssue"],
+                        },
+                    ],
+                }
+            ]
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql", "POST", fws, body=body
+        )
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["permission"] == "close"
+
+    def test_field_inline_fragment_field_at_depth2(self):
+        """Fields inside inline fragment body are at depth 2, not extracted."""
+        body = _gql_body(
+            "mutation { ... on Mutation { createIssue(input: {}) { id } } }",
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -2187,3 +2187,182 @@ class TestGraphQLMatching:
             body=body,
         )
         assert isinstance(result, FirewallBlock)
+
+
+class TestGraphQLFieldMatching:
+    """Tests for GraphQL field: modifier matching."""
+
+    def test_field_exact_match(self):
+        body = _gql_body("mutation { createIssue(input: {}) { id } }", "IssueCreate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_mismatch_blocks(self):
+        body = _gql_body('mutation { deleteIssue(id: "1") { id } }', "IssueDelete")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_wildcard_match(self):
+        body = _gql_body("mutation { createPullRequest(input: {}) { id } }", "PRCreate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:create*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_wildcard_no_match(self):
+        body = _gql_body('mutation { deleteIssue(id: "1") { id } }', "IssueDelete")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:create*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_without_type_filter(self):
+        """field: modifier works without type: filter."""
+        body = _gql_body("mutation { createIssue(input: {}) { id } }", "IssueCreate")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_type_mismatch_blocks(self):
+        """type: filter still applies when field: is present."""
+        body = _gql_body('query { repository(name: "foo") { id } }', "GetRepo")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:repository"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_with_alias(self):
+        """Aliased fields: 'myAlias: createIssue(...)' should match field:createIssue."""
+        body = _gql_body(
+            "mutation { myAlias: createIssue(input: {}) { id } }",
+            "IssueCreate",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_among_multiple_selections(self):
+        """Match when target field is one of several top-level selections."""
+        body = _gql_body(
+            "mutation { addReaction(input: {}) { id } createIssue(input: {}) { id } }",
+            "BatchOp",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_missing_body_blocks(self):
+        """Fail-closed: no body → blocked."""
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL field:createIssue"]),
+            body=None,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_empty_query_blocks(self):
+        """Fail-closed: empty query string → blocked."""
+        body = json.dumps({"query": ""}).encode()
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_field_with_variables_syntax(self):
+        """Mutation with variable definitions: field extraction still works."""
+        body = _gql_body(
+            "mutation CreateIssue($input: CreateIssueInput!) { createIssue(input: $input) { id } }",
+            "CreateIssue",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_compact_mutation_no_space(self):
+        """'mutation{createIssue(...)...}' — no space before brace."""
+        body = _gql_body(
+            "mutation{createIssue(input:{}){id}}",
+            "CreateIssue",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_bare_query(self):
+        """Bare query '{ viewer { id } }' — field extraction works."""
+        body = _gql_body("{ viewer { id } }", "GetViewer")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL field:viewer"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_catch_all_wildcard(self):
+        """field:* matches any field."""
+        body = _gql_body("mutation { createIssue(input: {}) { id } }", "Create")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL field:*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_field_nested_not_matched(self):
+        """Nested fields should NOT be matched — only top-level."""
+        body = _gql_body(
+            "mutation { updateIssue(input: {}) { issue { createComment { id } } } }",
+            "UpdateIssue",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createComment"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -505,6 +505,34 @@ describe("validateRule", () => {
       );
     }).toThrow("invalid GraphQL field pattern");
   });
+
+  it("should accept GraphQL field with underscore prefix", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL field:__typename", "p", "fw");
+    }).not.toThrow();
+  });
+
+  it("should accept GraphQL field with numbers", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL field:field123", "p", "fw");
+    }).not.toThrow();
+  });
+
+  it("should accept GraphQL field catch-all wildcard", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL field:*", "p", "fw");
+    }).not.toThrow();
+  });
+
+  it("should accept all three modifiers together", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL type:mutation operationName:IssueCreate field:createIssue",
+        "p",
+        "fw",
+      );
+    }).not.toThrow();
+  });
 });
 
 describe("validateBaseUrl", () => {

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -463,6 +463,48 @@ describe("validateRule", () => {
       return validateRule("POST noslash GraphQL type:query", "p", "fw");
     }).toThrow("path must start with");
   });
+
+  it("should accept GraphQL field: modifier", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL type:mutation field:createIssue",
+        "p",
+        "fw",
+      );
+    }).not.toThrow();
+  });
+
+  it("should accept GraphQL field wildcard", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL type:mutation field:create*",
+        "p",
+        "fw",
+      );
+    }).not.toThrow();
+  });
+
+  it("should accept GraphQL field-only modifier", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL field:createIssue", "p", "fw");
+    }).not.toThrow();
+  });
+
+  it("should reject empty GraphQL field name", () => {
+    expect(() => {
+      return validateRule("POST /graphql GraphQL field:", "p", "fw");
+    }).toThrow("empty GraphQL field name");
+  });
+
+  it("should reject invalid GraphQL field pattern", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL field:create-issue",
+        "p",
+        "fw",
+      );
+    }).toThrow("invalid GraphQL field pattern");
+  });
 });
 
 describe("validateBaseUrl", () => {

--- a/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
@@ -499,4 +499,155 @@ describe("findMatchingPermissions with GraphQL field: modifier", () => {
       [],
     );
   });
+
+  it("field + operationName without type — both must match", () => {
+    const config: FirewallConfig = {
+      name: "test",
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [
+            {
+              name: "issues",
+              rules: [
+                "POST /graphql GraphQL operationName:IssueCreate field:createIssue",
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", config, {
+        type: "mutation",
+        operationName: "IssueCreate",
+        fields: ["createIssue"],
+      }),
+    ).toEqual(["issues"]);
+    // operationName mismatch → blocked
+    expect(
+      findMatchingPermissions("POST", "/graphql", config, {
+        type: "mutation",
+        operationName: "WrongName",
+        fields: ["createIssue"],
+      }),
+    ).toEqual([]);
+    // field mismatch → blocked
+    expect(
+      findMatchingPermissions("POST", "/graphql", config, {
+        type: "mutation",
+        operationName: "IssueCreate",
+        fields: ["deleteIssue"],
+      }),
+    ).toEqual([]);
+  });
+
+  it("multiple permissions — correct one matched by field", () => {
+    const config: FirewallConfig = {
+      name: "github",
+      apis: [
+        {
+          base: "https://api.github.com",
+          auth: { headers: {} },
+          permissions: [
+            {
+              name: "issues-read",
+              rules: ["POST /graphql GraphQL type:query field:repository"],
+            },
+            {
+              name: "issues-write",
+              rules: ["POST /graphql GraphQL type:mutation field:createIssue"],
+            },
+            {
+              name: "pr-write",
+              rules: [
+                "POST /graphql GraphQL type:mutation field:mergePullRequest",
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["mergePullRequest"],
+    };
+    const perms = findMatchingPermissions("POST", "/graphql", config, body);
+    expect(perms).toContain("pr-write");
+    expect(perms).not.toContain("issues-write");
+    expect(perms).not.toContain("issues-read");
+  });
+
+  it("field rules coexist with REST rules in same config", () => {
+    const config: FirewallConfig = {
+      name: "github",
+      apis: [
+        {
+          base: "https://api.github.com",
+          auth: { headers: {} },
+          permissions: [
+            {
+              name: "issues-rest",
+              rules: ["GET /repos/{owner}/{repo}/issues"],
+            },
+            {
+              name: "issues-gql",
+              rules: ["POST /graphql GraphQL type:mutation field:createIssue"],
+            },
+          ],
+        },
+      ],
+    };
+    // REST rule matches REST request
+    expect(
+      findMatchingPermissions("GET", "/repos/vm0/vm0/issues", config),
+    ).toEqual(["issues-rest"]);
+    // GraphQL rule matches GraphQL request
+    expect(
+      findMatchingPermissions("POST", "/graphql", config, {
+        type: "mutation",
+        fields: ["createIssue"],
+      }),
+    ).toEqual(["issues-gql"]);
+  });
+
+  it("same field in multiple permissions — all matched", () => {
+    const config: FirewallConfig = {
+      name: "test",
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [
+            {
+              name: "reactions-issues",
+              rules: ["POST /graphql GraphQL type:mutation field:addReaction"],
+            },
+            {
+              name: "reactions-prs",
+              rules: ["POST /graphql GraphQL type:mutation field:addReaction"],
+            },
+          ],
+        },
+      ],
+    };
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["addReaction"],
+    };
+    const perms = findMatchingPermissions("POST", "/graphql", config, body);
+    expect(perms).toContain("reactions-issues");
+    expect(perms).toContain("reactions-prs");
+  });
+
+  it("underscore-prefixed fields match", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["__typename", "createIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", fieldConfig, body),
+    ).toContain("issues-write");
+  });
 });

--- a/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
@@ -477,4 +477,26 @@ describe("findMatchingPermissions with GraphQL field: modifier", () => {
       findMatchingPermissions("POST", "/graphql", fieldConfig, body),
     ).not.toContain("issues-write");
   });
+
+  it("field:* does not match empty fields", () => {
+    const config: FirewallConfig = {
+      name: "test",
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [
+            {
+              name: "any-field",
+              rules: ["POST /graphql GraphQL field:*"],
+            },
+          ],
+        },
+      ],
+    };
+    const body: GraphQLBody = { type: "mutation", fields: [] };
+    expect(findMatchingPermissions("POST", "/graphql", config, body)).toEqual(
+      [],
+    );
+  });
 });

--- a/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
@@ -365,3 +365,116 @@ describe("findMatchingPermissions with GraphQL rules", () => {
     ).toEqual(["rest-perm"]);
   });
 });
+
+describe("findMatchingPermissions with GraphQL field: modifier", () => {
+  const fieldConfig: FirewallConfig = {
+    name: "github",
+    apis: [
+      {
+        base: "https://api.github.com",
+        auth: { headers: {} },
+        permissions: [
+          {
+            name: "issues-write",
+            rules: [
+              "POST /graphql GraphQL type:mutation field:createIssue",
+              "POST /graphql GraphQL type:mutation field:closeIssue",
+              "POST /graphql GraphQL type:mutation field:updateIssue",
+            ],
+          },
+          {
+            name: "pr-write",
+            rules: [
+              "POST /graphql GraphQL type:mutation field:createPullRequest",
+              "POST /graphql GraphQL type:mutation field:mergePullRequest",
+            ],
+          },
+          {
+            name: "wildcard-create",
+            rules: ["POST /graphql GraphQL type:mutation field:create*"],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("field:createIssue matches mutation with createIssue field", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      operationName: "MyOp",
+      fields: ["createIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", fieldConfig, body),
+    ).toContain("issues-write");
+  });
+
+  it("field:createIssue does not match different field", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      operationName: "MyOp",
+      fields: ["deleteIssue"],
+    };
+    const perms = findMatchingPermissions(
+      "POST",
+      "/graphql",
+      fieldConfig,
+      body,
+    );
+    expect(perms).not.toContain("issues-write");
+  });
+
+  it("matches when target field is among multiple fields", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["addReaction", "createIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", fieldConfig, body),
+    ).toContain("issues-write");
+  });
+
+  it("field wildcard matches prefix", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["createPullRequest"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", fieldConfig, body),
+    ).toContain("wildcard-create");
+  });
+
+  it("field wildcard does not match different prefix", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["deleteIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", fieldConfig, body),
+    ).not.toContain("wildcard-create");
+  });
+
+  it("returns empty when no fields provided", () => {
+    const body: GraphQLBody = { type: "mutation" };
+    expect(
+      findMatchingPermissions("POST", "/graphql", fieldConfig, body),
+    ).toEqual([]);
+  });
+
+  it("returns empty when fields array is empty", () => {
+    const body: GraphQLBody = { type: "mutation", fields: [] };
+    expect(
+      findMatchingPermissions("POST", "/graphql", fieldConfig, body),
+    ).toEqual([]);
+  });
+
+  it("type filter still applies with field filter", () => {
+    const body: GraphQLBody = {
+      type: "query",
+      fields: ["createIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", fieldConfig, body),
+    ).not.toContain("issues-write");
+  });
+});

--- a/turbo/packages/core/src/contracts/firewall-expander.ts
+++ b/turbo/packages/core/src/contracts/firewall-expander.ts
@@ -22,8 +22,7 @@ const VALID_RULE_METHODS = new Set([
 
 const VALID_GRAPHQL_TYPES = new Set(["query", "mutation", "subscription"]);
 
-const GRAPHQL_OP_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]*\*?$/;
-const GRAPHQL_FIELD_RE = /^[a-zA-Z_][a-zA-Z0-9_]*\*?$/;
+const GRAPHQL_IDENTIFIER_RE = /^[a-zA-Z_][a-zA-Z0-9_]*\*?$/;
 
 function validateGraphQLModifiers(
   modifiers: string[],
@@ -33,7 +32,7 @@ function validateGraphQLModifiers(
 ): void {
   if (modifiers.length === 0) {
     throw new Error(
-      `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": GraphQL keyword requires at least one modifier (type: or operationName:)`,
+      `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": GraphQL keyword requires at least one modifier (type:, operationName:, or field:)`,
     );
   }
   for (const part of modifiers) {
@@ -51,7 +50,7 @@ function validateGraphQLModifiers(
           `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": empty GraphQL operationName`,
         );
       }
-      if (val !== "*" && !GRAPHQL_OP_NAME_RE.test(val)) {
+      if (val !== "*" && !GRAPHQL_IDENTIFIER_RE.test(val)) {
         throw new Error(
           `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": invalid GraphQL operationName pattern "${val}"`,
         );
@@ -63,7 +62,7 @@ function validateGraphQLModifiers(
           `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": empty GraphQL field name`,
         );
       }
-      if (val !== "*" && !GRAPHQL_FIELD_RE.test(val)) {
+      if (val !== "*" && !GRAPHQL_IDENTIFIER_RE.test(val)) {
         throw new Error(
           `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": invalid GraphQL field pattern "${val}"`,
         );

--- a/turbo/packages/core/src/contracts/firewall-expander.ts
+++ b/turbo/packages/core/src/contracts/firewall-expander.ts
@@ -23,6 +23,7 @@ const VALID_RULE_METHODS = new Set([
 const VALID_GRAPHQL_TYPES = new Set(["query", "mutation", "subscription"]);
 
 const GRAPHQL_OP_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]*\*?$/;
+const GRAPHQL_FIELD_RE = /^[a-zA-Z_][a-zA-Z0-9_]*\*?$/;
 
 function validateGraphQLModifiers(
   modifiers: string[],
@@ -53,6 +54,18 @@ function validateGraphQLModifiers(
       if (val !== "*" && !GRAPHQL_OP_NAME_RE.test(val)) {
         throw new Error(
           `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": invalid GraphQL operationName pattern "${val}"`,
+        );
+      }
+    } else if (part.startsWith("field:")) {
+      const val = part.slice(6);
+      if (!val) {
+        throw new Error(
+          `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": empty GraphQL field name`,
+        );
+      }
+      if (val !== "*" && !GRAPHQL_FIELD_RE.test(val)) {
+        throw new Error(
+          `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": invalid GraphQL field pattern "${val}"`,
         );
       }
     } else {

--- a/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
+++ b/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
@@ -63,6 +63,7 @@ interface GraphQLRule {
   path: string;
   typeFilter: string | null;
   opFilter: string | null;
+  fieldFilter: string | null;
 }
 
 /**
@@ -79,6 +80,7 @@ function parseGraphQLRule(rest: string): GraphQLRule | null {
 
   let typeFilter: string | null = null;
   let opFilter: string | null = null;
+  let fieldFilter: string | null = null;
 
   for (let i = 1; i < suffixParts.length; i++) {
     const part = suffixParts[i]!;
@@ -86,10 +88,12 @@ function parseGraphQLRule(rest: string): GraphQLRule | null {
       typeFilter = part.slice(5);
     } else if (part.startsWith("operationName:")) {
       opFilter = part.slice(14);
+    } else if (part.startsWith("field:")) {
+      fieldFilter = part.slice(6);
     }
   }
 
-  return { path, typeFilter, opFilter };
+  return { path, typeFilter, opFilter, fieldFilter };
 }
 
 /**
@@ -100,6 +104,8 @@ export interface GraphQLBody {
   type: "query" | "mutation" | "subscription";
   /** The named operation, if present. */
   operationName?: string;
+  /** Top-level selection field names (e.g., `["createIssue"]`). */
+  fields?: string[];
 }
 
 /**
@@ -107,10 +113,18 @@ export interface GraphQLBody {
  *
  * Fail-closed: returns false if required fields are missing.
  */
+function matchWildcard(value: string, pattern: string): boolean {
+  if (pattern.endsWith("*")) {
+    return value.startsWith(pattern.slice(0, -1));
+  }
+  return value === pattern;
+}
+
 function matchGraphQLBody(
   body: GraphQLBody | undefined,
   typeFilter: string | null,
   opFilter: string | null,
+  fieldFilter: string | null,
 ): boolean {
   if (!body) return false;
 
@@ -121,11 +135,18 @@ function matchGraphQLBody(
   if (opFilter !== null) {
     const opName = body.operationName;
     if (!opName) return false;
-    if (opFilter.endsWith("*")) {
-      if (!opName.startsWith(opFilter.slice(0, -1))) return false;
-    } else if (opName !== opFilter) {
+    if (!matchWildcard(opName, opFilter)) return false;
+  }
+
+  if (fieldFilter !== null) {
+    const fields = body.fields;
+    if (!fields || fields.length === 0) return false;
+    if (
+      !fields.some((f) => {
+        return matchWildcard(f, fieldFilter);
+      })
+    )
       return false;
-    }
   }
 
   return true;
@@ -167,8 +188,15 @@ export function findMatchingPermissions(
         if (matchFirewallPath(path, rulePath) !== null) {
           if (
             gql &&
-            (gql.typeFilter !== null || gql.opFilter !== null) &&
-            !matchGraphQLBody(graphqlBody, gql.typeFilter, gql.opFilter)
+            (gql.typeFilter !== null ||
+              gql.opFilter !== null ||
+              gql.fieldFilter !== null) &&
+            !matchGraphQLBody(
+              graphqlBody,
+              gql.typeFilter,
+              gql.opFilter,
+              gql.fieldFilter,
+            )
           ) {
             continue;
           }

--- a/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
+++ b/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
@@ -109,7 +109,7 @@ export interface GraphQLBody {
 }
 
 /**
- * Match a parsed GraphQL body against type and operationName filters.
+ * Match a parsed GraphQL body against type, operationName, and field filters.
  *
  * Fail-closed: returns false if required fields are missing.
  */
@@ -160,7 +160,7 @@ function matchGraphQLBody(
  * any HTTP method.
  *
  * When `graphqlBody` is provided, rules containing the `GraphQL` keyword
- * will also match against the parsed body's type and operationName.
+ * will also match against the parsed body's type, operationName, and fields.
  */
 export function findMatchingPermissions(
   method: string,


### PR DESCRIPTION
## Summary

- Add `field:` modifier to the GraphQL firewall rule syntax for matching against schema-defined top-level selection field names (e.g., `createIssue`, `mergePullRequest`)
- This enables reliable permission rules independent of client-chosen `operationName` values
- Prerequisite for #8411 — mapping GitHub GraphQL mutations to REST permission groups

### Rule format

```
POST /graphql GraphQL type:mutation field:createIssue
POST /graphql GraphQL type:mutation field:create*
```

### Changes

| Layer | File | What |
|-------|------|------|
| TypeScript matcher | `firewall-rule-matcher.ts` | Parse `field:` modifier, match against `GraphQLBody.fields` |
| TypeScript validator | `firewall-expander.ts` | Validate `field:` pattern (identifier + optional wildcard) |
| Python proxy | `matching.py` | Extract top-level fields from query string, match with wildcard support |
| Tests | Both TS and Python | 23 new test cases covering exact match, wildcard, alias, nested exclusion, fail-closed |

### Design decisions

- **Field extraction**: Parses GraphQL query string to find top-level selection fields at depth 1 only (nested fields are excluded)
- **Alias handling**: `myAlias: createIssue(...)` correctly matches `field:createIssue`
- **Wildcard**: `field:create*` matches any field starting with `create` (consistent with `operationName:` modifier)
- **Fail-closed**: Missing body, empty query, or unparseable query blocks the request

## Test plan

- [x] 8 new TypeScript tests in `firewall-rule-matcher.test.ts` (40 total pass)
- [x] 5 new TypeScript tests in `firewall-expander.test.ts` (83 total pass)
- [x] 15 new Python tests in `test_connectors.py::TestGraphQLFieldMatching` (45 GraphQL tests total pass)
- [x] All existing GraphQL tests still pass (no regressions)
- [x] Lint + type check + knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)