### PR TITLE
fix(platform): filter null header values from network logs

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -141,7 +141,7 @@ function filterHeaders(
   }
   const filtered = Object.fromEntries(
     Object.entries(raw).filter(([, v]) => {
-      return v != null && v !== "";
+      return v !== null && v !== undefined;
     }),
   );
   return Object.keys(filtered).length > 0 ? filtered : null;

--- a/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/captured-body-sections.tsx
@@ -141,7 +141,7 @@ function filterHeaders(
   }
   const filtered = Object.fromEntries(
     Object.entries(raw).filter(([, v]) => {
-      return v !== "";
+      return v != null && v !== "";
     }),
   );
   return Object.keys(filtered).length > 0 ? filtered : null;


### PR DESCRIPTION
## Summary
- Axiom columnar storage returns `null` for header values that were never set
- The existing `filterHeaders` only checked for empty strings (`""`), missing `null` values
- This caused non-HTTP entries (e.g. DNS) to still render empty Request/Response Headers sections

## Test plan
- [ ] Expand a DNS network log entry — should not show Request/Response Headers
- [ ] Expand an HTTP entry with real headers — headers still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)