### PR TITLE
feat: update SMS consent disclosure to meet carrier requirements

### DIFF
--- a/turbo/apps/platform/src/views/phone-page/phone-page.tsx
+++ b/turbo/apps/platform/src/views/phone-page/phone-page.tsx
@@ -135,9 +135,12 @@ export function PhonePage() {
         )}
         {error && <p className="text-sm text-red-500">{error}</p>}
         <p className="text-muted-foreground mt-2 text-xs">
-          By linking your phone number, you agree to our{" "}
+          By providing your phone number, you authorize VM0 to send text
+          messages including verification codes and notifications to the number
+          provided. Message and data rates may apply. Message frequency varies.
+          Reply HELP for help or STOP to opt out. See{" "}
           <a
-            href="https://vm0.ai/terms-of-use"
+            href="https://www.vm0.ai/terms-of-use"
             target="_blank"
             rel="noopener noreferrer"
             className="underline"
@@ -146,15 +149,14 @@ export function PhonePage() {
           </a>{" "}
           and{" "}
           <a
-            href="https://vm0.ai/privacy-policy"
+            href="https://www.vm0.ai/privacy-policy"
             target="_blank"
             rel="noopener noreferrer"
             className="underline"
           >
             Privacy Policy
           </a>
-          . You can unsubscribe at any time by removing your phone number on
-          this page.
+          .
         </p>
       </section>
     </div>


### PR DESCRIPTION
## Summary

- Replaces the generic phone linking disclaimer with carrier-compliant SMS consent text, per feedback from AgentPhone on our campaign registration
- Adds explicit authorization language, message frequency notice, and HELP/STOP opt-out instructions required by carriers
- Updates links to use `www.vm0.ai` domain

## Context

AgentPhone flagged our campaign registration for missing required consent disclosures on the SMS opt-in screen. This change addresses that requirement.

**Note:** After merging, Ethan will take a fresh screenshot of the consent text and resubmit the registration to AgentPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)