### PR TITLE
fix(web): always include error-report url in failed run error message

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -5,6 +5,7 @@ import {
   createTestRequest,
   createTestCompose,
   createTestRun,
+  createTestRunInDb,
   createTestSandboxToken,
   completeTestRun,
   createTestSchedule,
@@ -352,19 +353,25 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(session!.memoryName).toBe("persist-memory");
     });
 
-    it("should handle failed completion (exitCode≠0)", async () => {
+    it("should store error with report URL on failed completion", async () => {
+      // Create run directly in DB in running state to avoid runner_job_queue issues
+      const { runId } = await createTestRunInDb(user.userId, testComposeId, {
+        status: "running",
+        prompt: "Test prompt",
+      });
+      const token = await createTestSandboxToken(user.userId, runId);
+
       const request = createTestRequest(
         "http://localhost:3000/api/webhooks/agent/complete",
         {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${testToken}`,
+            Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({
-            runId: testRunId,
+            runId,
             exitCode: 1,
-            error: "Agent crashed",
           }),
         },
       );
@@ -375,21 +382,32 @@ describe("POST /api/webhooks/agent/complete", () => {
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.status).toBe("failed");
+
+      // Verify stored error contains report URL
+      const run = await findTestRunRecord(runId);
+      expect(run!.error).toContain(`/runs/${runId}/report-error`);
     });
 
-    it("should use default error message when exitCode≠0 and no error provided", async () => {
+    it("should ignore body.error and always use report URL", async () => {
+      // Create run directly in DB in running state to avoid runner_job_queue issues
+      const { runId } = await createTestRunInDb(user.userId, testComposeId, {
+        status: "running",
+        prompt: "Test prompt",
+      });
+      const token = await createTestSandboxToken(user.userId, runId);
+
       const request = createTestRequest(
         "http://localhost:3000/api/webhooks/agent/complete",
         {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            Authorization: `Bearer ${testToken}`,
+            Authorization: `Bearer ${token}`,
           },
           body: JSON.stringify({
-            runId: testRunId,
+            runId,
             exitCode: 127,
-            // no error provided
+            error: "Agent crashed with custom message",
           }),
         },
       );
@@ -400,6 +418,11 @@ describe("POST /api/webhooks/agent/complete", () => {
       const data = await response.json();
       expect(data.success).toBe(true);
       expect(data.status).toBe("failed");
+
+      // body.error should be ignored; stored error should contain report URL
+      const run = await findTestRunRecord(runId);
+      expect(run!.error).not.toContain("Agent crashed with custom message");
+      expect(run!.error).toContain(`/runs/${runId}/report-error`);
     });
   });
 

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -215,9 +215,7 @@ const router = tsr.router(webhookCompleteContract, {
     } else {
       // Failure: store error in run table
       const reportUrl = `${env().NEXT_PUBLIC_APP_URL}/runs/${body.runId}/report-error`;
-      const errorMessage =
-        body.error ||
-        `An unexpected error occurred. [Report this issue](${reportUrl})`;
+      const errorMessage = `An unexpected error occurred. [Report this issue](${reportUrl})`;
 
       const transitioned = await transitionRunStatus(
         body.runId,
@@ -246,7 +244,7 @@ const router = tsr.router(webhookCompleteContract, {
     // Dispatch all registered callbacks and drain run queue (non-blocking)
     const errorMsg =
       finalStatus === "failed"
-        ? (body.error ?? `Agent exited with code ${body.exitCode}`)
+        ? `Agent exited with code ${body.exitCode}`
         : undefined;
     scheduleTerminalSideEffects(body.runId, finalStatus, run.orgId, errorMsg);
 


### PR DESCRIPTION
## Summary
- Stop using `body.error` from runner when a run fails — previously this would override the error message and omit the error-report URL
- Failed runs now always store the error-report link in the error message so users can report issues
- Callback error message now uses `Agent exited with code {exitCode}` instead of `body.error`

## Test plan
- [x] Added test: `should store error with report URL on failed completion` — verifies error message contains report URL
- [x] Added test: `should ignore body.error and always use report URL` — verifies `body.error` is not used even when provided
- [x] Both new tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)