### PR TITLE
feat(firewalls): support comma-separated field values in graphql rules

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -220,11 +220,13 @@ class FirewallBlock(NamedTuple):
     path: str
 
 
-def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None, str | None] | None:
-    """Parse a rule's path+suffix into (path, type_filter, op_filter, field_filter).
+def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None, list[str] | None] | None:
+    """Parse a rule's path+suffix into (path, type_filter, op_filter, field_filters).
 
     If the rule contains the ``GraphQL`` keyword, returns the path portion
     and optional ``type:`` / ``operationName:`` / ``field:`` filters.
+    The ``field:`` value may be comma-separated for OR semantics
+    (e.g., ``field:createIssue,closeIssue``).
     Returns None when the ``GraphQL`` keyword is absent (plain REST rule).
     """
     gql_idx = rest.find(" GraphQL")
@@ -236,7 +238,7 @@ def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None, str | No
 
     type_filter: str | None = None
     op_filter: str | None = None
-    field_filter: str | None = None
+    field_filters: list[str] | None = None
 
     for part in suffix_parts[1:]:  # skip "GraphQL" itself
         if part.startswith("type:"):
@@ -244,9 +246,9 @@ def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None, str | No
         elif part.startswith("operationName:"):
             op_filter = part[14:]
         elif part.startswith("field:"):
-            field_filter = part[6:]
+            field_filters = part[6:].split(",")
 
-    return path, type_filter, op_filter, field_filter
+    return path, type_filter, op_filter, field_filters
 
 
 def _match_wildcard(value: str, pattern: str) -> bool:
@@ -260,9 +262,12 @@ def match_graphql_body(
     body: bytes | None,
     type_filter: str | None,
     op_filter: str | None,
-    field_filter: str | None = None,
+    field_filters: list[str] | None = None,
 ) -> bool:
     """Match a GraphQL request body against type, operationName, and field filters.
+
+    Multiple field filters (from comma-separated ``field:a,b,c``) use OR
+    semantics: the body matches if any extracted field matches any pattern.
 
     Fail-closed: returns False if the body cannot be parsed or required
     fields are missing.
