### PR TITLE
feat(web): add no-duplicate-route-param lint rule

### DIFF
--- a/turbo/apps/platform/custom-eslint/__tests__/no-duplicate-route-param.test.ts
+++ b/turbo/apps/platform/custom-eslint/__tests__/no-duplicate-route-param.test.ts
@@ -1,0 +1,89 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { describe, it, afterAll } from "vitest";
+import rule from "../rules/no-duplicate-route-param.ts";
+
+RuleTester.afterAll = afterAll;
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-duplicate-route-param", rule, {
+  valid: [
+    // Same param under same segment — OK
+    {
+      code: `
+        const ROUTES = {
+          agentDetail: "/agents/:agentId",
+          agentChat: "/agents/:agentId/chat",
+          agentIdeas: "/agents/:agentId/ideas",
+        };
+      `,
+    },
+    // Different params under different segments — OK
+    {
+      code: `
+        const ROUTES = {
+          agentDetail: "/agents/:agentId",
+          activityDetail: "/activities/:runId",
+          chat: "/chats/:threadId",
+        };
+      `,
+    },
+    // Single route with param — OK
+    {
+      code: `const path = "/users/:userId";`,
+    },
+    // No params — OK
+    {
+      code: `const path = "/dashboard";`,
+    },
+    // Non-route strings — OK
+    {
+      code: `const msg = "hello world";`,
+    },
+  ],
+  invalid: [
+    // Same :id under different segments — BAD
+    {
+      code: `
+        const ROUTES = {
+          agentDetail: "/agents/:id",
+          activityDetail: "/activities/:id",
+        };
+      `,
+      errors: [
+        { messageId: "duplicateRouteParam" },
+        { messageId: "duplicateRouteParam" },
+      ],
+    },
+    // Same :id under three different segments — BAD (3 errors)
+    {
+      code: `
+        const ROUTES = {
+          agentDetail: "/agents/:id",
+          activityDetail: "/activities/:id",
+          chat: "/chats/:id",
+        };
+      `,
+      errors: [
+        { messageId: "duplicateRouteParam" },
+        { messageId: "duplicateRouteParam" },
+        { messageId: "duplicateRouteParam" },
+      ],
+    },
+    // Mixed: nested routes with same param under different parent — BAD
+    {
+      code: `
+        const ROUTES = {
+          agentChat: "/agents/:id/chat",
+          scheduleDetail: "/schedules/:id",
+        };
+      `,
+      errors: [
+        { messageId: "duplicateRouteParam" },
+        { messageId: "duplicateRouteParam" },
+      ],
+    },
+  ],
+});

--- a/turbo/apps/platform/custom-eslint/index.ts
+++ b/turbo/apps/platform/custom-eslint/index.ts
@@ -51,6 +51,7 @@ import noTestDelay from "./rules/no-test-delay.ts";
 import requireAccept from "./rules/require-accept.ts";
 import noGetByRoleName from "./rules/no-get-by-role-name.ts";
 import noUserClearTab from "./rules/no-user-clear-tab.ts";
