### PR TITLE
fix(credit): decouple proxy usage comparison from credit processing

### DIFF
--- a/turbo/apps/web/app/api/cron/compare-proxy-usage/route.ts
+++ b/turbo/apps/web/app/api/cron/compare-proxy-usage/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from "next/server";
 import { initServices } from "../../../../src/lib/init-services";
 import { compareRecentRunsProxyUsage } from "../../../../src/lib/zero/credit/proxy-usage-comparison-service";
-import { logger } from "../../../../src/lib/shared/logger";
 import { env } from "../../../../src/env";
-
-const log = logger("cron:compare-proxy-usage");
 
 export async function GET(request: Request): Promise<Response> {
   initServices();
@@ -19,13 +16,7 @@ export async function GET(request: Request): Promise<Response> {
     );
   }
 
-  try {
-    await compareRecentRunsProxyUsage();
-  } catch (err) {
-    log.error("Proxy usage comparison failed", {
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
+  await compareRecentRunsProxyUsage();
 
   return NextResponse.json({ success: true });
 }

--- a/turbo/apps/web/app/api/cron/compare-proxy-usage/route.ts
+++ b/turbo/apps/web/app/api/cron/compare-proxy-usage/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { initServices } from "../../../../src/lib/init-services";
+import { compareRecentRunsProxyUsage } from "../../../../src/lib/zero/credit/proxy-usage-comparison-service";
+import { logger } from "../../../../src/lib/shared/logger";
+import { env } from "../../../../src/env";
+
+const log = logger("cron:compare-proxy-usage");
+
+export async function GET(request: Request): Promise<Response> {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = env().CRON_SECRET;
+
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { error: { message: "Invalid cron secret", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  try {
+    await compareRecentRunsProxyUsage();
+  } catch (err) {
+    log.error("Proxy usage comparison failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
@@ -461,6 +461,69 @@ export async function seedInsightsDaily(
 }
 
 // ---------------------------------------------------------------------------
+// Proxy usage comparison helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a completed run with a specific completedAt timestamp.
+ * Used by proxy usage comparison tests that need to control the time window.
+ */
+export async function createCompletedRun(
+  orgId: string,
+  userId: string,
+  completedAt: Date,
+): Promise<string> {
+  initServices();
+  const composeName = `compose-${randomBytes(4).toString("hex")}`;
+  const [compose] = await globalThis.services.db
+    .insert(agentComposes)
+    .values({ userId, orgId, name: composeName })
+    .returning();
+  const versionId = randomBytes(32).toString("hex");
+  await globalThis.services.db.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId: compose!.id,
+    content: {},
+    createdBy: userId,
+  });
+  const [run] = await globalThis.services.db
+    .insert(agentRuns)
+    .values({
+      userId,
+      orgId,
+      agentComposeVersionId: versionId,
+      prompt: "test",
+      status: "completed",
+      completedAt,
+    })
+    .returning();
+  return run!.id;
+}
+
+/**
+ * Insert a proxy_credit_usage row for testing.
+ */
+export async function insertTestProxyCreditUsage(params: {
+  runId: string;
+  orgId: string;
+  userId: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}): Promise<void> {
+  const { proxyCreditUsage } =
+    await import("../../db/schema/proxy-credit-usage");
+  await globalThis.services.db.insert(proxyCreditUsage).values({
+    runId: params.runId,
+    orgId: params.orgId,
+    userId: params.userId,
+    model: "claude-sonnet-4-20250514",
+    modelProvider: "anthropic",
+    inputTokens: params.inputTokens ?? 100,
+    outputTokens: params.outputTokens ?? 50,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Credit expires record helpers
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
@@ -1,12 +1,18 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type MockInstance,
+} from "vitest";
 import { randomBytes } from "crypto";
-import { eq } from "drizzle-orm";
-import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { testContext } from "../../../../__tests__/test-helpers";
 import { initServices } from "../../../init-services";
 import { compareRecentRunsProxyUsage } from "../proxy-usage-comparison-service";
 import { creditUsage } from "../../../../db/schema/credit-usage";
 import { proxyCreditUsage } from "../../../../db/schema/proxy-credit-usage";
-import { agentRuns } from "../../../../db/schema/agent-run";
 import {
   agentComposes,
   agentComposeVersions,
@@ -91,9 +97,14 @@ async function insertProxyUsage(
 }
 
 describe("compareRecentRunsProxyUsage", () => {
+  let logSpy: MockInstance;
+
   beforeEach(() => {
     context.setupMocks();
+    logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
   });
+
+  afterEach(() => {});
 
   it("does nothing when no runs in window", async () => {
     // No runs at all — should not throw
@@ -102,7 +113,6 @@ describe("compareRecentRunsProxyUsage", () => {
 
   it("skips runs completed less than 30s ago", async () => {
     const { orgId, userId } = await context.setupUser({ prefix: "recent" });
-    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
 
     // Run completed 10 seconds ago — inside the 30s floor
     const runId = await createRun(orgId, userId, new Date(Date.now() - 10_000));
@@ -113,12 +123,10 @@ describe("compareRecentRunsProxyUsage", () => {
 
     // Should NOT be compared (too recent)
     expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
   });
 
   it("skips runs completed more than 5m30s ago", async () => {
     const { orgId, userId } = await context.setupUser({ prefix: "old" });
-    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
 
     // Run completed 6 minutes ago — outside the 5m30s ceiling
     const runId = await createRun(
@@ -132,12 +140,10 @@ describe("compareRecentRunsProxyUsage", () => {
     await compareRecentRunsProxyUsage();
 
     expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
   });
 
   it("logs error for mismatching usage within window", async () => {
     const { orgId, userId } = await context.setupUser({ prefix: "mismatch" });
-    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
 
     // Run completed 2 minutes ago — inside window
     const runId = await createRun(
@@ -166,13 +172,10 @@ describe("compareRecentRunsProxyUsage", () => {
       return meta.field === "outputTokens";
     });
     expect(outputCalls).toHaveLength(0);
-
-    logSpy.mockRestore();
   });
 
   it("does not log when usage matches", async () => {
     const { orgId, userId } = await context.setupUser({ prefix: "match" });
-    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
 
     const runId = await createRun(
       orgId,
@@ -185,12 +188,10 @@ describe("compareRecentRunsProxyUsage", () => {
     await compareRecentRunsProxyUsage();
 
     expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
   });
 
   it("skips run with client data but no proxy data", async () => {
     const { orgId, userId } = await context.setupUser({ prefix: "no-proxy" });
-    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
 
     const runId = await createRun(
       orgId,
@@ -203,13 +204,11 @@ describe("compareRecentRunsProxyUsage", () => {
     await compareRecentRunsProxyUsage();
 
     expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
   });
 
   it("handles multiple orgs in one window", async () => {
     const user1 = await context.setupUser({ prefix: "org1" });
     const user2 = await context.setupUser({ prefix: "org2" });
-    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
 
     const completedAt = new Date(Date.now() - 120_000);
 
@@ -241,7 +240,5 @@ describe("compareRecentRunsProxyUsage", () => {
     });
     expect(calls).toHaveLength(1);
     expect((calls[0]![1] as Record<string, unknown>).orgId).toBe(user2.orgId);
-
-    logSpy.mockRestore();
   });
 });

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { randomBytes } from "crypto";
+import { eq } from "drizzle-orm";
+import { testContext, uniqueId } from "../../../../__tests__/test-helpers";
+import { initServices } from "../../../init-services";
+import { compareRecentRunsProxyUsage } from "../proxy-usage-comparison-service";
+import { creditUsage } from "../../../../db/schema/credit-usage";
+import { proxyCreditUsage } from "../../../../db/schema/proxy-credit-usage";
+import { agentRuns } from "../../../../db/schema/agent-run";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../../db/schema/agent-compose";
+import { logger } from "../../../shared/logger";
+
+const context = testContext();
+
+/** Create a run with a specific completedAt timestamp. Returns runId. */
+async function createRun(
+  orgId: string,
+  userId: string,
+  completedAt: Date,
+): Promise<string> {
+  initServices();
+  const db = globalThis.services.db;
+
+  const composeName = `compose-${randomBytes(4).toString("hex")}`;
+  const [compose] = await db
+    .insert(agentComposes)
+    .values({ userId, orgId, name: composeName })
+    .returning();
+  const versionId = randomBytes(32).toString("hex");
+  await db.insert(agentComposeVersions).values({
+    id: versionId,
+    composeId: compose!.id,
+    content: {},
+    createdBy: userId,
+  });
+
+  const [run] = await db
+    .insert(agentRuns)
+    .values({
+      userId,
+      orgId,
+      agentComposeVersionId: versionId,
+      prompt: "test",
+      status: "completed",
+      completedAt,
+    })
+    .returning();
+
+  return run!.id;
+}
+
+/** Insert a credit_usage row for a run. */
+async function insertClientUsage(
+  runId: string,
+  orgId: string,
+  userId: string,
+  tokens: { input: number; output: number },
+): Promise<void> {
+  await globalThis.services.db.insert(creditUsage).values({
+    runId,
+    orgId,
+    userId,
+    model: "claude-sonnet-4-20250514",
+    modelProvider: "anthropic",
+    inputTokens: tokens.input,
+    outputTokens: tokens.output,
+    status: "processed",
+    processedAt: new Date(),
+  });
+}
+
+/** Insert a proxy_credit_usage row for a run. */
+async function insertProxyUsage(
+  runId: string,
+  orgId: string,
+  userId: string,
+  tokens: { input: number; output: number },
+): Promise<void> {
+  await globalThis.services.db.insert(proxyCreditUsage).values({
+    runId,
+    orgId,
+    userId,
+    model: "claude-sonnet-4-20250514",
+    modelProvider: "anthropic",
+    inputTokens: tokens.input,
+    outputTokens: tokens.output,
+  });
+}
+
+describe("compareRecentRunsProxyUsage", () => {
+  beforeEach(() => {
+    context.setupMocks();
+  });
+
+  it("does nothing when no runs in window", async () => {
+    // No runs at all — should not throw
+    await compareRecentRunsProxyUsage();
+  });
+
+  it("skips runs completed less than 30s ago", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "recent" });
+    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
+
+    // Run completed 10 seconds ago — inside the 30s floor
+    const runId = await createRun(orgId, userId, new Date(Date.now() - 10_000));
+    await insertClientUsage(runId, orgId, userId, { input: 100, output: 50 });
+    await insertProxyUsage(runId, orgId, userId, { input: 200, output: 50 });
+
+    await compareRecentRunsProxyUsage();
+
+    // Should NOT be compared (too recent)
+    expect(logSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it("skips runs completed more than 5m30s ago", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "old" });
+    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
+
+    // Run completed 6 minutes ago — outside the 5m30s ceiling
+    const runId = await createRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 360_000),
+    );
+    await insertClientUsage(runId, orgId, userId, { input: 100, output: 50 });
+    await insertProxyUsage(runId, orgId, userId, { input: 200, output: 50 });
+
+    await compareRecentRunsProxyUsage();
+
+    expect(logSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it("logs error for mismatching usage within window", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "mismatch" });
+    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
+
+    // Run completed 2 minutes ago — inside window
+    const runId = await createRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 120_000),
+    );
+    await insertClientUsage(runId, orgId, userId, { input: 100, output: 50 });
+    await insertProxyUsage(runId, orgId, userId, { input: 200, output: 50 });
+
+    await compareRecentRunsProxyUsage();
+
+    // inputTokens mismatch should be logged
+    expect(logSpy).toHaveBeenCalledWith(
+      "Proxy usage mismatch",
+      expect.objectContaining({
+        runId,
+        field: "inputTokens",
+        clientValue: 100,
+        proxyValue: 200,
+      }),
+    );
+    // outputTokens match — should NOT be logged for this field
+    const outputCalls = logSpy.mock.calls.filter((call) => {
+      const meta = call[1] as Record<string, unknown>;
+      return meta.field === "outputTokens";
+    });
+    expect(outputCalls).toHaveLength(0);
+
+    logSpy.mockRestore();
+  });
+
+  it("does not log when usage matches", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "match" });
+    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
+
+    const runId = await createRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 120_000),
+    );
+    await insertClientUsage(runId, orgId, userId, { input: 100, output: 50 });
+    await insertProxyUsage(runId, orgId, userId, { input: 100, output: 50 });
+
+    await compareRecentRunsProxyUsage();
+
+    expect(logSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it("skips run with client data but no proxy data", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "no-proxy" });
+    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
+
+    const runId = await createRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 120_000),
+    );
+    await insertClientUsage(runId, orgId, userId, { input: 100, output: 50 });
+    // No proxy data inserted
+
+    await compareRecentRunsProxyUsage();
+
+    expect(logSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
+  it("handles multiple orgs in one window", async () => {
+    const user1 = await context.setupUser({ prefix: "org1" });
+    const user2 = await context.setupUser({ prefix: "org2" });
+    const logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
+
+    const completedAt = new Date(Date.now() - 120_000);
+
+    const run1 = await createRun(user1.orgId, user1.userId, completedAt);
+    await insertClientUsage(run1, user1.orgId, user1.userId, {
+      input: 100,
+      output: 50,
+    });
+    await insertProxyUsage(run1, user1.orgId, user1.userId, {
+      input: 100,
+      output: 50,
+    });
+
+    const run2 = await createRun(user2.orgId, user2.userId, completedAt);
+    await insertClientUsage(run2, user2.orgId, user2.userId, {
+      input: 100,
+      output: 50,
+    });
+    await insertProxyUsage(run2, user2.orgId, user2.userId, {
+      input: 300,
+      output: 50,
+    });
+
+    await compareRecentRunsProxyUsage();
+
+    // Only org2's run should have a mismatch
+    const calls = logSpy.mock.calls.filter((call) => {
+      return call[0] === "Proxy usage mismatch";
+    });
+    expect(calls).toHaveLength(1);
+    expect((calls[0]![1] as Record<string, unknown>).orgId).toBe(user2.orgId);
+
+    logSpy.mockRestore();
+  });
+});

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
@@ -18,6 +18,23 @@ import { logger } from "../../../shared/logger";
 
 const context = testContext();
 
+/** Filter logSpy calls to only those matching a specific orgId. */
+function callsForOrg(
+  spy: MockInstance,
+  orgId: string,
+): Array<Record<string, unknown>> {
+  return spy.mock.calls
+    .filter((call) => {
+      return call[0] === "Proxy usage mismatch";
+    })
+    .map((call) => {
+      return call[1] as Record<string, unknown>;
+    })
+    .filter((meta) => {
+      return meta.orgId === orgId;
+    });
+}
+
 describe("compareRecentRunsProxyUsage", () => {
   let logSpy: MockInstance;
 
@@ -31,7 +48,9 @@ describe("compareRecentRunsProxyUsage", () => {
   });
 
   it("does nothing when no runs in window", async () => {
+    const { orgId } = await context.setupUser({ prefix: "empty" });
     await compareRecentRunsProxyUsage();
+    expect(callsForOrg(logSpy, orgId)).toHaveLength(0);
   });
 
   it("skips runs completed less than 30s ago", async () => {
@@ -57,7 +76,7 @@ describe("compareRecentRunsProxyUsage", () => {
 
     await compareRecentRunsProxyUsage();
 
-    expect(logSpy).not.toHaveBeenCalled();
+    expect(callsForOrg(logSpy, orgId)).toHaveLength(0);
   });
 
   it("skips runs completed more than 5m30s ago", async () => {
@@ -83,7 +102,7 @@ describe("compareRecentRunsProxyUsage", () => {
 
     await compareRecentRunsProxyUsage();
 
-    expect(logSpy).not.toHaveBeenCalled();
+    expect(callsForOrg(logSpy, orgId)).toHaveLength(0);
   });
 
   it("logs error for mismatching usage within window", async () => {
@@ -110,20 +129,14 @@ describe("compareRecentRunsProxyUsage", () => {
 
     await compareRecentRunsProxyUsage();
 
-    expect(logSpy).toHaveBeenCalledWith(
-      "Proxy usage mismatch",
-      expect.objectContaining({
-        runId,
-        field: "inputTokens",
-        clientValue: 100,
-        proxyValue: 200,
-      }),
-    );
-    const outputCalls = logSpy.mock.calls.filter((call) => {
-      const meta = call[1] as Record<string, unknown>;
-      return meta.field === "outputTokens";
+    const calls = callsForOrg(logSpy, orgId);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      runId,
+      field: "inputTokens",
+      clientValue: 100,
+      proxyValue: 200,
     });
-    expect(outputCalls).toHaveLength(0);
   });
 
   it("does not log when usage matches", async () => {
@@ -144,7 +157,7 @@ describe("compareRecentRunsProxyUsage", () => {
 
     await compareRecentRunsProxyUsage();
 
-    expect(logSpy).not.toHaveBeenCalled();
+    expect(callsForOrg(logSpy, orgId)).toHaveLength(0);
   });
 
   it("skips run with client data but no proxy data", async () => {
@@ -164,7 +177,7 @@ describe("compareRecentRunsProxyUsage", () => {
 
     await compareRecentRunsProxyUsage();
 
-    expect(logSpy).not.toHaveBeenCalled();
+    expect(callsForOrg(logSpy, orgId)).toHaveLength(0);
   });
 
   it("handles multiple orgs in one window", async () => {
@@ -210,10 +223,7 @@ describe("compareRecentRunsProxyUsage", () => {
 
     await compareRecentRunsProxyUsage();
 
-    const calls = logSpy.mock.calls.filter((call) => {
-      return call[0] === "Proxy usage mismatch";
-    });
-    expect(calls).toHaveLength(1);
-    expect((calls[0]![1] as Record<string, unknown>).orgId).toBe(user2.orgId);
+    expect(callsForOrg(logSpy, user1.orgId)).toHaveLength(0);
+    expect(callsForOrg(logSpy, user2.orgId)).toHaveLength(1);
   });
 });

--- a/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
@@ -7,94 +7,16 @@ import {
   vi,
   type MockInstance,
 } from "vitest";
-import { randomBytes } from "crypto";
 import { testContext } from "../../../../__tests__/test-helpers";
-import { initServices } from "../../../init-services";
 import { compareRecentRunsProxyUsage } from "../proxy-usage-comparison-service";
-import { creditUsage } from "../../../../db/schema/credit-usage";
-import { proxyCreditUsage } from "../../../../db/schema/proxy-credit-usage";
 import {
-  agentComposes,
-  agentComposeVersions,
-} from "../../../../db/schema/agent-compose";
+  createCompletedRun,
+  insertTestCreditUsageForRun,
+  insertTestProxyCreditUsage,
+} from "../../../../__tests__/api-test-helpers";
 import { logger } from "../../../shared/logger";
 
 const context = testContext();
-
-/** Create a run with a specific completedAt timestamp. Returns runId. */
-async function createRun(
-  orgId: string,
-  userId: string,
-  completedAt: Date,
-): Promise<string> {
-  initServices();
-  const db = globalThis.services.db;
-
-  const composeName = `compose-${randomBytes(4).toString("hex")}`;
-  const [compose] = await db
-    .insert(agentComposes)
-    .values({ userId, orgId, name: composeName })
-    .returning();
-  const versionId = randomBytes(32).toString("hex");
-  await db.insert(agentComposeVersions).values({
-    id: versionId,
-    composeId: compose!.id,
-    content: {},
-    createdBy: userId,
-  });
-
-  const [run] = await db
-    .insert(agentRuns)
-    .values({
-      userId,
-      orgId,
-      agentComposeVersionId: versionId,
-      prompt: "test",
-      status: "completed",
-      completedAt,
-    })
-    .returning();
-
-  return run!.id;
-}
-
-/** Insert a credit_usage row for a run. */
-async function insertClientUsage(
-  runId: string,
-  orgId: string,
-  userId: string,
-  tokens: { input: number; output: number },
-): Promise<void> {
-  await globalThis.services.db.insert(creditUsage).values({
-    runId,
-    orgId,
-    userId,
-    model: "claude-sonnet-4-20250514",
-    modelProvider: "anthropic",
-    inputTokens: tokens.input,
-    outputTokens: tokens.output,
-    status: "processed",
-    processedAt: new Date(),
-  });
-}
-
-/** Insert a proxy_credit_usage row for a run. */
-async function insertProxyUsage(
-  runId: string,
-  orgId: string,
-  userId: string,
-  tokens: { input: number; output: number },
-): Promise<void> {
-  await globalThis.services.db.insert(proxyCreditUsage).values({
-    runId,
-    orgId,
-    userId,
-    model: "claude-sonnet-4-20250514",
-    modelProvider: "anthropic",
-    inputTokens: tokens.input,
-    outputTokens: tokens.output,
-  });
-}
 
 describe("compareRecentRunsProxyUsage", () => {
   let logSpy: MockInstance;
@@ -104,38 +26,60 @@ describe("compareRecentRunsProxyUsage", () => {
     logSpy = vi.spyOn(logger("service:proxy-usage-comparison"), "error");
   });
 
-  afterEach(() => {});
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
 
   it("does nothing when no runs in window", async () => {
-    // No runs at all — should not throw
     await compareRecentRunsProxyUsage();
   });
 
   it("skips runs completed less than 30s ago", async () => {
     const { orgId, userId } = await context.setupUser({ prefix: "recent" });
 
-    // Run completed 10 seconds ago — inside the 30s floor
-    const runId = await createRun(orgId, userId, new Date(Date.now() - 10_000));
-    await insertClientUsage(runId, orgId, userId, { input: 100, output: 50 });
-    await insertProxyUsage(runId, orgId, userId, { input: 200, output: 50 });
+    const runId = await createCompletedRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 10_000),
+    );
+    await insertTestCreditUsageForRun({
+      runId,
+      orgId,
+      userId,
+      status: "processed",
+    });
+    await insertTestProxyCreditUsage({
+      runId,
+      orgId,
+      userId,
+      inputTokens: 200,
+    });
 
     await compareRecentRunsProxyUsage();
 
-    // Should NOT be compared (too recent)
     expect(logSpy).not.toHaveBeenCalled();
   });
 
   it("skips runs completed more than 5m30s ago", async () => {
     const { orgId, userId } = await context.setupUser({ prefix: "old" });
 
-    // Run completed 6 minutes ago — outside the 5m30s ceiling
-    const runId = await createRun(
+    const runId = await createCompletedRun(
       orgId,
       userId,
       new Date(Date.now() - 360_000),
     );
-    await insertClientUsage(runId, orgId, userId, { input: 100, output: 50 });
-    await insertProxyUsage(runId, orgId, userId, { input: 200, output: 50 });
+    await insertTestCreditUsageForRun({
+      runId,
+      orgId,
+      userId,
+      status: "processed",
+    });
+    await insertTestProxyCreditUsage({
+      runId,
+      orgId,
+      userId,
+      inputTokens: 200,
+    });
 
     await compareRecentRunsProxyUsage();
 
@@ -145,18 +89,27 @@ describe("compareRecentRunsProxyUsage", () => {
   it("logs error for mismatching usage within window", async () => {
     const { orgId, userId } = await context.setupUser({ prefix: "mismatch" });
 
-    // Run completed 2 minutes ago — inside window
-    const runId = await createRun(
+    const runId = await createCompletedRun(
       orgId,
       userId,
       new Date(Date.now() - 120_000),
     );
-    await insertClientUsage(runId, orgId, userId, { input: 100, output: 50 });
-    await insertProxyUsage(runId, orgId, userId, { input: 200, output: 50 });
+    await insertTestCreditUsageForRun({
+      runId,
+      orgId,
+      userId,
+      status: "processed",
+    });
+    await insertTestProxyCreditUsage({
+      runId,
+      orgId,
+      userId,
+      inputTokens: 200,
+      outputTokens: 50,
+    });
 
     await compareRecentRunsProxyUsage();
 
-    // inputTokens mismatch should be logged
     expect(logSpy).toHaveBeenCalledWith(
       "Proxy usage mismatch",
       expect.objectContaining({
@@ -166,7 +119,6 @@ describe("compareRecentRunsProxyUsage", () => {
         proxyValue: 200,
       }),
     );
-    // outputTokens match — should NOT be logged for this field
     const outputCalls = logSpy.mock.calls.filter((call) => {
       const meta = call[1] as Record<string, unknown>;
       return meta.field === "outputTokens";
@@ -177,13 +129,18 @@ describe("compareRecentRunsProxyUsage", () => {
   it("does not log when usage matches", async () => {
     const { orgId, userId } = await context.setupUser({ prefix: "match" });
 
-    const runId = await createRun(
+    const runId = await createCompletedRun(
       orgId,
       userId,
       new Date(Date.now() - 120_000),
     );
-    await insertClientUsage(runId, orgId, userId, { input: 100, output: 50 });
-    await insertProxyUsage(runId, orgId, userId, { input: 100, output: 50 });
+    await insertTestCreditUsageForRun({
+      runId,
+      orgId,
+      userId,
+      status: "processed",
+    });
+    await insertTestProxyCreditUsage({ runId, orgId, userId });
 
     await compareRecentRunsProxyUsage();
 
@@ -193,13 +150,17 @@ describe("compareRecentRunsProxyUsage", () => {
   it("skips run with client data but no proxy data", async () => {
     const { orgId, userId } = await context.setupUser({ prefix: "no-proxy" });
 
-    const runId = await createRun(
+    const runId = await createCompletedRun(
       orgId,
       userId,
       new Date(Date.now() - 120_000),
     );
-    await insertClientUsage(runId, orgId, userId, { input: 100, output: 50 });
-    // No proxy data inserted
+    await insertTestCreditUsageForRun({
+      runId,
+      orgId,
+      userId,
+      status: "processed",
+    });
 
     await compareRecentRunsProxyUsage();
 
@@ -212,29 +173,43 @@ describe("compareRecentRunsProxyUsage", () => {
 
     const completedAt = new Date(Date.now() - 120_000);
 
-    const run1 = await createRun(user1.orgId, user1.userId, completedAt);
-    await insertClientUsage(run1, user1.orgId, user1.userId, {
-      input: 100,
-      output: 50,
+    const run1 = await createCompletedRun(
+      user1.orgId,
+      user1.userId,
+      completedAt,
+    );
+    await insertTestCreditUsageForRun({
+      runId: run1,
+      orgId: user1.orgId,
+      userId: user1.userId,
+      status: "processed",
     });
-    await insertProxyUsage(run1, user1.orgId, user1.userId, {
-      input: 100,
-      output: 50,
+    await insertTestProxyCreditUsage({
+      runId: run1,
+      orgId: user1.orgId,
+      userId: user1.userId,
     });
 
-    const run2 = await createRun(user2.orgId, user2.userId, completedAt);
-    await insertClientUsage(run2, user2.orgId, user2.userId, {
-      input: 100,
-      output: 50,
+    const run2 = await createCompletedRun(
+      user2.orgId,
+      user2.userId,
+      completedAt,
+    );
+    await insertTestCreditUsageForRun({
+      runId: run2,
+      orgId: user2.orgId,
+      userId: user2.userId,
+      status: "processed",
     });
-    await insertProxyUsage(run2, user2.orgId, user2.userId, {
-      input: 300,
-      output: 50,
+    await insertTestProxyCreditUsage({
+      runId: run2,
+      orgId: user2.orgId,
+      userId: user2.userId,
+      inputTokens: 300,
     });
 
     await compareRecentRunsProxyUsage();
 
-    // Only org2's run should have a mismatch
     const calls = logSpy.mock.calls.filter((call) => {
       return call[0] === "Proxy usage mismatch";
     });

--- a/turbo/apps/web/src/lib/zero/credit/credit-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/credit-service.ts
@@ -1,6 +1,5 @@
-import { eq, and, sql, inArray, sum } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { creditUsage } from "../../../db/schema/credit-usage";
-import { proxyCreditUsage } from "../../../db/schema/proxy-credit-usage";
 import { creditPricing } from "../../../db/schema/credit-pricing";
 import { deductOrgCredits } from "../org/org-service";
 import { deductFromExpiresRecords } from "./credit-expires-service";
@@ -53,11 +52,9 @@ export async function processOrgCredits(orgId: string): Promise<void> {
     let totalCredits = 0;
     let processedCount = 0;
     const affectedUserIds = new Set<string>();
-    const affectedRunIds = new Set<string>();
 
     for (const record of pendingRecords) {
       affectedUserIds.add(record.userId);
-      if (record.runId) affectedRunIds.add(record.runId);
       const pricing = pricingByKey.get(
         `${record.model}|${record.modelProvider}`,
       );
@@ -119,7 +116,7 @@ export async function processOrgCredits(orgId: string): Promise<void> {
       await deductFromExpiresRecords(tx, orgId, totalCredits);
     }
 
-    return { totalCredits, processedCount, affectedUserIds, affectedRunIds };
+    return { totalCredits, processedCount, affectedUserIds };
   });
 
   if (!result) return;
@@ -129,19 +126,6 @@ export async function processOrgCredits(orgId: string): Promise<void> {
     processedCount: result.processedCount,
     totalCredits: result.totalCredits,
   });
-
-  // Compare client-reported usage against proxy-observed usage per run.
-  // Mismatches indicate potential tampering or reporting bugs.
-  if (result.affectedRunIds.size > 0) {
-    try {
-      await compareProxyUsage(result.affectedRunIds, orgId);
-    } catch (err) {
-      log.warn("Proxy usage comparison failed", {
-        orgId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
 
   // After deduction, check if auto-recharge should trigger.
   // Fire-and-forget: errors are logged internally, never propagated.
@@ -179,100 +163,4 @@ export async function processStaleCredits(): Promise<number> {
   }
 
   return orgs.length;
-}
-
-/**
- * Compare client-reported credit_usage against proxy-observed proxy_credit_usage
- * for a set of runs.  Logs an error for each run where the token totals diverge.
- *
- * Comparison is by-run aggregate (sum of all records per runId) because the two
- * tables have different granularity (result-level vs API-call-level).
- */
-async function compareProxyUsage(
-  runIds: Set<string>,
-  orgId: string,
-): Promise<void> {
-  const db = globalThis.services.db;
-  const ids = [...runIds];
-  if (ids.length === 0) return;
-
-  // Client-reported totals (from credit_usage, already processed)
-  const clientRows = await db
-    .select({
-      runId: creditUsage.runId,
-      inputTokens: sum(creditUsage.inputTokens).mapWith(Number),
-      outputTokens: sum(creditUsage.outputTokens).mapWith(Number),
-      cacheReadInputTokens: sum(creditUsage.cacheReadInputTokens).mapWith(
-        Number,
-      ),
-      cacheCreationInputTokens: sum(
-        creditUsage.cacheCreationInputTokens,
-      ).mapWith(Number),
-      webSearchRequests: sum(creditUsage.webSearchRequests).mapWith(Number),
-    })
-    .from(creditUsage)
-    .where(and(eq(creditUsage.orgId, orgId), inArray(creditUsage.runId, ids)))
-    .groupBy(creditUsage.runId);
-
-  // Proxy-observed totals (from proxy_credit_usage)
-  const proxyRows = await db
-    .select({
-      runId: proxyCreditUsage.runId,
-      inputTokens: sum(proxyCreditUsage.inputTokens).mapWith(Number),
-      outputTokens: sum(proxyCreditUsage.outputTokens).mapWith(Number),
-      cacheReadInputTokens: sum(proxyCreditUsage.cacheReadInputTokens).mapWith(
-        Number,
-      ),
-      cacheCreationInputTokens: sum(
-        proxyCreditUsage.cacheCreationInputTokens,
-      ).mapWith(Number),
-      webSearchRequests: sum(proxyCreditUsage.webSearchRequests).mapWith(
-        Number,
-      ),
-    })
-    .from(proxyCreditUsage)
-    .where(
-      and(
-        eq(proxyCreditUsage.orgId, orgId),
-        inArray(proxyCreditUsage.runId, ids),
-      ),
-    )
-    .groupBy(proxyCreditUsage.runId);
-
-  const proxyByRun = new Map(
-    proxyRows.map((r) => {
-      return [r.runId, r];
-    }),
-  );
-
-  for (const client of clientRows) {
-    if (!client.runId) continue;
-    const proxy = proxyByRun.get(client.runId);
-    if (!proxy) {
-      // No proxy data yet — might arrive later, not an error
-      continue;
-    }
-
-    const fields = [
-      "inputTokens",
-      "outputTokens",
-      "cacheReadInputTokens",
-      "cacheCreationInputTokens",
-      "webSearchRequests",
-    ] as const;
-
-    for (const field of fields) {
-      const clientVal = client[field] ?? 0;
-      const proxyVal = proxy[field] ?? 0;
-      if (clientVal !== proxyVal) {
-        log.error("Proxy usage mismatch", {
-          orgId,
-          runId: client.runId,
-          field,
-          clientValue: clientVal,
-          proxyValue: proxyVal,
-        });
-      }
-    }
-  }
 }

--- a/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
@@ -1,0 +1,157 @@
+import { eq, and, inArray, sum, lte, gte } from "drizzle-orm";
+import { creditUsage } from "../../../db/schema/credit-usage";
+import { proxyCreditUsage } from "../../../db/schema/proxy-credit-usage";
+import { agentRuns } from "../../../db/schema/agent-run";
+import { logger } from "../../shared/logger";
+
+const log = logger("service:proxy-usage-comparison");
+
+/**
+ * Compare proxy-observed usage against client-reported usage for recently
+ * completed runs.  Designed to run as a standalone cron job, decoupled from
+ * credit processing so proxy usage reports have time to arrive (mitmproxy
+ * sends them asynchronously via a ThreadPoolExecutor).
+ *
+ * The 30-second floor gives mitmproxy time to deliver all reports.
+ * The 5m30s ceiling matches the cron interval (5 min) plus the floor so
+ * consecutive runs cover adjacent, non-overlapping windows.
+ */
+export async function compareRecentRunsProxyUsage(): Promise<void> {
+  const db = globalThis.services.db;
+  const now = Date.now();
+  const windowStart = new Date(now - 330_000); // 5m30s ago (oldest)
+  const windowEnd = new Date(now - 30_000); // 30s ago (newest)
+
+  const runs = await db
+    .select({ id: agentRuns.id, orgId: agentRuns.orgId })
+    .from(agentRuns)
+    .where(
+      and(
+        gte(agentRuns.completedAt, windowStart),
+        lte(agentRuns.completedAt, windowEnd),
+      ),
+    )
+    // Cap to keep the IN (...) clause in compareProxyUsage bounded.
+    // This is a verification tool — missing a few runs under extreme
+    // concurrency does not affect billing.
+    .limit(500);
+
+  // Group by org
+  const byOrg = new Map<string, string[]>();
+  for (const run of runs) {
+    let arr = byOrg.get(run.orgId);
+    if (!arr) {
+      arr = [];
+      byOrg.set(run.orgId, arr);
+    }
+    arr.push(run.id);
+  }
+
+  for (const [orgId, runIds] of byOrg) {
+    try {
+      await compareProxyUsage(runIds, orgId);
+    } catch (err) {
+      log.warn("Proxy usage comparison failed", {
+        orgId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/**
+ * Compare client-reported credit_usage against proxy-observed proxy_credit_usage
+ * for a set of runs.  Logs an error for each run where the token totals diverge.
+ *
+ * Comparison is by-run aggregate (sum of all records per runId) because the two
+ * tables have different granularity (result-level vs API-call-level).
+ */
+async function compareProxyUsage(
+  runIds: string[],
+  orgId: string,
+): Promise<void> {
+  const db = globalThis.services.db;
+  if (runIds.length === 0) return;
+
+  // Client-reported totals (from credit_usage, already processed)
+  const clientRows = await db
+    .select({
+      runId: creditUsage.runId,
+      inputTokens: sum(creditUsage.inputTokens).mapWith(Number),
+      outputTokens: sum(creditUsage.outputTokens).mapWith(Number),
+      cacheReadInputTokens: sum(creditUsage.cacheReadInputTokens).mapWith(
+        Number,
+      ),
+      cacheCreationInputTokens: sum(
+        creditUsage.cacheCreationInputTokens,
+      ).mapWith(Number),
+      webSearchRequests: sum(creditUsage.webSearchRequests).mapWith(Number),
+    })
+    .from(creditUsage)
+    .where(
+      and(eq(creditUsage.orgId, orgId), inArray(creditUsage.runId, runIds)),
+    )
+    .groupBy(creditUsage.runId);
+
+  // Proxy-observed totals (from proxy_credit_usage)
+  const proxyRows = await db
+    .select({
+      runId: proxyCreditUsage.runId,
+      inputTokens: sum(proxyCreditUsage.inputTokens).mapWith(Number),
+      outputTokens: sum(proxyCreditUsage.outputTokens).mapWith(Number),
+      cacheReadInputTokens: sum(proxyCreditUsage.cacheReadInputTokens).mapWith(
+        Number,
+      ),
+      cacheCreationInputTokens: sum(
+        proxyCreditUsage.cacheCreationInputTokens,
+      ).mapWith(Number),
+      webSearchRequests: sum(proxyCreditUsage.webSearchRequests).mapWith(
+        Number,
+      ),
+    })
+    .from(proxyCreditUsage)
+    .where(
+      and(
+        eq(proxyCreditUsage.orgId, orgId),
+        inArray(proxyCreditUsage.runId, runIds),
+      ),
+    )
+    .groupBy(proxyCreditUsage.runId);
+
+  const proxyByRun = new Map(
+    proxyRows.map((r) => {
+      return [r.runId, r];
+    }),
+  );
+
+  for (const client of clientRows) {
+    if (!client.runId) continue;
+    const proxy = proxyByRun.get(client.runId);
+    if (!proxy) {
+      // No proxy data yet — might arrive later, not an error
+      continue;
+    }
+
+    const fields = [
+      "inputTokens",
+      "outputTokens",
+      "cacheReadInputTokens",
+      "cacheCreationInputTokens",
+      "webSearchRequests",
+    ] as const;
+
+    for (const field of fields) {
+      const clientVal = client[field] ?? 0;
+      const proxyVal = proxy[field] ?? 0;
+      if (clientVal !== proxyVal) {
+        log.error("Proxy usage mismatch", {
+          orgId,
+          runId: client.runId,
+          field,
+          clientValue: clientVal,
+          proxyValue: proxyVal,
+        });
+      }
+    }
+  }
+}

--- a/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
@@ -2,7 +2,6 @@ import { eq, and, inArray, sum, lte, gte } from "drizzle-orm";
 import { creditUsage } from "../../../db/schema/credit-usage";
 import { proxyCreditUsage } from "../../../db/schema/proxy-credit-usage";
 import { agentRuns } from "../../../db/schema/agent-run";
-import { initServices } from "../../init-services";
 import { logger } from "../../shared/logger";
 
 const log = logger("service:proxy-usage-comparison");
@@ -18,7 +17,6 @@ const log = logger("service:proxy-usage-comparison");
  * consecutive runs cover adjacent, non-overlapping windows.
  */
 export async function compareRecentRunsProxyUsage(): Promise<void> {
-  initServices();
   const db = globalThis.services.db;
   const now = Date.now();
   const windowStart = new Date(now - 330_000); // 5m30s ago (oldest)

--- a/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
@@ -2,6 +2,7 @@ import { eq, and, inArray, sum, lte, gte } from "drizzle-orm";
 import { creditUsage } from "../../../db/schema/credit-usage";
 import { proxyCreditUsage } from "../../../db/schema/proxy-credit-usage";
 import { agentRuns } from "../../../db/schema/agent-run";
+import { initServices } from "../../init-services";
 import { logger } from "../../shared/logger";
 
 const log = logger("service:proxy-usage-comparison");
@@ -17,6 +18,7 @@ const log = logger("service:proxy-usage-comparison");
  * consecutive runs cover adjacent, non-overlapping windows.
  */
 export async function compareRecentRunsProxyUsage(): Promise<void> {
+  initServices();
   const db = globalThis.services.db;
   const now = Date.now();
   const windowStart = new Date(now - 330_000); // 5m30s ago (oldest)

--- a/turbo/apps/web/vercel.json
+++ b/turbo/apps/web/vercel.json
@@ -38,6 +38,10 @@
     {
       "path": "/api/cron/voice-chat-cleanup",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/compare-proxy-usage",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Decouple `compareProxyUsage` from `processOrgCredits` to fix a race condition where the comparison ran before the last proxy usage report arrived
- Extract comparison logic to `proxy-usage-comparison-service.ts` (separate from billing logic)
- Add dedicated cron job (`/api/cron/compare-proxy-usage`, every 5 min) with a 30s-5m30s time window
- Remove unused `affectedRunIds` tracking from `processOrgCredits`

## Context

Root cause analysis of #8796 (proxy usage mismatch) found that `compareProxyUsage` was called in the `complete` webhook's `after()` block — before mitmproxy's async usage reports had time to arrive. The last API call (with the largest `output_tokens`) was systematically missed, explaining the `outputTokens` client > proxy 2.7x discrepancy.

Full analysis: #8825

## Test plan

- [ ] Integration tests for `compareRecentRunsProxyUsage`:
  - Empty window (no runs)
  - Run too recent (< 30s) — skipped
  - Run too old (> 5m30s) — skipped
  - Matching usage — no error logged
  - Mismatching usage — error logged per field
  - Client data without proxy data — skipped
  - Multiple orgs in one window — compared independently
- [ ] Verify cron registered in `vercel.json` at `*/5 * * * *`
- [ ] Verify `credit-service.ts` no longer imports proxy/comparison code

🤖 Generated with [Claude Code](https://claude.com/claude-code)