### PR TITLE
fix(ci): pass plain api key in ci workflows and env template

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -328,6 +328,7 @@ jobs:
             CLERK_WEBHOOK_SIGNING_SECRET=${{ secrets.CLERK_WEBHOOK_SIGNING_SECRET }}
             ZERO_PRICE=${{ secrets.ZERO_PRICE }}
             AGENTPHONE_API_KEY=${{ secrets.AGENTPHONE_API_KEY }}
+            PLAIN_API_KEY=${{ secrets.PLAIN_API_KEY }}
             NGROK_API_KEY=${{ secrets.NGROK_API_KEY }}
             NGROK_COMPUTER_CONNECTOR_DOMAIN=${{ vars.NGROK_COMPUTER_CONNECTOR_DOMAIN }}
             APP_URL=https://app.vm0.ai

--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -690,6 +690,7 @@ jobs:
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           ZERO_PRICE: ${{ secrets.ZERO_PRICE }}
           AGENTPHONE_API_KEY: ${{ secrets.AGENTPHONE_API_KEY }}
+          PLAIN_API_KEY: ${{ secrets.PLAIN_API_KEY }}
           NGROK_API_KEY: ${{ secrets.NGROK_API_KEY }}
           NGROK_COMPUTER_CONNECTOR_DOMAIN: ${{ vars.NGROK_COMPUTER_CONNECTOR_DOMAIN }}
           APP_URL: ${{ needs.prepare.outputs.app-preview-url }}
@@ -896,6 +897,7 @@ jobs:
             STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }}
             STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }}
             ZERO_PRICE=${{ secrets.ZERO_PRICE }}
+            PLAIN_API_KEY=${{ secrets.PLAIN_API_KEY }}
             NGROK_API_KEY=${{ secrets.NGROK_API_KEY }}
             NGROK_COMPUTER_CONNECTOR_DOMAIN=${{ vars.NGROK_COMPUTER_CONNECTOR_DOMAIN }}
             APP_URL=${{ needs.prepare.outputs.app-preview-url }}

--- a/turbo/apps/web/.env.local.tpl
+++ b/turbo/apps/web/.env.local.tpl
@@ -145,6 +145,9 @@ ZERO_PRICE=op://Development/stripe/ZERO_PRICE
 # Optional: AgentPhone (Phone Channel)
 AGENTPHONE_API_KEY=op://Development/agentphone/AGENTPHONE_API_KEY
 
+# Optional: Plain.com (Developer Support)
+PLAIN_API_KEY=op://Development/plain/PLAIN_API_KEY
+
 # Optional: ngrok (Computer Connector)
 NGROK_API_KEY=op://Development/ngrok/NGROK_API_KEY
 NGROK_COMPUTER_CONNECTOR_DOMAIN=computer.vm7.io


### PR DESCRIPTION
## Summary

- Add `PLAIN_API_KEY` to `turbo.yml` (test and deploy jobs) and `release-please.yml` so CI can pass the secret to the app
- Add `PLAIN_API_KEY` entry to `.env.local.tpl` for local development setup

Missed in #8735.

## Test plan

- [ ] Verify CI workflows pass with the new env var
- [ ] Verify `script/sync-env.sh` picks up the new entry from `.env.local.tpl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)