### PR TITLE
fix(platform): hide profile/instructions tabs for non-owner non-admin

### DIFF
--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -858,7 +858,7 @@ function useAgentFields() {
   };
 }
 
-function useTabVisibility(agentId: string) {
+function useTabVisibility(agentId: string, ownerId: string) {
   const statusLoadable = useLastLoadable(zeroOnboardingStatus$);
   const isDefaultAgent =
     statusLoadable.state === "hasData" &&
@@ -867,9 +867,14 @@ function useTabVisibility(agentId: string) {
   const adminLoadable = useLoadable(isOrgAdmin$);
   const isAdmin = adminLoadable.state === "hasData" && adminLoadable.data;
 
+  const userLoadable = useLoadable(user$);
+  const currentUserId =
+    userLoadable.state === "hasData" ? userLoadable.data?.id : undefined;
+  const isOwner = currentUserId === ownerId;
+
   const rawTab = useGet(zeroJobActiveTab$);
   const setActiveTab = useSet(setZeroJobActiveTab$);
-  const hideProfileAndInstructions = isDefaultAgent && !isAdmin;
+  const hideProfileAndInstructions = !isAdmin && !isOwner;
   const activeTab = resolveVisibleTab(rawTab, hideProfileAndInstructions);
 
   return {
@@ -889,7 +894,7 @@ export function ZeroJobDetailPage() {
     hideProfileAndInstructions,
     activeTab,
     setActiveTab,
-  } = useTabVisibility(fields.agentId);
+  } = useTabVisibility(fields.agentId, fields.ownerId);
 
   if (!fields.detail && !error) {
     return <DetailSkeleton />;

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-job-detail-page-display.test.tsx
@@ -241,6 +241,114 @@ describe("zero job detail page - connector display", () => {
   });
 });
 
+describe("zero job detail page - tab visibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function findTab(label: RegExp) {
+    return screen.getAllByRole("tab").find((el) => {
+      return label.test(el.textContent ?? "");
+    });
+  }
+
+  it("should show all tabs when user is the agent owner", async () => {
+    mockAPIs();
+    // Default mock user is "test-user-123" which matches ownerId
+    await setupPage({ context, path: "/agents/my-agent" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "My Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(findTab(/Profile/i)).toBeInTheDocument();
+    expect(findTab(/Instructions/i)).toBeInTheDocument();
+  });
+
+  it("should show all tabs when user is org admin but not owner", async () => {
+    mockAPIs();
+    // Agent ownerId is "test-user-123", but user is "other-user"
+    // Default org mock role is "admin"
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      user: { id: "other-user", fullName: "Other User" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "My Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(findTab(/Profile/i)).toBeInTheDocument();
+    expect(findTab(/Instructions/i)).toBeInTheDocument();
+  });
+
+  it("should hide Profile and Instructions tabs for non-owner non-admin", async () => {
+    mockAPIs();
+    // Override org to "member" role and user to non-owner
+    server.use(
+      http.get("*/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "org_default",
+          slug: "default-org",
+          name: "Default Org",
+          role: "member",
+        });
+      }),
+    );
+    await setupPage({
+      context,
+      path: "/agents/my-agent",
+      user: { id: "other-user", fullName: "Other User" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "My Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(findTab(/Profile/i)).toBeUndefined();
+    expect(findTab(/Instructions/i)).toBeUndefined();
+    // Authorization and Scheduled should still be visible
+    expect(findTab(/Authorization/i)).toBeInTheDocument();
+    expect(findTab(/Scheduled/i)).toBeInTheDocument();
+  });
+
+  it("should coerce ?tab=profile to authorization for non-owner non-admin", async () => {
+    mockAPIs();
+    server.use(
+      http.get("*/api/zero/org", () => {
+        return HttpResponse.json({
+          id: "org_default",
+          slug: "default-org",
+          name: "Default Org",
+          role: "member",
+        });
+      }),
+    );
+    await setupPage({
+      context,
+      path: "/agents/my-agent?tab=profile",
+      user: { id: "other-user", fullName: "Other User" },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "My Agent" }),
+      ).toBeInTheDocument();
+    });
+
+    // Should show authorization tab content instead of profile
+    expect(findTab(/Profile/i)).toBeUndefined();
+    expect(findTab(/Authorization/i)).toBeInTheDocument();
+  });
+});
+
 describe("zero job detail page - delete dialog", () => {
   const user = userEvent.setup();
 


### PR DESCRIPTION
## Summary
- Hide Profile and Instructions tabs on all agent pages for users who are neither the agent owner nor an org admin
- Previously these tabs were only hidden on the default agent for non-admins; non-default agents showed all tabs to everyone
- Add 4 integration tests covering owner, admin, non-owner/non-admin, and URL coercion scenarios

## Test plan
- [x] Owner sees all tabs (default mock user matches ownerId)
- [x] Admin (non-owner) sees all tabs
- [x] Non-owner non-admin only sees Authorization and Scheduled tabs
- [x] `?tab=profile` coerced to authorization for non-owner non-admin
- [x] All 29 existing job detail page tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)