### PR TITLE
chore(runner): add diagnostics for session affinity routing

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -7,7 +7,7 @@ use clap::Args;
 use sandbox::{RuntimeProvider, Sandbox, SandboxFactory, SandboxRuntime};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::config::{self, ProfileConfig};
@@ -570,7 +570,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     send_heartbeat(&hb_ctx, current_mode).await;
                 }
                 _ = park_notify.notified() => {
-                    info!("park triggered immediate heartbeat");
+                    info!(source = "budget_exhausted", "park triggered immediate heartbeat");
                     send_heartbeat(&hb_ctx, current_mode).await;
                 }
             }
@@ -721,7 +721,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // Immediate heartbeat after a VM is parked — eliminates the
             // up-to-10s blind spot for session affinity routing.
             _ = park_notify.notified() => {
-                info!("park triggered immediate heartbeat");
+                info!(source = "main", "park triggered immediate heartbeat");
                 send_heartbeat(&hb_ctx, current_mode).await;
             }
         }
@@ -1143,9 +1143,10 @@ async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) {
     info!(
         mode = ?mode,
         running = state.running_count,
-        sessions = ?state.held_sessions,
+        sessions = state.held_sessions.len(),
         "heartbeat"
     );
+    debug!(held_sessions = ?state.held_sessions);
     hb.provider
         .set_held_sessions(state.held_sessions.clone())
         .await;

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -570,6 +570,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                     send_heartbeat(&hb_ctx, current_mode).await;
                 }
                 _ = park_notify.notified() => {
+                    info!("park triggered immediate heartbeat");
                     send_heartbeat(&hb_ctx, current_mode).await;
                 }
             }
@@ -649,7 +650,14 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                             destroy_tasks.spawn(destroy_idle_entry(stale, b));
                             None
                         }
-                        None => None,
+                        None => {
+                            info!(
+                                run_id = %run_id,
+                                session_id,
+                                "no idle VM found for session"
+                            );
+                            None
+                        }
                     }
                 } else {
                     None
@@ -713,6 +721,7 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
             // Immediate heartbeat after a VM is parked — eliminates the
             // up-to-10s blind spot for session affinity routing.
             _ = park_notify.notified() => {
+                info!("park triggered immediate heartbeat");
                 send_heartbeat(&hb_ctx, current_mode).await;
             }
         }
@@ -1131,6 +1140,12 @@ async fn send_heartbeat(hb: &HeartbeatContext<'_>, mode: RunnerMode) {
         mode,
     );
     drop(pool);
+    info!(
+        mode = ?mode,
+        running = state.running_count,
+        sessions = ?state.held_sessions,
+        "heartbeat"
+    );
     hb.provider
         .set_held_sessions(state.held_sessions.clone())
         .await;

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use reqeast::StatusCode;
@@ -174,7 +174,7 @@ impl JobProvider for ApiProvider {
                                 // Targeted to another runner: defer poll instead of
                                 // claiming immediately, giving the target a 2s head start.
                                 if notif.target_runner_id.as_deref().is_some_and(|t| t != self.runner_id) {
-                                    debug!(
+                                    info!(
                                         run_id = %notif.run_id,
                                         target = notif.target_runner_id.as_deref().unwrap_or(""),
                                         "ably: job targeted to another runner, deferring poll"
@@ -191,7 +191,8 @@ impl JobProvider for ApiProvider {
                                 // Fall back to default profile when server doesn't send one
                                 // (backwards compat with pre-profile API).
                                 let profile = notif.profile.unwrap_or_else(|| crate::profile::DEFAULT_PROFILE.to_owned());
-                                info!(run_id = %notif.run_id, %profile, "ably: job notification");
+                                let targeted = notif.target_runner_id.as_deref().is_some_and(|t| t == self.runner_id);
+                                info!(run_id = %notif.run_id, %profile, targeted, "ably: job notification");
                                 return Some((notif.run_id, profile));
                             }
                         }


### PR DESCRIPTION
## Summary

- Log held sessions on every heartbeat send (info level)
- Log when park triggers immediate heartbeat
- Promote Ably targeted-to-other-runner log from debug to info
- Log targeted vs broadcast in Ably job notifications
- Log when idle pool has no VM for a session

These logs trace the full keep-alive reuse path to diagnose why session affinity routing sometimes fails to reuse parked VMs.

## Test plan

- [ ] `cargo test` passes (447 tests)
- [ ] Deploy to staging and verify logs appear in runner output

🤖 Generated with [Claude Code](https://claude.com/claude-code)