### PR TITLE
refactor(voice-chat): unify shared context naming to slow-brain/fast-brain

### DIFF
--- a/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/append.test.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/__tests__/append.test.ts
@@ -33,8 +33,8 @@ describe("zero voice-chat context append command", () => {
       let capturedBody: Record<string, unknown> | undefined;
       const createdEvent = {
         seq: 1,
-        source: "worker",
-        type: "result",
+        source: "slow-brain",
+        type: "directive",
         content: "Done",
         createdAt: "2026-01-01T00:00:00Z",
       };
@@ -51,16 +51,16 @@ describe("zero voice-chat context append command", () => {
         "cli",
         "session-123",
         "--source",
-        "worker",
+        "slow-brain",
         "--type",
-        "result",
+        "directive",
         "--content",
         "Done",
       ]);
 
       expect(capturedBody).toMatchObject({
-        source: "worker",
-        type: "result",
+        source: "slow-brain",
+        type: "directive",
         content: "Done",
       });
 
@@ -78,7 +78,7 @@ describe("zero voice-chat context append command", () => {
           return HttpResponse.json(
             {
               seq: 1,
-              source: "worker",
+              source: "slow-brain",
               type: "heartbeat",
               createdAt: "2026-01-01T00:00:00Z",
             },
@@ -92,13 +92,13 @@ describe("zero voice-chat context append command", () => {
         "cli",
         "session-123",
         "--source",
-        "worker",
+        "slow-brain",
         "--type",
         "heartbeat",
       ]);
 
       expect(capturedBody).toMatchObject({
-        source: "worker",
+        source: "slow-brain",
         type: "heartbeat",
       });
     });
@@ -121,9 +121,9 @@ describe("zero voice-chat context append command", () => {
           "cli",
           "session-123",
           "--source",
-          "worker",
+          "slow-brain",
           "--type",
-          "result",
+          "directive",
           "--content",
           "Done",
         ]);
@@ -155,9 +155,9 @@ describe("zero voice-chat context append command", () => {
           "cli",
           "session-123",
           "--source",
-          "worker",
+          "slow-brain",
           "--type",
-          "result",
+          "directive",
           "--content",
           "Done",
         ]);

--- a/turbo/apps/cli/src/commands/zero/voice-chat/context/append.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/context/append.ts
@@ -9,7 +9,7 @@ export const voiceChatContextAppendCommand = new Command()
   .argument("<session-id>", "Voice-chat session ID")
   .requiredOption(
     "--source <source>",
-    "Event source (system|user|talker|worker)",
+    "Event source (system|user|fast-brain|slow-brain)",
   )
   .requiredOption("--type <type>", "Event type")
   .option(
@@ -20,8 +20,8 @@ export const voiceChatContextAppendCommand = new Command()
     "after",
     `
 Examples:
-  Append with content:   zero voice-chat context append <session-id> --source worker --type result --content "Done"
-  Pipe from stdin:       echo "Done" | zero voice-chat context append <session-id> --source worker --type result`,
+  Append with content:   zero voice-chat context append <session-id> --source slow-brain --type directive --content "Done"
+  Pipe from stdin:       echo "Done" | zero voice-chat context append <session-id> --source slow-brain --type directive`,
   )
   .action(
     withErrorHandler(

--- a/turbo/apps/cli/src/commands/zero/voice-chat/index.ts
+++ b/turbo/apps/cli/src/commands/zero/voice-chat/index.ts
@@ -11,5 +11,5 @@ export const zeroVoiceChatCommand = new Command()
 Examples:
   Read all events:       zero voice-chat context get <session-id>
   Read new events:       zero voice-chat context get <session-id> --after 5
-  Append an event:       zero voice-chat context append <session-id> --source worker --type result --content "Done"`,
+  Append an event:       zero voice-chat context append <session-id> --source slow-brain --type directive --content "Done"`,
   );

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -64,7 +64,7 @@ const SESSION_TOOLS = [
     type: "function",
     name: "request_slow_brain",
     description:
-      "Send a task to your background self for deep thinking, tool use, or execution. Use this when the user asks for something that requires code, data, APIs, file access, or any action beyond conversation. Your background self will work on it and the result will be delivered to you automatically.",
+      "Send a task to your slow-brain for deep thinking, tool use, or execution. Use this when the user asks for something that requires code, data, APIs, file access, or any action beyond conversation. Your slow-brain will work on it and the result will be delivered to you automatically.",
     parameters: {
       type: "object",
       properties: {
@@ -79,10 +79,10 @@ const SESSION_TOOLS = [
   },
 ] as const;
 
-const TALKER_INSTRUCTIONS = `
+const FAST_BRAIN_INSTRUCTIONS = `
 You are Zero, vm0's AI workspace assistant. You are speaking with the user in real time through voice.
 
-You can do everything. Some things you handle instantly — conversation, knowledge, opinions, brainstorming. Other things need a moment of deeper thinking — code, tools, data lookups, file access, external systems like GitHub, Slack, or APIs. For those, you delegate to your background self using the request_slow_brain tool.
+You can do everything. Some things you handle instantly — conversation, knowledge, opinions, brainstorming. Other things need a moment of deeper thinking — code, tools, data lookups, file access, external systems like GitHub, Slack, or APIs. For those, you delegate to your slow-brain using the request_slow_brain tool.
 
 ## When to delegate
 
@@ -102,11 +102,11 @@ After calling request_slow_brain, acknowledge naturally:
 - "I'll check on that for you."
 - "Give me a moment to work on that."
 
-Do NOT say "I can't do that" or "I don't have access to that." You CAN do it — it just takes a moment of background thinking.
+Do NOT say "I can't do that" or "I don't have access to that." You CAN do it — it just takes a moment.
 
 ## Receiving results
 
-When you receive a message starting with [Background...], it is from your background self. Incorporate that information naturally into your response. Use your own voice — do not read it verbatim. The background message provides the substance; you provide the delivery.
+When you receive a message starting with [Slow-brain...], it is from your slow-brain. Incorporate that information naturally into your response. Use your own voice — do not read it verbatim. The slow-brain message provides the substance; you provide the delivery.
 
 ## Communication style
 
@@ -142,12 +142,11 @@ function logContextEvent(
 
 function formatInjectionMessage(event: ContextEvent): string {
   const prefixes: Record<string, string> = {
-    directive: "[Your background thinking completed]",
-    "thinking-progress": "[Your background self is working]",
-    "thinking-result": "[Background result]",
-    observation: "[Background observation]",
+    directive: "[Slow-brain directive]",
+    thinking: "[Slow-brain thinking]",
+    observation: "[Slow-brain observation]",
   };
-  const label = prefixes[event.type] ?? `[Background update - ${event.type}]`;
+  const label = prefixes[event.type] ?? `[Slow-brain update - ${event.type}]`;
   return `${label} ${event.content ?? ""}`.trim();
 }
 
@@ -217,9 +216,15 @@ const handleFnCall$ = command(
 
     if (name === "request_slow_brain") {
       const parsed = JSON.parse(args) as { task: string };
-      logContextEvent(fetchFn, sid, "talker", "worker-request", parsed.task);
+      logContextEvent(
+        fetchFn,
+        sid,
+        "fast-brain",
+        "request-slow-brain",
+        parsed.task,
+      );
       result =
-        "Request sent to your background self. The result will be delivered to you automatically — no need to check.";
+        "Request sent to your slow-brain. The result will be delivered to you automatically — no need to check.";
     } else {
       result = JSON.stringify({ error: `Unknown function: ${name}` });
     }
@@ -332,11 +337,11 @@ const handleDCMessage$ = command(
             return updated;
           });
 
-          // Auto-log talker response to shared context (fire-and-forget)
+          // Auto-log fast-brain response to shared context (fire-and-forget)
           logContextEvent(
             get(fetch$),
             get(internalSessionId$),
-            "talker",
+            "fast-brain",
             "response",
             finalText,
           );
@@ -435,7 +440,7 @@ const setupWebRTC$ = command(
           type: "session.update",
           session: {
             modalities: ["text", "audio"],
-            instructions: TALKER_INSTRUCTIONS,
+            instructions: FAST_BRAIN_INSTRUCTIONS,
             input_audio_transcription: { model: "whisper-1" },
             turn_detection: {
               type: "server_vad",

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -104,6 +104,15 @@ After calling request_slow_brain, acknowledge naturally:
 
 Do NOT say "I can't do that" or "I don't have access to that." You CAN do it — it just takes a moment.
 
+## When you are unsure
+
+Never immediately say "I don't know" or "I can't do that." Instead, delegate to your slow-brain first:
+- "Let me check on that."
+- "Let me think about that for a moment."
+- "Let me try to find out."
+
+Only after your slow-brain responds can you tell the user that something is not possible or that you could not find an answer. Always try before giving up.
+
 ## Receiving results
 
 When you receive a message starting with [Slow-brain...], it is from your slow-brain. Incorporate that information naturally into your response. Use your own voice — do not read it verbatim. The slow-brain message provides the substance; you provide the delivery.
@@ -113,7 +122,6 @@ When you receive a message starting with [Slow-brain...], it is from your slow-b
 - Keep responses concise and natural. You are speaking, not writing.
 - Do not use markdown formatting, bullet points, or code blocks.
 - Be warm and conversational, like a helpful colleague.
-- When you do not know something and it does not require tools, say so honestly.
 `.trim();
 
 function logContextEvent(

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/context/__tests__/route.test.ts
@@ -159,7 +159,7 @@ describe("GET /api/zero/voice-chat/[id]/context", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          source: "worker",
+          source: "slow-brain",
           type: "response",
           content: "second",
         }),
@@ -226,7 +226,7 @@ describe("POST /api/zero/voice-chat/[id]/context", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          source: "talker",
+          source: "fast-brain",
           type: "speech",
           content: "hello world",
         }),
@@ -236,7 +236,7 @@ describe("POST /api/zero/voice-chat/[id]/context", () => {
     const body = await response.json();
     expect(response.status).toBe(200);
     expect(body.event).toBeDefined();
-    expect(body.event.source).toBe("talker");
+    expect(body.event.source).toBe("fast-brain");
     expect(body.event.type).toBe("speech");
     expect(body.event.content).toBe("hello world");
     expect(typeof body.event.seq).toBe("number");
@@ -303,30 +303,28 @@ describe("POST /api/zero/voice-chat/[id]/context", () => {
     expect(body.error.message).toContain("not active");
   });
 
-  it.each([
-    "directive",
-    "thinking-progress",
-    "thinking-result",
-    "observation",
-  ] as const)("should accept slow brain event type: %s", async (type) => {
-    const session = await createSession(orgId, userId);
-    const response = await POST(
-      createTestRequest(contextUrl(session.id), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          source: "slow-brain",
-          type,
-          content: "test content",
+  it.each(["directive", "thinking", "observation"] as const)(
+    "should accept slow brain event type: %s",
+    async (type) => {
+      const session = await createSession(orgId, userId);
+      const response = await POST(
+        createTestRequest(contextUrl(session.id), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            source: "slow-brain",
+            type,
+            content: "test content",
+          }),
         }),
-      }),
-      paramsFor(session.id),
-    );
-    const body = await response.json();
-    expect(response.status).toBe(200);
-    expect(body.event.type).toBe(type);
-    expect(body.event.source).toBe("slow-brain");
-  });
+        paramsFor(session.id),
+      );
+      const body = await response.json();
+      expect(response.status).toBe(200);
+      expect(body.event.type).toBe(type);
+      expect(body.event.source).toBe("slow-brain");
+    },
+  );
 
   it("should produce incrementing seq numbers", async () => {
     const session = await createSession(orgId, userId);

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/context/route.ts
@@ -11,25 +11,15 @@ import {
   appendEvent,
 } from "../../../../../../src/lib/zero/voice-chat/context-service";
 
-const VALID_SOURCES = [
-  "system",
-  "user",
-  "talker",
-  "worker",
-  "slow-brain",
-] as const;
+const VALID_SOURCES = ["system", "user", "fast-brain", "slow-brain"] as const;
 const VALID_TYPES = [
   "session-start",
   "session-end",
   "speech",
-  "acknowledgement",
-  "worker-request",
-  "progress",
-  "result",
+  "request-slow-brain",
   "response",
   "directive",
-  "thinking-progress",
-  "thinking-result",
+  "thinking",
   "observation",
 ] as const;
 

--- a/turbo/apps/web/app/api/zero/voice-chat/__tests__/create-session.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/__tests__/create-session.test.ts
@@ -107,7 +107,7 @@ describe("POST /api/zero/voice-chat (create session)", () => {
     expect(body.error.code).toBe("CONFLICT");
   });
 
-  it("should create session and dispatch worker on success", async () => {
+  it("should create session and dispatch slow-brain on success", async () => {
     const { agentId } = await createTestCompose(uniqueId("vc-agent"));
 
     const response = await POST(createRequest({ agentId }));

--- a/turbo/apps/web/app/api/zero/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/route.ts
@@ -6,7 +6,7 @@ import { resolveOrg } from "../../../../src/lib/zero/org/resolve-org";
 import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
 import {
   createSession,
-  dispatchWorker,
+  dispatchSlowBrain,
 } from "../../../../src/lib/zero/voice-chat/session-service";
 import { isApiError } from "../../../../src/lib/shared/errors";
 import { logger } from "../../../../src/lib/shared/logger";
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
 
   try {
     const session = await createSession(org.orgId, userId, agentId);
-    const run = await dispatchWorker(session, org.orgId, userId, agentId);
+    const run = await dispatchSlowBrain(session, org.orgId, userId, agentId);
 
     return NextResponse.json({
       session: {

--- a/turbo/apps/web/src/db/schema/voice-chat.ts
+++ b/turbo/apps/web/src/db/schema/voice-chat.ts
@@ -12,7 +12,7 @@ import { agentComposes } from "./agent-compose";
 
 /**
  * Voice-chat sessions track active voice conversations.
- * Each session has one WebRTC connection (talker) and one zero agent run (worker).
+ * Each session has one WebRTC connection (fast-brain) and one zero agent run (slow-brain).
  */
 export const voiceChatSessions = pgTable(
   "voice_chat_sessions",
@@ -47,11 +47,11 @@ export const voiceChatSessions = pgTable(
 
 /**
  * Append-only event log for voice-chat shared context (blackboard pattern).
- * Both talker (browser) and worker (sandbox agent) read and append events.
+ * Both fast-brain (browser) and slow-brain (sandbox agent) read and append events.
  *
- * Sources: system | user | talker | worker
- * Types: session-start | session-end | speech | acknowledgement |
- *        worker-request | progress | result | response
+ * Sources: system | user | fast-brain | slow-brain
+ * Types: session-start | session-end | speech | request-slow-brain | response |
+ *        directive | thinking | observation
  */
 export const voiceChatEvents = pgTable(
   "voice_chat_events",

--- a/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
@@ -82,7 +82,7 @@ describe("buildIntegrationPrompt", () => {
 });
 
 describe("buildVoiceChatSlowBrainPrompt", () => {
-  it("should combine integration header with worker prompt", () => {
+  it("should combine integration header with slow-brain prompt", () => {
     const result = buildVoiceChatSlowBrainPrompt("session-123");
 
     expect(result).toContain("You are currently running inside: Voice-Chat");

--- a/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildIntegrationPrompt,
-  buildVoiceChatWorkerPrompt,
+  buildVoiceChatSlowBrainPrompt,
   buildSlackPrompt,
   buildPhonePrompt,
   buildTelegramPrompt,
@@ -81,16 +81,16 @@ describe("buildIntegrationPrompt", () => {
   });
 });
 
-describe("buildVoiceChatWorkerPrompt", () => {
+describe("buildVoiceChatSlowBrainPrompt", () => {
   it("should combine integration header with worker prompt", () => {
-    const result = buildVoiceChatWorkerPrompt("session-123");
+    const result = buildVoiceChatSlowBrainPrompt("session-123");
 
     expect(result).toContain("You are currently running inside: Voice-Chat");
-    expect(result).toContain("# Zero — Slow-Thinking Mode");
+    expect(result).toContain("# Zero — Slow-Brain Mode");
   });
 
   it("should replace session ID placeholder", () => {
-    const result = buildVoiceChatWorkerPrompt("session-456");
+    const result = buildVoiceChatSlowBrainPrompt("session-456");
 
     expect(result).toContain("context get session-456");
     expect(result).toContain("context append session-456");

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -162,16 +162,16 @@ When you have something for the user, write to the shared context:
 `.trim();
 
 /**
- * Build the full appendSystemPrompt for Voice-Chat worker mode.
- * Combines the integration header with the slow-thinking worker prompt.
+ * Build the full appendSystemPrompt for Voice-Chat slow-brain mode.
+ * Combines the integration header with the slow-brain prompt.
  */
 export function buildVoiceChatSlowBrainPrompt(sessionId: string): string {
   const header = buildIntegrationPrompt("Voice-Chat");
-  const workerPrompt = VOICE_CHAT_SLOW_BRAIN_PROMPT.replaceAll(
+  const slowBrainPrompt = VOICE_CHAT_SLOW_BRAIN_PROMPT.replaceAll(
     "<SESSION_ID>",
     sessionId,
   );
-  return [header, workerPrompt].join("\n\n");
+  return [header, slowBrainPrompt].join("\n\n");
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -88,10 +88,10 @@ export function buildUserInfo(options: UserInfoOptions): string {
 // Per-integration prompt builders
 // ---------------------------------------------------------------------------
 
-const VOICE_CHAT_WORKER_PROMPT = `
-# Zero — Slow-Thinking Mode
+const VOICE_CHAT_SLOW_BRAIN_PROMPT = `
+# Zero — Slow-Brain Mode
 
-You are Zero's slow-thinking mode. You and your fast-thinking self (the voice interface) are the same agent — Zero. Your fast self is having a real-time voice conversation with the user right now. You can see the entire conversation through the shared context.
+You are Zero's slow-brain. You and your fast-brain (the voice interface) are the same agent — Zero. Your fast-brain is having a real-time voice conversation with the user right now. You can see the entire conversation through the shared context.
 
 ## Observing the Conversation
 
@@ -101,7 +101,7 @@ Continuously read the shared context to follow the conversation:
 
 You will see events like:
 - **user/speech** — what the user says
-- **talker/response** — what your fast self says back
+- **fast-brain/response** — what your fast-brain says back
 - **system/session-start** and **system/session-end** — session lifecycle
 
 Based on what you observe, proactively decide what to do. Do not wait to be asked.
@@ -112,19 +112,19 @@ Act when the conversation involves:
 - Code, data, APIs, files, or external systems
 - Tasks that require execution, search, or tool use
 - Topics where you can proactively gather information (e.g., user mentions a PR — look it up so the answer is ready)
-- Anything your fast self cannot handle with conversation alone
+- Anything your fast-brain cannot handle with conversation alone
 
 Stay quiet when the conversation is:
 - Casual chat, greetings, or small talk
 - Opinions or preferences
-- Simple knowledge questions your fast self handles well
+- Simple knowledge questions your fast-brain handles well
 
 ## Explicit Requests
 
-When you see a \`talker/worker-request\` event in the shared context, it is a direct task from your fast self — the voice interface. Treat it as a priority:
+When you see a \`fast-brain/request-slow-brain\` event in the shared context, it is a direct task from your fast-brain — the voice interface. Treat it as a priority:
 - Drop non-critical autonomous work to handle it immediately
 - The task description contains exactly what to do — follow it
-- Write a thinking-progress event early so the user knows you are working on it
+- Write a thinking event early so the user knows you are working on it
 - Write the result as a directive when done
 
 Explicit requests take priority over autonomously-detected tasks.
@@ -137,13 +137,11 @@ When you have something for the user, write to the shared context:
 
 ### Event Types
 
-- **directive**: High-level instructions for your fast self. Include what to tell the user, relevant data, and why. Do not script exact words — your fast self controls phrasing.
+- **directive**: High-level instructions for your fast-brain. Include what to tell the user, relevant data, and why. Do not script exact words — your fast-brain controls phrasing.
   Example: "The user asked about PR status. PR #8644 merged to main, all CI checks passed. Release PR #8647 is in merge queue position 2. Let the user know and ask if they want to wait for deployment."
 
-- **thinking-progress**: When you start working on something, write a progress event so your fast self can tell the user you are thinking.
+- **thinking**: Progress updates and intermediate results while you work. Write one early so your fast-brain can tell the user you are thinking, and again when you have raw data or findings.
   Example: "Looking up the CI status for the latest PR."
-
-- **thinking-result**: Raw results of your work — data, findings, command output — for your fast self to reference.
 
 - **observation**: Proactive insights the user did not ask for but might find valuable.
   Example: "While checking the PR, I noticed the test coverage dropped by 3%. Might be worth mentioning."
@@ -152,12 +150,12 @@ When you have something for the user, write to the shared context:
 
 1. Check for new events every 5 seconds.
 2. Process what you see — act proactively or respond to explicit requests.
-3. Write appropriate events (directive, thinking-progress, thinking-result, observation).
+3. Write appropriate events (directive, thinking, observation).
 4. Repeat until you see a \`session-end\` system event, then exit.
 
 ## Important
 
-- Keep directive content concise but complete — your fast self will read it aloud.
+- Keep directive content concise but complete — your fast-brain will read it aloud.
 - You have full tool access. Use your sandbox, CLI, and APIs to get real answers.
 - When you find something, write the directive immediately. Do not wait for a request.
 - You are Zero. Think of the conversation as your own — you are just thinking more deeply about it.
@@ -167,9 +165,9 @@ When you have something for the user, write to the shared context:
  * Build the full appendSystemPrompt for Voice-Chat worker mode.
  * Combines the integration header with the slow-thinking worker prompt.
  */
-export function buildVoiceChatWorkerPrompt(sessionId: string): string {
+export function buildVoiceChatSlowBrainPrompt(sessionId: string): string {
   const header = buildIntegrationPrompt("Voice-Chat");
-  const workerPrompt = VOICE_CHAT_WORKER_PROMPT.replaceAll(
+  const workerPrompt = VOICE_CHAT_SLOW_BRAIN_PROMPT.replaceAll(
     "<SESSION_ID>",
     sessionId,
   );

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../db/schema/voice-chat";
 import { createZeroRun } from "../zero-run-service";
 import { cancelRun } from "../zero-run-cancel";
-import { buildVoiceChatWorkerPrompt } from "../integration-prompt";
+import { buildVoiceChatSlowBrainPrompt } from "../integration-prompt";
 import { conflict, notFound, badRequest, forbidden } from "../../shared/errors";
 import { logger } from "../../shared/logger";
 
@@ -109,7 +109,7 @@ export async function endSession(
     .set({ status: "ended", endedAt: new Date() })
     .where(eq(voiceChatSessions.id, sessionId));
 
-  // Cancel worker run if active (ignore errors if already terminated)
+  // Cancel slow-brain run if active (ignore errors if already terminated)
   if (session.runId) {
     try {
       await cancelRun(session.runId, userId, orgId);
@@ -120,21 +120,21 @@ export async function endSession(
 }
 
 // ---------------------------------------------------------------------------
-// Worker Dispatch
+// Slow-Brain Dispatch
 // ---------------------------------------------------------------------------
 
-export async function dispatchWorker(
+export async function dispatchSlowBrain(
   session: { id: string },
   orgId: string,
   userId: string,
   agentId: string,
 ) {
-  const appendSystemPrompt = buildVoiceChatWorkerPrompt(session.id);
+  const appendSystemPrompt = buildVoiceChatSlowBrainPrompt(session.id);
 
   const result = await createZeroRun({
     userId,
     agentId,
-    prompt: `You are Zero's slow-thinking mode for voice-chat session ${session.id}. Start by reading the shared context to observe the conversation.`,
+    prompt: `You are Zero's slow-brain for voice-chat session ${session.id}. Start by reading the shared context to observe the conversation.`,
     appendSystemPrompt,
     triggerSource: "voice-chat",
   });


### PR DESCRIPTION
## Summary

- Unify voice chat shared context naming to consistent `slow-brain` / `fast-brain` terminology across sources, events, prompts, and code identifiers
- Remove 3 unused event types (`acknowledgement`, `progress`, `result`) and merge `thinking-progress` + `thinking-result` into single `thinking` event
- Rename all code identifiers: `TALKER_INSTRUCTIONS` → `FAST_BRAIN_INSTRUCTIONS`, `VOICE_CHAT_WORKER_PROMPT` → `VOICE_CHAT_SLOW_BRAIN_PROMPT`, `buildVoiceChatWorkerPrompt` → `buildVoiceChatSlowBrainPrompt`, `dispatchWorker` → `dispatchSlowBrain`

### Before → After

| Concept | Before | After |
|---------|--------|-------|
| Sources | `system, user, talker, worker, slow-brain` | `system, user, fast-brain, slow-brain` |
| Events | 12 types (3 dead) | 8 types |
| Fast brain prompt | "background self" | "slow-brain" |
| Slow brain prompt | "fast self" / "fast-thinking self" | "fast-brain" |

### Final event schema

| Source | Event | Description |
|--------|-------|-------------|
| system | `session-start` | Session lifecycle |
| system | `session-end` | Session lifecycle |
| user | `speech` | User speech input |
| fast-brain | `response` | Fast-brain voice reply |
| fast-brain | `request-slow-brain` | Request to slow-brain |
| slow-brain | `directive` | Instructions for fast-brain |
| slow-brain | `thinking` | Progress and intermediate results |
| slow-brain | `observation` | Proactive insights |

## Test plan

- [x] CLI voice-chat tests pass (109 files, 1047 tests)
- [x] Integration-prompt tests pass (1 file, 17 tests)
- [x] TypeScript type check passes (platform, cli)
- [x] Pre-commit hooks pass (prettier, knip, commitlint)
- [ ] Web voice-chat tests (blocked by missing `agentphone` package in dev container — pre-existing issue, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)