### PR TITLE
fix(platform): open markdown links in new tab

### DIFF
--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -199,11 +199,13 @@ export function Markdown({ className, style, ...rest }: MarkdownPreviewProps) {
       rehypeRewrite={rehypeRewriteHandler}
       components={{
         table: ResponsiveTable,
-        a: ({ children, ...props }) => (
-          <a {...props} target="_blank" rel="noopener noreferrer">
-            {children}
-          </a>
-        ),
+        a: ({ children, ...props }) => {
+          return (
+            <a {...props} target="_blank" rel="noopener noreferrer">
+              {children}
+            </a>
+          );
+        },
       }}
       {...rest}
     />

--- a/turbo/apps/platform/src/views/components/markdown.tsx
+++ b/turbo/apps/platform/src/views/components/markdown.tsx
@@ -197,7 +197,14 @@ export function Markdown({ className, style, ...rest }: MarkdownPreviewProps) {
       }}
       wrapperElement={{ "data-color-mode": theme }}
       rehypeRewrite={rehypeRewriteHandler}
-      components={{ table: ResponsiveTable }}
+      components={{
+        table: ResponsiveTable,
+        a: ({ children, ...props }) => (
+          <a {...props} target="_blank" rel="noopener noreferrer">
+            {children}
+          </a>
+        ),
+      }}
       {...rest}
     />
   );


### PR DESCRIPTION
## Summary
- Markdown-rendered links in the platform app now open in a new browser tab (`target="_blank"`) instead of navigating away from the current page
- Adds `rel="noopener noreferrer"` for security

Closes #8477

## Test plan
- [x] Existing markdown tests pass
- [x] Type check passes
- [ ] Verify links in chat messages open in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)