### PR TITLE
test(firewalls): add runtime matching tests for dot-separated field paths

### DIFF
--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -2664,3 +2664,103 @@ class TestGraphQLFieldMatching:
             body=body,
         )
         assert isinstance(result, FirewallAllow)
+
+
+class TestGraphQLNestedFieldPaths:
+    """Tests for dot-separated field path matching (e.g., field:repository.issues)."""
+
+    def test_nested_path_exact_match(self):
+        """field:repository.issues matches query with repository { issues }."""
+        body = _gql_body(
+            'query { repository(owner: "foo", name: "bar")'
+            " { issues(first: 10) { nodes { title } } } }",
+            "GetIssues",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query field:repository.issues"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_nested_path_deeper_match(self):
+        """field:repository.issues.nodes matches three-level nesting."""
+        body = _gql_body(
+            'query { repository(name: "x") { issues { nodes { title } } } }',
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query field:repository.issues.nodes"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_nested_path_no_match(self):
+        """field:repository.issues does not match repository.pullRequests."""
+        body = _gql_body(
+            'query { repository(name: "x") { pullRequests { nodes { title } } } }',
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query field:repository.issues"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_nested_wildcard_match(self):
+        """field:repository.* matches any nested field under repository."""
+        body = _gql_body(
+            'query { repository(name: "x") { pullRequests { totalCount } } }',
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query field:repository.*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_nested_wildcard_no_match_different_top(self):
+        """field:repository.* does not match viewer.login."""
+        body = _gql_body("query { viewer { login } }", "Op")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query field:repository.*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_nested_type_filter_blocks(self):
+        """type: filter still applies to nested field rules."""
+        body = _gql_body(
+            "mutation { repository { issues { id } } }",
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:query field:repository.issues"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_flat_field_still_works(self):
+        """Flat field:createIssue still works alongside nested path rules."""
+        body = _gql_body(
+            "mutation { createIssue(input: {}) { id } }",
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)

--- a/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
@@ -651,3 +651,109 @@ describe("findMatchingPermissions with GraphQL field: modifier", () => {
     ).toContain("issues-write");
   });
 });
+
+describe("findMatchingPermissions with dot-separated field paths", () => {
+  const nestedConfig: FirewallConfig = {
+    name: "github",
+    apis: [
+      {
+        base: "https://api.github.com",
+        auth: { headers: {} },
+        permissions: [
+          {
+            name: "issues-read",
+            rules: ["POST /graphql GraphQL type:query field:repository.issues"],
+          },
+          {
+            name: "deep-read",
+            rules: [
+              "POST /graphql GraphQL type:query field:repository.issues.nodes",
+            ],
+          },
+          {
+            name: "repo-wildcard",
+            rules: ["POST /graphql GraphQL type:query field:repository.*"],
+          },
+          {
+            name: "issues-write",
+            rules: ["POST /graphql GraphQL type:mutation field:createIssue"],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("matches exact nested path", () => {
+    const body: GraphQLBody = {
+      type: "query",
+      fields: ["repository.issues", "repository.issues.nodes"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", nestedConfig, body),
+    ).toContain("issues-read");
+  });
+
+  it("matches deeper nested path", () => {
+    const body: GraphQLBody = {
+      type: "query",
+      fields: [
+        "repository.issues",
+        "repository.issues.nodes",
+        "repository.issues.nodes.title",
+      ],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", nestedConfig, body),
+    ).toContain("deep-read");
+  });
+
+  it("does not match when nested path is absent", () => {
+    const body: GraphQLBody = {
+      type: "query",
+      fields: ["repository.pullRequests"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", nestedConfig, body),
+    ).not.toContain("issues-read");
+  });
+
+  it("wildcard matches any nested path under prefix", () => {
+    const body: GraphQLBody = {
+      type: "query",
+      fields: ["repository.pullRequests"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", nestedConfig, body),
+    ).toContain("repo-wildcard");
+  });
+
+  it("wildcard does not match different top-level", () => {
+    const body: GraphQLBody = {
+      type: "query",
+      fields: ["viewer.login"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", nestedConfig, body),
+    ).not.toContain("repo-wildcard");
+  });
+
+  it("flat field still works alongside nested rules", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["createIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", nestedConfig, body),
+    ).toContain("issues-write");
+  });
+
+  it("type filter blocks nested path match", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["repository.issues"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", nestedConfig, body),
+    ).not.toContain("issues-read");
+  });
+});


### PR DESCRIPTION
## Summary

- Add runtime matching tests for nested GraphQL field path patterns (e.g., `field:repository.issues`)
- The feature was shipped in #8520 but only had validation tests, not runtime matching tests
- Covers: exact match, deep nesting, wildcard (`repository.*`), type filter blocking, no-match cases

## Test plan

- [x] 53 TS rule-matcher tests pass (7 new)
- [x] 195 Python connector tests pass (7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)