### PR TITLE
fix(e2e): add defensive cleanup for stale playwright clerk test users

### DIFF
--- a/e2e/playwright/global-setup.ts
+++ b/e2e/playwright/global-setup.ts
@@ -3,7 +3,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   createUser,
-  deleteUserByEmail,
+  deleteStaleTestUsers,
   generatePassword,
   generateTestEmail,
 } from "./lib/clerk-api";
@@ -20,7 +20,7 @@ export default async function globalSetup(): Promise<void> {
   const email = generateTestEmail();
   const password = generatePassword();
 
-  await deleteUserByEmail(email);
+  await deleteStaleTestUsers();
   await createUser(email, password);
 
   await mkdir(path.dirname(CREDENTIALS_PATH), { recursive: true });

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -16,7 +16,7 @@ function getClerkHeaders(): Record<string, string> {
 export function generateTestEmail(): string {
   const jobRef = process.env.JOB_REF ?? "local";
   const randHex = randomBytes(4).toString("hex");
-  return `${jobRef}+clerk_test@${randHex}.ai`;
+  return `${jobRef}+clerk_test@e2e-browser-${randHex}.ai`;
 }
 
 export function generatePassword(): string {
@@ -45,6 +45,34 @@ export async function createUser(
     throw new Error(`Failed to create Clerk user: ${JSON.stringify(data)}`);
   }
   return data.id;
+}
+
+export async function deleteStaleTestUsers(): Promise<void> {
+  const jobRef = process.env.JOB_REF ?? "local";
+  const prefix = `${jobRef}+clerk_test@e2e-browser-`;
+  const searchResponse = await fetch(
+    `${CLERK_API_BASE}/users?query=${encodeURIComponent(`${jobRef}+clerk_test`)}&limit=100`,
+    { headers: getClerkHeaders() }
+  );
+  const users = (await searchResponse.json()) as Array<{
+    id: string;
+    email_addresses: Array<{ email_address: string }>;
+  }>;
+
+  for (const user of users) {
+    const userEmail = user.email_addresses[0]?.email_address;
+    if (userEmail?.startsWith(prefix)) {
+      const deleteResponse = await fetch(
+        `${CLERK_API_BASE}/users/${user.id}`,
+        { method: "DELETE", headers: getClerkHeaders() }
+      );
+      if (!deleteResponse.ok) {
+        console.warn(
+          `Failed to delete stale user ${user.id} (${userEmail}): ${deleteResponse.status}`
+        );
+      }
+    }
+  }
 }
 
 export async function deleteUserByEmail(email: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Change Playwright test email format to `{JOB_REF}+clerk_test@e2e-browser-{hex}.ai` to distinguish from other e2e tests
- Add `deleteStaleTestUsers()` in `clerk-api.ts` that searches and deletes all users matching the JOB_REF + `e2e-browser-` prefix
- Replace pointless `deleteUserByEmail(randomEmail)` in global-setup with `deleteStaleTestUsers()` to clean up orphans from interrupted runs before each test

## Test plan

- [ ] Verify `generateTestEmail()` produces emails in the new format
- [ ] Verify `deleteStaleTestUsers()` only deletes users whose email starts with `{JOB_REF}+clerk_test@e2e-browser-`
- [ ] Verify existing PR close cleanup workflows still match the new email format (they match on `${JOB_REF}+clerk_test` prefix)
- [ ] Run Playwright e2e tests end-to-end to confirm auth flow works with new email format

🤖 Generated with [Claude Code](https://claude.com/claude-code)