### PR TITLE
perf(runner): parallelize production runner deployment across hosts

### DIFF
--- a/ansible/playbooks/deploy-runner.yml
+++ b/ansible/playbooks/deploy-runner.yml
@@ -18,7 +18,6 @@
 
 - name: Deploy VM0 Runner
   hosts: all
-  serial: 1
   become: true
 
   vars:


### PR DESCRIPTION
## Summary

- Remove `serial: 1` from `deploy-runner.yml` so all hosts deploy concurrently
- Safe because each host is independent: new version gets its own bin dir and systemd service, old version is drained only after the new one passes health checks

## Test plan

- [ ] Deploy to staging with multiple hosts and verify all deploy in parallel
- [ ] Verify old runners are drained only after new runners pass health checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)