### PR TITLE
fix: make terms and privacy pages accessible without login on locale-prefixed urls

### DIFF
--- a/turbo/apps/platform/src/views/phone-page/__tests__/phone-page.test.tsx
+++ b/turbo/apps/platform/src/views/phone-page/__tests__/phone-page.test.tsx
@@ -221,32 +221,6 @@ describe("phone page - user phone linked", () => {
   });
 });
 
-describe("phone page - legal links", () => {
-  it("links to canonical terms-of-use URL", async () => {
-    mockPhoneStatusAPI({ orgPhone: "+18001234567", userPhone: null });
-    await renderPhonePage();
-
-    await waitFor(() => {
-      const link = screen.getAllByRole("link").find((el) => {
-        return /Terms of Use/.test(el.textContent ?? "");
-      });
-      expect(link).toHaveAttribute("href", "https://vm0.ai/terms-of-use");
-    });
-  });
-
-  it("links to canonical privacy-policy URL", async () => {
-    mockPhoneStatusAPI({ orgPhone: "+18001234567", userPhone: null });
-    await renderPhonePage();
-
-    await waitFor(() => {
-      const link = screen.getAllByRole("link").find((el) => {
-        return /Privacy Policy/.test(el.textContent ?? "");
-      });
-      expect(link).toHaveAttribute("href", "https://vm0.ai/privacy-policy");
-    });
-  });
-});
-
 describe("phone page - error display", () => {
   it("should show error message when link fails", async () => {
     const user = userEvent.setup();

--- a/turbo/apps/platform/src/views/phone-page/__tests__/phone-page.test.tsx
+++ b/turbo/apps/platform/src/views/phone-page/__tests__/phone-page.test.tsx
@@ -221,6 +221,32 @@ describe("phone page - user phone linked", () => {
   });
 });
 
+describe("phone page - legal links", () => {
+  it("links to canonical terms-of-use URL", async () => {
+    mockPhoneStatusAPI({ orgPhone: "+18001234567", userPhone: null });
+    await renderPhonePage();
+
+    await waitFor(() => {
+      const link = screen.getAllByRole("link").find((el) => {
+        return /Terms of Use/.test(el.textContent ?? "");
+      });
+      expect(link).toHaveAttribute("href", "https://vm0.ai/terms-of-use");
+    });
+  });
+
+  it("links to canonical privacy-policy URL", async () => {
+    mockPhoneStatusAPI({ orgPhone: "+18001234567", userPhone: null });
+    await renderPhonePage();
+
+    await waitFor(() => {
+      const link = screen.getAllByRole("link").find((el) => {
+        return /Privacy Policy/.test(el.textContent ?? "");
+      });
+      expect(link).toHaveAttribute("href", "https://vm0.ai/privacy-policy");
+    });
+  });
+});
+
 describe("phone page - error display", () => {
   it("should show error message when link fails", async () => {
     const user = userEvent.setup();

--- a/turbo/apps/platform/src/views/phone-page/phone-page.tsx
+++ b/turbo/apps/platform/src/views/phone-page/phone-page.tsx
@@ -135,7 +135,7 @@ export function PhonePage() {
         <p className="text-muted-foreground mt-2 text-xs">
           By linking your phone number, you agree to our{" "}
           <a
-            href="https://vm0.ai/terms"
+            href="https://vm0.ai/terms-of-use"
             target="_blank"
             rel="noopener noreferrer"
             className="underline"
@@ -144,7 +144,7 @@ export function PhonePage() {
           </a>{" "}
           and{" "}
           <a
-            href="https://vm0.ai/privacy"
+            href="https://vm0.ai/privacy-policy"
             target="_blank"
             rel="noopener noreferrer"
             className="underline"

--- a/turbo/apps/web/__tests__/proxy.legal-pages.test.ts
+++ b/turbo/apps/web/__tests__/proxy.legal-pages.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// Mock next-intl/middleware to avoid ESM resolution issues in test environment.
+// This is an external dependency mock (not internal code), which is acceptable.
+vi.mock("next-intl/middleware", () => {
+  return {
+    default: () => {
+      return () => {
+        return NextResponse.next();
+      };
+    },
+  };
+});
+
+import { legalRedirectLayer, runLayers } from "../proxy.layers";
+
+/**
+ * Helper to run the legalRedirectLayer through the real runLayers pipeline.
+ * This exercises the full middleware context creation including route classification.
+ */
+function runLegal(url: string) {
+  const request = new NextRequest(url);
+  return runLayers(request, [legalRedirectLayer]);
+}
+
+describe("legalRedirectLayer", () => {
+  describe("redirects locale-prefixed legal pages to root paths", () => {
+    it("redirects /en/terms-of-use to /terms-of-use with 308", async () => {
+      const response = await runLegal("https://www.vm0.ai/en/terms-of-use");
+      expect(response.status).toBe(308);
+      expect(new URL(response.headers.get("location")!).pathname).toBe(
+        "/terms-of-use",
+      );
+    });
+
+    it("redirects /de/privacy-policy to /privacy-policy with 308", async () => {
+      const response = await runLegal("https://www.vm0.ai/de/privacy-policy");
+      expect(response.status).toBe(308);
+      expect(new URL(response.headers.get("location")!).pathname).toBe(
+        "/privacy-policy",
+      );
+    });
+
+    it("redirects /ja/terms-of-use to /terms-of-use with 308", async () => {
+      const response = await runLegal("https://www.vm0.ai/ja/terms-of-use");
+      expect(response.status).toBe(308);
+      expect(new URL(response.headers.get("location")!).pathname).toBe(
+        "/terms-of-use",
+      );
+    });
+
+    it("redirects /es/privacy-policy to /privacy-policy with 308", async () => {
+      const response = await runLegal("https://www.vm0.ai/es/privacy-policy");
+      expect(response.status).toBe(308);
+      expect(new URL(response.headers.get("location")!).pathname).toBe(
+        "/privacy-policy",
+      );
+    });
+  });
+
+  describe("does not redirect root legal pages", () => {
+    it("passes through /terms-of-use without redirect", async () => {
+      const response = await runLegal("https://www.vm0.ai/terms-of-use");
+      expect(response.status).toBe(200);
+    });
+
+    it("passes through /privacy-policy without redirect", async () => {
+      const response = await runLegal("https://www.vm0.ai/privacy-policy");
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("does not redirect non-legal locale pages", () => {
+    it("passes through /en/pricing without redirect", async () => {
+      const response = await runLegal("https://www.vm0.ai/en/pricing");
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("does not redirect invalid locales", () => {
+    it("passes through /xx/terms-of-use (unsupported locale) without redirect", async () => {
+      const response = await runLegal("https://www.vm0.ai/xx/terms-of-use");
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -24,6 +24,8 @@ const isPublicRoute = createRouteMatcher([
   "/:locale/pricing",
   "/terms-of-use",
   "/privacy-policy",
+  "/:locale/terms-of-use",
+  "/:locale/privacy-policy",
   "/:locale/design-system",
   "/:locale/security",
   "/:locale/blog",


### PR DESCRIPTION
## Summary

- Fix `phone-page.tsx` to use canonical URLs (`/terms-of-use`, `/privacy-policy`) instead of short-form URLs (`/terms`, `/privacy`) that trigger auth protection
- Add `/:locale/terms-of-use` and `/:locale/privacy-policy` to `isPublicRoute` in `proxy.ts` so Clerk auth does not block locale-prefixed legal page requests
- The existing `legalRedirectLayer` handles 308-redirecting these locale-prefixed URLs to the canonical root paths

Fixes #8582

## Test plan

- [ ] New integration test file `proxy.legal-pages.test.ts` verifies `legalRedirectLayer` correctly 308-redirects `/en/terms-of-use`, `/de/privacy-policy`, `/ja/terms-of-use`, `/es/privacy-policy` to their root paths, and passes through root legal URLs and invalid locales without redirect
- [ ] New tests in `phone-page.test.tsx` verify links use canonical `https://vm0.ai/terms-of-use` and `https://vm0.ai/privacy-policy` hrefs
- [ ] All existing tests pass
- [ ] Lint, type-check, format, and knip checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)