### PR TITLE
fix(web): style terms-of-use and privacy-policy pages

### DIFF
--- a/turbo/apps/web/app/[locale]/security/SecurityPage.tsx
+++ b/turbo/apps/web/app/[locale]/security/SecurityPage.tsx
@@ -49,7 +49,7 @@ export default function SecurityPage() {
       </div>
 
       <main className="px-6 pb-20 pt-[calc(var(--total-header-height)+48px)] md:pb-28 md:pt-[calc(var(--total-header-height)+72px)]">
-        <div className="mx-auto max-w-xl">
+        <div className="mx-auto max-w-2xl">
           <h1 className="text-[32px] font-semibold leading-[1.2] tracking-tight sm:text-[40px]">
             Security
           </h1>

--- a/turbo/apps/web/app/globals.css
+++ b/turbo/apps/web/app/globals.css
@@ -154,6 +154,11 @@
   }
 }
 
+/* Termly embed — dark mode color inversion (cross-origin iframe) */
+[data-theme="dark"] .termly-embed-wrapper {
+  filter: invert(1) hue-rotate(180deg);
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar {
   width: 6px;

--- a/turbo/apps/web/app/privacy-policy/PrivacyPolicyClient.tsx
+++ b/turbo/apps/web/app/privacy-policy/PrivacyPolicyClient.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useEffect } from "react";
+import { NextIntlClientProvider } from "next-intl";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+import enMessages from "../../messages/en.json";
 
 export default function PrivacyPolicyClient() {
   useEffect(() => {
@@ -12,14 +16,25 @@ export default function PrivacyPolicyClient() {
   }, []);
 
   return (
-    <div
-      className="container"
-      style={{ padding: "40px 20px", minHeight: "600px" }}
-    >
-      <div
-        {...({ name: "termly-embed" } as React.HTMLAttributes<HTMLDivElement>)}
-        data-id="e2483c7f-905a-4618-b026-94f823ff2332"
-      />
-    </div>
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
+        <div className="header-container">
+          <Navbar />
+        </div>
+
+        <main className="px-6 pb-20 pt-[calc(var(--total-header-height)+48px)] md:pb-28 md:pt-[calc(var(--total-header-height)+72px)]">
+          <div className="termly-embed-wrapper mx-auto max-w-2xl">
+            <div
+              {...({
+                name: "termly-embed",
+              } as React.HTMLAttributes<HTMLDivElement>)}
+              data-id="e2483c7f-905a-4618-b026-94f823ff2332"
+            />
+          </div>
+        </main>
+
+        <Footer />
+      </div>
+    </NextIntlClientProvider>
   );
 }

--- a/turbo/apps/web/app/terms-of-use/TermsOfUseClient.tsx
+++ b/turbo/apps/web/app/terms-of-use/TermsOfUseClient.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useEffect } from "react";
+import { NextIntlClientProvider } from "next-intl";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+import enMessages from "../../messages/en.json";
 
 export default function TermsOfUseClient() {
   useEffect(() => {
@@ -12,14 +16,25 @@ export default function TermsOfUseClient() {
   }, []);
 
   return (
-    <div
-      className="container"
-      style={{ padding: "40px 20px", minHeight: "600px" }}
-    >
-      <div
-        {...({ name: "termly-embed" } as React.HTMLAttributes<HTMLDivElement>)}
-        data-id="2d4a38d0-0baf-410c-a39d-86976b13052d"
-      />
-    </div>
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <div className="landing-page min-h-screen bg-[hsl(var(--gray-0))] text-[hsl(var(--foreground))]">
+        <div className="header-container">
+          <Navbar />
+        </div>
+
+        <main className="px-6 pb-20 pt-[calc(var(--total-header-height)+48px)] md:pb-28 md:pt-[calc(var(--total-header-height)+72px)]">
+          <div className="termly-embed-wrapper mx-auto max-w-2xl">
+            <div
+              {...({
+                name: "termly-embed",
+              } as React.HTMLAttributes<HTMLDivElement>)}
+              data-id="2d4a38d0-0baf-410c-a39d-86976b13052d"
+            />
+          </div>
+        </main>
+
+        <Footer />
+      </div>
+    </NextIntlClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Add Navbar and Footer to terms-of-use and privacy-policy pages (previously bare pages with no site chrome)
- Add `NextIntlClientProvider` wrapper for i18n support required by Navbar
- Add dark mode support for Termly cross-origin iframe via CSS `filter: invert(1) hue-rotate(180deg)`
- Unify content width to `max-w-2xl` across security, terms, and privacy pages

## Test plan
- [ ] Visit `/terms-of-use` — verify Navbar and Footer are present
- [ ] Visit `/privacy-policy` — verify Navbar and Footer are present
- [ ] Toggle dark mode — verify Termly content is readable (inverted colors)
- [ ] Compare content width with `/en/security` — should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)