### PR TITLE
fix(slack): remove triggered-by footer from slack org replies

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/__tests__/route.test.ts
@@ -417,52 +417,6 @@ describe("POST /api/internal/callbacks/slack/org", () => {
     expect(blocksStr).not.toContain("clipboard");
   });
 
-  it("includes triggeredBy footer with Slack user mention in completion message", async () => {
-    const slackUserId = uniqueId("U-slack");
-    const { workspaceId } = await setupOrgSlack();
-    const { connectionId } = await seedTestSlackOrgConnection({
-      slackUserId,
-      slackWorkspaceId: workspaceId,
-      vm0UserId: user.userId,
-    });
-    const { composeId } = await createTestCompose(uniqueId("agent"));
-    const { runId } = await createTestRunInDb(user.userId, composeId, {
-      prompt: "Test prompt",
-    });
-    await completeTestRun(user.userId, runId);
-
-    const channelId = uniqueId("C-ch");
-    const threadTs = uniqueId("ts");
-    const payload: OrgCallbackPayload = {
-      workspaceId,
-      channelId,
-      threadTs,
-      messageTs: threadTs,
-      connectionId,
-      agentId: composeId,
-    };
-
-    const { secret } = await createTestCallback({
-      runId,
-      url: "http://localhost/api/internal/callbacks/slack/org",
-      payload: { ...payload },
-    });
-
-    const request = createCallbackRequest(
-      { runId, status: "completed", payload },
-      secret,
-    );
-    const response = await POST(request);
-    expect(response.status).toBe(200);
-
-    const { WebClient } = await import("@slack/web-api");
-    const mockClient = new WebClient();
-    const call = (mockClient.chat.postMessage as ReturnType<typeof vi.fn>).mock
-      .calls[0]![0] as { blocks: unknown[] };
-    const blocksStr = JSON.stringify(call.blocks);
-    expect(blocksStr).toContain(`Triggered by <@${slackUserId}>`);
-  });
-
   it("includes audit link block when AuditLink switch is on", async () => {
     const { workspaceId, connectionId } = await setupOrgSlack();
     const { composeId } = await createTestCompose(uniqueId("agent"));

--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -4,7 +4,6 @@ import { initServices } from "../../../../../../src/lib/init-services";
 import { verifyCallback } from "../../../../../../src/lib/infra/callback";
 import { decryptSecretValue } from "../../../../../../src/lib/shared/crypto/secrets-encryption";
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
-import { slackOrgConnections } from "../../../../../../src/db/schema/slack-org-connection";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
 import { findNewSessionId } from "../../../../../../src/lib/infra/session/find-new-session";
@@ -44,19 +43,6 @@ function parsePayload(payload: unknown): SlackOrgCallbackPayload | null {
 
 function errorResponse(message: string, status: number): NextResponse {
   return NextResponse.json({ error: message }, { status });
-}
-
-/** Best-effort resolution of the Slack user who triggered the run. */
-async function resolveTriggeredByLabel(
-  connectionId: string,
-): Promise<string | undefined> {
-  const [connection] = await globalThis.services.db
-    .select({ slackUserId: slackOrgConnections.slackUserId })
-    .from(slackOrgConnections)
-    .where(eq(slackOrgConnections.id, connectionId))
-    .limit(1);
-  if (!connection) return undefined;
-  return `Triggered by <@${connection.slackUserId}>`;
 }
 
 function buildResponseText(
@@ -206,13 +192,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // Resolve session
   await saveOrgThreadSession(payload, runId, status);
 
-  // Resolve triggering user for footer attribution (best-effort)
-  const triggeredByLabel = await resolveTriggeredByLabel(
-    payload.connectionId,
-  ).catch(() => {
-    return undefined;
-  });
-
   // Post each result as a separate Slack reply (in order)
   for (let i = 0; i < allOutputs.length; i++) {
     const output = allOutputs[i]!;
@@ -222,11 +201,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const isLast = i === allOutputs.length - 1;
     const logsUrl =
       isLast && auditLinkEnabled ? buildLogsUrl(runId) : undefined;
-    const triggeredBy = isLast ? triggeredByLabel : undefined;
 
     await postMessage(client, payload.channelId, responseText, {
       threadTs: payload.threadTs,
-      blocks: buildAgentResponseMessage(responseText, logsUrl, triggeredBy),
+      blocks: buildAgentResponseMessage(responseText, logsUrl),
     });
   }
 


### PR DESCRIPTION
## Summary

- Remove "Triggered by <@user>" footer from normal Slack org replies (mentions/DMs)
- Keep CLI `zero-slack-message-send` attribution unchanged — it has its own independent footer logic
- Remove the `resolveTriggeredByLabel()` function and unused `slackOrgConnections` import from the org callback handler

Closes #8628

## Test plan

- [x] Existing tests pass (9/9) after removing the triggered-by test
- [ ] Verify Slack org thread replies no longer show "Triggered by" footer
- [ ] Verify CLI `zero-slack-message-send` still shows user attribution footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)