### PR TITLE
ci: pass openai api key to vercel deploy in workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -336,6 +336,7 @@ jobs:
             RESEND_WEBHOOK_SECRET=${{ secrets.RESEND_WEBHOOK_SECRET }}
             RESEND_FROM_DOMAIN=${{ vars.RESEND_FROM_DOMAIN }}
             VM0_DEFAULT_AGENT=${{ vars.VM0_DEFAULT_AGENT }}
+            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
             GITHUB_APP_SLUG=${{ vars.VM0_GITHUB_APP_SLUG }}
             GITHUB_APP_ID=${{ vars.VM0_GITHUB_APP_ID }}
             GITHUB_APP_CLIENT_ID=${{ vars.VM0_GITHUB_APP_CLIENT_ID }}

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -904,6 +904,7 @@ jobs:
             RESEND_FROM_DOMAIN=${{ vars.RESEND_FROM_DOMAIN }}
             VM0_DEFAULT_AGENT=${{ vars.VM0_DEFAULT_AGENT }}
             STRAPI_URL=${{ github.event_name == 'merge_group' && vars.STRAPI_URL || '' }}
+            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
             GITHUB_APP_SLUG=${{ vars.VM0_GITHUB_APP_SLUG }}
             GITHUB_APP_ID=${{ vars.VM0_GITHUB_APP_ID }}
             GITHUB_APP_CLIENT_ID=${{ vars.VM0_GITHUB_APP_CLIENT_ID }}


### PR DESCRIPTION
## Summary
- Add `OPENAI_API_KEY` secret to Vercel deploy steps in both `release-please.yml` and `turbo.yml` workflows
- Fixes the "OpenAI API key not configured" 503 error on the voice-chat token endpoint in production

## Test plan
- [ ] Verify `OPENAI_API_KEY` exists in GitHub Secrets (already confirmed)
- [ ] After merge + deploy, voice-chat token endpoint returns 200 instead of 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)