### PR TITLE
feat(voice-chat): upgrade realtime model to gpt-realtime-1.5 and use onyx voice

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -29,7 +29,7 @@ interface ContextEvent {
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const POLL_INTERVAL_MS = 2000;
-const REALTIME_MODEL = "gpt-4o-realtime-preview";
+const REALTIME_MODEL = "gpt-realtime-1.5";
 
 const SESSION_TOOLS = [
   {

--- a/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
@@ -25,8 +25,8 @@ export async function createEphemeralToken(): Promise<EphemeralTokenResponse> {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-4o-realtime-preview",
-      voice: "alloy",
+      model: "gpt-realtime-1.5",
+      voice: "onyx",
     }),
   });
 


### PR DESCRIPTION
## Summary

- Upgrade OpenAI Realtime model from `gpt-4o-realtime-preview` to `gpt-realtime-1.5` (latest, released Feb 2026)
- Change voice from `alloy` to `onyx` for a deeper, more composed tone

Closes #8588

## Test plan

- [ ] Existing voice-chat tests pass (mocked, no model/voice assertions)
- [ ] Manual test: start voice chat session in platform UI with staff org access
- [ ] Verify WebRTC connection succeeds with new model
- [ ] Verify onyx voice is audible and working

🤖 Generated with [Claude Code](https://claude.com/claude-code)