### PR TITLE
feat(cli): add voice-chat context commands for worker sandbox

### DIFF
--- a/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero-capability-visibility.test.ts
@@ -24,6 +24,7 @@ function buildCommands(): Command[] {
     new Command("slack"),
     new Command("variable"),
     new Command("whoami"),
+    new Command("voice-chat"),
   ];
 }
 
@@ -138,6 +139,7 @@ describe("registerZeroCommands", () => {
       "secret",
       "slack",
       "variable",
+      "voice-chat",
     ]);
   });
 
@@ -272,5 +274,30 @@ describe("registerZeroCommands", () => {
     const prog = buildProgram();
 
     expect(hiddenCommandNames(prog)).toContain("connector");
+  });
+
+  it("should show voice-chat when voice-chat:write capability is present", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["voice-chat:write"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+
+    expect(visibleCommandNames(prog)).toContain("voice-chat");
+    expect(visibleCommandNames(prog)).toContain("whoami");
+  });
+
+  it("should hide voice-chat when voice-chat:write capability is missing", () => {
+    const token = buildZeroToken({
+      scope: "zero",
+      capabilities: ["agent:read"],
+    });
+    vi.stubEnv("ZERO_TOKEN", token);
+
+    const prog = buildProgram();
+
+    expect(hiddenCommandNames(prog)).toContain("voice-chat");
   });
 });

