### PR TITLE
fix: increase voice VAD sensitivity threshold

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -465,9 +465,9 @@ const setupWebRTC$ = command(
             input_audio_transcription: { model: "whisper-1" },
             turn_detection: {
               type: "server_vad",
-              threshold: 0.6,
+              threshold: 0.8,
               prefix_padding_ms: 300,
-              silence_duration_ms: 500,
+              silence_duration_ms: 600,
             },
             tools: SESSION_TOOLS,
           },


### PR DESCRIPTION
## Summary

- Raise `threshold`: `0.6` → `0.8` — requires louder/clearer audio to trigger, reduces false positives from yawns and ambient sounds
- Raise `silence_duration_ms`: `500` → `600` — waits slightly longer before ending a turn

## Context

Ethan reported the voice agent responding to yawns. The current `server_vad` mode is purely silence-based and cannot distinguish speech from non-speech sounds — the threshold and silence duration were the main levers to tune without switching VAD mode.

> If the issue persists, the next step would be switching `type` from `server_vad` to `semantic_vad` with `eagerness: "low"`, which uses a classifier to detect intent rather than just silence.

## Test plan

- [ ] Start a voice session and yawn / make filler sounds — agent should not trigger
- [ ] Normal speech still activates the agent reliably
- [ ] Turn ends naturally after speaking without noticeable lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)