### PR TITLE
fix(web): ignore progress callbacks in schedule cron/loop endpoints

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/schedule/cron/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/cron/__tests__/route.test.ts
@@ -32,7 +32,7 @@ function createCallbackRequest(
   body: {
     callbackId?: string;
     runId: string;
-    status: "completed" | "failed";
+    status: "completed" | "failed" | "progress";
     error?: string;
     payload: CronCallbackPayload;
   },
@@ -223,6 +223,34 @@ describe("POST /api/internal/callbacks/schedule/cron", () => {
       expect(updated!.consecutiveFailures).toBe(3);
       expect(updated!.enabled).toBe(false);
       expect(updated!.nextRunAt).toBeNull();
+    });
+  });
+
+  describe("Progress Callback", () => {
+    it("should ignore progress notifications without affecting failure count", async () => {
+      const { schedule, runId, secret } = await setupCronSchedule();
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "progress",
+          payload: {
+            scheduleId: schedule.id,
+            cronExpression: "0 9 * * *",
+            timezone: "UTC",
+          },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.skipped).toBe(true);
+
+      const updated = await findTestScheduleById(schedule.id);
+      expect(updated!.consecutiveFailures).toBe(0);
+      expect(updated!.enabled).toBe(true);
     });
   });
 

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/cron/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/cron/route.ts
@@ -47,6 +47,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const { scheduleId, cronExpression, timezone } = payload;
 
+  // Ignore progress notifications — only act on terminal states
+  if (status === "progress") {
+    return NextResponse.json({ success: true, skipped: true });
+  }
+
   log.debug("Processing cron schedule callback", {
     runId: result.data.runId,
     status,

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/__tests__/route.test.ts
@@ -31,7 +31,7 @@ function createCallbackRequest(
   body: {
     callbackId?: string;
     runId: string;
-    status: "completed" | "failed";
+    status: "completed" | "failed" | "progress";
     error?: string;
     payload: LoopCallbackPayload;
   },
@@ -257,6 +257,30 @@ describe("POST /api/internal/callbacks/schedule/loop", () => {
       expect(updated!.consecutiveFailures).toBe(3);
       expect(updated!.enabled).toBe(false);
       expect(updated!.nextRunAt).toBeNull();
+    });
+  });
+
+  describe("Progress Callback", () => {
+    it("should ignore progress notifications without affecting failure count", async () => {
+      const { schedule, runId, secret } = await setupLoopSchedule();
+
+      const request = createCallbackRequest(
+        {
+          runId,
+          status: "progress",
+          payload: { scheduleId: schedule.id, intervalSeconds: 300 },
+        },
+        secret,
+      );
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.skipped).toBe(true);
+
+      const updated = await findTestScheduleById(schedule.id);
+      expect(updated!.consecutiveFailures).toBe(0);
+      expect(updated!.enabled).toBe(true);
     });
   });
 

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/loop/route.ts
@@ -45,6 +45,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   const { scheduleId, intervalSeconds } = payload;
 
+  // Ignore progress notifications — only act on terminal states
+  if (status === "progress") {
+    return NextResponse.json({ success: true, skipped: true });
+  }
+
   log.debug("Processing loop schedule callback", {
     runId: result.data.runId,
     status,


### PR DESCRIPTION
## Summary
- Schedule cron/loop callback endpoints now ignore `status: "progress"` notifications (early return with `skipped: true`)
- Previously, heartbeat progress callbacks were treated as failures (`status !== "completed"` → increment `consecutiveFailures`), causing schedules to auto-disable after 3 heartbeats mid-run
- Only `"once"` schedules should auto-disable (by design); cron/loop schedules were incorrectly disabled due to this bug

## Root Cause
`dispatchProgressCallbacks()` (heartbeat webhook) sends `status: "progress"` to **all** callback URLs including schedule endpoints. The failure check `status === "completed" ? 0 : consecutiveFailures + 1` treated progress as failure. After 3 heartbeats → `consecutiveFailures >= 3` → schedule auto-disabled.

## Test plan
- [x] Added test: cron callback ignores progress without affecting failure count
- [x] Added test: loop callback ignores progress without affecting failure count
- [x] All 18 existing schedule callback tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)