+import noDuplicateRouteParam from "./rules/no-duplicate-route-param.ts";
 
 const plugin = {
   meta: {
@@ -83,6 +84,7 @@ const plugin = {
     "require-accept": requireAccept,
     "no-get-by-role-name": noGetByRoleName,
     "no-user-clear-tab": noUserClearTab,
+    "no-duplicate-route-param": noDuplicateRouteParam,
   },
 };
 

--- a/turbo/apps/platform/custom-eslint/rules/no-duplicate-route-param.ts
+++ b/turbo/apps/platform/custom-eslint/rules/no-duplicate-route-param.ts
@@ -1,0 +1,115 @@
+/**
+ * ESLint rule: no-duplicate-route-param
+ *
+ * Enforces that the same route parameter name is not reused under different
+ * path segments. This prevents cross-route signal leakage where a signal
+ * reads `pathParams$.paramName` and accidentally resolves on the wrong page.
+ *
+ * Good: `/agents/:agentId` and `/agents/:agentId/chat` (same segment)
+ * Bad:  `/agents/:id` and `/activities/:id` (different segments, same param)
+ */
+
+import { ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/anthropics/vm0/blob/main/docs/eslint/${name}.md`,
+);
+
+type MessageIds = "duplicateRouteParam";
+
+interface ParamOccurrence {
+  node: TSESTree.Literal;
+  segment: string;
+  path: string;
+}
+
+/**
+ * Extract (segment, paramName) pairs from a route path string.
+ * For "/agents/:agentId/chat", returns [["agents", "agentId"]].
+ * For "/connectors/:type/connect", returns [["connectors", "type"]].
+ */
+function extractSegmentParamPairs(
+  path: string,
+): { segment: string; param: string }[] {
+  const parts = path.split("/").filter(Boolean);
+  const pairs: { segment: string; param: string }[] = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i].startsWith(":") && i > 0) {
+      pairs.push({
+        segment: parts[i - 1],
+        param: parts[i].slice(1),
+      });
+    }
+  }
+
+  return pairs;
+}
+
+export default createRule<[], MessageIds>({
+  name: "no-duplicate-route-param",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow the same route parameter name under different path segments",
+    },
+    schema: [],
+    messages: {
+      duplicateRouteParam:
+        "Route param ':{{param}}' is used under segment '{{segment}}' but already appears under '{{existingSegment}}'. Use a unique param name to prevent cross-route signal leakage.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const paramMap = new Map<string, ParamOccurrence[]>();
+
+    return {
+      Literal(node) {
+        if (typeof node.value !== "string") {
+          return;
+        }
+
+        const value = node.value;
+        if (!value.includes("/:")) {
+          return;
+        }
+
+        const pairs = extractSegmentParamPairs(value);
+        for (const { segment, param } of pairs) {
+          const occurrences = paramMap.get(param) ?? [];
+          occurrences.push({ node, segment, path: value });
+          paramMap.set(param, occurrences);
+        }
+      },
+
+      "Program:exit"() {
+        for (const [param, occurrences] of paramMap) {
+          const segments = new Set(occurrences.map((o) => o.segment));
+          if (segments.size <= 1) {
+            continue;
+          }
+
+          const segmentList = [...segments];
+          for (const occurrence of occurrences) {
+            const otherSegments = segmentList.filter(
+              (s) => s !== occurrence.segment,
+            );
+            if (otherSegments.length > 0) {
+              context.report({
+                node: occurrence.node,
+                messageId: "duplicateRouteParam",
+                data: {
+                  param,
+                  segment: occurrence.segment,
+                  existingSegment: otherSegments.join(", "),
+                },
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+});

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -105,6 +105,13 @@ export default [
       ],
     },
   },
+  // Enforce unique route param names in route definitions
+  {
+    files: ["src/signals/route-paths.ts"],
+    rules: {
+      "ccstate/no-duplicate-route-param": "error",
+    },
+  },
   // Allow detach() in signal infrastructure (definition site)
   {
     files: ["src/signals/utils.ts"],

--- a/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
+++ b/turbo/apps/platform/src/signals/activity-page/activity-signals.ts
@@ -201,8 +201,8 @@ export const setZeroActivityFilter$ = command(
 
 export const currentRunId$ = computed((get) => {
   const params = get(pathParams$);
-  if (params && typeof params === "object" && "runId" in params) {
-    return String(params.runId);
+  if (params && typeof params === "object" && "activityRunId" in params) {
+    return String(params.activityRunId);
   }
   return null;
 });

--- a/turbo/apps/platform/src/signals/bootstrap.ts
+++ b/turbo/apps/platform/src/signals/bootstrap.ts
@@ -238,15 +238,15 @@ const ROUTE_CONFIG = [
   { path: "/activity", setup: redirectTo(ROUTES.activities) },
   {
     path: "/activity/:id",
-    setup: redirectWithId(ROUTES.activityDetail, "runId"),
+    setup: redirectWithId(ROUTES.activityDetail, "activityRunId"),
   },
   {
     path: "/activity/:id/context",
-    setup: redirectWithId(ROUTES.activityDetail, "runId"),
+    setup: redirectWithId(ROUTES.activityDetail, "activityRunId"),
   },
   {
     path: "/activity/:id/network",
-    setup: redirectWithId(ROUTES.activityDetail, "runId"),
+    setup: redirectWithId(ROUTES.activityDetail, "activityRunId"),
   },
   { path: "/chat/:id", setup: redirectWithId(ROUTES.chat, "threadId") },
   { path: "/schedule", setup: redirectTo(ROUTES.schedules) },

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -8,7 +8,7 @@ export const ROUTES = {
   agentPermissions: "/agents/:agentId/permissions",
   activities: "/activities",
   activityInspect: "/activities/inspect",
-  activityDetail: "/activities/:runId",
+  activityDetail: "/activities/:activityRunId",
   chatList: "/chats",
   chat: "/chats/:threadId",
   schedules: "/schedules",

--- a/turbo/apps/platform/src/signals/zero-page/zero-mobile-breadcrumb.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-mobile-breadcrumb.ts
@@ -103,10 +103,10 @@ const activityDetailBreadcrumb$ = computed(
       return null;
     }
     const params = get(pathParams$) as Params;
-    const runId = getStringParam(params, "runId");
-    if (runId) {
+    const activityRunId = getStringParam(params, "activityRunId");
+    if (activityRunId) {
       const detail = await get(zeroActivityDetail$);
-      if (detail && detail.id === runId) {
+      if (detail && detail.id === activityRunId) {
         return {
           section: "Activity logs",
           sectionPath: ROUTES.activities,

--- a/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-schedule.ts
@@ -490,8 +490,8 @@ export const runScheduleNow$ = command(
         createElement(
           Link,
           {
-            pathname: "/activities/:runId" as const,
-            options: { pathParams: { runId: data.runId } },
+            pathname: "/activities/:activityRunId" as const,
+            options: { pathParams: { activityRunId: data.runId } },
             className: "underline",
           },
           "View activity",

--- a/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/log-views/log-table.tsx
@@ -53,8 +53,8 @@ function LogRow({
 
   return (
     <Link
-      pathname="/activities/:runId"
-      options={{ pathParams: { runId: entry.id } }}
+      pathname="/activities/:activityRunId"
+      options={{ pathParams: { activityRunId: entry.id } }}
       className="block px-5 py-3 transition-colors hover:bg-muted/50 cursor-pointer border-b border-border/40 last:border-b-0 no-underline text-inherit"
     >
       <div className={cn(gridClassName)}>

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -739,8 +739,8 @@ function AssistantMessageActions({
           <Tooltip>
             <TooltipTrigger asChild>
               <Link
-                pathname="/activities/:runId"
-                options={{ pathParams: { runId: message.legacyRunId } }}
+                pathname="/activities/:activityRunId"
+                options={{ pathParams: { activityRunId: message.legacyRunId } }}
                 className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-accent transition-colors duration-150"
                 aria-label="View run logs"
               >


### PR DESCRIPTION
## Summary
- Add custom ESLint rule `no-duplicate-route-param` that flags reuse of the same route parameter name under different path segments, preventing cross-route signal leakage (follow-up to #8818, closes #8809)
- Rename `/activities/:runId` → `/activities/:activityRunId` to satisfy the rule, since `:runId` was also used under `/runs`
- Update all consumers (activity signals, bootstrap redirects, schedule toast link, chat thread link, log table, mobile breadcrumb)

## Test plan
- [ ] Verify lint rule tests pass (8 test cases)
- [ ] Verify `route-paths.ts` passes lint with the new rule
- [ ] Verify activity detail page loads correctly with the renamed param
- [ ] Verify legacy `/activity/:id` redirects still work
- [ ] Verify "View activity" links from schedule runs and chat threads navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)