### PR TITLE
refactor(cli): simplify phone call to only support --system-prompt-file

### DIFF
--- a/turbo/apps/cli/src/commands/zero/phone/__tests__/call.test.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/__tests__/call.test.ts
@@ -54,58 +54,6 @@ describe("zero phone call command", () => {
       expect(logCalls).toContain("call_abc123");
       expect(logCalls).toContain("initiated");
     });
-
-    it("should pass --greeting option to the API", async () => {
-      let capturedBody: Record<string, unknown> = {};
-      server.use(
-        http.post(
-          "http://localhost:3000/api/zero/phone-calls",
-          async ({ request }) => {
-            capturedBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json({
-              callId: "call_xyz",
-              status: "initiated",
-            });
-          },
-        ),
-      );
-
-      await callCommand.parseAsync([
-        "node",
-        "cli",
-        "+14155551234",
-        "--greeting",
-        "Hello, how can I help?",
-      ]);
-
-      expect(capturedBody.greeting).toBe("Hello, how can I help?");
-    });
-
-    it("should pass --system-prompt option to the API", async () => {
-      let capturedBody: Record<string, unknown> = {};
-      server.use(
-        http.post(
-          "http://localhost:3000/api/zero/phone-calls",
-          async ({ request }) => {
-            capturedBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json({
-              callId: "call_xyz",
-              status: "initiated",
-            });
-          },
-        ),
-      );
-
-      await callCommand.parseAsync([
-        "node",
-        "cli",
-        "+14155551234",
-        "--system-prompt",
-        "You are a helpful assistant.",
-      ]);
-
-      expect(capturedBody.systemPrompt).toBe("You are a helpful assistant.");
-    });
   });
 
   describe("validation", () => {
@@ -140,7 +88,7 @@ describe("zero phone call command", () => {
     });
   });
 