@@ -280,7 +285,7 @@ def match_graphql_body(
 
     # Extract query string early if any filter needs it.
     query_str: str | None = None
-    if type_filter is not None or field_filter is not None:
+    if type_filter is not None or field_filters is not None:
         raw = data.get("query")
         if not isinstance(raw, str):
             return False
@@ -309,12 +314,12 @@ def match_graphql_body(
         if not _match_wildcard(op_name, op_filter):
             return False
 
-    # Match field name (supports dot-separated paths like "repository.issues")
-    if field_filter is not None and query_str is not None:
+    # Match field filters (OR semantics: any pattern matching any field)
+    if field_filters is not None and query_str is not None:
         fields = extract_field_paths(query_str)
         if not fields:
             return False
-        if not any(_match_wildcard(f, field_filter) for f in fields):
+        if not any(_match_wildcard(f, pattern) for pattern in field_filters for f in fields):
             return False
 
     return True
@@ -388,10 +393,10 @@ def match_firewall_request(
                     # Check for GraphQL suffix
                     gql = parse_graphql_rule(rest)
                     if gql is not None:
-                        rule_pattern, type_filter, op_filter, field_filter = gql
+                        rule_pattern, type_filter, op_filter, field_filters = gql
                     else:
                         rule_pattern = rest
-                        type_filter, op_filter, field_filter = None, None, None
+                        type_filter, op_filter, field_filters = None, None, None
 
                     params = match_path(rel_path, rule_pattern)
                     if params is not None:
@@ -399,10 +404,10 @@ def match_firewall_request(
                         has_gql_filter = (
                             type_filter is not None
                             or op_filter is not None
-                            or field_filter is not None
+                            or field_filters is not None
                         )
                         if has_gql_filter and not match_graphql_body(
-                            body, type_filter, op_filter, field_filter
+                            body, type_filter, op_filter, field_filters
                         ):
                             continue
                         # Merge base params with rule params

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -2764,3 +2764,104 @@ class TestGraphQLNestedFieldPaths:
             body=body,
         )
         assert isinstance(result, FirewallAllow)
+
+
+class TestGraphQLCommaFieldFilter:
+    """Tests for comma-separated field: values (OR semantics)."""
+
+    def test_comma_matches_first(self):
+        """First value in comma-separated field matches."""
+        body = _gql_body("mutation { createIssue(input: {}) { id } }", "Op")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue,closeIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_comma_matches_second(self):
+        """Second value in comma-separated field matches."""
+        body = _gql_body('mutation { closeIssue(id: "1") { id } }', "Op")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue,closeIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_comma_no_match(self):
+        """No value in comma-separated field matches — blocked."""
+        body = _gql_body("mutation { deleteIssue(id: {}) { id } }", "Op")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue,closeIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_comma_with_wildcard(self):
+        """Mixed exact + wildcard in comma-separated field."""
+        body = _gql_body("mutation { deleteProject(id: {}) { id } }", "Op")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue,delete*"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_comma_type_filter_still_applies(self):
+        """type: filter blocks even when comma field matches."""
+        body = _gql_body("query { createIssue { id } }", "Op")
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue,closeIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_comma_empty_body_blocks(self):
+        """No body — blocked."""
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(["POST /graphql GraphQL field:createIssue,closeIssue"]),
+            body=None,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_comma_with_nested_paths(self):
+        """Comma-separated nested paths — OR semantics."""
+        body = _gql_body(
+            'query { repository(name: "x") { pullRequests { totalCount } } }',
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(
+                ["POST /graphql GraphQL type:query field:repository.issues,repository.pullRequests"]
+            ),
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_comma_nested_no_match(self):
+        """Comma-separated nested paths — none match."""
+        body = _gql_body(
+            'query { repository(name: "x") { labels { nodes { name } } } }',
+            "Op",
+        )
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(
+                ["POST /graphql GraphQL type:query field:repository.issues,repository.pullRequests"]
+            ),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)

--- a/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-expander.test.ts
@@ -593,6 +593,66 @@ describe("validateRule", () => {
       );
     }).toThrow("invalid GraphQL field pattern");
   });
+
+  it("should accept comma-separated field values", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL type:mutation field:createIssue,closeIssue,updateIssue",
+        "p",
+        "fw",
+      );
+    }).not.toThrow();
+  });
+
+  it("should accept comma-separated wildcards", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL type:mutation field:create*,delete*",
+        "p",
+        "fw",
+      );
+    }).not.toThrow();
+  });
+
+  it("should accept comma-separated nested paths", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL type:query field:repository.issues,repository.pullRequests",
+        "p",
+        "fw",
+      );
+    }).not.toThrow();
+  });
+
+  it("should reject trailing comma in field value", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL type:mutation field:createIssue,",
+        "p",
+        "fw",
+      );
+    }).toThrow("empty GraphQL field name");
+  });
+
+  it("should reject leading comma in field value", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL type:mutation field:,createIssue",
+        "p",
+        "fw",
+      );
+    }).toThrow("empty GraphQL field name");
+  });
+
+  it("should reject double comma in field value", () => {
+    expect(() => {
+      return validateRule(
+        "POST /graphql GraphQL type:mutation field:createIssue,,closeIssue",
+        "p",
+        "fw",
+      );
+    }).toThrow("empty GraphQL field name");
+  });
 });
 
 describe("validateBaseUrl", () => {

--- a/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/firewall-rule-matcher.test.ts
@@ -757,3 +757,163 @@ describe("findMatchingPermissions with dot-separated field paths", () => {
     ).not.toContain("issues-read");
   });
 });