--- a/turbo/apps/cli/src/__tests__/zero.test.ts
+++ b/turbo/apps/cli/src/__tests__/zero.test.ts
@@ -29,6 +29,7 @@ describe("zero CLI program", () => {
       "ask-user",
       "developer-support",
       "computer-use",
+      "voice-chat",
     ];
     for (const name of expectedCommands) {
       expect(commandNames).toContain(name);
@@ -52,7 +53,7 @@ describe("zero CLI program", () => {
     }
   });
 
-  it("should have exactly 16 commands", () => {
-    expect(commandNames).toHaveLength(16);
+  it("should have exactly 17 commands", () => {
+    expect(commandNames).toHaveLength(17);
   });
 });

--- a/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/append.test.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/append.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for zero voice-chat context append command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { voiceChatContextAppendCommand } from "../context/append";
+
+const CONTEXT_URL = "http://localhost:3000/api/zero/voice-chat/:id/context";
+
+describe("zero voice-chat context append command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful append", () => {
+    it("should append an event with --content", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      const createdEvent = {
+        seq: 1,
+        source: "worker",
+        type: "result",
+        content: "Done",
+        createdAt: "2026-01-01T00:00:00Z",
+      };
+
+      server.use(
+        http.post(CONTEXT_URL, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(createdEvent, { status: 200 });
+        }),
+      );
+
+      await voiceChatContextAppendCommand.parseAsync([
+        "node",
+        "cli",
+        "session-123",
+        "--source",
+        "worker",
+        "--type",
+        "result",
+        "--content",
+        "Done",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        source: "worker",
+        type: "result",
+        content: "Done",
+      });
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        JSON.stringify(createdEvent, null, 2),
+      );
+    });
+
+    it("should append an event without --content", async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
+      server.use(
+        http.post(CONTEXT_URL, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            {
+              seq: 1,
+              source: "worker",
+              type: "heartbeat",
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await voiceChatContextAppendCommand.parseAsync([
+        "node",
+        "cli",
+        "session-123",
+        "--source",
+        "worker",
+        "--type",
+        "heartbeat",
+      ]);
+
+      expect(capturedBody).toMatchObject({
+        source: "worker",
+        type: "heartbeat",
+      });
+    });
+  });
+
+  describe("API errors", () => {
+    it("should handle 401 unauthorized", async () => {
+      server.use(
+        http.post(CONTEXT_URL, () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await voiceChatContextAppendCommand.parseAsync([
+          "node",
+          "cli",
+          "session-123",
+          "--source",
+          "worker",
+          "--type",
+          "result",
+          "--content",
+          "Done",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+    });
+
+    it("should handle 404 not found", async () => {
+      server.use(
+        http.post(CONTEXT_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Voice-chat session not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await voiceChatContextAppendCommand.parseAsync([
+          "node",
+          "cli",
+          "session-123",
+          "--source",
+          "worker",
+          "--type",
+          "result",
+          "--content",
+          "Done",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Voice-chat session not found"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/get.test.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/get.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for zero voice-chat context get command
+ *
+ * Tests command-level behavior via parseAsync() following CLI testing principles:
+ * - Entry point: command.parseAsync()
+ * - Mock (external): Web API via MSW
+ * - Real (internal): All CLI code, formatters, validators
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../mocks/server";
+import { voiceChatContextGetCommand } from "../context/get";
+
+const CONTEXT_URL = "http://localhost:3000/api/zero/voice-chat/:id/context";
+
+describe("zero voice-chat context get command", () => {
+  vi.spyOn(process, "exit").mockImplementation((() => {
+    throw new Error("process.exit called");
+  }) as never);
+  const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+  const mockConsoleError = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.stubEnv("VM0_API_URL", "http://localhost:3000");
+    vi.stubEnv("VM0_TOKEN", "test-token");
+  });
+
+  describe("successful get", () => {
+    it("should get context events for a session", async () => {
+      const events = {
+        events: [
+          {
+            seq: 1,
+            source: "user",
+            type: "message",
+            content: "hello",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        ],
+      };
+
+      server.use(
+        http.get(CONTEXT_URL, () => {
+          return HttpResponse.json(events, { status: 200 });
+        }),
+      );
+
+      await voiceChatContextGetCommand.parseAsync([
+        "node",
+        "cli",
+        "session-123",
+      ]);
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        JSON.stringify(events, null, 2),
+      );
+    });
+
+    it("should pass --after query parameter", async () => {
+      let capturedUrl: URL | undefined;
+
+      server.use(
+        http.get(CONTEXT_URL, ({ request }) => {
+          capturedUrl = new URL(request.url);
+          return HttpResponse.json({ events: [] }, { status: 200 });
+        }),
+      );
+
+      await voiceChatContextGetCommand.parseAsync([
+        "node",
+        "cli",
+        "session-123",
+        "--after",
+        "5",
+      ]);
+
+      expect(capturedUrl?.searchParams.get("after")).toBe("5");
+    });
+  });
+
+  describe("API errors", () => {
+    it("should handle 401 unauthorized", async () => {
+      server.use(
+        http.get(CONTEXT_URL, () => {
+          return HttpResponse.json(
+            { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+            { status: 401 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await voiceChatContextGetCommand.parseAsync([
+          "node",
+          "cli",
+          "session-123",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Not authenticated"),
+      );
+    });
+
+    it("should handle 404 not found", async () => {
+      server.use(
+        http.get(CONTEXT_URL, () => {
+          return HttpResponse.json(
+            {
+              error: {
+                message: "Voice-chat session not found",
+                code: "NOT_FOUND",
+              },
+            },
+            { status: 404 },
+          );
+        }),
+      );
+
+      await expect(async () => {
+        await voiceChatContextGetCommand.parseAsync([
+          "node",
+          "cli",
+          "session-123",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Voice-chat session not found"),
+      );
+    });
+  });
+});

--- a/turbo/apps/cli/src/commands/zero/voice-chat/context/append.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/context/append.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "fs";
+import { Command } from "commander";
+import { withErrorHandler } from "../../../../lib/command";
+import { appendVoiceChatContextEvent } from "../../../../lib/api";
+
+export const voiceChatContextAppendCommand = new Command()
+  .name("append")
+  .description("Append an event to voice-chat shared context")
+  .argument("<session-id>", "Voice-chat session ID")
+  .requiredOption(
+    "--source <source>",
+    "Event source (system|user|talker|worker)",
+  )
+  .requiredOption("--type <type>", "Event type")
+  .option(
+    "--content <content>",
+    "Event content (reads from stdin if not provided)",
+  )
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Append with content:   zero voice-chat context append <session-id> --source worker --type result --content "Done"
+  Pipe from stdin:       echo "Done" | zero voice-chat context append <session-id> --source worker --type result`,
+  )
+  .action(
+    withErrorHandler(
+      async (
+        sessionId: string,
+        options: { source: string; type: string; content?: string },
+      ) => {
+        let content = options.content;
+
+        // Read from stdin if content not provided and stdin is piped
+        if (!content && process.stdin.isTTY === false) {
+          content = readFileSync("/dev/stdin", "utf8").trim();
+        }
+
+        const data = await appendVoiceChatContextEvent(sessionId, {
+          source: options.source,
+          type: options.type,
+          content,
+        });
+        console.log(JSON.stringify(data, null, 2));
+      },
+    ),
+  );

--- a/turbo/apps/cli/src/commands/zero/voice-chat/context/get.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/context/get.ts
@@ -1,0 +1,19 @@
+import { Command } from "commander";
+import { withErrorHandler } from "../../../../lib/command";
+import { getVoiceChatContextEvents } from "../../../../lib/api";
+
+export const voiceChatContextGetCommand = new Command()
+  .name("get")
+  .description("Read shared context events for a voice-chat session")
+  .argument("<session-id>", "Voice-chat session ID")
+  .option(
+    "--after <seq>",
+    "Only return events after this sequence number",
+    parseInt,
+  )
+  .action(
+    withErrorHandler(async (sessionId: string, options: { after?: number }) => {
+      const data = await getVoiceChatContextEvents(sessionId, options.after);
+      console.log(JSON.stringify(data, null, 2));
+    }),
+  );

--- a/turbo/apps/cli/src/commands/zero/voice-chat/context/index.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/context/index.ts
@@ -1,0 +1,9 @@
+import { Command } from "commander";
+import { voiceChatContextGetCommand } from "./get";
+import { voiceChatContextAppendCommand } from "./append";
+
+export const voiceChatContextCommand = new Command()
+  .name("context")
+  .description("Read and write voice-chat shared context")
+  .addCommand(voiceChatContextGetCommand)
+  .addCommand(voiceChatContextAppendCommand);

--- a/turbo/apps/cli/src/commands/zero/voice-chat/index.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/index.ts
@@ -1,0 +1,15 @@
+import { Command } from "commander";
+import { voiceChatContextCommand } from "./context";
+
+export const zeroVoiceChatCommand = new Command()
+  .name("voice-chat")
+  .description("Read and write voice-chat shared context events")
+  .addCommand(voiceChatContextCommand)
+  .addHelpText(
+    "after",
+    `
+Examples:
+  Read all events:       zero voice-chat context get <session-id>
+  Read new events:       zero voice-chat context get <session-id> --after 5
+  Append an event:       zero voice-chat context append <session-id> --source worker --type result --content "Done"`,
+  );

--- a/turbo/apps/cli/src/lib/api/domains/zero-voice-chat-context.ts
+++ b/turbo/apps/cli/src/lib/api/domains/zero-voice-chat-context.ts
@@ -1,0 +1,49 @@
+import { initClient } from "@ts-rest/core";
+import {
+  zeroVoiceChatContextGetContract,
+  zeroVoiceChatContextAppendContract,
+  type ContextEventsResponse,
+  type ContextEvent,
+  type AppendContextEventBody,
+} from "@vm0/core";
+import { getClientConfig, handleError } from "../core/client-factory";
+
+export async function getVoiceChatContextEvents(
+  sessionId: string,
+  after?: number,
+): Promise<ContextEventsResponse> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVoiceChatContextGetContract, config);
+
+  const result = await client.getEvents({
+    params: { id: sessionId },
+    query: { after },
+    headers: {},
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to get voice-chat context events");
+}
+
+export async function appendVoiceChatContextEvent(
+  sessionId: string,
+  body: AppendContextEventBody,
+): Promise<ContextEvent> {
+  const config = await getClientConfig();
+  const client = initClient(zeroVoiceChatContextAppendContract, config);
+
+  const result = await client.appendEvent({
+    params: { id: sessionId },
+    body,
+    headers: {},
+  });
+
+  if (result.status === 200) {
+    return result.body;
+  }
+
+  handleError(result, "Failed to append voice-chat context event");
+}

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -181,3 +181,9 @@ export {
   unregisterComputerUseHost,
   getComputerUseHost,
 } from "./domains/zero-computer-use";
+
+// Domain modules - Zero Voice Chat Context
+export {
+  getVoiceChatContextEvents,
+  appendVoiceChatContextEvent,
+} from "./domains/zero-voice-chat-context";

--- a/turbo/apps/cli/src/zero.ts
+++ b/turbo/apps/cli/src/zero.ts
@@ -19,6 +19,7 @@ import { zeroSkillCommand } from "./commands/zero/skill";
 import { zeroLogsCommand } from "./commands/zero/logs";
 import { zeroDeveloperSupportCommand } from "./commands/zero/developer-support";
 import { zeroComputerUseCommand } from "./commands/zero/computer-use";
+import { zeroVoiceChatCommand } from "./commands/zero/voice-chat";
 import {
   decodeZeroTokenPayload,
   type ZeroTokenPayload,
@@ -42,6 +43,7 @@ const COMMAND_CAPABILITY_MAP: Record<string, string | null> = {
   "ask-user": null,
   "developer-support": null,
   "computer-use": "computer-use:write",
+  "voice-chat": "voice-chat:write",
 };
 
 const DEFAULT_COMMANDS: Command[] = [
@@ -61,6 +63,7 @@ const DEFAULT_COMMANDS: Command[] = [
   zeroSkillCommand,
   zeroDeveloperSupportCommand,
   zeroComputerUseCommand,
+  zeroVoiceChatCommand,
 ];
 
 function shouldHideCommand(

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -269,7 +269,6 @@ describe("sandbox-token", () => {
         "schedule:write",
         "slack:write",
         "connector:read",
-        "voice-chat:write",
       ]);
       expect(auth?.capabilities).not.toContain("computer-use:write");
       expect(auth?.capabilities).not.toContain("voice-chat:write");

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -269,6 +269,7 @@ describe("sandbox-token", () => {
         "schedule:write",
         "slack:write",
         "connector:read",
+        "voice-chat:write",
       ]);
       expect(auth?.capabilities).not.toContain("computer-use:write");
       expect(auth?.capabilities).not.toContain("voice-chat:write");

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -770,3 +770,12 @@ export {
   type InsightsRangeResponse,
   type DayInsight,
 } from "./zero-insights";
+export {
+  zeroVoiceChatContextGetContract,
+  zeroVoiceChatContextAppendContract,
+  type ZeroVoiceChatContextGetContract,
+  type ZeroVoiceChatContextAppendContract,
+  type ContextEvent,
+  type ContextEventsResponse,
+  type AppendContextEventBody,
+} from "./zero-voice-chat-context";

--- a/turbo/packages/core/src/contracts/zero-voice-chat-context.ts
+++ b/turbo/packages/core/src/contracts/zero-voice-chat-context.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+const contextEventSchema = z.object({
+  seq: z.number(),
+  source: z.string(),
+  type: z.string(),
+  content: z.string().optional(),
+  createdAt: z.string(),
+});
+
+const contextEventsResponseSchema = z.object({
+  events: z.array(contextEventSchema),
+});
+
+const appendContextEventBodySchema = z.object({
+  source: z.string(),
+  type: z.string(),
+  content: z.string().optional(),
+});
+
+export const zeroVoiceChatContextGetContract = c.router({
+  getEvents: {
+    method: "GET",
+    path: "/api/zero/voice-chat/:id/context",
+    headers: authHeadersSchema,
+    pathParams: z.object({ id: z.string().min(1) }),
+    query: z.object({ after: z.coerce.number().optional() }),
+    responses: {
+      200: contextEventsResponseSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Get shared context events for a voice-chat session",
+  },
+});
+
+export const zeroVoiceChatContextAppendContract = c.router({
+  appendEvent: {
+    method: "POST",
+    path: "/api/zero/voice-chat/:id/context",
+    headers: authHeadersSchema,
+    pathParams: z.object({ id: z.string().min(1) }),
+    body: appendContextEventBodySchema,
+    responses: {
+      200: contextEventSchema,
+      401: apiErrorSchema,
+      404: apiErrorSchema,
+    },
+    summary: "Append an event to voice-chat shared context",
+  },
+});
+
+export type ZeroVoiceChatContextGetContract =
+  typeof zeroVoiceChatContextGetContract;
+export type ZeroVoiceChatContextAppendContract =
+  typeof zeroVoiceChatContextAppendContract;
+export type ContextEvent = z.infer<typeof contextEventSchema>;
+export type ContextEventsResponse = z.infer<typeof contextEventsResponseSchema>;
+export type AppendContextEventBody = z.infer<
+  typeof appendContextEventBodySchema
+>;


### PR DESCRIPTION
## Summary

- Add `zero voice-chat context get` and `zero voice-chat context append` CLI commands for worker agents in the sandbox to read/write shared context events
- Add `voice-chat:write` capability to `ZERO_CAPABILITIES` with capability-gated command visibility
- Create ts-rest contract for voice-chat context API (`GET`/`POST /api/zero/voice-chat/:id/context`)

## Changes

- **`@vm0/core`**: Add `voice-chat:write` capability + ts-rest contract (`zero-voice-chat-context.ts`)
- **`@vm0/cli`**: New command group `voice-chat > context > get|append`, API domain module, capability map registration
- **Tests**: Command integration tests (get, append) + capability visibility tests

## Test plan

- [x] `zero voice-chat context get <session-id>` outputs JSON events
- [x] `zero voice-chat context get <session-id> --after 5` passes query param
- [x] `zero voice-chat context append <session-id> --source worker --type result --content "Done"` posts event
- [x] `context append` works without `--content` (no stdin in test env)
- [x] API error handling (401, 404)
- [x] Command hidden when `voice-chat:write` capability missing from token
- [x] Command visible when `voice-chat:write` capability present
- [x] All existing tests pass
- [x] Lint, type-check, format, knip pass

Closes #8534

🤖 Generated with [Claude Code](https://claude.com/claude-code)