### PR TITLE
fix(runner): treat max_concurrent=0 as unlimited in session affinity routing

### DIFF
--- a/turbo/apps/web/src/lib/infra/run/__tests__/scheduling.test.ts
+++ b/turbo/apps/web/src/lib/infra/run/__tests__/scheduling.test.ts
@@ -105,6 +105,19 @@ describe("findBestRunner", () => {
     expect(result).toBeNull();
   });
 
+  it("treats maxConcurrent=0 as unlimited capacity", async () => {
+    const runnerId = randomUUID();
+    await insertTestRunnerState({
+      runnerId,
+      runnerGroup: GROUP,
+      heldSessions: ["session-1"],
+      maxConcurrent: 0,
+      runningCount: 5,
+    });
+    const result = await findBestRunner(GROUP, PROFILE, "session-1");
+    expect(result).toEqual({ runnerId });
+  });
+
   it("picks the affinity runner even with less free capacity", async () => {
     await insertTestRunnerState({
       runnerId: randomUUID(),

--- a/turbo/apps/web/src/lib/infra/run/scheduling.ts
+++ b/turbo/apps/web/src/lib/infra/run/scheduling.ts
@@ -35,8 +35,10 @@ export async function findBestRunner(
     );
 
   const candidates = runners.filter((r) => {
-    const freeSlots = r.maxConcurrent - r.runningCount;
-    return freeSlots > 0 && r.profiles.includes(profile);
+    // max_concurrent=0 means unlimited capacity on the runner side
+    const hasCapacity =
+      r.maxConcurrent === 0 || r.maxConcurrent > r.runningCount;
+    return hasCapacity && r.profiles.includes(profile);
   });
 
   if (candidates.length === 0) return null;


### PR DESCRIPTION
## Summary

- `findBestRunner` computed `freeSlots = maxConcurrent - runningCount`, which yields a negative number when `maxConcurrent=0` (the runner convention for unlimited capacity)
- This caused **every runner** to be excluded from session affinity dispatch, falling back to broadcast — VM keep-alive reuse across conversation turns was broken
- Fix: treat `maxConcurrent === 0` as unlimited capacity, matching the runner-side semantics in `resource_budget.rs`

**Root cause confirmed on prod**: investigated jobs `c9b4ee14` (prod-4, reused VM) and `38afe658` (prod-3, new VM) for the same session `991b8e54`. Despite prod-4 holding the idle VM, the job was broadcast and claimed by prod-3 because `findBestRunner` excluded all runners with `maxConcurrent=0`.

## Test plan

- [x] Added test: `maxConcurrent=0` with `runningCount=5` returns the affinity runner
- [x] Existing test: `maxConcurrent=4, runningCount=4` still excluded (full capacity)
- [x] All 11 scheduling tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)