### PR TITLE
feat(cli): add --mode flag to phone call command with onhold and fire-and-forget modes

### DIFF
--- a/turbo/apps/cli/src/commands/zero/phone/__tests__/call.test.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/__tests__/call.test.ts
@@ -36,8 +36,8 @@ describe("zero phone call command", () => {
     vi.unstubAllEnvs();
   });
 
-  describe("successful call", () => {
-    it("should initiate a call and display call ID and status", async () => {
+  describe("fire-and-forget mode", () => {
+    it("should initiate a call and return immediately", async () => {
       server.use(
         http.post("http://localhost:3000/api/zero/phone-calls", () => {
           return HttpResponse.json({
@@ -47,7 +47,13 @@ describe("zero phone call command", () => {
         }),
       );
 
-      await callCommand.parseAsync(["node", "cli", "+14155551234"]);
+      await callCommand.parseAsync([
+        "node",
+        "cli",
+        "+14155551234",
+        "--mode",
+        "fire-and-forget",
+      ]);
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Call initiated");
@@ -56,14 +62,103 @@ describe("zero phone call command", () => {
     });
   });
 
+  describe("onhold mode", () => {
+    it("should poll until call completes and print transcript", async () => {
+      vi.useFakeTimers();
+      let pollCount = 0;
+
+      server.use(
+        http.post("http://localhost:3000/api/zero/phone-calls", () => {
+          return HttpResponse.json({
+            callId: "call_hold123",
+            status: "initiated",
+          });
+        }),
+        http.get(
+          "http://localhost:3000/api/zero/phone-calls/call_hold123",
+          () => {
+            pollCount++;
+            if (pollCount < 2) {
+              return HttpResponse.json({
+                call: {
+                  id: "call_hold123",
+                  status: "active",
+                  fromNumber: "+16067551512",
+                  toNumber: "+14155551234",
+                  durationSeconds: 0,
+                  startedAt: "2026-04-09T08:00:00Z",
+                },
+                transcript: null,
+              });
+            }
+            return HttpResponse.json({
+              call: {
+                id: "call_hold123",
+                status: "completed",
+                fromNumber: "+16067551512",
+                toNumber: "+14155551234",
+                durationSeconds: 25,
+                startedAt: "2026-04-09T08:00:00Z",
+              },
+              transcript: [
+                { role: "agent", text: "Hello, is this a good time?" },
+                { role: "user", text: "Yes, go ahead." },
+              ],
+            });
+          },
+        ),
+      );
+
+      const promise = callCommand.parseAsync([
+        "node",
+        "cli",
+        "+14155551234",
+        "--mode",
+        "onhold",
+      ]);
+
+      // Advance past each 10s poll interval
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await promise;
+      vi.useRealTimers();
+
+      const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
+      expect(logCalls).toContain("Call initiated");
+      expect(logCalls).toContain("Call Detail");
+      expect(logCalls).toContain("Transcript");
+      expect(logCalls).toContain("Hello, is this a good time?");
+      expect(logCalls).toContain("Yes, go ahead.");
+      expect(pollCount).toBe(2);
+    });
+  });
+
   describe("validation", () => {
     it("should reject invalid phone number format", async () => {
       await expect(async () => {
-        await callCommand.parseAsync(["node", "cli", "5551234"]);
+        await callCommand.parseAsync([
+          "node",
+          "cli",
+          "5551234",
+          "--mode",
+          "fire-and-forget",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockConsoleError).toHaveBeenCalledWith(
         expect.stringContaining("Invalid phone number format"),
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should require --mode flag", async () => {
+      await expect(async () => {
+        await callCommand.parseAsync(["node", "cli", "+14155551234"]);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Missing required --mode flag"),
       );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
@@ -81,7 +176,13 @@ describe("zero phone call command", () => {
       );
 
       await expect(async () => {
-        await callCommand.parseAsync(["node", "cli", "+14155551234"]);
+        await callCommand.parseAsync([
+          "node",
+          "cli",
+          "+14155551234",
+          "--mode",
+          "fire-and-forget",
+        ]);
       }).rejects.toThrow("process.exit called");
 
       expect(mockExit).toHaveBeenCalledWith(1);
@@ -123,6 +224,8 @@ describe("zero phone call command", () => {
         "+14155551234",
         "--system-prompt-file",
         promptFile,
+        "--mode",
+        "fire-and-forget",
       ]);
 
       expect(capturedBody.systemPrompt).toBe(
@@ -138,6 +241,8 @@ describe("zero phone call command", () => {
           "+14155551234",
           "--system-prompt-file",
           "/nonexistent/path/prompt.txt",
+          "--mode",
+          "fire-and-forget",
         ]);
       }).rejects.toThrow("process.exit called");
 

--- a/turbo/apps/cli/src/commands/zero/phone/__tests__/call.test.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/__tests__/call.test.ts
@@ -13,7 +13,7 @@ import * as path from "path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../../mocks/server";
-import { callCommand } from "../call";
+import { callCommand, delay } from "../call";
 import chalk from "chalk";
 
 describe("zero phone call command", () => {
@@ -63,8 +63,16 @@ describe("zero phone call command", () => {
   });
 
   describe("onhold mode", () => {
+    const originalDelayMs = delay.ms;
+
+    afterEach(() => {
+      delay.ms = originalDelayMs;
+    });
+
     it("should poll until call completes and print transcript", async () => {
-      vi.useFakeTimers();
+      delay.ms = () => {
+        return Promise.resolve();
+      };
       let pollCount = 0;
 
       server.use(
@@ -109,20 +117,13 @@ describe("zero phone call command", () => {
         ),
       );
 
-      const promise = callCommand.parseAsync([
+      await callCommand.parseAsync([
         "node",
         "cli",
         "+14155551234",
         "--mode",
         "onhold",
       ]);
-
-      // Advance past each 10s poll interval
-      await vi.advanceTimersByTimeAsync(10_000);
-      await vi.advanceTimersByTimeAsync(10_000);
-
-      await promise;
-      vi.useRealTimers();
 
       const logCalls = mockConsoleLog.mock.calls.flat().join("\n");
       expect(logCalls).toContain("Call initiated");
@@ -157,9 +158,6 @@ describe("zero phone call command", () => {
         await callCommand.parseAsync(["node", "cli", "+14155551234"]);
       }).rejects.toThrow("process.exit called");
 
-      expect(mockConsoleError).toHaveBeenCalledWith(
-        expect.stringContaining("Missing required --mode flag"),
-      );
       expect(mockExit).toHaveBeenCalledWith(1);
     });
   });

--- a/turbo/apps/cli/src/commands/zero/phone/__tests__/record.test.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/__tests__/record.test.ts
@@ -46,8 +46,8 @@ const mockCallDetail = {
     startedAt: "2026-04-08T10:00:00Z",
   },
   transcript: [
-    { role: "agent", content: "Hello, how can I help?" },
-    { role: "user", content: "I have a question about my account." },
+    { role: "agent", text: "Hello, how can I help?" },
+    { role: "user", text: "I have a question about my account." },
   ],
 };
 

--- a/turbo/apps/cli/src/commands/zero/phone/call.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/call.ts
@@ -1,8 +1,21 @@
 import * as fs from "fs";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import chalk from "chalk";
-import { createPhoneCall } from "../../../lib/api";
+import { createPhoneCall, getPhoneCallDetail } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
+import { printTranscript, printCallInfo } from "./format";
+
+const POLL_INTERVAL_MS = 10_000;
+const POLL_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+
+const TERMINAL_STATUSES = new Set([
+  "completed",
+  "ended",
+  "failed",
+  "no-answer",
+  "busy",
+  "cancelled",
+]);
 
 function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && "code" in err;
@@ -15,6 +28,12 @@ export const callCommand = new Command()
     "<to-number>",
     "Phone number to call (E.164 format, e.g. +14155551234)",
   )
+  .addOption(
+    new Option(
+      "--mode <mode>",
+      "onhold: wait for call to complete and return transcript. fire-and-forget: initiate and return immediately.",
+    ).choices(["onhold", "fire-and-forget"]),
+  )
   .option(
     "--system-prompt-file <path>",
     "File that defines the agent's persona and task context for this call",
@@ -24,9 +43,20 @@ export const callCommand = new Command()
       async (
         toNumber: string,
         options: {
+          mode?: "onhold" | "fire-and-forget";
           systemPromptFile?: string;
         },
       ) => {
+        // --mode is required
+        if (!options.mode) {
+          console.error(
+            chalk.red(
+              "Missing required --mode flag. Use --mode onhold or --mode fire-and-forget.",
+            ),
+          );
+          process.exit(1);
+        }
+
         // Validate E.164 format
         if (!/^\+[1-9]\d{1,14}$/.test(toNumber)) {
           console.error(
@@ -60,6 +90,51 @@ export const callCommand = new Command()
         console.log(chalk.green("Call initiated"));
         console.log(`  ${"Call ID:".padEnd(12)}${chalk.cyan(result.callId)}`);
         console.log(`  ${"Status:".padEnd(12)}${result.status}`);
+
+        if (options.mode === "fire-and-forget") {
+          return;
+        }
+
+        // onhold: poll until call completes
+        console.log();
+        console.log(
+          chalk.dim("Waiting for call to complete (polling every 10s)..."),
+        );
+
+        const startTime = Date.now();
+
+        while (Date.now() - startTime < POLL_TIMEOUT_MS) {
+          await new Promise((resolve) => {
+            return setTimeout(resolve, POLL_INTERVAL_MS);
+          });
+
+          const detail = await getPhoneCallDetail(result.callId);
+          const status = String(detail.call.status ?? "");
+          const elapsed = Math.round((Date.now() - startTime) / 1000);
+
+          if (TERMINAL_STATUSES.has(status)) {
+            console.log();
+            console.log(chalk.bold("Call Detail"));
+            console.log();
+            printCallInfo(detail.call, result.callId);
+            console.log();
+            console.log(chalk.bold("Transcript"));
+            console.log();
+            printTranscript(detail.transcript);
+
+            if (status === "failed") {
+              process.exit(1);
+            }
+            return;
+          }
+
+          console.log(
+            chalk.dim(`  [${elapsed}s] status: ${status || "unknown"}`),
+          );
+        }
+
+        console.error(chalk.red("\nCall timed out after 15 minutes"));
+        process.exit(1);
       },
     ),
   );

--- a/turbo/apps/cli/src/commands/zero/phone/call.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/call.ts
@@ -8,6 +8,14 @@ import { printTranscript, printCallInfo } from "./format";
 const POLL_INTERVAL_MS = 10_000;
 const POLL_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
 
+export const delay = {
+  ms: (ms: number): Promise<void> => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  },
+};
+
 const TERMINAL_STATUSES = new Set([
   "completed",
   "ended",
@@ -32,7 +40,9 @@ export const callCommand = new Command()
     new Option(
       "--mode <mode>",
       "onhold: wait for call to complete and return transcript. fire-and-forget: initiate and return immediately.",
-    ).choices(["onhold", "fire-and-forget"]),
+    )
+      .choices(["onhold", "fire-and-forget"])
+      .makeOptionMandatory(),
   )
   .option(
     "--system-prompt-file <path>",
@@ -43,20 +53,10 @@ export const callCommand = new Command()
       async (
         toNumber: string,
         options: {
-          mode?: "onhold" | "fire-and-forget";
+          mode: "onhold" | "fire-and-forget";
           systemPromptFile?: string;
         },
       ) => {
-        // --mode is required
-        if (!options.mode) {
-          console.error(
-            chalk.red(
-              "Missing required --mode flag. Use --mode onhold or --mode fire-and-forget.",
-            ),
-          );
-          process.exit(1);
-        }
-
         // Validate E.164 format
         if (!/^\+[1-9]\d{1,14}$/.test(toNumber)) {
           console.error(
@@ -104,12 +104,10 @@ export const callCommand = new Command()
         const startTime = Date.now();
 
         while (Date.now() - startTime < POLL_TIMEOUT_MS) {
-          await new Promise((resolve) => {
-            return setTimeout(resolve, POLL_INTERVAL_MS);
-          });
+          await delay.ms(POLL_INTERVAL_MS);
 
           const detail = await getPhoneCallDetail(result.callId);
-          const status = String(detail.call.status ?? "");
+          const status = detail.call.status;
           const elapsed = Math.round((Date.now() - startTime) / 1000);
 
           if (TERMINAL_STATUSES.has(status)) {
@@ -128,9 +126,7 @@ export const callCommand = new Command()
             return;
           }
 
-          console.log(
-            chalk.dim(`  [${elapsed}s] status: ${status || "unknown"}`),
-          );
+          console.log(chalk.dim(`  [${elapsed}s] status: ${status}`));
         }
 
         console.error(chalk.red("\nCall timed out after 15 minutes"));

--- a/turbo/apps/cli/src/commands/zero/phone/format.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/format.ts
@@ -1,0 +1,42 @@
+import chalk from "chalk";
+
+export function printTranscript(transcript: unknown): void {
+  if (Array.isArray(transcript)) {
+    for (const entry of transcript) {
+      if (typeof entry === "string") {
+        console.log(`  ${entry}`);
+      } else if (typeof entry === "object" && entry !== null) {
+        const e = entry as Record<string, unknown>;
+        const role = e.role ?? e.speaker ?? "Unknown";
+        const text = e.text ?? e.content ?? e.body ?? "";
+        console.log(`  ${chalk.dim(`[${role}]`)} ${text}`);
+      }
+    }
+  } else if (typeof transcript === "string") {
+    console.log(`  ${transcript}`);
+  } else {
+    console.log(`  ${JSON.stringify(transcript, null, 2)}`);
+  }
+}
+
+export function printCallInfo(
+  call: Record<string, unknown>,
+  callId: string,
+): void {
+  console.log(
+    `  ${"Call ID:".padEnd(16)}${chalk.cyan(String(call.id ?? callId))}`,
+  );
+  console.log(
+    `  ${"From:".padEnd(16)}${String(call.fromNumber ?? call.from_number ?? "")}`,
+  );
+  console.log(
+    `  ${"To:".padEnd(16)}${String(call.toNumber ?? call.to_number ?? "")}`,
+  );
+  console.log(`  ${"Status:".padEnd(16)}${String(call.status ?? "")}`);
+  console.log(
+    `  ${"Duration:".padEnd(16)}${String(call.durationSeconds ?? call.duration_seconds ?? "N/A")}s`,
+  );
+  console.log(
+    `  ${"Started:".padEnd(16)}${String(call.startedAt ?? call.started_at ?? "")}`,
+  );
+}

--- a/turbo/apps/cli/src/commands/zero/phone/format.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/format.ts
@@ -1,42 +1,23 @@
 import chalk from "chalk";
+import type { PhoneCall, TranscriptEntry } from "../../../lib/api";
 
-export function printTranscript(transcript: unknown): void {
-  if (Array.isArray(transcript)) {
-    for (const entry of transcript) {
-      if (typeof entry === "string") {
-        console.log(`  ${entry}`);
-      } else if (typeof entry === "object" && entry !== null) {
-        const e = entry as Record<string, unknown>;
-        const role = e.role ?? e.speaker ?? "Unknown";
-        const text = e.text ?? e.content ?? e.body ?? "";
-        console.log(`  ${chalk.dim(`[${role}]`)} ${text}`);
-      }
-    }
-  } else if (typeof transcript === "string") {
-    console.log(`  ${transcript}`);
-  } else {
-    console.log(`  ${JSON.stringify(transcript, null, 2)}`);
+export function printTranscript(transcript: TranscriptEntry[] | null): void {
+  if (!transcript || transcript.length === 0) {
+    console.log("  (no transcript)");
+    return;
+  }
+  for (const entry of transcript) {
+    console.log(`  ${chalk.dim(`[${entry.role}]`)} ${entry.text}`);
   }
 }
 
-export function printCallInfo(
-  call: Record<string, unknown>,
-  callId: string,
-): void {
+export function printCallInfo(call: PhoneCall, callId: string): void {
+  console.log(`  ${"Call ID:".padEnd(16)}${chalk.cyan(call.id ?? callId)}`);
+  console.log(`  ${"From:".padEnd(16)}${call.fromNumber}`);
+  console.log(`  ${"To:".padEnd(16)}${call.toNumber}`);
+  console.log(`  ${"Status:".padEnd(16)}${call.status}`);
   console.log(
-    `  ${"Call ID:".padEnd(16)}${chalk.cyan(String(call.id ?? callId))}`,
+    `  ${"Duration:".padEnd(16)}${call.durationSeconds != null ? `${call.durationSeconds}s` : "N/A"}`,
   );
-  console.log(
-    `  ${"From:".padEnd(16)}${String(call.fromNumber ?? call.from_number ?? "")}`,
-  );
-  console.log(
-    `  ${"To:".padEnd(16)}${String(call.toNumber ?? call.to_number ?? "")}`,
-  );
-  console.log(`  ${"Status:".padEnd(16)}${String(call.status ?? "")}`);
-  console.log(
-    `  ${"Duration:".padEnd(16)}${String(call.durationSeconds ?? call.duration_seconds ?? "N/A")}s`,
-  );
-  console.log(
-    `  ${"Started:".padEnd(16)}${String(call.startedAt ?? call.started_at ?? "")}`,
-  );
+  console.log(`  ${"Started:".padEnd(16)}${call.startedAt ?? ""}`);
 }

--- a/turbo/apps/cli/src/commands/zero/phone/record.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/record.ts
@@ -2,44 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { listPhoneCalls, getPhoneCallDetail } from "../../../lib/api";
 import { withErrorHandler } from "../../../lib/command";
-
-function printTranscript(transcript: unknown) {
-  if (Array.isArray(transcript)) {
-    for (const entry of transcript) {
-      if (typeof entry === "string") {
-        console.log(`  ${entry}`);
-      } else if (typeof entry === "object" && entry !== null) {
-        const e = entry as Record<string, unknown>;
-        const role = e.role ?? e.speaker ?? "Unknown";
-        const text = e.text ?? e.content ?? e.body ?? "";
-        console.log(`  ${chalk.dim(`[${role}]`)} ${text}`);
-      }
-    }
-  } else if (typeof transcript === "string") {
-    console.log(`  ${transcript}`);
-  } else {
-    console.log(`  ${JSON.stringify(transcript, null, 2)}`);
-  }
-}
-
-function printCallInfo(call: Record<string, unknown>, callId: string) {
-  console.log(
-    `  ${"Call ID:".padEnd(16)}${chalk.cyan(String(call.id ?? callId))}`,
-  );
-  console.log(
-    `  ${"From:".padEnd(16)}${String(call.fromNumber ?? call.from_number ?? "")}`,
-  );
-  console.log(
-    `  ${"To:".padEnd(16)}${String(call.toNumber ?? call.to_number ?? "")}`,
-  );
-  console.log(`  ${"Status:".padEnd(16)}${String(call.status ?? "")}`);
-  console.log(
-    `  ${"Duration:".padEnd(16)}${String(call.durationSeconds ?? call.duration_seconds ?? "N/A")}s`,
-  );
-  console.log(
-    `  ${"Started:".padEnd(16)}${String(call.startedAt ?? call.started_at ?? "")}`,
-  );
-}
+import { printTranscript, printCallInfo } from "./format";
 
 async function showCallDetail(callId: string) {
   const result = await getPhoneCallDetail(callId);

--- a/turbo/apps/cli/src/commands/zero/phone/record.ts
+++ b/turbo/apps/cli/src/commands/zero/phone/record.ts
@@ -28,14 +28,12 @@ async function showCallList(limit: number) {
   console.log();
 
   for (const call of result.data) {
-    const id = String(call.id ?? "");
-    const from = String(call.fromNumber ?? call.from_number ?? "");
-    const to = String(call.toNumber ?? call.to_number ?? "");
-    const status = String(call.status ?? "");
-    const duration = call.durationSeconds ?? call.duration_seconds;
-    const snippet = String(
-      call.lastTranscriptSnippet ?? call.last_transcript_snippet ?? "",
-    );
+    const id = call.id;
+    const from = call.fromNumber;
+    const to = call.toNumber;
+    const status = call.status;
+    const duration = call.durationSeconds;
+    const snippet = call.lastTranscriptSnippet ?? "";
 
     console.log(`  ${chalk.cyan(id)}`);
     console.log(

--- a/turbo/apps/cli/src/lib/api/domains/phone-calls.ts
+++ b/turbo/apps/cli/src/lib/api/domains/phone-calls.ts
@@ -5,15 +5,30 @@ interface PhoneCallResponse {
   status: string;
 }
 
+export interface PhoneCall {
+  id: string;
+  status: string;
+  fromNumber: string;
+  toNumber: string;
+  durationSeconds: number | null;
+  startedAt: string | null;
+  lastTranscriptSnippet?: string | null;
+}
+
+export interface TranscriptEntry {
+  role: string;
+  text: string;
+}
+
 interface PhoneCallListResponse {
-  data: Array<Record<string, unknown>>;
+  data: PhoneCall[];
   total: number;
   hasMore: boolean;
 }
 
 interface PhoneCallDetailResponse {
-  call: Record<string, unknown>;
-  transcript: unknown;
+  call: PhoneCall;
+  transcript: TranscriptEntry[] | null;
 }
 
 async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {

--- a/turbo/apps/cli/src/lib/api/index.ts
+++ b/turbo/apps/cli/src/lib/api/index.ts
@@ -187,6 +187,8 @@ export {
   createPhoneCall,
   listPhoneCalls,
   getPhoneCallDetail,
+  type PhoneCall,
+  type TranscriptEntry,
 } from "./domains/phone-calls";
 
 // Domain modules - Zero Voice Chat Context

--- a/turbo/apps/web/src/lib/zero/phone/handlers/call-ended.ts
+++ b/turbo/apps/web/src/lib/zero/phone/handlers/call-ended.ts
@@ -104,7 +104,9 @@ export async function handleCallEnded(event: CallEndedEvent): Promise<void> {
       : null,
     ``,
     `# Available Actions`,
-    `You can call the user back using: zero phone call ${fromNumber}`,
+    `You can call the user back using: zero phone call --mode <mode> ${fromNumber}`,
+    `  --mode onhold: Stay on the line until the call completes, then get the transcript back. Use when you need a quick answer from the user.`,
+    `  --mode fire-and-forget: Initiate the call and return immediately. Use for open-ended conversations or when you don't need an immediate response.`,
     `You can view call history using: zero phone record`,
   ]
     .filter((line) => {


### PR DESCRIPTION
## Summary

- Add `--mode` required flag to `zero phone call` with two choices: `onhold` (blocks and polls until call completes, returns transcript) and `fire-and-forget` (initiates call and returns immediately)
- Extract shared `printTranscript` / `printCallInfo` formatters into `format.ts`, reuse in both `call.ts` and `record.ts`
- Update phone context in `call-ended.ts` to document both modes for the agent

## Test plan

- [x] All 7 call command tests pass (fire-and-forget, onhold with polling, validation, error handling, system-prompt-file)
- [x] All 5 record command tests pass (format extraction didn't break anything)
- [x] Lint passes
- [x] Type-check passes (CLI + web)
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)