### PR TITLE
feat(model-providers): add model selection for anthropic-api-key and claude-code-oauth-token

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/settings/org-provider-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/org-provider-dialog.tsx
@@ -119,7 +119,11 @@ export function OrgProviderDialog() {
           {shape === "oauth" && (
             <OAuthFields
               secret={formValues.secret}
+              selectedModel={formValues.selectedModel}
+              useDefaultModel={formValues.useDefaultModel}
               onSecretChange={setSecret}
+              onModelChange={setModel}
+              onUseDefaultModelChange={setUseDefaultModel}
               error={errors["secret"]}
               isLoading={isLoading}
             />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/provider-dialog-fields.tsx
@@ -27,32 +27,49 @@ import { ClaudeCodeSetupPrompt } from "./setup-prompt.tsx";
 
 export function OAuthFields({
   secret,
+  selectedModel,
+  useDefaultModel,
   onSecretChange,
+  onModelChange,
+  onUseDefaultModelChange,
   error,
   isLoading,
 }: {
   secret: string;
+  selectedModel: string;
+  useDefaultModel: boolean;
   onSecretChange: (value: string) => void;
+  onModelChange: (value: string) => void;
+  onUseDefaultModelChange: (value: boolean) => void;
   error?: string;
   isLoading: boolean;
 }) {
   return (
-    <div className="flex flex-col gap-2">
-      <label className="text-sm font-medium text-foreground">
-        Claude OAuth token
-      </label>
-      <Input
-        value={secret}
-        placeholder="sk-ant-XXXXXXX"
-        onChange={(e) => {
-          return onSecretChange(e.target.value);
-        }}
-        readOnly={isLoading}
-        className={error ? "border-destructive" : ""}
+    <>
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-foreground">
+          Claude OAuth token
+        </label>
+        <Input
+          value={secret}
+          placeholder="sk-ant-XXXXXXX"
+          onChange={(e) => {
+            return onSecretChange(e.target.value);
+          }}
+          readOnly={isLoading}
+          className={error ? "border-destructive" : ""}
+        />
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <ClaudeCodeSetupPrompt />
+      </div>
+      <ModelSelector
+        providerType="claude-code-oauth-token"
+        selectedModel={selectedModel}
+        useDefaultModel={useDefaultModel}
+        onModelChange={onModelChange}
+        onUseDefaultModelChange={onUseDefaultModelChange}
       />
-      {error && <p className="text-xs text-destructive">{error}</p>}
-      <ClaudeCodeSetupPrompt />
-    </div>
+    </>
   );
 }
 

--- a/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/build-zero-context.test.ts
@@ -74,6 +74,29 @@ describe("Org-Level Runtime Resolution (Zero Layer)", () => {
       });
     });
 
+    it("should inject ANTHROPIC_MODEL when selectedModel is set", async () => {
+      const agentName = uniqueId("model-sel-agent");
+      await createTestCompose(agentName, {
+        skipDefaultApiKey: true,
+      });
+      const modelAgentId = await getTestZeroAgentId(user.orgId, agentName);
+
+      await upsertOrgModelProvider(
+        user.orgId,
+        "anthropic-api-key",
+        "org-api-key",
+        "claude-opus-4.6",
+      );
+
+      const result = await createZeroRun(baseParams({ agentId: modelAgentId }));
+
+      const job = await findTestRunnerJobEntry(result.runId);
+      expect(job).toBeDefined();
+      expect(job!.executionContext.environment).toMatchObject({
+        ANTHROPIC_MODEL: "claude-opus-4.6",
+      });
+    });
+
     it("should error when no org default provider exists", async () => {
       const agentName = uniqueId("no-key-agent");
       await createTestCompose(agentName, {

--- a/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-model-provider.ts
@@ -180,7 +180,7 @@ async function resolveVm0Provider(
   const injectedEnvironment = resolveEnvironmentMapping(
     concreteType,
     concreteSecretName,
-    poolKey.model,
+    selectedModel,
   );
 
   log.debug(

--- a/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect } from "vitest";
 import {
   getProviderBaseUrl,
   areProvidersCompatible,
+  hasModelSelection,
+  getModels,
+  getDefaultModel,
+  getEnvironmentMapping,
   type ModelProviderType,
 } from "../model-providers";
 
@@ -80,5 +84,49 @@ describe("areProvidersCompatible", () => {
     expect(areProvidersCompatible("minimax-api-key", "zai-api-key")).toBe(
       false,
     );
+  });
+});
+
+describe("model selection for Anthropic-native providers", () => {
+  it.each(["claude-code-oauth-token", "anthropic-api-key"] as const)(
+    "%s supports model selection",
+    (type) => {
+      expect(hasModelSelection(type)).toBe(true);
+    },
+  );
+
+  it.each(["claude-code-oauth-token", "anthropic-api-key"] as const)(
+    "%s offers sonnet and opus models",
+    (type) => {
+      const models = getModels(type);
+      expect(models).toContain("claude-sonnet-4.6");
+      expect(models).toContain("claude-opus-4.6");
+    },
+  );
+
+  it.each(["claude-code-oauth-token", "anthropic-api-key"] as const)(
+    "%s defaults to auto mode (empty string)",
+    (type) => {
+      expect(getDefaultModel(type)).toBe("");
+    },
+  );
+
+  it("anthropic-api-key maps ANTHROPIC_MODEL via environment mapping", () => {
+    const mapping = getEnvironmentMapping("anthropic-api-key");
+    expect(mapping).toBeDefined();
+    expect(mapping!["ANTHROPIC_API_KEY"]).toBe("$secret");
+    expect(mapping!["ANTHROPIC_MODEL"]).toBe("$model");
+  });
+
+  it("claude-code-oauth-token maps ANTHROPIC_MODEL via environment mapping", () => {
+    const mapping = getEnvironmentMapping("claude-code-oauth-token");
+    expect(mapping).toBeDefined();
+    expect(mapping!["CLAUDE_CODE_OAUTH_TOKEN"]).toBe("$secret");
+    expect(mapping!["ANTHROPIC_MODEL"]).toBe("$model");
+  });
+
+  it("Anthropic-native providers have no ANTHROPIC_BASE_URL (use default)", () => {
+    expect(getProviderBaseUrl("anthropic-api-key")).toBeNull();
+    expect(getProviderBaseUrl("claude-code-oauth-token")).toBeNull();
   });
 });

--- a/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/model-providers.test.ts
@@ -105,9 +105,9 @@ describe("model selection for Anthropic-native providers", () => {
   );
 
   it.each(["claude-code-oauth-token", "anthropic-api-key"] as const)(
-    "%s defaults to auto mode (empty string)",
+    "%s defaults to claude-sonnet-4.6",
     (type) => {
-      expect(getDefaultModel(type)).toBe("");
+      expect(getDefaultModel(type)).toBe("claude-sonnet-4.6");
     },
   );
 

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -74,7 +74,7 @@ export const MODEL_PROVIDER_TYPES = {
       ANTHROPIC_MODEL: "$model",
     } as Record<string, string>,
     models: ["claude-sonnet-4.6", "claude-opus-4.6"] as string[],
-    defaultModel: "",
+    defaultModel: "claude-sonnet-4.6",
   },
   "anthropic-api-key": {
     framework: "claude-code" as const,
@@ -88,7 +88,7 @@ export const MODEL_PROVIDER_TYPES = {
       ANTHROPIC_MODEL: "$model",
     } as Record<string, string>,
     models: ["claude-sonnet-4.6", "claude-opus-4.6"] as string[],
-    defaultModel: "",
+    defaultModel: "claude-sonnet-4.6",
   },
   "openrouter-api-key": {
     framework: "claude-code" as const,

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -69,6 +69,12 @@ export const MODEL_PROVIDER_TYPES = {
     secretLabel: "OAuth token",
     helpText:
       "To get your OAuth token, run: claude setup-token\n(Requires Claude Pro or Max subscription)",
+    environmentMapping: {
+      CLAUDE_CODE_OAUTH_TOKEN: "$secret",
+      ANTHROPIC_MODEL: "$model",
+    } as Record<string, string>,
+    models: ["claude-sonnet-4.6", "claude-opus-4.6"] as string[],
+    defaultModel: "",
   },
   "anthropic-api-key": {
     framework: "claude-code" as const,
@@ -77,6 +83,12 @@ export const MODEL_PROVIDER_TYPES = {
     secretLabel: "API key",
     helpText:
       "Get your API key at: https://console.anthropic.com/settings/keys",
+    environmentMapping: {
+      ANTHROPIC_API_KEY: "$secret",
+      ANTHROPIC_MODEL: "$model",
+    } as Record<string, string>,
+    models: ["claude-sonnet-4.6", "claude-opus-4.6"] as string[],
+    defaultModel: "",
   },
   "openrouter-api-key": {
     framework: "claude-code" as const,


### PR DESCRIPTION
## Summary
- Add `models`, `defaultModel`, and `environmentMapping` to `claude-code-oauth-token` and `anthropic-api-key` providers, enabling model selection (claude-sonnet-4.6, claude-opus-4.6) in both UI and CLI
- Add `ModelSelector` to the OAuth provider dialog (previously missing)
- Fix VM0 built-in provider bug where user's model selection was ignored at runtime (`poolKey.model` → `selectedModel` in `resolveVm0Provider`)

## Test plan
- [x] Core contract tests: `hasModelSelection`, `getModels`, `getDefaultModel`, `getEnvironmentMapping` for both providers (23 tests passing)
- [x] Integration test: verify `ANTHROPIC_MODEL` is injected into runtime environment when `selectedModel` is set
- [x] Existing `getProviderBaseUrl` and `areProvidersCompatible` tests still pass (no `ANTHROPIC_BASE_URL` in new mappings → falls back to default)
- [ ] Manual: verify OAuth dialog shows model selector dropdown
- [ ] Manual: verify API key dialog shows model selector dropdown
- [ ] Manual: verify VM0 built-in model selection actually switches the runtime model

🤖 Generated with [Claude Code](https://claude.com/claude-code)