### PR TITLE
feat(runs): add session id to run context snapshot and ui

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
@@ -65,6 +65,7 @@ function makeBaseContext(
   return {
     prompt: "Default prompt text",
     appendSystemPrompt: null,
+    sessionId: null,
     secretNames: [],
     vars: null,
     environment: {},

--- a/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
@@ -206,6 +206,40 @@ describe("contextContent", () => {
     expect(screen.getByText("Be helpful")).toBeInTheDocument();
   });
 
+  it("should render session id when present (ACT-C-002c)", async () => {
+    setupMocks({
+      contextResponse: makeBaseContext({
+        sessionId: "sess-abc-123",
+      }),
+    });
+
+    await setupAndNavigateToTab("Context");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Session", level: 3 }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("sess-abc-123")).toBeInTheDocument();
+  });
+
+  it("should not render session id when null (ACT-C-002d)", async () => {
+    setupMocks({
+      contextResponse: makeBaseContext({ sessionId: null }),
+    });
+
+    await setupAndNavigateToTab("Context");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Prompt", level: 3 }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("heading", { name: "Session", level: 3 }),
+    ).not.toBeInTheDocument();
+  });
+
   it("should not render system prompt when null (ACT-C-002b)", async () => {
     setupMocks({
       contextResponse: makeBaseContext({ appendSystemPrompt: null }),

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
@@ -181,6 +181,7 @@ describe("zeroActivityDetailPageInteraction", () => {
     const contextResponse: RunContextResponse = {
       prompt: "What is the capital of France?",
       appendSystemPrompt: null,
+      sessionId: null,
       secretNames: [],
       vars: null,
       environment: {},

--- a/turbo/apps/platform/src/views/zero-page/components/context-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/context-content.tsx
@@ -124,6 +124,16 @@ export function ContextContent({ context }: { context: RunContextResponse }) {
         </section>
       )}
 
+      {/* Session */}
+      {context.sessionId && (
+        <section>
+          <SectionHeader title="Session" />
+          <p className="text-sm font-mono text-muted-foreground">
+            {context.sessionId}
+          </p>
+        </section>
+      )}
+
       {/* Secrets */}
       <section>
         <SectionHeader title="Secrets" />

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -96,6 +96,7 @@ describe("GET /api/zero/runs/:id/context", () => {
 
     const data = await response.json();
     expect(data.prompt).toBe("test prompt");
+    expect(data.sessionId).toBeNull();
     expect(data.secretNames).toEqual(["API_KEY", "DB_PASSWORD"]);
     expect(data.environment).toEqual({
       NODE_ENV: "production",

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -34,6 +34,7 @@ function makeSnapshot(runId: string, userId: string): RunContextSnapshot {
     userId,
     prompt: "test prompt",
     appendSystemPrompt: null,
+    sessionId: null,
     secretNames: ["API_KEY", "DB_PASSWORD"],
     environment: {
       NODE_ENV: "production",

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
@@ -53,6 +53,7 @@ const router = tsr.router(zeroRunContextContract, {
       body: {
         prompt: snapshot.prompt,
         appendSystemPrompt: snapshot.appendSystemPrompt,
+        sessionId: snapshot.sessionId ?? null,
         secretNames: snapshot.secretNames,
         vars: (run.vars as Record<string, string> | undefined) ?? null,
         environment: snapshot.environment,

--- a/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
@@ -184,6 +184,7 @@ function buildRunContextSnapshot(context: PreparedContext): RunContextSnapshot {
     userId: context.userId,
     prompt: context.prompt,
     appendSystemPrompt: context.appendSystemPrompt,
+    sessionId: context.continuedFromSessionId ?? null,
     secretNames: context.secrets ? Object.keys(context.secrets) : [],
     environment,
     firewalls,

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -190,6 +190,7 @@ const runContextFirewallSchema = z.object({
 const runContextResponseSchema = z.object({
   prompt: z.string(),
   appendSystemPrompt: z.string().nullable(),
+  sessionId: z.string().nullable(),
   secretNames: z.array(z.string()),
   vars: z.record(z.string(), z.string()).nullable(),
   environment: z.record(z.string(), z.string()),


### PR DESCRIPTION
## Summary

- Include `continuedFromSessionId` in the Axiom run context snapshot
- Expose `sessionId` via `GET /api/zero/runs/:id/context` endpoint
- Display session ID in the Context debug tab (between System Prompt and Secrets)

### Changes

| File | What |
|------|------|
| `zero-runs.ts` | Add `sessionId: z.string().nullable()` to `runContextResponseSchema` |
| `runner-executor.ts` | Write `continuedFromSessionId` into `buildRunContextSnapshot` |
| `route.ts` (context) | Return `sessionId` from Axiom snapshot |
| `context-content.tsx` | Show Session section when `sessionId` is present |
| 3 test files | Add `sessionId: null` to `RunContextResponse` fixtures |

## Test plan

- [x] 34 web run tests pass
- [x] 21 platform context/activity tests pass
- [x] Type check passes (app + core)
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)