### PR TITLE
fix(runner): prevent message_delta from overwriting proxy usage with zeros

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -255,17 +255,22 @@ def _extract_billing_usage(raw_usage, target: dict) -> None:
 
     Handles both flat fields (input_tokens, etc.) and the nested
     ``server_tool_use.web_search_requests`` field.
+
+    Only positive values overwrite existing entries — ``message_delta`` may
+    send ``0`` for fields already set correctly by ``message_start``.
     """
     if not raw_usage or not isinstance(raw_usage, dict):
         return
     for k, v in raw_usage.items():
         if k in _BILLING_FIELDS and isinstance(v, (int, float)):
-            target[k] = v
+            if v > 0 or k not in target:
+                target[k] = v
     stu = raw_usage.get("server_tool_use")
     if isinstance(stu, dict):
         wsr = stu.get("web_search_requests")
         if isinstance(wsr, (int, float)):
-            target["web_search_requests"] = wsr
+            if wsr > 0 or "web_search_requests" not in target:
+                target["web_search_requests"] = wsr
 
 
 def _create_sse_usage_extractor():

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -862,6 +862,90 @@ class TestSseUsageExtractor:
         assert usage["output_tokens"] == 100
         assert usage["web_search_requests"] == 3
 
+    def test_message_delta_zero_does_not_overwrite_message_start(self):
+        """message_delta sending 0 for cache fields must not overwrite message_start values.
+
+        The Anthropic API includes all usage fields in message_delta, but cache
+        fields may be 0 even when message_start reported non-zero values.
+        """
+        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse(
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":150,"cache_read_input_tokens":80000,'
+            b'"cache_creation_input_tokens":5000,"output_tokens":0}}}\n\n'
+        )
+        assert usage["cache_read_input_tokens"] == 80000
+        assert usage["cache_creation_input_tokens"] == 5000
+
+        # message_delta sends 0 for cache fields — must NOT overwrite
+        parse(
+            b"event: message_delta\n"
+            b'data: {"type":"message_delta",'
+            b'"usage":{"output_tokens":500,'
+            b'"input_tokens":0,"cache_read_input_tokens":0,'
+            b'"cache_creation_input_tokens":0}}\n\n'
+        )
+        assert usage["output_tokens"] == 500
+        assert usage["input_tokens"] == 150  # preserved from message_start
+        assert usage["cache_read_input_tokens"] == 80000  # preserved
+        assert usage["cache_creation_input_tokens"] == 5000  # preserved
+
+    def test_message_delta_positive_values_do_overwrite(self):
+        """message_delta with positive values should update the usage dict."""
+        parse, usage = mitm_addon._create_sse_usage_extractor()
+        parse(
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":{"model":"m",'
+            b'"usage":{"input_tokens":100,"cache_read_input_tokens":5000}}}\n\n'
+        )
+        # message_delta with higher positive values should overwrite
+        parse(
+            b"event: message_delta\n"
+            b'data: {"type":"message_delta",'
+            b'"usage":{"output_tokens":300,'
+            b'"cache_read_input_tokens":6000}}\n\n'
+        )
+        assert usage["output_tokens"] == 300
+        assert usage["cache_read_input_tokens"] == 6000  # updated
+        assert usage["input_tokens"] == 100  # unchanged (not in delta)
+
+
+class TestExtractBillingUsage:
+    """Tests for _extract_billing_usage zero-overwrite protection."""
+
+    def test_first_call_sets_zero_values(self):
+        """First extraction into empty target should set even zero values."""
+        target = {}
+        mitm_addon._extract_billing_usage(
+            {"input_tokens": 0, "cache_read_input_tokens": 50000}, target
+        )
+        assert target["input_tokens"] == 0
+        assert target["cache_read_input_tokens"] == 50000
+
+    def test_zero_does_not_overwrite_positive(self):
+        """A second extraction with 0 must not overwrite a positive value."""
+        target = {"input_tokens": 100, "cache_read_input_tokens": 50000}
+        mitm_addon._extract_billing_usage(
+            {"input_tokens": 0, "cache_read_input_tokens": 0, "output_tokens": 500},
+            target,
+        )
+        assert target["input_tokens"] == 100  # preserved
+        assert target["cache_read_input_tokens"] == 50000  # preserved
+        assert target["output_tokens"] == 500  # new field, set correctly
+
+    def test_positive_overwrites_positive(self):
+        """A second extraction with a positive value should overwrite."""
+        target = {"input_tokens": 100}
+        mitm_addon._extract_billing_usage({"input_tokens": 200}, target)
+        assert target["input_tokens"] == 200
+
+    def test_web_search_zero_does_not_overwrite(self):
+        """web_search_requests 0 must not overwrite a positive value."""
+        target = {"web_search_requests": 5}
+        mitm_addon._extract_billing_usage({"server_tool_use": {"web_search_requests": 0}}, target)
+        assert target["web_search_requests"] == 5
+
 
 class TestDoReportUsage:
     """Tests for _do_report_usage HTTP request construction."""


### PR DESCRIPTION
## Summary

- Fix `_extract_billing_usage` in the SSE parser to not overwrite positive values with 0 from `message_delta`
- The Anthropic API's `message_delta.usage` includes all fields (`cache_read_input_tokens`, `cache_creation_input_tokens`, etc.) but they may be 0 even when `message_start` reported correct non-zero values
- Add `> 0` guard matching [Claude Code's `updateUsage`](https://github.com/seven332/claude-code/blob/main/src/services/api/claude.ts) which has the same protection with comment: *"prevent message_delta from overwriting the real value with 0"*
- This fixes the ~3x undercount of cache tokens observed in production (`cacheReadInputTokens` client 3.1x proxy, `cacheCreationInputTokens` client 2.6x proxy)

Closes #8796

## Test plan

- [x] `test_message_delta_zero_does_not_overwrite_message_start` — end-to-end SSE: message_start sets cache tokens, message_delta sends 0, values preserved
- [x] `test_message_delta_positive_values_do_overwrite` — positive values from message_delta still update correctly
- [x] `TestExtractBillingUsage` — 4 unit tests for the `> 0` guard logic directly
- [x] All 95 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)