### PR TITLE
feat(voice-chat): update UI labels to Zero identity

### DIFF
--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -8,6 +8,7 @@ import {
   IconPhoneOff,
   IconLoader2,
 } from "@tabler/icons-react";
+import { defaultAgentName$ } from "../../signals/agent.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import {
@@ -77,6 +78,7 @@ export function VoiceChatPage() {
   const startSession = useSet(startVoiceChat$);
   const endSession = useSet(endVoiceChat$);
   const toggleMute = useSet(toggleVoiceChatMute$);
+  const agentName = useLastResolved(defaultAgentName$) ?? "Zero";
 
   if (enabled === false) {
     return (
@@ -178,7 +180,7 @@ export function VoiceChatPage() {
                   )}
                 >
                   <span className="text-xs font-medium text-muted-foreground block mb-0.5">
-                    {entry.role === "user" ? "You" : "Assistant"}
+                    {entry.role === "user" ? "You" : agentName}
                   </span>
                   {entry.text}
                 </div>


### PR DESCRIPTION
## Summary

- Replace hardcoded "Assistant" label with agent's configured display name in voice chat transcript
- Use `defaultAgentName$` signal (with "Zero" fallback), following the established pattern from phone-page and other platform views
- Header "Voice Chat" kept as-is (feature name, not identity label)

Closes #8672
Parent Epic: #8668

## Test plan

- [ ] Open voice chat page and verify "Zero" (or custom agent name) appears in transcript instead of "Assistant"
- [ ] Verify "You" label is unchanged for user messages
- [ ] CI: lint, type-check, format pass
- [ ] CI: all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)