### PR TITLE
ci(e2e): allow browser and playwright e2e jobs to soft-fail

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1137,6 +1137,7 @@ jobs:
       - name: Install E2E dependencies
         run: npm install -g agent-browser@0.22.0
       - name: Run browser E2E tests
+        continue-on-error: true
         run: |
           BATS_TEST_TIMEOUT=180 ./e2e/test/libs/bats/bin/bats -T ./e2e/tests/02-browser/*.bats
         env:
@@ -1183,6 +1184,7 @@ jobs:
       - name: Install Playwright browsers
         run: cd e2e && npx playwright install --with-deps chromium
       - name: Run Playwright E2E tests
+        continue-on-error: true
         run: cd e2e && npx playwright test --config playwright/playwright.config.ts
         env:
           VM0_API_URL: ${{ needs.deploy-web.outputs.preview-url }}


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the "Run browser E2E tests" step in `cli-e2e-02-browser`
- Add `continue-on-error: true` to the "Run Playwright E2E tests" step in `cli-e2e-02-playwright`

These jobs are already treated as informational in `ci-gate-turbo` (added in #8552), but without `continue-on-error: true` on the test steps the jobs themselves show as failed in GitHub checks, which can block the merge queue. This matches the same pattern used for `lighthouse-app` (#8513).

## Test plan
- [ ] CI passes — `cli-e2e-02-browser` and `cli-e2e-02-playwright` show as green even if the underlying tests fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)