### PR TITLE
fix: use defaultAgent displayName for sidebar footer nav labels

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -45,7 +45,7 @@ import {
 } from "../../signals/zero-page/zero-nav.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
 import type { RouteKey } from "../../signals/route-paths.ts";
-import { subagents$ } from "../../signals/agent.ts";
+import { subagents$, defaultAgentName$ } from "../../signals/agent.ts";
 import {
   currentChatAgentDisplayName$,
   currentChatAgentId$,
@@ -204,6 +204,7 @@ export function ZeroSidebar() {
   const onAccountAction = useSet(handleZeroAccountAction$);
   const pageSignal = useGet(pageSignal$);
   const displayName = displayNameRaw || "Zero";
+  const defaultDisplayName = useLastResolved(defaultAgentName$) ?? "Zero";
   const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
   const savingPinned = pinLoadable.state === "loading";
   const setPinnedIds = (ids: string[]) => {
@@ -231,7 +232,7 @@ export function ZeroSidebar() {
   }).map((item) => {
     return {
       ...item,
-      label: item.label.replace("Zero", displayName),
+      label: item.label.replace("Zero", defaultDisplayName),
     };
   });
 


### PR DESCRIPTION
## Summary

- The sidebar footer nav items (including "Where Zero works") were using `currentChatAgentDisplayName$` for label substitution, which caused the name to change dynamically as the user switched chat agents
- Changed footer nav to use `defaultAgentName$` instead, so the label always reflects the workspace's default agent display name

## Root Cause

`displayName` was derived from `currentChatAgentDisplayName$` and used for both `manageNav` and `footerNav` label replacements. The footer nav items (like "Where Zero works") are workspace-level features and should always show the default agent's name, not the currently active chat agent's name.

## Changes

- Import `defaultAgentName$` from `signals/agent.ts`
- Compute `defaultDisplayName` using `useLastResolved(defaultAgentName$)`
- Use `defaultDisplayName` for `footerNav` label replacement (keeps `displayName` from current chat agent for `manageNav`)