### PR TITLE
feat(insights): redesign allowed card and split credits into personal and team cards

### DIFF
--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -35,7 +35,7 @@ export interface TopTask {
 }
 
 export interface MemberCredits {
-  userId?: string;
+  userId: string;
   name: string;
   credits: number;
   agentNames: string[];

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -35,6 +35,7 @@ export interface TopTask {
 }
 
 export interface MemberCredits {
+  userId?: string;
   name: string;
   credits: number;
   agentNames: string[];

--- a/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
+++ b/turbo/apps/platform/src/signals/network-insights/network-insights-signals.ts
@@ -143,3 +143,26 @@ export const reloadInsights$ = command(({ set }) => {
     return x + 1;
   });
 });
+
+// ---------------------------------------------------------------------------
+// "Load more" toggle for allowed-permissions card (keyed by day date)
+// ---------------------------------------------------------------------------
+
+const internalExpandedAllowed$ = state<Set<string>>(new Set());
+
+export const expandedAllowedDays$ = computed((get) => {
+  return get(internalExpandedAllowed$);
+});
+
+export const toggleExpandedAllowed$ = command(
+  ({ get, set }, dayDate: string) => {
+    const current = get(internalExpandedAllowed$);
+    const next = new Set(current);
+    if (next.has(dayDate)) {
+      next.delete(dayDate);
+    } else {
+      next.add(dayDate);
+    }
+    set(internalExpandedAllowed$, next);
+  },
+);

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -58,12 +58,14 @@ function sampleDay(date: string, overrides?: Record<string, unknown>) {
     creditBalance: 9800,
     teamUsage: [
       {
+        userId: "user-alice",
         name: "alice",
         credits: 120,
         agentNames: ["Alpha Bot"],
         agentCredits: { "Alpha Bot": 120 },
       },
       {
+        userId: "user-bob",
         name: "bob",
         credits: 80,
         agentNames: ["Beta Bot"],
@@ -445,11 +447,22 @@ describe("network insights page - data refetch", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Team usage in credits card
+// Team credit usage card (admin-only)
 // ---------------------------------------------------------------------------
 
-describe("network insights page - credits card", () => {
-  it("should display team member names", async () => {
+describe("network insights page - team credit usage card", () => {
+  it("should display Team Credit Usage heading for admin users", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    // Default MSW handler returns role: "admin"
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Team Credit Usage")).toBeInTheDocument();
+    });
+  });
+
+  it("should display team member names in team card", async () => {
     mockInsightsAPI([sampleDay(day1Ago)]);
 
     await setupPage({ context, path: "/insights" });
@@ -468,5 +481,257 @@ describe("network insights page - credits card", () => {
     await waitFor(() => {
       expect(screen.getByText("9,800")).toBeInTheDocument();
     });
+  });
+
+  it("should not display Team Credit Usage card for non-admin users", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    // Override org API to return member role
+    server.use(
+      http.get("*/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "org_1",
+          slug: "user-12345678",
+          name: "User 12345678",
+          role: "member",
+        });
+      }),
+    );
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Your Credit Usage")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Team Credit Usage")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Your credit usage card (everyone)
+// ---------------------------------------------------------------------------
+
+describe("network insights page - your credit usage card", () => {
+  it("should display Your Credit Usage heading", async () => {
+    mockInsightsAPI([sampleDay(day1Ago)]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Your Credit Usage")).toBeInTheDocument();
+    });
+  });
+
+  it("should show personal credits matching the current user", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        teamUsage: [
+          {
+            userId: "test-user-123",
+            name: "me",
+            credits: 75,
+            agentNames: ["Alpha Bot"],
+            agentCredits: { "Alpha Bot": 75 },
+          },
+          {
+            userId: "other-user",
+            name: "other",
+            credits: 125,
+            agentNames: ["Beta Bot"],
+            agentCredits: { "Beta Bot": 125 },
+          },
+        ],
+      }),
+    ]);
+
+    await setupPage({ context, path: "/insights" });
+
+    // "Your Credit Usage" card should show the current user's credits (75)
+    await waitFor(() => {
+      expect(screen.getByText("Your Credit Usage")).toBeInTheDocument();
+    });
+    expect(screen.getByText("75")).toBeInTheDocument();
+  });
+
+  it("should show 0 credits when current user has no usage", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        teamUsage: [
+          {
+            userId: "someone-else",
+            name: "someone",
+            credits: 200,
+            agentNames: ["Alpha Bot"],
+          },
+        ],
+      }),
+    ]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Your Credit Usage")).toBeInTheDocument();
+    });
+    // No match for current user → 0
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Allowed permissions card — load more toggle
+// ---------------------------------------------------------------------------
+
+describe("network insights page - allowed permissions load more", () => {
+  it("should show Load more button when more than 5 permissions", async () => {
+    const manyPermissions = Array.from({ length: 8 }, (_, i) => {
+      return {
+        label: `perm-${i}`,
+        connectorType: `svc-${i}`,
+        allowed: i + 1,
+        denied: 0,
+        agentNames: ["Alpha Bot"],
+      };
+    });
+    mockInsightsAPI([sampleDay(day1Ago, { permissions: manyPermissions })]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Load more")).toBeInTheDocument();
+    });
+  });
+
+  it("should not show Load more button when 5 or fewer permissions", async () => {
+    const fewPermissions = Array.from({ length: 4 }, (_, i) => {
+      return {
+        label: `perm-${i}`,
+        connectorType: `svc-${i}`,
+        allowed: i + 1,
+        denied: 0,
+        agentNames: ["Alpha Bot"],
+      };
+    });
+    mockInsightsAPI([sampleDay(day1Ago, { permissions: fewPermissions })]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Allowed")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Load more")).not.toBeInTheDocument();
+  });
+
+  it("should expand all permissions on Load more click", async () => {
+    const user = userEvent.setup();
+    const manyPermissions = Array.from({ length: 7 }, (_, i) => {
+      return {
+        label: `action-${i}`,
+        connectorType: `connector-${i}`,
+        allowed: 1,
+        denied: 0,
+        agentNames: ["Alpha Bot"],
+      };
+    });
+    mockInsightsAPI([sampleDay(day1Ago, { permissions: manyPermissions })]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Load more")).toBeInTheDocument();
+    });
+
+    // Only first 5 visible initially; permission 6 (action-6) should not be visible
+    expect(screen.queryByText("action-6")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Load more"));
+
+    await waitFor(() => {
+      expect(screen.getByText("action-6")).toBeInTheDocument();
+    });
+    // Button should now say "Show less"
+    expect(screen.getByText("Show less")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Allowed permissions card — redesigned layout
+// ---------------------------------------------------------------------------
+
+describe("network insights page - allowed card layout", () => {
+  it("should show connector name and description on separate lines", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        services: [],
+        permissions: [
+          {
+            label: "chat:write",
+            connectorType: "slack",
+            allowed: 8,
+            denied: 0,
+            agentNames: ["Alpha Bot"],
+          },
+        ],
+      }),
+    ]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Allowed")).toBeInTheDocument();
+    });
+    // Description (label) displayed separately below the connector name
+    expect(screen.getByText("chat:write")).toBeInTheDocument();
+    // Call count with "calls" label
+    expect(screen.getByText("8 calls")).toBeInTheDocument();
+  });
+
+  it("should show calls count with singular form", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        permissions: [
+          {
+            label: "repo:read",
+            connectorType: "github",
+            allowed: 1,
+            denied: 0,
+            agentNames: ["Beta Bot"],
+          },
+        ],
+      }),
+    ]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("1 call")).toBeInTheDocument();
+    });
+  });
+
+  it("should not show description when label equals connectorType", async () => {
+    mockInsightsAPI([
+      sampleDay(day1Ago, {
+        services: [],
+        permissions: [
+          {
+            label: "github",
+            connectorType: "github",
+            allowed: 5,
+            denied: 0,
+            agentNames: ["Beta Bot"],
+          },
+        ],
+      }),
+    ]);
+
+    await setupPage({ context, path: "/insights" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Allowed")).toBeInTheDocument();
+    });
+    expect(screen.getByText("5 calls")).toBeInTheDocument();
+    // "calls made within 1 granted permission" — updated text
+    expect(
+      screen.getByText(/calls made within 1 granted permission/),
+    ).toBeInTheDocument();
   });
 });

