### PR TITLE
fix(billing): log error when result event lacks uuid for deduplication

### DIFF
--- a/turbo/apps/web/src/lib/zero/credit/credit-usage-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-usage-service.ts
@@ -84,6 +84,17 @@ export async function upsertCreditUsage(
   const model = selectedModel ?? extractModel(events) ?? "unknown";
 
   for (const result of results) {
+    if (!result.uuid) {
+      log.error(
+        "Result event missing uuid — deduplication disabled for this row",
+        {
+          runId,
+          inputTokens: result.inputTokens,
+          outputTokens: result.outputTokens,
+        },
+      );
+    }
+
     await db
       .insert(creditUsage)
       .values({


### PR DESCRIPTION
## Summary

- Add error log when a result event lacks `uuid`, which disables deduplication via the `(runId, resultUuid)` unique constraint (PostgreSQL treats `NULL != NULL`)
- This is a monitoring-first approach: if the log fires in production, we know the #8771 bug is actively triggering and can prioritize a fix

## Changes

**`turbo/apps/web/src/lib/zero/credit/credit-usage-service.ts`**: Log `runId`, `inputTokens`, `outputTokens` when `result.uuid` is missing.

## Test plan

- [x] Existing 747 mitm-addon tests pass (unrelated)
- [ ] Monitor production logs for `"Result event missing uuid"` errors

Refs #8771

🤖 Generated with [Claude Code](https://claude.com/claude-code)