### PR TITLE
refactor(platform): move org polling from dom ref to page setup lifecycle

### DIFF
--- a/turbo/apps/platform/src/signals/auth.ts
+++ b/turbo/apps/platform/src/signals/auth.ts
@@ -103,31 +103,29 @@ function persistOrgId(orgId: string | undefined) {
  * Command that monitors the active Clerk organization and reloads
  * the page when it changes. Persists the active org ID to session storage.
  */
-export const watchOrgSwitch$ = command(
-  async ({ get }, _el: HTMLElement, signal: AbortSignal) => {
-    const clerk = await get(clerk$);
-    signal.throwIfAborted();
+export const watchOrgSwitch$ = command(async ({ get }, signal: AbortSignal) => {
+  const clerk = await get(clerk$);
+  signal.throwIfAborted();
 
-    let prevOrgId = sessionStorage.getItem(ORG_ID_KEY) ?? undefined;
-    const currentOrgId = clerk.organization?.id ?? undefined;
-    prevOrgId = currentOrgId;
-    persistOrgId(currentOrgId);
+  let prevOrgId = sessionStorage.getItem(ORG_ID_KEY) ?? undefined;
+  const currentOrgId = clerk.organization?.id ?? undefined;
+  prevOrgId = currentOrgId;
+  persistOrgId(currentOrgId);
 
-    const unsubscribe = clerk.addListener(() => {
-      const newOrgId = clerk.organization?.id ?? undefined;
-      if (newOrgId !== prevOrgId) {
-        prevOrgId = newOrgId;
-        persistOrgId(newOrgId);
-        // Navigate to the Zero homepage on org switch. A full page load is
-        // required because server-side data (agents, jobs, secrets, etc.) is
-        // scoped to the active organization, and multiple signal trees depend
-        // on the org context established at bootstrap time.
-        location.href = "/";
-      }
-    });
-    signal.addEventListener("abort", unsubscribe);
-  },
-);
+  const unsubscribe = clerk.addListener(() => {
+    const newOrgId = clerk.organization?.id ?? undefined;
+    if (newOrgId !== prevOrgId) {
+      prevOrgId = newOrgId;
+      persistOrgId(newOrgId);
+      // Navigate to the Zero homepage on org switch. A full page load is
+      // required because server-side data (agents, jobs, secrets, etc.) is
+      // scoped to the active organization, and multiple signal trees depend
+      // on the org context established at bootstrap time.
+      location.href = "/";
+    }
+  });
+  signal.addEventListener("abort", unsubscribe);
+});
 
 export const user$ = computed(async (get) => {
   get(reload$);

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -1,11 +1,12 @@
 import { command, computed, state, type Command } from "ccstate";
 import { match } from "path-to-regexp";
 import type { RoutePath } from "../types/route.ts";
-import { clerk$, needsOrgSelection$ } from "./auth.ts";
+import { clerk$, needsOrgSelection$, watchOrgSwitch$ } from "./auth.ts";
 import { pathname, pushState, replaceState, search } from "./location.ts";
 import { setPageSignal$ } from "./page-signal.ts";
 import { rootSignal$ } from "./root-signal.ts";
-import { onDomEventFn, resetSignal } from "./utils.ts";
+import { pollUserInvitations$ } from "./user-invitations.ts";
+import { detach, onDomEventFn, Reason, resetSignal } from "./utils.ts";
 import { logger } from "./log.ts";
 
 const L = logger("Route");
@@ -248,6 +249,9 @@ export const setupAuthPageWrapper = (
         return;
       }
     }
+
+    detach(set(watchOrgSwitch$, signal), Reason.Entrance);
+    detach(set(pollUserInvitations$, signal), Reason.Entrance);
 
     await set(setupPageWrapper(fn), signal);
   });

--- a/turbo/apps/platform/src/signals/route.ts
+++ b/turbo/apps/platform/src/signals/route.ts
@@ -6,7 +6,7 @@ import { pathname, pushState, replaceState, search } from "./location.ts";
 import { setPageSignal$ } from "./page-signal.ts";
 import { rootSignal$ } from "./root-signal.ts";
 import { pollUserInvitations$ } from "./user-invitations.ts";
-import { detach, onDomEventFn, Reason, resetSignal } from "./utils.ts";
+import { onDomEventFn, resetSignal, throwIfNotAbort } from "./utils.ts";
 import { logger } from "./log.ts";
 
 const L = logger("Route");
@@ -250,8 +250,8 @@ export const setupAuthPageWrapper = (
       }
     }
 
