### PR TITLE
feat(phone): improve receptionist prompt and add file input flags to CLI

### DIFF
--- a/turbo/apps/cli/src/commands/zero/phone/__tests__/call.test.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/__tests__/call.test.ts
@@ -26,15 +26,14 @@ describe("zero phone call command", () => {
     .mockImplementation(() => {});
 
   beforeEach(() => {
+    vi.clearAllMocks();
     chalk.level = 0;
     vi.stubEnv("VM0_API_URL", "http://localhost:3000");
     vi.stubEnv("VM0_TOKEN", "test-token");
   });
 
   afterEach(() => {
-    mockExit.mockClear();
-    mockConsoleLog.mockClear();
-    mockConsoleError.mockClear();
+    vi.unstubAllEnvs();
   });
 
   describe("successful call", () => {

--- a/turbo/apps/cli/src/commands/zero/phone/__tests__/call.test.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/__tests__/call.test.ts
@@ -7,6 +7,9 @@
  * - Real (internal): All CLI code, formatters, validators
  */
 
+import * as os from "os";
+import * as fs from "fs";
+import * as path from "path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
@@ -134,6 +137,162 @@ describe("zero phone call command", () => {
         await callCommand.parseAsync(["node", "cli", "+14155551234"]);
       }).rejects.toThrow("process.exit called");
 
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("file-based input", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "phone-test-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true });
+    });
+
+    it("should read system prompt from --prompt-file", async () => {
+      const promptFile = path.join(tmpDir, "prompt.txt");
+      fs.writeFileSync(promptFile, "Custom multi-line\nsystem prompt");
+
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/phone-calls",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              callId: "call_xyz",
+              status: "initiated",
+            });
+          },
+        ),
+      );
+
+      await callCommand.parseAsync([
+        "node",
+        "cli",
+        "+14155551234",
+        "--prompt-file",
+        promptFile,
+      ]);
+
+      expect(capturedBody.systemPrompt).toBe(
+        "Custom multi-line\nsystem prompt",
+      );
+    });
+
+    it("should read greeting from --greeting-file", async () => {
+      const greetingFile = path.join(tmpDir, "greeting.txt");
+      fs.writeFileSync(greetingFile, "Hello, welcome to our service!");
+
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(
+          "http://localhost:3000/api/zero/phone-calls",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({
+              callId: "call_xyz",
+              status: "initiated",
+            });
+          },
+        ),
+      );
+
+      await callCommand.parseAsync([
+        "node",
+        "cli",
+        "+14155551234",
+        "--greeting-file",
+        greetingFile,
+      ]);
+
+      expect(capturedBody.greeting).toBe("Hello, welcome to our service!");
+    });
+
+    it("should error if --system-prompt and --prompt-file are both provided", async () => {
+      const promptFile = path.join(tmpDir, "prompt.txt");
+      fs.writeFileSync(promptFile, "file prompt");
+
+      await expect(async () => {
+        await callCommand.parseAsync([
+          "node",
+          "cli",
+          "+14155551234",
+          "--system-prompt",
+          "inline prompt",
+          "--prompt-file",
+          promptFile,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot use both --system-prompt and --prompt-file",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should error if --greeting and --greeting-file are both provided", async () => {
+      const greetingFile = path.join(tmpDir, "greeting.txt");
+      fs.writeFileSync(greetingFile, "file greeting");
+
+      await expect(async () => {
+        await callCommand.parseAsync([
+          "node",
+          "cli",
+          "+14155551234",
+          "--greeting",
+          "inline greeting",
+          "--greeting-file",
+          greetingFile,
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot use both --greeting and --greeting-file",
+        ),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should error if --prompt-file path does not exist", async () => {
+      await expect(async () => {
+        await callCommand.parseAsync([
+          "node",
+          "cli",
+          "+14155551234",
+          "--prompt-file",
+          "/nonexistent/path/prompt.txt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("File not found: /nonexistent/path/prompt.txt"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should error if --greeting-file path does not exist", async () => {
+      await expect(async () => {
+        await callCommand.parseAsync([
+          "node",
+          "cli",
+          "+14155551234",
+          "--greeting-file",
+          "/nonexistent/path/greeting.txt",
+        ]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "File not found: /nonexistent/path/greeting.txt",
+        ),
+      );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });

--- a/turbo/apps/cli/src/commands/zero/phone/call.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/call.ts
@@ -4,6 +4,10 @@ import chalk from "chalk";
 import { createPhoneCall } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
 
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}
+
 export const callCommand = new Command()
   .name("call")
   .description("Initiate an outbound phone call")
@@ -66,7 +70,7 @@ export const callCommand = new Command()
           try {
             systemPrompt = fs.readFileSync(options.promptFile, "utf-8");
           } catch (err) {
-            if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+            if (isErrnoException(err) && err.code === "ENOENT") {
               console.error(chalk.red(`File not found: ${options.promptFile}`));
               process.exit(1);
             }
@@ -80,7 +84,7 @@ export const callCommand = new Command()
           try {
             greeting = fs.readFileSync(options.greetingFile, "utf-8");
           } catch (err) {
-            if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+            if (isErrnoException(err) && err.code === "ENOENT") {
               console.error(
                 chalk.red(`File not found: ${options.greetingFile}`),
               );

--- a/turbo/apps/cli/src/commands/zero/phone/call.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/call.ts
@@ -1,3 +1,4 @@
+import * as fs from "fs";
 import { Command } from "commander";
 import chalk from "chalk";
 import { createPhoneCall } from "../../../lib/api";
@@ -12,14 +13,27 @@ export const callCommand = new Command()
   )
   .option("--greeting <message>", "Initial greeting when the recipient answers")
   .option(
+    "--greeting-file <path>",
+    "Read greeting from a file (use instead of --greeting)",
+  )
+  .option(
     "--system-prompt <prompt>",
     "Override the agent's system prompt for this call",
+  )
+  .option(
+    "--prompt-file <path>",
+    "Read system prompt from a file (use instead of --system-prompt)",
   )
   .action(
     withErrorHandler(
       async (
         toNumber: string,
-        options: { greeting?: string; systemPrompt?: string },
+        options: {
+          greeting?: string;
+          greetingFile?: string;
+          systemPrompt?: string;
+          promptFile?: string;
+        },
       ) => {
         // Validate E.164 format
         if (!/^\+[1-9]\d{1,14}$/.test(toNumber)) {
@@ -31,10 +45,45 @@ export const callCommand = new Command()
           process.exit(1);
         }
 
+        // Validate mutual exclusivity
+        if (options.systemPrompt && options.promptFile) {
+          console.error(
+            chalk.red("Cannot use both --system-prompt and --prompt-file"),
+          );
+          process.exit(1);
+        }
+
+        if (options.greeting && options.greetingFile) {
+          console.error(
+            chalk.red("Cannot use both --greeting and --greeting-file"),
+          );
+          process.exit(1);
+        }
+
+        // Resolve system prompt from file if provided
+        let systemPrompt = options.systemPrompt;
+        if (options.promptFile) {
+          if (!fs.existsSync(options.promptFile)) {
+            console.error(chalk.red(`File not found: ${options.promptFile}`));
+            process.exit(1);
+          }
+          systemPrompt = fs.readFileSync(options.promptFile, "utf-8");
+        }
+
+        // Resolve greeting from file if provided
+        let greeting = options.greeting;
+        if (options.greetingFile) {
+          if (!fs.existsSync(options.greetingFile)) {
+            console.error(chalk.red(`File not found: ${options.greetingFile}`));
+            process.exit(1);
+          }
+          greeting = fs.readFileSync(options.greetingFile, "utf-8");
+        }
+
         const result = await createPhoneCall({
           toNumber,
-          greeting: options.greeting,
-          systemPrompt: options.systemPrompt,
+          greeting,
+          systemPrompt,
         });
 
         console.log(chalk.green("Call initiated"));

--- a/turbo/apps/cli/src/commands/zero/phone/call.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/call.ts
@@ -63,21 +63,31 @@ export const callCommand = new Command()
         // Resolve system prompt from file if provided
         let systemPrompt = options.systemPrompt;
         if (options.promptFile) {
-          if (!fs.existsSync(options.promptFile)) {
-            console.error(chalk.red(`File not found: ${options.promptFile}`));
-            process.exit(1);
+          try {
+            systemPrompt = fs.readFileSync(options.promptFile, "utf-8");
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+              console.error(chalk.red(`File not found: ${options.promptFile}`));
+              process.exit(1);
+            }
+            throw err;
           }
-          systemPrompt = fs.readFileSync(options.promptFile, "utf-8");
         }
 
         // Resolve greeting from file if provided
         let greeting = options.greeting;
         if (options.greetingFile) {
-          if (!fs.existsSync(options.greetingFile)) {
-            console.error(chalk.red(`File not found: ${options.greetingFile}`));
-            process.exit(1);
+          try {
+            greeting = fs.readFileSync(options.greetingFile, "utf-8");
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+              console.error(
+                chalk.red(`File not found: ${options.greetingFile}`),
+              );
+              process.exit(1);
+            }
+            throw err;
           }
-          greeting = fs.readFileSync(options.greetingFile, "utf-8");
         }
 
         const result = await createPhoneCall({

--- a/turbo/apps/web/src/lib/zero/phone/receptionist-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/phone/receptionist-prompt.ts
@@ -4,15 +4,30 @@
  * request, and summarizes it before hanging up.
  */
 export function buildReceptionistPrompt(agentName: string): string {
-  return `You are a receptionist for ${agentName}, an AI assistant. Your role is to:
+  return `You are the receptionist for ${agentName}, an AI assistant powered by Zero.
 
-1. Greet the caller warmly and professionally
-2. Listen carefully to their request or message
-3. Ask clarifying questions if the request is unclear
-4. Confirm you've understood their request
-5. Let them know their message will be processed and they may receive a callback
+Your role is to greet callers, understand their request, and ensure their message is recorded accurately so ${agentName} can follow up.
 
-Keep the conversation concise and focused. Do not attempt to solve their problem yourself — your job is to record and summarize their request accurately.
+## How This Works
+- You take the caller's message and record it
+- ${agentName} will review the request and may call them back
+- You cannot resolve requests directly — your job is to capture them clearly
 
-At the end of the call, provide a brief summary of what the caller needs.`;
+## Your Responsibilities
+1. Greet the caller warmly
+2. Listen to their request
+3. Ask one or two clarifying questions if needed (keep it brief)
+4. Confirm their key request back to them
+5. Let them know their message has been received
+
+## Edge Cases
+- **Caller wants to leave a voicemail**: That is exactly what this is. Let them speak their message and record it faithfully.
+- **Caller wants to be transferred**: Explain that transfers are not available, but their request will be reviewed and they may receive a callback.
+- **Caller is confused**: Briefly explain that ${agentName} is an AI assistant and this is a message recording service.
+- **Caller has an urgent request**: Note the urgency clearly in your summary.
+
+## Guidelines
+- Keep the conversation under 2 minutes
+- Do not attempt to solve the caller's problem yourself
+- End the call by confirming their message was received and thanking them`;
 }


### PR DESCRIPTION
## Summary

- Improve `receptionist-prompt.ts` with context about Zero's async workflow, edge case handling (voicemail, transfer requests, confused callers, urgent requests), and structured guidelines
- Add `--prompt-file <path>` flag to `zero phone call` for reading multi-line system prompts from a file
- Add `--greeting-file <path>` flag to `zero phone call` for reading greeting text from a file
- Inline `--system-prompt` and `--greeting` flags remain fully backward compatible
- Validate mutual exclusivity of inline vs file flags and file existence with clear error messages

## Test plan

- [x] All existing phone CLI tests pass
- [x] New integration tests for `--prompt-file` reading content from a real temp file
- [x] New integration tests for `--greeting-file` reading content from a real temp file
- [x] New integration tests for mutual exclusivity errors (`--system-prompt` + `--prompt-file`)
- [x] New integration tests for mutual exclusivity errors (`--greeting` + `--greeting-file`)
- [x] New integration tests for missing file error messages
- [x] `pnpm format`, `pnpm turbo run lint`, `pnpm check-types` (CLI), `pnpm vitest` all pass

Closes #8538

🤖 Generated with [Claude Code](https://claude.com/claude-code)