### PR TITLE
fix(guest-download): pre-create target directories before parallel downloads

### DIFF
--- a/crates/guest-download/src/lib.rs
+++ b/crates/guest-download/src/lib.rs
@@ -213,6 +213,20 @@ pub fn run(manifest_path: &str) -> bool {
         });
     }
 
+    // Pre-create all target directories before parallel downloads.
+    // This avoids races between parent-child mount paths (e.g. /home/user/.claude
+    // and /home/user/.claude/skills/foo) when they land in the same concurrent chunk.
+    for task in &tasks {
+        if let Err(e) = fs::create_dir_all(&task.mount_path) {
+            log_error!(
+                LOG_TAG,
+                "Failed to create directory {}: {e}",
+                task.mount_path
+            );
+            return false;
+        }
+    }
+
     download_all_parallel(tasks)
 }
 
@@ -427,7 +441,6 @@ fn download_with_retry(url: &str, target_path: &str) -> Result<(), DownloadError
 }
 
 fn download_and_extract(url: &str, target_path: &str) -> Result<(), DownloadError> {
-    // Create target directory
     fs::create_dir_all(target_path).map_err(|e| DownloadError {
         message: format!("Failed to create directory {target_path}: {e}"),
         retriable: false,

--- a/crates/guest-download/tests/integration.rs
+++ b/crates/guest-download/tests/integration.rs
@@ -193,6 +193,92 @@ fn six_storages_parallel() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 2b: parent-child mount paths in same concurrent chunk
+// Regression test: storages with overlapping paths (e.g. /home/user/.claude and
+// /home/user/.claude/skills/foo) must not race on directory creation.
+// ---------------------------------------------------------------------------
+#[test]
+fn parent_child_mount_paths_parallel() {
+    let server = MockServer::start();
+    let dir = tempfile::tempdir().unwrap();
+
+    let parent_tar = create_tar_gz(&[("config.json", b"parent config")]).unwrap();
+    let child_a_tar = create_tar_gz(&[("skill.json", b"skill a")]).unwrap();
+    let child_b_tar = create_tar_gz(&[("skill.json", b"skill b")]).unwrap();
+    let child_c_tar = create_tar_gz(&[("skill.json", b"skill c")]).unwrap();
+
+    let m_parent = server.mock(|when, then| {
+        when.method(GET).path("/parent.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&parent_tar);
+    });
+    let m_child_a = server.mock(|when, then| {
+        when.method(GET).path("/child_a.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&child_a_tar);
+    });
+    let m_child_b = server.mock(|when, then| {
+        when.method(GET).path("/child_b.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&child_b_tar);
+    });
+    let m_child_c = server.mock(|when, then| {
+        when.method(GET).path("/child_c.tar.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(&child_c_tar);
+    });
+
+    // 4 tasks fill one concurrent chunk (MAX_CONCURRENT=4), ensuring parent
+    // and children are truly downloaded in parallel.
+    let parent_mount = dir.path().join("claude");
+    let child_a_mount = dir.path().join("claude/skills/alpha");
+    let child_b_mount = dir.path().join("claude/skills/beta");
+    let child_c_mount = dir.path().join("claude/skills/gamma");
+
+    let url_parent = server.url("/parent.tar.gz");
+    let url_child_a = server.url("/child_a.tar.gz");
+    let url_child_b = server.url("/child_b.tar.gz");
+    let url_child_c = server.url("/child_c.tar.gz");
+
+    let storages: Vec<(&str, Option<&str>)> = vec![
+        (parent_mount.to_str().unwrap(), Some(&url_parent)),
+        (child_a_mount.to_str().unwrap(), Some(&url_child_a)),
+        (child_b_mount.to_str().unwrap(), Some(&url_child_b)),
+        (child_c_mount.to_str().unwrap(), Some(&url_child_c)),
+    ];
+
+    let manifest = write_manifest(&dir, &storages, None).unwrap();
+    let result = guest_download::run(manifest.to_str().unwrap());
+
+    assert!(result);
+    m_parent.assert();
+    m_child_a.assert();
+    m_child_b.assert();
+    m_child_c.assert();
+
+    assert_eq!(
+        std::fs::read_to_string(parent_mount.join("config.json")).unwrap(),
+        "parent config"
+    );
+    assert_eq!(
+        std::fs::read_to_string(child_a_mount.join("skill.json")).unwrap(),
+        "skill a"
+    );
+    assert_eq!(
+        std::fs::read_to_string(child_b_mount.join("skill.json")).unwrap(),
+        "skill b"
+    );
+    assert_eq!(
+        std::fs::read_to_string(child_c_mount.join("skill.json")).unwrap(),
+        "skill c"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Test 3: artifact download succeeds
 // ---------------------------------------------------------------------------
 #[test]


### PR DESCRIPTION
## Summary
- Pre-create all target directories in `run()` before `download_all_parallel()` to eliminate races between parent-child mount paths (e.g. `/home/user/.claude` and `/home/user/.claude/skills/foo`) in the same concurrent chunk
- Keep `create_dir_all` in `download_and_extract` as belt-and-suspenders for retries
- Add regression test with 4 parent-child storages filling one `MAX_CONCURRENT=4` chunk

## Context
Observed in job `91c6fee7` on local-1 (yuma runner): `guest-download` failed because storages 3/4 (`/home/user/.claude/skills/*`) hit `canonicalize` ENOENT — their directories were created by `create_dir_all` but another thread's tar extraction into the parent `/home/user/.claude` interfered before `canonicalize` ran. The runner was on a pre-#8755 binary, but this pre-create hardens against similar future races.

## Test plan
- [x] `cargo test -p guest-download` — 51 tests pass (21 unit + 30 integration)
- [x] New `parent_child_mount_paths_parallel` test verifies parent + 3 children download correctly in one concurrent chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)