### PR TITLE
fix(proxy): remove firewall terminology from error responses

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -298,9 +298,9 @@ async def handle_firewall_request(
             502,
             json.dumps(
                 {
-                    "error": "firewall_auth_unavailable",
-                    "message": "Firewall auth secrets not configured",
-                    "firewall": match_info.get("ref", ""),
+                    "error": "auth_unavailable",
+                    "message": "Auth secrets not configured",
+                    "permission": match_info.get("ref", ""),
                     "base": firewall_base,
                 }
             ).encode(),
@@ -327,9 +327,9 @@ async def handle_firewall_request(
             502,
             json.dumps(
                 {
-                    "error": "firewall_auth_failed",
-                    "message": f"Failed to resolve firewall auth headers: {e}",
-                    "firewall": match_info.get("ref", ""),
+                    "error": "auth_failed",
+                    "message": f"Failed to resolve auth headers: {e}",
+                    "permission": match_info.get("ref", ""),
                     "base": firewall_base,
                 }
             ).encode(),
@@ -369,7 +369,7 @@ async def handle_firewall_request(
                     {
                         "error": "url_rewrite_forward_failed",
                         "message": "Failed to forward request to upstream",
-                        "firewall": match_info.get("ref", ""),
+                        "permission": match_info.get("ref", ""),
                     }
                 ).encode(),
                 {"Content-Type": "application/json"},

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -197,16 +197,12 @@ async def request(flow: http.HTTPFlow) -> None:
             flow.metadata["firewall_ref"] = result.ref
             error_body = json.dumps(
                 {
-                    "error": "firewall_permission_denied",
+                    "error": "permission_denied",
                     "message": "Request blocked: no matching permission rule",
                     "method": result.method,
                     "path": result.path,
-                    "firewall": result.ref,
+                    "permission": result.ref,
                     "base": result.base,
-                    "hint": (
-                        f"Add a permission rule for '{result.method} {result.path}'"
-                        f" to the {result.ref} firewall in vm0.yaml"
-                    ),
                 }
             )
             flow.response = http.Response.make(

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -1110,9 +1110,9 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata["firewall_error"] == "auth_failed"
         body = json.loads(flow.response.content)
-        assert body["error"] == "firewall_auth_failed"
+        assert body["error"] == "auth_failed"
         assert "API unreachable" in body["message"]
-        assert body["firewall"] == "github"
+        assert body["permission"] == "github"
 
     async def test_no_response_set_on_success(self):
         """On success, flow.response should remain None (request continues to origin)."""
@@ -1161,8 +1161,8 @@ class TestHandleFirewallRequest:
         assert flow.metadata["firewall_action"] == "ALLOW"
         assert flow.metadata["firewall_error"] == "auth_unavailable"
         body = json.loads(flow.response.content)
-        assert body["error"] == "firewall_auth_unavailable"
-        assert body["firewall"] == "github"
+        assert body["error"] == "auth_unavailable"
+        assert body["permission"] == "github"
 
 
 # =========================================================================

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -225,12 +225,11 @@ class TestRequestHandler:
         assert flow.metadata["firewall_action"] == "DENY"
         assert flow.metadata["firewall_base"] == "https://api.github.com"
         body = json.loads(flow.response.content)
-        assert body["error"] == "firewall_permission_denied"
+        assert body["error"] == "permission_denied"
         assert body["method"] == "GET"
         assert body["path"] == "/orgs"
-        assert body["firewall"] == "github"
+        assert body["permission"] == "github"
         assert body["base"] == "https://api.github.com"
-        assert "hint" in body
 
     async def test_firewall_permission_allows_matched(self, tmp_path):
         """Firewall with permissions and matching rule calls handler with match_info."""


### PR DESCRIPTION
## Summary

- Replace `"firewall"` key with `"permission"` in all user-facing error JSON responses from mitmproxy
- Rename error codes: `firewall_permission_denied` → `permission_denied`, `firewall_auth_unavailable` → `auth_unavailable`, `firewall_auth_failed` → `auth_failed`
- Remove `hint` field from permission denied response
- Remove "Firewall" from error messages
- Internal metadata (`firewall_action`, `firewall_base`, etc.) and logs unchanged

Closes #8483

## Test plan

- [x] Updated assertions in `test_handlers.py` and `test_connectors.py`
- [ ] `mitm-addon-test` CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)