### PR TITLE
feat(core): add schedule:delete capability and exclude from agent run tokens

### DIFF
--- a/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/__tests__/route.test.ts
@@ -7,12 +7,14 @@ import {
   getTestZeroAgentId,
   createTestOrg,
   createTestSchedule,
+  insertOrgMembersCacheEntry,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { generateZeroToken } from "../../../../../../src/lib/auth/sandbox-token";
 
 const context = testContext();
 
@@ -27,6 +29,7 @@ async function setupOrg(userId: string) {
 }
 
 describe("DELETE /api/zero/schedules/:name", () => {
+  let userId: string;
   let orgId: string;
   let testComposeId: string;
   let testZeroAgentId: string;
@@ -34,6 +37,7 @@ describe("DELETE /api/zero/schedules/:name", () => {
   beforeEach(async () => {
     context.setupMocks();
     const user = await context.setupUser();
+    userId = user.userId;
     const org = await setupOrg(user.userId);
     orgId = org.orgId;
 
@@ -100,5 +104,38 @@ describe("DELETE /api/zero/schedules/:name", () => {
     );
 
     expect(response.status).toBe(401);
+  });
+
+  it("should reject agent run token (schedule:delete is agent-excluded)", async () => {
+    await createTestSchedule(testComposeId, "agent-cant-delete", {
+      cronExpression: "0 9 * * *",
+      prompt: "Agent should not delete this",
+    });
+
+    await insertOrgMembersCacheEntry({
+      userId,
+      orgId,
+      role: "admin",
+    });
+
+    // Switch to zero token auth (agent run) — no Clerk session
+    mockClerk({ userId: null });
+    const token = await generateZeroToken(userId, "run-123", orgId);
+
+    const response = await DELETE(
+      createTestRequest(
+        `http://localhost:3000/api/zero/schedules/agent-cant-delete?agentId=${testZeroAgentId}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        },
+      ),
+    );
+
+    expect(response.status).toBe(403);
+    const data = await response.json();
+    expect(data.error.message).toBe(
+      "Missing required capability: schedule:delete",
+    );
   });
 });

--- a/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
+++ b/turbo/apps/web/app/api/zero/schedules/[name]/route.ts
@@ -18,7 +18,7 @@ const router = tsr.router(zeroSchedulesByNameContract, {
     initServices();
 
     const authCtx = await requireAuth(headers.authorization, {
-      requiredCapability: "schedule:write",
+      requiredCapability: "schedule:delete",
     });
     if (isAuthError(authCtx)) return authCtx;
     const { userId } = authCtx;

--- a/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/require-auth.test.ts
@@ -175,6 +175,22 @@ describe("requireAuth", () => {
       expect(result.body.error.code).toBe("FORBIDDEN");
     }
   });
+
+  it("should return 403 for zero token missing agent-excluded capability (schedule:delete)", async () => {
+    const token = await generateZeroToken("user-1", "run-1", "org-1");
+
+    const result = await requireAuth(`Bearer ${token}`, {
+      requiredCapability: "schedule:delete",
+    });
+
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.status).toBe(403);
+      expect(result.body.error.message).toBe(
+        "Missing required capability: schedule:delete",
+      );
+    }
+  });
 });
 
 describe("isAuthError", () => {

--- a/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
+++ b/turbo/apps/web/src/lib/auth/__tests__/sandbox-token.test.ts
@@ -296,6 +296,16 @@ describe("sandbox-token", () => {
       ]);
     });
 
+    it("should exclude agent-excluded capabilities from zero tokens", async () => {
+      mockIsFeatureEnabled.mockReturnValue(true);
+
+      const token = await generateZeroToken("user-123", "run-456", "org-789");
+      const auth = verifyZeroToken(token);
+
+      expect(auth?.capabilities).not.toContain("schedule:delete");
+      expect(auth?.capabilities).toContain("schedule:write");
+    });
+
     it("should return null for expired zero token", async () => {
       const token = await generateZeroToken("user-123", "run-456", "org-789");
 

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -20,6 +20,15 @@ const CONDITIONAL_CAPABILITIES: ReadonlyMap<ZeroCapability, FeatureSwitchKey> =
     ["voice-chat:write", FeatureSwitchKey.VoiceChat],
   ]);
 
+/**
+ * Capabilities that are never included in agent run (zero) tokens.
+ * Unlike CONDITIONAL_CAPABILITIES (feature-flag gated for gradual rollout),
+ * these are structurally excluded for safety — agents should never have them.
+ */
+const AGENT_EXCLUDED_CAPABILITIES: ReadonlySet<ZeroCapability> = new Set([
+  "schedule:delete",
+]);
+
 const log = logger("auth:sandbox");
 
 /**
@@ -327,9 +336,12 @@ export async function generateZeroToken(
   const now = Math.floor(Date.now() / 1000);
   const expiresIn = 2 * 60 * 60; // 2 hours
 
-  // Build capabilities, filtering out gated ones where the flag is disabled
+  // Build capabilities, filtering out agent-excluded and conditionally gated ones
   const capabilities: ZeroCapability[] = [];
   for (const cap of ZERO_CAPABILITIES) {
+    if (AGENT_EXCLUDED_CAPABILITIES.has(cap)) {
+      continue;
+    }
     const flag = CONDITIONAL_CAPABILITIES.get(cap);
     if (flag) {
       if (isFeatureEnabled(flag, { userId, orgId })) {

--- a/turbo/packages/core/src/contracts/__tests__/composes.test.ts
+++ b/turbo/packages/core/src/contracts/__tests__/composes.test.ts
@@ -23,13 +23,13 @@ describe("agentDefinitionSchema strips unknown experimental_capabilities", () =>
 });
 
 describe("ZERO_CAPABILITIES", () => {
-  it("should have exactly 10 capabilities", () => {
-    expect(ZERO_CAPABILITIES).toHaveLength(10);
+  it("should have exactly 11 capabilities", () => {
+    expect(ZERO_CAPABILITIES).toHaveLength(11);
   });
 
   it("should follow {resource}:{action} naming pattern", () => {
     for (const cap of ZERO_CAPABILITIES) {
-      expect(cap).toMatch(/^[a-z-]+:(read|write)$/);
+      expect(cap).toMatch(/^[a-z-]+:(read|write|delete)$/);
     }
   });
 

--- a/turbo/packages/core/src/contracts/composes.ts
+++ b/turbo/packages/core/src/contracts/composes.ts
@@ -33,6 +33,7 @@ export const ZERO_CAPABILITIES = [
   "agent-run:write",
   "schedule:read",
   "schedule:write",
+  "schedule:delete",
   "slack:write",
   "connector:read",
   "computer-use:write",
@@ -62,8 +63,9 @@ export const ZERO_CAPABILITY_META: Record<ZeroCapability, ZeroCapabilityMeta> =
     "schedule:read": { group: "Schedules", label: "View schedules" },
     "schedule:write": {
       group: "Schedules",
-      label: "Create & delete schedules",
+      label: "Create & manage schedules",
     },
+    "schedule:delete": { group: "Schedules", label: "Delete schedules" },
     "slack:write": { group: "Integrations", label: "Send Slack messages" },
     "connector:read": { group: "Connectors", label: "View connected services" },
     "computer-use:write": {


### PR DESCRIPTION
## Summary

- Add `schedule:delete` as a new first-class capability, separate from `schedule:write`
- Introduce `AGENT_EXCLUDED_CAPABILITIES` set — capabilities structurally excluded from agent run tokens
- Update DELETE schedule route to require `schedule:delete` instead of `schedule:write`
- Agent runs retain `schedule:write` (create/enable/disable) but can no longer delete schedules at the API level

Closes #8698

## Test plan

- [x] `pnpm check-types` — all packages pass
- [x] `pnpm turbo run lint` — no new warnings
- [x] `pnpm format` — no changes
- [x] `pnpm knip` — no issues
- [x] sandbox-token tests — 54/54 pass (including new agent-excluded test)
- [x] CLI capability visibility tests — 21/21 pass (unchanged)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)