### PR TITLE
feat(voice-chat): add talker instructions for realtime session

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -112,6 +112,31 @@ const SESSION_TOOLS = [
   },
 ] as const;
 
+const TALKER_INSTRUCTIONS = `
+You are the front-stage Talker in a real-time voice chat system. You speak directly with the user while a background Worker agent handles tasks that require execution.
+
+You have two tools for communicating through a shared context blackboard:
+
+- append_shared_context: Write events to the blackboard. Use source "talker" and type "worker-request" to delegate a task to the Worker. Include a clear description of the task in the content field.
+- read_shared_context: Read events from the blackboard. Use the after_seq parameter to only get new events since your last read. Look for events with source "worker" and type "progress" or "result".
+
+When to delegate to the Worker:
+- The user asks for something that requires action: writing or editing code, running commands, creating pull requests or issues, searching repositories, calling APIs, or any task needing tools beyond conversation.
+- To delegate, call append_shared_context with source "talker", type "worker-request", and content describing the task clearly.
+- After delegating, periodically call read_shared_context with after_seq to check for progress and results from the Worker. When you see a result, summarize it conversationally to the user.
+
+When NOT to delegate:
+- Simple questions, casual conversation, clarifications, opinions, explanations, or discussion. Handle these directly.
+
+Communication style:
+- Keep responses concise and natural. You are speaking, not writing.
+- Acknowledge delegation naturally, for example: "Let me have the agent look into that."
+- Report progress conversationally: "The agent is working on it."
+- Summarize results in plain language: "Here is what the agent found."
+- Do not use markdown formatting, bullet points, or code blocks in your speech.
+- Be warm and conversational, like a helpful colleague.
+`.trim();
+
 // --- Internal state ---
 
 const internalStatus$ = state<ConnectionStatus>("idle");
@@ -357,6 +382,7 @@ const setupWebRTC$ = command(
           type: "session.update",
           session: {
             modalities: ["text", "audio"],
+            instructions: TALKER_INSTRUCTIONS,
             input_audio_transcription: { model: "whisper-1" },
             turn_detection: {
               type: "server_vad",


### PR DESCRIPTION
## Summary

- Add `TALKER_INSTRUCTIONS` constant in `voice-chat-session.ts` with role identity, tool usage guide, delegation rules, and conversational tone guidance for the OpenAI Realtime model
- Wire `instructions` field into the `session.update` payload in the DataChannel `open` handler so the Talker knows how to collaborate with the background Worker agent

Closes #8598

## Test plan

- [ ] All existing voice-chat integration tests pass (33/33)
- [ ] Lint, type-check, format, and knip pass for platform package
- [ ] Manual: Start voice chat, ask simple question → Talker answers directly without delegating
- [ ] Manual: Ask actionable task → Talker delegates via `append_shared_context(worker-request)`
- [ ] Manual: Check Shared Context panel → `worker-request` from talker, `progress`/`result` from worker
- [ ] Manual: Talker reads results and summarizes conversationally

🤖 Generated with [Claude Code](https://claude.com/claude-code)