### PR TITLE
fix(voice-chat): write session-end event on cron timeout cleanup

### DIFF
--- a/turbo/apps/web/app/api/cron/voice-chat-cleanup/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/cron/voice-chat-cleanup/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { testContext } from "../../../../../src/__tests__/test-helpers";
 import {
   insertTestVoiceChatSession,
   getTestVoiceChatSessionStatus,
+  getTestVoiceChatEvents,
 } from "../../../../../src/__tests__/api-test-helpers";
 import { reloadEnv } from "../../../../../src/env";
 
@@ -97,6 +98,49 @@ describe("GET /api/cron/voice-chat-cleanup", () => {
     expect(response.status).toBe(200);
     expect(body.cleaned).toBe(0);
     expect(await getTestVoiceChatSessionStatus(sessionId)).toBe("active");
+  });
+
+  it("should write session-end event for each timed-out session", async () => {
+    const staleTime = new Date(Date.now() - 3 * 60 * 1000);
+    const sessionId = await insertTestVoiceChatSession({
+      orgId: "org_test",
+      userId: "user_test",
+      lastHeartbeatAt: staleTime,
+    });
+
+    await GET(cronRequest("test-cron-secret"));
+
+    const events = await getTestVoiceChatEvents(sessionId);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "session-end",
+      source: "system",
+    });
+  });
+
+  it("should write session-end events for multiple timed-out sessions", async () => {
+    const staleTime = new Date(Date.now() - 3 * 60 * 1000);
+    const sessionId1 = await insertTestVoiceChatSession({
+      orgId: "org_test",
+      userId: "user_test1",
+      lastHeartbeatAt: staleTime,
+    });
+    const sessionId2 = await insertTestVoiceChatSession({
+      orgId: "org_test",
+      userId: "user_test2",
+      lastHeartbeatAt: staleTime,
+    });
+
+    const response = await GET(cronRequest("test-cron-secret"));
+    const body = await response.json();
+    expect(body.cleaned).toBe(2);
+
+    const events1 = await getTestVoiceChatEvents(sessionId1);
+    const events2 = await getTestVoiceChatEvents(sessionId2);
+    expect(events1).toHaveLength(1);
+    expect(events1[0]).toMatchObject({ type: "session-end", source: "system" });
+    expect(events2).toHaveLength(1);
+    expect(events2[0]).toMatchObject({ type: "session-end", source: "system" });
   });
 
   it("should not clean up already-ended sessions", async () => {

--- a/turbo/apps/web/app/api/cron/voice-chat-cleanup/route.ts
+++ b/turbo/apps/web/app/api/cron/voice-chat-cleanup/route.ts
@@ -3,7 +3,10 @@ import { inArray, and, or, lt } from "drizzle-orm";
 import { initServices } from "../../../../src/lib/init-services";
 import { logger } from "../../../../src/lib/shared/logger";
 import { env } from "../../../../src/env";
-import { voiceChatSessions } from "../../../../src/db/schema/voice-chat";
+import {
+  voiceChatSessions,
+  voiceChatEvents,
+} from "../../../../src/db/schema/voice-chat";
 
 const log = logger("cron:voice-chat-cleanup");
 
@@ -41,6 +44,15 @@ export async function GET(request: Request): Promise<Response> {
     .returning({ id: voiceChatSessions.id });
 
   if (result.length > 0) {
+    await globalThis.services.db.insert(voiceChatEvents).values(
+      result.map((r) => {
+        return {
+          sessionId: r.id,
+          source: "system" as const,
+          type: "session-end" as const,
+        };
+      }),
+    );
     log.info("Voice chat cleanup completed", { cleaned: result.length });
   }
 


### PR DESCRIPTION
## Summary

- Write `session-end` event to `voiceChatEvents` when cron cleanup marks stale sessions as `timeout`, so slow-brain agents see the termination signal and stop polling
- Batch insert events for all timed-out sessions in a single query
- Add 2 integration tests verifying event creation for single and multiple session timeouts

Closes #8846

## Test plan

- [x] Existing 7 cleanup tests still pass
- [x] New test: session-end event written for single timed-out session
- [x] New test: session-end events written for multiple timed-out sessions
- [x] Lint passes
- [x] Format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)