### PR TITLE
feat(runner): read guest session id for first-run vm parking

### DIFF
--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -326,6 +326,17 @@ fn download_with_retry(url: &str, target_path: &str) -> Result<(), DownloadError
 }
 
 fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadError> {
+    // Remove existing contents so stale files from a previous turn on a
+    // reused VM don't leak into the new extraction.
+    let target = Path::new(target_path);
+    if target.exists() {
+        fs::remove_dir_all(target).map_err(|e| DownloadError {
+            message: format!("Failed to clean directory {target_path}: {e}"),
+            retriable: false,
+            status_code: None,
+        })?;
+    }
+
     // Create target directory
     fs::create_dir_all(target_path).map_err(|e| DownloadError {
         message: format!("Failed to create directory {target_path}: {e}"),

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -920,18 +920,30 @@ fn spawn_job(
             }
         });
 
-        let (exit_code, err, sandbox, source_ip) = match inner.await {
+        let (exit_code, err, sandbox, source_ip, guest_session_id) = match inner.await {
             Ok(outcome) => {
                 let err = if job_cancel.is_cancelled() {
                     Some("cancelled by user".to_string())
                 } else {
                     outcome.error
                 };
-                (outcome.exit_code, err, outcome.sandbox, outcome.source_ip)
+                (
+                    outcome.exit_code,
+                    err,
+                    outcome.sandbox,
+                    outcome.source_ip,
+                    outcome.guest_session_id,
+                )
             }
             Err(e) => {
                 error!(run_id = %run_id, error = %e, "executor task panicked");
-                (1, Some(format!("internal error: {e}")), None, String::new())
+                (
+                    1,
+                    Some(format!("internal error: {e}")),
+                    None,
+                    String::new(),
+                    None,
+                )
             }
         };
 
@@ -939,7 +951,9 @@ fn spawn_job(
         let parked = if let Some(sandbox) = sandbox {
             let parkable_session =
                 if exit_code == 0 && !job_cancel.is_cancelled() && mode == RunnerMode::Running {
-                    session_id.as_deref()
+                    // Prefer context session_id (from resume_session), fall back to
+                    // guest-reported session ID (first run — CLI generated it).
+                    session_id.as_deref().or(guest_session_id.as_deref())
                 } else {
                     None
                 };

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -50,6 +50,9 @@ pub struct ExecuteOutcome {
     /// during create/start (sandbox was destroyed inline).
     pub sandbox: Option<Box<dyn Sandbox>>,
     pub source_ip: String,
+    /// CLI-generated session ID read from the guest after execution.
+    /// Used for first-run VM parking when `resume_session` is absent.
+    pub guest_session_id: Option<String>,
 }
 
 /// Execute a single job inside a **new** Firecracker VM.
@@ -87,6 +90,7 @@ pub async fn execute_job(
                 error: Some(e.to_string()),
                 sandbox: None,
                 source_ip: String::new(),
+                guest_session_id: None,
             }
         }
     };
@@ -212,11 +216,24 @@ async fn execute_new_sandbox(
         Err(e) => (1, Some(e.to_string())),
     };
 
+    // Read CLI-generated session ID for first-run parking.
+    // Only needed when resume_session is absent (first turn in a conversation).
+    let guest_session_id = if exit_code == 0 && context.session_id().is_none() {
+        let id = read_guest_session_id(sandbox.as_ref(), context.run_id).await;
+        if let Some(ref sid) = id {
+            info!(run_id = %context.run_id, session_id = %sid, "read guest session ID for parking");
+        }
+        id
+    } else {
+        None
+    };
+
     Ok(ExecuteOutcome {
         exit_code,
         error,
         sandbox: Some(sandbox),
         source_ip,
+        guest_session_id,
     })
 }
 
@@ -250,6 +267,7 @@ async fn execute_reused_sandbox(
             error: Some(e.to_string()),
             sandbox: Some(sandbox),
             source_ip: source_ip.to_string(),
+            guest_session_id: None,
         };
     }
     if let Err(e) = reseed_guest_entropy(sandbox.as_ref()).await {
@@ -260,6 +278,7 @@ async fn execute_reused_sandbox(
             error: Some(e.to_string()),
             sandbox: Some(sandbox),
             source_ip: source_ip.to_string(),
+            guest_session_id: None,
         };
     }
 
