### PR TITLE
fix(platform): align permissions dialog unknown endpoints section

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/permissions-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/permissions-dialog.test.tsx
@@ -280,10 +280,10 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer();
 
-    expect(screen.getByText("Unknown endpoints")).toBeInTheDocument();
+    expect(screen.getByText("Other endpoints")).toBeInTheDocument();
 
     // Find the unknown endpoints row
-    const unknownLabel = screen.getByText("Unknown endpoints");
+    const unknownLabel = screen.getByText("Other endpoints");
     const unknownRow = unknownLabel.closest(
       ".flex.items-center.justify-between",
     ) as HTMLElement;
@@ -301,7 +301,7 @@ describe("permissions dialog - grouped connector (Slack)", () => {
     detachedSetupPage({ context, path: "/agents/my-agent" });
     await openPermissionsDrawer();
 
-    const unknownLabel = screen.getByText("Unknown endpoints");
+    const unknownLabel = screen.getByText("Other endpoints");
     const unknownRow = unknownLabel.closest(
       ".flex.items-center.justify-between",
     ) as HTMLElement;

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -215,14 +215,14 @@ function UnknownEndpointsToggle({
   onChange: (p: PermissionPolicy) => void;
 }) {
   return (
-    <div className="border-t border-border/40 mx-3 mt-2 pt-3 pb-1">
+    <div className="border-t border-border/40 -mx-6 px-3 pt-3 pb-1">
       <div className="flex items-center justify-between px-3">
         <div className="min-w-0 flex-1">
           <span className="text-xs font-medium text-foreground">
-            Unknown endpoints
+            Other endpoints
           </span>
           <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-            Endpoints not matching any permission rule above
+            API endpoints not matched by any rule above
           </p>
         </div>
         <PolicyPill policy={policy} disabled={disabled} onChange={onChange} />

--- a/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/settings/permissions-dialog.tsx
@@ -222,7 +222,7 @@ function UnknownEndpointsToggle({
             Other endpoints
           </span>
           <p className="mt-0.5 text-xs text-muted-foreground leading-relaxed">
-            API endpoints not matched by any rule above
+            API endpoints not matched by any permission above
           </p>
         </div>
         <PolicyPill policy={policy} disabled={disabled} onChange={onChange} />


### PR DESCRIPTION
## Summary
- Fix Allow/Deny pill and text misalignment in the "Other endpoints" toggle by matching the scroll container's negative margin pattern (`-mx-6 px-3` instead of `mx-3`)
- Remove extra top margin (`mt-2`) so `border-t` sits flush against content above
- Rename "Unknown endpoints" to "Other endpoints" for clearer wording

## Test plan
- [ ] Open any connector's permissions dialog (e.g. Datadog, Linear)
- [ ] Scroll to bottom — verify "Other endpoints" Allow/Deny pill is right-aligned with permission rows above
- [ ] Verify border line sits flush against the last permission row
- [ ] Verify text "Other endpoints" and description are left-aligned with permission names above

🤖 Generated with [Claude Code](https://claude.com/claude-code)