### PR TITLE
feat(runner): pass feature switch states through execution context

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -27,6 +27,7 @@ static SECRET_VALUES: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_SECR
 static DISALLOWED_TOOLS: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_DISALLOWED_TOOLS"));
 static TOOLS: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_TOOLS"));
 static SETTINGS: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_SETTINGS"));
+static FEATURE_FLAGS: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_FEATURE_FLAGS"));
 static USE_MOCK_CLAUDE: LazyLock<bool> = LazyLock::new(|| {
     std::env::var("USE_MOCK_CLAUDE")
         .map(|v| v == "true")
@@ -115,6 +116,9 @@ pub fn tools() -> &'static str {
 }
 pub fn settings() -> &'static str {
     &SETTINGS
+}
+pub fn feature_flags() -> &'static str {
+    &FEATURE_FLAGS
 }
 pub fn use_mock_claude() -> bool {
     *USE_MOCK_CLAUDE

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -1221,6 +1221,14 @@ fn build_env_json(context: &ExecutionContext, api_url: &str) -> HashMap<String, 
         env.insert("VM0_SETTINGS".into(), settings.clone());
     }
 
+    // Feature flags (JSON-encoded map of flag name → enabled)
+    if let Some(flags) = &context.feature_flags
+        && !flags.is_empty()
+        && let Ok(json) = serde_json::to_string(flags)
+    {
+        env.insert("VM0_FEATURE_FLAGS".into(), json);
+    }
+
     env
 }
 
@@ -1259,6 +1267,7 @@ mod tests {
             tools: None,
             settings: None,
             experimental_profile: None,
+            feature_flags: None,
         }
     }
 
@@ -1753,6 +1762,37 @@ mod tests {
         let ctx = minimal_context();
         let env = build_env_json(&ctx, "http://localhost");
         assert!(!env.contains_key("VM0_SETTINGS"));
+    }
+
+    #[test]
+    fn build_env_json_with_feature_flags() {
+        let mut ctx = minimal_context();
+        let mut flags = HashMap::new();
+        flags.insert("computerUse".into(), true);
+        flags.insert("voiceChat".into(), false);
+        ctx.feature_flags = Some(flags);
+        let env = build_env_json(&ctx, "http://localhost");
+        let raw = env
+            .get("VM0_FEATURE_FLAGS")
+            .expect("VM0_FEATURE_FLAGS should be set");
+        let parsed: HashMap<String, bool> = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.get("computerUse"), Some(&true));
+        assert_eq!(parsed.get("voiceChat"), Some(&false));
+    }
+
+    #[test]
+    fn build_env_json_empty_feature_flags_omitted() {
+        let mut ctx = minimal_context();
+        ctx.feature_flags = Some(HashMap::new());
+        let env = build_env_json(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_FEATURE_FLAGS"));
+    }
+
+    #[test]
+    fn build_env_json_no_feature_flags() {
+        let ctx = minimal_context();
+        let env = build_env_json(&ctx, "http://localhost");
+        assert!(!env.contains_key("VM0_FEATURE_FLAGS"));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -254,6 +254,7 @@ impl JobProvider for LocalProvider {
             tools: None,
             settings: None,
             experimental_profile: req.profile,
+            feature_flags: None,
         })
     }
 

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -87,6 +87,9 @@ pub struct ExecutionContext {
     #[allow(dead_code)]
     #[serde(default)]
     pub experimental_profile: Option<String>,
+    // Feature flags evaluated at job creation time (all switch states for user/org)
+    #[serde(default)]
+    pub feature_flags: Option<HashMap<String, bool>>,
 }
 
 /// A single firewall config with its name, ref key, and API entries.
@@ -336,7 +339,8 @@ mod tests {
             "disallowedTools": ["CronCreate"],
             "tools": ["Bash", "Read"],
             "settings": "{\"hooks\":{}}",
-            "experimentalProfile": "browser"
+            "experimentalProfile": "browser",
+            "featureFlags": {"computerUse": true, "voiceChat": false}
         });
         let ctx: ExecutionContext = serde_json::from_value(json).unwrap();
         assert_eq!(ctx.append_system_prompt.as_deref(), Some("be concise"));
