### PR TITLE
fix(firewalls): default all-allow for connectors without default-allowed list

### DIFF
--- a/turbo/apps/cli/src/commands/zero/agent/view.ts
+++ b/turbo/apps/cli/src/commands/zero/agent/view.ts
@@ -39,7 +39,9 @@ function getConnectorPermissionInfo(
     };
   }
 
-  const policies = resolvedPolicies?.[type] ?? null;
+  const rawPolicies = resolvedPolicies?.[type];
+  const policies =
+    rawPolicies && Object.keys(rawPolicies).length > 0 ? rawPolicies : null;
   const config = getConnectorFirewall(type);
   const permissions = config.apis.flatMap((a) => {
     return a.permissions ?? [];

--- a/turbo/apps/cli/src/commands/zero/whoami.ts
+++ b/turbo/apps/cli/src/commands/zero/whoami.ts
@@ -53,8 +53,8 @@ function printConnectorPermissions(
 ): void {
   if (!isFirewallConnectorType(type)) return;
 
-  const policies = resolvedPolicies?.[type] ?? null;
-  if (!policies) {
+  const policies = resolvedPolicies?.[type];
+  if (!policies || Object.keys(policies).length === 0) {
     console.log(chalk.dim("    full access — no permission rules configured"));
     return;
   }

--- a/turbo/packages/core/src/__tests__/firewall-default-policies.test.ts
+++ b/turbo/packages/core/src/__tests__/firewall-default-policies.test.ts
@@ -8,10 +8,9 @@ import {
 describe("getDefaultFirewallPolicies", () => {
   it("should return allow/deny map for connectors with defaults", () => {
     const policies = getDefaultFirewallPolicies("slack");
-    expect(policies).not.toBeNull();
 
     // Slack has defaults — every permission should be either "allow" or "deny"
-    const values = Object.values(policies!);
+    const values = Object.values(policies);
     expect(values.length).toBeGreaterThan(0);
     for (const v of values) {
       expect(["allow", "deny"]).toContain(v);
@@ -19,19 +18,19 @@ describe("getDefaultFirewallPolicies", () => {
   });
 
   it("should mark default-allowed permissions as allow", () => {
-    const policies = getDefaultFirewallPolicies("slack")!;
+    const policies = getDefaultFirewallPolicies("slack");
     // "channels:read" is in slackDefaultAllowed
     expect(policies["channels:read"]).toBe("allow");
   });
 
   it("should mark non-default permissions as deny", () => {
-    const policies = getDefaultFirewallPolicies("slack")!;
+    const policies = getDefaultFirewallPolicies("slack");
     // "admin" is a slack permission that is NOT in the default-allowed list
     expect(policies["admin"]).toBe("deny");
   });
 
   it("should cover every permission from the firewall config", () => {
-    const policies = getDefaultFirewallPolicies("slack")!;
+    const policies = getDefaultFirewallPolicies("slack");
     const config = getConnectorFirewall("slack");
     const allPermissions = new Set(
       config.apis.flatMap((api) => {

--- a/turbo/packages/core/src/__tests__/firewall-default-policies.test.ts
+++ b/turbo/packages/core/src/__tests__/firewall-default-policies.test.ts
@@ -49,8 +49,10 @@ describe("getDefaultFirewallPolicies", () => {
     expect(Object.keys(policies)).toHaveLength(allPermissions.size);
   });
 
-  it("should return null for connectors without defaults", () => {
-    expect(getDefaultFirewallPolicies("github")).toBeNull();
+  it("should return empty map for connectors with no permissions", () => {
+    // GitHub uses GraphQL field matching, not static permissions
+    const policies = getDefaultFirewallPolicies("github");
+    expect(Object.keys(policies)).toHaveLength(0);
   });
 });
 
@@ -90,14 +92,16 @@ describe("resolveFirewallPolicies", () => {
     expect(slack["admin"]).toBe("deny");
   });
 
-  it("should pass through connectors without defaults unchanged", () => {
-    const stored = { github: { "repo-read": "allow" as const } };
+  it("should preserve stored overrides for connectors without default-allowed list", () => {
+    const stored = { github: { "repo-read": "deny" as const } };
     const resolved = resolveFirewallPolicies(stored, ["github"]);
-    expect(resolved).toEqual(stored);
+    // GitHub has no static permissions → empty defaults, stored preserved
+    expect(resolved!["github"]!["repo-read"]).toBe("deny");
   });
 
   it("should skip non-firewall connector types", () => {
-    const resolved = resolveFirewallPolicies(null, ["jira"]);
+    // "computer" is a non-firewall connector type
+    const resolved = resolveFirewallPolicies(null, ["computer"]);
     expect(resolved).toBeNull();
   });
 
@@ -106,17 +110,19 @@ describe("resolveFirewallPolicies", () => {
     const resolved = resolveFirewallPolicies(stored, [
       "github",
       "slack",
-      "jira",
+      "computer",
     ]);
-    expect(resolved!["github"]).toEqual({ "repo-read": "allow" });
+    expect(resolved!["github"]!["repo-read"]).toBe("allow");
     const slackMixed = resolved!["slack"];
     expect(slackMixed).toBeDefined();
     expect(slackMixed!["channels:read"]).toBe("allow");
-    expect(resolved).not.toHaveProperty("jira");
+    expect(resolved).not.toHaveProperty("computer");
   });
 
-  it("should return null when no connectors need defaults", () => {
+  it("should produce entry for connectors with no stored policies", () => {
     const resolved = resolveFirewallPolicies(null, ["github"]);
-    expect(resolved).toBeNull();
+    expect(resolved).not.toBeNull();
+    // GitHub has no static permissions → empty defaults
+    expect(resolved!["github"]).toEqual({});
   });
 });

--- a/turbo/packages/core/src/firewalls/index.ts
+++ b/turbo/packages/core/src/firewalls/index.ts
@@ -428,24 +428,21 @@ const DEFAULT_ALLOWED: Partial<
 /**
  * Get the default firewall policies for a connector type.
  *
- * Builds a full permission → policy map from the connector's default-allowed
- * list: listed permissions get "allow", everything else gets "deny".
- *
- * Returns null when no defaults are defined (caller treats as unrestricted).
+ * Builds a full permission → policy map. Connectors with a default-allowed
+ * list get "allow" for listed permissions and "deny" for everything else.
+ * Connectors without a default-allowed list get "allow" for all permissions.
  */
 export function getDefaultFirewallPolicies(
   type: FirewallConnectorType,
-): Record<string, FirewallPolicyValue> | null {
+): Record<string, FirewallPolicyValue> {
   const allowed = DEFAULT_ALLOWED[type];
-  if (!allowed) return null;
-
-  const allowSet = new Set<string>(allowed);
+  const allowSet = allowed ? new Set<string>(allowed) : null;
   const config = getConnectorFirewall(type);
   const result: Record<string, FirewallPolicyValue> = {};
   for (const api of config.apis) {
     if (api.permissions) {
       for (const p of api.permissions) {
-        result[p.name] = allowSet.has(p.name) ? "allow" : "deny";
+        result[p.name] = !allowSet || allowSet.has(p.name) ? "allow" : "deny";
       }
     }
   }
@@ -455,10 +452,10 @@ export function getDefaultFirewallPolicies(
 /**
  * Merge stored firewall policies with per-connector defaults.
  *
- * For each connector that has a default-allowed list, fills in default
- * policies when no explicit entry exists in the stored policies.
- * Call this when reading `firewallPolicies` from the database so that
- * downstream consumers don't need to know about defaults.
+ * For each connector, builds a full default policy map (all-allow for
+ * connectors without a default-allowed list, selective for those with one),
+ * then layers stored overrides on top. This ensures unspecified permissions
+ * are never implicitly denied.
  */
 export function resolveFirewallPolicies(
   stored: FirewallPolicies | null,
@@ -468,7 +465,6 @@ export function resolveFirewallPolicies(
   for (const connector of connectors) {
     if (!isFirewallConnectorType(connector)) continue;
     const defaults = getDefaultFirewallPolicies(connector);
-    if (!defaults) continue;
     // Merge: defaults as base, stored overrides specific entries.
     resolved = {
       ...resolved,


### PR DESCRIPTION
## Summary

- Follow-up to #8697. `getDefaultFirewallPolicies()` returned `null` for connectors without a `DEFAULT_ALLOWED` entry (e.g. github, jira), causing `resolveFirewallPolicies` to skip them entirely
- This meant partial stored policies on those connectors still implicitly denied unspecified permissions — the same class of bug as #8697 but for connectors without a default list
- Fix: `getDefaultFirewallPolicies()` now always returns a full policy map — connectors with a default-allowed list get selective allow/deny, connectors without one get all-allow

## Test plan

- [x] Updated `firewall-default-policies.test.ts`: connectors without defaults return all-allow map, resolve merges correctly
- [x] All 12 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)