### PR TITLE
feat(voice-chat): auto-log conversation to shared context

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -136,6 +136,30 @@ Communication style:
 - Be warm and conversational, like a helpful colleague.
 `.trim();
 
+function logContextEvent(
+  fetchFn: (url: string, init?: RequestInit) => Promise<Response>,
+  sessionId: string | null,
+  source: string,
+  type: string,
+  content: string,
+): void {
+  if (!sessionId) {
+    return;
+  }
+  void fetchFn(`/api/zero/voice-chat/${sessionId}/context`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ source, type, content }),
+  }).then(
+    () => {
+      return undefined;
+    },
+    () => {
+      return undefined;
+    },
+  );
+}
+
 // --- Internal state ---
 
 const internalStatus$ = state<ConnectionStatus>("idle");
@@ -286,6 +310,15 @@ const handleDCMessage$ = command(
           set(internalTranscript$, (prev) => {
             return upsertUserTranscript(prev, itemId, event.transcript!);
           });
+
+          // Auto-log user speech to shared context (fire-and-forget)
+          logContextEvent(
+            get(fetch$),
+            get(internalSessionId$),
+            "user",
+            "speech",
+            event.transcript,
+          );
         }
         break;
       }
@@ -328,6 +361,15 @@ const handleDCMessage$ = command(
             }
             return updated;
           });
+
+          // Auto-log talker response to shared context (fire-and-forget)
+          logContextEvent(
+            get(fetch$),
+            get(internalSessionId$),
+            "talker",
+            "response",
+            finalText,
+          );
         }
         break;
       }


### PR DESCRIPTION
## Summary

- Auto-log user speech transcriptions to shared context when transcription completes (`user/speech` events)
- Auto-log Talker responses to shared context when audio transcript is finalized (`talker/response` events)
- Uses fire-and-forget pattern (matching `endVoiceChat$`) — no impact on voice conversation latency

## Details

Adds a `logContextEvent` helper that POSTs to the existing `/api/zero/voice-chat/{id}/context` endpoint. Two call sites in `handleDCMessage$`:

1. `conversation.item.input_audio_transcription.completed` → logs `{ source: "user", type: "speech" }`
2. `response.audio_transcript.done` → logs `{ source: "talker", type: "response" }`

This enables the slow brain (Worker) to see the conversation via the shared context blackboard.

Closes #8669

## Test plan

- [ ] Start a voice chat session and have a conversation
- [ ] Check `voice_chat_events` table: should see `user/speech` and `talker/response` events with correct content
- [ ] Verify voice conversation is not impacted (no added latency, no errors on failure)
- [ ] Shared Context Events panel in UI shows conversation events in real-time
- [ ] Verify lint, type-check, format pass (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)