### PR TITLE
fix(voice-chat): wrap end-session in transaction and surface polling errors

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -552,7 +552,11 @@ const startHeartbeat$ = command(async ({ get }, signal: AbortSignal) => {
   );
 });
 
+const POLL_FAILURE_THRESHOLD = 3;
+
 const startPoll$ = command(async ({ get, set }, signal: AbortSignal) => {
+  let consecutiveFailures = 0;
+
   await setLoop(
     async (signal: AbortSignal) => {
       const sid = get(internalSessionId$);
@@ -568,8 +572,17 @@ const startPoll$ = command(async ({ get, set }, signal: AbortSignal) => {
       );
 
       if (!res.ok) {
+        consecutiveFailures++;
+        if (consecutiveFailures >= POLL_FAILURE_THRESHOLD) {
+          set(internalError$, "Connection issues — retrying…");
+        }
         return false;
       }
+
+      if (consecutiveFailures >= POLL_FAILURE_THRESHOLD) {
+        set(internalError$, null);
+      }
+      consecutiveFailures = 0;
 
       const data = (await res.json()) as { events: ContextEvent[] };
       signal.throwIfAborted();

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -110,18 +110,18 @@ export async function endSession(
     throw badRequest("Session is not active");
   }
 
-  // Write session-end event
-  await db.insert(voiceChatEvents).values({
-    sessionId,
-    source: "system",
-    type: "session-end",
+  // Write session-end event and update status atomically
+  await db.transaction(async (tx) => {
+    await tx.insert(voiceChatEvents).values({
+      sessionId,
+      source: "system",
+      type: "session-end",
+    });
+    await tx
+      .update(voiceChatSessions)
+      .set({ status: "ended", endedAt: new Date() })
+      .where(eq(voiceChatSessions.id, sessionId));
   });
-
-  // Update session status
-  await db
-    .update(voiceChatSessions)
-    .set({ status: "ended", endedAt: new Date() })
-    .where(eq(voiceChatSessions.id, sessionId));
 
   // Cancel slow-brain run if active (ignore errors if already terminated)
   if (session.runId) {


### PR DESCRIPTION
## Summary

- Wrap `endSession()` DB operations (event INSERT + status UPDATE) in `db.transaction()` so they succeed or fail atomically. Run cancellation stays outside the transaction as it's an external API call.
- Add consecutive failure tracking to the event polling loop — after 3 consecutive poll failures, set the error signal so the UI shows "Connection issues — retrying…". Warning auto-clears when connection recovers.

Closes #8849

## Test plan

- [x] All 52 existing voice-chat tests pass (end session, create, context, heartbeat, cleanup)
- [x] Transaction wrapping is transparent to existing tests — behavior unchanged on success path
- [x] Lint, format, knip all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)