### PR TITLE
fix(platform): hide response body until task run completes

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/chat-activity-line-visibility.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/chat-activity-line-visibility.test.tsx
@@ -48,24 +48,27 @@ describe("activity line visibility while run is still running", () => {
       makeToolUseEvent("Read", { path: "/tmp/data.txt" }, 3),
     ]);
 
-    // The result content should appear
+    // The activity line (shimmer) should remain visible while the run is still running
+    await waitFor(() => {
+      const shimmer = document.querySelector(".zero-shimmer-text");
+      expect(shimmer).toBeInTheDocument();
+    });
+
+    // The result body should NOT appear while the run is still active (prevents layout shift)
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Here is the first part of the answer."),
+      ).not.toBeInTheDocument();
+    });
+
+    // Complete the run — the result body should appear after terminal state
+    ctrl.completeRun("Here is the first part of the answer.");
+
     await waitFor(() => {
       expect(
         screen.getByText("Here is the first part of the answer."),
       ).toBeInTheDocument();
     });
-
-    // The activity line (shimmer text or summary steps) should still be
-    // visible because run status is still "running".
-    const shimmer = document.querySelector(".zero-shimmer-text");
-    expect(shimmer).toBeInTheDocument();
-
-    // The activity line should appear ABOVE the result content in the DOM,
-    // so the user sees the ongoing CoT before the result text.
-    const resultEl = screen.getByText("Here is the first part of the answer.");
-    expect(shimmer!.compareDocumentPosition(resultEl)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
-    );
   });
 
   it("should hide activity line only after run reaches terminal status", async () => {
@@ -101,15 +104,15 @@ describe("activity line visibility while run is still running", () => {
       },
     ]);
 
-    // Result content should be displayed
+    // Result body should NOT be visible while run is still active (prevents layout shift)
     await waitFor(() => {
-      expect(screen.getByText("Intermediate result")).toBeInTheDocument();
+      expect(screen.queryByText("Intermediate result")).not.toBeInTheDocument();
     });
 
     // Activity line should still be visible (run is "running")
     expect(document.querySelector(".zero-shimmer-text")).toBeInTheDocument();
 
-    // Now complete the run — activity line should disappear
+    // Now complete the run — activity line should disappear and body should appear
     ctrl.completeRun("Final result");
 
     await waitFor(() => {

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -218,18 +218,17 @@ describe("chat message activity line", () => {
 
     detachedSetupPage({ context, path: "/chats/thread-activity-running" });
 
-    // The result content should be rendered
-    await waitFor(() => {
-      expect(
-        screen.getByText("Here is the partial result"),
-      ).toBeInTheDocument();
-    });
-
-    // The activity line (spinner) should still be visible since the run is not terminal
+    // The activity line (spinner) should be visible since the run is not terminal.
+    // The response body is hidden during active runs to prevent layout shift.
     await waitFor(() => {
       const shimmer = document.querySelector(".zero-shimmer-text");
       expect(shimmer).toBeInTheDocument();
     });
+
+    // The result body should not be rendered while the run is still active
+    expect(
+      screen.queryByText("Here is the partial result"),
+    ).not.toBeInTheDocument();
   });
 
   it("should hide activity line after run reaches terminal status", async () => {
@@ -258,12 +257,7 @@ describe("chat message activity line", () => {
 
     detachedSetupPage({ context, path: "/chats/thread-activity-done" });
 
-    // Wait for content to appear
-    await waitFor(() => {
-      expect(screen.getByText("Final answer")).toBeInTheDocument();
-    });
-
-    // Activity line should be visible while running
+    // Activity line should be visible while running; body is hidden during active runs
     await waitFor(() => {
       const shimmer = document.querySelector(".zero-shimmer-text");
       expect(shimmer).toBeInTheDocument();
@@ -272,10 +266,14 @@ describe("chat message activity line", () => {
     // Now complete the run
     lifecycle.completeRun("Final answer");
 
-    // Activity line should disappear after reaching terminal status
+    // Activity line should disappear and body should appear after reaching terminal status
     await waitFor(() => {
       const shimmer = document.querySelector(".zero-shimmer-text");
       expect(shimmer).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Final answer")).toBeInTheDocument();
     });
   });
 });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-session-chat-page.test.tsx
@@ -226,9 +226,11 @@ describe("chat message activity line", () => {
     });
 
     // The result body should not be rendered while the run is still active
-    expect(
-      screen.queryByText("Here is the partial result"),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Here is the partial result"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("should hide activity line after run reaches terminal status", async () => {

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -910,18 +910,13 @@ function StaticAssistantMessage({
     );
   }
 
-  if (content) {
+  if (content && !showActivityLine) {
     return (
       <div className="group flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300">
         <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
           <AssistantBubbleAvatar />
           <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
             {hasSummaries && <CollapsibleTimeline message={message} />}
-            {showActivityLine && (
-              <div className="mb-3 pb-3 border-b">
-                <MessageRunActivityLine message={message} />
-              </div>
-            )}
             <Markdown source={content} />
             {message.cancelled && (
               <div className="mt-3 pt-3 border-t flex items-center gap-1.5 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- Defer rendering of the response body Markdown until the agent run finishes, preventing the layout shift described in #8648
- During active runs, only the step progress (activity line) is shown; the body appears once the run reaches a terminal state
- Removes the now-unreachable activity line block that previously rendered inside the content branch

Closes #8648

## Test plan
- [ ] Trigger an agent task that produces intermediate steps and a text response
- [ ] Verify the response body does NOT appear while steps are still running
- [ ] Verify the response body appears smoothly after the task completes (no upward jump)
- [ ] Verify completed/saved messages still render correctly with CollapsibleTimeline + body

🤖 Generated with [Claude Code](https://claude.com/claude-code)