### PR TITLE
fix(auth): correct dark mode text colors on login interface

### DIFF
--- a/turbo/apps/web/app/components/auth/AuthLayout.tsx
+++ b/turbo/apps/web/app/components/auth/AuthLayout.tsx
@@ -241,10 +241,10 @@ button[class*="socialButtons"] span {
   background: hsl(var(--card)) !important;
 }
 
-/* Footer action text - muted foreground */
+/* Footer action text - use foreground for sufficient contrast in dark mode */
 .cl-footerActionText,
 [class*="footerActionText"] {
-  color: hsl(var(--muted-foreground)) !important;
+  color: hsl(var(--foreground)) !important;
 }
 
 /* Footer action link - primary color */
@@ -291,11 +291,10 @@ button[class*="alternativeMethodsBlockButton"] {
   color: hsl(var(--muted-foreground)) !important;
 }
 
-/* Email address display - use muted foreground */
+/* Email address display on verification screens */
 .cl-identityPreviewText,
 [class*="identityPreview"] [class*="text"],
-.cl-card [class*="userPreview"],
-.cl-card [class*="emailAddress"] {
+.cl-card [class*="userPreview"] {
   color: hsl(var(--muted-foreground)) !important;
 }
 


### PR DESCRIPTION
## Summary
- Remove overly broad `.cl-card [class*="emailAddress"]` CSS selector that was overriding form field label color with `muted-foreground`, causing the "Email address" label to appear gray instead of white in dark mode (higher specificity 0,2,0 beat the label selector's 0,1,0)
- Change footer action text from `muted-foreground` to `foreground` for proper contrast on "Already have an account?" text

Closes #8612

## Test plan
- [ ] Open sign-in page in dark mode — verify "Email address" label is white (same as "Password")
- [ ] Verify "Already have an account?" / "Don't have an account?" footer text has proper contrast
- [ ] Verify light mode is unaffected
- [ ] Verify identity preview text (email shown on verification screen) still uses muted color

🤖 Generated with [Claude Code](https://claude.com/claude-code)