### PR TITLE
feat(firewalls): add deny and ask lists to granted permissions schema

### DIFF
--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -48,7 +48,12 @@ def _grant_all(firewalls, allow_unknown=False):
         for api in fw.get("apis", []):
             for perm in api.get("permissions", []):
                 perms.add(perm["name"])
-        result[fw["ref"]] = {"allow": list(perms), "allowUnknown": allow_unknown}
+        result[fw["ref"]] = {
+            "allow": list(perms),
+            "deny": [],
+            "ask": [],
+            "allowUnknown": allow_unknown,
+        }
     return result
 
 

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -146,7 +146,12 @@ class TestRequestHandler:
                         },
                     ],
                     "grantedPermissions": {
-                        "github": {"allow": ["full-access"], "allowUnknown": True}
+                        "github": {
+                            "allow": ["full-access"],
+                            "deny": [],
+                            "ask": [],
+                            "allowUnknown": True,
+                        },
                     },
                     "encryptedSecrets": "iv:tag:data",
                 }
@@ -206,7 +211,12 @@ class TestRequestHandler:
                         },
                     ],
                     "grantedPermissions": {
-                        "github": {"allow": ["read-repos"], "allowUnknown": False}
+                        "github": {
+                            "allow": ["read-repos"],
+                            "deny": [],
+                            "ask": [],
+                            "allowUnknown": False,
+                        },
                     },
                     "encryptedSecrets": "iv:tag:data",
                 }
@@ -269,7 +279,12 @@ class TestRequestHandler:
                         },
                     ],
                     "grantedPermissions": {
-                        "github": {"allow": ["read-repos"], "allowUnknown": False}
+                        "github": {
+                            "allow": ["read-repos"],
+                            "deny": [],
+                            "ask": [],
+                            "allowUnknown": False,
+                        },
                     },
                     "encryptedSecrets": "iv:tag:data",
                 }
