### PR TITLE
fix(runner): clean up residual transient systemd units before service start

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -525,6 +525,9 @@ jobs:
           }
           trap cleanup EXIT
 
+          # Clean up any residual transient unit from a previous CI run
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
+
           # Start transient runner service
           echo "--- Starting runner ---"
           sudo "$BIN_DIR/runner" service start --name "$SVC" \
@@ -739,6 +742,9 @@ jobs:
           }
           trap cleanup EXIT
 
+          # Clean up any residual transient unit from a previous CI run
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
+
           # Start transient runner service
           echo "--- Starting runner ---"
           sudo "$BIN_DIR/runner" service start --name "$SVC" \
@@ -841,6 +847,9 @@ jobs:
             sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
           }
           trap cleanup EXIT
+
+          # Clean up any residual transient unit from a previous CI run
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
 
           # Start transient runner service
           echo "--- Starting runner ---"
@@ -1142,6 +1151,9 @@ jobs:
             sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
           }
           trap cleanup EXIT
+
+          # Clean up any residual transient unit from a previous CI run
+          sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
 
           # Start transient runner service with keep-alive
           echo "--- Starting runner (keep-alive enabled) ---"

--- a/crates/runner/src/cmd/service.rs
+++ b/crates/runner/src/cmd/service.rs
@@ -288,15 +288,29 @@ async fn start(args: ServiceRunArgs) -> RunnerResult<()> {
 }
 
 /// `service stop` — stop the named unit.
+///
+/// Also clears residual transient unit state so that a subsequent
+/// `service start` with the same name succeeds.
 async fn stop(args: ServiceNameArgs) -> RunnerResult<()> {
     let unit = unit_name(&args.name)?;
-    if !is_unit_active(&unit).await? {
-        info!(unit = %unit, "no active service found");
-        return Ok(());
-    }
     let svc = format!("{unit}.service");
-    run_systemctl(&["stop", &svc]).await?;
-    info!(unit = %unit, "stopped");
+
+    if is_unit_active(&unit).await? {
+        // Active unit: stop must succeed — failure means the runner process
+        // (and its Firecracker VMs) would keep running.
+        run_systemctl(&["stop", &svc]).await?;
+        info!(unit = %unit, "stopped");
+    } else {
+        // Unit may be loaded but inactive (residual transient unit).
+        // Try stop to trigger systemd GC.  Ignore errors — the unit may
+        // not exist at all (first run on this host).
+        let _ = run_systemctl(&["stop", &svc]).await;
+        info!(unit = %unit, "no active service found");
+    }
+
+    // Clear "failed" latch so systemd fully unloads the transient unit.
+    // (stop alone does not clear the failed state.)
+    let _ = run_systemctl(&["reset-failed", &svc]).await;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Add pre-start `service stop` in all 4 CI transient-service jobs to clear residual systemd units from previous runs
- Enhance `service stop` to call `systemctl reset-failed` after stopping, clearing the "failed" latch so systemd fully unloads the transient unit
- For inactive residual units, attempt best-effort stop to trigger systemd GC, while still propagating errors for active units

Closes #8640

## Test plan

- [ ] CI jobs (runner-exec, runner-cancel, runner-balloon, runner-keepalive) pass — these exercise the stop-then-start flow
- [ ] Re-run a failed CI job on the same host to verify residual unit cleanup works

🤖 Generated with [Claude Code](https://claude.com/claude-code)