### PR TITLE
refactor: normalize network policies schema from nullable optional to nullable

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/context-network-content.test.tsx
@@ -73,6 +73,7 @@ function makeBaseContext(
     volumes: [],
     artifact: null,
     memory: null,
+    networkPolicies: null,
     featureFlags: null,
     ...overrides,
   };

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-activity-detail-page-interaction.test.tsx
@@ -189,6 +189,7 @@ describe("zeroActivityDetailPageInteraction", () => {
       volumes: [],
       artifact: null,
       memory: null,
+      networkPolicies: null,
       featureFlags: null,
     };
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/__tests__/route.test.ts
@@ -71,6 +71,7 @@ function makeSnapshot(runId: string, userId: string): RunContextSnapshot {
       vasVersionId: "art-ver-1",
     },
     memory: null,
+    networkPolicies: null,
     featureFlags: { computerUse: true, voiceChat: false },
   };
 }
@@ -108,6 +109,7 @@ describe("GET /api/zero/runs/:id/context", () => {
     expect(data.volumes).toHaveLength(1);
     expect(data.artifact).toBeDefined();
     expect(data.memory).toBeNull();
+    expect(data.networkPolicies).toBeNull();
     expect(data.featureFlags).toEqual({ computerUse: true, voiceChat: false });
   });
 

--- a/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/runs/[id]/context/route.ts
@@ -58,11 +58,11 @@ const router = tsr.router(zeroRunContextContract, {
         vars: (run.vars as Record<string, string> | undefined) ?? null,
         environment: snapshot.environment,
         firewalls: snapshot.firewalls,
-        networkPolicies: snapshot.networkPolicies,
+        networkPolicies: snapshot.networkPolicies ?? null,
         volumes: snapshot.volumes,
         artifact: snapshot.artifact,
         memory: snapshot.memory,
-        featureFlags: snapshot.featureFlags ?? null,
+        featureFlags: snapshot.featureFlags,
       },
     };
   },

--- a/turbo/packages/core/src/contracts/zero-runs.ts
+++ b/turbo/packages/core/src/contracts/zero-runs.ts
@@ -196,7 +196,7 @@ const runContextResponseSchema = z.object({
   vars: z.record(z.string(), z.string()).nullable(),
   environment: z.record(z.string(), z.string()),
   firewalls: z.array(runContextFirewallSchema),
-  networkPolicies: networkPoliciesSchema.nullable().optional(),
+  networkPolicies: networkPoliciesSchema.nullable(),
   volumes: z.array(runContextVolumeSchema),
   artifact: runContextArtifactSchema.nullable(),
   memory: runContextArtifactSchema.nullable(),


### PR DESCRIPTION
## Summary
- Change `networkPolicies` in `runContextResponseSchema` from `.nullable().optional()` to `.nullable()` for consistency with adjacent fields (`artifact`, `memory`, `featureFlags`)
- Add `?? null` coercion in route handler for Axiom snapshots that may lack the field
- Remove redundant `?? null` on `featureFlags` (already `.nullable()`)
- Add `networkPolicies` to test fixtures and assertions

Closes #8803.

## Test plan
- [x] Type check passes (`tsc --noEmit` for web + platform)
- [x] Context route tests pass (7 files, 34 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)