### PR TITLE
fix(platform): call end session api when stopping voice chat

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -553,7 +553,17 @@ export const startVoiceChat$ = command(
   },
 );
 
-export const endVoiceChat$ = command(({ get, set }) => {
+export const endVoiceChat$ = command(async ({ get, set }) => {
+  const sid = get(internalSessionId$);
+  const fetchFn = get(fetch$);
+
+  // End session on server so it's no longer "active" in DB
+  if (sid && fetchFn) {
+    fetchFn(`/api/zero/voice-chat/${sid}/end`, { method: "POST" }).catch(
+      () => {},
+    );
+  }
+
   set(resetSessionSignal$);
 
   const dc = get(internalDc$);

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -553,14 +553,19 @@ export const startVoiceChat$ = command(
   },
 );
 
-export const endVoiceChat$ = command(async ({ get, set }) => {
+export const endVoiceChat$ = command(({ get, set }) => {
   const sid = get(internalSessionId$);
   const fetchFn = get(fetch$);
 
   // End session on server so it's no longer "active" in DB
   if (sid && fetchFn) {
-    fetchFn(`/api/zero/voice-chat/${sid}/end`, { method: "POST" }).catch(
-      () => {},
+    void fetchFn(`/api/zero/voice-chat/${sid}/end`, { method: "POST" }).then(
+      () => {
+        return undefined;
+      },
+      () => {
+        return undefined;
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- Fix voice chat sessions staying "active" after user clicks End Session or navigates away
- Add server-side end session API call (`POST /api/zero/voice-chat/{id}/end`) to `endVoiceChat$` command
- Fire-and-forget pattern ensures local cleanup isn't blocked by network issues
- Cron cleanup remains as a 2-minute safety net for edge cases (browser crash, network loss)

## Root Cause
`endVoiceChat$` only performed local cleanup (close WebRTC, stop media tracks, reset state) without telling the server. The session remained `status="active"` in the database, causing a 409 CONFLICT when the user tried to start a new session.

## Test plan
- [ ] Start voice chat session, click End Session, immediately start a new one — should work without 409
- [ ] Start voice chat session, navigate away, return and start new one — should work
- [ ] If server is unreachable, End Session still cleans up locally (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)