### PR TITLE
feat(platform): capture response headers and mark binary bodies in network logs

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -377,7 +377,8 @@ def _add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             if not body:
                 return
         except Exception:
-            # ZlibError or other decompression failure — skip body
+            # ZlibError or other decompression failure — mark as binary
+            log_entry["response_body_encoding"] = "binary"
             return
         res_ct = flow.response.headers.get("content-type", "")
         truncated = len(body) > _MAX_BODY_SIZE

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -330,22 +330,22 @@ def _is_sensitive_header(name: str) -> bool:
 
 
 def _redact_headers(headers) -> dict:
-    """Build a dict of headers with sensitive values replaced by [REDACTED]."""
+    """Build a dict of headers with sensitive values replaced by ***."""
     result = {}
     for name, value in headers.items(multi=True):
         if name in result:
             continue  # keep first occurrence only (headers.items gives all)
-        result[name] = "[REDACTED]" if _is_sensitive_header(name) else value
+        result[name] = "***" if _is_sensitive_header(name) else value
     return result
 
 
 def _add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
-    """Add request headers, request body, and response body to a log entry.
+    """Add request/response headers and bodies to a log entry.
 
     # [NETWORK_LOG_FIELDS] — capture-only fields, not part of the core schema.
     # Fields: request_headers, request_body, request_body_encoding,
