### PR TITLE
fix(voice-chat): show full content in shared context events panel

### DIFF
--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -213,11 +213,8 @@ export function VoiceChatPage() {
                   <span className="text-muted-foreground">:</span>{" "}
                   <span>{event.type}</span>
                   {event.content && (
-                    <span className="text-muted-foreground ml-1">
-                      -{" "}
-                      {event.content.length > 120
-                        ? `${event.content.slice(0, 120)}...`
-                        : event.content}
+                    <span className="text-muted-foreground ml-1 whitespace-pre-wrap">
+                      - {event.content}
                     </span>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

- Remove the 120-character truncation in the voice-chat shared context events panel so that event content (directives, thinking-progress, thinking-result, observation) is displayed in full
- Add `whitespace-pre-wrap` class for multi-line content readability

Closes #8709

## Test plan

- [ ] Open voice-chat page, start a session, verify shared context events show full content without truncation
- [ ] Long directive/result events display completely
- [ ] Multi-line content renders with preserved whitespace
- [ ] Null content events still render correctly (no content span shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)