### PR TITLE
feat(firewalls): include denied permission names in firewall block response

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -218,6 +218,7 @@ class FirewallBlock(NamedTuple):
     name: str
     method: str
     path: str
+    permissions: tuple[str, ...]  # denied permission names; empty for unknown-endpoint blocks
 
 
 def parse_graphql_rule(rest: str) -> tuple[str, str | None, str | None, list[str] | None] | None:
@@ -503,6 +504,7 @@ def match_firewall_request(
     # granted permission matches.  We record it instead of returning immediately
     # because a later permission may be granted for the same endpoint.
     denied_match: tuple[str, str, str, str, str] | None = None  # (base, ref, name, method, path)
+    denied_perm_names: list[str] = []
 
     for fw_entry in vm_firewalls:
         fw_name = fw_entry.get("name", "")
@@ -581,6 +583,7 @@ def match_firewall_request(
                                     fw_name,
                                     upper_method,
                                     rel_path,
+                                    (),
                                 )
 
                         # Merge base params with rule params
@@ -601,13 +604,15 @@ def match_firewall_request(
                             )
                         # Permission exists but not granted — record for
                         # DENY but keep checking other permissions.
+                        if perm_name not in denied_perm_names:
+                            denied_perm_names.append(perm_name)
                         if denied_match is None:
                             denied_match = (base, fw_ref, fw_name, upper_method, rel_path)
 
     if blocked_base is not None:
         # A non-granted permission matched — DENY takes priority over unknown.
         if denied_match is not None:
-            return FirewallBlock(*denied_match)
+            return FirewallBlock(*denied_match, tuple(denied_perm_names))
         # No permission rule matched — this is an "unknown" endpoint.
         # "ask" is treated as "deny" at the proxy level (same as ask permissions).
         if _get_unknown_policy(blocked_ref, network_policies) == "allow":
@@ -623,6 +628,6 @@ def match_firewall_request(
                 },
             )
         return FirewallBlock(
-            blocked_base, blocked_ref, blocked_name, upper_method, blocked_rel_path
+            blocked_base, blocked_ref, blocked_name, upper_method, blocked_rel_path, ()
         )
     return None

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -213,6 +213,7 @@ async def request(flow: http.HTTPFlow) -> None:
                     "message": "Request blocked: no matching permission rule",
                     "method": result.method,
                     "path": result.path,
+                    "ref": result.ref,
                     "permissions": list(result.permissions),
                     "base": result.base,
                 }

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -213,7 +213,7 @@ async def request(flow: http.HTTPFlow) -> None:
                     "message": "Request blocked: no matching permission rule",
                     "method": result.method,
                     "path": result.path,
-                    "permission": result.ref,
+                    "permissions": list(result.permissions),
                     "base": result.base,
                 }
             )

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -163,6 +163,7 @@ class TestMatchFirewallRequest:
         assert result.ref == "github"
         assert result.method == "GET"
         assert result.path == "/repos"
+        assert result.permissions == ()
 
     def test_permission_match_allows(self):
         fw_configs = _wrap_firewalls(
@@ -3794,6 +3795,7 @@ class TestThreeLevelMatching:
             network_policies=granted,
         )
         assert isinstance(result, FirewallBlock)
+        assert result.permissions == ("repo-read", "repo-admin")
 
     def test_multi_firewall_different_refs(self):
         """Two firewalls with different refs, each with own grants."""
@@ -3919,6 +3921,38 @@ class TestThreeLevelMatching:
         )
         # repo-write rule matches but is not granted → DENY, not overridden by unknownPolicy
         assert isinstance(result, FirewallBlock)
+        assert result.permissions == ("repo-write",)
+
+    def test_denied_permission_deduped_across_rules(self):
+        """Same permission with multiple matching rules appears once in permissions."""
+        fws = _wrap_firewalls(
+            [
+                {
+                    "base": "https://api.github.com",
+                    "auth": {"headers": {"Authorization": "Bearer token"}},
+                    "permissions": [
+                        {
+                            "name": "repo-read",
+                            "rules": [
+                                "GET /repos/{owner}/{repo}",
+                                "ANY /repos/{owner}/{repo}",
+                            ],
+                        },
+                    ],
+                }
+            ],
+            name="github",
+            ref="github",
+        )
+        granted = {"github": {"allow": [], "unknownPolicy": "deny"}}
+        result = matching.match_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            fws,
+            network_policies=granted,
+        )
+        assert isinstance(result, FirewallBlock)
+        assert result.permissions == ("repo-read",)
 
     def test_empty_permissions_list_denies_all_known(self):
         """permissions: [] means nothing is granted — all known endpoints denied."""

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -245,7 +245,7 @@ class TestRequestHandler:
         assert body["error"] == "permission_denied"
         assert body["method"] == "GET"
         assert body["path"] == "/orgs"
-        assert body["permission"] == "github"
+        assert body["permissions"] == []
         assert body["base"] == "https://api.github.com"
 
     async def test_firewall_permission_allows_matched(self, tmp_path):

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -245,6 +245,7 @@ class TestRequestHandler:
         assert body["error"] == "permission_denied"
         assert body["method"] == "GET"
         assert body["path"] == "/orgs"
+        assert body["ref"] == "github"
         assert body["permissions"] == []
         assert body["base"] == "https://api.github.com"
 


### PR DESCRIPTION
## Summary
- Add `permissions` field to `FirewallBlock` NamedTuple — a tuple of all denied permission names
- Update 403 response JSON: `"permissions": ["repo-read", "repo-admin"]` instead of `"permission": "github"`
- Collect all denied permission names (with dedup) instead of only recording the first match
- Empty tuple `()` for unknown-endpoint blocks and GraphQL uncovered-field blocks

## Test plan
- [x] Existing 753 tests pass
- [x] New test: dedup — same permission with multiple matching rules appears once
- [x] Assertion added: unknown endpoint block → `permissions == ()`
- [x] Assertion added: single denied permission → `permissions == ("repo-write",)`
- [x] Assertion added: multiple denied permissions → `permissions == ("repo-read", "repo-admin")`
- [x] Handler test updated: 403 JSON `permissions` field verified

Closes #8594

🤖 Generated with [Claude Code](https://claude.com/claude-code)