### PR TITLE
ci(e2e): add playwright ci job and update merge gate

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1153,6 +1153,53 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  cli-e2e-02-playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    concurrency:
+      group: cli-e2e-02-playwright-${{ needs.prepare.outputs.job-ref }}
+      cancel-in-progress: true
+    needs: [prepare, deploy-web, deploy-app]
+    if: |
+      always() &&
+      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore: release')) &&
+      needs.prepare.outputs.job-ref != '' && (
+        needs.prepare.outputs.web-changed == 'true' ||
+        needs.prepare.outputs.cli-changed == 'true' ||
+        needs.prepare.outputs.ci-changed == 'true' ||
+        needs.prepare.outputs.e2e-changed == 'true'
+      ) &&
+      needs.deploy-web.result == 'success' &&
+      needs.deploy-app.result == 'success'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Install E2E dependencies
+        run: cd e2e && npm ci
+      - name: Install Playwright browsers
+        run: cd e2e && npx playwright install --with-deps chromium
+      - name: Run Playwright E2E tests
+        run: cd e2e && npx playwright test --config playwright/playwright.config.ts
+        env:
+          VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}
+          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          JOB_REF: ${{ needs.prepare.outputs.job-ref }}
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: |
+            e2e/playwright-report/
+            e2e/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
   # Build CLI once and share via artifact — e2e jobs download instead of rebuilding
   build-cli:
     runs-on: ubuntu-latest
@@ -2036,6 +2083,7 @@ jobs:
       - build-cli
       - build-e2b-template
       - cli-e2e-02-browser
+      - cli-e2e-02-playwright
       - cli-e2e-01-serial
       - deploy-runner-prepare
       - deploy-runner-start
@@ -2100,6 +2148,7 @@ jobs:
           check_result "build-cli" "${{ needs.build-cli.result }}" "true"
           check_result "build-e2b-template" "${{ needs.build-e2b-template.result }}" "true"
           check_result "cli-e2e-02-browser" "${{ needs.cli-e2e-02-browser.result }}" "true"
+          check_result "cli-e2e-02-playwright" "${{ needs.cli-e2e-02-playwright.result }}" "true"
           check_result "cli-e2e-01-serial" "${{ needs.cli-e2e-01-serial.result }}" "true"
           check_result "deploy-runner-prepare" "${{ needs.deploy-runner-prepare.result }}" "true"
           check_result "deploy-runner-start" "${{ needs.deploy-runner-start.result }}" "true"

--- a/e2e/playwright/auth.setup.ts
+++ b/e2e/playwright/auth.setup.ts
@@ -29,6 +29,9 @@ setup("authenticate and complete onboarding", async ({ page }) => {
     },
   });
 
+  // Navigate to app URL after sign-in (Clerk may redirect to www domain)
+  await page.goto(appUrl);
+
   // Complete onboarding if present
   await completeOnboarding(page);
 

--- a/e2e/playwright/auth.setup.ts
+++ b/e2e/playwright/auth.setup.ts
@@ -7,6 +7,7 @@ import { STORAGE_STATE, deriveAppUrl } from "./playwright.config";
 const CREDENTIALS_PATH = path.join(__dirname, ".clerk", "credentials.json");
 
 setup("authenticate and complete onboarding", async ({ page }) => {
+  setup.setTimeout(120_000);
   const raw = await readFile(CREDENTIALS_PATH, "utf-8");
   const { email, password } = JSON.parse(raw) as {
     email: string;

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -8,7 +8,9 @@ if (!process.env.VM0_API_URL) {
 export const STORAGE_STATE = path.join(__dirname, ".clerk", "user.json");
 
 export function deriveAppUrl(webUrl: string): string {
-  return webUrl.replace(/^(https?:\/\/)www\./, "$1app.");
+  // Handle preview URLs like https://pr-8510-www.vm6.ai -> https://pr-8510-app.vm6.ai
+  // and production URLs like https://www.vm7.ai -> https://app.vm7.ai
+  return webUrl.replace(/-www\./, "-app.").replace(/\/\/www\./, "//app.");
 }
 
 export default defineConfig({

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   testDir: ".",
   globalSetup: "./global-setup",
   globalTeardown: "./global-teardown",
+  timeout: 120_000,
   use: {
     baseURL: process.env.VM0_API_URL,
     ignoreHTTPSErrors: true,

--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
   testDir: ".",
   globalSetup: "./global-setup",
   globalTeardown: "./global-teardown",
-  timeout: 120_000,
   use: {
     baseURL: process.env.VM0_API_URL,
     ignoreHTTPSErrors: true,


### PR DESCRIPTION
## Summary

- Adds `cli-e2e-02-playwright` CI job to run Playwright browser E2E tests in GitHub Actions
- Job runs in parallel with `cli-e2e-02-browser` using an independent test account via `global-setup.ts`
- Adds `cli-e2e-02-playwright` to the `ci-gate-turbo` merge gate (`needs:` array and `check_result` call)

This is PR 3 of 4 in the Playwright migration plan. PRs 1-2 (#8434, #8435) added the Playwright test infrastructure and feature tests.

Closes #8436

## Test plan

- [ ] `cli-e2e-02-playwright` job appears in CI and passes (green)
- [ ] `cli-e2e-02-browser` job is unchanged and still passes
- [ ] Both jobs appear in `ci-gate-turbo` merge gate
- [ ] Playwright report artifact (`playwright-report`) is uploaded
- [ ] Job completes within the 8-minute timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)