### PR TITLE
refactor: inject db feature switch overrides into backend call sites

### DIFF
--- a/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/slack/org/route.ts
@@ -6,6 +6,7 @@ import { decryptSecretValue } from "../../../../../../src/lib/shared/crypto/secr
 import { slackOrgInstallations } from "../../../../../../src/db/schema/slack-org-installation";
 import { agentRuns } from "../../../../../../src/db/schema/agent-run";
 import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
+import { loadFeatureSwitchOverrides } from "../../../../../../src/lib/zero/user/feature-switches-service";
 import { findNewSessionId } from "../../../../../../src/lib/infra/session/find-new-session";
 import {
   createSlackClient,
@@ -177,9 +178,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     .where(eq(agentRuns.id, runId))
     .limit(1);
 
+  const overrides = await loadFeatureSwitchOverrides(
+    runContext?.orgId,
+    runContext?.userId,
+  );
   const auditLinkEnabled = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
     userId: runContext?.userId,
     orgId: runContext?.orgId,
+    overrides,
   });
 
   // Resolve session

--- a/turbo/apps/web/app/api/zero/computer-use/host/route.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/host/route.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { getHost } from "../../../../../src/lib/zero/computer-use/computer-use-service";
+import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 
 const router = tsr.router(zeroComputerUseHostContract, {
   getHost: async ({ headers }) => {
@@ -30,9 +31,11 @@ const router = tsr.router(zeroComputerUseHostContract, {
 
     const { org } = await resolveOrg(authCtx);
 
+    const overrides = await loadFeatureSwitchOverrides(org.orgId, userId);
     const enabled = isFeatureEnabled(FeatureSwitchKey.ComputerUse, {
       orgId: org.orgId,
       userId,
+      overrides,
     });
     if (!enabled) {
       return createErrorResponse("FORBIDDEN", "Computer use is not enabled");

--- a/turbo/apps/web/app/api/zero/computer-use/register/route.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/register/route.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { registerHost } from "../../../../../src/lib/zero/computer-use/computer-use-service";
+import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 
 const router = tsr.router(zeroComputerUseRegisterContract, {
   register: async ({ headers }) => {
@@ -27,9 +28,11 @@ const router = tsr.router(zeroComputerUseRegisterContract, {
 
     const { org } = await resolveOrg(authCtx);
 
+    const overrides = await loadFeatureSwitchOverrides(org.orgId, userId);
     const enabled = isFeatureEnabled(FeatureSwitchKey.ComputerUse, {
       orgId: org.orgId,
       userId,
+      overrides,
     });
     if (!enabled) {
       return createErrorResponse("FORBIDDEN", "Computer use is not enabled");

--- a/turbo/apps/web/app/api/zero/computer-use/unregister/route.ts
+++ b/turbo/apps/web/app/api/zero/computer-use/unregister/route.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../../../src/lib/auth/require-auth";
 import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
 import { unregisterHost } from "../../../../../src/lib/zero/computer-use/computer-use-service";
+import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 import { isNotFound } from "../../../../../src/lib/shared/errors";
 
 const router = tsr.router(zeroComputerUseUnregisterContract, {
@@ -28,9 +29,11 @@ const router = tsr.router(zeroComputerUseUnregisterContract, {
 
     const { org } = await resolveOrg(authCtx);
 
+    const overrides = await loadFeatureSwitchOverrides(org.orgId, userId);
     const enabled = isFeatureEnabled(FeatureSwitchKey.ComputerUse, {
       orgId: org.orgId,
       userId,
+      overrides,
     });
     if (!enabled) {
       return createErrorResponse("FORBIDDEN", "Computer use is not enabled");

--- a/turbo/apps/web/app/api/zero/connectors/search/route.ts
+++ b/turbo/apps/web/app/api/zero/connectors/search/route.ts
@@ -13,6 +13,7 @@ import {
 } from "@vm0/core";
 import { initServices } from "../../../../../src/lib/init-services";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 
 const router = tsr.router(zeroConnectorsSearchContract, {
   search: async ({ headers, query }) => {
@@ -23,9 +24,14 @@ const router = tsr.router(zeroConnectorsSearchContract, {
       return createErrorResponse("UNAUTHORIZED", "Not authenticated");
     }
 
+    const overrides = await loadFeatureSwitchOverrides(
+      authCtx.orgId,
+      authCtx.userId,
+    );
     const featureStates = getAllFeatureStates({
       userId: authCtx.userId,
       orgId: authCtx.orgId,
+      overrides,
     });
     const keyword = query.keyword?.toLowerCase();
 

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/context/route.ts
@@ -5,6 +5,7 @@ import { getAuthContext } from "../../../../../../src/lib/auth/get-auth-context"
 import { resolveOrg } from "../../../../../../src/lib/zero/org/resolve-org";
 import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
 import { eq } from "drizzle-orm";
+import { loadFeatureSwitchOverrides } from "../../../../../../src/lib/zero/user/feature-switches-service";
 import { voiceChatSessions } from "../../../../../../src/db/schema/voice-chat";
 import {
   readEvents,
@@ -48,9 +49,14 @@ export async function GET(
     );
   }
 
+  const overrides = await loadFeatureSwitchOverrides(
+    authCtx.orgId,
+    authCtx.userId,
+  );
   const enabled = isFeatureEnabled(FeatureSwitchKey.VoiceChat, {
     orgId: authCtx.orgId,
     userId: authCtx.userId,
+    overrides,
   });
   if (!enabled) {
     return NextResponse.json(
@@ -101,9 +107,14 @@ export async function POST(
     );
   }
 
+  const overrides = await loadFeatureSwitchOverrides(
+    authCtx.orgId,
+    authCtx.userId,
+  );
   const enabled = isFeatureEnabled(FeatureSwitchKey.VoiceChat, {
     orgId: authCtx.orgId,
     userId: authCtx.userId,
+    overrides,
   });
   if (!enabled) {
     return NextResponse.json(

--- a/turbo/apps/web/app/api/zero/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/route.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../../src/lib/zero/voice-chat/session-service";
 import { isApiError } from "../../../../src/lib/shared/errors";
 import { logger } from "../../../../src/lib/shared/logger";
+import { loadFeatureSwitchOverrides } from "../../../../src/lib/zero/user/feature-switches-service";
 
 const bodySchema = z
   .object({
@@ -45,9 +46,11 @@ export async function POST(request: Request) {
   const { org } = await resolveOrg(authCtx);
   const { userId } = authCtx;
 
+  const overrides = await loadFeatureSwitchOverrides(org.orgId, userId);
   const enabled = isFeatureEnabled(FeatureSwitchKey.VoiceChat, {
     orgId: org.orgId,
     userId,
+    overrides,
   });
   if (!enabled) {
     return NextResponse.json(

--- a/turbo/apps/web/app/api/zero/voice-chat/token/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/token/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { FeatureSwitchKey, isFeatureEnabled } from "@vm0/core";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { initServices } from "../../../../../src/lib/init-services";
+import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
 import { env } from "../../../../../src/env";
 import { createEphemeralToken } from "../../../../../src/lib/zero/voice-chat/openai-token";
 import { logger } from "../../../../../src/lib/shared/logger";
@@ -20,9 +21,14 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
 
+  const overrides = await loadFeatureSwitchOverrides(
+    authCtx.orgId,
+    authCtx.userId,
+  );
   const enabled = isFeatureEnabled(FeatureSwitchKey.VoiceChat, {
     orgId: authCtx.orgId,
     userId: authCtx.userId,
+    overrides,
   });
   if (!enabled) {
     return NextResponse.json(

--- a/turbo/apps/web/src/lib/auth/sandbox-token.ts
+++ b/turbo/apps/web/src/lib/auth/sandbox-token.ts
@@ -332,6 +332,7 @@ export async function generateZeroToken(
   userId: string,
   runId: string,
   orgId: string,
+  overrides?: Partial<Record<FeatureSwitchKey, boolean>>,
 ): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const expiresIn = 2 * 60 * 60; // 2 hours
@@ -344,7 +345,7 @@ export async function generateZeroToken(
     }
     const flag = CONDITIONAL_CAPABILITIES.get(cap);
     if (flag) {
-      if (isFeatureEnabled(flag, { userId, orgId })) {
+      if (isFeatureEnabled(flag, { userId, orgId, overrides })) {
         capabilities.push(cap);
       }
     } else {

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/direct-message.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/direct-message.ts
@@ -1,4 +1,5 @@
 import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
+import { loadFeatureSwitchOverrides } from "../../user/feature-switches-service";
 import { decryptSecretValue } from "../../../shared/crypto/secrets-encryption";
 import { env } from "../../../../env";
 import {
@@ -221,9 +222,14 @@ export async function handleOrgDirectMessage(
     if (!runId) {
       const errorText =
         response ?? "Sorry, an error occurred. Please try again.";
+      const overrides = await loadFeatureSwitchOverrides(
+        orgId,
+        connection.vm0UserId,
+      );
       const logsUrl = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
         userId: connection.vm0UserId,
         orgId,
+        overrides,
       })
         ? buildAgentLogsUrl()
         : undefined;

--- a/turbo/apps/web/src/lib/zero/slack-org/handlers/mention.ts
+++ b/turbo/apps/web/src/lib/zero/slack-org/handlers/mention.ts
@@ -1,4 +1,5 @@
 import { isFeatureEnabled, FeatureSwitchKey } from "@vm0/core";
+import { loadFeatureSwitchOverrides } from "../../user/feature-switches-service";
 import { decryptSecretValue } from "../../../shared/crypto/secrets-encryption";
 import { env } from "../../../../env";
 import { createSlackClient, setThreadStatus } from "../../slack/client";
@@ -225,9 +226,14 @@ export async function handleOrgMention(
     if (!runId) {
       const errorText =
         response ?? "Sorry, an error occurred. Please try again.";
+      const overrides = await loadFeatureSwitchOverrides(
+        orgId,
+        connection.vm0UserId,
+      );
       const logsUrl = isFeatureEnabled(FeatureSwitchKey.AuditLink, {
         userId: connection.vm0UserId,
         orgId,
+        overrides,
       })
         ? buildAgentLogsUrl()
         : undefined;

--- a/turbo/apps/web/src/lib/zero/user/__tests__/load-feature-switch-overrides.test.ts
+++ b/turbo/apps/web/src/lib/zero/user/__tests__/load-feature-switch-overrides.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { FeatureSwitchKey } from "@vm0/core";
+import { testContext } from "../../../../__tests__/test-helpers";
+import {
+  loadFeatureSwitchOverrides,
+  updateUserFeatureSwitches,
+} from "../feature-switches-service";
+
+const context = testContext();
+
+describe("loadFeatureSwitchOverrides", () => {
+  it("should return undefined when orgId is undefined", async () => {
+    context.setupMocks();
+    const { userId } = await context.setupUser();
+
+    const result = await loadFeatureSwitchOverrides(undefined, userId);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when userId is undefined", async () => {
+    context.setupMocks();
+    const { orgId } = await context.setupUser();
+
+    const result = await loadFeatureSwitchOverrides(orgId, undefined);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when no overrides exist in DB", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+
+    const result = await loadFeatureSwitchOverrides(orgId, userId);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should return overrides when they exist in DB", async () => {
+    context.setupMocks();
+    const { userId, orgId } = await context.setupUser();
+
+    await updateUserFeatureSwitches(orgId, userId, {
+      [FeatureSwitchKey.VoiceChat]: false,
+      [FeatureSwitchKey.ComputerUse]: true,
+    });
+
+    const result = await loadFeatureSwitchOverrides(orgId, userId);
+
+    expect(result).toEqual({
+      [FeatureSwitchKey.VoiceChat]: false,
+      [FeatureSwitchKey.ComputerUse]: true,
+    });
+  });
+
+  it("should return undefined when both orgId and userId are undefined", async () => {
+    context.setupMocks();
+
+    const result = await loadFeatureSwitchOverrides(undefined, undefined);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/turbo/apps/web/src/lib/zero/user/feature-switches-service.ts
+++ b/turbo/apps/web/src/lib/zero/user/feature-switches-service.ts
@@ -1,4 +1,5 @@
 import { eq, and } from "drizzle-orm";
+import { FeatureSwitchKey } from "@vm0/core";
 import { userFeatureSwitches } from "../../../db/schema/user-feature-switches";
 
 /**
@@ -23,6 +24,21 @@ export async function getUserFeatureSwitches(
     .limit(1);
 
   return row ? (row.switches as Record<string, boolean>) : {};
+}
+
+/**
+ * Load per-user feature switch overrides from the database.
+ * Returns undefined if orgId/userId is missing or no overrides exist.
+ */
+export async function loadFeatureSwitchOverrides(
+  orgId: string | undefined,
+  userId: string | undefined,
+): Promise<Partial<Record<FeatureSwitchKey, boolean>> | undefined> {
+  if (!orgId || !userId) return undefined;
+  const switches = await getUserFeatureSwitches(orgId, userId);
+  return Object.keys(switches).length > 0
+    ? (switches as Partial<Record<FeatureSwitchKey, boolean>>)
+    : undefined;
 }
 
 /**

--- a/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-queue-service.ts
@@ -42,6 +42,7 @@ import type {
   CreateRunResult,
 } from "../infra/run/run-service";
 import { generateZeroToken, generateSandboxToken } from "../auth/sandbox-token";
+import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
 import { buildZeroExecutionContext } from "./build-zero-context";
 import { buildInfraExecutionContext } from "../infra/run/context/build-context";
 import {
@@ -446,10 +447,15 @@ export async function dispatchQueuedZeroRun(
     const apiStartTime = Date.now();
 
     // Generate fresh ZERO_TOKEN for queued dispatch
+    const overrides = await loadFeatureSwitchOverrides(
+      params.orgId,
+      params.userId,
+    );
     const zeroToken = await generateZeroToken(
       params.userId,
       runId,
       params.orgId,
+      overrides,
     );
     const updatedParams: CreateRunParams = {
       ...params,

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -31,6 +31,7 @@ import {
   dispatchQueuedZeroRun,
 } from "./zero-run-queue-service";
 import { generateZeroToken, generateSandboxToken } from "../auth/sandbox-token";
+import { loadFeatureSwitchOverrides } from "./user/feature-switches-service";
 import {
   buildZeroExecutionContext,
   MODEL_PROVIDER_ENV_VARS,
@@ -463,8 +464,12 @@ export async function dispatchZeroRun(
     }
 
     // 6. Generate ZERO_TOKEN + sandbox token (now we have runId)
+    const overrides = await loadFeatureSwitchOverrides(
+      orgId,
+      zeroParams.userId,
+    );
     const [zeroToken, sandboxToken] = await Promise.all([
-      generateZeroToken(zeroParams.userId, record.run.id, orgId),
+      generateZeroToken(zeroParams.userId, record.run.id, orgId, overrides),
       generateSandboxToken(zeroParams.userId, record.run.id),
     ]);
     const tokenTime = Date.now();


### PR DESCRIPTION
## Summary

- Add `loadFeatureSwitchOverrides` wrapper to `feature-switches-service.ts` that handles undefined orgId/userId gracefully
- Inject DB override loading at all 11 backend `isFeatureEnabled`/`getAllFeatureStates` call sites
- For `generateZeroToken`, accept overrides as a parameter (callers load from DB) to keep the utility DB-free and testable
- Add integration test for `loadFeatureSwitchOverrides` (5 test cases covering edge cases)

### Call sites updated:
1. voice-chat/token, voice-chat/route, voice-chat/[id]/context (GET + POST)
2. computer-use/register, unregister, host
3. connectors/search (uses `getAllFeatureStates`)
4. Slack handlers: direct-message, mention, org callback
5. sandbox-token via zero-run-service and zero-run-queue-service

Closes #8820

## Test plan

- [x] All 5 existing test files pass without modification (route handlers call `initServices()` which makes DB available for `loadFeatureSwitchOverrides`)
- [x] New integration test: `load-feature-switch-overrides.test.ts` (5 cases: undefined orgId, undefined userId, no DB row, with overrides, both undefined)
- [x] 102 total tests pass across 6 test files
- [x] Lint, format, knip pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)