### PR TITLE
fix(platform): gate create workspace button on clerk user permission

### DIFF
--- a/turbo/apps/platform/src/__tests__/mock-auth.ts
+++ b/turbo/apps/platform/src/__tests__/mock-auth.ts
@@ -26,6 +26,7 @@ interface MockedUser {
   firstName?: string;
   primaryEmailAddress: { emailAddress: string } | null;
   unsafeMetadata: Record<string, unknown>;
+  createOrganizationEnabled: boolean;
   organizationMemberships: MockedMembership[];
   getOrganizationInvitations: (params?: {
     status?: string;
@@ -59,6 +60,7 @@ export function mockUser(
       ...user,
       primaryEmailAddress: user.email ? { emailAddress: user.email } : null,
       unsafeMetadata: {},
+      createOrganizationEnabled: false,
       get organizationMemberships() {
         return internalMockedMemberships;
       },

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
@@ -214,6 +214,7 @@ describe("zero org switcher - dropdown opens (SIDEBAR-D-059)", () => {
         memberships: [{ id: "org_1" }],
       },
     });
+    mockedClerk.user!.createOrganizationEnabled = true;
 
     const user = userEvent.setup();
 
@@ -434,6 +435,7 @@ describe("zero org switcher - create workspace item starts creation flow (SIDEBA
         memberships: [{ id: "org_1" }],
       },
     });
+    mockedClerk.user!.createOrganizationEnabled = true;
 
     const user = userEvent.setup();
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-org-switcher.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
@@ -476,42 +476,9 @@ describe("zero org switcher - pending invitations badge hidden when none (SIDEBA
   });
 });
 
-describe("zero org switcher - hide create workspace for org owner in production", () => {
-  afterEach(() => {
-    // Only delete the env we stub — vi.unstubAllEnvs() would remove
-    // Vite-loaded vars like VITE_CLERK_PUBLISHABLE_KEY.
-    delete import.meta.env.VITE_VERCEL_ENV;
-  });
-
-  it("hides create workspace in production when user created the org", async () => {
-    vi.stubEnv("VITE_VERCEL_ENV", "production");
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_1",
-          slug: "my-org",
-          name: "My Org",
-          role: "admin",
-          createdBy: "test-user-123",
-        });
-      }),
-      http.get("*/api/zero/team", () => {
-        return HttpResponse.json([
-          {
-            id: "c0000000-0000-4000-a000-000000000001",
-            displayName: null,
-            description: null,
-            sound: null,
-            avatarUrl: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-          },
-        ]);
-      }),
-      http.get("*/api/zero/chat-threads", () => {
-        return HttpResponse.json({ threads: [] });
-      }),
-    );
+describe("zero org switcher - create workspace visibility based on createOrganizationEnabled", () => {
+  it("hides create workspace when createOrganizationEnabled is false", async () => {
+    mockAPIs();
 
     detachedSetupPage({
       context,
@@ -534,99 +501,24 @@ describe("zero org switcher - hide create workspace for org owner in production"
     expect(screen.queryByText("Create workspace")).not.toBeInTheDocument();
   });
 
-  it("shows create workspace in production when user did not create the org", async () => {
-    vi.stubEnv("VITE_VERCEL_ENV", "production");
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_1",
-          slug: "team-org",
-          name: "Team Org",
-          role: "member",
-          createdBy: "other-user-456",
-        });
-      }),
-      http.get("*/api/zero/team", () => {
-        return HttpResponse.json([
-          {
-            id: "c0000000-0000-4000-a000-000000000001",
-            displayName: null,
-            description: null,
-            sound: null,
-            avatarUrl: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-          },
-        ]);
-      }),
-      http.get("*/api/zero/chat-threads", () => {
-        return HttpResponse.json({ threads: [] });
-      }),
-    );
+  it("shows create workspace when createOrganizationEnabled is true", async () => {
+    mockAPIs();
 
     detachedSetupPage({
       context,
       path: "/",
       org: {
-        activeOrg: { id: "org_1", name: "Team Org" },
+        activeOrg: { id: "org_1", name: "My Org" },
         memberships: [{ id: "org_1" }],
       },
     });
+    mockedClerk.user!.createOrganizationEnabled = true;
 
     const user = userEvent.setup();
     await waitFor(() => {
-      expect(screen.getByText("Team Org")).toBeInTheDocument();
+      expect(screen.getByText("My Org")).toBeInTheDocument();
     });
-    await user.click(screen.getByText("Team Org"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Create workspace")).toBeInTheDocument();
-    });
-  });
-
-  it("shows create workspace in dev mode even when user created the org", async () => {
-    server.use(
-      http.get("*/api/zero/org", () => {
-        return HttpResponse.json({
-          id: "org_1",
-          slug: "dev-org",
-          name: "Dev Org",
-          role: "admin",
-          createdBy: "test-user-123",
-        });
-      }),
-      http.get("*/api/zero/team", () => {
-        return HttpResponse.json([
-          {
-            id: "c0000000-0000-4000-a000-000000000001",
-            displayName: null,
-            description: null,
-            sound: null,
-            avatarUrl: null,
-            headVersionId: "version_1",
-            updatedAt: "2024-01-01T00:00:00Z",
-          },
-        ]);
-      }),
-      http.get("*/api/zero/chat-threads", () => {
-        return HttpResponse.json({ threads: [] });
-      }),
-    );
-
-    detachedSetupPage({
-      context,
-      path: "/",
-      org: {
-        activeOrg: { id: "org_1", name: "Dev Org" },
-        memberships: [{ id: "org_1" }],
-      },
-    });
-
-    const user = userEvent.setup();
-    await waitFor(() => {
-      expect(screen.getByText("Dev Org")).toBeInTheDocument();
-    });
-    await user.click(screen.getByText("Dev Org"));
+    await user.click(screen.getByText("My Org"));
 
     await waitFor(() => {
       expect(screen.getByText("Create workspace")).toBeInTheDocument();

--- a/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-org-switcher.tsx
@@ -218,10 +218,7 @@ function OrgDropdownContent() {
 
   const hasPendingInvitations =
     pendingInvitations !== undefined && pendingInvitations.length > 0;
-  const isProduction = !!import.meta.env.VITE_VERCEL_ENV;
-  const currentUserId = clerk?.user?.id;
-  const hasOwnOrg =
-    isProduction && !!currentUserId && orgData?.createdBy === currentUserId;
+  const canCreateOrg = clerk?.user?.createOrganizationEnabled ?? false;
 
   return (
     <DropdownMenuContent align="start" className="w-72">
@@ -262,8 +259,7 @@ function OrgDropdownContent() {
         </>
       )}
 
-      {/* Create workspace — hidden in production when user already owns an org */}
-      {!hasOwnOrg && <CreateWorkspaceItem />}
+      {canCreateOrg && <CreateWorkspaceItem />}
     </DropdownMenuContent>
   );
 }


### PR DESCRIPTION
## Summary
- Replace broken `VITE_VERCEL_ENV` + `orgData.createdBy` check with Clerk's `createOrganizationEnabled` flag
- The previous check always evaluated to `false` because `VITE_VERCEL_ENV` was never set, making "Create workspace" visible to all users
- Now uses the Clerk user object's built-in permission flag, which is already managed server-side

## Test plan
- [ ] User with `createOrganizationEnabled: false` should NOT see "Create workspace" in org switcher
- [ ] User with `createOrganizationEnabled: true` should see "Create workspace"

🤖 Generated with [Claude Code](https://claude.com/claude-code)