--- a/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/network-insights/__tests__/network-insights-page-interaction.test.tsx
@@ -190,13 +190,13 @@ describe("network insights page - data rendering", () => {
     });
   });
 
-  it("should display blocked permissions card when denied > 0", async () => {
+  it("should display protected permissions card when denied > 0", async () => {
     mockInsightsAPI([sampleDay(day1Ago)]);
 
     await setupPage({ context, path: "/insights" });
 
     await waitFor(() => {
-      expect(screen.getByText("Blocked")).toBeInTheDocument();
+      expect(screen.getByText("Protected")).toBeInTheDocument();
     });
   });
 
@@ -227,7 +227,7 @@ describe("network insights page - data rendering", () => {
     expect(screen.getAllByText("GitHub").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("should not display blocked card when no denials", async () => {
+  it("should not display protected card when no denials", async () => {
     mockInsightsAPI([
       sampleDay(day1Ago, {
         permissions: [
@@ -246,7 +246,7 @@ describe("network insights page - data rendering", () => {
     await waitFor(() => {
       expect(screen.getByText("Allowed")).toBeInTheDocument();
     });
-    expect(screen.queryByText("Blocked")).not.toBeInTheDocument();
+    expect(screen.queryByText("Protected")).not.toBeInTheDocument();
   });
 
   it("should show Yesterday header for yesterday's data", async () => {

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -664,17 +664,28 @@ function YourCreditUsageCard({
   day,
   colorIndex,
   userName,
+  hoveredAgent,
 }: {
   day: DayInsight;
   colorIndex: number;
   userName: string | null;
+  hoveredAgent: string | null;
 }) {
   const { accent } = getCardPalette(colorIndex);
-  const personalCredits = userName
-    ? (day.teamUsage.find((m) => {
+  const myUsage = userName
+    ? day.teamUsage.find((m) => {
         return m.name === userName;
-      })?.credits ?? 0)
-    : 0;
+      })
+    : null;
+  const displayCredits =
+    hoveredAgent && myUsage?.agentCredits?.[hoveredAgent] !== undefined
+      ? myUsage.agentCredits[hoveredAgent]
+      : (myUsage?.credits ?? 0);
+  const hoveredAgentData = hoveredAgent
+    ? day.agents.find((a) => {
+        return a.agentName === hoveredAgent;
+      })
+    : null;
 
   return (
     <Card>
@@ -684,10 +695,14 @@ function YourCreditUsageCard({
       >
         Your Credit Usage
       </p>
-      <p className="text-5xl font-black leading-none tabular-nums font-serif">
-        {personalCredits.toLocaleString()}
+      <p className="text-5xl font-black leading-none tabular-nums font-serif transition-all duration-150">
+        {displayCredits.toLocaleString()}
       </p>
-      <p className="text-sm opacity-60 mt-2">consumed today</p>
+      <p className="text-sm opacity-60 mt-2">
+        {hoveredAgentData
+          ? `by ${hoveredAgentData.agentName}`
+          : "consumed today"}
+      </p>
     </Card>
   );
 }
@@ -905,13 +920,13 @@ function PermissionsBlockedCard({
         className="text-xs font-semibold uppercase tracking-widest mb-3"
         style={{ color: accent }}
       >
-        Blocked
+        Protected
       </p>
       <p className="text-5xl font-black leading-none tabular-nums font-serif">
         {totalBlocked}
       </p>
       <p className="text-sm opacity-60 mt-2">
-        calls blocked across {blocked.length}{" "}
+        calls protected across {blocked.length}{" "}
         {blocked.length === 1 ? "permission" : "permissions"}
       </p>
       <div className="flex flex-col gap-2 mt-4">
@@ -997,7 +1012,12 @@ function DaySection({
             hoveredAgent={hoveredAgent}
           />
         )}
-        <YourCreditUsageCard day={day} colorIndex={1} userName={userName} />
+        <YourCreditUsageCard
+          day={day}
+          colorIndex={1}
+          userName={userName}
+          hoveredAgent={hoveredAgent}
+        />
         <AgentsCard
           day={day}
           colorIndex={0}

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useSet, useLastLoadable, useLoadable } from "ccstate-react";
+import { useGet, useSet, useLastLoadable } from "ccstate-react";
 import {
   IconNetwork,
   IconChevronDown,
@@ -857,7 +857,7 @@ function PermissionsAllowedCard({
           const hasDescription = p.connectorType && p.label !== p.connectorType;
           return (
             <div
-              key={p.label}
+              key={`${p.connectorType ?? ""}:${p.label}`}
               className={`transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
             >
               <div className="flex items-center justify-between gap-2">
@@ -884,7 +884,7 @@ function PermissionsAllowedCard({
             toggleExpanded(day.date);
           }}
           className="text-xs font-medium mt-3"
-          style={{ color: "#ed4e01" }}
+          style={{ color: accent }}
         >
           {expanded ? "Show less" : "Load more"}
         </button>
@@ -936,7 +936,7 @@ function PermissionsBlockedCard({
           const fullyBlocked = p.allowed === 0;
           return (
             <div
-              key={p.label}
+              key={`${p.connectorType ?? ""}:${p.label}`}
               className={`flex items-center justify-between gap-2 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
             >
               <span className="text-sm font-medium">{permissionLabel(p)}</span>
@@ -1058,7 +1058,7 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
   const dateRange = useGet(insightsDateRange$);
   const setRange = useSet(setInsightsDateRange$);
   const prefsLoadable = useLastLoadable(userPreferences$);
-  const adminLoadable = useLoadable(isOrgAdmin$);
+  const adminLoadable = useLastLoadable(isOrgAdmin$);
   const userLoadable = useLastLoadable(user$);
   const timezone =
     prefsLoadable.state === "hasData" && prefsLoadable.data?.timezone

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import { useGet, useSet, useLastLoadable, useLoadable } from "ccstate-react";
 import {
   IconNetwork,
   IconChevronDown,
@@ -28,10 +28,14 @@ import {
   setInsightsCalendarMonth$,
   insightsHoveredAgent$,
   setInsightsHoveredAgent$,
+  expandedAllowedDays$,
+  toggleExpandedAllowed$,
   type DayInsight,
   type NetworkInsightsData,
 } from "../../signals/network-insights/network-insights-signals.ts";
 import { userPreferences$ } from "../../signals/zero-page/settings/user-preferences.ts";
+import { isOrgAdmin$ } from "../../signals/org.ts";
+import { user$ } from "../../signals/auth.ts";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 
 // ---------------------------------------------------------------------------
@@ -547,10 +551,10 @@ function AgentsCard({
 }
 
 // ---------------------------------------------------------------------------
-// Card: Credits consumed
+// Card: Team credit usage (admin-only)
 // ---------------------------------------------------------------------------
 
-function CreditsCard({
+function TeamCreditUsageCard({
   day,
   colorIndex,
   hoveredAgent,
@@ -585,7 +589,7 @@ function CreditsCard({
         className="text-xs font-semibold uppercase tracking-widest mb-3"
         style={{ color: accent }}
       >
-        Credits
+        Team Credit Usage
       </p>
       <p className="text-5xl font-black leading-none tabular-nums font-serif transition-all duration-150">
         {displayCredits.toLocaleString()}
@@ -596,60 +600,94 @@ function CreditsCard({
           : "consumed today"}
       </p>
 
-      <div>
-        <div className="flex items-center justify-between mt-4">
-          <span className="text-sm opacity-60">Balance</span>
-          <span className="text-sm font-semibold tabular-nums">
-            {day.creditBalance.toLocaleString()}
-          </span>
-        </div>
-
-        {sorted.length > 0 && (
-          <div className="mt-4">
-            <p
-              className="text-xs font-semibold uppercase tracking-widest mb-3"
-              style={{ color: accent }}
-            >
-              Team
-            </p>
-            <div className="flex flex-col gap-2">
-              {sorted.map((m) => {
-                const isActive =
-                  hoveredAgent === null || m.agentNames?.includes(hoveredAgent);
-                const memberCredits =
-                  hoveredAgent &&
-                  m.agentCredits?.[hoveredAgent] !== null &&
-                  m.agentCredits?.[hoveredAgent] !== undefined
-                    ? m.agentCredits[hoveredAgent]
-                    : m.credits;
-                const pct = (memberCredits / maxCredits) * 100;
-                return (
-                  <div
-                    key={m.name}
-                    className={`flex items-center gap-3 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
-                  >
-                    <span className="text-sm w-20 truncate shrink-0">
-                      {m.name}
-                    </span>
-                    <div className="flex-1 h-1.5 rounded-full bg-current/10 overflow-hidden">
-                      <div
-                        className="h-full rounded-full"
-                        style={{
-                          width: `${pct}%`,
-                          backgroundColor: accent,
-                        }}
-                      />
-                    </div>
-                    <span className="text-xs opacity-60 w-10 text-right shrink-0 tabular-nums">
-                      {memberCredits}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
+      <div className="flex items-center justify-between mt-4">
+        <span className="text-sm opacity-60">Balance</span>
+        <span className="text-sm font-semibold tabular-nums">
+          {day.creditBalance.toLocaleString()}
+        </span>
       </div>
+
+      {sorted.length > 0 && (
+        <div className="mt-4">
+          <p
+            className="text-xs font-semibold uppercase tracking-widest mb-3"
+            style={{ color: accent }}
+          >
+            Team
+          </p>
+          <div className="flex flex-col gap-2">
+            {sorted.map((m) => {
+              const isActive =
+                hoveredAgent === null || m.agentNames?.includes(hoveredAgent);
+              const memberCredits =
+                hoveredAgent &&
+                m.agentCredits?.[hoveredAgent] !== null &&
+                m.agentCredits?.[hoveredAgent] !== undefined
+                  ? m.agentCredits[hoveredAgent]
+                  : m.credits;
+              const pct = (memberCredits / maxCredits) * 100;
+              return (
+                <div
+                  key={m.name}
+                  className={`flex items-center gap-3 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
+                >
+                  <span className="text-sm w-20 truncate shrink-0">
+                    {m.name}
+                  </span>
+                  <div className="flex-1 h-1.5 rounded-full bg-current/10 overflow-hidden">
+                    <div
+                      className="h-full rounded-full"
+                      style={{
+                        width: `${pct}%`,
+                        backgroundColor: accent,
+                      }}
+                    />
+                  </div>
+                  <span className="text-xs opacity-60 w-10 text-right shrink-0 tabular-nums">
+                    {memberCredits}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card: Your credit usage (everyone)
+// ---------------------------------------------------------------------------
+
+function YourCreditUsageCard({
+  day,
+  colorIndex,
+  userName,
+}: {
+  day: DayInsight;
+  colorIndex: number;
+  userName: string | null;
+}) {
+  const { accent } = getCardPalette(colorIndex);
+  const personalCredits = userName
+    ? (day.teamUsage.find((m) => {
+        return m.name === userName;
+      })?.credits ?? 0)
+    : 0;
+
+  return (
+    <Card>
+      <p
+        className="text-xs font-semibold uppercase tracking-widest mb-3"
+        style={{ color: accent }}
+      >
+        Your Credit Usage
+      </p>
+      <p className="text-5xl font-black leading-none tabular-nums font-serif">
+        {personalCredits.toLocaleString()}
+      </p>
+      <p className="text-sm opacity-60 mt-2">consumed today</p>
     </Card>
   );
 }
@@ -752,6 +790,8 @@ function ServicesCard({
 // Card: Permissions
 // ---------------------------------------------------------------------------
 
+const ALLOWED_INITIAL_COUNT = 5;
+
 function PermissionsAllowedCard({
   day,
   colorIndex,
@@ -761,6 +801,10 @@ function PermissionsAllowedCard({
   colorIndex: number;
   hoveredAgent: string | null;
 }) {
+  const expandedDays = useGet(expandedAllowedDays$);
+  const toggleExpanded = useSet(toggleExpandedAllowed$);
+  const expanded = expandedDays.has(day.date);
+
   const allowed = day.permissions.filter((p) => {
     return p.allowed > 0;
   });
@@ -773,6 +817,8 @@ function PermissionsAllowedCard({
     return s + p.allowed;
   }, 0);
   const { accent } = getCardPalette(colorIndex);
+  const visible = expanded ? allowed : allowed.slice(0, ALLOWED_INITIAL_COUNT);
+  const hasMore = allowed.length > ALLOWED_INITIAL_COUNT;
 
   return (
     <Card>
@@ -786,26 +832,48 @@ function PermissionsAllowedCard({
         {totalAllowed}
       </p>
       <p className="text-sm opacity-60 mt-2">
-        calls passed across {allowed.length}{" "}
+        calls made within {allowed.length} granted{" "}
         {allowed.length === 1 ? "permission" : "permissions"}
       </p>
-      <div className="flex flex-col gap-2 mt-4">
-        {allowed.map((p) => {
+      <div className="flex flex-col gap-3 mt-4">
+        {visible.map((p) => {
           const isActive =
             hoveredAgent === null || p.agentNames.includes(hoveredAgent);
+          const hasDescription = p.connectorType && p.label !== p.connectorType;
           return (
             <div
               key={p.label}
-              className={`flex items-center justify-between gap-2 transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
+              className={`transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
             >
-              <span className="text-sm">{permissionLabel(p)}</span>
-              <span className="text-xs opacity-60 tabular-nums shrink-0">
-                {p.allowed}
-              </span>
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-medium decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-2">
+                  {connectorLabel(p.connectorType ?? p.label)}
+                </span>
+                <span className="text-xs opacity-60 tabular-nums shrink-0">
+                  {p.allowed} {p.allowed === 1 ? "call" : "calls"}
+                </span>
+              </div>
+              {hasDescription && (
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {p.label}
+                </p>
+              )}
             </div>
           );
         })}
       </div>
+      {hasMore && (
+        <button
+          type="button"
+          onClick={() => {
+            toggleExpanded(day.date);
+          }}
+          className="text-xs font-medium mt-3"
+          style={{ color: "#ed4e01" }}
+        >
+          {expanded ? "Show less" : "Load more"}
+        </button>
+      )}
     </Card>
   );
 }
@@ -899,7 +967,15 @@ function formatDate(iso: string): string {
 // Day section — masonry of cards (dim approach for hover)
 // ---------------------------------------------------------------------------
 
-function DaySection({ day }: { day: DayInsight }) {
+function DaySection({
+  day,
+  isAdmin,
+  userName,
+}: {
+  day: DayInsight;
+  isAdmin: boolean;
+  userName: string | null;
+}) {
   const hoveredAgent = useGet(insightsHoveredAgent$);
   const setHoveredAgent = useSet(setInsightsHoveredAgent$);
 
@@ -914,7 +990,14 @@ function DaySection({ day }: { day: DayInsight }) {
       </h2>
       <div className="columns-1 sm:columns-2 lg:columns-3 gap-3">
         <SummaryCard day={day} />
-        <CreditsCard day={day} colorIndex={1} hoveredAgent={hoveredAgent} />
+        {isAdmin && (
+          <TeamCreditUsageCard
+            day={day}
+            colorIndex={1}
+            hoveredAgent={hoveredAgent}
+          />
+        )}
+        <YourCreditUsageCard day={day} colorIndex={1} userName={userName} />
         <AgentsCard
           day={day}
           colorIndex={0}
@@ -951,15 +1034,45 @@ function formatAbsoluteTime(iso: string): string {
 // Main content
 // ---------------------------------------------------------------------------
 
+/** Resolve display name from Clerk user, matching backend aggregation logic. */
+function resolveUserName(
+  user:
+    | {
+        firstName?: string | null;
+        username?: string | null;
+        primaryEmailAddress?: { emailAddress: string } | null;
+      }
+    | undefined,
+): string | null {
+  if (!user) {
+    return null;
+  }
+  return (
+    user.firstName ??
+    user.username ??
+    user.primaryEmailAddress?.emailAddress?.split("@")[0] ??
+    null
+  );
+}
+
 function InsightsContent({ data }: { data: NetworkInsightsData }) {
   const dateRange = useGet(insightsDateRange$);
   const setRange = useSet(setInsightsDateRange$);
   const prefsLoadable = useLastLoadable(userPreferences$);
+  const adminLoadable = useLoadable(isOrgAdmin$);
+  const userLoadable = useLastLoadable(user$);
   const timezone =
     prefsLoadable.state === "hasData" && prefsLoadable.data?.timezone
       ? prefsLoadable.data.timezone
       : new Intl.DateTimeFormat().resolvedOptions().timeZone;
   const filtered = filterDays(data.days, dateRange, timezone);
+
+  const isAdmin =
+    adminLoadable.state === "hasData" ? adminLoadable.data : false;
+  const userName =
+    userLoadable.state === "hasData"
+      ? resolveUserName(userLoadable.data)
+      : null;
 
   return (
     <div className="h-full overflow-auto">
@@ -1009,7 +1122,14 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
           </div>
         ) : (
           filtered.map((day) => {
-            return <DaySection key={day.date} day={day} />;
+            return (
+              <DaySection
+                key={day.date}
+                day={day}
+                isAdmin={isAdmin}
+                userName={userName}
+              />
+            );
           })
         )}
       </div>

--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -663,18 +663,18 @@ function TeamCreditUsageCard({
 function YourCreditUsageCard({
   day,
   colorIndex,
-  userName,
+  userId,
   hoveredAgent,
 }: {
   day: DayInsight;
   colorIndex: number;
-  userName: string | null;
+  userId: string | null;
   hoveredAgent: string | null;
 }) {
   const { accent } = getCardPalette(colorIndex);
-  const myUsage = userName
+  const myUsage = userId
     ? day.teamUsage.find((m) => {
-        return m.name === userName;
+        return m.userId === userId;
       })
     : null;
   const displayCredits =
@@ -985,11 +985,11 @@ function formatDate(iso: string): string {
 function DaySection({
   day,
   isAdmin,
-  userName,
+  userId,
 }: {
   day: DayInsight;
   isAdmin: boolean;
-  userName: string | null;
+  userId: string | null;
 }) {
   const hoveredAgent = useGet(insightsHoveredAgent$);
   const setHoveredAgent = useSet(setInsightsHoveredAgent$);
@@ -1015,7 +1015,7 @@ function DaySection({
         <YourCreditUsageCard
           day={day}
           colorIndex={1}
-          userName={userName}
+          userId={userId}
           hoveredAgent={hoveredAgent}
         />
         <AgentsCard
@@ -1054,27 +1054,6 @@ function formatAbsoluteTime(iso: string): string {
 // Main content
 // ---------------------------------------------------------------------------
 
-/** Resolve display name from Clerk user, matching backend aggregation logic. */
-function resolveUserName(
-  user:
-    | {
-        firstName?: string | null;
-        username?: string | null;
-        primaryEmailAddress?: { emailAddress: string } | null;
-      }
-    | undefined,
-): string | null {
-  if (!user) {
-    return null;
-  }
-  return (
-    user.firstName ??
-    user.username ??
-    user.primaryEmailAddress?.emailAddress?.split("@")[0] ??
-    null
-  );
-}
-
 function InsightsContent({ data }: { data: NetworkInsightsData }) {
   const dateRange = useGet(insightsDateRange$);
   const setRange = useSet(setInsightsDateRange$);
@@ -1089,10 +1068,8 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
 
   const isAdmin =
     adminLoadable.state === "hasData" ? adminLoadable.data : false;
-  const userName =
-    userLoadable.state === "hasData"
-      ? resolveUserName(userLoadable.data)
-      : null;
+  const userId =
+    userLoadable.state === "hasData" ? (userLoadable.data?.id ?? null) : null;
 
   return (
     <div className="h-full overflow-auto">
@@ -1147,7 +1124,7 @@ function InsightsContent({ data }: { data: NetworkInsightsData }) {
                 key={day.date}
                 day={day}
                 isAdmin={isAdmin}
-                userName={userName}
+                userId={userId}
               />
             );
           })

--- a/turbo/apps/web/app/api/cron/aggregate-insights/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/__tests__/route.test.ts
@@ -367,6 +367,113 @@ describe("GET /api/cron/aggregate-insights", () => {
     expect(row!.data.permissions).toEqual([]);
   });
 
+  it("should include userId in teamUsage entries", async () => {
+    const { date } = recentDate();
+
+    const runId = await createCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: new Date(date.getTime() + 5000),
+    });
+
+    await seedUserCacheEntry(userId, "test@example.com");
+
+    await seedCreditUsageRecord({
+      runId,
+      orgId,
+      userId,
+      creditsCharged: 100,
+      createdAt: date,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+
+    const teamUsage = row!.data.teamUsage as Array<{
+      userId: string;
+      name: string;
+      credits: number;
+    }>;
+    expect(teamUsage).toHaveLength(1);
+    expect(teamUsage[0]!.userId).toBe(userId);
+  });
+
+  it("should use cached name when available in user_cache", async () => {
+    const { date } = recentDate();
+
+    const runId = await createCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: new Date(date.getTime() + 5000),
+    });
+
+    await seedUserCacheEntry(userId, "alice@example.com", "Alice");
+
+    await seedCreditUsageRecord({
+      runId,
+      orgId,
+      userId,
+      creditsCharged: 200,
+      createdAt: date,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+
+    const teamUsage = row!.data.teamUsage as Array<{
+      name: string;
+      credits: number;
+    }>;
+    expect(teamUsage).toHaveLength(1);
+    expect(teamUsage[0]!.name).toBe("Alice");
+  });
+
+  it("should fall back to email prefix when name is null in user_cache", async () => {
+    const { date } = recentDate();
+
+    const runId = await createCompletedTestRun({
+      composeVersionId,
+      userId,
+      createdAt: date,
+      startedAt: date,
+      completedAt: new Date(date.getTime() + 5000),
+    });
+
+    // Seed cache entry without name (name=null)
+    await seedUserCacheEntry(userId, "bob@example.com");
+
+    await seedCreditUsageRecord({
+      runId,
+      orgId,
+      userId,
+      creditsCharged: 150,
+      createdAt: date,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    expect(response.status).toBe(200);
+
+    const row = await findInsightsDaily(orgId, todayDateStr(), userId);
+    expect(row).toBeDefined();
+
+    const teamUsage = row!.data.teamUsage as Array<{
+      name: string;
+      credits: number;
+    }>;
+    expect(teamUsage).toHaveLength(1);
+    expect(teamUsage[0]!.name).toBe("bob");
+  });
+
   it("should be idempotent on rerun", async () => {
     const { date } = recentDate();
 

--- a/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
@@ -161,13 +161,17 @@ async function resolveUserNames(
   const db = globalThis.services.db;
 
   const cachedUsers = await db
-    .select({ userId: userCache.userId, email: userCache.email })
+    .select({
+      userId: userCache.userId,
+      email: userCache.email,
+      name: userCache.name,
+    })
     .from(userCache)
     .where(inArray(userCache.userId, userIds));
 
   const nameMap = new Map(
     cachedUsers.map((u) => {
-      return [u.userId, u.email.split("@")[0] ?? u.email];
+      return [u.userId, u.name ?? u.email.split("@")[0] ?? u.email];
     }),
   );
 
@@ -193,10 +197,10 @@ async function resolveUserNames(
 
       await db
         .insert(userCache)
-        .values({ userId: user.id, email, cachedAt: now })
+        .values({ userId: user.id, email, name, cachedAt: now })
         .onConflictDoUpdate({
           target: userCache.userId,
-          set: { email, cachedAt: now },
+          set: { email, name, cachedAt: now },
         });
     }
   }

--- a/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
@@ -301,6 +301,7 @@ interface InsightData {
   creditsUsed: number;
   creditBalance: number;
   teamUsage: {
+    userId: string;
     name: string;
     credits: number;
     agentNames: string[];
@@ -328,6 +329,7 @@ function buildUserInsight(
   orgCreditsUsed: number,
   orgCreditBalance: number,
   orgTeamUsage: Array<{
+    userId: string;
     name: string;
     credits: number;
     agentNames: string[];
@@ -394,6 +396,7 @@ function buildUserInsight(
 // ---------------------------------------------------------------------------
 
 interface TeamUsageEntry {
+  userId: string;
   name: string;
   credits: number;
   agentNames: string[];
@@ -453,6 +456,7 @@ function aggregateOrgCredits(
     for (const [userId, data] of members) {
       creditsUsed += data.credits;
       teamUsage.push({
+        userId,
         name: userNameMap.get(userId) ?? userId,
         credits: data.credits,
         agentNames: [...data.agentNames],

--- a/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
@@ -86,13 +86,14 @@ export async function getTestVm0ApiKey(vendor: string) {
 export async function seedUserCacheEntry(
   userId: string,
   email: string,
+  name?: string,
 ): Promise<void> {
   await globalThis.services.db
     .insert(userCache)
-    .values({ userId, email, cachedAt: new Date() })
+    .values({ userId, email, name: name ?? null, cachedAt: new Date() })
     .onConflictDoUpdate({
       target: userCache.userId,
-      set: { email, cachedAt: new Date() },
+      set: { email, name: name ?? null, cachedAt: new Date() },
     });
 }
 


### PR DESCRIPTION
## Summary
- Redesign **Allowed** permissions card to display connector name and permission description on separate lines, with a "Load more" toggle for long lists
- Split the **Credits** card into two: **Team Credit Usage** (admin-only, with per-member bar chart) and **Your Credit Usage** (personal consumption, visible to everyone)
- Gate team credit visibility behind `isOrgAdmin$` signal

## Test plan
- [ ] Type check passes (`pnpm check-types`)
- [ ] Lint passes (`pnpm turbo run lint`)
- [ ] Existing insights page tests pass (22/22)
- [ ] Knip reports no unused exports
- [ ] Manual: admin user sees both Team Credit Usage and Your Credit Usage cards
- [ ] Manual: non-admin user sees only Your Credit Usage card
- [ ] Manual: Allowed card shows connector name with dotted underline + description below
- [ ] Manual: "Load more" button appears when >5 permissions, toggles between truncated and full list

🤖 Generated with [Claude Code](https://claude.com/claude-code)