### PR TITLE
fix(web): pass report-error link to callbacks on run failure

### DIFF
--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -565,6 +565,48 @@ describe("POST /api/webhooks/agent/complete", () => {
       expect(callbacks[0]!.attempts).toBe(1);
     });
 
+    it("should dispatch callback with report-error link in error field", async () => {
+      const fetchSpy = vi.spyOn(global, "fetch");
+
+      // Register a callback for this run
+      await createTestCallback({
+        runId: testRunId,
+        url: "http://localhost/api/internal/callbacks/test",
+        payload: { testKey: "testValue" },
+      });
+
+      // Fail the run
+      const request = createTestRequest(
+        "http://localhost:3000/api/webhooks/agent/complete",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${testToken}`,
+          },
+          body: JSON.stringify({
+            runId: testRunId,
+            exitCode: 1,
+          }),
+        },
+      );
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+
+      await context.mocks.flushAfter();
+
+      // Find the callback fetch call
+      const callbackCall = fetchSpy.mock.calls.find(([url]) => {
+        return String(url).includes("/api/internal/callbacks/test");
+      });
+      expect(callbackCall).toBeDefined();
+
+      const body = JSON.parse(callbackCall![1]!.body as string);
+      expect(body.error).toContain(`/runs/${testRunId}/report-error`);
+
+      fetchSpy.mockRestore();
+    });
+
     it("should register only one after() callback for dispatch", async () => {
       // When a non-scheduled run completes (testRunId has no callbacks)
       const request = createTestRequest(

--- a/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/__tests__/route.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { http, HttpResponse } from "msw";
 import { Resend } from "resend";
+import { server } from "../../../../../../src/mocks/server";
 import { POST } from "../route";
 import {
   createTestRequest,
@@ -566,7 +568,18 @@ describe("POST /api/webhooks/agent/complete", () => {
     });
 
     it("should dispatch callback with report-error link in error field", async () => {
-      const fetchSpy = vi.spyOn(global, "fetch");
+      let capturedBody: { error?: string } | undefined;
+
+      // Intercept the callback request with MSW
+      server.use(
+        http.post(
+          "http://localhost/api/internal/callbacks/test",
+          async ({ request }) => {
+            capturedBody = (await request.json()) as { error?: string };
+            return HttpResponse.json({ success: true });
+          },
+        ),
+      );
 
       // Register a callback for this run
       await createTestCallback({
@@ -595,16 +608,9 @@ describe("POST /api/webhooks/agent/complete", () => {
 
       await context.mocks.flushAfter();
 
-      // Find the callback fetch call
-      const callbackCall = fetchSpy.mock.calls.find(([url]) => {
-        return String(url).includes("/api/internal/callbacks/test");
-      });
-      expect(callbackCall).toBeDefined();
-
-      const body = JSON.parse(callbackCall![1]!.body as string);
-      expect(body.error).toContain(`/runs/${testRunId}/report-error`);
-
-      fetchSpy.mockRestore();
+      // Verify the callback received the error with report-error link
+      expect(capturedBody).toBeDefined();
+      expect(capturedBody!.error).toContain(`/runs/${testRunId}/report-error`);
     });
 
     it("should register only one after() callback for dispatch", async () => {

--- a/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
+++ b/turbo/apps/web/app/api/webhooks/agent/complete/route.ts
@@ -138,6 +138,7 @@ const router = tsr.router(webhookCompleteContract, {
     }
 
     let finalStatus: "completed" | "failed";
+    let errorMessage: string | undefined;
 
     if (body.exitCode === 0) {
       // Success: query checkpoint and store result in run table
@@ -215,7 +216,7 @@ const router = tsr.router(webhookCompleteContract, {
     } else {
       // Failure: store error in run table
       const reportUrl = `${env().NEXT_PUBLIC_APP_URL}/runs/${body.runId}/report-error`;
-      const errorMessage = `An unexpected error occurred. [Report this issue](${reportUrl})`;
+      errorMessage = `An unexpected error occurred. [Report this issue](${reportUrl})`;
 
       const transitioned = await transitionRunStatus(
         body.runId,
@@ -242,11 +243,12 @@ const router = tsr.router(webhookCompleteContract, {
     }
 
     // Dispatch all registered callbacks and drain run queue (non-blocking)
-    const errorMsg =
-      finalStatus === "failed"
-        ? `Agent exited with code ${body.exitCode}`
-        : undefined;
-    scheduleTerminalSideEffects(body.runId, finalStatus, run.orgId, errorMsg);
+    scheduleTerminalSideEffects(
+      body.runId,
+      finalStatus,
+      run.orgId,
+      errorMessage,
+    );
 
     return {
       status: 200 as const,


### PR DESCRIPTION
## Summary
- The complete webhook was sending a generic `Agent exited with code X` error to callbacks, while storing the error with the `report-error` link in the database
- Slack/Telegram users saw a generic message instead of the actionable report-error URL
- Now callbacks receive the same error message stored in the run record, which includes the `[Report this issue](/runs/{runId}/report-error)` link

## Test plan
- [x] Added test: verifies callback fetch body contains report-error link on failure
- [x] All 20 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)