### PR TITLE
fix(voice-chat): inject preparation events into fast brain after webrtc connects

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -646,6 +646,12 @@ const connectVoiceSession$ = command(
       return;
     }
 
+    // Inject slow-brain events collected during preparation phase
+    const existingEvents = get(internalEvents$);
+    if (existingEvents.length > 0) {
+      set(injectSlowBrainEvents$, existingEvents);
+    }
+
     await Promise.allSettled([
       set(startHeartbeat$, sessionSignal),
       set(startPoll$, sessionSignal),


### PR DESCRIPTION
## Summary

- Fix critical bug where slow brain preparation directives are never received by the fast brain
- The preparation polling loop advances the seq cursor past directive events but never injects them (data channel not open yet)
- After WebRTC connects, inject all previously collected slow-brain events before starting the regular poll loop

## Root Cause

`prepareActivateConnect$` polls events during preparation and advances `internalLastSeq$`. When `startPoll$` begins after WebRTC connects, it starts from the already-advanced cursor — the directive is silently skipped.

## Fix

4 lines added to `connectVoiceSession$`: after `setupWebRTC$` succeeds, read all existing events and call `injectSlowBrainEvents$`.

Closes #8851

## Test plan

- [ ] Start voice meeting with prompt → verify fast brain receives and responds to preparation directive
- [ ] Start voice chat → verify fast brain receives quick preparation context
- [ ] Verify ongoing slow-brain events (during conversation) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)