### PR TITLE
refactor(auth): rename verifyMembershipCached to getMemberRole

### DIFF
--- a/turbo/apps/web/app/api/cli/auth/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cli/auth/org/__tests__/route.test.ts
@@ -41,7 +41,7 @@ describe("POST /api/cli/auth/org", () => {
 
   it("should return 200 with new JWT when switching to valid org", async () => {
     // setupUser already creates org_cache for the default org.
-    // Insert membership cache so verifyMembershipCached succeeds without Clerk call.
+    // Insert membership cache so getMemberRole succeeds without Clerk call.
     await insertOrgMembersCacheEntry({
       orgId: user.orgId,
       userId: user.userId,

--- a/turbo/apps/web/app/api/cli/auth/org/route.ts
+++ b/turbo/apps/web/app/api/cli/auth/org/route.ts
@@ -8,7 +8,7 @@ import crypto from "crypto";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { getOrgIdBySlug } from "../../../../../src/lib/auth/org-cache";
-import { verifyMembershipCached } from "../../../../../src/lib/auth/org-membership-cache";
+import { getMemberRole } from "../../../../../src/lib/auth/org-membership-cache";
 import { generateCliToken } from "../../../../../src/lib/auth/sandbox-token";
 import { cliTokens } from "../../../../../src/db/schema/cli-tokens";
 
@@ -45,7 +45,7 @@ const router = tsr.router(cliAuthOrgContract, {
     }
 
     // 3. Verify membership
-    const membership = await verifyMembershipCached(orgId, authCtx.userId);
+    const membership = await getMemberRole(orgId, authCtx.userId);
     if (!membership) {
       return {
         status: 403 as const,

--- a/turbo/apps/web/src/lib/auth/__tests__/org-membership-cache.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/org-membership-cache.test.ts
@@ -6,11 +6,11 @@ import {
   findOrgMembersCacheEntry,
 } from "../../../__tests__/api-test-helpers";
 import { mockClerk } from "../../../__tests__/clerk-mock";
-import { verifyMembershipCached } from "../org-membership-cache";
+import { getMemberRole } from "../org-membership-cache";
 
 const context = testContext();
 
-describe("verifyMembershipCached", () => {
+describe("getMemberRole", () => {
   beforeEach(() => {
     context.setupMocks();
   });
@@ -22,7 +22,7 @@ describe("verifyMembershipCached", () => {
     const foreignOrgId = "org_foreign_no_membership";
     await insertOrgCacheEntry({ orgId: foreignOrgId, slug: "foreign-org" });
 
-    const result = await verifyMembershipCached(foreignOrgId, userId);
+    const result = await getMemberRole(foreignOrgId, userId);
     expect(result).toBeNull();
   });
 
@@ -30,7 +30,7 @@ describe("verifyMembershipCached", () => {
     const { userId, orgId } = await context.setupUser();
 
     // No cache entry exists — should call Clerk API
-    const result = await verifyMembershipCached(orgId, userId);
+    const result = await getMemberRole(orgId, userId);
 
     expect(result).not.toBeNull();
     expect(result!.role).toBe("admin");
@@ -45,7 +45,7 @@ describe("verifyMembershipCached", () => {
     // Mock Clerk to return a different role — if cache is used, we should get "member"
     mockClerk({ userId });
 
-    const result = await verifyMembershipCached(orgId, userId);
+    const result = await getMemberRole(orgId, userId);
     expect(result).not.toBeNull();
     expect(result!.role).toBe("member"); // From cache, not Clerk
   });
@@ -63,7 +63,7 @@ describe("verifyMembershipCached", () => {
     });
 
     // Clerk returns admin role — should override stale cache
-    const result = await verifyMembershipCached(orgId, userId);
+    const result = await getMemberRole(orgId, userId);
     expect(result).not.toBeNull();
     expect(result!.role).toBe("admin"); // From Clerk, not stale cache
   });
@@ -83,8 +83,8 @@ describe("verifyMembershipCached", () => {
       cachedAt: staleTime,
     });
 
-    // verifyMembershipCached should check Clerk, find no membership, return null
-    const result = await verifyMembershipCached(foreignOrgId, userId);
+    // getMemberRole should check Clerk, find no membership, return null
+    const result = await getMemberRole(foreignOrgId, userId);
     expect(result).toBeNull();
 
     // Wait for fire-and-forget cache delete to complete

--- a/turbo/apps/web/src/lib/auth/get-auth-context.ts
+++ b/turbo/apps/web/src/lib/auth/get-auth-context.ts
@@ -9,7 +9,7 @@ import {
   verifyZeroToken,
   verifyCliToken,
 } from "./sandbox-token";
-import { verifyMembershipCached } from "./org-membership-cache";
+import { getMemberRole } from "./org-membership-cache";
 import { logger } from "../shared/logger";
 
 const log = logger("auth:user");
@@ -52,7 +52,7 @@ export async function getAuthContext(
         const resolved = await resolveCliTokenFromDb(cliAuth);
         if (!resolved) return null;
         if (resolved.orgId) {
-          const membership = await verifyMembershipCached(
+          const membership = await getMemberRole(
             resolved.orgId,
             resolved.userId,
           );
@@ -80,7 +80,7 @@ export async function getAuthContext(
         if (!resolved) return null;
         // Resolve org role so downstream admin checks work correctly
         if (resolved.orgId) {
-          const membership = await verifyMembershipCached(
+          const membership = await getMemberRole(
             resolved.orgId,
             resolved.userId,
           );
@@ -129,10 +129,7 @@ async function authenticateSandboxToken(
   if (zeroAuth) {
     const result = resolveZeroAuth(zeroAuth, options);
     if (result && result.orgId) {
-      const membership = await verifyMembershipCached(
-        result.orgId,
-        result.userId,
-      );
+      const membership = await getMemberRole(result.orgId, result.userId);
       if (!membership) {
         // User no longer a member — omit orgId (same pattern as CLI JWT path)
         return { userId: result.userId, runId: result.runId };

--- a/turbo/apps/web/src/lib/auth/org-membership-cache.ts
+++ b/turbo/apps/web/src/lib/auth/org-membership-cache.ts
@@ -10,12 +10,12 @@ const log = logger("org:membership-cache");
 const CACHE_TTL_MS = 60_000; // 1 minute
 
 /**
- * Verify a user's org membership via org_members_cache with Clerk API fallback.
+ * Get a user's org role via org_members_cache with Clerk API fallback.
  *
  * Returns { role } if the user is a member, null if not.
  * Cache hit: ~1ms (DB read). Cache miss: ~50-200ms (Clerk API + cache write).
  */
-export async function verifyMembershipCached(
+export async function getMemberRole(
   orgId: string,
   userId: string,
 ): Promise<{ role: OrgRole } | null> {

--- a/turbo/apps/web/src/lib/zero/email/handlers/inbound-trigger.ts
+++ b/turbo/apps/web/src/lib/zero/email/handlers/inbound-trigger.ts
@@ -15,7 +15,7 @@ import { buildIntegrationContext } from "../../integration-context";
 import { generateCallbackSecret, getApiUrl } from "../../../infra/callback";
 import { getUserIdByEmail } from "../../../auth/get-user-id-by-email";
 import { getOrgIdBySlug } from "../../../auth/org-cache";
-import { verifyMembershipCached } from "../../../auth/org-membership-cache";
+import { getMemberRole } from "../../../auth/org-membership-cache";
 import { logger } from "../../../shared/logger";
 
 const log = logger("email:inbound-trigger");
@@ -82,7 +82,7 @@ async function resolveTrigger(
   }
 
   // 4. Verify org membership
-  const membership = await verifyMembershipCached(orgId, userId);
+  const membership = await getMemberRole(orgId, userId);
   if (!membership) {
     log.debug("User is not a member of org", { userId, orgId });
     return {

--- a/turbo/apps/web/src/lib/zero/org/resolve-org.ts
+++ b/turbo/apps/web/src/lib/zero/org/resolve-org.ts
@@ -6,7 +6,7 @@ import {
 } from "../../shared/errors";
 import { getOrgMetadata } from "./org-metadata-service";
 import type { OrgMetadata } from "./org-metadata-service";
-import { verifyMembershipCached } from "../../auth/org-membership-cache";
+import { getMemberRole } from "../../auth/org-membership-cache";
 import type { AuthContext } from "../../auth/get-auth-context";
 
 import type { OrgRole } from "@vm0/core";
@@ -55,7 +55,7 @@ async function verifyMembership(
   }
 
   // Cache-backed path: check org_members_cache, fall back to Clerk API
-  const result = await verifyMembershipCached(resolved.orgId, authCtx.userId);
+  const result = await getMemberRole(resolved.orgId, authCtx.userId);
   if (!result) {
     throw forbidden("You are not a member of this organization");
   }


### PR DESCRIPTION
## Summary

- Rename `verifyMembershipCached` → `getMemberRole` across 7 files (~20 replacements)
- Update JSDoc to reflect new name semantics ("Get a user's org role" instead of "Verify a user's org membership")
- No logic changes — pure rename, same signature, same behavior

Closes #8497

## Test plan

- [x] All 5 tests in `org-membership-cache.test.ts` pass (cache hit, cache miss, TTL, stale delete, non-member)
- [x] All 6 tests in `cli/auth/org/route.test.ts` pass
- [x] `grep -r verifyMembershipCached turbo/` returns 0 results
- [x] Lint passes with 0 errors
- [x] Knip finds no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)