### PR TITLE
perf(runner): skip storage re-download when artifact version unchanged

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -977,7 +977,7 @@ fn spawn_job(
                     source_ip,
                     parked_at: std::time::Instant::now(),
                     idle_timeout,
-                    storage_fingerprints: storage_fingerprints.clone(),
+                    storage_fingerprints,
                 };
                 match pool.park(session_id.to_string(), entry) {
                     ParkResult::Parked => {

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -898,6 +898,12 @@ fn spawn_job(
         use_snapshot: job_profile.use_snapshot,
     };
 
+    let storage_fingerprints = context
+        .storage_manifest
+        .as_ref()
+        .map(crate::idle_pool::StorageFingerprints::from_manifest)
+        .unwrap_or_default();
+
     let provider = Arc::clone(&ctx.provider);
     let exec_config = Arc::clone(&ctx.exec_config);
     let budget = Arc::clone(&ctx.budget);
@@ -971,6 +977,7 @@ fn spawn_job(
                     source_ip,
                     parked_at: std::time::Instant::now(),
                     idle_timeout,
+                    storage_fingerprints: storage_fingerprints.clone(),
                 };
                 match pool.park(session_id.to_string(), entry) {
                     ParkResult::Parked => {
@@ -1415,6 +1422,7 @@ mod tests {
             source_ip: "10.0.0.1".into(),
             parked_at: std::time::Instant::now(),
             idle_timeout: Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
         }
     }
 

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -408,9 +408,13 @@ async fn run_in_sandbox(
 
     // 3. Download storages (skipping entries unchanged since the previous turn)
     if let Some(manifest) = &context.storage_manifest {
+        let filtered;
         let effective = match prev_storage {
-            Some(prev) => filter_unchanged_storages(manifest, prev),
-            None => manifest.clone(),
+            Some(prev) => {
+                filtered = filter_unchanged_storages(manifest, prev);
+                &filtered
+            }
+            None => manifest,
         };
         // Short-circuit: skip the vsock exec if every entry was filtered out.
         let has_work = effective.storages.iter().any(|s| s.archive_url.is_some())
@@ -427,7 +431,7 @@ async fn run_in_sandbox(
         }
         let t = Instant::now();
         let result = if has_work {
-            download_storages(sandbox, context, &effective, &log_file).await
+            download_storages(sandbox, context, effective, &log_file).await
         } else {
             Ok(())
         };
@@ -916,19 +920,22 @@ fn filter_unchanged_storages(
     manifest: &StorageManifest,
     prev: &crate::idle_pool::StorageFingerprints,
 ) -> StorageManifest {
+    let mut skipped: usize = 0;
+
     let storages = manifest
         .storages
         .iter()
         .map(|s| {
-            let unchanged = s
-                .archive_url
-                .as_ref()
-                .and_then(|url| {
-                    prev.storages
-                        .get(&s.mount_path)
-                        .filter(|prev_url| *prev_url == url)
-                })
-                .is_some();
+            let unchanged = match (&s.vas_storage_name, &s.vas_version_id) {
+                (Some(name), Some(ver)) => prev
+                    .storages
+                    .get(&s.mount_path)
+                    .is_some_and(|(pn, pv)| pn == name && pv == ver),
+                _ => false, // no version info → always download
+            };
+            if unchanged {
+                skipped += 1;
+            }
             StorageEntry {
                 mount_path: s.mount_path.clone(),
                 archive_url: if unchanged {
@@ -936,31 +943,46 @@ fn filter_unchanged_storages(
                 } else {
                     s.archive_url.clone()
                 },
+                vas_storage_name: s.vas_storage_name.clone(),
+                vas_version_id: s.vas_version_id.clone(),
             }
         })
         .collect();
 
     let filter_artifact =
-        |a: &ArtifactEntry, prev_ver: &Option<(String, String)>| -> ArtifactEntry {
+        |a: &ArtifactEntry, prev_ver: &Option<(String, String)>, skipped: &mut usize| {
             let same = prev_ver
                 .as_ref()
                 .is_some_and(|(name, ver)| *name == a.vas_storage_name && *ver == a.vas_version_id);
+            if same {
+                *skipped += 1;
+            }
             ArtifactEntry {
                 archive_url: if same { None } else { a.archive_url.clone() },
                 ..a.clone()
             }
         };
 
+    let artifact = manifest
+        .artifact
+        .as_ref()
+        .map(|a| filter_artifact(a, &prev.artifact, &mut skipped));
+    let memory = manifest
+        .memory
+        .as_ref()
+        .map(|m| filter_artifact(m, &prev.memory, &mut skipped));
+
+    if skipped > 0 {
+        let total = manifest.storages.len()
+            + manifest.artifact.iter().count()
+            + manifest.memory.iter().count();
+        info!(skipped, total, "filtered unchanged storage entries");
+    }
+
     StorageManifest {
         storages,
-        artifact: manifest
-            .artifact
-            .as_ref()
-            .map(|a| filter_artifact(a, &prev.artifact)),
-        memory: manifest
-            .memory
-            .as_ref()
-            .map(|m| filter_artifact(m, &prev.memory)),
+        artifact,
+        memory,
     }
 }
 
@@ -1274,6 +1296,8 @@ mod tests {
             storages: vec![StorageEntry {
                 mount_path: "/data".into(),
                 archive_url: None,
+                vas_storage_name: None,
+                vas_version_id: None,
             }],
             artifact: Some(ArtifactEntry {
                 mount_path: "/artifacts".into(),
@@ -1875,6 +1899,8 @@ mod tests {
             storages: vec![StorageEntry {
                 mount_path: "/data".into(),
                 archive_url: Some("https://s3/archive.tar.gz".into()),
+                vas_storage_name: None,
+                vas_version_id: None,
             }],
             artifact: None,
             memory: None,
@@ -2242,6 +2268,8 @@ mod tests {
             storages: vec![StorageEntry {
                 mount_path: "/data".into(),
                 archive_url: Some("https://example.com/data.tar.gz".into()),
+                vas_storage_name: None,
+                vas_version_id: None,
             }],
             artifact: None,
             memory: None,
@@ -2749,6 +2777,8 @@ mod tests {
             storages: vec![StorageEntry {
                 mount_path: "/data".into(),
                 archive_url: Some("https://s3/data".into()),
+                vas_storage_name: Some("vol-1".into()),
+                vas_version_id: Some("v1".into()),
             }],
             artifact: Some(art("my-art", "v1", "https://s3/v1")),
             memory: Some(art("mem", "m1", "https://s3/m1")),
@@ -2766,12 +2796,14 @@ mod tests {
             storages: vec![StorageEntry {
                 mount_path: "/data".into(),
                 archive_url: Some("https://s3/same-url".into()),
+                vas_storage_name: Some("vol-1".into()),
+                vas_version_id: Some("v1".into()),
             }],
             artifact: Some(art("my-art", "v1", "https://s3/v1")),
             memory: Some(art("mem", "m1", "https://s3/m1")),
         };
         let mut storages = HashMap::new();
-        storages.insert("/data".into(), "https://s3/same-url".into());
+        storages.insert("/data".into(), ("vol-1".into(), "v1".into()));
         let prev = crate::idle_pool::StorageFingerprints {
             storages,
             artifact: Some(("my-art".into(), "v1".into())),

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -23,7 +23,7 @@ use crate::network_logs;
 use crate::paths::{LogPaths, guest};
 use crate::proxy::{self, ProxyRegistryHandle};
 use crate::telemetry::JobTelemetry;
-use crate::types::{ExecutionContext, ResumeSession, StorageManifest};
+use crate::types::{ArtifactEntry, ExecutionContext, ResumeSession, StorageEntry, StorageManifest};
 
 /// Shared configuration for all executions (profile-independent).
 pub struct ExecutorConfig {
@@ -119,6 +119,7 @@ pub async fn execute_job_reuse(
     telemetry.record("vm_reuse", Duration::ZERO, true, None);
 
     let source_ip = idle_entry.source_ip.clone();
+    let prev_storage = idle_entry.storage_fingerprints;
     let sandbox = idle_entry.sandbox;
 
     // execute_reused_sandbox never returns Err — it always returns the sandbox
@@ -128,6 +129,7 @@ pub async fn execute_job_reuse(
         &source_ip,
         &context,
         config,
+        &prev_storage,
         &mut telemetry,
         cancel,
     )
@@ -196,12 +198,13 @@ async fn execute_new_sandbox(
     }
     telemetry.record("vm_create", t.elapsed(), true, None);
 
-    // Run job inside sandbox
+    // Run job inside sandbox (new VM — no previous storage fingerprints)
     let result = run_in_sandbox(
         sandbox.as_ref(),
         context,
         config,
         params.use_snapshot,
+        None,
         telemetry,
         cancel,
     )
@@ -244,6 +247,7 @@ async fn execute_reused_sandbox(
     source_ip: &str,
     context: &ExecutionContext,
     config: &ExecutorConfig,
+    prev_storage: &crate::idle_pool::StorageFingerprints,
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
 ) -> ExecuteOutcome {
@@ -287,6 +291,7 @@ async fn execute_reused_sandbox(
         context,
         config,
         false, // clock/entropy already handled
+        Some(prev_storage),
         telemetry,
         cancel,
     )
@@ -382,6 +387,7 @@ async fn run_in_sandbox(
     context: &ExecutionContext,
     config: &ExecutorConfig,
     use_snapshot: bool,
+    prev_storage: Option<&crate::idle_pool::StorageFingerprints>,
     telemetry: &mut JobTelemetry,
     cancel: CancellationToken,
 ) -> RunnerResult<(i32, Option<String>)> {
@@ -400,10 +406,31 @@ async fn run_in_sandbox(
     // 2. Set guest timezone from user preference (best-effort, never fails).
     sync_guest_timezone(sandbox, context).await;
 
-    // 3. Download storages
+    // 3. Download storages (skipping entries unchanged since the previous turn)
     if let Some(manifest) = &context.storage_manifest {
+        let effective = match prev_storage {
+            Some(prev) => filter_unchanged_storages(manifest, prev),
+            None => manifest.clone(),
+        };
+        // Short-circuit: skip the vsock exec if every entry was filtered out.
+        let has_work = effective.storages.iter().any(|s| s.archive_url.is_some())
+            || effective
+                .artifact
+                .as_ref()
+                .is_some_and(|a| a.archive_url.is_some())
+            || effective
+                .memory
+                .as_ref()
+                .is_some_and(|m| m.archive_url.is_some());
+        if !has_work {
+            info!(run_id = %context.run_id, "all storages unchanged, skipping download");
+        }
         let t = Instant::now();
-        let result = download_storages(sandbox, context, manifest, &log_file).await;
+        let result = if has_work {
+            download_storages(sandbox, context, &effective, &log_file).await
+        } else {
+            Ok(())
+        };
         let err = result.as_ref().err().map(|e| e.to_string());
         telemetry.record(
             "storage_download",
@@ -879,6 +906,61 @@ async fn sync_guest_timezone(sandbox: &dyn Sandbox, context: &ExecutionContext) 
         .await
     {
         tracing::warn!(tz = %tz, error = %e, "failed to set guest timezone");
+    }
+}
+
+/// Filter a storage manifest by nulling `archive_url` for entries whose
+/// version matches the previous turn's fingerprints. `guest-download`
+/// skips entries without a valid URL, so unchanged storages stay on disk.
+fn filter_unchanged_storages(
+    manifest: &StorageManifest,
+    prev: &crate::idle_pool::StorageFingerprints,
+) -> StorageManifest {
+    let storages = manifest
+        .storages
+        .iter()
+        .map(|s| {
+            let unchanged = s
+                .archive_url
+                .as_ref()
+                .and_then(|url| {
+                    prev.storages
+                        .get(&s.mount_path)
+                        .filter(|prev_url| *prev_url == url)
+                })
+                .is_some();
+            StorageEntry {
+                mount_path: s.mount_path.clone(),
+                archive_url: if unchanged {
+                    None
+                } else {
+                    s.archive_url.clone()
+                },
+            }
+        })
+        .collect();
+
+    let filter_artifact =
+        |a: &ArtifactEntry, prev_ver: &Option<(String, String)>| -> ArtifactEntry {
+            let same = prev_ver
+                .as_ref()
+                .is_some_and(|(name, ver)| *name == a.vas_storage_name && *ver == a.vas_version_id);
+            ArtifactEntry {
+                archive_url: if same { None } else { a.archive_url.clone() },
+                ..a.clone()
+            }
+        };
+
+    StorageManifest {
+        storages,
+        artifact: manifest
+            .artifact
+            .as_ref()
+            .map(|a| filter_artifact(a, &prev.artifact)),
+        memory: manifest
+            .memory
+            .as_ref()
+            .map(|m| filter_artifact(m, &prev.memory)),
     }
 }
 
@@ -2282,6 +2364,7 @@ mod tests {
             source_ip: outcome.source_ip,
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
         };
 
         // Reuse the sandbox for a second turn
@@ -2325,6 +2408,7 @@ mod tests {
             source_ip: outcome.source_ip,
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
         };
 
         // Second turn: reuse with new session history
@@ -2384,6 +2468,7 @@ mod tests {
             source_ip: outcome.source_ip,
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
         };
 
         let result = pool.park("session-1".into(), entry);
@@ -2426,6 +2511,7 @@ mod tests {
             source_ip: "10.0.0.1".into(),
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
         };
         let _ = pool.park("session-1".into(), entry);
 
@@ -2459,6 +2545,7 @@ mod tests {
             source_ip: "10.0.0.1".into(),
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -2499,6 +2586,7 @@ mod tests {
             source_ip: "10.0.0.1".into(),
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -2541,6 +2629,7 @@ mod tests {
             source_ip: "10.0.0.1".into(),
             parked_at: std::time::Instant::now(),
             idle_timeout: std::time::Duration::from_secs(300),
+            storage_fingerprints: crate::idle_pool::StorageFingerprints::default(),
         };
 
         let cancel = tokio_util::sync::CancellationToken::new();
@@ -2576,5 +2665,121 @@ mod tests {
             outcome.sandbox.is_some(),
             "sandbox must be returned for caller to stop+destroy or park"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // filter_unchanged_storages tests
+    // -----------------------------------------------------------------------
+
+    fn art(name: &str, ver: &str, url: &str) -> ArtifactEntry {
+        ArtifactEntry {
+            mount_path: "/workspace".into(),
+            archive_url: Some(url.into()),
+            vas_storage_name: name.into(),
+            vas_version_id: ver.into(),
+        }
+    }
+
+    #[test]
+    fn filter_same_artifact_version_nulls_url() {
+        let manifest = StorageManifest {
+            storages: vec![],
+            artifact: Some(art("my-art", "v1", "https://s3/v1")),
+            memory: None,
+        };
+        let prev = crate::idle_pool::StorageFingerprints {
+            storages: HashMap::new(),
+            artifact: Some(("my-art".into(), "v1".into())),
+            memory: None,
+        };
+        let result = filter_unchanged_storages(&manifest, &prev);
+        assert!(result.artifact.as_ref().unwrap().archive_url.is_none());
+    }
+
+    #[test]
+    fn filter_different_artifact_version_keeps_url() {
+        let manifest = StorageManifest {
+            storages: vec![],
+            artifact: Some(art("my-art", "v2", "https://s3/v2")),
+            memory: None,
+        };
+        let prev = crate::idle_pool::StorageFingerprints {
+            storages: HashMap::new(),
+            artifact: Some(("my-art".into(), "v1".into())),
+            memory: None,
+        };
+        let result = filter_unchanged_storages(&manifest, &prev);
+        assert_eq!(
+            result.artifact.as_ref().unwrap().archive_url.as_deref(),
+            Some("https://s3/v2"),
+        );
+    }
+
+    #[test]
+    fn filter_different_artifact_name_keeps_url() {
+        let manifest = StorageManifest {
+            storages: vec![],
+            artifact: Some(art("other-art", "v1", "https://s3/v1")),
+            memory: None,
+        };
+        let prev = crate::idle_pool::StorageFingerprints {
+            storages: HashMap::new(),
+            artifact: Some(("my-art".into(), "v1".into())),
+            memory: None,
+        };
+        let result = filter_unchanged_storages(&manifest, &prev);
+        assert!(result.artifact.as_ref().unwrap().archive_url.is_some());
+    }
+
+    #[test]
+    fn filter_new_artifact_not_in_prev_keeps_url() {
+        let manifest = StorageManifest {
+            storages: vec![],
+            artifact: Some(art("my-art", "v1", "https://s3/v1")),
+            memory: None,
+        };
+        let prev = crate::idle_pool::StorageFingerprints::default();
+        let result = filter_unchanged_storages(&manifest, &prev);
+        assert!(result.artifact.as_ref().unwrap().archive_url.is_some());
+    }
+
+    #[test]
+    fn filter_empty_prev_downloads_everything() {
+        let manifest = StorageManifest {
+            storages: vec![StorageEntry {
+                mount_path: "/data".into(),
+                archive_url: Some("https://s3/data".into()),
+            }],
+            artifact: Some(art("my-art", "v1", "https://s3/v1")),
+            memory: Some(art("mem", "m1", "https://s3/m1")),
+        };
+        let prev = crate::idle_pool::StorageFingerprints::default();
+        let result = filter_unchanged_storages(&manifest, &prev);
+        assert!(result.storages[0].archive_url.is_some());
+        assert!(result.artifact.as_ref().unwrap().archive_url.is_some());
+        assert!(result.memory.as_ref().unwrap().archive_url.is_some());
+    }
+
+    #[test]
+    fn filter_all_unchanged_nulls_all_urls() {
+        let manifest = StorageManifest {
+            storages: vec![StorageEntry {
+                mount_path: "/data".into(),
+                archive_url: Some("https://s3/same-url".into()),
+            }],
+            artifact: Some(art("my-art", "v1", "https://s3/v1")),
+            memory: Some(art("mem", "m1", "https://s3/m1")),
+        };
+        let mut storages = HashMap::new();
+        storages.insert("/data".into(), "https://s3/same-url".into());
+        let prev = crate::idle_pool::StorageFingerprints {
+            storages,
+            artifact: Some(("my-art".into(), "v1".into())),
+            memory: Some(("mem".into(), "m1".into())),
+        };
+        let result = filter_unchanged_storages(&manifest, &prev);
+        assert!(result.storages[0].archive_url.is_none());
+        assert!(result.artifact.as_ref().unwrap().archive_url.is_none());
+        assert!(result.memory.as_ref().unwrap().archive_url.is_none());
     }
 }

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -4,8 +4,41 @@ use std::time::{Duration, Instant};
 
 use sandbox::{Sandbox, SandboxFactory};
 
+use crate::types::{ArtifactEntry, StorageManifest};
+
 /// Default idle timeout for kept-alive VMs (5 minutes).
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 300;
+
+/// Compact version fingerprints for storage manifest entries.
+/// Used to skip re-downloading unchanged storages on VM reuse.
+#[derive(Clone, Debug, Default)]
+pub struct StorageFingerprints {
+    /// mount_path → archive_url for regular storages.
+    pub storages: HashMap<String, String>,
+    /// (vas_storage_name, vas_version_id) for artifact.
+    pub artifact: Option<(String, String)>,
+    /// (vas_storage_name, vas_version_id) for memory.
+    pub memory: Option<(String, String)>,
+}
+
+impl StorageFingerprints {
+    pub fn from_manifest(manifest: &StorageManifest) -> Self {
+        let mut storages = HashMap::new();
+        for s in &manifest.storages {
+            if let Some(url) = &s.archive_url {
+                storages.insert(s.mount_path.clone(), url.clone());
+            }
+        }
+        fn version_tuple(entry: &ArtifactEntry) -> (String, String) {
+            (entry.vas_storage_name.clone(), entry.vas_version_id.clone())
+        }
+        Self {
+            storages,
+            artifact: manifest.artifact.as_ref().map(version_tuple),
+            memory: manifest.memory.as_ref().map(version_tuple),
+        }
+    }
+}
 
 /// Configuration for the idle sandbox pool.
 #[derive(Debug, Clone)]
@@ -39,6 +72,9 @@ pub struct IdleEntry {
     pub source_ip: String,
     pub parked_at: Instant,
     pub idle_timeout: Duration,
+    /// Version fingerprints of storages downloaded in the previous turn.
+    /// Used to skip re-downloading unchanged entries on reuse.
+    pub storage_fingerprints: StorageFingerprints,
 }
 
 impl IdleEntry {
@@ -184,6 +220,7 @@ mod tests {
             source_ip: "10.0.0.1".into(),
             parked_at: Instant::now(),
             idle_timeout: Duration::from_secs(300),
+            storage_fingerprints: StorageFingerprints::default(),
         }
     }
 
@@ -203,6 +240,7 @@ mod tests {
             source_ip: "10.0.0.1".into(),
             parked_at,
             idle_timeout,
+            storage_fingerprints: StorageFingerprints::default(),
         }
     }
 

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -4,17 +4,21 @@ use std::time::{Duration, Instant};
 
 use sandbox::{Sandbox, SandboxFactory};
 
-use crate::types::{ArtifactEntry, StorageManifest};
+use crate::types::StorageManifest;
 
 /// Default idle timeout for kept-alive VMs (5 minutes).
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 300;
 
 /// Compact version fingerprints for storage manifest entries.
 /// Used to skip re-downloading unchanged storages on VM reuse.
+///
+/// All comparisons use `(vas_storage_name, vas_version_id)` tuples.
+/// For regular storages without version fields, the entry is omitted
+/// from the map and will always be re-downloaded.
 #[derive(Clone, Debug, Default)]
 pub struct StorageFingerprints {
-    /// mount_path → archive_url for regular storages.
-    pub storages: HashMap<String, String>,
+    /// mount_path → (vas_storage_name, vas_version_id) for regular storages.
+    pub storages: HashMap<String, (String, String)>,
     /// (vas_storage_name, vas_version_id) for artifact.
     pub artifact: Option<(String, String)>,
     /// (vas_storage_name, vas_version_id) for memory.
@@ -25,12 +29,12 @@ impl StorageFingerprints {
     pub fn from_manifest(manifest: &StorageManifest) -> Self {
         let mut storages = HashMap::new();
         for s in &manifest.storages {
-            if let Some(url) = &s.archive_url {
-                storages.insert(s.mount_path.clone(), url.clone());
+            if let (Some(name), Some(ver)) = (&s.vas_storage_name, &s.vas_version_id) {
+                storages.insert(s.mount_path.clone(), (name.clone(), ver.clone()));
             }
         }
-        fn version_tuple(entry: &ArtifactEntry) -> (String, String) {
-            (entry.vas_storage_name.clone(), entry.vas_version_id.clone())
+        fn version_tuple(e: &crate::types::ArtifactEntry) -> (String, String) {
+            (e.vas_storage_name.clone(), e.vas_version_id.clone())
         }
         Self {
             storages,

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -165,6 +165,10 @@ pub struct StorageEntry {
     pub mount_path: String,
     #[serde(default)]
     pub archive_url: Option<String>,
+    #[serde(default)]
+    pub vas_storage_name: Option<String>,
+    #[serde(default)]
+    pub vas_version_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -149,7 +149,7 @@ pub struct GrantedPermission {
     pub unknown_policy: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StorageManifest {
     pub storages: Vec<StorageEntry>,
@@ -159,7 +159,7 @@ pub struct StorageManifest {
     pub memory: Option<ArtifactEntry>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StorageEntry {
     pub mount_path: String,
@@ -167,7 +167,7 @@ pub struct StorageEntry {
     pub archive_url: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ArtifactEntry {
     pub mount_path: String,


### PR DESCRIPTION
## Summary

- Store storage version fingerprints (`vas_version_id` for artifact/memory, `archive_url` for volumes) in `IdleEntry` when parking a VM
- On reuse, compare fingerprints with the new execution context and null out `archive_url` for unchanged entries
- `guest-download` already skips entries without a valid URL — zero guest-side changes
- When all entries are unchanged, short-circuit the entire download step (no vsock exec)

**Before**: Every reuse re-downloads all storages (~4s for 164 items)
**After**: Unchanged storages skipped; only changed entries downloaded. Common case (same artifact) saves ~4s per reuse.

Closes #8737
Depends on #8731

## Test plan

- [x] `cargo clippy -p runner` — clean
- [x] `cargo test -p runner` — 449 passed (6 new filter tests)
- [ ] E2E: `runner-keep-alive` — no manifest, no fingerprints, filesystem persists
- [ ] E2E: `t06-vm0-agent-session` — artifact version changes between turns, detected and re-downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)