### PR TITLE
fix(platform): center typewriter text in loading skeleton

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
+++ b/turbo/apps/platform/src/views/zero-page/app-skeleton.tsx
@@ -79,10 +79,11 @@ export function AppSkeleton({ visible = true }: { visible?: boolean }) {
           </p>
           {/* Typewriter message: appears at 800ms, types over 1.5s */}
           <p
-            className="absolute inset-0 text-base font-medium text-foreground/70 overflow-hidden whitespace-nowrap border-r-2 border-current"
+            className="absolute top-0 left-1/2 text-base font-medium text-foreground/70 overflow-hidden whitespace-nowrap border-r-2 border-current"
             style={{
               visibility: "hidden",
               width: 0,
+              marginLeft: `${-CHAR_COUNT / 2}ch`,
               animation: `sk-show-typewriter 800ms forwards, sk-typing 1.5s steps(${CHAR_COUNT}) 800ms forwards, sk-blink 0.6s step-end 800ms infinite`,
             }}
           >


### PR DESCRIPTION
## Summary
- Fix skeleton loading screen typewriter text drifting off-center when random messages have different lengths
- Replace `absolute inset-0` (anchored to container sized by static message) with `absolute top-0 left-1/2` + negative `ch` margin of half the final width, so the typewriter centers independently of the static message

## Test plan
- [ ] Manual: reload page multiple times, verify loading text stays centered regardless of which random messages are picked
- [ ] Manual: verify typewriter animation still types left-to-right with blinking caret

🤖 Generated with [Claude Code](https://claude.com/claude-code)