### PR TITLE
fix(ci): add legal_accepted_at to clerk user provisioning

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -961,7 +961,7 @@ jobs:
             user=$(curl -sS -X POST "https://api.clerk.com/v1/users" \
               -H "Authorization: Bearer ${CLERK_SECRET_KEY}" \
               -H "Content-Type: application/json" \
-              -d "{\"email_address\":[\"${email}\"],\"skip_password_requirement\":true}")
+              -d "{\"email_address\":[\"${email}\"],\"skip_password_requirement\":true,\"legal_accepted_at\":\"$(date -u +'%Y-%m-%dT%H:%M:%SZ')\"}")
             user_id=$(echo "$user" | jq -r '.id')
             if [[ "$user_id" == "null" || -z "$user_id" ]]; then
               echo "Error: Failed to create user ${email}"

--- a/e2e/playwright/lib/clerk-api.ts
+++ b/e2e/playwright/lib/clerk-api.ts
@@ -26,6 +26,7 @@ export async function createUser(email: string): Promise<string> {
     body: JSON.stringify({
       email_address: [email],
       skip_password_requirement: true,
+      legal_accepted_at: new Date().toISOString(),
     }),
   });
   const data = (await response.json()) as { id?: string; errors?: unknown[] };


### PR DESCRIPTION
## Summary
- Clerk API now requires `legal_accepted_at` when `legal_consent_enabled` is true
- Adds the parameter to both CI workflow (`turbo.yml`) and Playwright helper (`clerk-api.ts`)
- Fixes deploy-web CI failures blocking PRs #8674 and #8675

## Test plan
- [ ] CI deploy-web job passes (Clerk user provisioning succeeds)
- [ ] E2E Playwright tests can create test users

🤖 Generated with [Claude Code](https://claude.com/claude-code)