### PR TITLE
fix(ui): improve dark mode contrast and layer hierarchy

### DIFF
--- a/turbo/apps/platform/src/views/css/index.css
+++ b/turbo/apps/platform/src/views/css/index.css
@@ -196,7 +196,7 @@
 }
 :where([data-theme="dark"]) .zero-nav {
   --color-sidebar: hsl(240 5% 8%);
-  --color-sidebar-accent: hsl(var(--gray-50));
+  --color-sidebar-accent: hsl(var(--gray-100));
   --color-sidebar-primary: #ffffff;
 }
 
@@ -315,6 +315,9 @@
 .zero-app .zero-chat-bubble-user {
   background-color: hsl(var(--gray-100));
   color: hsl(var(--foreground));
+}
+:where([data-theme="dark"]) .zero-app .zero-chat-bubble-user {
+  background-color: hsl(var(--gray-200));
 }
 
 /* Chat: assistant (Zero) message bubble */

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -106,8 +106,8 @@ function ChatThreadItem({
                 onClick={handleDeleteClick}
                 className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 ${
                   isSelected
-                    ? "text-slate-500 hover:text-slate-900 hover:bg-slate-300"
-                    : "text-sidebar-foreground/80 hover:text-foreground hover:bg-sidebar-foreground/10"
+                    ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
+                    : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
                 }`}
                 aria-label="Delete chat"
               >
@@ -266,7 +266,7 @@ function ChatThreadsTitle() {
     </div>
   ) : (
     <div
-      className="zero-nav-recent-label group flex h-8 shrink-0 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-sidebar-accent/50 transition-colors"
+      className="zero-nav-recent-label group flex h-8 shrink-0 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-sidebar-accent transition-colors"
       onClick={() => {
         return setCollapsed(!collapsed);
       }}
@@ -292,7 +292,7 @@ function ChatThreadsTitle() {
                   e.stopPropagation();
                   setSearchOpen(true);
                 }}
-                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
                 aria-label="Search chats"
               >
                 <IconSearch size={15} stroke={2.5} />
@@ -313,7 +313,7 @@ function ChatThreadsTitle() {
                   onNewChat();
                 }}
                 disabled={newChatDisabled}
-                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors disabled:opacity-50 disabled:pointer-events-none"
+                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors disabled:opacity-50 disabled:pointer-events-none"
                 aria-label={`New chat with ${agentDisplayName}`}
               >
                 <IconPlus size={15} stroke={2.5} />

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -241,7 +241,7 @@ function OrgDropdownContent() {
         <button
           type="button"
           onClick={handleManage}
-          className="shrink-0 flex items-center gap-1 px-2 h-7 rounded-md text-xs font-medium text-muted-foreground border border-border hover:text-foreground hover:bg-accent transition-colors"
+          className="shrink-0 flex items-center gap-1 px-2 h-7 rounded-md text-xs font-medium text-muted-foreground border border-[hsl(var(--gray-400))] hover:text-foreground hover:bg-accent transition-colors"
         >
           <IconSettings size={13} />
           Manage
@@ -284,7 +284,7 @@ export function ZeroOrgSwitcher() {
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className="w-full flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-sidebar-accent/50 text-sidebar-foreground transition-colors"
+            className="w-full flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-sidebar-accent text-sidebar-foreground transition-colors"
           >
             <span className="relative shrink-0">
               <OrgAvatar name={orgName} imageUrl={currentOrg?.imageUrl} />

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-account.tsx
@@ -157,8 +157,8 @@ export function AccountDropdown({
           type="button"
           className={`rounded-lg transition-colors duration-200 ${
             collapsed
-              ? "inline-flex h-8 w-8 shrink-0 items-center justify-center p-0 hover:bg-sidebar-accent/50"
-              : "flex w-full items-center gap-2 p-2 text-left hover:bg-sidebar-accent/50"
+              ? "inline-flex h-8 w-8 shrink-0 items-center justify-center p-0 hover:bg-sidebar-accent"
+              : "flex w-full items-center gap-2 p-2 text-left hover:bg-sidebar-accent"
           }`}
         >
           <AccountAvatar

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -88,7 +88,7 @@ export function PinnedAgentListSection() {
   return (
     <div className="shrink-0">
       <div
-        className="group flex h-8 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-sidebar-accent/50 transition-colors"
+        className="group flex h-8 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-sidebar-accent transition-colors"
         data-testid="pinned-section-header"
         onClick={() => {
           return setCollapsed(!collapsed);
@@ -114,7 +114,7 @@ export function PinnedAgentListSection() {
                   setChatListOpenFn(true);
                   reloadAgents();
                 }}
-                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+                className="relative z-10 flex h-8 w-8 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
                 aria-label="Open a conversation"
               >
                 <IconPlus size={15} stroke={2.5} />
@@ -158,7 +158,7 @@ export function PinnedAgentListSection() {
                     options={{ pathParams: { id: agent.id } }}
                     className={`flex w-full h-8 shrink-0 items-center gap-2 rounded-lg px-2 text-left text-sm leading-5 no-underline transition-colors duration-200 ${
                       isPrimarySelected
-                        ? "bg-gray-200 text-gray-900 font-medium"
+                        ? "bg-gray-200 text-foreground font-medium"
                         : isFromChat
                           ? "border-l-2 border-[hsl(var(--gray-400))] bg-sidebar-accent/50"
                           : "text-sidebar-foreground hover:bg-sidebar-accent"
@@ -191,8 +191,8 @@ export function PinnedAgentListSection() {
                               disabled={savingPinned}
                               className={`flex h-6 w-6 cursor-pointer items-center justify-center rounded-md invisible group-hover:visible transition-opacity duration-150 disabled:cursor-not-allowed disabled:opacity-50 ${
                                 isPrimarySelected
-                                  ? "text-slate-500 hover:text-slate-900 hover:bg-slate-300"
-                                  : "text-sidebar-foreground/80 hover:text-foreground hover:bg-sidebar-foreground/10"
+                                  ? "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-300))]"
+                                  : "text-sidebar-foreground/80 hover:text-foreground hover:bg-[hsl(var(--gray-200))]"
                               }`}
                               aria-label="Remove from list"
                             >

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -264,7 +264,7 @@ export function ZeroSidebar() {
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 transition-colors hover:bg-[hsl(var(--gray-200))] hover:text-sidebar-foreground"
                   onClick={onCollapse}
                   aria-label="Expand sidebar"
                 >
@@ -380,7 +380,7 @@ export function ZeroSidebar() {
                 <TooltipTrigger asChild>
                   <button
                     type="button"
-                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent transition-colors"
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-[hsl(var(--gray-200))] transition-colors"
                     onClick={onCollapse}
                     aria-label="Collapse sidebar"
                   >
@@ -402,7 +402,7 @@ export function ZeroSidebar() {
           {/* Manage section */}
           <div className="shrink-0">
             <div
-              className="group flex h-8 shrink-0 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-sidebar-accent/50 transition-colors"
+              className="group flex h-8 shrink-0 cursor-pointer items-center justify-between rounded-lg pl-2 pr-0 hover:bg-sidebar-accent transition-colors"
               onClick={() => {
                 return setManageCollapsed(!manageCollapsed);
               }}

--- a/turbo/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/turbo/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -21,7 +21,7 @@ const DropdownMenuContent = React.forwardRef<
         ref={ref}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 min-w-[8rem] overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[8rem] overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg dark:shadow-[0_8px_40px_-8px_rgba(0,0,0,0.6)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}
@@ -91,7 +91,7 @@ const DropdownMenuSubContent = React.forwardRef<
       <DropdownMenuPrimitive.SubContent
         ref={ref}
         className={cn(
-          "z-50 min-w-[8rem] overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-50 min-w-[8rem] overflow-hidden rounded-lg border-[0.7px] border-[hsl(var(--gray-400))] bg-card p-1 text-foreground shadow-lg dark:shadow-[0_8px_40px_-8px_rgba(0,0,0,0.6)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/turbo/packages/ui/src/components/ui/sheet.tsx
+++ b/turbo/packages/ui/src/components/ui/sheet.tsx
@@ -44,9 +44,9 @@ const SheetContent = React.forwardRef<
         className={cn(
           "sheet-content fixed z-50 flex flex-col gap-4 overflow-x-hidden bg-card p-6",
           side === "right" &&
-            "inset-y-0 right-0 h-full w-3/4 sm:max-w-lg shadow-[-8px_0_24px_-12px_rgba(0,0,0,0.1)]",
+            "inset-y-0 right-0 h-full w-3/4 sm:max-w-lg shadow-[-8px_0_24px_-12px_rgba(0,0,0,0.1)] dark:shadow-[-16px_0_48px_-8px_rgba(0,0,0,0.5)]",
           side === "left" &&
-            "inset-y-0 left-0 h-full w-3/4 sm:max-w-md shadow-[8px_0_24px_-12px_rgba(0,0,0,0.1)]",
+            "inset-y-0 left-0 h-full w-3/4 sm:max-w-md shadow-[8px_0_24px_-12px_rgba(0,0,0,0.1)] dark:shadow-[16px_0_48px_-8px_rgba(0,0,0,0.5)]",
           side === "top" && "inset-x-0 top-0",
           side === "bottom" && "inset-x-0 bottom-0",
           className,

--- a/turbo/packages/ui/src/components/ui/tooltip.tsx
+++ b/turbo/packages/ui/src/components/ui/tooltip.tsx
@@ -25,7 +25,7 @@ const TooltipContent = React.forwardRef<
           className,
         )}
         style={{
-          backgroundColor: "#1a1a1a",
+          backgroundColor: "var(--tooltip-bg, #1a1a1a)",
           color: "hsl(var(--on-filled))",
           ...props.style,
         }}

--- a/turbo/packages/ui/src/styles/globals.css
+++ b/turbo/packages/ui/src/styles/globals.css
@@ -253,21 +253,21 @@
     --primary-950: 16 100% 90%; /* #FED5C7 */
 
     /* Background/Gray Color Scale (Neutral - Dark) */
-    --gray-0: 240 3% 7%; /* #111113 */
-    --gray-50: 240 3% 10%; /* #19191B */
-    --gray-100: 240 3% 14%; /* #222325 */
-    --gray-200: 240 3% 17%; /* #292A2E */
-    --gray-300: 240 3% 19%; /* #303136 */
-    --gray-400: 228 4% 22%; /* #363840 - subtle border, softer against dark cards */
-    --gray-500: 228 4% 28%; /* #46484F */
-    --gray-600: 228 6% 39%; /* #5F606A */
-    --gray-700: 228 7% 45%; /* #6C6E79 */
-    --gray-800: 228 7% 50%; /* #797B86 */
-    --gray-900: 228 7% 71%; /* #B2B3BD */
-    --gray-950: 230 8% 85%; /* #D5D6DC */
+    --gray-0: 240 3% 7%; /* #111113 - deepest page bg */
+    --gray-50: 240 3% 10%; /* #19191B - page bg */
+    --gray-100: 240 3% 15%; /* #252527 - sidebar, popover */
+    --gray-200: 240 3% 19%; /* #2F2F32 - border, input */
+    --gray-300: 240 3% 23%; /* #393A3D - accent hover */
+    --gray-400: 228 4% 27%; /* #434550 - stronger border */
+    --gray-500: 228 4% 33%; /* #525460 */
+    --gray-600: 228 6% 42%; /* #686A74 */
+    --gray-700: 228 7% 49%; /* #787A85 */
+    --gray-800: 228 7% 58%; /* #8C8E9A */
+    --gray-900: 228 7% 78%; /* #C5C6CF */
+    --gray-950: 230 8% 92%; /* #E8E9ED */
 
     /* Divider Color (Dark) */
-    --divider: 240 3% 19%; /* #2F2F32 */
+    --divider: 240 3% 22%; /* #373739 */
 
     /* Theme-aware Colors (Dark - inverted) */
     --white: 240 3% 10%; /* #19191B */
@@ -279,7 +279,7 @@
     --background: var(--gray-50); /* gray-50 */
     --foreground: var(--gray-950); /* gray-950 */
 
-    --card: 240 4% 12%; /* between gray-50 and gray-100 - deeper card surface */
+    --card: 240 4% 14%; /* between gray-50 and gray-100 - card surface */
     --card-foreground: var(--gray-950); /* gray-950 */
 
     --popover: var(--gray-100); /* gray-100 - dark background */
@@ -322,8 +322,12 @@
     --sidebar-primary: var(--primary-800); /* primary-800 */
     --sidebar-primary-foreground: var(--gray-50); /* gray-50 */
     --sidebar-accent: var(
-      --gray-200
-    ); /* gray-200 - lighter than sidebar for hover */
+      --gray-300
+    ); /* gray-300 - visible hover against sidebar */
+
+    --tooltip-bg: hsl(
+      var(--gray-300)
+    ); /* tooltip - visible against dark surfaces */
 
     --semantic-foreground: var(--gray-0); /* gray-0 */
 


### PR DESCRIPTION
## Summary
- **Gray scale**: Widen dark mode surface spread from 15% to 20% lightness range for clearer layer separation (page bg → card → sidebar → border)
- **Text colors**: Brighten foreground (85% → 92%), muted-foreground (50% → 58%), gray-900 (71% → 78%) — all WCAG AA compliant, main text reaches AAA
- **Tooltip**: Add `--tooltip-bg` variable using gray-300 so tooltips don't blend into dark backgrounds
- **Sheet**: Stronger shadow in dark mode (`0.5` opacity vs `0.1`)
- **Dropdown**: Add dark mode shadow for clearer popover depth
- **Sidebar hover**: Remove `/50` opacity from hover states, use full `sidebar-accent`; icon buttons use `gray-200` for stronger hover
- **Active nav**: Use `text-foreground` instead of `text-gray-900` to prevent text darkening on selection
- **Chat bubble**: Darken user message bubble in dark mode for visibility
- **Manage button**: Use `gray-400` border for better contrast in dropdowns

## Test plan
- [ ] Toggle dark mode — verify cards, sidebar, and page bg have clear layer separation
- [ ] Hover sidebar items — verify hover state is visible
- [ ] Hover icon buttons (search, new chat, delete, remove) — verify they stand out from row hover
- [ ] Click a pinned agent — verify active state text doesn't get darker
- [ ] Open org switcher — verify dropdown shadow and Manage button border are visible
- [ ] Hover tooltip — verify it's clearly visible against dark background
- [ ] Open a sheet/drawer — verify it's distinguishable from page background
- [ ] Send a chat message — verify user bubble is visible
- [ ] Switch to light mode — verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)