### PR TITLE
feat(voice-chat): rewrite slow brain prompt for proactive system 2 role

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/context/__tests__/route.test.ts
@@ -303,6 +303,31 @@ describe("POST /api/zero/voice-chat/[id]/context", () => {
     expect(body.error.message).toContain("not active");
   });
 
+  it.each([
+    "directive",
+    "thinking-progress",
+    "thinking-result",
+    "observation",
+  ] as const)("should accept slow brain event type: %s", async (type) => {
+    const session = await createSession(orgId, userId);
+    const response = await POST(
+      createTestRequest(contextUrl(session.id), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          source: "worker",
+          type,
+          content: "test content",
+        }),
+      }),
+      paramsFor(session.id),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.event.type).toBe(type);
+    expect(body.event.source).toBe("worker");
+  });
+
   it("should produce incrementing seq numbers", async () => {
     const session = await createSession(orgId, userId);
 

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/context/__tests__/route.test.ts
@@ -315,7 +315,7 @@ describe("POST /api/zero/voice-chat/[id]/context", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          source: "worker",
+          source: "slow-brain",
           type,
           content: "test content",
         }),
@@ -325,7 +325,7 @@ describe("POST /api/zero/voice-chat/[id]/context", () => {
     const body = await response.json();
     expect(response.status).toBe(200);
     expect(body.event.type).toBe(type);
-    expect(body.event.source).toBe("worker");
+    expect(body.event.source).toBe("slow-brain");
   });
 
   it("should produce incrementing seq numbers", async () => {

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/context/route.ts
@@ -11,7 +11,13 @@ import {
   appendEvent,
 } from "../../../../../../src/lib/zero/voice-chat/context-service";
 
-const VALID_SOURCES = ["system", "user", "talker", "worker"] as const;
+const VALID_SOURCES = [
+  "system",
+  "user",
+  "talker",
+  "worker",
+  "slow-brain",
+] as const;
 const VALID_TYPES = [
   "session-start",
   "session-end",

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/context/route.ts
@@ -21,6 +21,10 @@ const VALID_TYPES = [
   "progress",
   "result",
   "response",
+  "directive",
+  "thinking-progress",
+  "thinking-result",
+  "observation",
 ] as const;
 
 const appendEventBodySchema = z.object({

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -124,19 +124,68 @@ export async function endSession(
 // ---------------------------------------------------------------------------
 
 const VOICE_CHAT_WORKER_PROMPT = `
-# Voice-Chat Worker Instructions
+# Zero — Slow-Thinking Mode
 
-You are a background worker supporting a real-time voice conversation between a user and a front-stage Talker AI.
+You are Zero's slow-thinking mode. You and your fast-thinking self (the voice interface) are the same agent — Zero. Your fast self is having a real-time voice conversation with the user right now. You can see the entire conversation through the shared context.
 
-Your job:
-1. Periodically check for new events using: \`zero voice-chat context get <SESSION_ID> --after <LAST_SEQ>\`
-2. When you find a \`worker-request\` event, process it:
-   - Append a \`progress\` event to acknowledge: \`zero voice-chat context append <SESSION_ID> --source worker --type progress --content "Working on it..."\`
-   - Complete the task using your available tools
-   - Append a \`result\` event with a concise summary: \`zero voice-chat context append <SESSION_ID> --source worker --type result --content "<summary>"\`
-3. Keep your output concise — the Talker will read it aloud to the user.
-4. Check for new events every 5 seconds.
-5. Exit when you see a \`session-end\` system event.
+## Observing the Conversation
+
+Continuously read the shared context to follow the conversation:
+
+\`zero voice-chat context get <SESSION_ID> --after <LAST_SEQ>\`
+
+You will see events like:
+- **user/speech** — what the user says
+- **talker/response** — what your fast self says back
+- **system/session-start** and **system/session-end** — session lifecycle
+
+Based on what you observe, proactively decide what to do. Do not wait to be asked.
+
+## When to Act
+
+Act when the conversation involves:
+- Code, data, APIs, files, or external systems
+- Tasks that require execution, search, or tool use
+- Topics where you can proactively gather information (e.g., user mentions a PR — look it up so the answer is ready)
+- Anything your fast self cannot handle with conversation alone
+
+Stay quiet when the conversation is:
+- Casual chat, greetings, or small talk
+- Opinions or preferences
+- Simple knowledge questions your fast self handles well
+
+## Writing to Shared Context
+
+When you have something for the user, write to the shared context:
+
+\`zero voice-chat context append <SESSION_ID> --source worker --type <TYPE> --content "<CONTENT>"\`
+
+### Event Types
+
+- **directive**: High-level instructions for your fast self. Include what to tell the user, relevant data, and why. Do not script exact words — your fast self controls phrasing.
+  Example: "The user asked about PR status. PR #8644 merged to main, all CI checks passed. Release PR #8647 is in merge queue position 2. Let the user know and ask if they want to wait for deployment."
+
+- **thinking-progress**: When you start working on something, write a progress event so your fast self can tell the user you are thinking.
+  Example: "Looking up the CI status for the latest PR."
+
+- **thinking-result**: Raw results of your work — data, findings, command output — for your fast self to reference.
+
+- **observation**: Proactive insights the user did not ask for but might find valuable.
+  Example: "While checking the PR, I noticed the test coverage dropped by 3%. Might be worth mentioning."
+
+## Polling and Lifecycle
+
+1. Check for new events every 5 seconds.
+2. Process what you see — act proactively or respond to explicit requests.
+3. Write appropriate events (directive, thinking-progress, thinking-result, observation).
+4. Repeat until you see a \`session-end\` system event, then exit.
+
+## Important
+
+- Keep directive content concise but complete — your fast self will read it aloud.
+- You have full tool access. Use your sandbox, CLI, and APIs to get real answers.
+- When you find something, write the directive immediately. Do not wait for a request.
+- You are Zero. Think of the conversation as your own — you are just thinking more deeply about it.
 `.trim();
 
 export async function dispatchWorker(
@@ -155,7 +204,7 @@ export async function dispatchWorker(
   const result = await createZeroRun({
     userId,
     agentId,
-    prompt: `You are now the background worker for voice-chat session ${session.id}. Start by checking for new events.`,
+    prompt: `You are Zero's slow-thinking mode for voice-chat session ${session.id}. Start by reading the shared context to observe the conversation.`,
     appendSystemPrompt,
     triggerSource: "voice-chat",
   });

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -158,7 +158,7 @@ Stay quiet when the conversation is:
 
 When you have something for the user, write to the shared context:
 
-\`zero voice-chat context append <SESSION_ID> --source worker --type <TYPE> --content "<CONTENT>"\`
+\`zero voice-chat context append <SESSION_ID> --source slow-brain --type <TYPE> --content "<CONTENT>"\`
 
 ### Event Types
 


### PR DESCRIPTION
## Summary

- Rewrite `VOICE_CHAT_WORKER_PROMPT` to reflect Zero's slow-thinking identity — the slow brain now proactively observes the conversation and writes high-level directives for the fast brain instead of waiting for explicit worker-request delegation
- Add 4 new event types to shared context validation: `directive`, `thinking-progress`, `thinking-result`, `observation`
- Update initial dispatch prompt to align with new System 2 identity

## Test plan

- [x] All 33 existing voice-chat tests pass without modification
- [x] 4 new integration tests verify each new event type is accepted by the context append endpoint
- [ ] Manual: start a voice chat and verify slow brain writes `thinking-progress` when starting work
- [ ] Manual: verify slow brain writes `directive` events with high-level context
- [ ] Manual: verify slow brain proactively acts on conversation topics

Closes #8671

🤖 Generated with [Claude Code](https://claude.com/claude-code)