### PR TITLE
docs: add sequential execution note to commit skill checks

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -30,6 +30,8 @@ pnpm test             # Run all tests
 
 ## Execution Order
 
+**IMPORTANT: Run checks sequentially, one at a time.** Each check can take several minutes in this monorepo. Running them in parallel will saturate CPU/memory and make everything slower (or freeze the machine).
+
 1. **Format** (`pnpm format`) - Auto-fixes formatting
 2. **Lint** (`pnpm lint`) - Auto-fix with `--fix` flag if needed
 3. **Type Check** (`pnpm check-types`) - Requires manual fixes


### PR DESCRIPTION
## Summary
- Add a note to the commit skill's execution order section warning that pre-commit checks (format, lint, type-check, test) must run sequentially
- Each check can take several minutes in this monorepo; running them in parallel saturates CPU/memory and makes everything slower or freezes the machine

## Test plan
- [ ] Verify the commit skill SKILL.md renders correctly
- [ ] Confirm the note is visible in the execution order section

🤖 Generated with [Claude Code](https://claude.com/claude-code)