### PR TITLE
feat(voice-chat): add quick preparation phase to voice chat mode

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -653,6 +653,86 @@ const connectVoiceSession$ = command(
   },
 );
 
+// --- Shared preparation → activate → connect flow ---
+
+const prepareActivateConnect$ = command(
+  async (
+    { get, set },
+    sessionId: string,
+    sessionSignal: AbortSignal,
+    signal: AbortSignal,
+  ) => {
+    const fetchFn = get(fetch$);
+
+    // Start heartbeat during preparation to prevent session timeout
+    const heartbeatPromise = set(startHeartbeat$, sessionSignal);
+
+    // Poll for preparation-ready event
+    await setLoop(
+      async (loopSignal: AbortSignal) => {
+        const sid = get(internalSessionId$);
+        if (!sid) {
+          return true;
+        }
+
+        const lastSeq = get(internalLastSeq$);
+        const res = await fetchFn(
+          `/api/zero/voice-chat/${sid}/context?after=${lastSeq}`,
+          { signal: loopSignal },
+        );
+
+        if (!res.ok) {
+          return false;
+        }
+
+        const data = (await res.json()) as { events: ContextEvent[] };
+        loopSignal.throwIfAborted();
+
+        if (data.events.length > 0) {
+          set(internalEvents$, (prev) => {
+            return [...prev, ...data.events];
+          });
+          const lastEvent = data.events[data.events.length - 1];
+          if (lastEvent) {
+            set(internalLastSeq$, lastEvent.seq);
+          }
+
+          if (
+            data.events.some((e) => {
+              return e.type === "preparation-ready";
+            })
+          ) {
+            return true;
+          }
+        }
+        return false;
+      },
+      POLL_INTERVAL_MS,
+      sessionSignal,
+    );
+    signal.throwIfAborted();
+
+    // Activate session (preparing → active)
+    const activateRes = await fetchFn(
+      `/api/zero/voice-chat/${sessionId}/activate`,
+      { method: "POST" },
+    );
+    signal.throwIfAborted();
+
+    if (!activateRes.ok) {
+      set(internalError$, "Failed to activate session");
+      set(internalStatus$, "error");
+      return;
+    }
+
+    // Connect voice (token → mic → WebRTC → poll/heartbeat)
+    await Promise.allSettled([
+      heartbeatPromise,
+      set(connectVoiceSession$, sessionSignal),
+    ]);
+  },
+);
+
 // --- Exported commands ---
 
 export const startVoiceChat$ = command(
@@ -665,7 +745,7 @@ export const startVoiceChat$ = command(
       return;
     }
 
-    set(internalStatus$, "connecting");
+    set(internalStatus$, "preparing");
     set(internalError$, null);
     set(internalTranscript$, []);
     set(internalEvents$, []);
@@ -710,7 +790,7 @@ export const startVoiceChat$ = command(
     signal.throwIfAborted();
     set(internalSessionId$, session.id);
 
-    await set(connectVoiceSession$, sessionSignal);
+    await set(prepareActivateConnect$, session.id, sessionSignal, signal);
   },
 );
 
