### PR TITLE
feat(runner): enable keep-alive for production runners

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -75,6 +75,7 @@
         --runner-dirname {{ runner_name }}
         --api-url {{ api_url }}
         --token vm0_official_{{ official_runner_secret }}
+        --keep-alive
 
     - name: Install and start runner service
       command: >


### PR DESCRIPTION
## Summary
- Adds `--keep-alive` flag to the deploy playbook's `runner config` command
- Production runners will preserve VMs between conversation turns for session reuse
- Works with session affinity dispatch (#8474) to route follow-up turns to the same runner

## Test plan
- [ ] Deploy to a runner and verify `runner.yaml` contains `keep_alive: true`
- [ ] Run a multi-turn session and verify VM reuse in runner logs ("reusing idle VM for session")

🤖 Generated with [Claude Code](https://claude.com/claude-code)