-    #         request_body_truncated, response_body, response_body_encoding,
-    #         response_body_truncated
+    #         request_body_truncated, response_headers, response_body,
+    #         response_body_encoding, response_body_truncated
     """
     # Request headers (always available)
     log_entry["request_headers"] = _redact_headers(flow.request.headers)
@@ -363,6 +363,12 @@ def _add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             log_entry["request_body_encoding"] = encoding
             if truncated:
                 log_entry["request_body_truncated"] = True
+        else:
+            log_entry["request_body_encoding"] = "binary"
+
+    # Response headers
+    if flow.response:
+        log_entry["response_headers"] = _redact_headers(flow.response.headers)
 
     # Response body — only available when streaming is disabled
     if flow.response:
@@ -383,6 +389,8 @@ def _add_capture_fields(flow: http.HTTPFlow, log_entry: dict) -> None:
             log_entry["response_body_encoding"] = encoding
             if truncated:
                 log_entry["response_body_truncated"] = True
+        else:
+            log_entry["response_body_encoding"] = "binary"
 
 
 def response(flow: http.HTTPFlow) -> None:

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -166,9 +166,9 @@ class TestRedactHeaders:
         )
         result = _redact_headers(headers)
         assert result["Content-Type"] == "application/json"
-        assert result["Authorization"] == "[REDACTED]"
+        assert result["Authorization"] == "***"
         assert result["Host"] == "api.example.com"
-        assert result["Cookie"] == "[REDACTED]"
+        assert result["Cookie"] == "***"
 
 
 class TestAddCaptureFields:
@@ -191,6 +191,10 @@ class TestAddCaptureFields:
         flow.response.content = response_body
         flow.response.headers = MagicMock()
         flow.response.headers.get.return_value = response_ct
+        res_pairs = [("Content-Type", response_ct), ("X-Request-Id", "req-123")]
+        flow.response.headers.items.side_effect = lambda multi=False: (
+            iter(res_pairs) if multi else iter([])
+        )
         return flow
 
     def test_captures_request_body(self):
@@ -216,6 +220,33 @@ class TestAddCaptureFields:
         assert entry["request_headers"]["Content-Type"] == "application/json"
         assert entry["request_headers"]["Host"] == "api.example.com"
 
+    def test_captures_response_headers(self):
+        flow = self._make_flow()
+        entry = {}
+        _add_capture_fields(flow, entry)
+        assert "response_headers" in entry
+        assert entry["response_headers"]["Content-Type"] == "application/json"
+        assert entry["response_headers"]["X-Request-Id"] == "req-123"
+
+    def test_response_headers_redacts_sensitive(self):
+        flow = self._make_flow()
+        flow.response.headers.items.side_effect = lambda multi=False: (
+            iter([("Set-Cookie", "session=abc"), ("Content-Type", "text/html")])
+            if multi
+            else iter([])
+        )
+        entry = {}
+        _add_capture_fields(flow, entry)
+        assert entry["response_headers"]["Set-Cookie"] == "***"
+        assert entry["response_headers"]["Content-Type"] == "text/html"
+
+    def test_no_response_headers_when_no_response(self):
+        flow = self._make_flow()
+        flow.response = None
+        entry = {}
+        _add_capture_fields(flow, entry)
+        assert "response_headers" not in entry
+
     def test_truncates_large_request_body(self):
         body = b"x" * (_MAX_BODY_SIZE + 1000)
         flow = self._make_flow(request_body=body, request_ct="text/plain")
@@ -239,8 +270,11 @@ class TestAddCaptureFields:
         entry = {}
         _add_capture_fields(flow, entry)
         assert "request_body" not in entry
+        assert "request_body_encoding" not in entry  # no body = no encoding
         assert "response_body" not in entry
+        assert "response_body_encoding" not in entry  # no body = no encoding
         assert "request_headers" in entry  # headers always captured
+        assert "response_headers" in entry  # headers captured despite empty body
 
     def test_response_decompression_error_skips_body(self):
         flow = self._make_flow(request_body=b"ok")
@@ -251,22 +285,25 @@ class TestAddCaptureFields:
         entry = {}
         _add_capture_fields(flow, entry)
         assert "request_body" in entry  # request body still captured
+        assert "response_headers" in entry  # headers captured before body access
         assert "response_body" not in entry  # response body skipped
 
-    def test_skips_binary_request_body(self):
+    def test_binary_request_body_marks_encoding(self):
         flow = self._make_flow(request_body=b"\x89PNG\r\n", request_ct="image/png")
         entry = {}
         _add_capture_fields(flow, entry)
         assert "request_body" not in entry
+        assert entry["request_body_encoding"] == "binary"
         assert "request_headers" in entry  # headers still captured
 
-    def test_skips_binary_response_body(self):
+    def test_binary_response_body_marks_encoding(self):
         flow = self._make_flow(
             response_body=b"\x00\x01\x02", response_ct="application/octet-stream"
         )
         entry = {}
         _add_capture_fields(flow, entry)
         assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
 
     def test_request_body_exactly_at_limit_not_truncated(self):
         body = b"x" * _MAX_BODY_SIZE
@@ -292,7 +329,7 @@ class TestAddCaptureFields:
             ("Host", "example.com"),
         ]
         result = _redact_headers(headers)
-        assert result["Set-Cookie"] == "[REDACTED]"
+        assert result["Set-Cookie"] == "***"
         assert result["Host"] == "example.com"
         assert len(result) == 2
 
@@ -318,6 +355,23 @@ class TestAddCaptureFields:
         _add_capture_fields(flow, entry)
         assert entry["request_body"] == '{"q": "test"}'
         assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
+
+    def test_both_bodies_binary(self):
+        flow = self._make_flow(
+            request_body=b"\x89PNG",
+            response_body=b"\x1f\x8b\x08",
+            request_ct="image/png",
+            response_ct="application/gzip",
+        )
+        entry = {}
+        _add_capture_fields(flow, entry)
+        assert "request_body" not in entry
+        assert entry["request_body_encoding"] == "binary"
+        assert "response_body" not in entry
+        assert entry["response_body_encoding"] == "binary"
+        assert "request_headers" in entry
+        assert "response_headers" in entry
 
     def test_both_request_and_response(self):
         flow = self._make_flow(

--- a/crates/runner/mitm-addon/tests/test_body_capture.py
+++ b/crates/runner/mitm-addon/tests/test_body_capture.py
@@ -287,6 +287,7 @@ class TestAddCaptureFields:
         assert "request_body" in entry  # request body still captured
         assert "response_headers" in entry  # headers captured before body access
         assert "response_body" not in entry  # response body skipped
+        assert entry["response_body_encoding"] == "binary"  # marked as binary
 
     def test_binary_request_body_marks_encoding(self):
         flow = self._make_flow(request_body=b"\x89PNG\r\n", request_ct="image/png")

--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -159,8 +159,8 @@ function BinaryBadge({ title }: { title: string }) {
 export function CapturedBodySections({ entry }: { entry: NetworkLogEntry }) {
   const requestHeaders = filterHeaders(entry.request_headers);
   const responseHeaders = filterHeaders(entry.response_headers);
-  const requestBody = entry.request_body || null;
-  const responseBody = entry.response_body || null;
+  const requestBody = entry.request_body ?? null;
+  const responseBody = entry.response_body ?? null;
   const requestBodyBinary =
     !requestBody && entry.request_body_encoding === "binary";
   const responseBodyBinary =

--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -67,7 +67,13 @@ function CollapsibleSection({
   );
 }
 
-function RequestHeaders({ headers }: { headers: Record<string, string> }) {
+function HeadersSection({
+  title,
+  headers,
+}: {
+  title: string;
+  headers: Record<string, string>;
+}) {
   const entries = Object.entries(headers);
   const copyText = entries
     .map(([k, v]) => {
@@ -77,7 +83,7 @@ function RequestHeaders({ headers }: { headers: Record<string, string> }) {
 
   return (
     <CollapsibleSection
-      title={`Request Headers (${entries.length})`}
+      title={`${title} (${entries.length})`}
       copyText={copyText}
     >
       <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
@@ -127,21 +133,55 @@ function BodyBlock({
   );
 }
 
-export function CapturedBodySections({ entry }: { entry: NetworkLogEntry }) {
-  const requestHeaders =
-    entry.request_headers && Object.keys(entry.request_headers).length > 0
-      ? entry.request_headers
-      : null;
-  const requestBody = entry.request_body ?? null;
-  const responseBody = entry.response_body ?? null;
+function filterHeaders(
+  raw: Record<string, string> | undefined,
+): Record<string, string> | null {
+  if (!raw) {
+    return null;
+  }
+  const filtered = Object.fromEntries(
+    Object.entries(raw).filter(([, v]) => {
+      return v !== "";
+    }),
+  );
+  return Object.keys(filtered).length > 0 ? filtered : null;
+}
 
-  if (!requestHeaders && !requestBody && !responseBody) {
+function BinaryBadge({ title }: { title: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <span className="font-medium">{title}</span>
+      <InlineBadge color="muted">binary</InlineBadge>
+    </div>
+  );
+}
+
+export function CapturedBodySections({ entry }: { entry: NetworkLogEntry }) {
+  const requestHeaders = filterHeaders(entry.request_headers);
+  const responseHeaders = filterHeaders(entry.response_headers);
+  const requestBody = entry.request_body || null;
+  const responseBody = entry.response_body || null;
+  const requestBodyBinary =
+    !requestBody && entry.request_body_encoding === "binary";
+  const responseBodyBinary =
+    !responseBody && entry.response_body_encoding === "binary";
+
+  if (
+    !requestHeaders &&
+    !responseHeaders &&
+    !requestBody &&
+    !responseBody &&
+    !requestBodyBinary &&
+    !responseBodyBinary
+  ) {
     return null;
   }
 
   return (
     <div className="mt-3 space-y-2">
-      {requestHeaders && <RequestHeaders headers={requestHeaders} />}
+      {requestHeaders && (
+        <HeadersSection title="Request Headers" headers={requestHeaders} />
+      )}
       {requestBody && (
         <BodyBlock
           title="Request Body"
@@ -149,6 +189,10 @@ export function CapturedBodySections({ entry }: { entry: NetworkLogEntry }) {
           encoding={entry.request_body_encoding}
           truncated={entry.request_body_truncated}
         />
+      )}
+      {requestBodyBinary && <BinaryBadge title="Request Body" />}
+      {responseHeaders && (
+        <HeadersSection title="Response Headers" headers={responseHeaders} />
       )}
       {responseBody && (
         <BodyBlock
@@ -158,6 +202,7 @@ export function CapturedBodySections({ entry }: { entry: NetworkLogEntry }) {
           truncated={entry.response_body_truncated}
         />
       )}
+      {responseBodyBinary && <BinaryBadge title="Response Body" />}
     </div>
   );
 }

--- a/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
+++ b/turbo/apps/web/app/api/agent/runs/[id]/telemetry/network/route.ts
@@ -108,6 +108,7 @@ ${sinceFilter}
         request_body: e.request_body,
         request_body_encoding: e.request_body_encoding,
         request_body_truncated: e.request_body_truncated,
+        response_headers: e.response_headers,
         response_body: e.response_body,
         response_body_encoding: e.response_body_encoding,
         response_body_truncated: e.response_body_truncated,

--- a/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/network/route.ts
@@ -88,6 +88,7 @@ ${sinceFilter}
         request_body: e.request_body,
         request_body_encoding: e.request_body_encoding,
         request_body_truncated: e.request_body_truncated,
+        response_headers: e.response_headers,
         response_body: e.response_body,
         response_body_encoding: e.response_body_encoding,
         response_body_truncated: e.response_body_truncated,

--- a/turbo/packages/core/src/contracts/runs.ts
+++ b/turbo/packages/core/src/contracts/runs.ts
@@ -383,10 +383,11 @@ const networkLogEntrySchema = z.object({
   // Capture-only fields (opt-in via captureNetworkBodies)
   request_headers: z.record(z.string(), z.string()).optional(),
   request_body: z.string().optional(),
-  request_body_encoding: z.enum(["utf-8", "base64"]).optional(),
+  request_body_encoding: z.enum(["utf-8", "base64", "binary"]).optional(),
   request_body_truncated: z.boolean().optional(),
+  response_headers: z.record(z.string(), z.string()).optional(),
   response_body: z.string().optional(),
-  response_body_encoding: z.enum(["utf-8", "base64"]).optional(),
+  response_body_encoding: z.enum(["utf-8", "base64", "binary"]).optional(),
   response_body_truncated: z.boolean().optional(),
 });
 


### PR DESCRIPTION
## Summary
- Capture **response headers** in MITM addon network logs (using existing `_redact_headers` for sensitive header masking)
- Add `response_headers` field through the full stack: Zod schema, API routes, frontend display
- Mark binary request/response bodies with `encoding: "binary"` instead of silently skipping, so the UI can distinguish "no body" from "binary body"
- Filter out empty-value headers in frontend to fix DNS entries incorrectly showing Request Headers (Axiom column artifact)
- Change header redaction placeholder from `[REDACTED]` to `***`

## Test plan
- [x] Python tests: 52 passing (3 new response_headers tests, 3 updated binary encoding tests, 1 new both-bodies-binary test)
- [x] TypeScript lint: all packages pass
- [x] Type check: no new errors
- [ ] Manual: verify response headers display on HTTP network log entries
- [ ] Manual: verify binary badge shows for binary response bodies (e.g. `.tar.gz` downloads)
- [ ] Manual: verify DNS entries no longer show empty Request Headers section

🤖 Generated with [Claude Code](https://claude.com/claude-code)