### PR TITLE
test: reproduce skeleton cycling infinite loop

### DIFF
--- a/turbo/apps/platform/src/signals/app-skeleton.ts
+++ b/turbo/apps/platform/src/signals/app-skeleton.ts
@@ -60,7 +60,7 @@ export const startSkeletonCycling$ = command(
     const signal = set(resetSkeletonCycling$, parentSignal);
     const isFirst = get(skeletonFirstCycle$);
     await delay(isFirst ? get(firstCycleMs$) : get(cycleMs$), { signal });
-    while (!signal.aborted) {
+    while (true) {
       set(cycleSkeletonMessage$);
       await delay(get(cycleMs$), { signal });
     }


### PR DESCRIPTION
## Summary

- Change `while (!signal.aborted)` to `while (true)` in `startSkeletonCycling$` (`app-skeleton.ts`) to verify whether this causes an infinite loop in CI (test-app).
- This is a reproduction PR — **do not merge**. The goal is to confirm whether the while condition change causes the second test in test-app to hang indefinitely.

## Background

There was a randomly occurring issue where the app would get stuck for hours locally. This change isolates the risk by forcing the skeleton cycling loop to ignore signal abort, which should reproduce the hang in CI.

## Test plan

- [ ] Observe whether `test-app` CI job hangs (specifically the second test)
- [ ] If reproduced, revert this change and investigate the root cause in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)