@@ -326,7 +341,12 @@ class TestRequestHandler:
                         },
                     ],
                     "grantedPermissions": {
-                        "github": {"allow": ["full-access"], "allowUnknown": True}
+                        "github": {
+                            "allow": ["full-access"],
+                            "deny": [],
+                            "ask": [],
+                            "allowUnknown": True,
+                        },
                     },
                     "encryptedSecrets": "iv:tag:data",
                 }

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -140,6 +140,10 @@ pub struct FirewallAuth {
 pub struct GrantedPermission {
     /// Permission names granted by the user.
     pub allow: Vec<String>,
+    /// Permission names explicitly denied by the admin.
+    pub deny: Vec<String>,
+    /// Permission names requiring user approval before use.
+    pub ask: Vec<String>,
     /// Whether to allow requests that don't match any known permission rule.
     pub allow_unknown: bool,
 }

--- a/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
@@ -45,6 +45,8 @@ describe("applyConnectorPolicies", () => {
     expect(grantedPermissions).toEqual({
       github: {
         allow: ["repo-read", "repo-write"],
+        deny: [],
+        ask: [],
         allowUnknown: true,
       },
     });
@@ -77,10 +79,12 @@ describe("applyConnectorPolicies", () => {
 
     // Firewalls carry ALL permissions (unfiltered)
     expect(firewalls[0]?.apis[0]?.permissions).toEqual(allPermissions);
-    // grantedPermissions only includes "allow" ones
+    // grantedPermissions splits by policy
     expect(grantedPermissions).toEqual({
       github: {
         allow: ["repo-read", "issues-read"],
+        deny: ["repo-write"],
+        ask: [],
         allowUnknown: true,
       },
     });
@@ -112,6 +116,8 @@ describe("applyConnectorPolicies", () => {
     expect(grantedPermissions).toEqual({
       "custom-api": {
         allow: [],
+        deny: [],
+        ask: [],
         allowUnknown: true,
       },
     });
@@ -137,6 +143,8 @@ describe("applyConnectorPolicies", () => {
     expect(grantedPermissions).toEqual({
       "custom-api": {
         allow: [],
+        deny: [],
+        ask: [],
         allowUnknown: true,
       },
     });
@@ -164,6 +172,8 @@ describe("applyConnectorPolicies", () => {
 
     expect(grantedPermissions.github).toEqual({
       allow: ["repo-read"],
+      deny: [],
+      ask: [],
       allowUnknown: true,
     });
   });
@@ -188,6 +198,8 @@ describe("applyConnectorPolicies", () => {
 
     expect(grantedPermissions.github).toEqual({
       allow: ["repo-read"],
+      deny: [],
+      ask: [],
       allowUnknown: true,
     });
   });

--- a/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/apply-connector-policies.test.ts
@@ -178,6 +178,38 @@ describe("applyConnectorPolicies", () => {
     });
   });
 
+  it("classifies ask policy into ask array", () => {
+    const fw = makeFirewall({
+      ref: "github",
+      apis: [
+        {
+          base: "https://api.github.com",
+          auth: { headers: { Authorization: "Bearer token" } },
+          permissions: [
+            { name: "repo-read", rules: ["GET /repos/{owner}/{repo}"] },
+            { name: "repo-write", rules: ["PUT /repos/{owner}/{repo}"] },
+            { name: "admin", rules: ["DELETE /repos/{owner}/{repo}"] },
+          ],
+        },
+      ],
+    });
+
+    const { grantedPermissions } = applyConnectorPolicies([fw], {
+      github: {
+        "repo-read": "allow",
+        "repo-write": "ask",
+        admin: "deny",
+      },
+    });
+
+    expect(grantedPermissions.github).toEqual({
+      allow: ["repo-read"],
+      deny: ["admin"],
+      ask: ["repo-write"],
+      allowUnknown: true,
+    });
+  });
+
   it("defaults allowUnknown to true when ref absent from allowUnknownEndpoints", () => {
     const fw = makeFirewall({
       ref: "github",

--- a/turbo/apps/web/src/lib/zero/context/resolve-permissions.ts
+++ b/turbo/apps/web/src/lib/zero/context/resolve-permissions.ts
@@ -59,6 +59,8 @@ export function mergePermissions(
   if (modelProviderFirewall) {
     grantedPermissions[modelProviderFirewall.ref] = {
       allow: collectPermissionNames(modelProviderFirewall.apis),
+      deny: [],
+      ask: [],
       allowUnknown: true,
     };
   }
@@ -122,13 +124,28 @@ export function applyConnectorPolicies(
     const allowUnknown = allowUnknownEndpoints?.[fw.ref] ?? true;
     const allPermNames = collectPermissionNames(fw.apis);
     if (!refPolicies) {
-      // No policies configured → all granted
-      grantedPermissions[fw.ref] = { allow: allPermNames, allowUnknown };
+      // No policies configured → all granted, none denied
+      grantedPermissions[fw.ref] = {
+        allow: allPermNames,
+        deny: [],
+        ask: [],
+        allowUnknown,
+      };
     } else {
-      const granted = allPermNames.filter((name) => {
-        return refPolicies[name] === "allow";
-      });
-      grantedPermissions[fw.ref] = { allow: granted, allowUnknown };
+      const allow: string[] = [];
+      const deny: string[] = [];
+      const ask: string[] = [];
+      for (const name of allPermNames) {
+        const policy = refPolicies[name];
+        if (policy === "allow") {
+          allow.push(name);
+        } else if (policy === "deny") {
+          deny.push(name);
+        } else if (policy === "ask") {
+          ask.push(name);
+        }
+      }
+      grantedPermissions[fw.ref] = { allow, deny, ask, allowUnknown };
     }
   }
 

--- a/turbo/packages/core/src/contracts/firewalls.ts
+++ b/turbo/packages/core/src/contracts/firewalls.ts
@@ -86,12 +86,14 @@ export type FirewallPolicies = z.infer<typeof firewallPoliciesSchema>;
  */
 const grantedPermissionSchema = z.object({
   allow: z.array(z.string()),
+  deny: z.array(z.string()),
+  ask: z.array(z.string()),
   allowUnknown: z.boolean(),
 });
 
 /**
  * Granted permissions map — firewall ref → grant config.
- * Example: { "github": { allow: ["repo-read"], allowUnknown: false } }
+ * Example: { "github": { allow: ["repo-read"], deny: ["admin"], ask: [], allowUnknown: false } }
  */
 export const grantedPermissionsSchema = z.record(
   z.string(),


### PR DESCRIPTION
## Summary

- Add `deny` and `ask` arrays to `grantedPermissionSchema` alongside existing `allow`
- `applyConnectorPolicies()` now classifies permissions into `allow`, `deny`, and `ask` based on policy values; unconfigured permissions are omitted from all lists
- Rust `GrantedPermission` struct updated with matching fields
- Proxy matching logic unchanged — still uses `allow` set only (deny/ask usage deferred)

Closes #8713

## Test plan

- [x] `apply-connector-policies.test.ts` — all 6 tests updated and passing
- [x] TypeScript type check passing
- [x] Rust build passing
- [x] Python tests unaffected (730 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)