### PR TITLE
test: add integration tests for voice-chat end and heartbeat endpoints

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/end/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/end/__tests__/route.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  createTestOrg,
+  createTestCompose,
+  createTestRunInDb,
+  insertTestVoiceChatSession,
+  getTestVoiceChatSessionStatus,
+  getTestVoiceChatEvents,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+import * as zeroRunCancelModule from "../../../../../../../src/lib/zero/zero-run-cancel";
+
+const { POST } = await import("../route");
+
+const context = testContext();
+
+const BASE_URL = "http://localhost:3000/api/zero/voice-chat";
+
+function endUrl(sessionId: string): string {
+  return `${BASE_URL}/${sessionId}/end`;
+}
+
+function paramsFor(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zvc");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+describe("POST /api/zero/voice-chat/[id]/end", () => {
+  let orgId: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    userId = user.userId;
+    const org = await setupOrg(userId);
+    orgId = org.orgId;
+
+    vi.spyOn(zeroRunCancelModule, "cancelRun").mockResolvedValue({
+      runId: "mock",
+      previousStatus: "running",
+      orgId,
+      sandboxId: null,
+      runnerGroup: null,
+    });
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+    const response = await POST(
+      createTestRequest(endUrl("any-id"), { method: "POST" }),
+      paramsFor("any-id"),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 404 for non-existent session", async () => {
+    const response = await POST(
+      createTestRequest(endUrl("00000000-0000-0000-0000-000000000000"), {
+        method: "POST",
+      }),
+      paramsFor("00000000-0000-0000-0000-000000000000"),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 403 when session belongs to different user", async () => {
+    // Create session owned by a different user
+    const otherUser = await context.setupUser({ prefix: "other-user" });
+    const otherOrg = await setupOrg(otherUser.userId);
+    const sessionId = await insertTestVoiceChatSession({
+      orgId: otherOrg.orgId,
+      userId: otherUser.userId,
+    });
+
+    // Switch auth back to original user
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const response = await POST(
+      createTestRequest(endUrl(sessionId), { method: "POST" }),
+      paramsFor(sessionId),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should return 400 when session is already ended", async () => {
+    const sessionId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      status: "ended",
+    });
+
+    const response = await POST(
+      createTestRequest(endUrl(sessionId), { method: "POST" }),
+      paramsFor(sessionId),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should end active session, write event, and cancel run", async () => {
+    // Create a run record for FK constraint
+    const compose = await createTestCompose(uniqueId("vc-agent"));
+    const testRun = await createTestRunInDb(userId, compose.composeId);
+
+    const sessionId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      runId: testRun.runId,
+    });
+
+    const response = await POST(
+      createTestRequest(endUrl(sessionId), { method: "POST" }),
+      paramsFor(sessionId),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+
+    // Verify session status updated to "ended"
+    const status = await getTestVoiceChatSessionStatus(sessionId);
+    expect(status).toBe("ended");
+
+    // Verify session-end event written
+    const events = await getTestVoiceChatEvents(sessionId);
+    expect(events).toHaveLength(1);
+    const event = events[0]!;
+    expect(event.type).toBe("session-end");
+    expect(event.source).toBe("system");
+
+    // Verify cancelRun was called
+    expect(zeroRunCancelModule.cancelRun).toHaveBeenCalledWith(
+      testRun.runId,
+      userId,
+      orgId,
+    );
+  });
+});

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/heartbeat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/heartbeat/__tests__/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  createTestRequest,
+  createTestOrg,
+  insertTestVoiceChatSession,
+  getTestVoiceChatSessionHeartbeat,
+} from "../../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
+
+const { POST } = await import("../route");
+
+const context = testContext();
+
+const BASE_URL = "http://localhost:3000/api/zero/voice-chat";
+
+function heartbeatUrl(sessionId: string): string {
+  return `${BASE_URL}/${sessionId}/heartbeat`;
+}
+
+function paramsFor(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zvc");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+describe("POST /api/zero/voice-chat/[id]/heartbeat", () => {
+  let orgId: string;
+  let userId: string;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    const user = await context.setupUser();
+    userId = user.userId;
+    const org = await setupOrg(userId);
+    orgId = org.orgId;
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+    const response = await POST(
+      createTestRequest(heartbeatUrl("any-id"), { method: "POST" }),
+      paramsFor("any-id"),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 404 for non-existent session", async () => {
+    const response = await POST(
+      createTestRequest(heartbeatUrl("00000000-0000-0000-0000-000000000000"), {
+        method: "POST",
+      }),
+      paramsFor("00000000-0000-0000-0000-000000000000"),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 404 when session belongs to different user", async () => {
+    const otherUser = await context.setupUser({ prefix: "other-user" });
+    const otherOrg = await setupOrg(otherUser.userId);
+    const sessionId = await insertTestVoiceChatSession({
+      orgId: otherOrg.orgId,
+      userId: otherUser.userId,
+    });
+
+    // Switch auth back to original user
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const response = await POST(
+      createTestRequest(heartbeatUrl(sessionId), { method: "POST" }),
+      paramsFor(sessionId),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return 404 when session is not active", async () => {
+    const sessionId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      status: "ended",
+    });
+
+    const response = await POST(
+      createTestRequest(heartbeatUrl(sessionId), { method: "POST" }),
+      paramsFor(sessionId),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(404);
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should update lastHeartbeatAt for active session", async () => {
+    const pastDate = new Date("2024-01-01T00:00:00Z");
+    const sessionId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      lastHeartbeatAt: pastDate,
+    });
+
+    const response = await POST(
+      createTestRequest(heartbeatUrl(sessionId), { method: "POST" }),
+      paramsFor(sessionId),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+
+    // Verify lastHeartbeatAt was updated
+    const heartbeatAt = await getTestVoiceChatSessionHeartbeat(sessionId);
+    expect(heartbeatAt!.getTime()).toBeGreaterThan(pastDate.getTime());
+  });
+});

