### PR TITLE
feat(voice-chat): add auto-scroll to transcript and events panels

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-auto-scroll.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-auto-scroll.ts
@@ -1,0 +1,45 @@
+import { command, state } from "ccstate";
+
+const NEAR_BOTTOM_THRESHOLD = 80;
+
+// --- Transcript panel ---
+
+const transcriptScrollContainer$ = state<HTMLElement | null>(null);
+
+export const setTranscriptScrollContainer$ = command(
+  ({ set }, el: HTMLElement | null) => {
+    set(transcriptScrollContainer$, el);
+  },
+);
+
+export const autoScrollTranscript$ = command(({ get }) => {
+  const el = get(transcriptScrollContainer$);
+  if (!el) {
+    return;
+  }
+  const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+  if (distanceFromBottom < NEAR_BOTTOM_THRESHOLD) {
+    el.scrollTop = el.scrollHeight;
+  }
+});
+
+// --- Events panel ---
+
+const eventsScrollContainer$ = state<HTMLElement | null>(null);
+
+export const setEventsScrollContainer$ = command(
+  ({ set }, el: HTMLElement | null) => {
+    set(eventsScrollContainer$, el);
+  },
+);
+
+export const autoScrollEvents$ = command(({ get }) => {
+  const el = get(eventsScrollContainer$);
+  if (!el) {
+    return;
+  }
+  const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+  if (distanceFromBottom < NEAR_BOTTOM_THRESHOLD) {
+    el.scrollTop = el.scrollHeight;
+  }
+});

--- a/turbo/apps/platform/src/views/voice-chat/use-voice-chat-auto-scroll.ts
+++ b/turbo/apps/platform/src/views/voice-chat/use-voice-chat-auto-scroll.ts
@@ -1,0 +1,23 @@
+// useLayoutEffect needed for synchronous scroll-to-bottom before paint
+// when new voice chat events arrive.
+// oxlint-disable-next-line no-restricted-imports
+import { useLayoutEffect } from "react";
+import { useSet } from "ccstate-react";
+import {
+  autoScrollTranscript$,
+  autoScrollEvents$,
+} from "../../signals/voice-chat/voice-chat-auto-scroll.ts";
+
+export function useTranscriptAutoScroll(trigger: unknown) {
+  const scroll = useSet(autoScrollTranscript$);
+  useLayoutEffect(() => {
+    scroll();
+  }, [scroll, trigger]);
+}
+
+export function useEventsAutoScroll(trigger: unknown) {
+  const scroll = useSet(autoScrollEvents$);
+  useLayoutEffect(() => {
+    scroll();
+  }, [scroll, trigger]);
+}

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -27,6 +27,14 @@ import {
   endVoiceChat$,
   toggleVoiceChatMute$,
 } from "../../signals/voice-chat/voice-chat-session.ts";
+import {
+  setTranscriptScrollContainer$,
+  setEventsScrollContainer$,
+} from "../../signals/voice-chat/voice-chat-auto-scroll.ts";
+import {
+  useTranscriptAutoScroll,
+  useEventsAutoScroll,
+} from "./use-voice-chat-auto-scroll.ts";
 
 type ConnectionStatus =
   | "idle"
@@ -90,6 +98,11 @@ export function VoiceChatPage() {
   const meetingPrompt = useGet(vcMeetingPromptInput$);
   const setMeetingPrompt = useSet(setMeetingPromptInput$);
   const agentName = useLastResolved(defaultAgentName$) ?? "Zero";
+  const setTranscriptContainer = useSet(setTranscriptScrollContainer$);
+  const setEventsContainer = useSet(setEventsScrollContainer$);
+
+  useTranscriptAutoScroll(transcript.length);
+  useEventsAutoScroll(events.length);
 
   if (enabled === false) {
     return (
@@ -186,7 +199,10 @@ export function VoiceChatPage() {
           </div>
         )}
 
-        <div className="flex-1 overflow-y-auto p-4 space-y-2">
+        <div
+          ref={setEventsContainer}
+          className="flex-1 overflow-y-auto p-4 space-y-2"
+        >
           <h2 className="text-sm font-medium text-muted-foreground mb-3">
             Slow Brain Activity
           </h2>
@@ -258,7 +274,10 @@ export function VoiceChatPage() {
               Live Transcript
             </h2>
           </div>
-          <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          <div
+            ref={setTranscriptContainer}
+            className="flex-1 overflow-y-auto p-4 space-y-3"
+          >
             {transcript.length === 0 && (
               <p className="text-sm text-muted-foreground text-center py-8">
                 {status === "connecting"
@@ -294,7 +313,10 @@ export function VoiceChatPage() {
               Shared Context Events
             </h2>
           </div>
-          <div className="flex-1 overflow-y-auto p-4 space-y-1">
+          <div
+            ref={setEventsContainer}
+            className="flex-1 overflow-y-auto p-4 space-y-1"
+          >
             {events.length === 0 && (
               <p className="text-sm text-muted-foreground text-center py-8">
                 No events yet.


### PR DESCRIPTION
## Summary

- Add auto-scroll behavior to the voice chat page's scrollable panels (live transcript, shared context events, and preparation slow-brain events)
- Auto-scroll respects user's manual scroll position — pauses when scrolled up (>80px from bottom), resumes when near bottom
- Follows existing ccstate signal pattern with dedicated `voice-chat-auto-scroll.ts` signals and `useVoiceChatAutoScroll` hooks

## Changes

- **New:** `signals/voice-chat/voice-chat-auto-scroll.ts` — scroll container state and auto-scroll commands with near-bottom threshold detection
- **New:** `views/voice-chat/use-voice-chat-auto-scroll.ts` — `useTranscriptAutoScroll` and `useEventsAutoScroll` hooks using `useLayoutEffect`
- **Modified:** `views/voice-chat/voice-chat-page.tsx` — wire refs and hooks into 3 scrollable containers (preparing events, connected transcript, connected events)

Closes #8832

## Test plan

- [ ] Start voice chat → transcript panel auto-scrolls as speech/response events appear
- [ ] Start voice meeting → events panel auto-scrolls during preparation (thinking events)
- [ ] Manually scroll up in either panel → auto-scroll pauses
- [ ] Scroll back to bottom → auto-scroll resumes
- [ ] Both panels work independently
- [ ] Lint, type-check, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)