### PR TITLE
feat(runner): clean stale files on vm reuse before downloading storages

### DIFF
--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -69,12 +69,16 @@ const LOG_TAG: &str = "sandbox:download";
 
 /// Storage manifest format (matches TypeScript StorageManifest).
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct Manifest {
     #[serde(default)]
     storages: Vec<Storage>,
     artifact: Option<Artifact>,
     #[serde(default)]
     memory: Option<Artifact>,
+    /// Paths to clean before downloading (stale file cleanup on VM reuse).
+    #[serde(default)]
+    cleanup_paths: Vec<String>,
 }
 
 /// Check if archive URL is valid (not None and not string "null").
@@ -137,6 +141,32 @@ pub fn run(manifest_path: &str) -> bool {
         }
     };
 
+    // Clean stale files from changed/removed storages before downloading.
+    // This must run before parallel downloads to avoid race conditions with
+    // parent-child mount path overlaps.
+    if !manifest.cleanup_paths.is_empty() {
+        // Collect all mount paths that should be preserved (unchanged storages,
+        // artifact, and memory).
+        let mut preserved: Vec<&str> = manifest
+            .storages
+            .iter()
+            .filter(|s| !is_valid_url(&s.archive_url))
+            .map(|s| s.mount_path.as_str())
+            .collect();
+        if let Some(a) = &manifest.artifact
+            && !is_valid_url(&a.archive_url)
+        {
+            preserved.push(a.mount_path.as_str());
+        }
+        if let Some(m) = &manifest.memory
+            && !is_valid_url(&m.archive_url)
+        {
+            preserved.push(m.mount_path.as_str());
+        }
+
+        cleanup_stale_paths(&manifest.cleanup_paths, &preserved);
+    }
+
     // Build unified task list: storages + artifact + memory, all downloaded in parallel.
     let mut tasks: Vec<DownloadTask> = Vec::new();
 
@@ -184,6 +214,77 @@ pub fn run(manifest_path: &str) -> bool {
     }
 
     download_all_parallel(tasks)