--- a/turbo/apps/web/src/__tests__/api-test-helpers.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers.ts
@@ -61,7 +61,7 @@ import { creditUsage } from "../db/schema/credit-usage";
 import { sandboxTelemetry } from "../db/schema/sandbox-telemetry";
 import { creditPricing } from "../db/schema/credit-pricing";
 import { runnerState } from "../db/schema/runner-state";
-import { voiceChatSessions } from "../db/schema/voice-chat";
+import { voiceChatSessions, voiceChatEvents } from "../db/schema/voice-chat";
 import { insightsDaily } from "../db/schema/insights-daily";
 import { users } from "../db/schema/user";
 import { and, eq, like, or, sql } from "drizzle-orm";
@@ -5340,6 +5340,7 @@ export async function insertTestVoiceChatSession(overrides: {
   orgId: string;
   userId: string;
   status?: string;
+  runId?: string;
   createdAt?: Date;
   lastHeartbeatAt?: Date;
 }): Promise<string> {
@@ -5351,6 +5352,7 @@ export async function insertTestVoiceChatSession(overrides: {
       orgId: overrides.orgId,
       userId: overrides.userId,
       status: overrides.status ?? "active",
+      runId: overrides.runId,
       createdAt: overrides.createdAt ?? now,
       lastHeartbeatAt: overrides.lastHeartbeatAt ?? now,
     })
@@ -5367,4 +5369,29 @@ export async function getTestVoiceChatSessionStatus(
     .from(voiceChatSessions)
     .where(eq(voiceChatSessions.id, id));
   return row?.status;
+}
+
+export async function getTestVoiceChatSessionHeartbeat(
+  id: string,
+): Promise<Date | undefined> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ lastHeartbeatAt: voiceChatSessions.lastHeartbeatAt })
+    .from(voiceChatSessions)
+    .where(eq(voiceChatSessions.id, id));
+  return row?.lastHeartbeatAt;
+}
+
+export async function getTestVoiceChatEvents(
+  sessionId: string,
+): Promise<Array<{ type: string; source: string; content: string | null }>> {
+  initServices();
+  return globalThis.services.db
+    .select({
+      type: voiceChatEvents.type,
+      source: voiceChatEvents.source,
+      content: voiceChatEvents.content,
+    })
+    .from(voiceChatEvents)
+    .where(eq(voiceChatEvents.sessionId, sessionId));
 }


### PR DESCRIPTION
## Summary

- Add dedicated integration tests for `POST /api/zero/voice-chat/[id]/end` (5 tests) and `POST /api/zero/voice-chat/[id]/heartbeat` (5 tests)
- Add test helpers: `getTestVoiceChatSessionHeartbeat`, `getTestVoiceChatEvents`, and `runId` support in `insertTestVoiceChatSession`

## Test plan

End session tests:
- [x] 401 Unauthorized — no auth
- [x] 404 Not Found — non-existent session
- [x] 403 Forbidden — session belongs to different user
- [x] 400 Bad Request — session already ended
- [x] 200 Success — ends session, writes event, cancels run

Heartbeat tests:
- [x] 401 Unauthorized — no auth
- [x] 404 Not Found — non-existent session
- [x] 404 Not Found — session belongs to different user
- [x] 404 Not Found — session not active
- [x] 200 Success — updates lastHeartbeatAt

All 10 tests passing locally with real DB, only `cancelRun` mocked.

Closes #8559

🤖 Generated with [Claude Code](https://claude.com/claude-code)