### PR TITLE
feat(voice-chat): add voice meeting frontend ui and signals

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -7,6 +7,7 @@ import { resetSignal, throwIfAbort, onDomEventFn, setLoop } from "../utils.ts";
 
 type ConnectionStatus =
   | "idle"
+  | "preparing"
   | "connecting"
   | "connected"
   | "disconnected"
@@ -175,6 +176,9 @@ const internalPc$ = state<RTCPeerConnection | null>(null);
 const internalDc$ = state<RTCDataChannel | null>(null);
 const internalStream$ = state<MediaStream | null>(null);
 const internalAudioEl$ = state<HTMLAudioElement | null>(null);
+const internalPrompt$ = state<string | null>(null);
+
+const meetingPromptInput$ = state("");
 
 const resetSessionSignal$ = resetSignal();
 
@@ -201,6 +205,15 @@ export const vcEnabled$ = computed(async (get) => {
 });
 export const vcAgentId$ = computed(async (get) => {
   return await get(currentChatAgentId$);
+});
+export const vcPrompt$ = computed((get) => {
+  return get(internalPrompt$);
+});
+export const vcMeetingPromptInput$ = computed((get) => {
+  return get(meetingPromptInput$);
+});
+export const setMeetingPromptInput$ = command(({ set }, value: string) => {
+  set(meetingPromptInput$, value);
 });
 
 // --- Internal commands ---
@@ -578,12 +591,76 @@ const startPoll$ = command(async ({ get, set }, signal: AbortSignal) => {
   );
 });
 
+// --- Shared connection logic ---
+
+const connectVoiceSession$ = command(
+  async ({ get, set }, sessionSignal: AbortSignal) => {
+    const fetchFn = get(fetch$);
+
+    set(internalStatus$, "connecting");
+
+    const tokenRes = await fetchFn("/api/zero/voice-chat/token", {
+      method: "POST",
+    });
+    sessionSignal.throwIfAborted();
+
+    if (!tokenRes.ok) {
+      const body = (await tokenRes.json()) as {
+        error: { message: string };
+      };
+      sessionSignal.throwIfAborted();
+      set(internalError$, body.error.message);
+      set(internalStatus$, "error");
+      return;
+    }
+
+    const { client_secret: clientSecret } = (await tokenRes.json()) as {
+      client_secret: { value: string; expires_at: number };
+    };
+    sessionSignal.throwIfAborted();
+
+    let stream: MediaStream;
+    // eslint-disable-next-line no-restricted-syntax -- getUserMedia can fail due to permission denial or missing hardware
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (error) {
+      throwIfAbort(error);
+      set(
+        internalError$,
+        "Microphone access denied. Please allow microphone access.",
+      );
+      set(internalStatus$, "error");
+      return;
+    }
+    sessionSignal.throwIfAborted();
+    set(internalStream$, stream);
+
+    const ok = await set(
+      setupWebRTC$,
+      stream,
+      clientSecret.value,
+      sessionSignal,
+    );
+    sessionSignal.throwIfAborted();
+    if (!ok) {
+      return;
+    }
+
+    await Promise.allSettled([
+      set(startHeartbeat$, sessionSignal),
+      set(startPoll$, sessionSignal),
+    ]);
+  },
+);
+
 // --- Exported commands ---
+
 export const startVoiceChat$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     if (
       get(internalStatus$) === "connecting" ||
-      get(internalStatus$) === "connected"
+      get(internalStatus$) === "connected" ||
+      get(internalStatus$) === "preparing"
     ) {
       return;
     }
