### PR TITLE
fix(firewalls): merge default policies with stored instead of skipping

### DIFF
--- a/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
+++ b/turbo/apps/platform/src/views/permission-allow/permission-allow-page.tsx
@@ -15,7 +15,7 @@ import {
 import {
   isFirewallConnectorType,
   CONNECTOR_TYPES,
-  getDefaultFirewallPolicies,
+  resolveFirewallPolicies,
   type FirewallPolicies,
 } from "@vm0/core";
 import { user$ } from "../../signals/auth.ts";
@@ -656,13 +656,8 @@ function DoctorModeView({
   const agentDisplayName = agent.displayName ?? agentId;
 
   // Check effective policy
-  const defaults = isFirewallConnectorType(ref)
-    ? getDefaultFirewallPolicies(ref)
-    : null;
-  const effectivePolicy =
-    agent.permissionPolicies?.[ref]?.[permission.name] ??
-    defaults?.[permission.name] ??
-    "allow";
+  const resolved = resolveFirewallPolicies(agent.permissionPolicies, [ref]);
+  const effectivePolicy = resolved?.[ref]?.[permission.name] ?? "allow";
 
   // Policy already matches — show result
   if (effectivePolicy === action) {

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -13,9 +13,9 @@ import {
 } from "@vm0/ui";
 import {
   getConnectorFirewall,
-  getDefaultFirewallPolicies,
   groupPermissionsByCategory,
   isFirewallConnectorType,
+  resolveFirewallPolicies,
   CONNECTOR_TYPES,
   type ConnectorType,
   type FirewallConfig,
@@ -196,13 +196,10 @@ function buildInitialPolicies(
     return result;
   }
   const perms = extractPermissions(config);
-  const defaults = isFirewallConnectorType(ref)
-    ? getDefaultFirewallPolicies(ref)
-    : null;
+  const resolved = resolveFirewallPolicies(initialPolicies, [ref]);
   const refPolicies: Record<string, PermissionPolicy> = {};
   for (const p of perms) {
-    refPolicies[p.name] =
-      initialPolicies[ref]?.[p.name] ?? defaults?.[p.name] ?? "allow";
+    refPolicies[p.name] = resolved?.[ref]?.[p.name] ?? "allow";
   }
   result[ref] = refPolicies;
   return result;

--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -444,7 +444,7 @@ describe("createZeroRun()", () => {
       expect(grantedPerms).not.toContain("chat:write");
     });
 
-    it("should grant no permissions when all are denied", async () => {
+    it("should merge partial stored denies with default policies", async () => {
       const agentName = uniqueId("fw-allden");
       await createTestCompose(agentName);
       await createTestConnector({ type: "slack" });
@@ -467,10 +467,14 @@ describe("createZeroRun()", () => {
       expect(slackFw).toBeDefined();
       expect(slackFw!.apis[0]!.permissions!.length).toBeGreaterThan(0);
 
-      // grantedPermissions has empty array (nothing allowed)
+      // Explicitly denied permissions are not granted
       const granted = job!.executionContext.grantedPermissions;
       expect(granted).toBeDefined();
-      expect(granted!.slack!.allow).toEqual([]);
+      expect(granted!.slack!.allow).not.toContain("bookmarks:read");
+      expect(granted!.slack!.allow).not.toContain("bookmarks:write");
+      // Default-allowed permissions (not overridden) are still granted
+      expect(granted!.slack!.allow).toContain("channels:read");
+      expect(granted!.slack!.allow).toContain("users:read");
       expect(granted!.slack!.allowUnknown).toBe(true);
     });
 

--- a/turbo/packages/core/src/__tests__/firewall-default-policies.test.ts
+++ b/turbo/packages/core/src/__tests__/firewall-default-policies.test.ts
@@ -64,11 +64,30 @@ describe("resolveFirewallPolicies", () => {
     expect(slack!["admin"]).toBe("deny");
   });
 
-  it("should not overwrite existing stored policies", () => {
+  it("should merge defaults with stored policies (stored overrides)", () => {
     const stored = { slack: { "channels:read": "deny" as const } };
     const resolved = resolveFirewallPolicies(stored, ["slack"]);
-    // Stored entry exists — should keep the original, not merge defaults
-    expect(resolved!["slack"]).toEqual({ "channels:read": "deny" });
+    const slack = resolved!["slack"]!;
+    // Stored override takes precedence
+    expect(slack["channels:read"]).toBe("deny");
+    // Defaults fill in for non-specified permissions
+    expect(slack["admin"]).toBe("deny");
+    expect(slack["users:read"]).toBe("allow");
+  });
+
+  it("should merge stored partial policy with defaults", () => {
+    // Simulates: admin approved files:read, but defaults should still apply
+    const stored = { slack: { "files:read": "allow" as const } };
+    const resolved = resolveFirewallPolicies(stored, ["slack"]);
+    const slack = resolved!["slack"]!;
+    // Explicitly stored
+    expect(slack["files:read"]).toBe("allow");
+    // From defaults (slackDefaultAllowed)
+    expect(slack["channels:read"]).toBe("allow");
+    expect(slack["channels:history"]).toBe("allow");
+    expect(slack["users:read"]).toBe("allow");
+    // Not in defaults — should be deny
+    expect(slack["admin"]).toBe("deny");
   });
 
   it("should pass through connectors without defaults unchanged", () => {

--- a/turbo/packages/core/src/firewalls/index.ts
+++ b/turbo/packages/core/src/firewalls/index.ts
@@ -467,10 +467,13 @@ export function resolveFirewallPolicies(
   let resolved: FirewallPolicies | null = stored;
   for (const connector of connectors) {
     if (!isFirewallConnectorType(connector)) continue;
-    if (resolved?.[connector]) continue;
     const defaults = getDefaultFirewallPolicies(connector);
     if (!defaults) continue;
-    resolved = { ...resolved, [connector]: defaults };
+    // Merge: defaults as base, stored overrides specific entries.
+    resolved = {
+      ...resolved,
+      [connector]: { ...defaults, ...resolved?.[connector] },
+    };
   }
   return resolved;
 }


### PR DESCRIPTION
## Summary

- `resolveFirewallPolicies()` skipped applying defaults entirely when any stored policy existed for a connector, so approving a single permission (e.g. `files:read`) via the permission-allow flow caused all other permissions—including `slackDefaultAllowed` entries like `channels:read`—to be implicitly denied at runtime
- The UI (`permissions-dialog.tsx`, `permission-allow-page.tsx`) correctly displayed defaults via its own fallback chain (`stored ?? defaults ?? "allow"`), masking the runtime bug
- Fix: use defaults as base layer with stored overrides on top (`{ ...defaults, ...stored }`), and unify UI to call `resolveFirewallPolicies()` instead of reimplementing the chain

## Test plan

- [x] Updated `firewall-default-policies.test.ts`: partial stored policy merges with defaults (stored overrides, defaults fill gaps)
- [ ] Verify Slack connector with partial stored policy injects default-allowed permissions at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)