### PR TITLE
refactor(firewalls): cache graphql field coverage check per api entry

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -536,6 +536,11 @@ def match_firewall_request(
                 # No permissions defined — handled by unknown logic below
                 continue
 
+            # Lazy cache for GraphQL field coverage check.  The inputs
+            # (body, permissions, upper_method) are constant within an
+            # api_entry, so we compute at most once and reuse.
+            gql_uncovered: list[str] | None = None
+
             for perm in permissions:
                 perm_name = perm.get("name", "")
                 for rule_str in perm.get("rules", []):
@@ -573,10 +578,11 @@ def match_firewall_request(
                         # permissions. Blocks queries that mix authorized
                         # and unauthorized fields.
                         if field_filters is not None and body is not None:
-                            uncovered = _find_uncovered_graphql_fields(
-                                body, permissions, upper_method
-                            )
-                            if uncovered:
+                            if gql_uncovered is None:
+                                gql_uncovered = _find_uncovered_graphql_fields(
+                                    body, permissions, upper_method
+                                )
+                            if gql_uncovered:
                                 return FirewallBlock(
                                     base,
                                     fw_ref,


### PR DESCRIPTION
## Summary
- Cache the `_find_uncovered_graphql_fields` result per API entry using a lazy sentinel variable
- The function's inputs (`body`, `permissions`, `upper_method`) are constant within an API entry, so it was computing identical results on every rule iteration

Closes #8816

## Test plan
- [x] All 749 existing mitm-addon tests pass — pure refactor, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)