### PR TITLE
ci: allow lighthouse-app job to soft-fail

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1963,6 +1963,7 @@ jobs:
       - name: Install LHCI CLI
         run: npm install -g @lhci/cli
       - name: Run Lighthouse CI (app)
+        continue-on-error: true
         working-directory: e2e/lighthouse
         run: |
           lhci collect \


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to the lighthouse-app CI step so it soft-fails instead of hard-failing
- The job fails intermittently due to staging environment timeouts during Puppeteer authentication (e.g. [run #24129174112](https://github.com/vm0-ai/vm0/actions/runs/24129174112)), unrelated to code changes
- Already treated as `informational` in `ci-gate-turbo`, so this change makes the job-level status consistent

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm lighthouse-app job shows green even if lhci times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)