@@ -278,13 +297,20 @@ async fn execute_reused_sandbox(
     // Post-job cleanup (copy logs to host, unregister proxy, upload network logs)
     post_job_cleanup(sandbox.as_ref(), config, context, source_ip).await;
 
-    // Clean up guest log files from this turn — they've been copied to the host
-    // and would otherwise accumulate across turns on the reused VM.
-    clean_stale_guest_logs(sandbox.as_ref()).await;
-
     let (exit_code, error) = match result {
         Ok((code, err)) => (code, err),
         Err(e) => (1, Some(e.to_string())),
+    };
+
+    // Read CLI-generated session ID for first-run parking.
+    let guest_session_id = if exit_code == 0 && context.session_id().is_none() {
+        let id = read_guest_session_id(sandbox.as_ref(), context.run_id).await;
+        if let Some(ref sid) = id {
+            info!(run_id = %context.run_id, session_id = %sid, "read guest session ID for parking");
+        }
+        id
+    } else {
+        None
     };
 
     ExecuteOutcome {
@@ -292,6 +318,7 @@ async fn execute_reused_sandbox(
         error,
         sandbox: Some(sandbox),
         source_ip: source_ip.to_string(),
+        guest_session_id,
     }
 }
 
@@ -583,6 +610,34 @@ async fn read_guest_error_file(sandbox: &dyn Sandbox, run_id: Uuid) -> Option<St
     }
 }
 
+/// Read the CLI-generated session ID from the guest filesystem.
+///
+/// The guest-agent writes the session ID to `/tmp/vm0-session-{run_id}.txt`
+/// after the CLI emits its `system/init` event. On first runs (no
+/// `resume_session`), the runner uses this to park the VM for keep-alive.
+///
+/// NOTE: Path must match `crates/guest-agent/src/paths.rs` (`session_id_file()`).
+async fn read_guest_session_id(sandbox: &dyn Sandbox, run_id: Uuid) -> Option<String> {
+    // Mirror of guest-agent paths::session_id_file()
+    let path = format!("/tmp/vm0-session-{run_id}.txt");
+    let cmd = format!("cat {path} 2>/dev/null");
+    match sandbox
+        .exec(&ExecRequest {
+            cmd: &cmd,
+            timeout: Duration::from_secs(5),
+            env: &[],
+            sudo: false,
+        })
+        .await
+    {
+        Ok(result) if result.exit_code == 0 && !result.stdout.is_empty() => {
+            let id = String::from_utf8_lossy(&result.stdout).trim().to_string();
+            Some(id).filter(|s| !s.is_empty())
+        }
+        _ => None,
+    }
+}
+
 /// Returns true if dmesg output indicates an OOM kill.
 fn dmesg_indicates_oom(stdout: &str) -> bool {
     let lower = stdout.to_lowercase();
@@ -672,34 +727,11 @@ async fn drain_stdout_to_file(
 }
 
 /// Guest log file path prefixes. Each turn creates files named
-/// `{PREFIX}{run_id}{SUFFIX}` under `/tmp`. Used by both `copy_guest_logs`
-/// (to read) and `clean_stale_guest_logs` (to remove).
+/// `{PREFIX}{run_id}{SUFFIX}` under `/tmp`. Used by `copy_guest_logs`.
 const GUEST_SYSTEM_LOG_PREFIX: &str = "/tmp/vm0-system-";
 const GUEST_SYSTEM_LOG_SUFFIX: &str = ".log";
 const GUEST_METRICS_LOG_PREFIX: &str = "/tmp/vm0-metrics-";
 const GUEST_METRICS_LOG_SUFFIX: &str = ".jsonl";
-
-/// Remove stale guest log files from previous turns (best-effort).
-///
-/// On a reused VM, each turn leaves guest log files behind. These are
-/// already copied to the host by `post_job_cleanup`, so the guest copies
-/// are just waste.
-async fn clean_stale_guest_logs(sandbox: &dyn Sandbox) {
-    let cmd = format!(
-        "rm -f {GUEST_SYSTEM_LOG_PREFIX}*{GUEST_SYSTEM_LOG_SUFFIX} {GUEST_METRICS_LOG_PREFIX}*{GUEST_METRICS_LOG_SUFFIX}"
-    );
-    if let Err(e) = sandbox
-        .exec(&ExecRequest {
-            cmd: &cmd,
-            timeout: DEFAULT_EXEC_TIMEOUT,
-            env: &[],
-            sudo: false,
-        })
-        .await
-    {
-        warn!(error = %e, "failed to clean stale guest logs");
-    }
-}
 
 /// Copy guest log files to host (best-effort, post-job).
 ///
@@ -1943,32 +1975,6 @@ mod tests {
 
         assert!(!log_paths.system_log(ctx.run_id).exists());
         assert!(!log_paths.metrics_log(ctx.run_id).exists());
-    }
-
-    // -----------------------------------------------------------------------
-    // clean_stale_guest_logs tests
-    // -----------------------------------------------------------------------
-
-    #[tokio::test]
-    async fn clean_stale_guest_logs_succeeds() {
-        let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Ok(ExecResult {
-            exit_code: 0,
-            stdout: Vec::new(),
-            stderr: Vec::new(),
-        }));
-
-        clean_stale_guest_logs(&sandbox).await;
-        // No panic, exec result consumed — cleanup ran successfully.
-    }
-
-    #[tokio::test]
-    async fn clean_stale_guest_logs_tolerates_exec_failure() {
-        let sandbox = MockSandbox::new("test");
-        sandbox.push_exec_result(Err(SandboxError::ExecFailed("vsock down".into())));
-
-        // Should not panic
-        clean_stale_guest_logs(&sandbox).await;
     }
 
     // -----------------------------------------------------------------------

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -202,7 +202,6 @@ async fn execute_new_sandbox(
         context,
         config,
         params.use_snapshot,
-        false, // new sandbox — download storages normally
         telemetry,
         cancel,
     )
