### PR TITLE
feat(e2e): add playwright feature tests for chat, team, and schedule pages

### DIFF
--- a/e2e/playwright/auth.setup.ts
+++ b/e2e/playwright/auth.setup.ts
@@ -2,7 +2,7 @@ import { clerk } from "@clerk/testing/playwright";
 import { expect, test as setup } from "@playwright/test";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { STORAGE_STATE } from "./playwright.config";
+import { STORAGE_STATE, deriveAppUrl } from "./playwright.config";
 
 const CREDENTIALS_PATH = path.join(__dirname, ".clerk", "credentials.json");
 
@@ -39,10 +39,6 @@ setup("authenticate and complete onboarding", async ({ page }) => {
 
   await page.context().storageState({ path: STORAGE_STATE });
 });
-
-function deriveAppUrl(webUrl: string): string {
-  return webUrl.replace(/^(https?:\/\/)www\./, "$1app.");
-}
 
 async function completeOnboarding(
   page: import("@playwright/test").Page

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -7,6 +7,10 @@ if (!process.env.VM0_API_URL) {
 
 export const STORAGE_STATE = path.join(__dirname, ".clerk", "user.json");
 
+export function deriveAppUrl(webUrl: string): string {
+  return webUrl.replace(/^(https?:\/\/)www\./, "$1app.");
+}
+
 export default defineConfig({
   testDir: ".",
   globalSetup: "./global-setup",

--- a/e2e/playwright/tests/chat.spec.ts
+++ b/e2e/playwright/tests/chat.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "@playwright/test";
+import { deriveAppUrl } from "../playwright.config";
+
+const appUrl = deriveAppUrl(process.env.VM0_API_URL ?? "");
+
+test("chat page loads after onboarding", async ({ page }) => {
+  await page.goto(appUrl);
+  await page.waitForURL(/agents\/.*\/chat/, { timeout: 30_000 });
+  await expect(page.getByTestId("chat-tagline")).toBeVisible({
+    timeout: 20_000,
+  });
+});

--- a/e2e/playwright/tests/schedule.spec.ts
+++ b/e2e/playwright/tests/schedule.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import { deriveAppUrl } from "../playwright.config";
+
+const appUrl = deriveAppUrl(process.env.VM0_API_URL ?? "");
+
+let schedulePrompt: string;
+
+test.describe.serial("schedule page CRUD", () => {
+  test.beforeAll(() => {
+    schedulePrompt = `E2E schedule ${Date.now()}-${Math.floor(Math.random() * 10_000)}`;
+  });
+
+  test("navigate to schedule page and open creation dialog", async ({
+    page,
+  }) => {
+    await page.goto(`${appUrl}/schedules`);
+    await expect(page.getByText("Scheduled tasks")).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.getByRole("button", { name: "Add schedule" }).click();
+    await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("fill and submit schedule creation form", async ({ page }) => {
+    await page.goto(`${appUrl}/schedules`);
+    await page.getByRole("button", { name: "Add schedule" }).click();
+    await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: 10_000 });
+    await page.getByLabel("Prompt").fill(schedulePrompt);
+    await page.getByRole("button", { name: "Create" }).click();
+    // Do not wait for schedule creation to complete (can take 60–120s backend processing)
+    // Just verify the click was accepted
+    await page.waitForTimeout(2_000);
+  });
+
+  test("verify schedule list page still loads after creation", async ({
+    page,
+  }) => {
+    await page.goto(`${appUrl}/schedules`);
+    await expect(page.getByText("Scheduled tasks")).toBeVisible({
+      timeout: 20_000,
+    });
+  });
+});

--- a/e2e/playwright/tests/schedule.spec.ts
+++ b/e2e/playwright/tests/schedule.spec.ts
@@ -14,7 +14,9 @@ test.describe.serial("schedule page CRUD", () => {
     page,
   }) => {
     await page.goto(`${appUrl}/schedules`);
-    await expect(page.getByText("Scheduled tasks")).toBeVisible({
+    await expect(
+      page.getByRole("heading", { name: "Scheduled tasks" })
+    ).toBeVisible({
       timeout: 20_000,
     });
     await page.getByRole("button", { name: "Add schedule" }).click();
@@ -27,16 +29,17 @@ test.describe.serial("schedule page CRUD", () => {
     await expect(page.getByLabel("Prompt")).toBeVisible({ timeout: 10_000 });
     await page.getByLabel("Prompt").fill(schedulePrompt);
     await page.getByRole("button", { name: "Create" }).click();
-    // Do not wait for schedule creation to complete (can take 60–120s backend processing)
-    // Just verify the click was accepted
-    await page.waitForTimeout(2_000);
+    // Assert the dialog closes to confirm the submission was accepted
+    await expect(page.getByLabel("Prompt")).not.toBeVisible({ timeout: 10_000 });
   });
 
   test("verify schedule list page still loads after creation", async ({
     page,
   }) => {
     await page.goto(`${appUrl}/schedules`);
-    await expect(page.getByText("Scheduled tasks")).toBeVisible({
+    await expect(
+      page.getByRole("heading", { name: "Scheduled tasks" })
+    ).toBeVisible({
       timeout: 20_000,
     });
   });

--- a/e2e/playwright/tests/team.spec.ts
+++ b/e2e/playwright/tests/team.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+import { deriveAppUrl } from "../playwright.config";
+
+const appUrl = deriveAppUrl(process.env.VM0_API_URL ?? "");
+
+let agentName: string;
+
+test.describe.serial("team page agent CRUD", () => {
+  test.beforeAll(() => {
+    agentName = `E2E-Agent-${Date.now()}-${Math.floor(Math.random() * 10_000)}`;
+  });
+
+  test("navigate to team page and verify default agent", async ({ page }) => {
+    await page.goto(`${appUrl}/agents`);
+    await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(page.getByText("Your core agent")).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(
+      page.getByRole("button", { name: "New agent" })
+    ).toBeVisible();
+  });
+
+  test("create new agent via dialog", async ({ page }) => {
+    await page.goto(`${appUrl}/agents`);
+    await page.getByRole("button", { name: "New agent" }).click();
+    await expect(page.getByText("Create a new agent")).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByPlaceholder("e.g. Research Assistant").fill(agentName);
+    await page.getByRole("button", { name: "Create" }).click();
+    await expect(page.getByText(agentName)).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("verify new agent appears on team page", async ({ page }) => {
+    await page.goto(`${appUrl}/agents`);
+    await expect(page.getByText(agentName)).toBeVisible({ timeout: 20_000 });
+    await expect(page).toHaveURL(/\/agents/);
+  });
+});

--- a/e2e/playwright/tests/team.spec.ts
+++ b/e2e/playwright/tests/team.spec.ts
@@ -15,7 +15,9 @@ test.describe.serial("team page agent CRUD", () => {
     await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible({
       timeout: 20_000,
     });
-    await expect(page.getByText("Your core agent")).toBeVisible({
+    await expect(
+      page.getByRole("heading", { name: "Your core agent" })
+    ).toBeVisible({
       timeout: 20_000,
     });
     await expect(
@@ -26,7 +28,9 @@ test.describe.serial("team page agent CRUD", () => {
   test("create new agent via dialog", async ({ page }) => {
     await page.goto(`${appUrl}/agents`);
     await page.getByRole("button", { name: "New agent" }).click();
-    await expect(page.getByText("Create a new agent")).toBeVisible({
+    await expect(
+      page.getByRole("heading", { name: "Create a new agent" })
+    ).toBeVisible({
       timeout: 10_000,
     });
     await page.getByPlaceholder("e.g. Research Assistant").fill(agentName);


### PR DESCRIPTION
## Summary

- Add `e2e/playwright/tests/chat.spec.ts` — single test that verifies the chat page loads after onboarding (ports BATS test 5)
- Add `e2e/playwright/tests/team.spec.ts` — 3 serial tests for team page agent CRUD: navigate, create agent, verify agent (ports BATS tests 6–8)
- Add `e2e/playwright/tests/schedule.spec.ts` — 3 serial tests for schedule page CRUD: navigate + open dialog, fill + submit, verify list (ports BATS tests 9–11)
- Export `deriveAppUrl` from `playwright.config.ts` and update `auth.setup.ts` to import it (eliminates duplication)

This is **PR 2 of 4** in the Playwright migration plan. Depends on #8434 (Playwright infrastructure).

## Test plan

- [ ] `VM0_API_URL`, `CLERK_SECRET_KEY`, and `CLERK_PUBLISHABLE_KEY` are set in the environment
- [ ] A running platform instance is available (dev tunnel or deployed environment)
- [ ] Run `cd e2e && npx playwright test --config playwright/playwright.config.ts`
- [ ] Verify `setup` project runs first (auth.setup.ts creates storageState)
- [ ] Verify `features` project runs 7 tests (1 chat + 3 team + 3 schedule) in parallel workers
- [ ] Verify `team.spec.ts` and `schedule.spec.ts` run their internal tests serially via `test.describe.serial`

Closes #8435

🤖 Generated with [Claude Code](https://claude.com/claude-code)