### PR TITLE
fix: revert contact email changes except developer-support route

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,7 +8,7 @@ This isn’t an exhaustive list of things that you can’t do. Rather, take it i
 
 This code of conduct applies to all spaces managed by the VM0 project or vm0-ai. This includes IRC, the mailing lists, the issue tracker, DSF events, and any other forums created by the project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing [support@vm0.ai](mailto:support@vm0.ai).
+If you believe someone is violating the code of conduct, we ask that you report it by emailing [contact@vm0.ai](mailto:contact@vm0.ai).
 
 - **Be friendly and patient.**
 - **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
@@ -29,4 +29,4 @@ Original text courtesy of the [Speak Up! project](http://web.archive.org/web/201
 
 ## Questions?
 
-If you have questions, please see . If that doesn't answer your questions, feel free to [contact us](mailto:support@vm0.ai).
+If you have questions, please see . If that doesn't answer your questions, feel free to [contact us](mailto:contact@vm0.ai).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ We only provide security updates for the latest release. We recommend always run
 
 If you discover a security vulnerability, please report it responsibly by emailing us at:
 
-**[support@vm0.ai](mailto:support@vm0.ai)**
+**[contact@vm0.ai](mailto:contact@vm0.ai)**
 
 ### What to Include
 

--- a/docs/create-oauth-app.md
+++ b/docs/create-oauth-app.md
@@ -19,7 +19,7 @@ When integrating a new OAuth provider, create **two separate apps** per provider
 |-------------|--------------------------------|
 | Developer / Company | Max & Zoe, Inc.        |
 | Contact Email       | contact@vm0.ai         |
-| Support Email       | contact@vm0.ai         |
+| Support Email       | support@vm0.ai         |
 | Website             | https://www.vm0.ai     |
 | Documentation URL   | https://docs.vm0.ai    |
 

--- a/docs/create-oauth-app.md
+++ b/docs/create-oauth-app.md
@@ -18,8 +18,8 @@ When integrating a new OAuth provider, create **two separate apps** per provider
 | Field       | Value                          |
 |-------------|--------------------------------|
 | Developer / Company | Max & Zoe, Inc.        |
-| Contact Email       | support@vm0.ai         |
-| Support Email       | support@vm0.ai         |
+| Contact Email       | contact@vm0.ai         |
+| Support Email       | contact@vm0.ai         |
 | Website             | https://www.vm0.ai     |
 | Documentation URL   | https://docs.vm0.ai    |
 

--- a/turbo/apps/platform/src/views/default-error-boundary.tsx
+++ b/turbo/apps/platform/src/views/default-error-boundary.tsx
@@ -19,7 +19,7 @@ export function DefaultErrorFallback({ error }: ErrorFallbackProps) {
           <div className="mt-2 w-80 text-center text-sm text-gray-500">
             Give it another try or reach out{" "}
             <a
-              href="mailto:support@vm0.ai"
+              href="mailto:contact@vm0.ai"
               className="text-blue-500 hover:underline"
             >
               support

--- a/turbo/apps/web/app/[locale]/security/SecurityPage.tsx
+++ b/turbo/apps/web/app/[locale]/security/SecurityPage.tsx
@@ -81,7 +81,7 @@ export default function SecurityPage() {
             <p className="text-[15px] leading-relaxed text-[hsl(var(--muted-foreground))]">
               Questions about security?{" "}
               <a
-                href="mailto:support@vm0.ai"
+                href="mailto:contact@vm0.ai"
                 className="text-[hsl(var(--foreground))] underline underline-offset-4"
               >
                 Contact us

--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -197,7 +197,7 @@ export default function RootLayout({
                 logo: "https://vm0.ai/assets/vm0-logo.svg",
                 description:
                   "Your trustworthy AI teammate. Works in Slack and on the web, for individuals and team collaboration.",
-                email: "support@vm0.ai",
+                email: "contact@vm0.ai",
                 foundingDate: "2025",
                 sameAs: [
                   "https://twitter.com/vm0_ai",
@@ -206,7 +206,7 @@ export default function RootLayout({
                 ],
                 contactPoint: {
                   "@type": "ContactPoint",
-                  email: "support@vm0.ai",
+                  email: "contact@vm0.ai",
                   contactType: "customer support",
                 },
               }),

--- a/turbo/apps/web/src/lib/push/send-push.ts
+++ b/turbo/apps/web/src/lib/push/send-push.ts
@@ -29,7 +29,7 @@ export async function sendUserPushNotifications(
   }
 
   webpush.setVapidDetails(
-    "mailto:support@vm0.ai",
+    "mailto:contact@vm0.ai",
     VAPID_PUBLIC_KEY,
     VAPID_PRIVATE_KEY,
   );


### PR DESCRIPTION
## Summary

- Revert `support@vm0.ai` back to `contact@vm0.ai` in 7 files that were incorrectly changed in #8617
- The only file that should use `support@vm0.ai` is `turbo/apps/web/app/api/zero/developer-support/route.ts` — left unchanged

### Files reverted:
- `SECURITY.md`
- `CODE_OF_CONDUCT.md` (2 occurrences)
- `docs/create-oauth-app.md` (2 occurrences)
- `turbo/apps/platform/src/views/default-error-boundary.tsx`
- `turbo/apps/web/app/[locale]/security/SecurityPage.tsx`
- `turbo/apps/web/app/layout.tsx` (2 occurrences)
- `turbo/apps/web/src/lib/push/send-push.ts`

## Test plan

- [x] Verified `support@vm0.ai` only remains in `developer-support/route.ts`
- [x] All pre-commit checks pass (lint, format, knip)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)