+}
+
+/// Remove stale files from cleanup paths, preserving directories that belong
+/// to unchanged storages.
+///
+/// For each path in `cleanup_paths`:
+/// - If no `preserved` path is a child of it: `remove_dir_all` (clean slate).
+/// - If a preserved path is a child: remove only top-level entries that don't
+///   overlap with any preserved child path.
+fn cleanup_stale_paths(cleanup_paths: &[String], preserved: &[&str]) {
+    // Sort cleanup paths shortest-first so parents are cleaned before children.
+    let mut sorted: Vec<&str> = cleanup_paths.iter().map(|s| s.as_str()).collect();
+    sorted.sort_by_key(|p| p.len());
+
+    for path in sorted {
+        let path_with_slash = format!("{path}/");
+
+        // Find preserved paths that are children of this cleanup path.
+        let has_preserved_children = preserved.iter().any(|p| p.starts_with(&path_with_slash));
+
+        if !has_preserved_children {
+            // No unchanged children — safe to remove everything.
+            if let Err(e) = fs::remove_dir_all(path) {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    log_warn!(LOG_TAG, "Failed to clean {path}: {e}");
+                }
+            } else {
+                log_info!(LOG_TAG, "Cleaned stale path: {path}");
+            }
+        } else {
+            // Has unchanged children — selectively remove entries that don't
+            // overlap with preserved paths.
+            let entries = match fs::read_dir(path) {
+                Ok(entries) => entries,
+                Err(e) => {
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        log_warn!(LOG_TAG, "Failed to read dir {path}: {e}");
+                    }
+                    continue;
+                }
+            };
+            for entry in entries.flatten() {
+                let entry_path = entry.path();
+                let entry_str = entry_path.to_string_lossy();
+                let entry_prefix = format!("{entry_str}/");
+
+                // Check if this entry is or contains a preserved path.
+                let is_preserved = preserved
+                    .iter()
+                    .any(|p| *p == entry_str.as_ref() || p.starts_with(&entry_prefix));
+
+                if !is_preserved {
+                    if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                        if let Err(e) = fs::remove_dir_all(&entry_path) {
+                            log_warn!(LOG_TAG, "Failed to remove {}: {e}", entry_str);
+                        }
+                    } else if let Err(e) = fs::remove_file(&entry_path) {
+                        log_warn!(LOG_TAG, "Failed to remove {}: {e}", entry_str);
+                    }
+                }
+            }
+            log_info!(
+                LOG_TAG,
+                "Selectively cleaned {path} (preserved {} children)",
+                preserved
+                    .iter()
+                    .filter(|p| p.starts_with(&path_with_slash))
+                    .count()
+            );
+        }
+    }
 }
 
 struct DownloadTask {
@@ -609,5 +710,64 @@ mod tests {
         assert!(is_valid_url(&Some(
             "https://example.com/archive.tar.gz".to_string()
         )));
+    }
+
+    // -- cleanup_stale_paths tests --
+
+    #[test]
+    fn cleanup_removes_path_without_preserved_children() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mount");
+        fs::create_dir_all(&path).unwrap();
+        fs::write(path.join("stale.txt"), "old").unwrap();
+
+        cleanup_stale_paths(&[path.to_string_lossy().into()], &[]);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn cleanup_preserves_unchanged_children() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("claude");
+        let child = parent.join("skills").join("foo");
+        fs::create_dir_all(&child).unwrap();
+        fs::write(parent.join("CLAUDE.md"), "old instructions").unwrap();
+        fs::write(child.join("skill.md"), "keep me").unwrap();
+
+        let parent_str = parent.to_string_lossy().to_string();
+        let child_str = child.to_string_lossy().to_string();
+
+        cleanup_stale_paths(&[parent_str], &[&child_str]);
+
+        // Parent dir still exists (not fully removed)
+        assert!(parent.exists());
+        // Child preserved
+        assert!(child.join("skill.md").exists());
+        // Stale file at parent level removed
+        assert!(!parent.join("CLAUDE.md").exists());
+    }
+
+    #[test]
+    fn cleanup_handles_nonexistent_path() {
+        // Should not panic
+        cleanup_stale_paths(&["/nonexistent/path/12345".into()], &[]);
+    }
+
+    #[test]
+    fn manifest_deserializes_camel_case_cleanup_paths() {
+        let json = r#"{
+            "storages": [],
+            "cleanupPaths": ["/home/user/.claude", "/home/user/.claude/skills/old"]
+        }"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+        assert_eq!(manifest.cleanup_paths.len(), 2);
+        assert_eq!(manifest.cleanup_paths[0], "/home/user/.claude");
+    }
+
+    #[test]
+    fn manifest_defaults_cleanup_paths_when_absent() {
+        let json = r#"{"storages": []}"#;
+        let manifest: Manifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.cleanup_paths.is_empty());
     }
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -416,7 +416,8 @@ async fn run_in_sandbox(
             }
             None => manifest,
         };
-        // Short-circuit: skip the vsock exec if every entry was filtered out.
+        // Short-circuit: skip the vsock exec if every entry was filtered out
+        // and there are no paths to clean up.
         let has_work = effective.storages.iter().any(|s| s.archive_url.is_some())
             || effective
                 .artifact