@@ -769,72 +849,7 @@ export const startVoiceMeeting$ = command(
     signal.throwIfAborted();
     set(internalSessionId$, session.id);
 
-    // Start heartbeat during preparation to prevent session timeout
-    const heartbeatPromise = set(startHeartbeat$, sessionSignal);
-
-    // Poll for preparation-ready event
-    await setLoop(
-      async (loopSignal: AbortSignal) => {
-        const sid = get(internalSessionId$);
-        if (!sid) {
-          return true;
-        }
-
-        const lastSeq = get(internalLastSeq$);
-        const res = await fetchFn(
-          `/api/zero/voice-chat/${sid}/context?after=${lastSeq}`,
-          { signal: loopSignal },
-        );
-
-        if (!res.ok) {
-          return false;
-        }
-
-        const data = (await res.json()) as { events: ContextEvent[] };
-        loopSignal.throwIfAborted();
-
-        if (data.events.length > 0) {
-          set(internalEvents$, (prev) => {
-            return [...prev, ...data.events];
-          });
-          const lastEvent = data.events[data.events.length - 1];
-          if (lastEvent) {
-            set(internalLastSeq$, lastEvent.seq);
-          }
-
-          if (
-            data.events.some((e) => {
-              return e.type === "preparation-ready";
-            })
-          ) {
-            return true;
-          }
-        }
-        return false;
-      },
-      POLL_INTERVAL_MS,
-      sessionSignal,
-    );
-    signal.throwIfAborted();
-
-    // Activate session (preparing → active)
-    const activateRes = await fetchFn(
-      `/api/zero/voice-chat/${session.id}/activate`,
-      { method: "POST" },
-    );
-    signal.throwIfAborted();
-
-    if (!activateRes.ok) {
-      set(internalError$, "Failed to activate meeting session");
-      set(internalStatus$, "error");
-      return;
-    }
-
-    // Connect voice (token → mic → WebRTC → poll/heartbeat)
-    await Promise.allSettled([
-      heartbeatPromise,
-      set(connectVoiceSession$, sessionSignal),
-    ]);
+    await set(prepareActivateConnect$, session.id, sessionSignal, signal);
   },
 );
 

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -164,7 +164,9 @@ export function VoiceChatPage() {
       <div className="flex flex-col h-full">
         <div className="flex items-center justify-between border-b px-4 py-3">
           <div className="flex items-center gap-3">
-            <h1 className="text-lg font-semibold">Preparing Meeting</h1>
+            <h1 className="text-lg font-semibold">
+              {prompt ? "Preparing Meeting" : "Preparing..."}
+            </h1>
             <StatusBadge status={status} />
           </div>
           <Button

--- a/turbo/apps/web/app/api/zero/voice-chat/__tests__/create-session.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/__tests__/create-session.test.ts
@@ -117,7 +117,7 @@ describe("POST /api/zero/voice-chat (create session)", () => {
     expect(response.status).toBe(200);
     expect(body.session).toBeDefined();
     expect(body.session.id).toBeDefined();
-    expect(body.session.status).toBe("active");
+    expect(body.session.status).toBe("preparing");
     expect(body.session.mode).toBe("chat");
     expect(body.session.runId).toBeDefined();
     expect(body.session.createdAt).toBeDefined();

--- a/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildIntegrationPrompt,
-  buildVoiceChatSlowBrainPrompt,
+  buildVoiceChatQuickPrepPrompt,
   buildVoiceChatMeetingPrompt,
   buildSlackPrompt,
   buildPhonePrompt,
@@ -82,20 +82,40 @@ describe("buildIntegrationPrompt", () => {
   });
 });
 
-describe("buildVoiceChatSlowBrainPrompt", () => {
-  it("should combine integration header with slow-brain prompt", () => {
-    const result = buildVoiceChatSlowBrainPrompt("session-123");
+describe("buildVoiceChatQuickPrepPrompt", () => {
+  it("should combine integration header with quick preparation prompt", () => {
+    const result = buildVoiceChatQuickPrepPrompt("session-123");
 
     expect(result).toContain("You are currently running inside: Voice-Chat");
-    expect(result).toContain("# Zero — Slow-Brain Mode");
+    expect(result).toContain("# Zero — Slow-Brain Quick Preparation Mode");
   });
 
   it("should replace session ID placeholder", () => {
-    const result = buildVoiceChatSlowBrainPrompt("session-456");
+    const result = buildVoiceChatQuickPrepPrompt("session-456");
 
     expect(result).toContain("context get session-456");
     expect(result).toContain("context append session-456");
     expect(result).not.toContain("<SESSION_ID>");
+  });
+
+  it("should contain preparation-ready instruction", () => {
+    const result = buildVoiceChatQuickPrepPrompt("session-123");
+
+    expect(result).toContain("preparation-ready");
+  });
+
+  it("should contain thinking and directive event instructions", () => {
+    const result = buildVoiceChatQuickPrepPrompt("session-123");
+
+    expect(result).toContain("thinking");
+    expect(result).toContain("directive");
+  });
+
+  it("should contain observation mode instructions for after preparation", () => {
+    const result = buildVoiceChatQuickPrepPrompt("session-123");
+
+    expect(result).toContain("Phase 2: Live Observation");
+    expect(result).toContain("session-end");
   });
 });
 

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -88,39 +88,9 @@ export function buildUserInfo(options: UserInfoOptions): string {
 // Per-integration prompt builders
 // ---------------------------------------------------------------------------
 
-const VOICE_CHAT_QUICK_PREPARATION_PROMPT = `
-# Zero — Slow-Brain Quick Preparation Mode
-
-You are Zero's slow-brain. The voice conversation has not started yet. Your job is to do a quick warm-up — review the agent context and user identity, prepare a brief initial directive, then transition to live observation.
-
-## Phase 1: Quick Preparation
-
-This should only take a few seconds. Do NOT do deep research — just review what you already know.
-
-### Steps
-
-1. **Review context** — Read the agent's system prompt, instructions, and memory. Note the user's identity (name, role, timezone).
-2. **Write a thinking event** — Let the user know you are preparing: "Reviewing agent context and preparing initial guidance..."
-3. **Write a directive** — Summarize the key context for the fast-brain:
-   - Who the user is (name, role if known)
-   - What the agent specializes in
-   - Any relevant recent context from memory
-4. **Signal readiness** — Write a \`preparation-ready\` event to indicate you are done.
-
-### CLI Commands
-
-Read shared context:
-\`zero voice-chat context get <SESSION_ID> --after <LAST_SEQ>\`
-
-Write events:
-\`zero voice-chat context append <SESSION_ID> --source slow-brain --type <TYPE> --content "<CONTENT>"\`
-
-### Event Types for Preparation
-
-- **thinking**: Brief progress update. Example: "Reviewing agent context and preparing initial guidance..."
-- **directive**: Initial context summary for the fast-brain.
-- **preparation-ready**: Signal that preparation is complete (no content needed).
-
+// Shared observation instructions used by both quick prep and meeting prompts.
+// Editing this section updates observation behavior for all voice chat modes.
+const SHARED_OBSERVATION_PROMPT = `
 ## Phase 2: Live Observation
 
 Once you have written the preparation-ready event, the voice conversation will begin. Transition to observation mode:
@@ -180,7 +150,41 @@ When you see a \`fast-brain/request-slow-brain\` event, it is a direct task from
 - You have full tool access. Use your sandbox, CLI, and APIs to get real answers.
 - When you find something, write the directive immediately. Do not wait for a request.
 - You are Zero. Think of the conversation as your own — you are just thinking more deeply about it.
-`.trim();
+`;
+
+const VOICE_CHAT_QUICK_PREPARATION_PROMPT = `
+# Zero — Slow-Brain Quick Preparation Mode
+
+You are Zero's slow-brain. The voice conversation has not started yet. Your job is to do a quick warm-up — review the agent context and user identity, prepare a brief initial directive, then transition to live observation.
+
+## Phase 1: Quick Preparation
+
+This should only take a few seconds. Do NOT do deep research — just review what you already know.
+
+### Steps
+
+1. **Review context** — Read the agent's system prompt, instructions, and memory. Note the user's identity (name, role, timezone).
+2. **Write a thinking event** — Let the user know you are preparing: "Reviewing agent context and preparing initial guidance..."
+3. **Write a directive** — Summarize the key context for the fast-brain:
+   - Who the user is (name, role if known)
+   - What the agent specializes in
+   - Any relevant recent context from memory
+4. **Signal readiness** — Write a \`preparation-ready\` event to indicate you are done.
+
+### CLI Commands
+
+Read shared context:
+\`zero voice-chat context get <SESSION_ID> --after <LAST_SEQ>\`
+
+Write events:
+\`zero voice-chat context append <SESSION_ID> --source slow-brain --type <TYPE> --content "<CONTENT>"\`
+
+### Event Types for Preparation
+
+- **thinking**: Brief progress update. Example: "Reviewing agent context and preparing initial guidance..."
+- **directive**: Initial context summary for the fast-brain.
+- **preparation-ready**: Signal that preparation is complete (no content needed).
+${SHARED_OBSERVATION_PROMPT}`.trim();
 
 /**
  * Build the full appendSystemPrompt for Voice-Chat quick preparation mode.
@@ -233,67 +237,8 @@ Write events:
 - **directive**: Your final preparation findings and meeting guidance for the fast-brain.
 - **preparation-ready**: Signal that preparation is complete (no content needed).
 
-## Phase 2: Live Observation
-
-Once you have written the preparation-ready event, the voice conversation will begin. Transition to observation mode:
-
-### Observing the Conversation
-
-Continuously read the shared context to follow the conversation:
-
-\`zero voice-chat context get <SESSION_ID> --after <LAST_SEQ>\`
-
-You will see events like:
-- **user/speech** — what the user says
-- **fast-brain/response** — what your fast-brain says back
-- **system/session-start** and **system/session-end** — session lifecycle
-
-You already prepared for this meeting. Use your preparation context to assist more effectively.
-
-### When to Act
-
-Act when the conversation involves:
-- Code, data, APIs, files, or external systems
-- Tasks that require execution, search, or tool use
-- Topics where you can proactively gather information (e.g., user mentions a PR — look it up so the answer is ready)
-- Anything your fast-brain cannot handle with conversation alone
-- Topics related to your preparation — you may already have the answer
-
-Stay quiet when the conversation is:
-- Casual chat, greetings, or small talk
-- Opinions or preferences
-- Simple knowledge questions your fast-brain handles well
-
-### Explicit Requests
-
-When you see a \`fast-brain/request-slow-brain\` event, it is a direct task from your fast-brain. Treat it as a priority:
-- Drop non-critical autonomous work to handle it immediately
-- The task description contains exactly what to do — follow it
-- Write a thinking event early so the user knows you are working on it
-- Write the result as a directive when done
-
-### Writing to Shared Context
-
-\`zero voice-chat context append <SESSION_ID> --source slow-brain --type <TYPE> --content "<CONTENT>"\`
-
-- **directive**: High-level instructions for your fast-brain. Include what to tell the user, relevant data, and why. Do not script exact words — your fast-brain controls phrasing.
-- **thinking**: Progress updates and intermediate results while you work.
-- **observation**: Proactive insights the user did not ask for but might find valuable.
-
-### Polling and Lifecycle
-
-1. Check for new events every 5 seconds.
-2. Process what you see — act proactively or respond to explicit requests.
-3. Write appropriate events (directive, thinking, observation).
-4. Repeat until you see a \`session-end\` system event, then exit.
-
-## Important
-
-- Keep directive content concise but complete — your fast-brain will read it aloud.
-- You have full tool access. Use your sandbox, CLI, and APIs to get real answers.
-- When you find something, write the directive immediately. Do not wait for a request.
-- You are Zero. Think of the conversation as your own — you are just thinking more deeply about it.
-`.trim();
+**After preparation**: You already prepared for this meeting. Use your preparation context to assist more effectively during the live conversation. Topics related to your preparation — you may already have the answer.
+${SHARED_OBSERVATION_PROMPT}`.trim();
 
 /**
  * Build the full appendSystemPrompt for Voice-Chat meeting preparation mode.

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -88,12 +88,44 @@ export function buildUserInfo(options: UserInfoOptions): string {
 // Per-integration prompt builders
 // ---------------------------------------------------------------------------
 
-const VOICE_CHAT_SLOW_BRAIN_PROMPT = `
-# Zero — Slow-Brain Mode
+const VOICE_CHAT_QUICK_PREPARATION_PROMPT = `
+# Zero — Slow-Brain Quick Preparation Mode
 
-You are Zero's slow-brain. You and your fast-brain (the voice interface) are the same agent — Zero. Your fast-brain is having a real-time voice conversation with the user right now. You can see the entire conversation through the shared context.
+You are Zero's slow-brain. The voice conversation has not started yet. Your job is to do a quick warm-up — review the agent context and user identity, prepare a brief initial directive, then transition to live observation.
 
-## Observing the Conversation
+## Phase 1: Quick Preparation
+
+This should only take a few seconds. Do NOT do deep research — just review what you already know.
+
+### Steps
+
+1. **Review context** — Read the agent's system prompt, instructions, and memory. Note the user's identity (name, role, timezone).
+2. **Write a thinking event** — Let the user know you are preparing: "Reviewing agent context and preparing initial guidance..."
+3. **Write a directive** — Summarize the key context for the fast-brain:
+   - Who the user is (name, role if known)
+   - What the agent specializes in
+   - Any relevant recent context from memory
+4. **Signal readiness** — Write a \`preparation-ready\` event to indicate you are done.
+
+### CLI Commands
+
+Read shared context:
+\`zero voice-chat context get <SESSION_ID> --after <LAST_SEQ>\`
+
+Write events:
+\`zero voice-chat context append <SESSION_ID> --source slow-brain --type <TYPE> --content "<CONTENT>"\`
+
+### Event Types for Preparation
+
+- **thinking**: Brief progress update. Example: "Reviewing agent context and preparing initial guidance..."
+- **directive**: Initial context summary for the fast-brain.
+- **preparation-ready**: Signal that preparation is complete (no content needed).
+
+## Phase 2: Live Observation
+
+Once you have written the preparation-ready event, the voice conversation will begin. Transition to observation mode:
+
+### Observing the Conversation
 
 Continuously read the shared context to follow the conversation:
 
@@ -106,7 +138,7 @@ You will see events like:
 
 Based on what you observe, proactively decide what to do. Do not wait to be asked.
 
-## When to Act
+### When to Act
 
 Act when the conversation involves:
 - Code, data, APIs, files, or external systems
@@ -119,34 +151,23 @@ Stay quiet when the conversation is:
 - Opinions or preferences
 - Simple knowledge questions your fast-brain handles well
 
-## Explicit Requests
+### Explicit Requests
 
-When you see a \`fast-brain/request-slow-brain\` event in the shared context, it is a direct task from your fast-brain — the voice interface. Treat it as a priority:
+When you see a \`fast-brain/request-slow-brain\` event, it is a direct task from your fast-brain. Treat it as a priority:
 - Drop non-critical autonomous work to handle it immediately
 - The task description contains exactly what to do — follow it
 - Write a thinking event early so the user knows you are working on it
 - Write the result as a directive when done
 
-Explicit requests take priority over autonomously-detected tasks.
-
-## Writing to Shared Context
-
-When you have something for the user, write to the shared context:
+### Writing to Shared Context
 
 \`zero voice-chat context append <SESSION_ID> --source slow-brain --type <TYPE> --content "<CONTENT>"\`
 
-### Event Types
-
 - **directive**: High-level instructions for your fast-brain. Include what to tell the user, relevant data, and why. Do not script exact words — your fast-brain controls phrasing.
-  Example: "The user asked about PR status. PR #8644 merged to main, all CI checks passed. Release PR #8647 is in merge queue position 2. Let the user know and ask if they want to wait for deployment."
-
-- **thinking**: Progress updates and intermediate results while you work. Write one early so your fast-brain can tell the user you are thinking, and again when you have raw data or findings.
-  Example: "Looking up the CI status for the latest PR."
-
+- **thinking**: Progress updates and intermediate results while you work.
 - **observation**: Proactive insights the user did not ask for but might find valuable.
-  Example: "While checking the PR, I noticed the test coverage dropped by 3%. Might be worth mentioning."
 
-## Polling and Lifecycle
+### Polling and Lifecycle
 
 1. Check for new events every 5 seconds.
 2. Process what you see — act proactively or respond to explicit requests.
@@ -162,16 +183,16 @@ When you have something for the user, write to the shared context:
 `.trim();
 
 /**
- * Build the full appendSystemPrompt for Voice-Chat slow-brain mode.
- * Combines the integration header with the slow-brain prompt.
+ * Build the full appendSystemPrompt for Voice-Chat quick preparation mode.
+ * Combines the integration header with the quick preparation prompt.
  */
-export function buildVoiceChatSlowBrainPrompt(sessionId: string): string {
+export function buildVoiceChatQuickPrepPrompt(sessionId: string): string {
   const header = buildIntegrationPrompt("Voice-Chat");
-  const slowBrainPrompt = VOICE_CHAT_SLOW_BRAIN_PROMPT.replaceAll(
+  const quickPrepPrompt = VOICE_CHAT_QUICK_PREPARATION_PROMPT.replaceAll(
     "<SESSION_ID>",
     sessionId,
   );
-  return [header, slowBrainPrompt].join("\n\n");
+  return [header, quickPrepPrompt].join("\n\n");
 }
 
 const VOICE_CHAT_MEETING_PREPARATION_PROMPT = `

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -6,7 +6,7 @@ import {
 import { createZeroRun } from "../zero-run-service";
 import { cancelRun } from "../zero-run-cancel";
 import {
-  buildVoiceChatSlowBrainPrompt,
+  buildVoiceChatQuickPrepPrompt,
   buildVoiceChatMeetingPrompt,
 } from "../integration-prompt";
 import { conflict, notFound, badRequest, forbidden } from "../../shared/errors";
@@ -43,7 +43,7 @@ export async function createSession(
   }
 
   const mode = options?.mode ?? "chat";
-  const status = mode === "meeting" ? "preparing" : "active";
+  const status = "preparing";
 
   const [session] = await db
     .insert(voiceChatSessions)
@@ -150,11 +150,11 @@ export async function dispatchSlowBrain(
 
   const appendSystemPrompt = meetingPrompt
     ? buildVoiceChatMeetingPrompt(session.id, meetingPrompt)
-    : buildVoiceChatSlowBrainPrompt(session.id);
+    : buildVoiceChatQuickPrepPrompt(session.id);
 
   const prompt = meetingPrompt
     ? `You are Zero's slow-brain for voice-chat session ${session.id}. A meeting has been requested. Read the shared context for the meeting prompt and begin preparation.`
-    : `You are Zero's slow-brain for voice-chat session ${session.id}. Start by reading the shared context to observe the conversation.`;
+    : `You are Zero's slow-brain for voice-chat session ${session.id}. Review the agent configuration and user context, then prepare an initial directive before the conversation begins.`;
 
   // Write meeting-prompt event before session-start (meeting mode only)
   if (meetingPrompt) {


### PR DESCRIPTION
## Summary

- Add `VOICE_CHAT_QUICK_PREPARATION_PROMPT` — brief slow brain warm-up (review agent config, user identity, write initial directive) before voice chat starts
- Remove `VOICE_CHAT_SLOW_BRAIN_PROMPT` (dead code — replaced by quick prep prompt that includes observation)
- Chat mode sessions now start with `preparing` status, same lifecycle as meeting mode (`preparing → active → ended`)
- Extract shared `prepareActivateConnect$` command — eliminates ~60 lines of duplication between `startVoiceChat$` and `startVoiceMeeting$`
- Update preparing UI header: "Preparing Meeting" for meeting mode, "Preparing..." for chat mode

Closes #8814

## Test plan

- [x] 26 integration-prompt tests pass (5 new quick prep tests replacing 2 old slow brain tests)
- [x] 45 voice-chat integration tests pass (6 test files)
- [x] Chat mode status assertion updated from "active" to "preparing"
- [x] Lint (web + platform), type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)