### PR TITLE
fix(insights): fix dark mode text color and remove connector underlines

### DIFF
--- a/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
+++ b/turbo/apps/platform/src/views/network-insights/network-insights-page.tsx
@@ -431,8 +431,8 @@ function SummaryCard({ day }: { day: DayInsight }) {
     { bg: "bg-[#E1C43C]", dark: false }, // mustard gold
   ];
   const v = variants[dayHash(day.date, variants.length)] ?? variants[0];
-  const textMain = v.dark ? "text-white/90" : "text-foreground/90";
-  const textSub = v.dark ? "text-white/50" : "text-foreground/50";
+  const textMain = v.dark ? "text-white/90" : "text-[rgba(0,0,0,0.8)]";
+  const textSub = v.dark ? "text-white/50" : "text-[rgba(0,0,0,0.4)]";
 
   return (
     <div
@@ -861,7 +861,7 @@ function PermissionsAllowedCard({
               className={`transition-opacity duration-150 ${isActive ? "opacity-100" : "opacity-30"}`}
             >
               <div className="flex items-center justify-between gap-2">
-                <span className="text-sm font-medium decoration-dotted underline decoration-foreground/40 decoration-[1px] underline-offset-2">
+                <span className="text-sm font-medium">
                   {connectorLabel(p.connectorType ?? p.label)}
                 </span>
                 <span className="text-xs opacity-60 tabular-nums shrink-0">


### PR DESCRIPTION
## Summary
- Fix summary card text unreadable on light-bg cards (mustard, sandy, rose) in dark mode — `text-foreground` resolves to white due to semantic color inversion, replaced with fixed `rgba(0,0,0,...)` values
- Remove dotted underline decoration from connector names in the allowed permissions card

## Test plan
- [ ] Open insights page in dark mode, verify summary cards with light backgrounds show dark text
- [ ] Verify summary cards with dark backgrounds still show white text
- [ ] Verify connector names in "ALLOWED" section no longer have underlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)