@@ -425,7 +426,8 @@ async fn run_in_sandbox(
             || effective
                 .memory
                 .as_ref()
-                .is_some_and(|m| m.archive_url.is_some());
+                .is_some_and(|m| m.archive_url.is_some())
+            || !effective.cleanup_paths.is_empty();
         if !has_work {
             info!(run_id = %context.run_id, "all storages unchanged, skipping download");
         }
@@ -921,8 +923,9 @@ fn filter_unchanged_storages(
     prev: &crate::idle_pool::StorageFingerprints,
 ) -> StorageManifest {
     let mut skipped: usize = 0;
+    let mut cleanup_paths: Vec<String> = Vec::new();
 
-    let storages = manifest
+    let storages: Vec<StorageEntry> = manifest
         .storages
         .iter()
         .map(|s| {
@@ -935,6 +938,8 @@ fn filter_unchanged_storages(
             };
             if unchanged {
                 skipped += 1;
+            } else if s.archive_url.is_some() {
+                cleanup_paths.push(s.mount_path.clone());
             }
             StorageEntry {
                 mount_path: s.mount_path.clone(),
@@ -949,28 +954,44 @@ fn filter_unchanged_storages(
         })
         .collect();
 
-    let filter_artifact =
-        |a: &ArtifactEntry, prev_ver: &Option<(String, String)>, skipped: &mut usize| {
-            let same = prev_ver
-                .as_ref()
-                .is_some_and(|(name, ver)| *name == a.vas_storage_name && *ver == a.vas_version_id);
-            if same {
-                *skipped += 1;
-            }
-            ArtifactEntry {
-                archive_url: if same { None } else { a.archive_url.clone() },
-                ..a.clone()
-            }
-        };
+    // Detect removed storages: paths in previous fingerprints not in current manifest.
+    let current_paths: std::collections::HashSet<&str> = manifest
+        .storages
+        .iter()
+        .map(|s| s.mount_path.as_str())
+        .collect();
+    for prev_path in prev.storages.keys() {
+        if !current_paths.contains(prev_path.as_str()) {
+            cleanup_paths.push(prev_path.clone());
+        }
+    }
+
+    let filter_artifact = |a: &ArtifactEntry,
+                           prev_ver: &Option<(String, String)>,
+                           skipped: &mut usize,
+                           cleanup: &mut Vec<String>| {
+        let same = prev_ver
+            .as_ref()
+            .is_some_and(|(name, ver)| *name == a.vas_storage_name && *ver == a.vas_version_id);
+        if same {
+            *skipped += 1;
+        } else if a.archive_url.is_some() {
+            cleanup.push(a.mount_path.clone());
+        }
+        ArtifactEntry {
+            archive_url: if same { None } else { a.archive_url.clone() },
+            ..a.clone()
+        }
+    };
 
     let artifact = manifest
         .artifact
         .as_ref()
-        .map(|a| filter_artifact(a, &prev.artifact, &mut skipped));
+        .map(|a| filter_artifact(a, &prev.artifact, &mut skipped, &mut cleanup_paths));
     let memory = manifest
         .memory
         .as_ref()
-        .map(|m| filter_artifact(m, &prev.memory, &mut skipped));
+        .map(|m| filter_artifact(m, &prev.memory, &mut skipped, &mut cleanup_paths));
 
     if skipped > 0 {
         let total = manifest.storages.len()
@@ -979,10 +1000,18 @@ fn filter_unchanged_storages(
         info!(skipped, total, "filtered unchanged storage entries");
     }
 
+    if !cleanup_paths.is_empty() {
+        info!(
+            count = cleanup_paths.len(),
+            "computed cleanup paths for stale file removal"
+        );
+    }
+
     StorageManifest {
         storages,
         artifact,
         memory,
+        cleanup_paths,
     }
 }
 
@@ -1306,6 +1335,7 @@ mod tests {
                 vas_version_id: "v1".into(),
             }),
             memory: None,
+            cleanup_paths: vec![],
         });
 
         let env = build_env_json(&ctx, "http://localhost");
@@ -1904,6 +1934,7 @@ mod tests {
             }],
             artifact: None,
             memory: None,
+            cleanup_paths: vec![],
         };
         download_storages(&sandbox, &ctx, &manifest, "/tmp/log")
             .await
@@ -1924,6 +1955,7 @@ mod tests {
             storages: vec![],
             artifact: None,
             memory: None,
+            cleanup_paths: vec![],
         };
         let err = download_storages(&sandbox, &ctx, &manifest, "/tmp/log")
             .await
@@ -1996,6 +2028,7 @@ mod tests {
                 vas_storage_name: "project-mem".into(),
                 vas_version_id: "v2".into(),
             }),
+            cleanup_paths: vec![],
         });
         let env = build_env_json(&ctx, "http://localhost");
         assert_eq!(env.get("VM0_MEMORY_DRIVER").unwrap(), "vas");
