### PR TITLE
fix(runner): use resume session id for runner job queue and notifications

### DIFF
--- a/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
@@ -95,7 +95,7 @@ export async function executeRunnerJob(
     runId: context.runId,
     runnerGroup,
     profile,
-    sessionId: context.continuedFromSessionId ?? null,
+    sessionId: context.resumeSession?.sessionId ?? null,
     executionContext: storedContext,
     expiresAt,
   });
@@ -114,7 +114,7 @@ export async function executeRunnerJob(
     runnerGroup,
     context.runId,
     profile,
-    context.continuedFromSessionId ?? null,
+    context.resumeSession?.sessionId ?? null,
   );
 
   return {
@@ -184,7 +184,7 @@ function buildRunContextSnapshot(context: PreparedContext): RunContextSnapshot {
     userId: context.userId,
     prompt: context.prompt,
     appendSystemPrompt: context.appendSystemPrompt,
-    sessionId: context.continuedFromSessionId ?? null,
+    sessionId: context.resumeSession?.sessionId ?? null,
     secretNames: context.secrets ? Object.keys(context.secrets) : [],
     environment,
     firewalls,


### PR DESCRIPTION
## Summary
- `continuedFromSessionId` in `PreparedContext` is always `null` even for continued sessions
- The correct source is `resumeSession.sessionId`, which is what the runner already uses for keep-alive VM reuse (`ExecutionContext::session_id()` in `types.rs`)
- Fixed 3 usages in `runner-executor.ts`: job queue insert, runner notification, and Axiom context snapshot

## Impact
- Runner can now match parked VMs for keep-alive reuse on continued sessions
- Axiom run context data will show the correct session ID
- Run context UI will display session ID properly

Closes #8657

## Test plan
- [x] Type check passes (no new errors)
- [x] Existing runner executor tests cover the changed code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)