@@ -351,6 +355,9 @@ mod tests {
         assert_eq!(ctx.tools.as_ref().unwrap(), &["Bash", "Read"]);
         assert_eq!(ctx.settings.as_deref(), Some("{\"hooks\":{}}"));
         assert!(ctx.storage_manifest.is_some());
+        let flags = ctx.feature_flags.as_ref().unwrap();
+        assert_eq!(flags.get("computerUse"), Some(&true));
+        assert_eq!(flags.get("voiceChat"), Some(&false));
     }
 
     #[test]

--- a/turbo/apps/platform/src/views/zero-page/components/context-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/context-content.tsx
@@ -134,6 +134,33 @@ export function ContextContent({ context }: { context: RunContextResponse }) {
         </section>
       )}
 
+      {/* Feature Flags */}
+      {context.featureFlags && Object.keys(context.featureFlags).length > 0 && (
+        <section>
+          <SectionHeader title="Feature Flags" />
+          <div className="flex flex-wrap gap-1.5">
+            {Object.entries(context.featureFlags)
+              .sort(([, a], [, b]) => {
+                return a === b ? 0 : a ? -1 : 1;
+              })
+              .map(([name, enabled]) => {
+                return (
+                  <span
+                    key={name}
+                    className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono ${
+                      enabled
+                        ? "bg-muted/50"
+                        : "bg-transparent text-muted-foreground line-through"
+                    }`}
+                  >
+                    {name}
+                  </span>
+                );
+              })}
+          </div>
+        </section>
+      )}
+
       {/* Secrets */}
       <section>
         <SectionHeader title="Secrets" />

--- a/turbo/apps/platform/src/views/zero-page/components/context-content.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/context-content.tsx
@@ -107,6 +107,40 @@ function StorageTable({
   );
 }
 
+function FeatureFlagsSection({
+  flags,
+}: {
+  flags: Record<string, boolean> | null | undefined;
+}) {
+  if (!flags || Object.keys(flags).length === 0) {
+    return null;
+  }
+  const sorted = Object.entries(flags).sort(([, a], [, b]) => {
+    return a === b ? 0 : a ? -1 : 1;
+  });
+  return (
+    <section>
+      <SectionHeader title="Feature Flags" />
+      <div className="flex flex-wrap gap-1.5">
+        {sorted.map(([name, enabled]) => {
+          return (
+            <span
+              key={name}
+              className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono ${
+                enabled
+                  ? "bg-muted/50"
+                  : "bg-transparent text-muted-foreground line-through"
+              }`}
+            >
+              {name}
+            </span>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 export function ContextContent({ context }: { context: RunContextResponse }) {
   return (
     <div className="flex flex-col gap-6 pb-8">
@@ -135,31 +169,7 @@ export function ContextContent({ context }: { context: RunContextResponse }) {
       )}
 
       {/* Feature Flags */}
-      {context.featureFlags && Object.keys(context.featureFlags).length > 0 && (
-        <section>
-          <SectionHeader title="Feature Flags" />
-          <div className="flex flex-wrap gap-1.5">
-            {Object.entries(context.featureFlags)
-              .sort(([, a], [, b]) => {
-                return a === b ? 0 : a ? -1 : 1;
-              })
-              .map(([name, enabled]) => {
-                return (
-                  <span
-                    key={name}
-                    className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-mono ${
-                      enabled
-                        ? "bg-muted/50"
-                        : "bg-transparent text-muted-foreground line-through"
-                    }`}
-                  >
-                    {name}
-                  </span>
-                );
-              })}
-          </div>
-        </section>
-      )}
+      <FeatureFlagsSection flags={context.featureFlags} />
 
       {/* Secrets */}
       <section>

--- a/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
+++ b/turbo/apps/web/app/api/runners/jobs/[id]/claim/route.ts
@@ -210,6 +210,7 @@ const router = tsr.router(runnersJobClaimContract, {
         apiStartTime: storedContext.apiStartTime,
         userTimezone: storedContext.userTimezone,
         memoryName: storedContext.memoryName,
+        featureFlags: storedContext.featureFlags,
       },
     };
   },

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
@@ -62,6 +62,7 @@ const router = tsr.router(zeroRunContextContract, {
         volumes: snapshot.volumes,
         artifact: snapshot.artifact,
         memory: snapshot.memory,
+        featureFlags: snapshot.featureFlags ?? null,
       },
     };
   },

--- a/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
+++ b/turbo/apps/web/src/lib/infra/run/context/execution-preparer.ts
@@ -7,7 +7,7 @@ import {
   ensureStorageExists,
 } from "../../../infra/storage/storage-service";
 import type { StorageManifest } from "../../../infra/storage/types";
-import { DEFAULT_PROFILE } from "@vm0/core";
+import { DEFAULT_PROFILE, getAllFeatureStates } from "@vm0/core";
 import { badRequest } from "../../../shared/errors";
 import { logger } from "../../../shared/logger";
 import { extractWorkingDir } from "../utils/extract-working-dir";
@@ -254,6 +254,12 @@ function buildPreparedContext(
 
     // Routing
     runnerGroup,
+
+    // Feature flags (evaluated once at preparation time)
+    featureFlags: getAllFeatureStates({
+      userId: context.userId,
+      orgId: context.orgId,
+    }),
 
     // Metadata
     ...metadata,

--- a/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/runner-executor.ts
@@ -57,34 +57,7 @@ export async function executeRunnerJob(
     throw forbidden("Only vm0/* runner groups are supported");
   }
 
-  // Encrypt secrets map (key-value pairs) before storing
-  const encryptedSecrets = encryptSecretsMap(
-    context.secrets ?? null,
-    globalThis.services.env.SECRETS_ENCRYPTION_KEY,
-  );
-
-  // Build stored execution context with encrypted secrets
-  // Storage manifest is already prepared in PreparedContext
-  const storedContext: StoredExecutionContext = {
-    workingDir: context.workingDir,
-    storageManifest: context.storageManifest,
-    environment: context.environment,
-    resumeSession: context.resumeSession,
-    encryptedSecrets,
-    secretConnectorMap: context.secretConnectorMap,
-    cliAgentType: context.cliAgentType,
-    firewalls: context.firewalls ?? undefined,
-    networkPolicies: context.networkPolicies ?? undefined,
-    disallowedTools: context.disallowedTools ?? undefined,
-    tools: context.tools ?? undefined,
-    settings: context.settings ?? undefined,
-    experimentalProfile: profile,
-    debugNoMockClaude: context.debugNoMockClaude || undefined,
-    captureNetworkBodies: context.captureNetworkBodies || undefined,
-    apiStartTime: context.apiStartTime ?? undefined,
-    userTimezone: context.userTimezone ?? undefined,
-    memoryName: context.memoryName ?? undefined,
-  };
+  const storedContext = buildStoredContext(context, profile);
 
   // Ingest sanitized context snapshot to Axiom for debugging
   ingestRunContext(buildRunContextSnapshot(context));
@@ -156,6 +129,41 @@ async function notifyRunners(
 }
 
 /**
+ * Build stored execution context with encrypted secrets for the runner job queue.
+ */
+function buildStoredContext(
+  context: PreparedContext,
+  profile: string,
+): StoredExecutionContext {
+  const encryptedSecrets = encryptSecretsMap(
+    context.secrets ?? null,
+    globalThis.services.env.SECRETS_ENCRYPTION_KEY,
+  );
+
+  return {
+    workingDir: context.workingDir,
+    storageManifest: context.storageManifest,
+    environment: context.environment,
+    resumeSession: context.resumeSession,
+    encryptedSecrets,
+    secretConnectorMap: context.secretConnectorMap,
+    cliAgentType: context.cliAgentType,
+    firewalls: context.firewalls ?? undefined,
+    networkPolicies: context.networkPolicies ?? undefined,
+    disallowedTools: context.disallowedTools ?? undefined,
+    tools: context.tools ?? undefined,
+    settings: context.settings ?? undefined,
+    experimentalProfile: profile,
+    debugNoMockClaude: context.debugNoMockClaude || undefined,
+    captureNetworkBodies: context.captureNetworkBodies || undefined,
+    apiStartTime: context.apiStartTime ?? undefined,
+    userTimezone: context.userTimezone ?? undefined,
+    memoryName: context.memoryName ?? undefined,
+    featureFlags: context.featureFlags ?? undefined,
+  };
+}
+
+/**
  * Build a sanitized context snapshot for Axiom ingestion.
  * - Secret values in environment are masked as "***"
  * - Firewall auth headers are stripped entirely
@@ -212,6 +220,7 @@ function buildRunContextSnapshot(context: PreparedContext): RunContextSnapshot {
           vasVersionId: manifest.memory.vasVersionId,
         }
       : null,
+    featureFlags: context.featureFlags,
   };
 }
 

--- a/turbo/apps/web/src/lib/infra/run/executors/types.ts
+++ b/turbo/apps/web/src/lib/infra/run/executors/types.ts
@@ -80,6 +80,9 @@ export interface PreparedContext {
   // User's timezone preference (IANA format, e.g., "Asia/Shanghai")
   // Injected as TZ environment variable in sandbox if not already set in environment
   userTimezone: string | null;
+
+  // Feature flags evaluated at job creation time (all switch states for user/org)
+  featureFlags: Record<string, boolean> | null;
 }
 
 /**

--- a/turbo/packages/core/src/contracts/runners.ts
+++ b/turbo/packages/core/src/contracts/runners.ts
@@ -134,6 +134,8 @@ export const storedExecutionContextSchema = z.object({
   settings: z.string().optional(),
   // VM profile for resource allocation (e.g., "vm0/default")
   experimentalProfile: z.string().optional(),
+  // Feature flags evaluated at job creation time (all switch states for user/org)
+  featureFlags: z.record(z.string(), z.boolean()).optional(),
 });
 
 /**
@@ -182,6 +184,8 @@ export const executionContextSchema = z.object({
   settings: z.string().optional(),
   // VM profile for resource allocation (e.g., "vm0/default")
   experimentalProfile: z.string().optional(),
+  // Feature flags evaluated at job creation time (all switch states for user/org)
+  featureFlags: z.record(z.string(), z.boolean()).optional(),
 });
 
 /**

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -200,6 +200,7 @@ const runContextResponseSchema = z.object({
   volumes: z.array(runContextVolumeSchema),
   artifact: runContextArtifactSchema.nullable(),
   memory: runContextArtifactSchema.nullable(),
+  featureFlags: z.record(z.string(), z.boolean()).nullable().optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Evaluate all feature switch states at job creation time via `getAllFeatureStates({ userId, orgId })`
- Store in `StoredExecutionContext` (DB) and `RunContextSnapshot` (Axiom)
- Pass through claim response → Rust `ExecutionContext.feature_flags` → `VM0_FEATURE_FLAGS` JSON env var → guest-agent
- Display in run context page: enabled flags first (normal style), disabled flags after (muted + strikethrough)
- Extract `buildStoredContext()` from `executeRunnerJob()` to reduce complexity

## Changes (12 files)

| Layer | File | Change |
|---|---|---|
| Schema | `core/contracts/runners.ts` | Add `featureFlags` to both Zod schemas |
| Schema | `core/contracts/zero-runs.ts` | Add `featureFlags` to run context response |
| Evaluate | `execution-preparer.ts` | Call `getAllFeatureStates()` in `buildPreparedContext()` |
| Store | `runner-executor.ts` | Include in stored context + Axiom snapshot, extract `buildStoredContext()` |
| Pass-through | `claim/route.ts` | Forward `featureFlags` in response |
| Pass-through | `context/route.ts` | Forward `featureFlags` in context API |
| Types | `executors/types.ts` | Add `featureFlags` to `PreparedContext` |
| UI | `context-content.tsx` | Display flags as sorted badges |
| Rust type | `types.rs` | Add `feature_flags: Option<HashMap<String, bool>>` |
| Rust env | `executor.rs` | JSON-serialize to `VM0_FEATURE_FLAGS` + 3 tests |
| Rust local | `local.rs` | Add field to local provider |
| Guest | `guest-agent/env.rs` | Read `VM0_FEATURE_FLAGS` via `LazyLock` |

## Test plan

- [x] Rust unit tests: `build_env_json_with_feature_flags`, `empty_feature_flags_omitted`, `no_feature_flags`
- [x] Rust deserialization: `execution_context_all_optional_fields` updated with `featureFlags`
- [ ] CI passes (lint, type-check, clippy, tests)

Closes #8770

🤖 Generated with [Claude Code](https://claude.com/claude-code)