### PR TITLE
fix(voice-chat): use valid realtime api voice parameter

### DIFF
--- a/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
@@ -26,7 +26,7 @@ export async function createEphemeralToken(): Promise<EphemeralTokenResponse> {
     },
     body: JSON.stringify({
       model: "gpt-realtime-1.5",
-      voice: "onyx",
+      voice: "verse",
     }),
   });
 


### PR DESCRIPTION
## Summary
- Replace `onyx` voice with `verse` in OpenAI Realtime API ephemeral token creation
- `onyx` is only available in the regular TTS API, not the Realtime API, causing a 400 error on session start

## Test plan
- [ ] Start a voice chat session and verify it connects without "Failed to create ephemeral token" error
- [ ] Verify the voice sounds correct (verse voice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)