### PR TITLE
fix(runner): pin discover future to prevent heartbeat cancellation

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -497,6 +497,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
         provider: &*provider,
     };
 
+    // Pin the discover future so it survives cancellation by other select!
+    // branches (heartbeat, idle cleanup, etc.). Without pinning, heartbeat
+    // (10s) cancels discover() on every tick, restarting its internal poll
+    // sleep (30s) from scratch — so poll never fires. See #8747.
+    let mut discover_fut = Box::pin(provider.discover());
+
     let mut current_mode = RunnerMode::Running;
     let mut spawn_ctx = SpawnContext {
         provider: Arc::clone(&provider),
@@ -579,9 +585,12 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
 
         tokio::select! {
             // Job discovery via provider (Ably push + poll).
-            // discover() has no server-side side effects — safe to cancel.
-            discovered = provider.discover() => {
+            // The future is pinned outside the loop so heartbeat/cleanup ticks
+            // don't cancel and restart its internal poll timer. See #8747.
+            discovered = &mut discover_fut => {
                 let Some((run_id, profile_name)) = discovered else { break };
+                // Future completed — create a new one for the next discovery.
+                discover_fut = Box::pin(provider.discover());
                 // Look up profile config for resource requirements.
                 let Some(profile_config) = profiles.get(&profile_name) else {
                     warn!(run_id = %run_id, profile = %profile_name, "unknown profile, skipping");


### PR DESCRIPTION
## Summary

- Pin the `discover()` future outside the main `tokio::select!` loop so it survives cancellation by heartbeat and other unrelated branches
- Previously, heartbeat (10s) cancelled `discover()` on every tick, restarting its internal poll sleep (30s) from scratch — poll HTTP requests never reached the server

Closes #8747

## Test plan

- [x] `cargo build`, `cargo clippy`, `cargo test` pass (447 tests)
- [ ] Runner logs should show periodic `poll: no pending jobs` entries (previously absent)
- [ ] Ably push discovery continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)