### PR TITLE
fix(voice-chat): add missing event type and validate after parameter

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/context/__tests__/route.test.ts
@@ -138,6 +138,28 @@ describe("GET /api/zero/voice-chat/[id]/context", () => {
     expect(body.events[1].seq).toBeLessThan(body.events[2].seq);
   });
 
+  it("should return 400 for non-numeric after parameter", async () => {
+    const session = await createSession(orgId, userId);
+    const response = await GET(
+      createTestRequest(contextUrl(session.id, "after=abc")),
+      paramsFor(session.id),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return 400 for negative after parameter", async () => {
+    const session = await createSession(orgId, userId);
+    const response = await GET(
+      createTestRequest(contextUrl(session.id, "after=-1")),
+      paramsFor(session.id),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
   it("should filter events with ?after=seq", async () => {
     const session = await createSession(orgId, userId);
 
@@ -241,6 +263,26 @@ describe("POST /api/zero/voice-chat/[id]/context", () => {
     expect(body.event.content).toBe("hello world");
     expect(typeof body.event.seq).toBe("number");
     expect(body.event.id).toBeDefined();
+  });
+
+  it("should accept meeting-prompt event type", async () => {
+    const session = await createSession(orgId, userId);
+    const response = await POST(
+      createTestRequest(contextUrl(session.id), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          source: "user",
+          type: "meeting-prompt",
+          content: "discuss Q3 roadmap",
+        }),
+      }),
+      paramsFor(session.id),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.event.type).toBe("meeting-prompt");
+    expect(body.event.source).toBe("user");
   });
 
   it("should reject invalid source", async () => {

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/context/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/context/route.ts
@@ -22,6 +22,7 @@ const VALID_TYPES = [
   "thinking",
   "observation",
   "preparation-ready",
+  "meeting-prompt",
 ] as const;
 
 const appendEventBodySchema = z.object({
@@ -77,6 +78,13 @@ export async function GET(
   const url = new URL(request.url);
   const afterParam = url.searchParams.get("after");
   const afterSeq = afterParam ? parseInt(afterParam, 10) : undefined;
+
+  if (afterSeq !== undefined && (Number.isNaN(afterSeq) || afterSeq < 0)) {
+    return NextResponse.json(
+      { error: { message: "Invalid after parameter", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
 
   const events = await readEvents(id, afterSeq);
 

--- a/turbo/apps/web/src/db/schema/voice-chat.ts
+++ b/turbo/apps/web/src/db/schema/voice-chat.ts
@@ -56,7 +56,7 @@ export const voiceChatSessions = pgTable(
  *
  * Sources: system | user | fast-brain | slow-brain
  * Types: session-start | session-end | speech | request-slow-brain | response |
- *        directive | thinking | observation
+ *        directive | thinking | observation | preparation-ready | meeting-prompt
  */
 export const voiceChatEvents = pgTable(
   "voice_chat_events",


### PR DESCRIPTION
## Summary

- Add `meeting-prompt` to `VALID_TYPES` in the voice-chat context API route so CLI agents can POST this event type (previously only writable by `session-service.ts` directly)
- Validate the `after` query parameter: return 400 for NaN and negative values instead of silently producing incorrect results
- Update `voiceChatEvents` schema comment to include `preparation-ready` and `meeting-prompt`

## Test plan

- [x] New test: POST `meeting-prompt` event type → 200
- [x] New test: GET `?after=abc` → 400
- [x] New test: GET `?after=-1` → 400
- [x] All 14 existing context route tests pass
- [x] Lint, format, knip pass

Closes #8845

🤖 Generated with [Claude Code](https://claude.com/claude-code)