### PR TITLE
fix(firewalls): pick narrowest permission in firewall-deny diagnostic

### DIFF
--- a/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/__tests__/firewall-deny.test.ts
@@ -118,6 +118,24 @@ describe("zero doctor firewall-deny command", () => {
     });
   });
 
+  describe("overlapping permissions", () => {
+    it("should pick the most specific (narrowest) permission for gmail send", async () => {
+      await firewallDenyCommand.parseAsync([
+        "node",
+        "cli",
+        "gmail",
+        "--method",
+        "POST",
+        "--path",
+        "/v1/users/me/messages/send",
+      ]);
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain('covered by the "gmail.send"');
+      expect(logCalls).toContain("--permission gmail.send --enable");
+    });
+  });
+
   describe("next-step command format", () => {
     it("should include the exact firewall ref in the suggested command", async () => {
       await firewallDenyCommand.parseAsync([

--- a/turbo/apps/cli/src/commands/zero/doctor/firewall-deny.ts
+++ b/turbo/apps/cli/src/commands/zero/doctor/firewall-deny.ts
@@ -57,7 +57,25 @@ Notes:
           return;
         }
 
-        const permission = permissions[0]!;
+        // Count total rules per permission name across all APIs
+        const ruleCount = new Map<string, number>();
+        for (const api of config.apis) {
+          if (!api.permissions) continue;
+          for (const perm of api.permissions) {
+            ruleCount.set(
+              perm.name,
+              (ruleCount.get(perm.name) ?? 0) + perm.rules.length,
+            );
+          }
+        }
+
+        // Pick the permission with the fewest rules (most specific)
+        const permission = permissions.reduce((narrowest, current) => {
+          return (ruleCount.get(current) ?? Infinity) <
+            (ruleCount.get(narrowest) ?? Infinity)
+            ? current
+            : narrowest;
+        });
         console.log(`This is covered by the "${permission}" permission.`);
         console.log(
           `To request this permission, run: zero doctor firewall-permissions-change ${firewallRef} --permission ${permission} --enable --reason "why this is needed"`,


### PR DESCRIPTION
## Summary

- When multiple permissions match a denied request, `firewall-deny` now selects the most specific permission (fewest total rules) instead of blindly taking `permissions[0]`
- Prevents recommending a broad permission like `gmail` when the narrow `gmail.send` is the one actually missing
- Added integration test verifying `gmail.send` is picked over `gmail` for `POST /v1/users/me/messages/send`

Closes #8488

## Test plan

- [x] Existing `firewall-deny` tests pass (7 tests)
- [x] New test verifies narrowest permission selection for gmail send overlap
- [x] Lint passes (oxlint + eslint)
- [x] Knip passes (no unused exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)