### PR TITLE
fix: reload agents list after onboarding completes

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-onboarding-actions.ts
@@ -16,6 +16,7 @@ import { allConnectorTypes$ } from "./settings/connectors.ts";
 import { detachedNavigateTo$ } from "../route.ts";
 import { slackOrgData$ } from "./zero-slack.ts";
 import { reloadBillingStatus$ } from "./billing.ts";
+import { reloadAgents$ } from "../agent.ts";
 import { showAppSkeleton$ } from "../app-skeleton.ts";
 import { CONNECTOR_TYPES, type ConnectorType } from "@vm0/core";
 
@@ -237,9 +238,12 @@ const completeOnboarding$ = command(
 
     const isAdmin = await get(zeroNeedsOnboarding$);
     signal.throwIfAborted();
-    return isAdmin
+    const agentId = isAdmin
       ? await set(completeZeroOnboarding$, signal)
       : await set(completeMemberOnboarding$, signal);
+
+    set(reloadAgents$);
+    return agentId;
   },
 );
 


### PR DESCRIPTION
## Summary

- After onboarding, a new agent is created server-side but `agents$` (the frontend cache) is never invalidated
- The sidebar stays stale until the user manually refreshes the page
- Call `reloadAgents$` inside `completeOnboarding$` so both admin and member paths trigger a fresh fetch

## Test plan

- [ ] Complete admin onboarding — verify the new agent appears in the sidebar immediately without a page refresh
- [ ] Complete member onboarding — verify the sidebar agent list updates immediately