### PR TITLE
fix(platform): remove incorrect clerk satellite configuration

### DIFF
--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -39,18 +39,10 @@ export const clerk$ = computed(async () => {
 
   const webOrigin = resolveWebOrigin();
   const clerkInstance = new Clerk(publishableKey);
-  // When running on an "app" subdomain (e.g. app.vm7.ai or pr-N-app.vm6.ai),
-  // this is a Clerk satellite application whose primary domain is the "www"
-  // subdomain.  Without isSatellite + domain, Clerk JS won't process the
-  // __clerk_db_jwt handoff token and authentication will loop back to sign-in.
-  const isSatellite = /(-app\.|^app\.)/.test(location.hostname);
   await clerkInstance.load({
     signInUrl: `${webOrigin}/sign-in`,
     signUpUrl: `${webOrigin}/sign-up`,
     afterSignOutUrl: `${webOrigin}/sign-in`,
-    ...(isSatellite && webOrigin
-      ? { isSatellite: true, domain: webOrigin }
-      : {}),
   });
   return clerkInstance;
 });


### PR DESCRIPTION
## Summary

- Remove `isSatellite` / `domain` configuration from Clerk initialization that was accidentally introduced in #8555
- This project does not use Clerk satellite mode — the config causes `Missing domain and proxyUrl` errors on app subdomains

## Test plan

- [ ] Verify Clerk auth works without `Missing domain and proxyUrl` error
- [ ] Verify sign-in/sign-out redirects still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)