### PR TITLE
fix(platform): prevent tooltip auto-show on pricing page back button

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -264,7 +264,14 @@ function PricingPage({
   };
 
   return (
-    <div className="flex flex-col gap-5">
+    <div
+      className="flex flex-col gap-5 outline-none"
+      role="group"
+      tabIndex={-1}
+      ref={(el) => {
+        el?.focus();
+      }}
+    >
       <div className="flex items-center gap-3">
         <TooltipProvider delayDuration={200}>
           <Tooltip>


### PR DESCRIPTION
## Summary
- Prevent the "Back" tooltip from automatically appearing when the Compare Plans pricing page opens
- Focus the PricingPage container `div` on mount so the dialog's focus trap targets the container instead of the back button
- Tooltip still shows normally on hover

## Test plan
- [ ] Open workspace settings → Billing → Compare plans
- [ ] Verify the "Back" tooltip does NOT auto-appear on page open
- [ ] Hover over the back arrow and verify the tooltip appears correctly
- [ ] Click back button to verify navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)