@@ -282,13 +281,12 @@ async fn execute_reused_sandbox(
         };
     }
 
-    // Run job — clock/entropy already handled, storage persists from previous turn
+    // Run job — clock/entropy already handled.
     let result = run_in_sandbox(
         sandbox.as_ref(),
         context,
         config,
         false, // clock/entropy already handled
-        true,  // skip storage download — filesystem persists across turns
         telemetry,
         cancel,
     )
@@ -384,7 +382,6 @@ async fn run_in_sandbox(
     context: &ExecutionContext,
     config: &ExecutorConfig,
     use_snapshot: bool,
-    skip_storage_download: bool,
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
 ) -> RunnerResult<(i32, Option<String>)> {
@@ -403,8 +400,8 @@ async fn run_in_sandbox(
     // 2. Set guest timezone from user preference (best-effort, never fails).
     sync_guest_timezone(sandbox, context).await;
 
-    // 3. Download storages (skipped for reused VMs — filesystem persists)
-    if !skip_storage_download && let Some(manifest) = &context.storage_manifest {
+    // 3. Download storages
+    if let Some(manifest) = &context.storage_manifest {
         let t = Instant::now();
         let result = download_storages(sandbox, context, manifest, &log_file).await;
         let err = result.as_ref().err().map(|e| e.to_string());
@@ -2515,56 +2512,6 @@ mod tests {
         );
     }
 
-    /// Verify that the reuse path skips storage download even when context
-    /// has a storage_manifest. Strategy: push a write_file error — if download
-    /// ran, it would call write_file (consuming the error and failing).
-    /// Since download is skipped, write_file is never called and the test passes.
-    #[tokio::test]
-    async fn execute_job_reuse_skips_storage_download() {
-        let dir = tempfile::tempdir().unwrap();
-        let config = test_executor_config(dir.path()).await;
-
-        let sandbox = MockSandbox::new("reuse-skip-download");
-        // Poison write_file: if called, it would fail with this error.
-        sandbox.push_write_file_result(Err(SandboxError::ExecFailed(
-            "download should be skipped".into(),
-        )));
-
-        let mut ctx = minimal_context();
-        ctx.storage_manifest = Some(StorageManifest {
-            storages: vec![StorageEntry {
-                mount_path: "/data".into(),
-                archive_url: Some("https://s3/archive.tar.gz".into()),
-            }],
-            artifact: None,
-            memory: None,
-        });
-
-        let idle_entry = crate::idle_pool::IdleEntry {
-            sandbox: Box::new(sandbox),
-            factory: std::sync::Arc::new(
-                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-            ),
-            session_id: "sess-1".into(),
-            profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 2048,
-            source_ip: "10.0.0.1".into(),
-            parked_at: std::time::Instant::now(),
-            idle_timeout: std::time::Duration::from_secs(300),
-        };
-
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job_reuse(idle_entry, ctx, &config, cancel).await;
-
-        // If storage download was NOT skipped, write_file would have been called
-        // with the poisoned error, causing the job to fail with "download should
-        // be skipped". Success here proves download was truly skipped.
-        assert_eq!(outcome.exit_code, 0, "reuse should skip storage download");
-        assert!(outcome.error.is_none());
-        assert!(outcome.sandbox.is_some());
-    }
-
     /// Verify that session restore failure during reuse still returns the sandbox.
     #[tokio::test]
     async fn execute_job_reuse_session_restore_failure_returns_sandbox() {
@@ -2605,78 +2552,6 @@ mod tests {
             outcome.sandbox.is_some(),
             "sandbox must be returned on session restore failure"
         );
-    }
-
-    /// Verify that reuse skips storage download but still runs session restore
-    /// when both storage_manifest and resume_session are present.
-    ///
-    /// Strategy: push a write_file error. If storage download ran, it would
-    /// call write_file first (for the manifest), consuming the error and
-    /// failing with "storage should be skipped". Since download IS skipped,
-    /// the first write_file call is for restore_session (session history),
-    /// which consumes the error and fails with "storage should be skipped"
-    /// — proving both that download was skipped AND session restore ran.
-    #[tokio::test]
-    async fn execute_job_reuse_skips_storage_but_runs_session_restore() {
-        let dir = tempfile::tempdir().unwrap();
-        let config = test_executor_config(dir.path()).await;
-
-        let sandbox = MockSandbox::new("reuse-combined");
-        // Poison write_file: consumed by whichever calls write_file first.
-        sandbox.push_write_file_result(Err(SandboxError::ExecFailed(
-            "storage should be skipped".into(),
-        )));
-
-        let mut ctx = minimal_context();
-        ctx.storage_manifest = Some(StorageManifest {
-            storages: vec![StorageEntry {
-                mount_path: "/data".into(),
-                archive_url: Some("https://s3/archive.tar.gz".into()),
-            }],
-            artifact: None,
-            memory: None,
-        });
-        ctx.resume_session = Some(ResumeSession {
-            session_id: "sess-combined".into(),
-            session_history: r#"{"type":"init"}"#.into(),
-        });
-
-        let idle_entry = crate::idle_pool::IdleEntry {
-            sandbox: Box::new(sandbox),
-            factory: std::sync::Arc::new(
-                Box::new(MockSandboxFactory::new()) as Box<dyn SandboxFactory>
-            ),
-            session_id: "sess-combined".into(),
-            profile_name: "vm0/default".into(),
-            vcpu: 2,
-            memory_mb: 2048,
-            source_ip: "10.0.0.1".into(),
-            parked_at: std::time::Instant::now(),
-            idle_timeout: std::time::Duration::from_secs(300),
-        };
-
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let outcome = execute_job_reuse(idle_entry, ctx, &config, cancel).await;
-
-        // If storage download was NOT skipped, write_file would be called for
-        // the manifest, consuming the error. Session restore's write_file would
-        // then succeed (default), and the download exec would fail — the error
-        // message would NOT contain "storage should be skipped".
-        //
-        // Since storage IS skipped, session restore is the first write_file
-        // caller, it consumes the error, and we see it in the outcome.
-        assert_eq!(outcome.exit_code, 1);
-        assert!(
-            outcome
-                .error
-                .as_ref()
-                .unwrap()
-                .contains("storage should be skipped"),
-            "session restore should have consumed the write_file error, \
-             proving it ran while storage download was skipped. Got: {:?}",
-            outcome.error,
-        );
-        assert!(outcome.sandbox.is_some());
     }
 
     #[tokio::test]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -184,10 +184,11 @@ pub struct ResumeSession {
 }
 
 impl ExecutionContext {
-    /// Extract the session ID for keep-alive VM reuse.
+    /// Extract the session ID from `resume_session` for keep-alive VM reuse.
     ///
-    /// Phase 1: only continued sessions (with `resume_session`) benefit.
-    /// Phase 2: a top-level `session_id` field will enable first-turn reuse.
+    /// Returns `Some` for continued sessions. For first runs this returns
+    /// `None`; the executor reads the CLI-generated session ID from the
+    /// guest filesystem post-execution (see `read_guest_session_id`).
     pub fn session_id(&self) -> Option<&str> {
         self.resume_session.as_ref().map(|r| r.session_id.as_str())
     }


### PR DESCRIPTION
## Summary

- After agent exits on first runs (no `resume_session`), the executor reads `/tmp/vm0-session-{run_id}.txt` from the guest via vsock exec to obtain the CLI-generated session ID
- Uses this session ID as a fallback in the parking decision, enabling first-run VMs to be parked for keep-alive
- Removes `clean_stale_guest_logs` — log files are scoped by `run_id` and don't conflict across turns

**Before**: Keep-alive reuse only possible from 3rd run onwards (1st run has no session ID → can't park)
**After**: Keep-alive reuse possible from 2nd run (1st run reads session ID from guest → parks VM)

Closes #8724

## Test plan

- [x] `cargo clippy -p runner` — clean
- [x] `cargo test -p runner` — 445 passed
- [ ] Deploy to dev and verify with two consecutive runs:
  - Run 1: check for `read guest session ID for parking` and `VM parked for keep-alive` in runner logs
  - Run 2: check for `claimed idle VM` instead of `no idle VM found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)