-    detach(set(watchOrgSwitch$, signal), Reason.Entrance);
-    detach(set(pollUserInvitations$, signal), Reason.Entrance);
+    void set(watchOrgSwitch$, signal).catch(throwIfNotAbort);
+    void set(pollUserInvitations$, signal).catch(throwIfNotAbort);
 
     await set(setupPageWrapper(fn), signal);
   });

--- a/turbo/apps/platform/src/signals/user-invitations.ts
+++ b/turbo/apps/platform/src/signals/user-invitations.ts
@@ -1,7 +1,6 @@
 import { command, computed, state } from "ccstate";
 import { delay } from "signal-timers";
-import { clerk$, watchOrgSwitch$ } from "./auth.ts";
-import { onRef } from "./utils.ts";
+import { clerk$ } from "./auth.ts";
 
 const POLL_INTERVAL_MS = 30_000;
 
@@ -35,26 +34,13 @@ export const refreshUserInvitations$ = command(({ set }) => {
 /**
  * Poll invitations on a fixed interval until aborted.
  */
-const pollUserInvitations$ = command(async ({ set }, signal: AbortSignal) => {
-  while (!signal.aborted) {
-    await delay(POLL_INTERVAL_MS, { signal });
-    set(reloadInvitations$, (x) => {
-      return x + 1;
-    });
-  }
-});
-
-/**
- * Org switcher lifecycle — watches org changes and polls invitations.
- * Wire to a DOM element via `onRef`.
- */
-const orgSwitcherSetup$ = command(
-  async ({ set }, el: HTMLElement, signal: AbortSignal) => {
-    await Promise.all([
-      set(watchOrgSwitch$, el, signal),
-      set(pollUserInvitations$, signal),
-    ]);
+export const pollUserInvitations$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    while (!signal.aborted) {
+      await delay(POLL_INTERVAL_MS, { signal });
+      set(reloadInvitations$, (x) => {
+        return x + 1;
+      });
+    }
   },
 );
-
-export const orgSwitcherRef$ = onRef(orgSwitcherSetup$);

--- a/turbo/apps/platform/src/views/select-org/select-org-page.tsx
+++ b/turbo/apps/platform/src/views/select-org/select-org-page.tsx
@@ -1,17 +1,10 @@
 import { OrganizationList } from "@clerk/clerk-react";
-import { useSet } from "ccstate-react";
-import { watchOrgSwitch$ } from "../../signals/auth.ts";
-import { onRef } from "../../signals/utils.ts";
 import { VM0ClerkProvider } from "../clerk/clerk-provider.tsx";
 
-const orgListRef$ = onRef(watchOrgSwitch$);
-
 export function SelectOrgPage() {
-  const orgListRef = useSet(orgListRef$);
-
   return (
     <div className="flex min-h-screen items-center justify-center bg-sidebar">
-      <div ref={orgListRef} className="flex flex-col items-center gap-6">
+      <div className="flex flex-col items-center gap-6">
         <div className="text-center">
           <h1 className="text-2xl font-semibold text-sidebar-foreground">
             Select an Organization

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -18,7 +18,6 @@ import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-ma
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { org$ } from "../../signals/org.ts";
 import {
-  orgSwitcherRef$,
   userInvitations$,
   refreshUserInvitations$,
 } from "../../signals/user-invitations.ts";
@@ -63,7 +62,6 @@ function OrgAvatar({
 }
 
 export function ZeroOrgSwitcher() {
-  const orgSwitcherRef = useSet(orgSwitcherRef$);
   const openManage = useSet(setOrgManageDialogOpen$);
   const pageSignal = useGet(pageSignal$);
   const clerkLoadable = useLoadable(clerk$);
@@ -137,7 +135,7 @@ export function ZeroOrgSwitcher() {
     pendingInvitations !== undefined && pendingInvitations.length > 0;
 
   return (
-    <div ref={orgSwitcherRef}>
+    <div>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button


### PR DESCRIPTION
## Summary

- Replace `onRef`-based lifecycle for `watchOrgSwitch$` and `pollUserInvitations$` with `detach` calls in `setupAuthPageWrapper`
- Remove unused `_el: HTMLElement` parameter from `watchOrgSwitch$`
- Remove `orgSwitcherSetup$`, `orgSwitcherRef$`, and `orgListRef$` that tied page-level side effects to DOM element mount/unmount
- `select-org-page.tsx` becomes a pure view component with no signal wiring

## Test plan

- [x] All 11 `zero-org-switcher.test.tsx` tests pass
- [x] TypeScript type check passes (platform package)
- [x] Knip finds no unused exports
- [ ] Verify org switching still reloads the page
- [ ] Verify invitation polling still works in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)