### PR TITLE
fix(platform): prevent horizontal scrollbar on long chat content

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -612,6 +612,7 @@
 .wmde-markdown a {
   color: hsl(216 70% 45%);
   text-decoration: none;
+  overflow-wrap: break-word;
 }
 
 .wmde-markdown a:hover {
@@ -722,11 +723,13 @@
   background-color: hsl(var(--gray-100));
   color: hsl(var(--foreground));
   border-radius: 4px;
+  overflow-wrap: break-word;
 }
 
 /* --- Code Blocks -------------------------------------------------------- */
 .wmde-markdown pre {
   overflow-x: auto;
+  max-width: 100%;
   border: 0.7px solid hsl(var(--gray-400));
   border-radius: 8px;
 }


### PR DESCRIPTION
## Summary

- Add `max-width: 100%` to `.wmde-markdown pre` so `overflow-x: auto` scrolls internally instead of expanding the parent container
- Add `overflow-wrap: break-word` to `.wmde-markdown code/tt` for long inline code tokens
- Add `overflow-wrap: break-word` to `.wmde-markdown a` for long URLs

Fixes the horizontal scrollbar that appears when chat messages contain excessively long text without line breaks.

Closes #8606, Closes #8516

## Test plan

This is a CSS-only fix with no JavaScript changes. Automated integration tests cannot verify overflow layout in headless JSDOM.

Manual verification:
- [ ] Long single-line code block scrolls internally within the code block (no page-level horizontal scroll)
- [ ] Long inline `code` token wraps at the container edge
- [ ] Long URL link wraps at the container edge
- [ ] Normal markdown content (paragraphs, headings, lists) renders unchanged
- [ ] Avatar positioning at ≥900px viewport (`-ml-[46px]` negative margin) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)