### PR TITLE
chore(platform): add eslint rule to ban try statements in production code

### DIFF
--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -152,6 +152,23 @@ export default [
       "ccstate/no-new-abort-controller": "off",
     },
   },
+  // Ban try statements in production source code.
+  // Use accept() for API errors, useLoadableSet for loading states.
+  // If genuinely needed (JSON.parse, clipboard, polling), add an inline eslint-disable.
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["src/**/__tests__/**", "src/mocks/**"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "TryStatement",
+          message:
+            "try statements are not allowed. Use accept() for API errors, useLoadableSet for loading states. If genuinely needed (JSON.parse, clipboard, polling), add an inline eslint-disable with justification.",
+        },
+      ],
+    },
+  },
   {
     ignores: [
       "dist/**",

--- a/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-network-signals.ts
@@ -161,6 +161,7 @@ export const loadNetworkLogsNextPage$ = command(
 
     set(pagination$, { ...pg, loading: true });
 
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove try/finally — restructure loading flag cleanup
     try {
       const client = get(zeroClient$)(zeroRunNetworkLogsContract);
       const { logs, hasMore } = await fetchPage(client, runId, pg.since);

--- a/turbo/apps/platform/src/signals/agent-chat.ts
+++ b/turbo/apps/platform/src/signals/agent-chat.ts
@@ -30,6 +30,7 @@ export const currentChatAgent$ = computed(async (get) => {
     return null;
   }
 
+  // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() multi-status [200, 404]
   try {
     return await get(agentById(agentId));
   } catch (error) {

--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -17,6 +17,7 @@ export const hideAppSkeleton$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     // Avatar prefetch is a best-effort cache warm-up: a missing or
     // unavailable agent should not prevent the skeleton from hiding.
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — restructure best-effort prefetch
     try {
       const currentChatAgent = await get(currentChatAgent$);
       signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/bootstrap/loggers.ts
+++ b/turbo/apps/platform/src/signals/bootstrap/loggers.ts
@@ -11,6 +11,7 @@ export const setupLoggers$ = command(({ get }) => {
   const debugLoggers = get(get$);
   if (debugLoggers) {
     let loggerNames: string[] = [];
+    // eslint-disable-next-line no-restricted-syntax -- JSON.parse on untrusted localStorage data
     try {
       loggerNames = JSON.parse(debugLoggers);
     } catch (error) {
@@ -35,6 +36,7 @@ export const extendDebugLoggerLocalStorage$ = command(
     const debugLoggers = get(get$);
     let loggerNames: string[] = [];
     if (debugLoggers) {
+      // eslint-disable-next-line no-restricted-syntax -- JSON.parse on untrusted localStorage data
       try {
         loggerNames = JSON.parse(debugLoggers);
       } catch (error) {

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -858,6 +858,7 @@ const sendChatMessageRequest$ = command(
     signal: AbortSignal,
   ): Promise<{ threadId: string; runId: string }> => {
     const client = get(zeroClient$)(chatMessagesContract);
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() error mapping
     try {
       const result = await accept(
         client.send({ body: message, fetchOptions: { signal } }),

--- a/turbo/apps/platform/src/signals/external/feature-switch.ts
+++ b/turbo/apps/platform/src/signals/external/feature-switch.ts
@@ -54,6 +54,7 @@ export const featureSwitch$ = computed(async (get) => {
   // Layer 3: localStorage overrides (highest priority)
   const override = get(get$);
   if (override) {
+    // eslint-disable-next-line no-restricted-syntax -- JSON.parse on untrusted localStorage data
     try {
       const parsed = JSON.parse(override) as
         | Partial<Record<string, boolean>>
@@ -72,6 +73,7 @@ export const overrideFeatureSwitch$ = command(
     const current = get(get$);
     let parsed: Partial<Record<FeatureSwitchKey, boolean>> = {};
     if (current) {
+      // eslint-disable-next-line no-restricted-syntax -- JSON.parse on untrusted localStorage data
       try {
         parsed = JSON.parse(current);
       } catch (error) {

--- a/turbo/apps/platform/src/signals/external/org-domains.ts
+++ b/turbo/apps/platform/src/signals/external/org-domains.ts
@@ -20,6 +20,7 @@ const domainsResponse$ = computed(async (get) => {
 
   const createClient = get(zeroClient$);
   const client = createClient(zeroOrgDomainsContract);
+  // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() error propagation
   try {
     const result = await accept(client.list(), [200], { toast: false });
     return result.body;

--- a/turbo/apps/platform/src/signals/external/org-members.ts
+++ b/turbo/apps/platform/src/signals/external/org-members.ts
@@ -23,6 +23,7 @@ const orgMembersResponse$ = computed(async (get) => {
 
   const createClient = get(zeroClient$);
   const client = createClient(zeroOrgMembersContract);
+  // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() error propagation
   try {
     const result = await accept(client.members(), [200], { toast: false });
     return result.body;

--- a/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
+++ b/turbo/apps/platform/src/signals/queue-page/queue-signals.ts
@@ -28,6 +28,7 @@ export const startQueuePolling$ = command(
   async ({ set }, signal: AbortSignal) => {
     // Polling loop — initial data comes from queueData$ async computed
     while (!signal.aborted) {
+      // eslint-disable-next-line no-restricted-syntax -- polling loop requires try/catch for transient error retry
       try {
         await delay(POLL_INTERVAL, { signal });
         signal.throwIfAborted();

--- a/turbo/apps/platform/src/signals/zero-page/clipboard.ts
+++ b/turbo/apps/platform/src/signals/zero-page/clipboard.ts
@@ -11,6 +11,7 @@ import { throwIfAbort } from "../utils.ts";
  * Returns `true` if the text was copied, `false` if both methods failed.
  */
 export async function writeToClipboard(text: string): Promise<boolean> {
+  // eslint-disable-next-line no-restricted-syntax -- clipboard API requires try/catch for browser compatibility fallback
   try {
     await navigator.clipboard.writeText(text);
     return true;
@@ -19,6 +20,7 @@ export async function writeToClipboard(text: string): Promise<boolean> {
     // Clipboard API can throw NotAllowedError on iOS Safari when the user
     // gesture context is lost (e.g. after an async boundary). Fall back to
     // the legacy execCommand approach.
+    // eslint-disable-next-line no-restricted-syntax -- clipboard API requires try/catch for legacy execCommand fallback
     try {
       const textarea = document.createElement("textarea");
       textarea.value = text;

--- a/turbo/apps/platform/src/signals/zero-page/member-credit-caps.ts
+++ b/turbo/apps/platform/src/signals/zero-page/member-credit-caps.ts
@@ -120,6 +120,7 @@ function createMemberCapSetting(
     );
     set(internalSavingPromise$, promise);
 
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() auto-toast
     try {
       await promise;
       set(internalSavingPromise$, null);
@@ -139,6 +140,7 @@ function createMemberCapSetting(
     );
     set(internalSavingPromise$, promise);
 
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() auto-toast
     try {
       await promise;
       set(internalSavingPromise$, null);

--- a/turbo/apps/platform/src/signals/zero-page/polling.ts
+++ b/turbo/apps/platform/src/signals/zero-page/polling.ts
@@ -43,6 +43,7 @@ export async function setLoop(
 ): Promise<void> {
   let fibIndex = 0;
   while (true) {
+    // eslint-disable-next-line no-restricted-syntax -- polling loop requires try/catch for transient error retry with backoff
     try {
       const done = await loopBody(signal);
       if (done) {
@@ -166,6 +167,7 @@ function createQueuePosition(runId: string) {
     queuePosition$: computed(async (get) => {
       const createClient = get(zeroClient$);
       const client = createClient(zeroQueuePositionContract);
+      // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() error propagation
       try {
         const result = await accept(
           client.getPosition({ query: { runId } }),

--- a/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/connectors.ts
@@ -113,6 +113,7 @@ const hiddenConnectorTypes$ = computed((get): Set<ConnectorType> => {
   if (!raw) {
     return new Set();
   }
+  // eslint-disable-next-line no-restricted-syntax -- JSON.parse on untrusted localStorage data
   try {
     const arr = JSON.parse(raw) as string[];
     return new Set(arr as ConnectorType[]);
@@ -363,6 +364,7 @@ export const connectConnector$ = command(
       document.addEventListener("visibilitychange", onVisibilityChange);
     }
 
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove try/finally — restructure event listener cleanup
     try {
       while (true) {
         if (!visibilityPollRequested) {

--- a/turbo/apps/platform/src/signals/zero-page/settings/preferences-page.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/preferences-page.ts
@@ -37,6 +37,7 @@ export const sendModeSaving$ = computed((get) => {
 export const updateSendMode$ = command(
   async ({ get, set }, value: SendMode, signal: AbortSignal) => {
     set(internalSendModeSaving$, value);
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() auto-toast
     try {
       await set(updateUserPreference$, { sendMode: value }, signal);
       // After the command completes the refetch has been triggered.
@@ -72,6 +73,7 @@ export const captureSaving$ = computed((get) => {
 export const updateCaptureNetworkBodies$ = command(
   async ({ set }, remaining: number, signal: AbortSignal) => {
     set(internalCaptureSaving$, true);
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() auto-toast
     try {
       await set(
         updateUserPreference$,

--- a/turbo/apps/platform/src/signals/zero-page/settings/settings-tab.ts
+++ b/turbo/apps/platform/src/signals/zero-page/settings/settings-tab.ts
@@ -175,6 +175,7 @@ export const uploadAvatar$ = command(
     ) => Promise<Response>,
     _signal: AbortSignal,
   ): Promise<void> => {
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() auto-toast
     try {
       const formData = new FormData();
       formData.append("file", file);

--- a/turbo/apps/platform/src/signals/zero-page/slack-channels.ts
+++ b/turbo/apps/platform/src/signals/zero-page/slack-channels.ts
@@ -15,6 +15,7 @@ export const slackChannelsInitialized$ = computed((get) => {
 export const fetchSlackChannels$ = command(
   async ({ get, set }, _signal: AbortSignal) => {
     const client = get(zeroClient$)(zeroSlackChannelsContract);
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() error propagation
     try {
       const result = await accept(client.list(), [200], { toast: false });
       set(slackChannelsState$, result.body.channels);

--- a/turbo/apps/platform/src/signals/zero-page/slack-connect-signals.ts
+++ b/turbo/apps/platform/src/signals/zero-page/slack-connect-signals.ts
@@ -51,6 +51,7 @@ export const initSlackConnectPage$ = command(
     if (!initialStatus && !initialError && workspaceId) {
       set(internalStatus$, "checking");
       const client = get(zeroClient$)(zeroSlackConnectContract);
+      // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() error propagation
       try {
         const result = await accept(client.getStatus(), [200], {
           toast: false,
@@ -86,6 +87,7 @@ export const connectSlackAccount$ = command(
     const client = get(zeroClient$)(zeroSlackConnectContract);
     const channelId = params.get("c");
     const threadTs = params.get("t");
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() auto-toast
     try {
       await accept(
         client.connect({

--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -239,6 +239,7 @@ const completeOnboarding$ = command(
       return undefined;
     }
     set(onboardingSubmitting$, true);
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove try/finally — use useLoadableSet for loading state
     try {
       set(reloadBillingStatus$);
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -161,6 +161,7 @@ export const fetchZeroSchedules$ = command(
       return;
     }
 
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() error propagation
     try {
       const client = get(zeroClient$)(zeroSchedulesMainContract);
       const result = await accept(client.list(), [200], { toast: false });
@@ -393,6 +394,7 @@ export const allOrgScheduleEntries$ = computed((get) => {
 
 export const fetchAllOrgSchedules$ = command(
   async ({ get, set }, _signal: AbortSignal) => {
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() error propagation
     try {
       const client = get(zeroClient$)(zeroSchedulesMainContract);
       const result = await accept(client.list(), [200], { toast: false });
@@ -484,6 +486,7 @@ export const runScheduleNow$ = command(
     });
     const client = get(zeroClient$)(zeroScheduleRunContract);
     let result;
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() auto-toast with toastId
     try {
       result = await accept(client.run({ body: { scheduleId } }), [201], {
         toast: false,

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-general-tab.tsx
@@ -152,6 +152,7 @@ function ProfileSection({
     }
     setSaving(true);
     setSaveError(null);
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove try/finally — use useLoadableSet for loading state
     try {
       if (pendingLogoFile) {
         const result = await uploadLogo(fetchFn, pendingLogoFile);
@@ -390,6 +391,7 @@ function DangerZoneSection({
       return;
     }
     setLeaving(true);
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove try/finally — use useLoadableSet for loading state
     try {
       const client = createClient(zeroOrgLeaveContract);
       const result = await client.leave({ body: {} });
@@ -411,6 +413,7 @@ function DangerZoneSection({
       return;
     }
     setDeleting(true);
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove try/finally — use useLoadableSet for loading state
     try {
       const client = createClient(zeroOrgDeleteContract);
       const result = await client.delete({ body: { slug: org.slug } });

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-composer.tsx
@@ -494,6 +494,7 @@ export function ZeroChatComposer({
 
   const handleConnectSuccess = async (type: string) => {
     const label = resolveConnectorLabel(type, connectorMap);
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() auto-toast
     try {
       await addConnector(type, pageSignal);
       toast.success(`${label} connected and authorized for ${displayName}`, {
@@ -512,6 +513,7 @@ export function ZeroChatComposer({
     setSavingType(type);
     detach(
       (async () => {
+        // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove — use accept() auto-toast
         try {
           if (checked) {
             await addConnector(type, pageSignal);

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-card.tsx
@@ -332,6 +332,7 @@ export function ZeroScheduleCard({
         setRunningIds((prev) => {
           return new Set([...prev, id]);
         });
+        // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove try/finally — use useLoadableSet for loading state
         try {
           await onRunNow(entry);
         } finally {

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-page.tsx
@@ -533,6 +533,7 @@ export function ZeroSchedulePage() {
     setTogglingIds((prev) => {
       return new Set([...prev, id]);
     });
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove try/finally — use useLoadableSet for loading state
     try {
       await toggleEnabled(
         {
@@ -556,6 +557,7 @@ export function ZeroSchedulePage() {
     setRunningIds((prev) => {
       return new Set([...prev, id]);
     });
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove try/finally — use useLoadableSet for loading state
     try {
       await runScheduleNow(entry.id, pageSignal);
     } finally {

--- a/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-schedule-tab.tsx
@@ -103,6 +103,7 @@ export function ZeroScheduleTab({
 
   const handleSave = async (params: ZeroScheduleSaveParams) => {
     setSaving(true);
+    // eslint-disable-next-line no-restricted-syntax -- TODO(no-try): remove try/finally — use useLoadableSet for loading state
     try {
       await onSave(params);
     } finally {


### PR DESCRIPTION
## Summary

- Add `no-restricted-syntax` ESLint rule with `TryStatement` selector to ban `try` statements in platform production source code (`src/**`, excluding tests and mocks)
- All 38 existing `try` blocks receive inline `eslint-disable-next-line` with categorized justifications:
  - **9 legitimate** (permanent disable): JSON.parse on untrusted localStorage (5), clipboard API browser compat (2), polling retry with backoff (2)
  - **29 TODO(no-try)** (to be refactored): accept() error propagation (15), useLoadableSet for loading state (8), accept() multi-status/error mapping (3), other restructuring (3)

New code writing `try {` will get an immediate ESLint error with guidance to use `accept()` or `useLoadableSet`.

## Test plan

- [x] `pnpm turbo run lint --filter=@vm0/app` — 0 warnings, 0 errors
- [x] `pnpm turbo run check-types --filter=@vm0/app` — passed
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)