### PR TITLE
feat(web): enrich diagnostic bundle with system log and full network log

### DIFF
--- a/turbo/apps/web/app/api/zero/report-error/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/report-error/__tests__/route.test.ts
@@ -240,6 +240,102 @@ describe("POST /api/zero/report-error", () => {
     expect(entryNames).toContain("activity-log.json");
   });
 
+  it("should include system-log.txt when Axiom returns system log data", async () => {
+    const { runId } = await setupFailedRun(userId);
+
+    context.mocks.axiom.queryAxiom
+      .mockResolvedValueOnce([]) // agentEvents
+      .mockResolvedValueOnce([{ log: "booting sandbox\n" }, { log: "ready\n" }]) // systemLog
+      .mockResolvedValueOnce([]); // networkLog
+
+    await postReportError({ runId, title: "Bug" });
+
+    const zipBuffer = context.mocks.s3.uploadS3Buffer.mock
+      .calls[0]![2] as Buffer;
+    const zip = new AdmZip(zipBuffer);
+    const systemLog = zip
+      .getEntry("system-log.txt")
+      ?.getData()
+      .toString("utf-8");
+
+    expect(systemLog).toBe("booting sandbox\nready\n");
+  });
+
+  it("should include network-log.jsonl when Axiom returns network log data", async () => {
+    const { runId } = await setupFailedRun(userId);
+
+    const networkEntry = {
+      _time: "2024-01-01T00:00:01Z",
+      runId,
+      method: "GET",
+      url: "https://api.github.com/repos",
+      status: 200,
+      firewall_action: "allow",
+    };
+
+    context.mocks.axiom.queryAxiom
+      .mockResolvedValueOnce([]) // agentEvents
+      .mockResolvedValueOnce([]) // systemLog
+      .mockResolvedValueOnce([networkEntry]); // networkLog
+
+    await postReportError({ runId, title: "Bug" });
+
+    const zipBuffer = context.mocks.s3.uploadS3Buffer.mock
+      .calls[0]![2] as Buffer;
+    const zip = new AdmZip(zipBuffer);
+    const networkLog = zip
+      .getEntry("network-log.jsonl")
+      ?.getData()
+      .toString("utf-8");
+
+    expect(networkLog).toBeDefined();
+    const parsed = JSON.parse(networkLog!);
+    expect(parsed.method).toBe("GET");
+    expect(parsed.firewall_action).toBe("allow");
+  });
+
+  it("should exclude system-log.txt and network-log.jsonl when data is empty", async () => {
+    const { runId } = await setupFailedRun(userId);
+
+    await postReportError({ runId, title: "Bug" });
+
+    const zipBuffer = context.mocks.s3.uploadS3Buffer.mock
+      .calls[0]![2] as Buffer;
+    const zip = new AdmZip(zipBuffer);
+    const entryNames = zip.getEntries().map((e) => {
+      return e.entryName;
+    });
+
+    expect(entryNames).not.toContain("system-log.txt");
+    expect(entryNames).not.toContain("network-log.jsonl");
+  });
+
+  it("should succeed when system log or network log query fails", async () => {
+    const { runId } = await setupFailedRun(userId);
+
+    context.mocks.axiom.queryAxiom
+      .mockResolvedValueOnce([]) // agentEvents succeeds
+      .mockRejectedValueOnce(new Error("system log timeout")) // systemLog fails
+      .mockRejectedValueOnce(new Error("network log timeout")); // networkLog fails
+
+    const response = await postReportError({ runId, title: "Bug" });
+    expect(response.status).toBe(200);
+
+    const zipBuffer = context.mocks.s3.uploadS3Buffer.mock
+      .calls[0]![2] as Buffer;
+    const zip = new AdmZip(zipBuffer);
+    const entryNames = zip.getEntries().map((e) => {
+      return e.entryName;
+    });
+
+    // Core files still present
+    expect(entryNames).toContain("manifest.json");
+    expect(entryNames).toContain("chat-history.jsonl");
+    // Failed logs excluded gracefully
+    expect(entryNames).not.toContain("system-log.txt");
+    expect(entryNames).not.toContain("network-log.jsonl");
+  });
+
   it("should include run metadata in manifest.json", async () => {
     const { runId } = await setupFailedRun(userId);
 

--- a/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
+++ b/turbo/apps/web/src/lib/zero/support/diagnostic-bundle-service.ts
@@ -115,11 +115,15 @@ export async function submitDiagnosticBundle(
     collectSessionRuns(db, runId, sessionId),
   ]);
 
-  // Query Axiom for agent events
+  // Query Axiom for agent events, system log, and network log in parallel
   const sessionRunIds = sessionRuns.map((r) => {
     return r.id;
   });
-  const agentEvents = await collectAgentEvents(sessionRunIds);
+  const [agentEvents, systemLogText, networkLogEntries] = await Promise.all([
+    collectAgentEvents(sessionRunIds),
+    collectSystemLog(sessionRunIds),
+    collectNetworkLog(sessionRunIds),
+  ]);
 
   // Synthesize user_prompt events
   const promptEvents: ChatHistoryEvent[] = sessionRuns.map((r) => {
@@ -221,6 +225,21 @@ export async function submitDiagnosticBundle(
       content: JSON.stringify(activityLog),
     },
   ];
+
+  if (systemLogText) {
+    zipEntries.push({ path: "system-log.txt", content: systemLogText });
+  }
+
+  if (networkLogEntries.length > 0) {
+    zipEntries.push({
+      path: "network-log.jsonl",
+      content: networkLogEntries
+        .map((e) => {
+          return JSON.stringify(e);
+        })
+        .join("\n"),
+    });
+  }
 
   const zipBuffer = await assembleZip(zipEntries);
 
@@ -374,6 +393,51 @@ async function collectSessionRuns(
     .from(agentRuns)
     .where(eq(agentRuns.id, runId))
     .limit(1);
+}
+
+async function collectSystemLog(sessionRunIds: string[]): Promise<string> {
+  if (sessionRunIds.length === 0) return "";
+  const runIdList = sessionRunIds
+    .map((id) => {
+      return `"${id}"`;
+    })
+    .join(", ");
+  const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_SYSTEM);
+  const apl = `['${dataset}']
+| where runId in (${runIdList})
+| order by _time asc`;
+  const events = await queryAxiom<{ log: string }>(apl).catch((err) => {
+    log.warn("Failed to collect system log from Axiom", {
+      error: String(err),
+    });
+    return [] as { log: string }[];
+  });
+  return events
+    .map((e) => {
+      return e.log;
+    })
+    .join("");
+}
+
+async function collectNetworkLog(
+  sessionRunIds: string[],
+): Promise<Record<string, unknown>[]> {
+  if (sessionRunIds.length === 0) return [];
+  const runIdList = sessionRunIds
+    .map((id) => {
+      return `"${id}"`;
+    })
+    .join(", ");
+  const dataset = getDatasetName(DATASETS.SANDBOX_TELEMETRY_NETWORK);
+  const apl = `['${dataset}']
+| where runId in (${runIdList})
+| order by _time asc`;
+  return queryAxiom<Record<string, unknown>>(apl).catch((err) => {
+    log.warn("Failed to collect network log from Axiom", {
+      error: String(err),
+    });
+    return [] as Record<string, unknown>[];
+  });
 }
 
 async function collectAgentEvents(


### PR DESCRIPTION
## Summary
- Add `system-log.txt` (concatenated stdout/stderr from `SANDBOX_TELEMETRY_SYSTEM`) to diagnostic ZIP
- Add `network-log.jsonl` (full unstripped entries from `SANDBOX_TELEMETRY_NETWORK`) to diagnostic ZIP
- Both query all session run IDs and run in parallel with existing Axiom queries
- Non-empty check: files are only included when data exists

Closes #8799

## Test plan
- [ ] Trigger `report-error` or `developer-support` for a completed run
- [ ] Download the diagnostic ZIP and verify `system-log.txt` contains sandbox stdout/stderr
- [ ] Verify `network-log.jsonl` contains full network log entries (including `firewall_*`, `auth_*`, request/response bodies)
- [ ] Verify existing files (`chat-history.jsonl`, `activity-log.json`, etc.) are unaffected
- [ ] Verify bundle still generates correctly when Axiom is unavailable (graceful fallback to empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)