### PR TITLE
fix(web): use primary color for legal consent links in dark mode

### DIFF
--- a/turbo/apps/web/app/components/auth/AuthLayout.tsx
+++ b/turbo/apps/web/app/components/auth/AuthLayout.tsx
@@ -305,6 +305,11 @@ button[class*="alternativeMethodsBlockButton"] {
 a[class*="resendCode"] {
   color: hsl(var(--primary)) !important;
 }
+
+/* Legal consent checkbox label links (Terms of Service, Privacy Policy) */
+.cl-formFieldCheckboxLabel a {
+  color: hsl(var(--primary)) !important;
+}
 `;
 
 interface AuthLayoutProps {


### PR DESCRIPTION
## Summary
- Style the Terms of Service and Privacy Policy links in Clerk's sign-up legal consent checkbox with the primary theme color
- Links were hard to read in dark mode due to default Clerk styling

## Test plan
- [ ] Open sign-up page in dark mode, verify links are visible with primary color
- [ ] Verify links still look correct in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)