### PR TITLE
refactor(platform): move voice chat button from chat page to sidebar

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -60,6 +60,7 @@ export type SidebarNavId =
   | "settingsUsage"
   | "queues"
   | "phone"
+  | "voiceChat"
   | "lab";
 
 export function isChatRoute(key: RouteKey | null): boolean {
@@ -86,6 +87,7 @@ export const handleZeroNavSelect$ = command(({ set }, id: SidebarNavId) => {
       settings: ROUTES.settings,
       settingsUsage: ROUTES.settingsUsage,
       phone: ROUTES.phone,
+      voiceChat: ROUTES.voiceChat,
       lab: ROUTES.lab,
     } satisfies Record<
       Exclude<SidebarNavId, "queues">,

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -44,9 +44,6 @@ import {
 } from "../../signals/zero-page/zero-chat-page.ts";
 import { ConnectorIcon } from "./components/settings/connector-icons.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
-import { FeatureSwitchKey } from "@vm0/core";
-import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
-import { ROUTES } from "../../signals/route-paths.ts";
 import { Link } from "../router/link.tsx";
 import {
   resetTalkSendSignal$,
@@ -212,7 +209,6 @@ export function AgentChatPage() {
 
   const suggestedPrompts = useGet(suggestedPrompts$);
   const navigate = useSet(detachedNavigateTo$);
-  const features = useLastResolved(featureSwitch$);
 
   const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
   const pinnedStatus = useLastResolved(currentChatAgentPinned$);
@@ -402,27 +398,6 @@ export function AgentChatPage() {
                 <IconArrowUpRight size={14} stroke={2} />
               </div>
             </button>
-            {features?.[FeatureSwitchKey.VoiceChat] && (
-              <button
-                type="button"
-                className="zero-card cursor-pointer p-4 text-left flex flex-col relative group hover:bg-muted/30 transition-colors"
-                onClick={() => {
-                  navigate(ROUTES.voiceChat);
-                }}
-              >
-                <IconArrowUpRight
-                  size={14}
-                  stroke={2}
-                  className="absolute top-4 right-4 text-muted-foreground/0 group-hover:text-muted-foreground transition-colors"
-                />
-                <p className="text-sm font-semibold text-foreground pr-5">
-                  Voice chat
-                </p>
-                <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">
-                  Talk to your agent with real-time voice
-                </p>
-              </button>
-            )}
           </div>
         </div>
       </main>

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   IconPlug,
   IconFlask,
   IconPhone,
+  IconMicrophone,
   IconSparkles,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/core";
@@ -152,6 +153,15 @@ const FOOTER_NAV = [
     icon: IconPhone as NavIcon,
     iconImg: undefined,
     featureGate: FeatureSwitchKey.PhoneIntegration,
+  },
+  {
+    id: "voiceChat",
+    activeKeys: ["voiceChat"],
+    pathname: "/voice-chat",
+    label: "Voice Chat",
+    icon: IconMicrophone as NavIcon,
+    iconImg: undefined,
+    featureGate: FeatureSwitchKey.VoiceChat,
   },
   {
     id: "lab",


### PR DESCRIPTION
## Summary
- Remove Voice Chat card from the agent chat page's suggested prompts grid
- Add Voice Chat entry to sidebar footer navigation (next to Phone), gated by `FeatureSwitchKey.VoiceChat`
- Uses `IconMicrophone` icon, consistent with voice/audio UX

## Test plan
- [ ] With VoiceChat feature enabled: Voice Chat appears in sidebar footer (below Phone)
- [ ] Voice Chat button navigates to `/voice-chat` route
- [ ] With VoiceChat feature disabled: button is hidden in sidebar
- [ ] Agent chat page no longer shows Voice Chat card

🤖 Generated with [Claude Code](https://claude.com/claude-code)