### PR TITLE
feat(voice-chat): add slow brain meeting preparation prompt

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-chat/__tests__/create-session.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/__tests__/create-session.test.ts
@@ -138,14 +138,15 @@ describe("POST /api/zero/voice-chat (create session)", () => {
     expect(ctxBody.events[0].type).toBe("session-start");
   });
 
-  it("should create meeting session with preparing status", async () => {
+  it("should create meeting session with preparing status and meeting-prompt event", async () => {
     const { agentId } = await createTestCompose(uniqueId("vc-meeting"));
+    const meetingPrompt = "Review PR #123 before standup";
 
     const response = await POST(
       createRequest({
         agentId,
         mode: "meeting",
-        prompt: "Review PR #123 before standup",
+        prompt: meetingPrompt,
       }),
     );
     const body = await response.json();
@@ -154,6 +155,19 @@ describe("POST /api/zero/voice-chat (create session)", () => {
     expect(body.session.status).toBe("preparing");
     expect(body.session.mode).toBe("meeting");
     expect(body.session.runId).toBeDefined();
+
+    // Verify meeting-prompt event was written before session-start
+    const ctxResponse = await getContext(
+      contextRequest(body.session.id),
+      paramsFor(body.session.id),
+    );
+    const ctxBody = await ctxResponse.json();
+    expect(ctxBody.events).toHaveLength(2);
+    expect(ctxBody.events[0].source).toBe("user");
+    expect(ctxBody.events[0].type).toBe("meeting-prompt");
+    expect(ctxBody.events[0].content).toBe(meetingPrompt);
+    expect(ctxBody.events[1].source).toBe("system");
+    expect(ctxBody.events[1].type).toBe("session-start");
   });
 
   it("should return 400 when meeting mode has no prompt", async () => {

--- a/turbo/apps/web/app/api/zero/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/route.ts
@@ -76,7 +76,10 @@ export async function POST(request: Request) {
       mode,
       prompt,
     });
-    const run = await dispatchSlowBrain(session, org.orgId, userId, agentId);
+    const run = await dispatchSlowBrain(session, org.orgId, userId, agentId, {
+      mode,
+      prompt,
+    });
 
     return NextResponse.json({
       session: {

--- a/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildIntegrationPrompt,
   buildVoiceChatSlowBrainPrompt,
+  buildVoiceChatMeetingPrompt,
   buildSlackPrompt,
   buildPhonePrompt,
   buildTelegramPrompt,
@@ -95,6 +96,53 @@ describe("buildVoiceChatSlowBrainPrompt", () => {
     expect(result).toContain("context get session-456");
     expect(result).toContain("context append session-456");
     expect(result).not.toContain("<SESSION_ID>");
+  });
+});
+
+describe("buildVoiceChatMeetingPrompt", () => {
+  it("should combine integration header with meeting preparation prompt", () => {
+    const result = buildVoiceChatMeetingPrompt("session-789", "Review PR #123");
+
+    expect(result).toContain("You are currently running inside: Voice-Chat");
+    expect(result).toContain("# Zero — Slow-Brain Meeting Preparation Mode");
+  });
+
+  it("should replace session ID placeholder", () => {
+    const result = buildVoiceChatMeetingPrompt("session-789", "Review PR #123");
+
+    expect(result).toContain("context get session-789");
+    expect(result).toContain("context append session-789");
+    expect(result).not.toContain("<SESSION_ID>");
+  });
+
+  it("should replace meeting prompt placeholder", () => {
+    const result = buildVoiceChatMeetingPrompt(
+      "session-789",
+      "Review PR #123 before standup",
+    );
+
+    expect(result).toContain("Review PR #123 before standup");
+    expect(result).not.toContain("<MEETING_PROMPT>");
+  });
+
+  it("should contain preparation-ready instruction", () => {
+    const result = buildVoiceChatMeetingPrompt("session-789", "Review PR #123");
+
+    expect(result).toContain("preparation-ready");
+  });
+
+  it("should contain thinking event instruction", () => {
+    const result = buildVoiceChatMeetingPrompt("session-789", "Review PR #123");
+
+    expect(result).toContain("thinking");
+    expect(result).toContain("directive");
+  });
+
+  it("should contain observation mode instructions for after preparation", () => {
+    const result = buildVoiceChatMeetingPrompt("session-789", "Review PR #123");
+
+    expect(result).toContain("Phase 2: Live Observation");
+    expect(result).toContain("session-end");
   });
 });
 

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -174,6 +174,123 @@ export function buildVoiceChatSlowBrainPrompt(sessionId: string): string {
   return [header, slowBrainPrompt].join("\n\n");
 }
 
+const VOICE_CHAT_MEETING_PREPARATION_PROMPT = `
+# Zero — Slow-Brain Meeting Preparation Mode
+
+You are Zero's slow-brain. A meeting has been requested and the voice conversation has not started yet. Your job is to prepare first, then transition to live observation.
+
+## The User's Meeting Prompt
+
+<MEETING_PROMPT>
+
+## Phase 1: Preparation
+
+You have full tool access. Use your sandbox, CLI, and APIs to research and prepare.
+
+### Steps
+
+1. **Research context** — Based on the meeting prompt above, look up everything relevant: code, PRs, issues, documentation, recent changes, deployment status, etc.
+2. **Write thinking events as you work** — The user is waiting and can see your progress. Write a thinking event when you start, and again when you find something significant.
+3. **Plan the meeting flow** — Organize your findings into a suggested agenda or list of talking points.
+4. **Write a directive** — When preparation is complete, write a directive event containing:
+   - Summary of what you found
+   - Suggested meeting flow / talking points
+   - Key data and references the fast-brain should mention
+5. **Signal readiness** — Write a \`preparation-ready\` event to indicate you are done preparing.
+
+### CLI Commands
+
+Read shared context:
+\`zero voice-chat context get <SESSION_ID> --after <LAST_SEQ>\`
+
+Write events:
+\`zero voice-chat context append <SESSION_ID> --source slow-brain --type <TYPE> --content "<CONTENT>"\`
+
+### Event Types for Preparation
+
+- **thinking**: Progress updates while you research. Example: "Looking up PR #123 and recent CI results..."
+- **directive**: Your final preparation findings and meeting guidance for the fast-brain.
+- **preparation-ready**: Signal that preparation is complete (no content needed).
+
+## Phase 2: Live Observation
+
+Once you have written the preparation-ready event, the voice conversation will begin. Transition to observation mode:
+
+### Observing the Conversation
+
+Continuously read the shared context to follow the conversation:
+
+\`zero voice-chat context get <SESSION_ID> --after <LAST_SEQ>\`
+
+You will see events like:
+- **user/speech** — what the user says
+- **fast-brain/response** — what your fast-brain says back
+- **system/session-start** and **system/session-end** — session lifecycle
+
+You already prepared for this meeting. Use your preparation context to assist more effectively.
+
+### When to Act
+
+Act when the conversation involves:
+- Code, data, APIs, files, or external systems
+- Tasks that require execution, search, or tool use
+- Topics where you can proactively gather information (e.g., user mentions a PR — look it up so the answer is ready)
+- Anything your fast-brain cannot handle with conversation alone
+- Topics related to your preparation — you may already have the answer
+
+Stay quiet when the conversation is:
+- Casual chat, greetings, or small talk
+- Opinions or preferences
+- Simple knowledge questions your fast-brain handles well
+
+### Explicit Requests
+
+When you see a \`fast-brain/request-slow-brain\` event, it is a direct task from your fast-brain. Treat it as a priority:
+- Drop non-critical autonomous work to handle it immediately
+- The task description contains exactly what to do — follow it
+- Write a thinking event early so the user knows you are working on it
+- Write the result as a directive when done
+
+### Writing to Shared Context
+
+\`zero voice-chat context append <SESSION_ID> --source slow-brain --type <TYPE> --content "<CONTENT>"\`
+
+- **directive**: High-level instructions for your fast-brain. Include what to tell the user, relevant data, and why. Do not script exact words — your fast-brain controls phrasing.
+- **thinking**: Progress updates and intermediate results while you work.
+- **observation**: Proactive insights the user did not ask for but might find valuable.
+
+### Polling and Lifecycle
+
+1. Check for new events every 5 seconds.
+2. Process what you see — act proactively or respond to explicit requests.
+3. Write appropriate events (directive, thinking, observation).
+4. Repeat until you see a \`session-end\` system event, then exit.
+
+## Important
+
+- Keep directive content concise but complete — your fast-brain will read it aloud.
+- You have full tool access. Use your sandbox, CLI, and APIs to get real answers.
+- When you find something, write the directive immediately. Do not wait for a request.
+- You are Zero. Think of the conversation as your own — you are just thinking more deeply about it.
+`.trim();
+
+/**
+ * Build the full appendSystemPrompt for Voice-Chat meeting preparation mode.
+ * Combines the integration header with the meeting preparation prompt,
+ * replacing session ID and meeting prompt placeholders.
+ */
+export function buildVoiceChatMeetingPrompt(
+  sessionId: string,
+  prompt: string,
+): string {
+  const header = buildIntegrationPrompt("Voice-Chat");
+  const meetingPrompt = VOICE_CHAT_MEETING_PREPARATION_PROMPT.replaceAll(
+    "<SESSION_ID>",
+    sessionId,
+  ).replaceAll("<MEETING_PROMPT>", prompt);
+  return [header, meetingPrompt].join("\n\n");
+}
+
 /**
  * Build the full appendSystemPrompt for Slack integration.
  */

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -5,7 +5,10 @@ import {
 } from "../../../db/schema/voice-chat";
 import { createZeroRun } from "../zero-run-service";
 import { cancelRun } from "../zero-run-cancel";
-import { buildVoiceChatSlowBrainPrompt } from "../integration-prompt";
+import {
+  buildVoiceChatSlowBrainPrompt,
+  buildVoiceChatMeetingPrompt,
+} from "../integration-prompt";
 import { conflict, notFound, badRequest, forbidden } from "../../shared/errors";
 import { logger } from "../../shared/logger";
 
@@ -139,19 +142,39 @@ export async function dispatchSlowBrain(
   orgId: string,
   userId: string,
   agentId: string,
+  options?: { mode?: "chat" | "meeting"; prompt?: string },
 ) {
-  const appendSystemPrompt = buildVoiceChatSlowBrainPrompt(session.id);
+  const db = globalThis.services.db;
+  const meetingPrompt =
+    options?.mode === "meeting" ? options.prompt : undefined;
+
+  const appendSystemPrompt = meetingPrompt
+    ? buildVoiceChatMeetingPrompt(session.id, meetingPrompt)
+    : buildVoiceChatSlowBrainPrompt(session.id);
+
+  const prompt = meetingPrompt
+    ? `You are Zero's slow-brain for voice-chat session ${session.id}. A meeting has been requested. Read the shared context for the meeting prompt and begin preparation.`
+    : `You are Zero's slow-brain for voice-chat session ${session.id}. Start by reading the shared context to observe the conversation.`;
+
+  // Write meeting-prompt event before session-start (meeting mode only)
+  if (meetingPrompt) {
+    await db.insert(voiceChatEvents).values({
+      sessionId: session.id,
+      source: "user",
+      type: "meeting-prompt",
+      content: meetingPrompt,
+    });
+  }
 
   const result = await createZeroRun({
     userId,
     agentId,
-    prompt: `You are Zero's slow-brain for voice-chat session ${session.id}. Start by reading the shared context to observe the conversation.`,
+    prompt,
     appendSystemPrompt,
     triggerSource: "voice-chat",
   });
 
   // Update session with runId
-  const db = globalThis.services.db;
   await db
     .update(voiceChatSessions)
     .set({ runId: result.runId })


### PR DESCRIPTION
## Summary

- Add `VOICE_CHAT_MEETING_PREPARATION_PROMPT` constant with two-phase lifecycle: preparation (research context, write findings, signal readiness) then live observation
- Add `buildVoiceChatMeetingPrompt(sessionId, prompt)` builder function
- Extend `dispatchSlowBrain()` to accept `mode`/`prompt` options and use meeting prompt when mode is "meeting"
- Write `user/meeting-prompt` event to shared context before `session-start` for meeting sessions
- Chat mode dispatch is completely unchanged

Closes #8792

## Test plan

- [x] `buildVoiceChatMeetingPrompt` unit tests: header, session ID replacement, meeting prompt replacement, preparation-ready instruction, thinking/directive instructions, observation mode section
- [x] Meeting session integration test extended: verifies `user/meeting-prompt` event is written before `session-start`
- [x] All 23 integration-prompt tests pass
- [x] All 45 voice-chat tests pass (6 test files)
- [x] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)