### PR TITLE
refactor: replace contact@vm0.ai with support@vm0.ai

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,7 +8,7 @@ This isn’t an exhaustive list of things that you can’t do. Rather, take it i
 
 This code of conduct applies to all spaces managed by the VM0 project or vm0-ai. This includes IRC, the mailing lists, the issue tracker, DSF events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing [contact@vm0.ai](mailto:contact@vm0.ai).
+If you believe someone is violating the code of conduct, we ask that you report it by emailing [support@vm0.ai](mailto:support@vm0.ai).
 
 - **Be friendly and patient.**
 - **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
@@ -29,4 +29,4 @@ Original text courtesy of the [Speak Up! project](http://web.archive.org/web/201
 
 ## Questions?
 
-If you have questions, please see . If that doesn't answer your questions, feel free to [contact us](mailto:contact@vm0.ai).
+If you have questions, please see . If that doesn't answer your questions, feel free to [contact us](mailto:support@vm0.ai).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ We only provide security updates for the latest release. We recommend always run
 
 If you discover a security vulnerability, please report it responsibly by emailing us at:
 
-**[contact@vm0.ai](mailto:contact@vm0.ai)**
+**[support@vm0.ai](mailto:support@vm0.ai)**
 
 ### What to Include
 

--- a/docs/create-oauth-app.md
+++ b/docs/create-oauth-app.md
@@ -18,7 +18,7 @@ When integrating a new OAuth provider, create **two separate apps** per provider
 | Field       | Value                          |
 |-------------|--------------------------------|
 | Developer / Company | Max & Zoe, Inc.        |
-| Contact Email       | contact@vm0.ai         |
+| Contact Email       | support@vm0.ai         |
 | Support Email       | support@vm0.ai         |
 | Website             | https://www.vm0.ai     |
 | Documentation URL   | https://docs.vm0.ai    |

--- a/turbo/apps/platform/src/views/default-error-boundary.tsx
+++ b/turbo/apps/platform/src/views/default-error-boundary.tsx
@@ -19,7 +19,7 @@ export function DefaultErrorFallback({ error }: ErrorFallbackProps) {
           <div className="mt-2 w-80 text-center text-sm text-gray-500">
             Give it another try or reach out{" "}
             <a
-              href="mailto:contact@vm0.ai"
+              href="mailto:support@vm0.ai"
               className="text-blue-500 hover:underline"
             >
               support

--- a/turbo/apps/web/app/[locale]/security/SecurityPage.tsx
+++ b/turbo/apps/web/app/[locale]/security/SecurityPage.tsx
@@ -81,7 +81,7 @@ export default function SecurityPage() {
             <p className="text-[15px] leading-relaxed text-[hsl(var(--muted-foreground))]">
               Questions about security?{" "}
               <a
-                href="mailto:contact@vm0.ai"
+                href="mailto:support@vm0.ai"
                 className="text-[hsl(var(--foreground))] underline underline-offset-4"
               >
                 Contact us

--- a/turbo/apps/web/app/api/zero/developer-support/route.ts
+++ b/turbo/apps/web/app/api/zero/developer-support/route.ts
@@ -397,7 +397,7 @@ const router = tsr.router(zeroDeveloperSupportContract, {
     // Send email notification
     await enqueueEmail({
       from: buildFromAddress("vm0"),
-      to: "contact@vm0.ai",
+      to: "support@vm0.ai",
       subject: `[Developer Support] ${body.title}`,
       template: {
         template: "developer-support",

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -197,7 +197,7 @@ export default function RootLayout({
                 logo: "https://vm0.ai/assets/vm0-logo.svg",
                 description:
                   "Your trustworthy AI teammate. Works in Slack and on the web, for individuals and team collaboration.",
-                email: "contact@vm0.ai",
+                email: "support@vm0.ai",
                 foundingDate: "2025",
                 sameAs: [
                   "https://twitter.com/vm0_ai",
@@ -206,7 +206,7 @@ export default function RootLayout({
                 ],
                 contactPoint: {
                   "@type": "ContactPoint",
-                  email: "contact@vm0.ai",
+                  email: "support@vm0.ai",
                   contactType: "customer support",
                 },
               }),

--- a/turbo/apps/web/src/lib/push/send-push.ts
+++ b/turbo/apps/web/src/lib/push/send-push.ts
@@ -29,7 +29,7 @@ export async function sendUserPushNotifications(
   }
 
   webpush.setVapidDetails(
-    "mailto:contact@vm0.ai",
+    "mailto:support@vm0.ai",
     VAPID_PUBLIC_KEY,
     VAPID_PRIVATE_KEY,
   );


### PR DESCRIPTION
## Summary

- Replace all 10 occurrences of `contact@vm0.ai` with `support@vm0.ai` across 8 files
- Updates documentation (SECURITY.md, CODE_OF_CONDUCT.md, docs/create-oauth-app.md)
- Updates frontend UI (error boundary, JSON-LD structured data, security page)
- Updates backend services (developer support email recipient, VAPID contact)

Closes #8615

## Test plan

- [x] Verified zero remaining occurrences of `contact@vm0.ai` via grep
- [x] Lint passes (0 errors)
- [x] Type check errors are pre-existing (verified identical on main)
- [x] Format check passes (all files unchanged by prettier)
- [x] Knip passes (no unused exports/deps)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)