### PR TITLE
fix(firewall): use consistent ref for model-provider firewalls

### DIFF
--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -407,7 +407,7 @@ function mpFirewall(
     : secretRef;
   return {
     name: `model-provider:${type}`,
-    ref: "__auto__",
+    ref: `model-provider:${type}`,
     apis: [
       {
         base: getFirewallBaseUrl(type),


### PR DESCRIPTION
## Summary
- Replace hardcoded `"__auto__"` ref with `model-provider:${type}` so that model-provider firewall `ref` matches `name`
- Connector firewalls already have ref === name; this aligns model-provider firewalls to the same convention

## Test plan
- [x] Type check passes
- [x] Core tests pass (520 tests)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)