@@ -2137,6 +2170,7 @@ mod tests {
             storages: vec![],
             artifact: None,
             memory: None,
+            cleanup_paths: vec![],
         };
         let err = download_storages(&sandbox, &ctx, &manifest, "/tmp/log")
             .await
@@ -2273,6 +2307,7 @@ mod tests {
             }],
             artifact: None,
             memory: None,
+            cleanup_paths: vec![],
         });
         let (exit_code, _) = run_execute_inner(&factory, &ctx, &config, &default_params())
             .await
@@ -2714,6 +2749,7 @@ mod tests {
             storages: vec![],
             artifact: Some(art("my-art", "v1", "https://s3/v1")),
             memory: None,
+            cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints {
             storages: HashMap::new(),
@@ -2730,6 +2766,7 @@ mod tests {
             storages: vec![],
             artifact: Some(art("my-art", "v2", "https://s3/v2")),
             memory: None,
+            cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints {
             storages: HashMap::new(),
@@ -2749,6 +2786,7 @@ mod tests {
             storages: vec![],
             artifact: Some(art("other-art", "v1", "https://s3/v1")),
             memory: None,
+            cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints {
             storages: HashMap::new(),
@@ -2765,6 +2803,7 @@ mod tests {
             storages: vec![],
             artifact: Some(art("my-art", "v1", "https://s3/v1")),
             memory: None,
+            cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints::default();
         let result = filter_unchanged_storages(&manifest, &prev);
@@ -2782,6 +2821,7 @@ mod tests {
             }],
             artifact: Some(art("my-art", "v1", "https://s3/v1")),
             memory: Some(art("mem", "m1", "https://s3/m1")),
+            cleanup_paths: vec![],
         };
         let prev = crate::idle_pool::StorageFingerprints::default();
         let result = filter_unchanged_storages(&manifest, &prev);
@@ -2801,6 +2841,7 @@ mod tests {
             }],
             artifact: Some(art("my-art", "v1", "https://s3/v1")),
             memory: Some(art("mem", "m1", "https://s3/m1")),
+            cleanup_paths: vec![],
         };
         let mut storages = HashMap::new();
         storages.insert("/data".into(), ("vol-1".into(), "v1".into()));
@@ -2813,5 +2854,107 @@ mod tests {
         assert!(result.storages[0].archive_url.is_none());
         assert!(result.artifact.as_ref().unwrap().archive_url.is_none());
         assert!(result.memory.as_ref().unwrap().archive_url.is_none());
+    }
+
+    #[test]
+    fn filter_computes_cleanup_for_changed_storages() {
+        let manifest = StorageManifest {
+            storages: vec![
+                StorageEntry {
+                    mount_path: "/home/user/.claude".into(),
+                    archive_url: Some("https://s3/instructions".into()),
+                    vas_storage_name: Some("instructions".into()),
+                    vas_version_id: Some("v2".into()),
+                },
+                StorageEntry {
+                    mount_path: "/home/user/.claude/skills/foo".into(),
+                    archive_url: Some("https://s3/foo".into()),
+                    vas_storage_name: Some("skill-foo".into()),
+                    vas_version_id: Some("v1".into()),
+                },
+            ],
+            artifact: None,
+            memory: None,
+            cleanup_paths: vec![],
+        };
+        let mut storages = HashMap::new();
+        storages.insert(
+            "/home/user/.claude".into(),
+            ("instructions".into(), "v1".into()),
+        );
+        storages.insert(
+            "/home/user/.claude/skills/foo".into(),
+            ("skill-foo".into(), "v1".into()),
+        );
+        let prev = crate::idle_pool::StorageFingerprints {
+            storages,
+            artifact: None,
+            memory: None,
+        };
+        let result = filter_unchanged_storages(&manifest, &prev);
+        // Instructions changed (v1→v2), skill-foo unchanged
+        assert!(result.storages[0].archive_url.is_some());
+        assert!(result.storages[1].archive_url.is_none());
+        // Only changed storage in cleanup_paths
+        assert_eq!(result.cleanup_paths, vec!["/home/user/.claude"]);
+    }
+
+    #[test]
+    fn filter_detects_removed_storages() {
+        let manifest = StorageManifest {
+            storages: vec![StorageEntry {
+                mount_path: "/home/user/.claude".into(),
+                archive_url: Some("https://s3/instructions".into()),
+                vas_storage_name: Some("instructions".into()),
+                vas_version_id: Some("v1".into()),
+            }],
+            artifact: None,
+            memory: None,
+            cleanup_paths: vec![],
+        };
+        let mut storages = HashMap::new();
+        storages.insert(
+            "/home/user/.claude".into(),
+            ("instructions".into(), "v1".into()),
+        );
+        storages.insert(
+            "/home/user/.claude/skills/old-skill".into(),
+            ("old-skill".into(), "v1".into()),
+        );
+        let prev = crate::idle_pool::StorageFingerprints {
+            storages,
+            artifact: None,
+            memory: None,
+        };
+        let result = filter_unchanged_storages(&manifest, &prev);
+        // instructions unchanged, old-skill removed
+        assert!(result.storages[0].archive_url.is_none());
+        assert!(
+            result
+                .cleanup_paths
+                .contains(&"/home/user/.claude/skills/old-skill".to_string())
+        );
+    }
+
+    #[test]
+    fn filter_changed_artifact_adds_cleanup_path() {
+        let manifest = StorageManifest {
+            storages: vec![],
+            artifact: Some(art("my-art", "v2", "https://s3/v2")),
+            memory: None,
+            cleanup_paths: vec![],
+        };
+        let prev = crate::idle_pool::StorageFingerprints {
+            storages: HashMap::new(),
+            artifact: Some(("my-art".into(), "v1".into())),
+            memory: None,
+        };
+        let result = filter_unchanged_storages(&manifest, &prev);
+        assert!(result.artifact.as_ref().unwrap().archive_url.is_some());
+        assert!(
+            result
+                .cleanup_paths
+                .contains(&result.artifact.as_ref().unwrap().mount_path)
+        );
     }
 }

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -157,6 +157,10 @@ pub struct StorageManifest {
     pub artifact: Option<ArtifactEntry>,
     #[serde(default)]
     pub memory: Option<ArtifactEntry>,
+    /// Paths to clean before downloading (computed from previous fingerprints).
+    /// Used on VM reuse to remove stale files from changed/removed storages.
+    #[serde(default)]
+    pub cleanup_paths: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Summary
- Runner computes `cleanup_paths` from fingerprint diffs (changed versions, removed storages, changed artifact/memory) and passes them to guest-download via `StorageManifest`
- Guest cleans stale paths before parallel downloads, handling parent-child mount path overlaps by selectively preserving unchanged children
- Only active on VM reuse (keep-alive); no impact when keep-alive is disabled

## Changes
- `crates/runner/src/types.rs`: Add `cleanup_paths: Vec<String>` to `StorageManifest`
- `crates/runner/src/executor.rs`: Compute cleanup paths in `filter_unchanged_storages()`, update `has_work` check (+3 tests)
- `crates/guest-download/src/lib.rs`: Add `cleanup_stale_paths()` with selective preservation, fix `#[serde(rename_all = "camelCase")]` on `Manifest` (+5 tests)

## Test plan
- [x] `filter_computes_cleanup_for_changed_storages` — changed storage version adds cleanup path
- [x] `filter_detects_removed_storages` — storage in prev but not current adds cleanup path
- [x] `filter_changed_artifact_adds_cleanup_path` — changed artifact adds cleanup path
- [x] `cleanup_removes_path_without_preserved_children` — full removal when no children preserved
- [x] `cleanup_preserves_unchanged_children` — selective removal preserving child directories
- [x] `cleanup_handles_nonexistent_path` — graceful handling of missing paths
- [x] `manifest_deserializes_camel_case_cleanup_paths` — serde camelCase compatibility
- [x] `manifest_defaults_cleanup_paths_when_absent` — backward compatibility with old manifests

Closes #8757

🤖 Generated with [Claude Code](https://claude.com/claude-code)