### PR TITLE
fix(platform): pass explicit locale to all date formatting calls

### DIFF
--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -1042,7 +1042,7 @@ function DaySection({
 
 /** Format an ISO timestamp as a locale-aware absolute time. */
 function formatAbsoluteTime(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
+  return new Date(iso).toLocaleString("en-US", {
     month: "short",
     day: "numeric",
     hour: "numeric",

--- a/turbo/apps/platform/src/views/org/__tests__/org-invoices-tab.test.tsx
+++ b/turbo/apps/platform/src/views/org/__tests__/org-invoices-tab.test.tsx
@@ -112,7 +112,7 @@ describe("invoice list display", () => {
 // ORG-D-060
 it("formats date and amount correctly", async () => {
   const timestamp = 1_700_000_000;
-  const expectedDate = new Date(timestamp * 1000).toLocaleDateString();
+  const expectedDate = new Date(timestamp * 1000).toLocaleDateString("en-US");
   mockAPIs();
   server.use(
     http.get("*/api/zero/billing/invoices", () => {

--- a/turbo/apps/platform/src/views/usage-page/usage-page.tsx
+++ b/turbo/apps/platform/src/views/usage-page/usage-page.tsx
@@ -6,7 +6,7 @@ function formatNumber(n: number): string {
 }
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
+  return new Date(iso).toLocaleDateString("en-US", {
     year: "numeric",
     month: "short",
     day: "numeric",

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-billing-tab.tsx
@@ -498,8 +498,8 @@ export function OrgBillingTab() {
   const periodLabel =
     periodEnd !== undefined && periodEnd !== null && periodEnd !== ""
       ? isCancelling
-        ? `Ends on ${new Date(periodEnd).toLocaleDateString()}`
-        : `Renews ${new Date(periodEnd).toLocaleDateString()}`
+        ? `Ends on ${new Date(periodEnd).toLocaleDateString("en-US")}`
+        : `Renews ${new Date(periodEnd).toLocaleDateString("en-US")}`
       : null;
 
   const handleDowngrade = () => {
@@ -577,7 +577,7 @@ export function OrgBillingTab() {
                     <p className="text-[13px] text-amber-600 dark:text-amber-400">
                       Your {formatTierLabel(currentTier)} plan has been
                       cancelled and will end on{" "}
-                      {new Date(periodEnd).toLocaleDateString()}.
+                      {new Date(periodEnd).toLocaleDateString("en-US")}.
                     </p>
                   </div>
                 </>

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-invoices-tab.tsx
@@ -14,7 +14,7 @@ const cardBorder = { border: "0.7px solid hsl(var(--gray-400))" } as const;
 const ROW_GRID = "grid grid-cols-[1fr_8rem_6rem_3rem] gap-x-6 items-center";
 
 function formatDate(unixTimestamp: number): string {
-  return new Date(unixTimestamp * 1000).toLocaleDateString();
+  return new Date(unixTimestamp * 1000).toLocaleDateString("en-US");
 }
 
 function formatAmount(cents: number): string {

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -153,7 +153,9 @@ function CreditUsageBar({
                 />
                 <span className="text-orange-600 dark:text-orange-400">
                   Expiring on{" "}
-                  {new Date(creditExpiry.nextExpiryDate).toLocaleDateString()}
+                  {new Date(creditExpiry.nextExpiryDate).toLocaleDateString(
+                    "en-US",
+                  )}
                 </span>
                 <span className="tabular-nums text-orange-600 dark:text-orange-400">
                   {creditExpiry.expiringNextCycle.toLocaleString()}


### PR DESCRIPTION
## Summary

- All `toLocaleDateString()` and `toLocaleString(undefined, ...)` calls now pass `"en-US"` as the locale parameter
- Affects: Insights page, Usage page, Billing tab, Invoices tab, Usage tab
- Prevents dates from rendering in Chinese format (e.g. "4月9日") on non-English locale systems

Fixes #8751

## Test plan

- [x] All 194 platform test files pass (1611 tests)
- [x] Type check passes
- [x] Lint + format clean
- [ ] Manual: open Insights page with Chinese locale browser → dates show English format (e.g. "Apr 9, 8:00 PM")

🤖 Generated with [Claude Code](https://claude.com/claude-code)