### PR TITLE
refactor(web): eliminate internal imports in phone tests (AP-12 batch B)

### DIFF
--- a/turbo/apps/web/app/api/zero/phone-calls/[callId]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/phone-calls/[callId]/__tests__/route.test.ts
@@ -4,7 +4,7 @@ import { GET } from "../route";
 import { createTestRequest } from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
-import { createPhoneOrg } from "../../../../../../src/__tests__/api-test-helpers";
+import { createPhoneOrg } from "../../../../../../src/__tests__/api-test-helpers/phone";
 import { server } from "../../../../../../src/mocks/server";
 import { reloadEnv } from "../../../../../../src/env";
 

--- a/turbo/apps/web/app/api/zero/phone-calls/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/phone-calls/__tests__/route.test.ts
@@ -4,11 +4,13 @@ import { POST, GET } from "../route";
 import {
   createTestRequest,
   insertOrgDefaultModelProvider,
-  setOrgAgentphoneNumberId,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { createPhoneOrg } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  createPhoneOrg,
+  setOrgAgentphoneNumberId,
+} from "../../../../../src/__tests__/api-test-helpers/phone";
 import { server } from "../../../../../src/mocks/server";
 import { reloadEnv } from "../../../../../src/env";
 

--- a/turbo/apps/web/app/api/zero/phone/setup/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/phone/setup/__tests__/route.test.ts
@@ -4,11 +4,13 @@ import { POST } from "../route";
 import {
   createTestRequest,
   updateOrgTier,
-  getOrgAgentphoneConfig,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
-import { createPhoneOrg } from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  createPhoneOrg,
+  getOrgAgentphoneConfig,
+} from "../../../../../../src/__tests__/api-test-helpers/phone";
 import { server } from "../../../../../../src/mocks/server";
 import { reloadEnv } from "../../../../../../src/env";
 

--- a/turbo/apps/web/app/api/zero/phone/webhook/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/phone/webhook/__tests__/route.test.ts
@@ -4,7 +4,7 @@ import { testContext } from "../../../../../../src/__tests__/test-helpers";
 import {
   createPhoneOrg,
   linkPhoneNumber,
-} from "../../../../../../src/__tests__/api-test-helpers";
+} from "../../../../../../src/__tests__/api-test-helpers/phone";
 import {
   insertOrgDefaultModelProvider,
   findMostRecentRunForUser,


### PR DESCRIPTION
## Summary

- Part of AP-12 remediation (#8441), batch B
- Updates 4 phone test files to import phone-specific helpers (`createPhoneOrg`, `linkPhoneNumber`, `setOrgAgentphoneNumberId`, `getOrgAgentphoneConfig`) from the `api-test-helpers/phone` sub-module instead of the barrel `api-test-helpers`
- Non-phone helpers (`createTestRequest`, `insertOrgDefaultModelProvider`, `updateOrgTier`, `findMostRecentRunForUser`) remain as barrel imports — only phone-specific functions are moved
- Zero logic changes — purely mechanical import path refactoring; TypeScript compilation confirms correctness

## Test plan

- [ ] TypeScript type check passes (`pnpm check-types`)
- [ ] Lint passes (`pnpm turbo run lint`)
- [ ] Knip reports no unused exports or imports
- [ ] All 4 modified files import phone helpers from `api-test-helpers/phone` (verified via grep)

Closes #8633

🤖 Generated with [Claude Code](https://claude.com/claude-code)