### PR TITLE
fix(e2e): accept legal consent checkbox in browser sign-up test

### DIFF
--- a/e2e/helpers/browser.bash
+++ b/e2e/helpers/browser.bash
@@ -100,6 +100,21 @@ full_snapshot() {
 }
 
 # ---------------------------------------------------------------------------
+# accept_legal_consent — Check legal consent checkbox if present
+# Clerk renders this when legal_consent_enabled is on. Safe to call always.
+# ---------------------------------------------------------------------------
+accept_legal_consent() {
+  local snap_i
+  snap_i=$(agent-browser snapshot -i 2>/dev/null || true)
+  local ref
+  ref=$(echo "$snap_i" | grep -iE 'checkbox.*(terms|legal|agree|privacy|consent)' | grep -oE '\[ref=e[0-9]+\]' | head -1 | sed 's/\[ref=/@/; s/\]//')
+  if [[ -n "$ref" ]]; then
+    agent-browser click "$ref" 2>/dev/null || true
+    agent-browser wait 300
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # click_continue — Click form "Continue" button (not "Continue with Google")
 # ---------------------------------------------------------------------------
 click_continue() {

--- a/e2e/tests/02-browser/brw-t01-platform-e2e.bats
+++ b/e2e/tests/02-browser/brw-t01-platform-e2e.bats
@@ -68,6 +68,7 @@ teardown_file() {
   agent-browser wait 500
   agent-browser find label "Password" fill "$SIGNUP_PASSWORD"
   agent-browser wait 500
+  accept_legal_consent
   click_continue
   agent-browser wait 5000
   step_screenshot "after-sign-up-continue"


### PR DESCRIPTION
## Summary
- Add `accept_legal_consent` helper to `e2e/helpers/browser.bash` that finds and clicks the Clerk legal consent checkbox if present (no-ops if absent)
- Call it in the sign-up test after filling email + password, before clicking Continue

Closes #8716

## Test plan
- [ ] e2e-browser CI passes with the legal consent checkbox enabled
- [ ] Safe to run when checkbox is not present (no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)