### PR TITLE
fix(slack): fix queued run ephemeral visibility and missing callback registration

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/run-queue-service.test.ts
@@ -8,6 +8,7 @@ import {
   createTestCompose,
   createTestRunInDb,
   findTestRunRecord,
+  findTestRunCallbacks,
   findTestQueueEntry,
   markRunningRunsAsCompleted,
   expireQueueEntry,
@@ -115,6 +116,42 @@ describe("run-queue-service", () => {
       // Queue entry should be deleted
       const queueEntry = await findTestQueueEntry(queued.runId);
       expect(queueEntry).toBeUndefined();
+    });
+
+    it("should register callbacks for queued zero runs on dispatch", async () => {
+      // Create a run directly (simulates what dequeueNextAtomic produces)
+      const { runId } = await createTestRunInDb(user.userId, composeId, {
+        prompt: "With callback",
+      });
+
+      const callbackUrl = "https://example.com/callback";
+      const callbackPayload = { channelId: "C123", threadTs: "123.456" };
+      const params = baseParams({
+        prompt: "With callback",
+        composeId,
+        vars: { ZERO_AGENT_ID: composeId },
+        callbacks: [
+          {
+            url: callbackUrl,
+            secret: "test-secret",
+            payload: callbackPayload,
+          },
+        ],
+      });
+
+      // No callbacks registered yet
+      const callbacksBefore = await findTestRunCallbacks(runId);
+      expect(callbacksBefore).toHaveLength(0);
+
+      // dispatchQueuedZeroRun registers callbacks early, then fails later
+      // during token generation / context building — that's expected in tests.
+      await dispatchQueuedZeroRun(runId, params).catch(() => {});
+
+      // Callbacks should be registered in the database despite later failure
+      const callbacksAfter = await findTestRunCallbacks(runId);
+      expect(callbacksAfter).toHaveLength(1);
+      expect(callbacksAfter[0]!.url).toBe(callbackUrl);
+      expect(callbacksAfter[0]!.payload).toEqual(callbackPayload);
     });
 
     it("should drain across users in the same org", async () => {

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/mention.ts
@@ -92,7 +92,7 @@ export async function handleOrgMention(
     await client.chat.postEphemeral({
       channel: context.channelId,
       user: context.userId,
-      thread_ts: threadTs,
+      ...(context.threadTs && { thread_ts: threadTs }),
       text: "No agent is configured for this org. Please ask your org admin to set a default agent.",
     });
     return;
@@ -103,7 +103,7 @@ export async function handleOrgMention(
     await client.chat.postEphemeral({
       channel: context.channelId,
       user: context.userId,
-      thread_ts: threadTs,
+      ...(context.threadTs && { thread_ts: threadTs }),
       text: "The configured agent could not be found. Please contact your org admin.",
     });
     return;
@@ -199,7 +199,7 @@ export async function handleOrgMention(
     await client.chat.postEphemeral({
       channel: context.channelId,
       user: context.userId,
-      thread_ts: threadTs,
+      ...(context.threadTs && { thread_ts: threadTs }),
       text: `⚠ Run queued — concurrency limit reached. Will start automatically when a slot is available. <${queueUrl}|View queue>`,
       blocks: [
         {

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -478,6 +478,11 @@ export async function dispatchQueuedZeroRun(
       await validateComposeRequirements(composeContent);
     }
 
+    // Register callbacks early so they persist even if context building fails
+    if (params.callbacks && params.callbacks.length > 0) {
+      await registerCallbacks(runId, params.callbacks);
+    }
+
     // Generate sandbox token + build zero context
     const sandboxToken = await generateSandboxToken(params.userId, runId);
     const tokenTime = Date.now();


### PR DESCRIPTION
## Summary

- **Mention ephemeral messages** (run queued, no agent configured) were posted with `thread_ts` even for top-level mentions, making them invisible in the main channel view. Now only sets `thread_ts` when the mention is actually in a thread, matching the existing login prompt pattern at line 80.
- **`dispatchQueuedZeroRun()` zero path** was missing `registerCallbacks()`, so queued zero runs (Slack, Telegram, Schedule) never registered callbacks and completion results were never sent back. Added the missing call to match the direct dispatch and non-zero queued paths.

Closes #8638

## Test plan

- [ ] Send a top-level @mention in a Slack channel when concurrency limit is reached — verify "run queued" ephemeral appears at channel level
- [ ] Send a threaded @mention when concurrency limit is reached — verify "run queued" ephemeral appears in thread
- [ ] Trigger a queued Slack run (hit concurrency limit) — verify result is sent back to Slack after completion
- [ ] Verify DM queued notification still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)