### PR TITLE
fix(platform): redesign avatar and create-agent dialogs

### DIFF
--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -13,7 +13,6 @@ import {
   CardContent,
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
   Button,

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -341,7 +341,7 @@ function CreateTeammateDialogContent({
       {/* Content */}
       <div className="flex flex-col items-center gap-4 px-6 py-6">
         <div className="text-center">
-          <h2 className="text-base font-semibold">Create a new agent</h2>
+          <p className="text-base font-semibold">Create a new agent</p>
           <p className="text-sm text-muted-foreground mt-0.5">
             Name your agent to get started.
           </p>

--- a/turbo/apps/platform/src/views/agents-page/agents-page.tsx
+++ b/turbo/apps/platform/src/views/agents-page/agents-page.tsx
@@ -6,6 +6,7 @@ import {
   IconList,
   IconLoader2,
   IconPlus,
+  IconWand,
 } from "@tabler/icons-react";
 import {
   Card,
@@ -20,6 +21,10 @@ import {
   Tabs,
   TabsList,
   TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from "@vm0/ui";
 import { createSubagent$ } from "../../signals/zero-page/zero-agents.ts";
 import {
@@ -291,41 +296,57 @@ function CreateTeammateDialogContent({
   const setAvatarUrl = useSet(setJobsAvatarUrl$);
 
   return (
-    <DialogContent className="sm:max-w-[420px]">
-      <DialogHeader className="flex flex-col items-center text-center pt-4">
-        <div className="mb-2">
-          <AvatarMaker
-            onConfirm={(cfg) => {
-              setAvatarUrl(serializeAvatarSvgConfig(cfg));
-              return Promise.resolve();
-            }}
-            trigger={(openMaker) => {
-              return (
-                <button
-                  type="button"
-                  onClick={openMaker}
-                  className="rounded-full transition-transform duration-200 hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                  aria-label="Customize avatar"
-                >
-                  <AvatarFromUrl
-                    avatarUrl={avatarUrl}
-                    alt="New agent"
-                    className="h-14 w-14 rounded-full object-cover object-top"
-                  />
-                </button>
-              );
-            }}
-          />
-        </div>
-        <DialogTitle className="text-base font-semibold">
-          Create a new agent
-        </DialogTitle>
-        <DialogDescription className="text-sm text-muted-foreground">
-          Name your agent to get started.
-        </DialogDescription>
+    <DialogContent className="sm:max-w-[480px] p-0 gap-0 overflow-hidden">
+      <DialogHeader className="sr-only">
+        <DialogTitle>Create a new agent</DialogTitle>
       </DialogHeader>
 
-      <div className="py-2">
+      {/* Avatar preview */}
+      <div className="flex flex-col items-center pt-10 pb-6 bg-muted/30">
+        <AvatarMaker
+          onConfirm={(cfg) => {
+            setAvatarUrl(serializeAvatarSvgConfig(cfg));
+            return Promise.resolve();
+          }}
+          trigger={(openMaker) => {
+            return (
+              <button
+                type="button"
+                onClick={openMaker}
+                className="relative rounded-full transition-transform duration-200 hover:scale-110 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                aria-label="Customize avatar"
+              >
+                <AvatarFromUrl
+                  avatarUrl={avatarUrl}
+                  alt="New agent"
+                  className="h-16 w-16 rounded-full object-cover object-top"
+                />
+                <TooltipProvider delayDuration={200}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="absolute -right-0.5 -bottom-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-background text-muted-foreground shadow-sm border border-border">
+                        <IconWand size={10} stroke={1.5} />
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <p className="text-xs">Customize avatar</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </button>
+            );
+          }}
+        />
+      </div>
+
+      {/* Content */}
+      <div className="flex flex-col items-center gap-4 px-6 py-6">
+        <div className="text-center">
+          <h2 className="text-base font-semibold">Create a new agent</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Name your agent to get started.
+          </p>
+        </div>
         <Input
           value={newName}
           onChange={(e) => {
@@ -342,17 +363,12 @@ function CreateTeammateDialogContent({
         />
       </div>
 
-      <div className="flex justify-end gap-2 pt-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={onCancel}
-          disabled={creating}
-        >
+      {/* Footer */}
+      <div className="flex justify-center gap-3 px-6 pt-4 pb-8">
+        <Button variant="outline" onClick={onCancel} disabled={creating}>
           Cancel
         </Button>
         <Button
-          size="sm"
           onClick={() => {
             return onConfirm(avatarUrl);
           }}

--- a/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
+++ b/turbo/apps/platform/src/views/team-page/zero-job-detail-page.tsx
@@ -19,6 +19,7 @@ import {
   IconSearch,
   IconX,
   IconMessageCircle,
+  IconWand,
 } from "@tabler/icons-react";
 import {
   Button,
@@ -74,6 +75,7 @@ import { Link } from "../router/link.tsx";
 import { detachedNavigateTo$ } from "../../signals/route.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { AgentAvatarImg } from "../zero-page/zero-sidebar-shared.tsx";
+import { openAvatarMaker$ } from "../../signals/zero-page/settings/avatar-maker.ts";
 import { currentAgent$ } from "../../signals/agent.ts";
 import { isOrgAdmin$ } from "../../signals/org.ts";
 import { user$ } from "../../signals/auth.ts";
@@ -732,16 +734,41 @@ function AgentHeader({
   showProfileAndInstructions: boolean;
 }) {
   const nav = useSet(detachedNavigateTo$);
+  const openMaker = useSet(openAvatarMaker$);
 
   return (
     <header className="shrink-0 bg-transparent px-4 sm:px-6 pt-6 pb-0">
       <div className="mx-auto max-w-[900px]">
         <div className="flex items-center gap-4">
-          <AgentAvatarImg
-            name={agentId}
-            alt={displayName}
-            className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
-          />
+          <div className="group relative shrink-0">
+            <AgentAvatarImg
+              name={agentId}
+              alt={displayName}
+              className="h-14 w-14 shrink-0 rounded-full object-cover object-top sm:h-16 sm:w-16"
+            />
+            {showProfileAndInstructions && (
+              <TooltipProvider delayDuration={200}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onTabChange("profile");
+                        openMaker();
+                      }}
+                      className="absolute -right-0.5 -bottom-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-background text-muted-foreground shadow-sm border border-border opacity-0 group-hover:opacity-100 hover:text-foreground transition-all"
+                      aria-label="Customize avatar"
+                    >
+                      <IconWand size={12} stroke={1.5} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p className="text-xs">Customize avatar</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
           <div className="min-w-0">
             <h1 className="text-lg font-semibold tracking-tight text-foreground sm:text-xl truncate">
               {displayName}

--- a/turbo/apps/platform/src/views/zero-page/__tests__/avatar-maker-saving.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/avatar-maker-saving.test.tsx
@@ -87,14 +87,14 @@ describe("avatar maker - saving state", () => {
     );
     await openAvatarMaker(user);
 
-    const applyBtn = screen.getByText(/Apply/i);
+    const applyBtn = screen.getByText(/Use this avatar/i);
     expect(applyBtn.closest("button")).not.toBeDisabled();
 
     await user.click(applyBtn);
 
     // After the error, the button should become clickable again
     await waitFor(() => {
-      const btn = screen.getByText(/Apply/i);
+      const btn = screen.getByText(/Use this avatar/i);
       expect(btn.closest("button")).not.toBeDisabled();
     });
   });

--- a/turbo/apps/platform/src/views/zero-page/__tests__/avatar-maker-saving.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/avatar-maker-saving.test.tsx
@@ -72,7 +72,7 @@ async function openAvatarMaker(user: ReturnType<typeof userEvent.setup>) {
   });
   await user.click(screen.getByLabelText("Create custom avatar"));
   await waitFor(() => {
-    expect(screen.getByText("Give your agent a face")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/avatar-maker-saving.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/avatar-maker-saving.test.tsx
@@ -72,7 +72,7 @@ async function openAvatarMaker(user: ReturnType<typeof userEvent.setup>) {
   });
   await user.click(screen.getByLabelText("Create custom avatar"));
   await waitFor(() => {
-    expect(screen.getByText("Create Avatar")).toBeInTheDocument();
+    expect(screen.getByText("Give your agent a face")).toBeInTheDocument();
   });
 }
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
@@ -266,7 +266,7 @@ describe("zero settings tab - avatar", () => {
 
     // The avatar maker dialog should open
     await waitFor(() => {
-      expect(screen.getByText("Give your agent a face")).toBeInTheDocument();
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
 
     // Click Apply to save the avatar

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
@@ -269,8 +269,8 @@ describe("zero settings tab - avatar", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
     });
 
-    // Click Apply to save the avatar
-    await user.click(screen.getByText("Apply"));
+    // Click "Use this avatar" to save
+    await user.click(screen.getByText("Use this avatar"));
 
     await waitFor(() => {
       expect(capturedPayload).toBeTruthy();

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-settings-tab.test.tsx
@@ -266,7 +266,7 @@ describe("zero settings tab - avatar", () => {
 
     // The avatar maker dialog should open
     await waitFor(() => {
-      expect(screen.getByText("Create Avatar")).toBeInTheDocument();
+      expect(screen.getByText("Give your agent a face")).toBeInTheDocument();
     });
 
     // Click Apply to save the avatar

--- a/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
@@ -6,6 +6,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
   cn,
 } from "@vm0/ui";
 import {
@@ -13,7 +17,6 @@ import {
   IconChevronLeft,
   IconChevronRight,
   IconDice,
-  IconCheck,
 } from "@tabler/icons-react";
 import type { AvatarSvgConfig } from "./avatar-svg-utils.ts";
 import { AvatarSvgPreview } from "./avatar-svg-preview.tsx";
@@ -209,25 +212,32 @@ function AvatarPreviewWithShuffle() {
     >
       <AvatarSvgPreview config={config} size={96} />
       <Sparkles active={showSparkles} />
-      <button
-        type="button"
-        className={cn(
-          "absolute -right-1 -bottom-1 flex h-7 w-7 items-center justify-center rounded-full bg-background text-muted-foreground shadow-sm border border-border transition-opacity hover:text-foreground",
-          shuffling ? "opacity-100" : "opacity-0 group-hover:opacity-100",
-        )}
-        onClick={shuffle}
-        aria-label="Randomize avatar"
-      >
-        <IconDice
-          size={14}
-          stroke={1.5}
-          style={
-            shuffling
-              ? { animation: "avatar-dice-spin 0.6s ease-out" }
-              : undefined
-          }
-        />
-      </button>
+      <TooltipProvider delayDuration={800} skipDelayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              tabIndex={-1}
+              className="absolute -right-1 -bottom-1 flex h-7 w-7 items-center justify-center rounded-full bg-background text-muted-foreground shadow-sm border border-border hover:text-foreground transition-colors"
+              onClick={shuffle}
+              aria-label="Randomize avatar"
+            >
+              <IconDice
+                size={14}
+                stroke={1.5}
+                style={
+                  shuffling
+                    ? { animation: "avatar-dice-spin 0.6s ease-out" }
+                    : undefined
+                }
+              />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p className="text-xs">Shuffle — try a random look!</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </div>
   );
 }
@@ -324,13 +334,24 @@ function AvatarMakerDialogBody({
   };
 
   return (
-    <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-md">
-      <DialogHeader>
-        <DialogTitle>Create Avatar</DialogTitle>
+    <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-lg p-0 gap-0 overflow-hidden">
+      <DialogHeader className="sr-only">
+        <DialogTitle>Give your agent a face</DialogTitle>
       </DialogHeader>
 
-      <div className="flex flex-col items-center gap-4 py-2">
+      {/* Preview section */}
+      <div className="flex flex-col items-center gap-3 px-6 pt-8 pb-5 bg-muted/30">
         <AvatarPreviewWithShuffle />
+      </div>
+
+      {/* Controls section */}
+      <div className="flex flex-col items-center gap-4 px-6 py-5">
+        <div className="text-center">
+          <h2 className="text-base font-semibold">Give your agent a face</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Pick a style or hit shuffle for a surprise.
+          </p>
+        </div>
         <StepNavigator />
         <div className="flex gap-3 flex-wrap justify-center">
           <StepOptions
@@ -342,15 +363,15 @@ function AvatarMakerDialogBody({
         </div>
       </div>
 
-      <DialogFooter>
+      {/* Footer */}
+      <div className="flex justify-center gap-3 px-6 pt-6 pb-6">
         <Button variant="outline" onClick={closeMaker} disabled={saving}>
           Cancel
         </Button>
         <Button onClick={handleConfirm} disabled={saving}>
-          <IconCheck size={16} className="mr-1" />
-          {saving ? "Saving…" : "Apply"}
+          {saving ? "Saving…" : "Use this avatar"}
         </Button>
-      </DialogFooter>
+      </div>
     </DialogContent>
   );
 }
@@ -387,16 +408,25 @@ export function AvatarMaker({ onConfirm, trigger }: AvatarMakerProps) {
       {trigger ? (
         trigger(openMaker)
       ) : (
-        <button
-          type="button"
-          onClick={() => {
-            return openMaker();
-          }}
-          className="h-12 w-12 shrink-0 rounded-full border-2 border-dashed border-muted-foreground/30 flex items-center justify-center text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          aria-label="Create custom avatar"
-        >
-          <IconWand size={16} stroke={1.5} />
-        </button>
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => {
+                  return openMaker();
+                }}
+                className="h-12 w-12 shrink-0 rounded-full border-2 border-dashed border-muted-foreground/30 flex items-center justify-center text-muted-foreground hover:border-muted-foreground/50 hover:text-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                aria-label="Create custom avatar"
+              >
+                <IconWand size={16} stroke={1.5} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p className="text-xs">Customize avatar</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       )}
       <Dialog
         open={open}

--- a/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
+++ b/turbo/apps/platform/src/views/zero-page/avatar-maker.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   Dialog,
   DialogContent,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   Tooltip,

--- a/turbo/packages/ui/src/components/ui/dialog.tsx
+++ b/turbo/packages/ui/src/components/ui/dialog.tsx
@@ -20,7 +20,7 @@ const DialogOverlay = React.forwardRef<
     <DialogPrimitive.Overlay
       ref={ref}
       className={cn(
-        "fixed inset-0 z-50 bg-black/80 dark:bg-background/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/80 dark:bg-background/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Redesign avatar maker dialog with three-section layout (preview / controls / footer)
- Redesign create-agent dialog with matching layout style
- Title: "Give your agent a face" with subtitle "Pick a style or hit shuffle for a surprise."
- Dice shuffle button always visible with tooltip on hover
- "Apply" → "Use this avatar", removed check icon, buttons centered
- Add wand icon on agent header avatar (hover to reveal, opens avatar maker)
- Add wand icon with tooltip on create-agent dialog avatar
- Reduce dark mode dialog overlay opacity (50%) for better background visibility

## Test plan
- [ ] Open avatar maker from profile tab — verify new layout, title, subtitle
- [ ] Hover dice button — verify tooltip appears (not on dialog open)
- [ ] Click "Use this avatar" — verify save works
- [ ] Open create-agent dialog — verify matching layout style
- [ ] Hover wand icon on create-agent avatar — verify tooltip
- [ ] Hover agent header avatar — verify wand icon appears
- [ ] Click wand on non-profile tab — verify switches to profile tab and opens maker
- [ ] Open any dialog in dark mode — verify overlay is semi-transparent
- [ ] Verify light mode dialogs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)