### PR TITLE
feat(slack): include triggering user in slack message footers

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -417,6 +417,52 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     expect(blocksStr).not.toContain("clipboard");
   });
 
+  it("includes triggeredBy footer with Slack user mention in completion message", async () => {
+    const slackUserId = uniqueId("U-slack");
+    const { workspaceId } = await setupOrgSlack();
+    const { connectionId } = await seedTestSlackOrgConnection({
+      slackUserId,
+      slackWorkspaceId: workspaceId,
+      vm0UserId: user.userId,
+    });
+    const { composeId } = await createTestCompose(uniqueId("agent"));
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      prompt: "Test prompt",
+    });
+    await completeTestRun(user.userId, runId);
+
+    const channelId = uniqueId("C-ch");
+    const threadTs = uniqueId("ts");
+    const payload: OrgCallbackPayload = {
+      workspaceId,
+      channelId,
+      threadTs,
+      messageTs: threadTs,
+      connectionId,
+      agentId: composeId,
+    };
+
+    const { secret } = await createTestCallback({
+      runId,
+      url: "http://localhost/api/internal/callbacks/slack/org",
+      payload: { ...payload },
+    });
+
+    const request = createCallbackRequest(
+      { runId, status: "completed", payload },
+      secret,
+    );
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const { WebClient } = await import("@slack/web-api");
+    const mockClient = new WebClient();
+    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as { blocks: unknown[] };
+    const blocksStr = JSON.stringify(call.blocks);
+    expect(blocksStr).toContain(`Triggered by <@${slackUserId}>`);
+  });
+
   it("includes audit link block when AuditLink switch is on", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -4,6 +4,7 @@ import { initServices } from "../../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../../src/lib/infra/callback";
 import { decryptSecretValue } from "../../../../../../src/lib/shared/crypto/secrets-encryption";
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
+import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-connection";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
 import { findNewSessionId } from "../../../../../../src/lib/infra/session/find-new-session";
@@ -43,6 +44,19 @@ function parsePayload(payload: unknown): SlackOrgCallbackPayload | null {
 
 function errorResponse(message: string, status: number): NextResponse {
   return NextResponse.json({ error: message }, { status });
+}
+
+/** Best-effort resolution of the Slack user who triggered the run. */
+async function resolveTriggeredByLabel(
+  connectionId: string,
+): Promise<string | undefined> {
+  const [connection] = await globalThis.services.db
+    .select({ slackUserId: slackOrgConnections.slackUserId })
+    .from(slackOrgConnections)
+    .where(eq(slackOrgConnections.id, connectionId))
+    .limit(1);
+  if (!connection) return undefined;
+  return `Triggered by <@${connection.slackUserId}>`;
 }
 
 function buildResponseText(
@@ -192,6 +206,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // Resolve session
   await saveOrgThreadSession(payload, runId, status);
 
+  // Resolve triggering user for footer attribution (best-effort)
+  const triggeredByLabel = await resolveTriggeredByLabel(
+    payload.connectionId,
+  ).catch(() => {
+    return undefined;
+  });
+
   // Post each result as a separate Slack reply (in order)
   for (let i = 0; i < allOutputs.length; i++) {
     const output = allOutputs[i]!;
@@ -201,10 +222,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const isLast = i === allOutputs.length - 1;
     const logsUrl =
       isLast && auditLinkEnabled ? buildLogsUrl(runId) : undefined;
+    const triggeredBy = isLast ? triggeredByLabel : undefined;
 
     await postMessage(client, payload.channelId, responseText, {
       threadTs: payload.threadTs,
-      blocks: buildAgentResponseMessage(responseText, logsUrl),
+      blocks: buildAgentResponseMessage(responseText, logsUrl, triggeredBy),
     });
   }
 

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/__tests__/route.test.ts
@@ -9,6 +9,7 @@ import {
   createTestSlackOrgInstallation,
   insertOrgMembersCacheEntry,
   createTestSchedule,
+  seedTestSlackOrgConnection,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -302,7 +303,7 @@ describe("POST /api/zero/integrations/slack/message", () => {
     expect(footerCtx.elements![0]!.text).toBe("Sent via My Assistant");
   });
 
-  it("appends schedule context in footer when run is triggered by a schedule", async () => {
+  it("appends schedule and creator in footer when run is triggered by a schedule", async () => {
     const agentName = uniqueId("agent");
     const { composeId } = await createTestCompose(agentName);
     await createTestZeroAgent(user.orgId, agentName, {
@@ -320,6 +321,17 @@ describe("POST /api/zero/integrations/slack/message", () => {
       triggerSource: "schedule",
     });
 
+    // Seed Slack connection so the creator is resolvable
+    const slackUserId = uniqueId("U-slack");
+    const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+      orgId: user.orgId,
+    });
+    await seedTestSlackOrgConnection({
+      slackUserId,
+      slackWorkspaceId,
+      vm0UserId: user.userId,
+    });
+
     mockClerk({ userId: null });
     await insertOrgMembersCacheEntry({
       orgId: user.orgId,
@@ -327,7 +339,6 @@ describe("POST /api/zero/integrations/slack/message", () => {
       role: "admin",
     });
     const token = await generateZeroToken(user.userId, runId, user.orgId);
-    await createTestSlackOrgInstallation({ orgId: user.orgId });
 
     const request = createTestRequest(URL, {
       method: "POST",
@@ -352,7 +363,61 @@ describe("POST /api/zero/integrations/slack/message", () => {
     const footerCtx = blocks[blocks.length - 1]!;
     expect(footerCtx.type).toBe("context");
     expect(footerCtx.elements![0]!.text).toBe(
-      'Sent via My Assistant · Triggered by schedule "Daily standup summary"',
+      `Sent via My Assistant · Triggered by schedule "Daily standup summary" · Created by <@${slackUserId}>`,
+    );
+  });
+
+  it("appends user attribution footer when run is user-triggered (not scheduled)", async () => {
+    const agentName = uniqueId("agent");
+    const { composeId } = await createTestCompose(agentName);
+    await createTestZeroAgent(user.orgId, agentName, {
+      displayName: "My Assistant",
+    });
+    const { runId } = await createTestRunInDb(user.userId, composeId);
+
+    // Seed a Slack connection for the user so resolveUserLabel can find the Slack user ID
+    const slackUserId = uniqueId("U-slack");
+    const { slackWorkspaceId } = await createTestSlackOrgInstallation({
+      orgId: user.orgId,
+    });
+    await seedTestSlackOrgConnection({
+      slackUserId,
+      slackWorkspaceId,
+      vm0UserId: user.userId,
+    });
+
+    mockClerk({ userId: null });
+    await insertOrgMembersCacheEntry({
+      orgId: user.orgId,
+      userId: user.userId,
+      role: "admin",
+    });
+    const token = await generateZeroToken(user.userId, runId, user.orgId);
+
+    const request = createTestRequest(URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ channel: "C123456", text: "Hello" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+
+    const mockClient = vi.mocked(new WebClient(""));
+    const call = vi.mocked(mockClient.chat.postMessage).mock.calls[0]![0] as {
+      blocks: Array<{ type: string; elements?: Array<{ text: string }> }>;
+    };
+
+    const blocks = call.blocks;
+    expect(blocks).toHaveLength(3); // section + divider + context
+
+    const footerCtx = blocks[blocks.length - 1]!;
+    expect(footerCtx.type).toBe("context");
+    expect(footerCtx.elements![0]!.text).toBe(
+      `Sent via My Assistant · Triggered by <@${slackUserId}>`,
     );
   });
 });

--- a/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/message/route.ts
@@ -6,6 +6,8 @@ import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { zeroAgents } from "../../../../../../src/db/schema/zero-agent";
 import { zeroRuns } from "../../../../../../src/db/schema/zero-run";
 import { zeroAgentSchedules } from "../../../../../../src/db/schema/zero-agent-schedule";
+import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-connection";
+import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
 import {
   isSlackPlatformError,
   openDMChannel,
@@ -17,7 +19,7 @@ import {
 } from "../../../../../../src/lib/zero/slack/resolve-slack-client";
 import { buildFooterBlocks } from "../../../../../../src/lib/zero/slack/blocks";
 import type { Block, KnownBlock } from "@slack/web-api";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 
 /** Best-effort agent display name resolution from a run ID. */
 async function resolveAgentLabel(runId: string): Promise<string | undefined> {
@@ -53,6 +55,30 @@ async function resolveScheduleLabel(
   return row?.description ?? undefined;
 }
 
+/** Best-effort resolution of the Slack user mention for the run owner. */
+async function resolveUserMention(runId: string): Promise<string | undefined> {
+  const [row] = await globalThis.services.db
+    .select({ slackUserId: slackOrgConnections.slackUserId })
+    .from(agentRuns)
+    .innerJoin(
+      slackOrgInstallations,
+      eq(slackOrgInstallations.orgId, agentRuns.orgId),
+    )
+    .innerJoin(
+      slackOrgConnections,
+      and(
+        eq(slackOrgConnections.vm0UserId, agentRuns.userId),
+        eq(
+          slackOrgConnections.slackWorkspaceId,
+          slackOrgInstallations.slackWorkspaceId,
+        ),
+      ),
+    )
+    .where(eq(agentRuns.id, runId))
+    .limit(1);
+  return row ? `<@${row.slackUserId}>` : undefined;
+}
+
 const router = tsr.router(integrationsSlackMessageContract, {
   sendMessage: async ({ body, headers }) => {
     initServices();
@@ -75,11 +101,25 @@ const router = tsr.router(integrationsSlackMessageContract, {
         })
       : undefined;
 
+    // Resolve user mention for footer attribution (best-effort)
+    const userMention = slackCtx.authRunId
+      ? await resolveUserMention(slackCtx.authRunId).catch(() => {
+          return undefined;
+        })
+      : undefined;
+
     // Build combined footer text from available context
     const footerParts: string[] = [];
     if (agentLabel) footerParts.push(`Sent via ${agentLabel}`);
     if (scheduleLabel)
       footerParts.push(`Triggered by schedule "${scheduleLabel}"`);
+    if (userMention) {
+      footerParts.push(
+        scheduleLabel
+          ? `Created by ${userMention}`
+          : `Triggered by ${userMention}`,
+      );
+    }
 
     // Resolve target channel: DM via user ID or direct channel ID
     let targetChannel: string;


### PR DESCRIPTION
## Summary

- Add triggering Slack user's `<@userId>` mention to message footers in both the callback handler and message send API
- User-triggered runs show `Triggered by <@user>`, schedule-triggered runs show `Created by <@user>`
- Gracefully omits user attribution when Slack connection is not found

## Footer format examples

- **User-triggered:** `Sent via my-agent · Triggered by <@ethan>`
- **Schedule-triggered:** `Sent via my-agent · Triggered by schedule "Daily standup" · Created by <@ethan>`
- **No connection:** `Sent via my-agent` (unchanged)

## Changes

- `callbacks/slack/org/route.ts` — Add `resolveTriggeredByLabel()` that looks up `slackOrgConnections` by `connectionId`, pass result to `buildAgentResponseMessage`
- `integrations/slack/message/route.ts` — Add `resolveUserMention()` using `agentRuns → slackOrgInstallations → slackOrgConnections` join, include in footer parts with context-aware prefix
- Tests added for both paths (callback handler + message API)

## Test plan

- [x] Callback handler: verified triggeredBy footer appears with correct `<@userId>` format
- [x] Message API: verified user-triggered runs show `Triggered by <@user>`
- [x] Message API: verified schedule-triggered runs show `Created by <@user>` alongside schedule label
- [x] All existing tests pass (20/20 across both test files)
- [x] Lint, format, knip all clean

Closes #8575

🤖 Generated with [Claude Code](https://claude.com/claude-code)