### PR TITLE
test(voice-chat): add missing test coverage for preparation-related flows

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/context/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/context/__tests__/route.test.ts
@@ -326,6 +326,28 @@ describe("POST /api/zero/voice-chat/[id]/context", () => {
     },
   );
 
+  it.each(["preparation-ready", "request-slow-brain"] as const)(
+    "should accept system event type: %s",
+    async (type) => {
+      const session = await createSession(orgId, userId);
+      const response = await POST(
+        createTestRequest(contextUrl(session.id), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            source: "system",
+            type,
+          }),
+        }),
+        paramsFor(session.id),
+      );
+      const body = await response.json();
+      expect(response.status).toBe(200);
+      expect(body.event.type).toBe(type);
+      expect(body.event.source).toBe("system");
+    },
+  );
+
   it("should produce incrementing seq numbers", async () => {
     const session = await createSession(orgId, userId);
 

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/end/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/end/__tests__/route.test.ts
@@ -109,6 +109,33 @@ describe("POST /api/zero/voice-chat/[id]/end", () => {
     expect(body.error.code).toBe("BAD_REQUEST");
   });
 
+  it("should end session in preparing state", async () => {
+    const sessionId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      status: "preparing",
+    });
+
+    const response = await POST(
+      createTestRequest(endUrl(sessionId), { method: "POST" }),
+      paramsFor(sessionId),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+
+    // Verify session status updated to "ended"
+    const status = await getTestVoiceChatSessionStatus(sessionId);
+    expect(status).toBe("ended");
+
+    // Verify session-end event written
+    const events = await getTestVoiceChatEvents(sessionId);
+    expect(events).toHaveLength(1);
+    const event = events[0]!;
+    expect(event.type).toBe("session-end");
+    expect(event.source).toBe("system");
+  });
+
   it("should end active session, write event, and cancel run", async () => {
     // Create a run record for FK constraint
     const compose = await createTestCompose(uniqueId("vc-agent"));

--- a/turbo/apps/web/app/api/zero/voice-chat/[id]/heartbeat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/[id]/heartbeat/__tests__/route.test.ts
@@ -104,6 +104,28 @@ describe("POST /api/zero/voice-chat/[id]/heartbeat", () => {
     expect(body.error.code).toBe("NOT_FOUND");
   });
 
+  it("should update lastHeartbeatAt for preparing session", async () => {
+    const pastDate = new Date("2024-01-01T00:00:00Z");
+    const sessionId = await insertTestVoiceChatSession({
+      orgId,
+      userId,
+      status: "preparing",
+      lastHeartbeatAt: pastDate,
+    });
+
+    const response = await POST(
+      createTestRequest(heartbeatUrl(sessionId), { method: "POST" }),
+      paramsFor(sessionId),
+    );
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+
+    // Verify lastHeartbeatAt was updated
+    const heartbeatAt = await getTestVoiceChatSessionHeartbeat(sessionId);
+    expect(heartbeatAt!.getTime()).toBeGreaterThan(pastDate.getTime());
+  });
+
   it("should update lastHeartbeatAt for active session", async () => {
     const pastDate = new Date("2024-01-01T00:00:00Z");
     const sessionId = await insertTestVoiceChatSession({


### PR DESCRIPTION
## Summary

- Add integration tests for `preparation-ready` and `request-slow-brain` event types in context POST
- Add test for ending a voice chat session in `preparing` state
- Add test for heartbeat on a session in `preparing` state

Closes #8847

## Test plan

- [x] All 4 new tests pass locally
- [x] All 49 voice-chat tests pass (6 test files)
- [x] Lint passes with no new warnings
- [x] Format check passes (no changes needed)
- [x] Knip passes (no unused exports/files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)