### PR TITLE
fix(firewalls): require all graphql fields to be covered by permissions

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -258,6 +258,20 @@ def _match_wildcard(value: str, pattern: str) -> bool:
     return value == pattern
 
 
+def _extract_op_type(query_str: str) -> str:
+    """Extract the GraphQL operation type from a query string.
+
+    Returns ``"query"``, ``"mutation"``, or ``"subscription"`` based on the
+    leading keyword.  Defaults to ``"query"`` when no keyword is present
+    (bare ``{ … }`` shorthand).
+    """
+    stripped = query_str.lstrip()
+    end = 0
+    while end < len(stripped) and stripped[end].isalpha():
+        end += 1
+    return stripped[:end].lower() if end > 0 else "query"
+
+
 def match_graphql_body(
     body: bytes | None,
     type_filter: str | None,
@@ -291,19 +305,11 @@ def match_graphql_body(
             return False
         query_str = raw
 
-    # Extract operation type from the query string.
-    # GraphQL allows compact forms like `mutation{`, `query($id: ID!)`,
-    # so we extract only leading alpha characters as the keyword.
+    # Match operation type (query / mutation / subscription).
     if type_filter is not None and query_str is not None:
-        stripped = query_str.lstrip()
-        if not stripped:
+        if not query_str.lstrip():
             return False
-        # Extract leading alphabetic chars: "mutation(" → "mutation"
-        end = 0
-        while end < len(stripped) and stripped[end].isalpha():
-            end += 1
-        keyword = stripped[:end].lower() if end > 0 else "query"
-        if keyword != type_filter:
+        if _extract_op_type(query_str) != type_filter:
             return False
 
     # Match operationName
@@ -382,6 +388,11 @@ def _find_uncovered_graphql_fields(
     each field against all field patterns from all permissions. Returns a
     list of uncovered fields (empty if all fields are covered or if no
     field rules exist for the operation type).
+
+    Returns ``[]`` on parse failure.  This is safe because the caller
+    (``match_firewall_request``) only reaches the coverage check after
+    ``match_graphql_body()`` has already successfully parsed the body —
+    so a parse failure here cannot happen in practice.
     """
     try:
         data = json.loads(body)
@@ -399,12 +410,7 @@ def _find_uncovered_graphql_fields(
     if not fields:
         return []
 
-    # Determine operation type
-    stripped = query_str.lstrip()
-    end = 0
-    while end < len(stripped) and stripped[end].isalpha():
-        end += 1
-    op_type = stripped[:end].lower() if end > 0 else "query"
+    op_type = _extract_op_type(query_str)
 
     # Collect field patterns matching this operation type
     all_patterns = _collect_field_patterns(permissions, method, op_type)

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -335,8 +335,13 @@ def _collect_field_patterns(
     permissions: list,
     method: str,
     op_type: str,
-) -> list[str]:
-    """Collect all GraphQL field patterns from rules matching the operation type."""
+) -> list[str] | None:
+    """Collect all GraphQL field patterns from rules matching the operation type.
+
+    Returns ``None`` when a broad rule (matching method and type but with no
+    field filter) exists — the caller should skip the coverage check entirely
+    because the broad rule allows any field.
+    """
     patterns: list[str] = []
     for perm in permissions:
         for rule_str in perm.get("rules", []):
@@ -352,8 +357,10 @@ def _collect_field_patterns(
             _, type_filter, _, field_filters = gql
             if type_filter is not None and type_filter != op_type:
                 continue
-            if field_filters is not None:
-                patterns.extend(field_filters)
+            if field_filters is None:
+                # Broad rule with no field filter — covers everything.
+                return None
+            patterns.extend(field_filters)
     return patterns
 
 
@@ -412,9 +419,10 @@ def _find_uncovered_graphql_fields(
 
     op_type = _extract_op_type(query_str)
 
-    # Collect field patterns matching this operation type
+    # Collect field patterns matching this operation type.
+    # None means a broad rule exists — skip coverage check.
     all_patterns = _collect_field_patterns(permissions, method, op_type)
-    if not all_patterns:
+    if all_patterns is None or len(all_patterns) == 0:
         return []
 
     return [f for f in fields if not _is_field_covered(f, all_patterns)]

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -325,6 +325,95 @@ def match_graphql_body(
     return True
 
 
+def _collect_field_patterns(
+    permissions: list,
+    method: str,
+    op_type: str,
+) -> list[str]:
+    """Collect all GraphQL field patterns from rules matching the operation type."""
+    patterns: list[str] = []
+    for perm in permissions:
+        for rule_str in perm.get("rules", []):
+            parts = rule_str.split(" ", 1)
+            if len(parts) != 2:
+                continue
+            rule_method = parts[0].upper()
+            if rule_method != "ANY" and rule_method != method:
+                continue
+            gql = parse_graphql_rule(parts[1])
+            if gql is None:
+                continue
+            _, type_filter, _, field_filters = gql
+            if type_filter is not None and type_filter != op_type:
+                continue
+            if field_filters is not None:
+                patterns.extend(field_filters)
+    return patterns
+
+
+def _is_field_covered(field: str, patterns: list[str]) -> bool:
+    """Check if a field is covered by any pattern.
+
+    A field is covered if:
+    - It matches a pattern (exact or wildcard), OR
+    - A pattern is a prefix of it (field is under a covered parent), OR
+    - It is a prefix of a pattern (structural parent of a covered field)
+    """
+    for pattern in patterns:
+        if _match_wildcard(field, pattern):
+            return True
+        # Field is descendant of exact pattern
+        if not pattern.endswith("*") and field.startswith(pattern + "."):
+            return True
+        # Field is ancestor of any pattern (structural parent)
+        if pattern.startswith(field + "."):
+            return True
+    return False
+
+
+def _find_uncovered_graphql_fields(
+    body: bytes,
+    permissions: list,
+    method: str,
+) -> list[str]:
+    """Find GraphQL body fields not covered by any field rule.
+
+    Parses the body to extract operation type and field paths, then checks
+    each field against all field patterns from all permissions. Returns a
+    list of uncovered fields (empty if all fields are covered or if no
+    field rules exist for the operation type).
+    """
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    query_str = data.get("query")
+    if not isinstance(query_str, str):
+        return []
+
+    fields = extract_field_paths(query_str)
+    if not fields:
+        return []
+
+    # Determine operation type
+    stripped = query_str.lstrip()
+    end = 0
+    while end < len(stripped) and stripped[end].isalpha():
+        end += 1
+    op_type = stripped[:end].lower() if end > 0 else "query"
+
+    # Collect field patterns matching this operation type
+    all_patterns = _collect_field_patterns(permissions, method, op_type)
+    if not all_patterns:
+        return []
+
+    return [f for f in fields if not _is_field_covered(f, all_patterns)]
+
+
 def match_firewall_request(
     url: str,
     method: str,
@@ -332,6 +421,10 @@ def match_firewall_request(
     body: bytes | None = None,
 ) -> FirewallAllow | FirewallBlock | None:
     """Match request against firewall permissions.
+
+    For GraphQL requests with field-level rules, ALL fields in the query
+    body must be covered by some rule in the permissions. A query that
+    includes both authorized and unauthorized fields is blocked.
 
     Returns:
       FirewallAllow — permission matched, inject headers
@@ -410,6 +503,24 @@ def match_firewall_request(
                             body, type_filter, op_filter, field_filters
                         ):
                             continue
+
+                        # For GraphQL rules with field filters, verify ALL
+                        # body fields are covered by some rule in the
+                        # permissions. Blocks queries that mix authorized
+                        # and unauthorized fields.
+                        if field_filters is not None and body is not None:
+                            uncovered = _find_uncovered_graphql_fields(
+                                body, permissions, upper_method
+                            )
+                            if uncovered:
+                                return FirewallBlock(
+                                    base,
+                                    fw_ref,
+                                    fw_name,
+                                    upper_method,
+                                    rel_path,
+                                )
+
                         # Merge base params with rule params
                         all_params = {**base_params, **params}
                         return FirewallAllow(

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -2269,15 +2269,29 @@ class TestGraphQLFieldMatching:
         assert isinstance(result, FirewallAllow)
 
     def test_field_among_multiple_selections(self):
-        """Match when target field is one of several top-level selections."""
+        """Match when target field is one of several — all fields must be covered."""
         body = _gql_body(
             "mutation { addReaction(input: {}) { id } createIssue(input: {}) { id } }",
             "BatchOp",
         )
+        # Only createIssue covered → blocked (addReaction uncovered)
         result = matching.match_firewall_request(
             "https://api.linear.app/graphql",
             "POST",
             _gql_firewalls(["POST /graphql GraphQL type:mutation field:createIssue"]),
+            body=body,
+        )
+        assert isinstance(result, FirewallBlock)
+        # Both fields covered → allowed
+        result = matching.match_firewall_request(
+            "https://api.linear.app/graphql",
+            "POST",
+            _gql_firewalls(
+                [
+                    "POST /graphql GraphQL type:mutation field:createIssue",
+                    "POST /graphql GraphQL type:mutation field:addReaction",
+                ]
+            ),
             body=body,
         )
         assert isinstance(result, FirewallAllow)
@@ -2495,10 +2509,16 @@ class TestGraphQLFieldMatching:
     def test_field_underscore_prefix(self):
         """Fields starting with underscore (e.g., __typename) are extracted."""
         body = _gql_body("mutation { __typename createIssue(input: {}) { id } }", "Op")
+        # Both __typename and createIssue must be covered
         result = matching.match_firewall_request(
             "https://api.linear.app/graphql",
             "POST",
-            _gql_firewalls(["POST /graphql GraphQL type:mutation field:__typename"]),
+            _gql_firewalls(
+                [
+                    "POST /graphql GraphQL type:mutation field:__typename",
+                    "POST /graphql GraphQL type:mutation field:createIssue",
+                ]
+            ),
             body=body,
         )
         assert isinstance(result, FirewallAllow)
@@ -2865,3 +2885,156 @@ class TestGraphQLCommaFieldFilter:
             body=body,
         )
         assert isinstance(result, FirewallBlock)
+
+
+class TestGraphQLFieldCoverage:
+    """Verify that GraphQL requests with multiple fields are only allowed
+    when ALL fields are covered by some permission rule."""
+
+    def _make_fw(self, rules_by_perm):
+        """Build firewalls with multiple permissions, each with its own rules."""
+        perms = [{"name": name, "rules": rules} for name, rules in rules_by_perm.items()]
+        return [
+            {
+                "name": "test",
+                "ref": "test",
+                "apis": [
+                    {
+                        "base": "https://api.example.com",
+                        "auth": {"headers": {"Authorization": "Bearer tok"}},
+                        "permissions": perms,
+                    }
+                ],
+            }
+        ]
+
+    def test_all_fields_covered_allows(self):
+        """Query with all fields covered by permissions → allow."""
+        fw = self._make_fw(
+            {
+                "issues:read": ["POST /graphql GraphQL type:query field:repository.issues"],
+                "pull_requests:read": [
+                    "POST /graphql GraphQL type:query field:repository.pullRequests"
+                ],
+            }
+        )
+        body = json.dumps(
+            {
+                "query": "query { repository { issues { nodes { id } } "
+                "pullRequests { nodes { id } } } }"
+            }
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_uncovered_field_blocks(self):
+        """Query with an uncovered field → block."""
+        fw = self._make_fw(
+            {
+                "issues:read": ["POST /graphql GraphQL type:query field:repository.issues"],
+            }
+        )
+        body = json.dumps(
+            {
+                "query": "query { repository { issues { nodes { id } } "
+                "pullRequests { nodes { id } } } }"
+            }
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_single_field_covered_allows(self):
+        """Query with only one field, covered → allow."""
+        fw = self._make_fw(
+            {
+                "issues:read": ["POST /graphql GraphQL type:query field:repository.issues"],
+            }
+        )
+        body = json.dumps({"query": "query { repository { issues { nodes { id } } } }"}).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_mutation_all_covered_allows(self):
+        """Mutation with all fields covered → allow."""
+        fw = self._make_fw(
+            {
+                "issues:write": ["POST /graphql GraphQL type:mutation field:createIssue"],
+            }
+        )
+        body = json.dumps(
+            {"query": 'mutation { createIssue(input: {title: "x"}) { issue { id } } }'}
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_mutation_uncovered_blocks(self):
+        """Mutation with an uncovered mutation field → block."""
+        fw = self._make_fw(
+            {
+                "issues:write": ["POST /graphql GraphQL type:mutation field:createIssue"],
+            }
+        )
+        body = json.dumps(
+            {
+                "query": "mutation { createIssue(input: {}) { issue { id } } "
+                "deleteIssue(input: {}) { clientMutationId } }"
+            }
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_no_field_rules_skips_coverage_check(self):
+        """When no field rules exist, the coverage check is skipped."""
+        fw = self._make_fw(
+            {
+                "graphql:all": ["POST /graphql GraphQL type:query"],
+            }
+        )
+        body = json.dumps({"query": "query { repository { anything } }"}).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_type_filter_isolates_coverage(self):
+        """Query field rules don't affect mutation coverage checks."""
+        fw = self._make_fw(
+            {
+                "issues:read": ["POST /graphql GraphQL type:query field:repository.issues"],
+                "issues:write": ["POST /graphql GraphQL type:mutation field:createIssue"],
+            }
+        )
+        # Mutation with only createIssue — should be allowed even though
+        # query field rules don't cover mutation fields
+        body = json.dumps(
+            {"query": 'mutation { createIssue(input: {title: "x"}) { issue { id } } }'}
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_wildcard_pattern_covers_descendants(self):
+        """Wildcard pattern covers all matching fields."""
+        fw = self._make_fw(
+            {
+                "repo:read": ["POST /graphql GraphQL type:query field:repository.*"],
+            }
+        )
+        body = json.dumps(
+            {"query": "query { repository { issues { id } pullRequests { id } } }"}
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallAllow)

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -3040,17 +3040,36 @@ class TestGraphQLFieldCoverage:
         assert isinstance(result, FirewallAllow)
 
     def test_broad_rule_bypasses_field_coverage(self):
-        """A broad rule (no field filter) allows without triggering coverage check."""
-        fw = self._make_fw(
+        """A broad rule (no field filter) skips coverage — regardless of permission order."""
+        body = json.dumps(
+            {"query": "query { repository { issues { id } unknown { id } } }"}
+        ).encode()
+        # Broad rule BEFORE narrow rule
+        fw_broad_first = self._make_fw(
             {
                 "graphql:all": ["POST /graphql GraphQL type:query"],
                 "issues:read": ["POST /graphql GraphQL type:query field:repository.issues"],
             }
         )
-        # The broad type:query rule matches first — no field filter means
-        # the coverage check is skipped entirely, so unknown fields are OK.
-        body = json.dumps({"query": "query { repository { unknown { id } } }"}).encode()
         result = matching.match_firewall_request(
-            "https://api.example.com/graphql", "POST", fw, body=body
+            "https://api.example.com/graphql",
+            "POST",
+            fw_broad_first,
+            body=body,
+        )
+        assert isinstance(result, FirewallAllow)
+
+        # Narrow rule BEFORE broad rule — must still allow
+        fw_narrow_first = self._make_fw(
+            {
+                "issues:read": ["POST /graphql GraphQL type:query field:repository.issues"],
+                "graphql:all": ["POST /graphql GraphQL type:query"],
+            }
+        )
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql",
+            "POST",
+            fw_narrow_first,
+            body=body,
         )
         assert isinstance(result, FirewallAllow)

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -3073,3 +3073,40 @@ class TestGraphQLFieldCoverage:
             body=body,
         )
         assert isinstance(result, FirewallAllow)
+
+    def test_comma_patterns_in_coverage_check(self):
+        """Comma-separated patterns expand correctly in coverage check."""
+        fw = self._make_fw(
+            {
+                "repo:read": [
+                    "POST /graphql GraphQL type:query "
+                    "field:repository.issues,repository.pullRequests"
+                ],
+            }
+        )
+        # Both fields covered by comma pattern → allow
+        body_ok = json.dumps(
+            {"query": "query { repository { issues { id } pullRequests { id } } }"}
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql",
+            "POST",
+            fw,
+            body=body_ok,
+        )
+        assert isinstance(result, FirewallAllow)
+
+        # Third field not in comma pattern → block
+        body_extra = json.dumps(
+            {
+                "query": "query { repository { issues { id } "
+                "pullRequests { id } stargazers { id } } }"
+            }
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql",
+            "POST",
+            fw,
+            body=body_extra,
+        )
+        assert isinstance(result, FirewallBlock)

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -3038,3 +3038,19 @@ class TestGraphQLFieldCoverage:
             "https://api.example.com/graphql", "POST", fw, body=body
         )
         assert isinstance(result, FirewallAllow)
+
+    def test_broad_rule_bypasses_field_coverage(self):
+        """A broad rule (no field filter) allows without triggering coverage check."""
+        fw = self._make_fw(
+            {
+                "graphql:all": ["POST /graphql GraphQL type:query"],
+                "issues:read": ["POST /graphql GraphQL type:query field:repository.issues"],
+            }
+        )
+        # The broad type:query rule matches first — no field filter means
+        # the coverage check is skipped entirely, so unknown fields are OK.
+        body = json.dumps({"query": "query { repository { unknown { id } } }"}).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallAllow)


### PR DESCRIPTION
## Summary

- Fix fail-open vulnerability in GraphQL firewall matching: previously a query was allowed if ANY field matched a rule, even if other fields had no matching permission
- Now ALL fields in a GraphQL query must be covered by some permission rule — uncovered fields cause the request to be blocked
- A field is covered if it matches a rule pattern, is a descendant of a matched pattern, or is a structural parent of one

### Example

With only `issues:read` granted (rule: `field:repository.issues`):

```graphql
# Before: ALLOWED (repository.issues matches → entire query passes)
# After:  BLOCKED (repository.pullRequests has no matching rule)
query {
  repository {
    issues { nodes { id } }
    pullRequests { nodes { id } }
  }
}
```

## Test plan

- [x] 8 new tests for field coverage logic (all-covered allow, uncovered block, mutations, type isolation, wildcards, no-field-rules skip)
- [x] 2 existing tests updated to reflect new fail-closed behavior
- [x] 211 total mitm-addon tests pass
- [x] ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)