+
+describe("findMatchingPermissions with comma-separated field values", () => {
+  const commaConfig: FirewallConfig = {
+    name: "github",
+    apis: [
+      {
+        base: "https://api.github.com",
+        auth: { headers: {} },
+        permissions: [
+          {
+            name: "issues-write",
+            rules: [
+              "POST /graphql GraphQL type:mutation field:createIssue,closeIssue,updateIssue",
+            ],
+          },
+          {
+            name: "pr-write",
+            rules: [
+              "POST /graphql GraphQL type:mutation field:createPullRequest,mergePullRequest",
+            ],
+          },
+          {
+            name: "mixed-wildcard",
+            rules: [
+              "POST /graphql GraphQL type:mutation field:create*,delete*",
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("matches first value in comma-separated field", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["createIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", commaConfig, body),
+    ).toContain("issues-write");
+  });
+
+  it("matches second value in comma-separated field", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["closeIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", commaConfig, body),
+    ).toContain("issues-write");
+  });
+
+  it("matches third value in comma-separated field", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["updateIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", commaConfig, body),
+    ).toContain("issues-write");
+  });
+
+  it("does not match unrelated field", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["deleteIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", commaConfig, body),
+    ).not.toContain("issues-write");
+  });
+
+  it("comma wildcards — matches first pattern", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["createProject"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", commaConfig, body),
+    ).toContain("mixed-wildcard");
+  });
+
+  it("comma wildcards — matches second pattern", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["deleteProject"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", commaConfig, body),
+    ).toContain("mixed-wildcard");
+  });
+
+  it("comma wildcards — no match for other prefix", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: ["updateProject"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", commaConfig, body),
+    ).not.toContain("mixed-wildcard");
+  });
+
+  it("type filter still applies", () => {
+    const body: GraphQLBody = {
+      type: "query",
+      fields: ["createIssue"],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", commaConfig, body),
+    ).not.toContain("issues-write");
+  });
+
+  it("empty fields — no match", () => {
+    const body: GraphQLBody = {
+      type: "mutation",
+      fields: [],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", commaConfig, body),
+    ).toEqual([]);
+  });
+
+  it("comma-separated with nested paths", () => {
+    const config: FirewallConfig = {
+      name: "test",
+      apis: [
+        {
+          base: "https://api.example.com",
+          auth: { headers: {} },
+          permissions: [
+            {
+              name: "repo-read",
+              rules: [
+                "POST /graphql GraphQL type:query field:repository.issues,repository.pullRequests",
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(
+      findMatchingPermissions("POST", "/graphql", config, {
+        type: "query",
+        fields: ["repository.pullRequests"],
+      }),
+    ).toContain("repo-read");
+    expect(
+      findMatchingPermissions("POST", "/graphql", config, {
+        type: "query",
+        fields: ["repository.issues"],
+      }),
+    ).toContain("repo-read");
+    expect(
+      findMatchingPermissions("POST", "/graphql", config, {
+        type: "query",
+        fields: ["repository.labels"],
+      }),
+    ).not.toContain("repo-read");
+  });
+});

--- a/turbo/packages/core/src/contracts/firewall-expander.ts
+++ b/turbo/packages/core/src/contracts/firewall-expander.ts
@@ -60,16 +60,18 @@ function validateGraphQLModifiers(
         );
       }
     } else if (part.startsWith("field:")) {
-      const val = part.slice(6);
-      if (!val) {
-        throw new Error(
-          `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": empty GraphQL field name`,
-        );
-      }
-      if (val !== "*" && !GRAPHQL_FIELD_PATTERN_RE.test(val)) {
-        throw new Error(
-          `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": invalid GraphQL field pattern "${val}"`,
-        );
+      const fields = part.slice(6).split(",");
+      for (const val of fields) {
+        if (!val) {
+          throw new Error(
+            `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": empty GraphQL field name`,
+          );
+        }
+        if (val !== "*" && !GRAPHQL_FIELD_PATTERN_RE.test(val)) {
+          throw new Error(
+            `Invalid rule "${rule}" in permission "${permName}" of firewall "${serviceName}": invalid GraphQL field pattern "${val}"`,
+          );
+        }
       }
     } else {
       throw new Error(

--- a/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
+++ b/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
@@ -114,6 +114,9 @@ export interface GraphQLBody {
 /**
  * Match a parsed GraphQL body against type, operationName, and field filters.
  *
+ * Multiple field filters (from comma-separated `field:a,b,c`) use OR
+ * semantics: the body matches if any extracted field matches any pattern.
+ *
  * Fail-closed: returns false if required fields are missing.
  */
 function matchWildcard(value: string, pattern: string): boolean {

--- a/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
+++ b/turbo/packages/core/src/contracts/firewall-rule-matcher.ts
@@ -63,11 +63,14 @@ interface GraphQLRule {
   path: string;
   typeFilter: string | null;
   opFilter: string | null;
-  fieldFilter: string | null;
+  fieldFilters: string[] | null;
 }
 
 /**
  * Parse the path+suffix portion of a rule for an optional GraphQL qualifier.
+ *
+ * The `field:` value may be comma-separated for OR semantics
+ * (e.g., `field:createIssue,closeIssue`).
  *
  * Returns null when the `GraphQL` keyword is absent (plain REST rule).
  */
@@ -80,7 +83,7 @@ function parseGraphQLRule(rest: string): GraphQLRule | null {
 
   let typeFilter: string | null = null;
   let opFilter: string | null = null;
-  let fieldFilter: string | null = null;
+  let fieldFilters: string[] | null = null;
 
   for (let i = 1; i < suffixParts.length; i++) {
     const part = suffixParts[i]!;
@@ -89,11 +92,11 @@ function parseGraphQLRule(rest: string): GraphQLRule | null {
     } else if (part.startsWith("operationName:")) {
       opFilter = part.slice(14);
     } else if (part.startsWith("field:")) {
-      fieldFilter = part.slice(6);
+      fieldFilters = part.slice(6).split(",");
     }
   }
 
-  return { path, typeFilter, opFilter, fieldFilter };
+  return { path, typeFilter, opFilter, fieldFilters };
 }
 
 /**
@@ -124,7 +127,7 @@ function matchGraphQLBody(
   body: GraphQLBody | undefined,
   typeFilter: string | null,
   opFilter: string | null,
-  fieldFilter: string | null,
+  fieldFilters: string[] | null,
 ): boolean {
   if (!body) return false;
 
@@ -138,12 +141,14 @@ function matchGraphQLBody(
     if (!matchWildcard(opName, opFilter)) return false;
   }
 
-  if (fieldFilter !== null) {
+  if (fieldFilters !== null) {
     const fields = body.fields;
     if (!fields || fields.length === 0) return false;
     if (
-      !fields.some((f) => {
-        return matchWildcard(f, fieldFilter);
+      !fieldFilters.some((pattern) => {
+        return fields.some((f) => {
+          return matchWildcard(f, pattern);
+        });
       })
     )
       return false;
@@ -190,12 +195,12 @@ export function findMatchingPermissions(
             gql &&
             (gql.typeFilter !== null ||
               gql.opFilter !== null ||
-              gql.fieldFilter !== null) &&
+              gql.fieldFilters !== null) &&
             !matchGraphQLBody(
               graphqlBody,
               gql.typeFilter,
               gql.opFilter,
-              gql.fieldFilter,
+              gql.fieldFilters,
             )
           ) {
             continue;


### PR DESCRIPTION
## Summary

- Support comma-separated values in `field:` modifier for OR semantics
- `field:createIssue,closeIssue,updateIssue` matches if the body contains **any** of these fields
- Each modifier keyword appears exactly once — no AND/OR ambiguity

### Syntax

```
POST /graphql GraphQL type:mutation field:createIssue,closeIssue,updateIssue
```

### Changes

| File | What |
|------|------|
| `matching.py` | `parse_graphql_rule` splits `field:` value by comma; `match_graphql_body` accepts `list[str]` |
| `firewall-rule-matcher.ts` | Same: `fieldFilters: string[] \| null` with OR matching |
| `firewall-expander.ts` | Validation splits on comma, validates each value independently |
| `test_connectors.py` | 8 new tests for comma-separated fields |
| `firewall-rule-matcher.test.ts` | 10 new tests for comma-separated fields |
| `firewall-expander.test.ts` | 6 new validation tests (accept/reject comma edge cases) |

### Validation edge cases

- `field:a,b,c` — accepted
- `field:create*,delete*` — accepted (wildcards)
- `field:repository.issues,repository.pullRequests` — accepted (nested paths)
- `field:a,` / `field:,a` / `field:a,,b` — rejected (empty value)

## Test plan

- [x] 162 TS tests pass (63 rule-matcher + 99 expander)
- [x] 203 Python tests pass
- [x] Lint clean
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)