### PR TITLE
test(platform): add integration test for markdown links opening in new tab

### DIFF
--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -92,3 +92,37 @@ describe("chat-d-065: theme signal applied to markdown rendering", () => {
     });
   });
 });
+
+describe("chat-d-066: markdown links open in new tab", () => {
+  it("should render links with target=_blank and rel=noopener noreferrer", async () => {
+    server.use(
+      http.get("*/api/zero/chat-threads/:id", () => {
+        return HttpResponse.json({
+          id: "thread-link",
+          ...THREAD_BASE,
+          chatMessages: [
+            {
+              role: "assistant",
+              content: "[example](https://example.com)",
+              createdAt: "2026-01-01T00:00:00Z",
+            },
+          ],
+        });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
+      }),
+    );
+
+    await setupPage({ context, path: "/chats/thread-link" });
+
+    await waitFor(() => {
+      const link = screen.getAllByRole("link").find((el) => {
+        return el.textContent === "example";
+      });
+      expect(link).toHaveAttribute("href", "https://example.com");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
+++ b/turbo/apps/platform/src/views/components/__tests__/markdown.test.tsx
@@ -118,7 +118,7 @@ describe("chat-d-066: markdown links open in new tab", () => {
 
     await waitFor(() => {
       const link = screen.getAllByRole("link").find((el) => {
-        return el.textContent === "example";
+        return /example/.test(el.textContent ?? "");
       });
       expect(link).toHaveAttribute("href", "https://example.com");
       expect(link).toHaveAttribute("target", "_blank");


### PR DESCRIPTION
## Summary

- Adds `chat-d-066` integration test verifying that markdown links rendered in chat messages carry `target="_blank"` and `rel="noopener noreferrer"` attributes
- The underlying feature (`ExternalLink` custom `a` component in `markdown.tsx`) was already implemented in #8494
- Test follows the established pattern in `markdown.test.tsx` using `setupPage` + MSW mocks

## Test plan

- [x] New test `chat-d-066` passes locally
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Type check passes for platform app (`pnpm check-types --filter=@vm0/app`)
- [x] Knip passes with no issues
- [x] Pre-commit hooks pass (prettier, knip, commitlint)

Closes #8473

🤖 Generated with [Claude Code](https://claude.com/claude-code)