### PR TITLE
fix(firewalls): skip __typename in graphql field coverage check

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -425,7 +425,15 @@ def _find_uncovered_graphql_fields(
     if all_patterns is None or len(all_patterns) == 0:
         return []
 
-    return [f for f in fields if not _is_field_covered(f, all_patterns)]
+    return [
+        f
+        for f in fields
+        # __typename is a built-in introspection field on every type.
+        # Many clients (Apollo, Relay) inject it automatically.
+        # It carries no data access beyond what the parent covers.
+        if not (f == "__typename" or f.endswith(".__typename"))
+        and not _is_field_covered(f, all_patterns)
+    ]
 
 
 def match_firewall_request(

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -3110,3 +3110,53 @@ class TestGraphQLFieldCoverage:
             body=body_extra,
         )
         assert isinstance(result, FirewallBlock)
+
+    def test_typename_ignored_in_coverage_check(self):
+        """__typename is a built-in introspection field injected by many
+        clients (Apollo, Relay).  It should not cause coverage failures."""
+        fw = self._make_fw(
+            {
+                "issues:read": ["POST /graphql GraphQL type:query field:repository.issues"],
+            }
+        )
+        body = json.dumps(
+            {
+                "query": "query { repository { __typename issues "
+                "{ __typename nodes { __typename title } } } }"
+            }
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallAllow)
+
+    def test_typename_alone_does_not_bypass(self):
+        """A query with ONLY __typename still needs a matching rule to
+        pass the rule-matching step (coverage check is moot)."""
+        fw = self._make_fw(
+            {
+                "issues:read": ["POST /graphql GraphQL type:query field:repository.issues"],
+            }
+        )
+        body = json.dumps({"query": "query { repository { __typename } }"}).encode()
+        # field filter is "repository.issues" — the query has no matching
+        # field (only __typename), so the rule itself doesn't match → block.
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_uncovered_field_with_typename_still_blocks(self):
+        """__typename is ignored but other uncovered fields still block."""
+        fw = self._make_fw(
+            {
+                "issues:read": ["POST /graphql GraphQL type:query field:repository.issues"],
+            }
+        )
+        body = json.dumps(
+            {"query": "query { repository { __typename issues { id } stargazers { id } } }"}
+        ).encode()
+        result = matching.match_firewall_request(
+            "https://api.example.com/graphql", "POST", fw, body=body
+        )
+        assert isinstance(result, FirewallBlock)


### PR DESCRIPTION
## Summary
- Skip `__typename` fields in the GraphQL field coverage check
- `__typename` is a built-in introspection field on every GraphQL type that many clients (Apollo, Relay) inject automatically
- Without this fix, queries with auto-injected `__typename` would be falsely blocked by the coverage check
- Uses precise segment matching (`f == "__typename" or f.endswith(".__typename")`) to avoid false positives

## Test plan
- [x] `test_typename_ignored_in_coverage_check` — `__typename` at multiple depths with covered fields → allow
- [x] `test_typename_alone_does_not_bypass` — query with only `__typename` and no matching field → block (rule matching still enforced)
- [x] `test_uncovered_field_with_typename_still_blocks` — `__typename` + covered + uncovered field → block
- [x] All 714 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)