@@ -596,6 +673,7 @@ export const startVoiceChat$ = command(
     set(internalSessionId$, null);
     set(internalLastSeq$, 0);
     set(internalCurrentAssistant$, null);
+    set(internalPrompt$, null);
 
     const sessionSignal = set(resetSessionSignal$, signal);
 
@@ -632,13 +710,51 @@ export const startVoiceChat$ = command(
     signal.throwIfAborted();
     set(internalSessionId$, session.id);
 
-    const tokenRes = await fetchFn("/api/zero/voice-chat/token", {
+    await set(connectVoiceSession$, sessionSignal);
+  },
+);
+
+export const startVoiceMeeting$ = command(
+  async ({ get, set }, prompt: string, signal: AbortSignal) => {
+    if (
+      get(internalStatus$) === "connecting" ||
+      get(internalStatus$) === "connected" ||
+      get(internalStatus$) === "preparing"
+    ) {
+      return;
+    }
+
+    set(internalStatus$, "preparing");
+    set(internalError$, null);
+    set(internalTranscript$, []);
+    set(internalEvents$, []);
+    set(internalMuted$, false);
+    set(internalSessionId$, null);
+    set(internalLastSeq$, 0);
+    set(internalCurrentAssistant$, null);
+    set(internalPrompt$, prompt);
+
+    const sessionSignal = set(resetSessionSignal$, signal);
+
+    const fetchFn = get(fetch$);
+    const agentId = await get(currentChatAgentId$);
+    signal.throwIfAborted();
+
+    if (!agentId) {
+      set(internalError$, "No agent selected");
+      set(internalStatus$, "error");
+      return;
+    }
+
+    const sessionRes = await fetchFn("/api/zero/voice-chat", {
       method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId, mode: "meeting", prompt }),
     });
     signal.throwIfAborted();
 
-    if (!tokenRes.ok) {
-      const body = (await tokenRes.json()) as {
+    if (!sessionRes.ok) {
+      const body = (await sessionRes.json()) as {
         error: { message: string };
       };
       signal.throwIfAborted();
@@ -647,41 +763,77 @@ export const startVoiceChat$ = command(
       return;
     }
 
-    const { client_secret: clientSecret } = (await tokenRes.json()) as {
-      client_secret: { value: string; expires_at: number };
+    const { session } = (await sessionRes.json()) as {
+      session: { id: string };
     };
     signal.throwIfAborted();
+    set(internalSessionId$, session.id);
 
-    let stream: MediaStream;
-    // eslint-disable-next-line no-restricted-syntax -- getUserMedia can fail due to permission denial or missing hardware
-    try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    } catch (error) {
-      throwIfAbort(error);
-      set(
-        internalError$,
-        "Microphone access denied. Please allow microphone access.",
-      );
-      set(internalStatus$, "error");
-      return;
-    }
-    signal.throwIfAborted();
-    set(internalStream$, stream);
+    // Start heartbeat during preparation to prevent session timeout
+    const heartbeatPromise = set(startHeartbeat$, sessionSignal);
 
-    const ok = await set(
-      setupWebRTC$,
-      stream,
-      clientSecret.value,
+    // Poll for preparation-ready event
+    await setLoop(
+      async (loopSignal: AbortSignal) => {
+        const sid = get(internalSessionId$);
+        if (!sid) {
+          return true;
+        }
+
+        const lastSeq = get(internalLastSeq$);
+        const res = await fetchFn(
+          `/api/zero/voice-chat/${sid}/context?after=${lastSeq}`,
+          { signal: loopSignal },
+        );
+
+        if (!res.ok) {
+          return false;
+        }
+
+        const data = (await res.json()) as { events: ContextEvent[] };
+        loopSignal.throwIfAborted();
+
+        if (data.events.length > 0) {
+          set(internalEvents$, (prev) => {
+            return [...prev, ...data.events];
+          });
+          const lastEvent = data.events[data.events.length - 1];
+          if (lastEvent) {
+            set(internalLastSeq$, lastEvent.seq);
+          }
+
+          if (
+            data.events.some((e) => {
+              return e.type === "preparation-ready";
+            })
+          ) {
+            return true;
+          }
+        }
+        return false;
+      },
+      POLL_INTERVAL_MS,
       sessionSignal,
     );
     signal.throwIfAborted();
-    if (!ok) {
+
+    // Activate session (preparing → active)
+    const activateRes = await fetchFn(
+      `/api/zero/voice-chat/${session.id}/activate`,
+      { method: "POST" },
+    );
+    signal.throwIfAborted();
+
+    if (!activateRes.ok) {
+      set(internalError$, "Failed to activate meeting session");
+      set(internalStatus$, "error");
       return;
     }
 
+    // Connect voice (token → mic → WebRTC → poll/heartbeat)
     await Promise.allSettled([
-      set(startHeartbeat$, sessionSignal),
-      set(startPoll$, sessionSignal),
+      heartbeatPromise,
+      set(connectVoiceSession$, sessionSignal),
     ]);
   },
 );
@@ -732,6 +884,7 @@ export const endVoiceChat$ = command(({ get, set }) => {
   }
 
   set(internalSessionId$, null);
+  set(internalPrompt$, null);
   set(internalStatus$, "idle");
 });
 

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -19,13 +19,18 @@ import {
   vcError$,
   vcEnabled$,
   vcAgentId$,
+  vcPrompt$,
+  vcMeetingPromptInput$,
+  setMeetingPromptInput$,
   startVoiceChat$,
+  startVoiceMeeting$,
   endVoiceChat$,
   toggleVoiceChatMute$,
 } from "../../signals/voice-chat/voice-chat-session.ts";
 
 type ConnectionStatus =
   | "idle"
+  | "preparing"
   | "connecting"
   | "connected"
   | "disconnected"
@@ -34,6 +39,7 @@ type ConnectionStatus =
 function StatusBadge({ status }: { status: ConnectionStatus }) {
   const label: Record<ConnectionStatus, string> = {
     idle: "Ready",
+    preparing: "Preparing...",
     connecting: "Connecting...",
     connected: "Connected",
     disconnected: "Disconnected",
@@ -41,6 +47,7 @@ function StatusBadge({ status }: { status: ConnectionStatus }) {
   };
   const color: Record<ConnectionStatus, string> = {
     idle: "bg-muted text-muted-foreground",
+    preparing: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
     connecting:
       "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
     connected:
@@ -55,7 +62,7 @@ function StatusBadge({ status }: { status: ConnectionStatus }) {
         color[status],
       )}
     >
-      {status === "connecting" && (
+      {(status === "connecting" || status === "preparing") && (
         <IconLoader2 size={12} className="animate-spin" />
       )}
       {status === "connected" && (
@@ -76,8 +83,12 @@ export function VoiceChatPage() {
   const muted = useGet(vcMuted$);
   const error = useGet(vcError$);
   const startSession = useSet(startVoiceChat$);
+  const startMeeting = useSet(startVoiceMeeting$);
   const endSession = useSet(endVoiceChat$);
   const toggleMute = useSet(toggleVoiceChatMute$);
+  const prompt = useGet(vcPrompt$);
+  const meetingPrompt = useGet(vcMeetingPromptInput$);
+  const setMeetingPrompt = useSet(setMeetingPromptInput$);
   const agentName = useLastResolved(defaultAgentName$) ?? "Zero";
 
   if (enabled === false) {
@@ -96,29 +107,116 @@ export function VoiceChatPage() {
       <div className="flex flex-col items-center justify-center h-full gap-6 p-8">
         <h1 className="text-2xl font-bold">Voice Chat</h1>
         <p className="text-muted-foreground max-w-md text-center">
-          Start a voice conversation with the AI agent. Your microphone will be
-          used to capture audio.
+          Start a voice conversation with the AI agent, or prepare a meeting
+          with a specific topic.
         </p>
         {error && (
           <p className="text-sm text-destructive max-w-md text-center">
             {error}
           </p>
         )}
-        <Button
-          size="lg"
-          onClick={() => {
-            detach(startSession(pageSignal), Reason.DomCallback);
+        <textarea
+          className="w-full max-w-md rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          rows={3}
+          placeholder="What would you like to discuss? (required for meetings)"
+          value={meetingPrompt}
+          onChange={(e) => {
+            setMeetingPrompt(e.target.value);
           }}
-          disabled={!agentId}
-        >
-          <IconMicrophone size={18} className="mr-2" />
-          Start Voice Chat
-        </Button>
+        />
+        <div className="flex gap-3">
+          <Button
+            size="lg"
+            onClick={() => {
+              detach(startSession(pageSignal), Reason.DomCallback);
+            }}
+            disabled={!agentId}
+          >
+            <IconMicrophone size={18} className="mr-2" />
+            Start Voice Chat
+          </Button>
+          <Button
+            size="lg"
+            variant="secondary"
+            onClick={() => {
+              detach(
+                startMeeting(meetingPrompt, pageSignal),
+                Reason.DomCallback,
+              );
+            }}
+            disabled={!agentId || !meetingPrompt.trim()}
+          >
+            <IconLoader2 size={18} className="mr-2" />
+            Start Voice Meeting
+          </Button>
+        </div>
         {!agentId && (
           <p className="text-xs text-muted-foreground">
             No agent selected. Please select an agent first.
           </p>
         )}
+      </div>
+    );
+  }
+
+  if (status === "preparing") {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <div className="flex items-center gap-3">
+            <h1 className="text-lg font-semibold">Preparing Meeting</h1>
+            <StatusBadge status={status} />
+          </div>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => {
+              endSession();
+            }}
+          >
+            <IconPhoneOff size={16} className="mr-1.5" />
+            Cancel
+          </Button>
+        </div>
+
+        {prompt && (
+          <div className="border-b px-4 py-3">
+            <p className="text-sm text-muted-foreground">Your prompt:</p>
+            <p className="text-sm mt-1">{prompt}</p>
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-2">
+          <h2 className="text-sm font-medium text-muted-foreground mb-3">
+            Slow Brain Activity
+          </h2>
+          {events.filter((e) => {
+            return e.source === "slow-brain";
+          }).length === 0 && (
+            <p className="text-sm text-muted-foreground text-center py-8">
+              Waiting for slow brain to start preparation...
+            </p>
+          )}
+          {events
+            .filter((e) => {
+              return e.source === "slow-brain";
+            })
+            .map((event) => {
+              return (
+                <div
+                  key={event.seq}
+                  className="text-sm py-1.5 border-b border-border/50 last:border-0"
+                >
+                  <span className="text-muted-foreground font-mono text-xs">
+                    [{event.type}]
+                  </span>{" "}
+                  {event.content && (
+                    <span className="whitespace-pre-wrap">{event.content}</span>
+                  )}
+                </div>
+              );
+            })}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- Add `"preparing"` to `ConnectionStatus` type for meeting preparation phase
- Extract shared `connectVoiceSession$` command (token → mic → WebRTC → poll/heartbeat) to avoid duplication between chat and meeting modes
- Add `startVoiceMeeting$` command that creates a meeting session, polls for `preparation-ready` event, activates the session, then connects voice
- Update idle page with prompt textarea and "Start Voice Meeting" button (disabled when prompt is empty)
- Add preparing state UI showing slow brain thinking events and cancel button
- Export `vcPrompt$`, `vcMeetingPromptInput$`, `setMeetingPromptInput$` signals

Closes #8793

## Test plan

- [ ] Navigate to `/voice-chat` — both "Start Voice Chat" and "Start Voice Meeting" buttons visible
- [ ] "Start Voice Meeting" is disabled when prompt textarea is empty
- [ ] Enter a prompt, click "Start Voice Meeting" — status transitions to "preparing"
- [ ] During preparation: thinking events from slow brain appear in real-time
- [ ] When preparation completes: status automatically transitions to "connecting" then "connected"
- [ ] During preparation: click "Cancel" — session ends, returns to idle
- [ ] "Start Voice Chat" (without prompt) works exactly as before — no regression
- [ ] All 1614 existing tests pass (`pnpm -F @vm0/app exec vitest run`)
- [ ] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)