### PR TITLE
refactor: AP-12 batch D+E — eliminate internal imports in email, agent, session, and utility tests

### DIFF
--- a/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/composes/[id]/instructions/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import {
   createTestCompose,
   createTestVolume,
   insertOrgMembersCacheEntry,
+  createTestTarFile,
 } from "../../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -13,10 +14,9 @@ import {
 } from "../../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../../src/__tests__/clerk-mock";
 import { getInstructionsStorageName } from "@vm0/core";
-import { createSingleFileTar } from "../../../../../../../src/lib/infra/tar";
 
 function buildTarGz(filename: string, content: string): Buffer {
-  return gzipSync(createSingleFileTar(filename, Buffer.from(content, "utf-8")));
+  return gzipSync(createTestTarFile(filename, Buffer.from(content, "utf-8")));
 }
 
 const context = testContext();

--- a/turbo/apps/web/app/api/agent/sessions/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/agent/sessions/__tests__/route.test.ts
@@ -6,6 +6,7 @@ import {
   createTestRun,
   completeTestRun,
   insertOrgCacheEntry,
+  appendTestChatMessages,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -13,7 +14,6 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { appendChatMessages } from "../../../../../src/lib/zero/zero-session-service";
 
 const context = testContext();
 
@@ -35,9 +35,18 @@ describe("GET /api/agent/sessions", () => {
     const { agentSessionId } = await completeTestRun(user.userId, runId);
 
     // Append chat messages to the session so it appears in the list
-    await appendChatMessages(agentSessionId, user.userId, [
-      { role: "user", content: "Hello agent" },
-      { role: "assistant", content: "Hello user", runId },
+    await appendTestChatMessages(agentSessionId, [
+      {
+        role: "user",
+        content: "Hello agent",
+        createdAt: new Date().toISOString(),
+      },
+      {
+        role: "assistant",
+        content: "Hello user",
+        runId,
+        createdAt: new Date().toISOString(),
+      },
     ]);
 
     const request = createTestRequest(

--- a/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/agents/__tests__/route.test.ts
@@ -31,6 +31,7 @@ import {
   clearOrgMembersCacheEntry,
   insertOrgMembersCacheEntry,
   getTestComposeVersionContent,
+  createTestTarFile,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { getInstructionsStorageName } from "@vm0/core";
 import {
@@ -38,7 +39,6 @@ import {
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { createSingleFileTar } from "../../../../../src/lib/infra/tar";
 import { POST as runSchedule } from "../../schedules/run/route";
 
 const context = testContext();
@@ -609,7 +609,7 @@ describe("Zero Agents API", () => {
       });
       context.mocks.s3.downloadS3Buffer.mockResolvedValueOnce(
         gzipSync(
-          createSingleFileTar(
+          createTestTarFile(
             canonicalFilename,
             Buffer.from(instructionsContent, "utf-8"),
           ),

--- a/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat-threads/[id]/__tests__/route.test.ts
@@ -6,17 +6,15 @@ import {
   createTestCompose,
   createTestSessionWithConversation,
   createTestRunInDb,
+  appendTestChatMessages,
+  addTestRunToThread,
+  updateTestChatThreadTitle,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   uniqueId,
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
-import { appendChatMessages } from "../../../../../../src/lib/zero/zero-session-service";
-import {
-  addRunToThread,
-  updateChatThreadTitle,
-} from "../../../../../../src/lib/zero/chat-thread";
 
 const context = testContext();
 
@@ -119,8 +117,12 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     });
 
     // 4. Append chat messages with summaries to the session
-    await appendChatMessages(session.id, userId, [
-      { role: "user", content: "What files changed?" },
+    await appendTestChatMessages(session.id, [
+      {
+        role: "user",
+        content: "What files changed?",
+        createdAt: new Date().toISOString(),
+      },
       {
         role: "assistant",
         content: "Here are the changed files.",
@@ -130,11 +132,12 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
           { kind: "tool", name: "Read", input: { file_path: "src/index.ts" } },
           { kind: "tool", name: "Grep" },
         ],
+        createdAt: new Date().toISOString(),
       },
     ]);
 
     // 5. Link run to thread
-    await addRunToThread(threadId, runId, testUserId);
+    await addTestRunToThread(threadId, runId, testUserId);
 
     // 6. GET thread detail — summaries should be present
     const response = await GET(
@@ -205,7 +208,7 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     const { id: threadId } = await createResponse.json();
 
     // Update title via service (simulates what the complete webhook does)
-    await updateChatThreadTitle(threadId, "AI-Generated Title");
+    await updateTestChatThreadTitle(threadId, "AI-Generated Title");
 
     // Fetch thread detail and verify title was updated
     const response = await GET(
@@ -236,7 +239,7 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     const { id: threadId } = await createResponse.json();
 
     // Update title
-    await updateChatThreadTitle(threadId, "After AI update");
+    await updateTestChatThreadTitle(threadId, "After AI update");
 
     // List threads and verify title is reflected
     const listResponse = await listThreads(
@@ -272,7 +275,7 @@ describe("GET /api/zero/chat-threads/:id - Get Thread Detail", () => {
     });
 
     // Link run to thread
-    await addRunToThread(threadId, runId, testUserId);
+    await addTestRunToThread(threadId, runId, testUserId);
 
     // GET thread detail
     const response = await GET(

--- a/turbo/apps/web/app/api/zero/email/inbound/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/email/inbound/__tests__/route.test.ts
@@ -13,6 +13,7 @@ import {
   findTestCallbacksByRunId,
   insertOrgDefaultModelProvider,
   updateOrgDefaultAgent,
+  generateTestReplyToken,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -21,7 +22,6 @@ import {
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 import { server } from "../../../../../../src/mocks/server";
 import { http } from "../../../../../../src/__tests__/msw";
-import { generateReplyToken } from "../../../../../../src/lib/zero/email/handlers/shared";
 
 const context = testContext();
 const mockResend = vi.mocked(new Resend(""), true);
@@ -149,7 +149,7 @@ describe("POST /api/zero/email/inbound", () => {
     );
 
     // Generate a valid HMAC reply token
-    const replyToken = generateReplyToken(agentSession.id);
+    const replyToken = generateTestReplyToken(agentSession.id);
 
     // Create email thread session that links the token to the compose/session
     await createTestEmailThreadSession({
@@ -252,7 +252,7 @@ describe("POST /api/zero/email/inbound", () => {
       uniqueId("empty-agent"),
     );
     const agentSession = await createTestAgentSession(user.userId, composeId);
-    const replyToken = generateReplyToken(agentSession.id);
+    const replyToken = generateTestReplyToken(agentSession.id);
 
     await createTestEmailThreadSession({
       userId: user.userId,
@@ -355,7 +355,7 @@ describe("POST /api/zero/email/inbound", () => {
       composeId,
     );
 
-    const replyToken = generateReplyToken(agentSession.id);
+    const replyToken = generateTestReplyToken(agentSession.id);
     await createTestEmailThreadSession({
       userId: user.userId,
       agentId,
@@ -411,7 +411,7 @@ describe("POST /api/zero/email/inbound", () => {
       composeId,
     );
 
-    const replyToken = generateReplyToken(agentSession.id);
+    const replyToken = generateTestReplyToken(agentSession.id);
     await createTestEmailThreadSession({
       userId: userA.userId,
       agentId,
@@ -465,7 +465,7 @@ describe("POST /api/zero/email/inbound", () => {
       composeId,
     );
 
-    const replyToken = generateReplyToken(agentSession.id);
+    const replyToken = generateTestReplyToken(agentSession.id);
     await createTestEmailThreadSession({
       userId: user.userId,
       agentId,
@@ -1055,7 +1055,7 @@ describe("POST /api/zero/email/inbound", () => {
       user.userId,
       composeId,
     );
-    const replyToken = generateReplyToken(agentSession.id);
+    const replyToken = generateTestReplyToken(agentSession.id);
 
     await createTestEmailThreadSession({
       userId: user.userId,
@@ -1614,7 +1614,7 @@ describe("POST /api/zero/email/inbound", () => {
         user.userId,
         composeId,
       );
-      const replyToken = generateReplyToken(agentSession.id);
+      const replyToken = generateTestReplyToken(agentSession.id);
 
       await createTestEmailThreadSession({
         userId: user.userId,

--- a/turbo/apps/web/app/api/zero/skills/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/skills/__tests__/route.test.ts
@@ -13,13 +13,13 @@ import {
   seedTestCompose,
   getAgentCustomSkills,
   insertOrgMembersCacheEntry,
+  createTestTarFile,
 } from "../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
   type UserContext,
 } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import { createSingleFileTar } from "../../../../../src/lib/infra/tar";
 
 const context = testContext();
 
@@ -91,7 +91,7 @@ function mockSkillContent(
   content: string,
   extraFiles?: Array<{ path: string; size: number }>,
 ) {
-  const tarBuffer = createSingleFileTar(
+  const tarBuffer = createTestTarFile(
     "SKILL.md",
     Buffer.from(content, "utf-8"),
   );

--- a/turbo/apps/web/app/api/zero/user-preferences/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/user-preferences/__tests__/route.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { GET, POST } from "../route";
-import { createTestRequest } from "../../../../../src/__tests__/api-test-helpers";
+import {
+  createTestRequest,
+  consumeTestCaptureNetworkBodies,
+  getTestUserPreferencesAll,
+  updateTestUserPreferencesAll,
+} from "../../../../../src/__tests__/api-test-helpers";
 import { testContext } from "../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
-import {
-  consumeCaptureNetworkBodies,
-  getUserPreferences,
-  updateUserPreferences,
-} from "../../../../../src/lib/zero/user/user-preferences-service";
 
 vi.mock("@axiomhq/logging");
 
@@ -483,40 +483,52 @@ describe("consumeCaptureNetworkBodies", () => {
   it("should return false when remaining is 0", async () => {
     const user = await context.setupUser();
 
-    const consumed = await consumeCaptureNetworkBodies(user.orgId, user.userId);
+    const consumed = await consumeTestCaptureNetworkBodies(
+      user.orgId,
+      user.userId,
+    );
     expect(consumed).toBe(false);
   });
 
   it("should decrement and return true when remaining > 0", async () => {
     const user = await context.setupUser();
 
-    await updateUserPreferences(user.orgId, user.userId, {
+    await updateTestUserPreferencesAll(user.orgId, user.userId, {
       captureNetworkBodiesRemaining: 3,
     });
 
-    const consumed = await consumeCaptureNetworkBodies(user.orgId, user.userId);
+    const consumed = await consumeTestCaptureNetworkBodies(
+      user.orgId,
+      user.userId,
+    );
     expect(consumed).toBe(true);
 
-    const prefs = await getUserPreferences(user.orgId, user.userId);
+    const prefs = await getTestUserPreferencesAll(user.orgId, user.userId);
     expect(prefs.captureNetworkBodiesRemaining).toBe(2);
   });
 
   it("should decrement to zero and stop", async () => {
     const user = await context.setupUser();
 
-    await updateUserPreferences(user.orgId, user.userId, {
+    await updateTestUserPreferencesAll(user.orgId, user.userId, {
       captureNetworkBodiesRemaining: 1,
     });
 
-    const first = await consumeCaptureNetworkBodies(user.orgId, user.userId);
+    const first = await consumeTestCaptureNetworkBodies(
+      user.orgId,
+      user.userId,
+    );
     expect(first).toBe(true);
 
-    const second = await consumeCaptureNetworkBodies(user.orgId, user.userId);
+    const second = await consumeTestCaptureNetworkBodies(
+      user.orgId,
+      user.userId,
+    );
     expect(second).toBe(false);
   });
 
   it("should return false for user with no preferences row", async () => {
-    const consumed = await consumeCaptureNetworkBodies(
+    const consumed = await consumeTestCaptureNetworkBodies(
       "org_nonexistent",
       "user_nonexistent",
     );

--- a/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
@@ -2,6 +2,10 @@ import { and, eq } from "drizzle-orm";
 import type { RawPermissionPolicies } from "@vm0/core";
 import { initServices } from "../../lib/init-services";
 import {
+  addRunToThread,
+  updateChatThreadTitle,
+} from "../../lib/zero/chat-thread";
+import {
   agentComposes,
   agentComposeVersions,
 } from "../../db/schema/agent-compose";
@@ -690,4 +694,27 @@ export async function getTestAgentSessionWithConversation(
     memoryName: session.memoryName ?? null,
     chatMessages: (zeroSession?.chatMessages ?? []) as StoredChatMessage[],
   };
+}
+
+/**
+ * Link a run to a chat thread for test setup.
+ * Wraps addRunToThread from chat-thread-service.
+ */
+export async function addTestRunToThread(
+  threadId: string,
+  runId: string,
+  userId: string,
+): Promise<void> {
+  return addRunToThread(threadId, runId, userId);
+}
+
+/**
+ * Update the title of a chat thread for test setup.
+ * Wraps updateChatThreadTitle from chat-thread-service.
+ */
+export async function updateTestChatThreadTitle(
+  threadId: string,
+  title: string,
+): Promise<void> {
+  return updateChatThreadTitle(threadId, title);
 }

--- a/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/users.ts
@@ -1,5 +1,10 @@
 import { and, eq, sql } from "drizzle-orm";
 import { initServices } from "../../lib/init-services";
+import {
+  consumeCaptureNetworkBodies,
+  getUserPreferences,
+  updateUserPreferences,
+} from "../../lib/zero/user/user-preferences-service";
 import { users } from "../../db/schema/user";
 import { userCache } from "../../db/schema/user-cache";
 import { vm0ApiKeys } from "../../db/schema/vm0-api-key";
@@ -340,4 +345,53 @@ export async function getTestVoiceChatEvents(
     })
     .from(voiceChatEvents)
     .where(eq(voiceChatEvents.sessionId, sessionId));
+}
+
+/**
+ * Atomically consume one network body capture quota for testing.
+ * Wraps consumeCaptureNetworkBodies from user-preferences-service.
+ */
+export async function consumeTestCaptureNetworkBodies(
+  orgId: string,
+  userId: string,
+): Promise<boolean> {
+  return consumeCaptureNetworkBodies(orgId, userId);
+}
+
+/**
+ * Get the full user preferences object for testing.
+ * Wraps getUserPreferences from user-preferences-service.
+ */
+export async function getTestUserPreferencesAll(
+  orgId: string,
+  userId: string,
+): Promise<{
+  timezone: string | null;
+  pinnedAgentIds: string[];
+  sendMode: string;
+  captureNetworkBodiesRemaining: number;
+}> {
+  return getUserPreferences(orgId, userId);
+}
+
+/**
+ * Update user preferences for test setup.
+ * Wraps updateUserPreferences from user-preferences-service.
+ */
+export async function updateTestUserPreferencesAll(
+  orgId: string,
+  userId: string,
+  prefs: {
+    timezone?: string;
+    pinnedAgentIds?: string[];
+    sendMode?: "enter" | "cmd-enter";
+    captureNetworkBodiesRemaining?: number;
+  },
+): Promise<{
+  timezone: string | null;
+  pinnedAgentIds: string[];
+  sendMode: string;
+  captureNetworkBodiesRemaining: number;
+}> {
+  return updateUserPreferences(orgId, userId, prefs);
 }


### PR DESCRIPTION
## Summary

- Add thin wrapper helpers `addTestRunToThread` and `updateTestChatThreadTitle` to `api-test-helpers/agents.ts`
- Add thin wrapper helpers `consumeTestCaptureNetworkBodies`, `getTestUserPreferencesAll`, `updateTestUserPreferencesAll` to `api-test-helpers/users.ts`
- Update 7 test files to import from `api-test-helpers` instead of internal service modules

Closes #8635. Part of AP-12 remediation (#8441).

## Test plan

- [x] All 7 modified test files pass with no behavioral changes
- [x] Zero imports from `lib/zero/zero-session-service` in test files
- [x] Zero imports from `lib/zero/chat-thread` in test files
- [x] Zero imports from `lib/zero/user/user-preferences-service` in test files
- [x] Zero imports from `lib/infra/tar` in test files
- [x] Zero imports from `lib/zero/email/handlers/shared` in email inbound test
- [x] Lint passes (0 errors, pre-existing warnings only)
- [x] Knip passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)