### PR TITLE
feat: add unified tasks endpoint for mission control

### DIFF
--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -46,6 +46,7 @@ import { setupSkeletonPage$, setupErrorPage$ } from "./skeleton-page-setup.ts";
 import { startSkeletonCycling$ } from "./app-skeleton.ts";
 import { throwIfNotAbort } from "./utils.ts";
 import { pollUserInvitations$ } from "./user-invitations.ts";
+import { setupMissionControlPage$ } from "./mission-control-page/mission-control-page.ts";
 
 /**
  * Catch-all fallback — redirects unknown paths to /.
@@ -201,6 +202,10 @@ const ROUTE_CONFIG = [
   {
     path: ROUTES.internalConnectorLogos,
     setup: setupInternalConnectorLogos$,
+  },
+  {
+    path: ROUTES.missionControl,
+    setup: setupAuthPageWrapper(setupMissionControlPage$),
   },
   {
     path: ROUTES.skeleton,

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-page.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-page.ts
@@ -1,0 +1,24 @@
+import { command } from "ccstate";
+import { updatePage$ } from "../react-router";
+import { createElement } from "react";
+import { updateDocumentTitle$ } from "../document-title";
+import { SidebarLayout } from "../../views/zero-page/sidebar-layout";
+import { MissionControlPage } from "../../views/mission-control-page/mission-control-page";
+import { hideAppSkeleton$ } from "../app-skeleton";
+import { onboardGuard$ } from "../zero-page/onboard-guard";
+
+export const setupMissionControlPage$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    set(
+      updatePage$,
+      createElement(SidebarLayout, null, createElement(MissionControlPage)),
+    );
+
+    set(updateDocumentTitle$, "MissionControl");
+    await set(hideAppSkeleton$, signal);
+
+    if (await set(onboardGuard$, signal)) {
+      return;
+    }
+  },
+);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -32,6 +32,7 @@ export const ROUTES = {
   reportError: "/runs/:runId/report-error",
   skeleton: "/_/skeleton",
   error: "/_/error",
+  missionControl: "/_/mission-control",
 } as const;
 
 export type RouteKey = keyof typeof ROUTES;

--- a/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
@@ -1,0 +1,3 @@
+export function MissionControlPage() {
+  return <div>MissionControl</div>;
+}

--- a/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
@@ -247,14 +247,14 @@ describe("GET /api/zero/tasks", () => {
 
     expect(response.status).toBe(200);
     expect(
-      data.tasks.some(
-        (t: Record<string, unknown>) => t.title === "User1 Thread",
-      ),
+      data.tasks.some((t: Record<string, unknown>) => {
+        return t.title === "User1 Thread";
+      }),
     ).toBe(true);
     expect(
-      data.tasks.some(
-        (t: Record<string, unknown>) => t.title === "User2 Thread",
-      ),
+      data.tasks.some((t: Record<string, unknown>) => {
+        return t.title === "User2 Thread";
+      }),
     ).toBe(false);
   });
 
@@ -276,9 +276,9 @@ describe("GET /api/zero/tasks", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    const scheduleTasks = data.tasks.filter(
-      (t: Record<string, unknown>) => t.type === "schedule",
-    );
+    const scheduleTasks = data.tasks.filter((t: Record<string, unknown>) => {
+      return t.type === "schedule";
+    });
     expect(scheduleTasks).toHaveLength(1);
     expect(scheduleTasks[0].title).toBe("agent1-schedule");
   });

--- a/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { GET } from "../route";
+import {
+  createTestRequest,
+  createTestCompose,
+  createTestZeroAgent,
+  createTestAgentSession,
+  createTestRunInDb,
+  addTestRunToThread,
+  insertTestChatThread,
+  getTestAgentComposeName,
+  createTestSchedule,
+  insertTestSlackOrgInstallation,
+  insertTestSlackOrgConnection,
+  insertTestSlackOrgThreadSession,
+  createTestEmailThreadSession,
+  generateTestReplyToken,
+} from "../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+  type UserContext,
+} from "../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../src/__tests__/clerk-mock";
+
+const context = testContext();
+
+describe("GET /api/zero/tasks", () => {
+  let user: UserContext;
+
+  beforeEach(async () => {
+    context.setupMocks();
+    user = await context.setupUser();
+  });
+
+  it("should require authentication", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return empty tasks array when no data exists", async () => {
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.tasks).toEqual([]);
+  });
+
+  it("should return chat thread tasks with agent info and latest run", async () => {
+    const { composeId } = await createTestCompose(uniqueId("chat-task"));
+    const agentName = await getTestAgentComposeName(composeId);
+    await createTestZeroAgent(user.orgId, agentName, {
+      displayName: "My Agent",
+    });
+
+    // Create a chat thread
+    const threadId = await insertTestChatThread(
+      user.userId,
+      composeId,
+      "Test Chat",
+    );
+
+    // Create a run and link it to the thread
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      status: "completed",
+    });
+    await addTestRunToThread(threadId, runId, user.userId);
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.tasks).toHaveLength(1);
+
+    const task = data.tasks[0];
+    expect(task.type).toBe("chat");
+    expect(task.title).toBe("Test Chat");
+    expect(task.chatThreadId).toBe(threadId);
+    expect(task.agent.id).toBe(composeId);
+    expect(task.agent.displayName).toBe("My Agent");
+    expect(task.latestRunId).toBe(runId);
+    expect(task.status).toBe("completed");
+  });
+
+  it("should return schedule tasks with latest run", async () => {
+    const { composeId } = await createTestCompose(uniqueId("sched-task"));
+
+    const schedule = await createTestSchedule(composeId, "daily-check", {
+      cronExpression: "0 0 * * *",
+      prompt: "Run daily check",
+    });
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const schedTask = data.tasks.find((t: Record<string, unknown>) => {
+      return t.type === "schedule";
+    });
+    expect(schedTask).toBeDefined();
+    expect(schedTask.title).toBe("daily-check");
+    expect(schedTask.scheduleId).toBe(schedule.id);
+    expect(schedTask.latestRunId).toBeNull();
+    expect(schedTask.status).toBeNull();
+  });
+
+  it("should return slack thread tasks", async () => {
+    const { composeId } = await createTestCompose(uniqueId("slack-task"));
+
+    // Create slack installation + connection
+    const slackWorkspaceId = uniqueId("ws");
+    await insertTestSlackOrgInstallation({
+      slackWorkspaceId,
+      slackWorkspaceName: "Test Workspace",
+      orgId: user.orgId,
+      installedByUserId: user.userId,
+    });
+    const { id: connectionId } = await insertTestSlackOrgConnection({
+      slackUserId: uniqueId("slack-user"),
+      slackWorkspaceId,
+      vm0UserId: user.userId,
+    });
+
+    // Create agent session + slack thread session
+    const session = await createTestAgentSession(user.userId, composeId);
+    const { id: slackThreadId } = await insertTestSlackOrgThreadSession({
+      connectionId,
+      agentSessionId: session.id,
+    });
+
+    // Create a run linked to the session
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      status: "running",
+      continuedFromSessionId: session.id,
+      triggerSource: "slack",
+    });
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const slackTask = data.tasks.find((t: Record<string, unknown>) => {
+      return t.type === "slack";
+    });
+    expect(slackTask).toBeDefined();
+    expect(slackTask.slackThreadSessionId).toBe(slackThreadId);
+    expect(slackTask.latestRunId).toBe(runId);
+    expect(slackTask.status).toBe("running");
+  });
+
+  it("should return email thread tasks", async () => {
+    const { composeId } = await createTestCompose(uniqueId("email-task"));
+
+    // Create agent session for email
+    const session = await createTestAgentSession(user.userId, composeId);
+
+    // Create email thread session
+    const replyToken = generateTestReplyToken(session.id);
+    const emailThread = await createTestEmailThreadSession({
+      userId: user.userId,
+      agentId: composeId,
+      agentSessionId: session.id,
+      replyToToken: replyToken,
+    });
+
+    // Create a run linked to the session
+    const { runId } = await createTestRunInDb(user.userId, composeId, {
+      status: "completed",
+      continuedFromSessionId: session.id,
+      triggerSource: "email",
+    });
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const emailTask = data.tasks.find((t: Record<string, unknown>) => {
+      return t.type === "email";
+    });
+    expect(emailTask).toBeDefined();
+    expect(emailTask.emailThreadSessionId).toBe(emailThread.id);
+    expect(emailTask.latestRunId).toBe(runId);
+    expect(emailTask.status).toBe("completed");
+  });
+
+  it("should filter by agentId", async () => {
+    const { composeId: agent1 } = await createTestCompose(uniqueId("agent-1"));
+    const { composeId: agent2 } = await createTestCompose(uniqueId("agent-2"));
+
+    await insertTestChatThread(user.userId, agent1, "Agent 1 Thread");
+    await insertTestChatThread(user.userId, agent2, "Agent 2 Thread");
+
+    // Filter by agent1
+    const request = createTestRequest(
+      `http://localhost:3000/api/zero/tasks?agentId=${agent1}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.tasks).toHaveLength(1);
+    expect(data.tasks[0].title).toBe("Agent 1 Thread");
+    expect(data.tasks[0].agent.id).toBe(agent1);
+  });
+
+  it("should sort by latest run time DESC and limit to 25", async () => {
+    const { composeId } = await createTestCompose(uniqueId("sort-test"));
+
+    // Create 30 chat threads with runs at different times
+    const baseTime = new Date("2025-01-01T00:00:00Z").getTime();
+    for (let i = 0; i < 30; i++) {
+      const threadId = await insertTestChatThread(
+        user.userId,
+        composeId,
+        `Thread ${i}`,
+      );
+
+      const { runId } = await createTestRunInDb(user.userId, composeId, {
+        status: "completed",
+        createdAt: new Date(baseTime + i * 60_000),
+      });
+      await addTestRunToThread(threadId, runId, user.userId);
+    }
+
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.tasks).toHaveLength(25);
+    // Most recent should be first (Thread 29)
+    expect(data.tasks[0].title).toBe("Thread 29");
+    // Least recent in the 25 should be Thread 5
+    expect(data.tasks[24].title).toBe("Thread 5");
+  });
+});

--- a/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
@@ -217,9 +217,7 @@ describe("GET /api/zero/tasks", () => {
   it("should return 401 when no org is selected", async () => {
     mockClerk({ userId: user.userId, orgId: null });
 
-    const request = createTestRequest(
-      "http://localhost:3000/api/zero/tasks",
-    );
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
     const response = await GET(request);
     const data = await response.json();
 
@@ -243,9 +241,7 @@ describe("GET /api/zero/tasks", () => {
 
     mockClerk({ userId: user.userId });
 
-    const request = createTestRequest(
-      "http://localhost:3000/api/zero/tasks",
-    );
+    const request = createTestRequest("http://localhost:3000/api/zero/tasks");
     const response = await GET(request);
     const data = await response.json();
 

--- a/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/tasks/__tests__/route.test.ts
@@ -214,6 +214,79 @@ describe("GET /api/zero/tasks", () => {
     expect(data.tasks[0].agent.id).toBe(agent1);
   });
 
+  it("should return 401 when no org is selected", async () => {
+    mockClerk({ userId: user.userId, orgId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/tasks",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should not return tasks belonging to another user", async () => {
+    const { composeId } = await createTestCompose(uniqueId("user1-agent"));
+    await insertTestChatThread(user.userId, composeId, "User1 Thread");
+
+    const otherUser = await context.setupUser({ prefix: "other-user" });
+    const { composeId: otherComposeId } = await createTestCompose(
+      uniqueId("user2-agent"),
+    );
+    await insertTestChatThread(
+      otherUser.userId,
+      otherComposeId,
+      "User2 Thread",
+    );
+
+    mockClerk({ userId: user.userId });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/tasks",
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(
+      data.tasks.some(
+        (t: Record<string, unknown>) => t.title === "User1 Thread",
+      ),
+    ).toBe(true);
+    expect(
+      data.tasks.some(
+        (t: Record<string, unknown>) => t.title === "User2 Thread",
+      ),
+    ).toBe(false);
+  });
+
+  it("should filter schedule tasks by agentId", async () => {
+    const { composeId: agent1 } = await createTestCompose(
+      uniqueId("sched-filter-1"),
+    );
+    const { composeId: agent2 } = await createTestCompose(
+      uniqueId("sched-filter-2"),
+    );
+
+    await createTestSchedule(agent1, "agent1-schedule");
+    await createTestSchedule(agent2, "agent2-schedule");
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/zero/tasks?agentId=${agent1}`,
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    const scheduleTasks = data.tasks.filter(
+      (t: Record<string, unknown>) => t.type === "schedule",
+    );
+    expect(scheduleTasks).toHaveLength(1);
+    expect(scheduleTasks[0].title).toBe("agent1-schedule");
+  });
+
   it("should sort by latest run time DESC and limit to 25", async () => {
     const { composeId } = await createTestCompose(uniqueId("sort-test"));
 

--- a/turbo/apps/web/app/api/zero/tasks/route.ts
+++ b/turbo/apps/web/app/api/zero/tasks/route.ts
@@ -1,0 +1,48 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../src/lib/ts-rest-handler";
+import { tasksContract } from "@vm0/core";
+import { initServices } from "../../../../src/lib/init-services";
+import { getAuthContext } from "../../../../src/lib/auth/get-auth-context";
+import { listTasks } from "../../../../src/lib/zero/task/task-service";
+
+const router = tsr.router(tasksContract, {
+  list: async ({ query, headers }) => {
+    initServices();
+
+    const authCtx = await getAuthContext(headers.authorization);
+    if (!authCtx) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "Not authenticated", code: "UNAUTHORIZED" },
+        },
+      };
+    }
+
+    const orgId = authCtx.orgId;
+    if (!orgId) {
+      return {
+        status: 401 as const,
+        body: {
+          error: { message: "No organization selected", code: "UNAUTHORIZED" },
+        },
+      };
+    }
+
+    const tasks = await listTasks(authCtx.userId, orgId, query.agentId);
+
+    return {
+      status: 200 as const,
+      body: { tasks },
+    };
+  },
+});
+
+const handler = createHandler(tasksContract, router, {
+  errorHandler: createSafeErrorHandler("zero-tasks"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/agents.ts
@@ -1,4 +1,5 @@
 import { and, eq } from "drizzle-orm";
+import { chatThreads } from "../../db/schema/chat-thread";
 import type { RawPermissionPolicies } from "@vm0/core";
 import { initServices } from "../../lib/init-services";
 import {
@@ -717,4 +718,36 @@ export async function updateTestChatThreadTitle(
   title: string,
 ): Promise<void> {
   return updateChatThreadTitle(threadId, title);
+}
+
+/**
+ * Insert a chat thread directly in the database.
+ * Returns the thread ID.
+ */
+export async function insertTestChatThread(
+  userId: string,
+  agentComposeId: string,
+  title: string,
+): Promise<string> {
+  initServices();
+  const [thread] = await globalThis.services.db
+    .insert(chatThreads)
+    .values({ userId, agentComposeId, title })
+    .returning({ id: chatThreads.id });
+  return thread!.id;
+}
+
+/**
+ * Get the agent compose name by compose ID.
+ */
+export async function getTestAgentComposeName(
+  composeId: string,
+): Promise<string> {
+  initServices();
+  const [row] = await globalThis.services.db
+    .select({ name: agentComposes.name })
+    .from(agentComposes)
+    .where(eq(agentComposes.id, composeId))
+    .limit(1);
+  return row!.name;
 }

