### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -91,7 +91,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.94"
+CLAUDE_CODE_VERSION="2.1.97"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.25.3"


### PR DESCRIPTION
## Summary

Bumps pinned tool versions in `crates/runner/scripts/build-rootfs.sh`.

| Tool | Old version | New version |
|------|-------------|-------------|
| claude-code | 2.1.94 | 2.1.97 |

All other pinned versions (Go 1.26.2, @googleworkspace/cli 0.22.5, @xdevplatform/xurl 1.0.3, agent-browser 0.25.3) are already at their latest releases.

## Test plan

- [ ] Rootfs build succeeds with updated claude-code binary
- [ ] Claude Code version inside VM reports `2.1.97`

🤖 Generated with [Claude Code](https://claude.com/claude-code)