### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -91,7 +91,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.97"
+CLAUDE_CODE_VERSION="2.1.98"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.25.3"


### PR DESCRIPTION
## Summary

Updated pinned package versions in `crates/runner/scripts/build-rootfs.sh`:

- **claude-code**: `2.1.97` → `2.1.98`

All other pinned versions are already at the latest:
- Go: `1.26.2` (latest)
- `@googleworkspace/cli`: `0.22.5` (latest)
- `@xdevplatform/xurl`: `1.0.3` (latest)
- `agent-browser`: `0.25.3` (latest)

---
🤖 Generated by Zero (automated daily check)