### PR TITLE
fix(runner): address feature switch review findings

### DIFF
--- a/crates/guest-agent/src/env.rs
+++ b/crates/guest-agent/src/env.rs
@@ -27,7 +27,6 @@ static SECRET_VALUES: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_SECR
 static DISALLOWED_TOOLS: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_DISALLOWED_TOOLS"));
 static TOOLS: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_TOOLS"));
 static SETTINGS: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_SETTINGS"));
-static FEATURE_FLAGS: LazyLock<String> = LazyLock::new(|| env_or_empty("VM0_FEATURE_FLAGS"));
 static USE_MOCK_CLAUDE: LazyLock<bool> = LazyLock::new(|| {
     std::env::var("USE_MOCK_CLAUDE")
         .map(|v| v == "true")
@@ -116,9 +115,6 @@ pub fn tools() -> &'static str {
 }
 pub fn settings() -> &'static str {
     &SETTINGS
-}
-pub fn feature_flags() -> &'static str {
-    &FEATURE_FLAGS
 }
 pub fn use_mock_claude() -> bool {
     *USE_MOCK_CLAUDE

--- a/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
@@ -73,6 +73,7 @@ function makeBaseContext(
     volumes: [],
     artifact: null,
     memory: null,
+    featureFlags: null,
     ...overrides,
   };
 }

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
@@ -189,6 +189,7 @@ describe("zeroActivityDetailPageInteraction", () => {
       volumes: [],
       artifact: null,
       memory: null,
+      featureFlags: null,
     };
 
     server.use(

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -71,6 +71,7 @@ function makeSnapshot(runId: string, userId: string): RunContextSnapshot {
       vasVersionId: "art-ver-1",
     },
     memory: null,
+    featureFlags: { computerUse: true, voiceChat: false },
   };
 }
 
@@ -107,6 +108,7 @@ describe("GET /api/zero/runs/:id/context", () => {
     expect(data.volumes).toHaveLength(1);
     expect(data.artifact).toBeDefined();
     expect(data.memory).toBeNull();
+    expect(data.featureFlags).toEqual({ computerUse: true, voiceChat: false });
   });
 
   it("should return 404 when run not found", async () => {

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -200,7 +200,7 @@ const runContextResponseSchema = z.object({
   volumes: z.array(runContextVolumeSchema),
   artifact: runContextArtifactSchema.nullable(),
   memory: runContextArtifactSchema.nullable(),
-  featureFlags: z.record(z.string(), z.boolean()).nullable().optional(),
+  featureFlags: z.record(z.string(), z.boolean()).nullable(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Remove unused `FEATURE_FLAGS` static and `feature_flags()` export from guest-agent `env.rs` (YAGNI)
- Change `featureFlags` schema from `.nullable().optional()` to `.nullable()` for consistency with adjacent fields
- Add `featureFlags` to context route test snapshot and assertion

Follow-up to #8778 based on code review findings.

## Test plan
- [x] Rust clippy passes (no dead code warning)
- [x] Context route test passes with new `featureFlags` assertion
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)