### PR TITLE
refactor: AP-12 batch F — eliminate internal imports in slack and webhook-complete tests

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -16,10 +16,11 @@ import {
   findTestCallbacksByRunId,
   findTestRunRecord,
   findTestQueueEntry,
+  enqueueTestRun,
+  getTestAgentSessionWithConversation,
+  generateTestReplyToken,
 } from "../../../../../../src/__tests__/api-test-helpers";
-import { enqueueRun } from "../../../../../../src/lib/zero/zero-run-queue-service";
 import { reloadEnv } from "../../../../../../src/env";
-import { getAgentSessionWithConversation } from "../../../../../../src/lib/infra/agent-session";
 import {
   testContext,
   uniqueId,
@@ -28,7 +29,6 @@ import {
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { randomUUID } from "crypto";
 import { POST as checkpointWebhook } from "../../checkpoints/route";
-import { generateReplyToken } from "../../../../../../src/lib/zero/email/handlers/shared";
 
 const context = testContext();
 
@@ -345,7 +345,7 @@ describe("POST /api/webhooks/agent/complete", () => {
       };
 
       // Verify agent session has memoryName
-      const session = await getAgentSessionWithConversation(
+      const session = await getTestAgentSessionWithConversation(
         checkpointData.agentSessionId,
       );
       expect(session).toBeDefined();
@@ -607,7 +607,7 @@ describe("POST /api/webhooks/agent/complete", () => {
         emailUser.userId,
         composeId,
       );
-      const replyToken = generateReplyToken(agentSession.id);
+      const replyToken = generateTestReplyToken(agentSession.id);
 
       const emailSession = await createTestEmailThreadSession({
         userId: emailUser.userId,
@@ -675,7 +675,7 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(run1.status).toBe("pending");
 
       // Enqueue a run with proper encrypted params (startRun no longer enqueues)
-      const run2 = await enqueueRun({
+      const run2 = await enqueueTestRun({
         userId: qUser.userId,
         agentComposeVersionId: versionId,
         prompt: "Queued run",

--- a/turbo/apps/web/app/api/zero/integrations/slack/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/integrations/slack/__tests__/route.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { WebClient } from "@slack/web-api";
 import { GET, DELETE } from "../route";
-import { SLACK_BOT_SCOPES } from "../../../../../../src/lib/zero/slack-org/scopes";
 import {
   testContext,
   uniqueId,
@@ -13,6 +12,7 @@ import {
   createTestSlackOrgConnection,
   findTestSlackOrgConnection,
   findTestSlackOrgInstallation,
+  SLACK_BOT_SCOPES,
 } from "../../../../../../src/__tests__/api-test-helpers";
 
 const context = testContext();

--- a/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
@@ -662,6 +662,7 @@ export async function getTestAgentSessionWithConversation(
       orgId: string;
       agentComposeId: string;
       conversationId: string | null;
+      memoryName: string | null;
       chatMessages: StoredChatMessage[];
     }
   | undefined
@@ -686,6 +687,7 @@ export async function getTestAgentSessionWithConversation(
     orgId: session.orgId,
     agentComposeId: session.agentComposeId,
     conversationId: session.conversationId ?? null,
+    memoryName: session.memoryName ?? null,
     chatMessages: (zeroSession?.chatMessages ?? []) as StoredChatMessage[],
   };
 }

--- a/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/runs.ts
@@ -842,9 +842,13 @@ export async function enqueueTestRun(params: {
   agentComposeVersionId: string;
   orgId: string;
   prompt: string;
-}): Promise<{ runId: string; queuedAt: Date }> {
+}): Promise<{ runId: string; status: string; queuedAt: Date }> {
   const result = await enqueueRun(params);
-  return { runId: result.runId, queuedAt: result.createdAt };
+  return {
+    runId: result.runId,
+    status: result.status,
+    queuedAt: result.createdAt,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Removes `SLACK_BOT_SCOPES` import from internal `lib/zero/slack-org/scopes` in the slack route test, replacing it with the re-export already available in `api-test-helpers/slack`
- Removes `enqueueRun`, `getAgentSessionWithConversation`, and `generateReplyToken` internal imports in the webhook complete route test, replacing them with `enqueueTestRun`, `getTestAgentSessionWithConversation`, and `generateTestReplyToken` from `api-test-helpers`
- Extends `getTestAgentSessionWithConversation` helper to include `memoryName` field in its return type (required by the test)
- Extends `enqueueTestRun` helper to return `status` field alongside `runId` and `queuedAt` (required by the test)

Closes #8636

## Test plan

- [x] Lint passes (`pnpm turbo run lint`) with 0 errors
- [x] Format passes (`pnpm format`) with no changes
- [x] Knip passes with no issues
- [x] Pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)