--- a/turbo/apps/web/src/__tests__/api-test-helpers/slack.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/slack.ts
@@ -218,13 +218,17 @@ export async function insertTestSlackOrgConnection(params: {
 export async function insertTestSlackOrgThreadSession(params: {
   connectionId: string;
   agentSessionId?: string;
-}): Promise<void> {
-  await globalThis.services.db.insert(slackOrgThreadSessions).values({
-    connectionId: params.connectionId,
-    slackChannelId: "C-test",
-    slackThreadTs: uniqueId("ts"),
-    ...(params.agentSessionId && { agentSessionId: params.agentSessionId }),
-  });
+}): Promise<{ id: string }> {
+  const [row] = await globalThis.services.db
+    .insert(slackOrgThreadSessions)
+    .values({
+      connectionId: params.connectionId,
+      slackChannelId: "C-test",
+      slackThreadTs: uniqueId("ts"),
+      ...(params.agentSessionId && { agentSessionId: params.agentSessionId }),
+    })
+    .returning({ id: slackOrgThreadSessions.id });
+  return row!;
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -1,0 +1,340 @@
+import { and, eq, inArray, sql, desc } from "drizzle-orm";
+import type { TaskItem } from "@vm0/core";
+import { chatThreads, chatThreadRuns } from "../../../db/schema/chat-thread";
+import { zeroAgentSchedules } from "../../../db/schema/zero-agent-schedule";
+import { slackOrgThreadSessions } from "../../../db/schema/slack-org-thread-session";
+import { slackOrgConnections } from "../../../db/schema/slack-org-connection";
+import { slackOrgInstallations } from "../../../db/schema/slack-org-installation";
+import { emailThreadSessions } from "../../../db/schema/email-thread-session";
+import { agentSessions } from "../../../db/schema/agent-session";
+import { agentRuns } from "../../../db/schema/agent-run";
+import { zeroAgents } from "../../../db/schema/zero-agent";
+
+const TASKS_LIMIT = 25;
+
+interface AgentInfo {
+  id: string;
+  name: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+interface RawTask {
+  id: string;
+  type: TaskItem["type"];
+  title: string | null;
+  agent: AgentInfo;
+  latestRunId: string | null;
+  sourceUpdatedAt: Date;
+}
+
+/**
+ * List unified tasks across chat threads, schedules, slack threads, and email threads.
+ * Returns up to 25 tasks sorted by latest run time DESC.
+ */
+export async function listTasks(
+  userId: string,
+  orgId: string,
+  agentId?: string,
+): Promise<TaskItem[]> {
+  const db = globalThis.services.db;
+
+  const [chatTasks, scheduleTasks, slackTasks, emailTasks] = await Promise.all([
+    listChatTasks(db, userId, orgId, agentId),
+    listScheduleTasks(db, userId, orgId, agentId),
+    listSlackTasks(db, userId, orgId, agentId),
+    listEmailTasks(db, userId, orgId, agentId),
+  ]);
+
+  const allTasks = [
+    ...chatTasks,
+    ...scheduleTasks,
+    ...slackTasks,
+    ...emailTasks,
+  ];
+
+  // Batch-fetch run info for all tasks with a latestRunId
+  const runIds = allTasks
+    .map((t) => {
+      return t.latestRunId;
+    })
+    .filter((id): id is string => {
+      return id !== null;
+    });
+
+  const runInfoMap = new Map<string, { status: string; createdAt: Date }>();
+
+  if (runIds.length > 0) {
+    const runs = await db
+      .select({
+        id: agentRuns.id,
+        status: agentRuns.status,
+        createdAt: agentRuns.createdAt,
+      })
+      .from(agentRuns)
+      .where(inArray(agentRuns.id, runIds));
+
+    for (const run of runs) {
+      runInfoMap.set(run.id, { status: run.status, createdAt: run.createdAt });
+    }
+  }
+
+  // Build final task items with sort key
+  const tasksWithSortKey = allTasks.map((raw) => {
+    const runInfo = raw.latestRunId
+      ? runInfoMap.get(raw.latestRunId)
+      : undefined;
+    const sortKey = runInfo ? runInfo.createdAt : raw.sourceUpdatedAt;
+
+    const task: TaskItem = {
+      id: raw.id,
+      type: raw.type,
+      title: raw.title,
+      agent: raw.agent,
+      latestRunId: raw.latestRunId,
+      status: runInfo ? (runInfo.status as TaskItem["status"]) : null,
+      createdAt: raw.sourceUpdatedAt.toISOString(),
+      updatedAt: sortKey.toISOString(),
+    };
+
+    // Add type-specific ID
+    switch (raw.type) {
+      case "chat":
+        task.chatThreadId = raw.id;
+        break;
+      case "schedule":
+        task.scheduleId = raw.id;
+        break;
+      case "slack":
+        task.slackThreadSessionId = raw.id;
+        break;
+      case "email":
+        task.emailThreadSessionId = raw.id;
+        break;
+    }
+
+    return { task, sortKey };
+  });
+
+  // Sort by sortKey DESC (latest first) and take top N
+  tasksWithSortKey.sort((a, b) => {
+    return b.sortKey.getTime() - a.sortKey.getTime();
+  });
+
+  return tasksWithSortKey.slice(0, TASKS_LIMIT).map((t) => {
+    return t.task;
+  });
+}
+
+// -- Per-source query functions --
+
+type DB = typeof globalThis.services.db;
+
+async function listChatTasks(
+  db: DB,
+  userId: string,
+  orgId: string,
+  agentId?: string,
+): Promise<RawTask[]> {
+  const conditions = [
+    eq(chatThreads.userId, userId),
+    eq(zeroAgents.orgId, orgId),
+  ];
+  if (agentId) conditions.push(eq(chatThreads.agentComposeId, agentId));
+
+  const rows = await db
+    .select({
+      id: chatThreads.id,
+      title: chatThreads.title,
+      agentId: chatThreads.agentComposeId,
+      agentName: zeroAgents.name,
+      agentDisplayName: zeroAgents.displayName,
+      agentAvatarUrl: zeroAgents.avatarUrl,
+      updatedAt: chatThreads.updatedAt,
+      latestRunId: sql<string | null>`(
+        SELECT ${chatThreadRuns.runId}
+        FROM ${chatThreadRuns}
+        WHERE ${chatThreadRuns.chatThreadId} = ${chatThreads.id}
+        ORDER BY ${chatThreadRuns.createdAt} DESC
+        LIMIT 1
+      )`,
+    })
+    .from(chatThreads)
+    .innerJoin(zeroAgents, eq(chatThreads.agentComposeId, zeroAgents.id))
+    .where(and(...conditions));
+
+  return rows.map((r) => {
+    return {
+      id: r.id,
+      type: "chat" as const,
+      title: r.title,
+      agent: {
+        id: r.agentId,
+        name: r.agentName,
+        displayName: r.agentDisplayName,
+        avatarUrl: r.agentAvatarUrl,
+      },
+      latestRunId: r.latestRunId,
+      sourceUpdatedAt: r.updatedAt,
+    };
+  });
+}
+
+async function listScheduleTasks(
+  db: DB,
+  userId: string,
+  orgId: string,
+  agentId?: string,
+): Promise<RawTask[]> {
+  const conditions = [
+    eq(zeroAgentSchedules.userId, userId),
+    eq(zeroAgentSchedules.orgId, orgId),
+  ];
+  if (agentId) conditions.push(eq(zeroAgentSchedules.agentId, agentId));
+
+  const rows = await db
+    .select({
+      id: zeroAgentSchedules.id,
+      name: zeroAgentSchedules.name,
+      agentId: zeroAgentSchedules.agentId,
+      agentName: zeroAgents.name,
+      agentDisplayName: zeroAgents.displayName,
+      agentAvatarUrl: zeroAgents.avatarUrl,
+      lastRunId: zeroAgentSchedules.lastRunId,
+      updatedAt: zeroAgentSchedules.updatedAt,
+    })
+    .from(zeroAgentSchedules)
+    .innerJoin(zeroAgents, eq(zeroAgentSchedules.agentId, zeroAgents.id))
+    .where(and(...conditions));
+
+  return rows.map((r) => {
+    return {
+      id: r.id,
+      type: "schedule" as const,
+      title: r.name,
+      agent: {
+        id: r.agentId,
+        name: r.agentName,
+        displayName: r.agentDisplayName,
+        avatarUrl: r.agentAvatarUrl,
+      },
+      latestRunId: r.lastRunId,
+      sourceUpdatedAt: r.updatedAt,
+    };
+  });
+}
+
+async function listSlackTasks(
+  db: DB,
+  userId: string,
+  orgId: string,
+  agentId?: string,
+): Promise<RawTask[]> {
+  const conditions = [
+    eq(slackOrgConnections.vm0UserId, userId),
+    eq(slackOrgInstallations.orgId, orgId),
+  ];
+  if (agentId) conditions.push(eq(agentSessions.agentComposeId, agentId));
+
+  const rows = await db
+    .select({
+      id: slackOrgThreadSessions.id,
+      agentId: agentSessions.agentComposeId,
+      agentName: zeroAgents.name,
+      agentDisplayName: zeroAgents.displayName,
+      agentAvatarUrl: zeroAgents.avatarUrl,
+      agentSessionId: slackOrgThreadSessions.agentSessionId,
+      updatedAt: slackOrgThreadSessions.updatedAt,
+      latestRunId: sql<string | null>`(
+        SELECT ${agentRuns.id}
+        FROM ${agentRuns}
+        WHERE ${agentRuns.continuedFromSessionId} = ${slackOrgThreadSessions.agentSessionId}
+        ORDER BY ${agentRuns.createdAt} DESC
+        LIMIT 1
+      )`,
+    })
+    .from(slackOrgThreadSessions)
+    .innerJoin(
+      slackOrgConnections,
+      eq(slackOrgThreadSessions.connectionId, slackOrgConnections.id),
+    )
+    .innerJoin(
+      slackOrgInstallations,
+      eq(
+        slackOrgConnections.slackWorkspaceId,
+        slackOrgInstallations.slackWorkspaceId,
+      ),
+    )
+    .innerJoin(
+      agentSessions,
+      eq(slackOrgThreadSessions.agentSessionId, agentSessions.id),
+    )
+    .innerJoin(zeroAgents, eq(agentSessions.agentComposeId, zeroAgents.id))
+    .where(and(...conditions));
+
+  return rows.map((r) => {
+    return {
+      id: r.id,
+      type: "slack" as const,
+      title: null,
+      agent: {
+        id: r.agentId,
+        name: r.agentName,
+        displayName: r.agentDisplayName,
+        avatarUrl: r.agentAvatarUrl,
+      },
+      latestRunId: r.latestRunId,
+      sourceUpdatedAt: r.updatedAt,
+    };
+  });
+}
+
+async function listEmailTasks(
+  db: DB,
+  userId: string,
+  orgId: string,
+  agentId?: string,
+): Promise<RawTask[]> {
+  const conditions = [
+    eq(emailThreadSessions.userId, userId),
+    eq(zeroAgents.orgId, orgId),
+  ];
+  if (agentId) conditions.push(eq(emailThreadSessions.agentId, agentId));
+
+  const rows = await db
+    .select({
+      id: emailThreadSessions.id,
+      agentId: emailThreadSessions.agentId,
+      agentName: zeroAgents.name,
+      agentDisplayName: zeroAgents.displayName,
+      agentAvatarUrl: zeroAgents.avatarUrl,
+      agentSessionId: emailThreadSessions.agentSessionId,
+      updatedAt: emailThreadSessions.updatedAt,
+      latestRunId: sql<string | null>`(
+        SELECT ${agentRuns.id}
+        FROM ${agentRuns}
+        WHERE ${agentRuns.continuedFromSessionId} = ${emailThreadSessions.agentSessionId}
+        ORDER BY ${agentRuns.createdAt} DESC
+        LIMIT 1
+      )`,
+    })
+    .from(emailThreadSessions)
+    .innerJoin(zeroAgents, eq(emailThreadSessions.agentId, zeroAgents.id))
+    .where(and(...conditions));
+
+  return rows.map((r) => {
+    return {
+      id: r.id,
+      type: "email" as const,
+      title: null,
+      agent: {
+        id: r.agentId,
+        name: r.agentName,
+        displayName: r.agentDisplayName,
+        avatarUrl: r.agentAvatarUrl,
+      },
+      latestRunId: r.latestRunId,
+      sourceUpdatedAt: r.updatedAt,
+    };
+  });
+}

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -786,3 +786,13 @@ export {
   type ContextEventsResponse,
   type AppendContextEventBody,
 } from "./zero-voice-chat-context";
+export {
+  tasksContract,
+  taskItemSchema,
+  taskTypeSchema,
+  taskAgentSchema,
+  type TasksContract,
+  type TaskItem,
+  type TaskType,
+  type TaskAgent,
+} from "./tasks";

--- a/turbo/packages/core/src/contracts/tasks.ts
+++ b/turbo/packages/core/src/contracts/tasks.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+import { runStatusSchema } from "./runs";
+
+const c = initContract();
+
+const taskTypeSchema = z.enum(["chat", "schedule", "slack", "email"]);
+
+const taskAgentSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  displayName: z.string().nullable(),
+  avatarUrl: z.string().nullable(),
+});
+
+const taskItemSchema = z.object({
+  id: z.string(),
+  type: taskTypeSchema,
+  title: z.string().nullable(),
+  agent: taskAgentSchema,
+  latestRunId: z.string().nullable(),
+  status: runStatusSchema.nullable(),
+  chatThreadId: z.string().optional(),
+  scheduleId: z.string().optional(),
+  slackThreadSessionId: z.string().optional(),
+  emailThreadSessionId: z.string().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const tasksContract = c.router({
+  list: {
+    method: "GET",
+    path: "/api/zero/tasks",
+    headers: authHeadersSchema,
+    query: z.object({
+      agentId: z.string().optional(),
+    }),
+    responses: {
+      200: z.object({ tasks: z.array(taskItemSchema) }),
+      401: apiErrorSchema,
+    },
+    summary: "List unified tasks across all sources",
+  },
+});
+
+export type TasksContract = typeof tasksContract;
+export type TaskItem = z.infer<typeof taskItemSchema>;
+export type TaskType = z.infer<typeof taskTypeSchema>;
+export type TaskAgent = z.infer<typeof taskAgentSchema>;
+
+export { taskItemSchema, taskTypeSchema, taskAgentSchema };


### PR DESCRIPTION
## Summary
- Add `GET /api/zero/tasks` endpoint that aggregates chat threads, schedules, slack threads, and email threads into a single unified task list
- Each task includes agent metadata (id, name, displayName, avatarUrl), latest run status, and type-specific IDs
- Returns top 25 tasks sorted by latest run time DESC, with optional `agentId` filtering
- Four parallel DB queries with application-level merge for maintainability and testability

## Test plan
- [x] 8 integration tests covering auth, empty results, all 4 task types, agentId filtering, and sort/limit behavior
- [x] Lint, format, knip all pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)