-  describe("file-based input", () => {
+  describe("--system-prompt-file", () => {
     let tmpDir: string;
 
     beforeEach(() => {
@@ -151,7 +99,7 @@ describe("zero phone call command", () => {
       fs.rmSync(tmpDir, { recursive: true });
     });
 
-    it("should read system prompt from --prompt-file", async () => {
+    it("should read system prompt from file and pass to API", async () => {
       const promptFile = path.join(tmpDir, "prompt.txt");
       fs.writeFileSync(promptFile, "Custom multi-line\nsystem prompt");
 
@@ -173,7 +121,7 @@ describe("zero phone call command", () => {
         "node",
         "cli",
         "+14155551234",
-        "--prompt-file",
+        "--system-prompt-file",
         promptFile,
       ]);
 
@@ -182,115 +130,19 @@ describe("zero phone call command", () => {
       );
     });
 
-    it("should read greeting from --greeting-file", async () => {
-      const greetingFile = path.join(tmpDir, "greeting.txt");
-      fs.writeFileSync(greetingFile, "Hello, welcome to our service!");
-
-      let capturedBody: Record<string, unknown> = {};
-      server.use(
-        http.post(
-          "http://localhost:3000/api/zero/phone-calls",
-          async ({ request }) => {
-            capturedBody = (await request.json()) as Record<string, unknown>;
-            return HttpResponse.json({
-              callId: "call_xyz",
-              status: "initiated",
-            });
-          },
-        ),
-      );
-
-      await callCommand.parseAsync([
-        "node",
-        "cli",
-        "+14155551234",
-        "--greeting-file",
-        greetingFile,
-      ]);
-
-      expect(capturedBody.greeting).toBe("Hello, welcome to our service!");
-    });
-
-    it("should error if --system-prompt and --prompt-file are both provided", async () => {
-      const promptFile = path.join(tmpDir, "prompt.txt");
-      fs.writeFileSync(promptFile, "file prompt");
-
+    it("should error if file does not exist", async () => {
       await expect(async () => {
         await callCommand.parseAsync([
           "node",
           "cli",
           "+14155551234",
-          "--system-prompt",
-          "inline prompt",
-          "--prompt-file",
-          promptFile,
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Cannot use both --system-prompt and --prompt-file",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should error if --greeting and --greeting-file are both provided", async () => {
-      const greetingFile = path.join(tmpDir, "greeting.txt");
-      fs.writeFileSync(greetingFile, "file greeting");
-
-      await expect(async () => {
-        await callCommand.parseAsync([
-          "node",
-          "cli",
-          "+14155551234",
-          "--greeting",
-          "inline greeting",
-          "--greeting-file",
-          greetingFile,
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "Cannot use both --greeting and --greeting-file",
-        ),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should error if --prompt-file path does not exist", async () => {
-      await expect(async () => {
-        await callCommand.parseAsync([
-          "node",
-          "cli",
-          "+14155551234",
-          "--prompt-file",
+          "--system-prompt-file",
           "/nonexistent/path/prompt.txt",
         ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("File not found: /nonexistent/path/prompt.txt"),
-      );
-      expect(mockExit).toHaveBeenCalledWith(1);
-    });
-
-    it("should error if --greeting-file path does not exist", async () => {
-      await expect(async () => {
-        await callCommand.parseAsync([
-          "node",
-          "cli",
-          "+14155551234",
-          "--greeting-file",
-          "/nonexistent/path/greeting.txt",
-        ]);
-      }).rejects.toThrow("process.exit called");
-
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "File not found: /nonexistent/path/greeting.txt",
-        ),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });

--- a/turbo/apps/cli/src/commands/zero/phone/call.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/call.ts
@@ -15,28 +15,16 @@ export const callCommand = new Command()
     "<to-number>",
     "Phone number to call (E.164 format, e.g. +14155551234)",
   )
-  .option("--greeting <message>", "Initial greeting when the recipient answers")
   .option(
-    "--greeting-file <path>",
-    "Read greeting from a file (use instead of --greeting)",
-  )
-  .option(
-    "--system-prompt <prompt>",
-    "Override the agent's system prompt for this call",
-  )
-  .option(
-    "--prompt-file <path>",
-    "Read system prompt from a file (use instead of --system-prompt)",
+    "--system-prompt-file <path>",
+    "File that defines the agent's persona and task context for this call",
   )
   .action(
     withErrorHandler(
       async (
         toNumber: string,
         options: {
-          greeting?: string;
-          greetingFile?: string;
-          systemPrompt?: string;
-          promptFile?: string;
+          systemPromptFile?: string;
         },
       ) => {
         // Validate E.164 format
@@ -49,44 +37,14 @@ export const callCommand = new Command()
           process.exit(1);
         }
 
-        // Validate mutual exclusivity
-        if (options.systemPrompt && options.promptFile) {
-          console.error(
-            chalk.red("Cannot use both --system-prompt and --prompt-file"),
-          );
-          process.exit(1);
-        }
-
-        if (options.greeting && options.greetingFile) {
-          console.error(
-            chalk.red("Cannot use both --greeting and --greeting-file"),
-          );
-          process.exit(1);
-        }
-
-        // Resolve system prompt from file if provided
-        let systemPrompt = options.systemPrompt;
-        if (options.promptFile) {
+        let systemPrompt: string | undefined;
+        if (options.systemPromptFile) {
           try {
-            systemPrompt = fs.readFileSync(options.promptFile, "utf-8");
-          } catch (err) {
-            if (isErrnoException(err) && err.code === "ENOENT") {
-              console.error(chalk.red(`File not found: ${options.promptFile}`));
-              process.exit(1);
-            }
-            throw err;
-          }
-        }
-
-        // Resolve greeting from file if provided
-        let greeting = options.greeting;
-        if (options.greetingFile) {
-          try {
-            greeting = fs.readFileSync(options.greetingFile, "utf-8");
+            systemPrompt = fs.readFileSync(options.systemPromptFile, "utf-8");
           } catch (err) {
             if (isErrnoException(err) && err.code === "ENOENT") {
               console.error(
-                chalk.red(`File not found: ${options.greetingFile}`),
+                chalk.red(`File not found: ${options.systemPromptFile}`),
               );
               process.exit(1);
             }
@@ -96,7 +54,6 @@ export const callCommand = new Command()
 
         const result = await createPhoneCall({
           toNumber,
-          greeting,
           systemPrompt,
         });
 


### PR DESCRIPTION
## Summary

Simplify the `zero phone call` CLI command by replacing all prompt/greeting options with a single `--system-prompt-file`.

**Before:** 4 options with mutual exclusivity checks
- `--greeting <message>`
- `--greeting-file <path>`
- `--system-prompt <prompt>`
- `--prompt-file <path>`

**After:** 1 option
- `--system-prompt-file <path>` — File that defines the agent's persona and task context for this call

When `--system-prompt-file` is provided, AgentPhone uses its built-in hosted LLM mode for the call instead of webhook mode. The system prompt gives the agent a persona and the full context needed to handle the user's task conversationally — not just read a greeting.

### Usage
```bash
zero phone call +12135481848 --system-prompt-file ./prompts/support-agent.md
```

## Test plan

- [x] Basic call without options works
- [x] `--system-prompt-file` reads file and passes as `systemPrompt` to API
- [x] Non-existent file path returns error
- [x] Invalid phone number format rejected
- [x] API errors handled gracefully
- [x] All 5 tests pass, lint/knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)