### PR TITLE
feat(voice-chat): add proactive injection of slow-brain events into realtime data channel

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -128,6 +128,17 @@ function logContextEvent(
   );
 }
 
+function formatInjectionMessage(event: ContextEvent): string {
+  const prefixes: Record<string, string> = {
+    directive: "[Your background thinking completed]",
+    "thinking-progress": "[Your background self is working]",
+    "thinking-result": "[Background result]",
+    observation: "[Background observation]",
+  };
+  const label = prefixes[event.type] ?? `[Background update - ${event.type}]`;
+  return `${label} ${event.content ?? ""}`.trim();
+}
+
 // --- Internal state ---
 
 const internalStatus$ = state<ConnectionStatus>("idle");
@@ -343,6 +354,48 @@ const handleDCMessage$ = command(
   },
 );
 
+const injectSlowBrainEvents$ = command(
+  ({ get, set }, events: ContextEvent[]) => {
+    const dc = get(internalDc$);
+    if (!dc || dc.readyState !== "open") {
+      return;
+    }
+
+    const slowBrainEvents = events.filter((e) => {
+      return e.source === "slow-brain" && e.content;
+    });
+    if (slowBrainEvents.length === 0) {
+      return;
+    }
+
+    // Interrupt if model is mid-speech
+    const current = get(internalCurrentAssistant$);
+    if (current) {
+      dc.send(JSON.stringify({ type: "response.cancel" }));
+      set(internalCurrentAssistant$, null);
+    }
+
+    // Inject each event as a user message
+    for (const event of slowBrainEvents) {
+      dc.send(
+        JSON.stringify({
+          type: "conversation.item.create",
+          item: {
+            type: "message",
+            role: "user",
+            content: [
+              { type: "input_text", text: formatInjectionMessage(event) },
+            ],
+          },
+        }),
+      );
+    }
+
+    // Trigger model to respond to injected content
+    dc.send(JSON.stringify({ type: "response.create" }));
+  },
+);
+
 const setupWebRTC$ = command(
   async (
     { get, set },
@@ -497,6 +550,7 @@ const startPoll$ = command(async ({ get, set }, signal: AbortSignal) => {
         if (lastEvent) {
           set(internalLastSeq$, lastEvent.seq);
         }
+        set(injectSlowBrainEvents$, data.events);
       }
       return false;
     },


### PR DESCRIPTION
## Summary

- Add proactive injection logic to the voice chat polling loop so slow-brain events are automatically injected into the OpenAI Realtime data channel
- When the model is mid-speech and a slow-brain event arrives, it is interrupted via `response.cancel` before injection
- Each slow-brain event is injected as a `conversation.item.create` user message with type-specific prefixes, followed by a single `response.create`

## Changes

**Single file:** `turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts`

1. **`formatInjectionMessage()`** — Pure function that formats a `ContextEvent` into a human-readable injection message with type-specific prefixes (directive, thinking-progress, thinking-result, observation)
2. **`injectSlowBrainEvents$`** — New ccstate command that filters for slow-brain events, optionally cancels mid-speech responses, injects events into the data channel, and triggers a new model response
3. **Integration in `startPoll$`** — One-line addition calling `injectSlowBrainEvents$` after updating UI events and sequence tracking

## Test plan

- [ ] `grep "response.cancel"` finds it in the injection logic
- [ ] `grep "conversation.item.create"` finds both existing function_call_output AND new injection usage
- [ ] Lint, type-check, format pass
- [ ] All existing platform tests pass (1611 tests)
- [ ] Manual: Start voice chat → slow brain writes directive → Talker responds without calling `read_shared_context`
- [ ] Manual: Talker mid-speech when directive arrives → interrupted and responds to directive

Closes #8744

🤖 Generated with [Claude Code](https://claude.com/claude-code)