### PR TITLE
feat(voice-chat): add webrtc disconnect recovery with auto-reconnect

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -187,6 +187,8 @@ const internalPrepStartTime$ = state<number | null>(null);
 const internalPrepElapsedMs$ = state(0);
 const internalReconnectAttempt$ = state(0);
 
+const internalParentSignal$ = state<AbortSignal | null>(null);
+
 const meetingPromptInput$ = state("");
 
 const resetSessionSignal$ = resetSignal();
@@ -740,7 +742,13 @@ const reconnectVoiceSession$ = command(
       if (ok) {
         // Success — restart heartbeat and poll loops
         set(internalReconnectAttempt$, 0);
-        const sessionSignal = set(resetSessionSignal$, signal);
+        const parentSignal = get(internalParentSignal$);
+        if (!parentSignal) {
+          set(internalError$, "No parent signal for reconnect");
+          set(internalStatus$, "error");
+          return;
+        }
+        const sessionSignal = set(resetSessionSignal$, parentSignal);
         await Promise.allSettled([
           set(startHeartbeat$, sessionSignal),
           set(startPoll$, sessionSignal),
@@ -960,6 +968,7 @@ export const startVoiceChat$ = command(
     set(internalCurrentAssistant$, null);
     set(internalPrompt$, null);
     set(internalPrepStartTime$, Date.now());
+    set(internalParentSignal$, signal);
 
     const sessionSignal = set(resetSessionSignal$, signal);
 
@@ -1027,6 +1036,7 @@ export const startVoiceMeeting$ = command(
     set(internalCurrentAssistant$, null);
     set(internalPrompt$, prompt);
     set(internalPrepStartTime$, Date.now());
+    set(internalParentSignal$, signal);
 
     const sessionSignal = set(resetSessionSignal$, signal);
 
@@ -1123,6 +1133,7 @@ export const endVoiceChat$ = command(({ get, set }) => {
   set(internalPrepStartTime$, null);
   set(internalPrepElapsedMs$, 0);
   set(internalReconnectAttempt$, 0);
+  set(internalParentSignal$, null);
   set(internalStatus$, "idle");
 });
 

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -3,6 +3,7 @@ import { FeatureSwitchKey } from "@vm0/core";
 import { fetch$ } from "../fetch.ts";
 import { featureSwitch$ } from "../external/feature-switch.ts";
 import { currentChatAgentId$ } from "../agent-chat.ts";
+import { delay } from "signal-timers";
 import { resetSignal, throwIfAbort, onDomEventFn, setLoop } from "../utils.ts";
 
 type ConnectionStatus =
@@ -10,6 +11,7 @@ type ConnectionStatus =
   | "preparing"
   | "connecting"
   | "connected"
+  | "reconnecting"
   | "disconnected"
   | "error";
 
@@ -60,6 +62,8 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
 const POLL_INTERVAL_MS = 2000;
 const PREP_TIMEOUT_CHAT_MS = 60_000;
 const PREP_TIMEOUT_MEETING_MS = 300_000;
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_BASE_DELAY_MS = 1000;
 const REALTIME_MODEL = "gpt-realtime-1.5";
 
 const SESSION_TOOLS = [
@@ -181,6 +185,7 @@ const internalAudioEl$ = state<HTMLAudioElement | null>(null);
 const internalPrompt$ = state<string | null>(null);
 const internalPrepStartTime$ = state<number | null>(null);
 const internalPrepElapsedMs$ = state(0);
+const internalReconnectAttempt$ = state(0);
 
 const meetingPromptInput$ = state("");
 
@@ -215,6 +220,9 @@ export const vcPrompt$ = computed((get) => {
 });
 export const vcPrepElapsedMs$ = computed((get) => {
   return get(internalPrepElapsedMs$);
+});
+export const vcReconnectAttempt$ = computed((get) => {
+  return get(internalReconnectAttempt$);
 });
 export const vcMeetingPromptInput$ = computed((get) => {
   return get(meetingPromptInput$);
@@ -490,22 +498,28 @@ const setupWebRTC$ = command(
       }),
     );
 
-    dc.addEventListener("close", () => {
-      if (get(internalStatus$) === "connected") {
-        set(internalStatus$, "disconnected");
-      }
-    });
-
-    pc.addEventListener("iceconnectionstatechange", () => {
-      if (
-        pc.iceConnectionState === "failed" ||
-        pc.iceConnectionState === "disconnected"
-      ) {
+    dc.addEventListener(
+      "close",
+      onDomEventFn((): void | Promise<void> => {
         if (get(internalStatus$) === "connected") {
-          set(internalStatus$, "disconnected");
+          return set(reconnectVoiceSession$, signal);
         }
-      }
-    });
+      }),
+    );
+
+    pc.addEventListener(
+      "iceconnectionstatechange",
+      onDomEventFn((): void | Promise<void> => {
+        if (
+          pc.iceConnectionState === "failed" ||
+          pc.iceConnectionState === "disconnected"
+        ) {
+          if (get(internalStatus$) === "connected") {
+            return set(reconnectVoiceSession$, signal);
+          }
+        }
+      }),
+    );
 
     const offer = await pc.createOffer();
     signal.throwIfAborted();
@@ -610,6 +624,139 @@ const startPoll$ = command(async ({ get, set }, signal: AbortSignal) => {
     signal,
   );
 });
+
+// --- WebRTC cleanup (preserves session state) ---
+
+const cleanupWebRTC$ = command(({ get, set }) => {
+  const dc = get(internalDc$);
+  if (dc) {
+    dc.close();
+    set(internalDc$, null);
+  }
+
+  const pc = get(internalPc$);
+  if (pc) {
+    pc.close();
+    set(internalPc$, null);
+  }
+
+  const audioEl = get(internalAudioEl$);
+  if (audioEl) {
+    audioEl.pause();
+    audioEl.srcObject = null;
+    set(internalAudioEl$, null);
+  }
+});
+
+// --- Reconnect logic ---
+
+const reconnectVoiceSession$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    set(internalStatus$, "reconnecting");
+    set(internalError$, null);
+    set(internalReconnectAttempt$, 0);
+
+    const fetchFn = get(fetch$);
+    const sid = get(internalSessionId$);
+    if (!sid) {
+      set(internalError$, "No session to reconnect");
+      set(internalStatus$, "error");
+      return;
+    }
+
+    for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt++) {
+      signal.throwIfAborted();
+      set(internalReconnectAttempt$, attempt);
+
+      // Exponential backoff delay (skip on first attempt)
+      if (attempt > 1) {
+        const backoff = Math.min(
+          RECONNECT_BASE_DELAY_MS * Math.pow(2, attempt - 2),
+          30_000,
+        );
+        await delay(backoff, { signal });
+      }
+
+      // Check if session is still alive via heartbeat
+      const heartbeatRes = await fetchFn(
+        `/api/zero/voice-chat/${sid}/heartbeat`,
+        { method: "POST", signal },
+      );
+      if (!heartbeatRes.ok) {
+        set(internalError$, "Session is no longer active");
+        set(internalStatus$, "error");
+        return;
+      }
+
+      // Clean up old WebRTC resources
+      set(cleanupWebRTC$);
+
+      // Fetch new token
+      const tokenRes = await fetchFn("/api/zero/voice-chat/token", {
+        method: "POST",
+        signal,
+      });
+      if (!tokenRes.ok) {
+        if (tokenRes.status === 401 || tokenRes.status === 403) {
+          const body = (await tokenRes.json()) as {
+            error?: { message?: string };
+          };
+          set(internalError$, body.error?.message ?? "Authentication failed");
+          set(internalStatus$, "error");
+          return;
+        }
+        // Transient failure — retry
+        continue;
+      }
+
+      const { client_secret: clientSecret } = (await tokenRes.json()) as {
+        client_secret: { value: string; expires_at: number };
+      };
+      signal.throwIfAborted();
+
+      // Check if existing mic stream is still active
+      let stream = get(internalStream$);
+      if (
+        !stream ||
+        stream.getAudioTracks().every((t) => {
+          return !t.enabled || t.readyState === "ended";
+        })
+      ) {
+        // eslint-disable-next-line no-restricted-syntax -- getUserMedia can fail due to permission denial
+        try {
+          stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+          set(internalStream$, stream);
+        } catch (error) {
+          throwIfAbort(error);
+          set(internalError$, "Microphone access denied");
+          set(internalStatus$, "error");
+          return;
+        }
+      }
+      signal.throwIfAborted();
+
+      // Setup new WebRTC connection
+      const ok = await set(setupWebRTC$, stream, clientSecret.value, signal);
+      if (ok) {
+        // Success — restart heartbeat and poll loops
+        set(internalReconnectAttempt$, 0);
+        const sessionSignal = set(resetSessionSignal$, signal);
+        await Promise.allSettled([
+          set(startHeartbeat$, sessionSignal),
+          set(startPoll$, sessionSignal),
+        ]);
+        signal.throwIfAborted();
+        return;
+      }
+
+      // setupWebRTC$ failed — will retry on next iteration
+    }
+
+    // Max retries exhausted
+    set(internalReconnectAttempt$, 0);
+    set(internalStatus$, "disconnected");
+  },
+);
 
 // --- Shared connection logic ---
 
@@ -797,7 +944,8 @@ export const startVoiceChat$ = command(
     if (
       get(internalStatus$) === "connecting" ||
       get(internalStatus$) === "connected" ||
-      get(internalStatus$) === "preparing"
+      get(internalStatus$) === "preparing" ||
+      get(internalStatus$) === "reconnecting"
     ) {
       return;
     }
@@ -863,7 +1011,8 @@ export const startVoiceMeeting$ = command(
     if (
       get(internalStatus$) === "connecting" ||
       get(internalStatus$) === "connected" ||
-      get(internalStatus$) === "preparing"
+      get(internalStatus$) === "preparing" ||
+      get(internalStatus$) === "reconnecting"
     ) {
       return;
     }
@@ -973,8 +1122,19 @@ export const endVoiceChat$ = command(({ get, set }) => {
   set(internalPrompt$, null);
   set(internalPrepStartTime$, null);
   set(internalPrepElapsedMs$, 0);
+  set(internalReconnectAttempt$, 0);
   set(internalStatus$, "idle");
 });
+
+export const retryVoiceChat$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const status = get(internalStatus$);
+    if (status !== "disconnected") {
+      return;
+    }
+    await set(reconnectVoiceSession$, signal);
+  },
+);
 
 export const toggleVoiceChatMute$ = command(({ get, set }) => {
   const stream = get(internalStream$);

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -7,6 +7,7 @@ import {
   IconMicrophoneOff,
   IconPhoneOff,
   IconLoader2,
+  IconRefresh,
 } from "@tabler/icons-react";
 import { defaultAgentName$ } from "../../signals/agent.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
@@ -21,11 +22,13 @@ import {
   vcAgentId$,
   vcPrompt$,
   vcPrepElapsedMs$,
+  vcReconnectAttempt$,
   vcMeetingPromptInput$,
   setMeetingPromptInput$,
   startVoiceChat$,
   startVoiceMeeting$,
   endVoiceChat$,
+  retryVoiceChat$,
   toggleVoiceChatMute$,
 } from "../../signals/voice-chat/voice-chat-session.ts";
 import {
@@ -42,15 +45,23 @@ type ConnectionStatus =
   | "preparing"
   | "connecting"
   | "connected"
+  | "reconnecting"
   | "disconnected"
   | "error";
 
-function StatusBadge({ status }: { status: ConnectionStatus }) {
+function StatusBadge({
+  status,
+  reconnectAttempt,
+}: {
+  status: ConnectionStatus;
+  reconnectAttempt?: number;
+}) {
   const label: Record<ConnectionStatus, string> = {
     idle: "Ready",
     preparing: "Preparing...",
     connecting: "Connecting...",
     connected: "Connected",
+    reconnecting: "Reconnecting...",
     disconnected: "Disconnected",
     error: "Error",
   };
@@ -61,9 +72,15 @@ function StatusBadge({ status }: { status: ConnectionStatus }) {
       "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
     connected:
       "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    reconnecting:
+      "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200",
     disconnected: "bg-muted text-muted-foreground",
     error: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
   };
+  const displayLabel =
+    status === "reconnecting" && reconnectAttempt
+      ? `Reconnecting (${reconnectAttempt}/5)...`
+      : label[status];
   return (
     <span
       className={cn(
@@ -71,13 +88,15 @@ function StatusBadge({ status }: { status: ConnectionStatus }) {
         color[status],
       )}
     >
-      {(status === "connecting" || status === "preparing") && (
+      {(status === "connecting" ||
+        status === "preparing" ||
+        status === "reconnecting") && (
         <IconLoader2 size={12} className="animate-spin" />
       )}
       {status === "connected" && (
         <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
       )}
-      {label[status]}
+      {displayLabel}
     </span>
   );
 }
@@ -95,6 +114,8 @@ export function VoiceChatPage() {
   const startMeeting = useSet(startVoiceMeeting$);
   const endSession = useSet(endVoiceChat$);
   const toggleMute = useSet(toggleVoiceChatMute$);
+  const reconnectAttempt = useGet(vcReconnectAttempt$);
+  const retrySession = useSet(retryVoiceChat$);
   const prompt = useGet(vcPrompt$);
   const prepElapsedMs = useGet(vcPrepElapsedMs$);
   const meetingPrompt = useGet(vcMeetingPromptInput$);
@@ -255,7 +276,7 @@ export function VoiceChatPage() {
       <div className="flex items-center justify-between border-b px-4 py-3">
         <div className="flex items-center gap-3">
           <h1 className="text-lg font-semibold">Voice Chat</h1>
-          <StatusBadge status={status} />
+          <StatusBadge status={status} reconnectAttempt={reconnectAttempt} />
         </div>
         <Button
           variant="destructive"
@@ -263,7 +284,6 @@ export function VoiceChatPage() {
           onClick={() => {
             endSession();
           }}
-          disabled={status === "disconnected"}
         >
           <IconPhoneOff size={16} className="mr-1.5" />
           End Session
@@ -373,6 +393,18 @@ export function VoiceChatPage() {
             <IconMicrophone size={20} />
           )}
         </Button>
+        {status === "disconnected" && (
+          <Button
+            variant="secondary"
+            size="icon"
+            className="h-12 w-12 rounded-full"
+            onClick={() => {
+              detach(retrySession(pageSignal), Reason.DomCallback);
+            }}
+          >
+            <IconRefresh size={20} />
+          </Button>
+        )}
         <Button
           variant="destructive"
           size="icon"
@@ -380,7 +412,6 @@ export function VoiceChatPage() {
           onClick={() => {
             endSession();
           }}
-          disabled={status === "disconnected"}
         >
           <IconPhoneOff size={20} />
         </Button>


### PR DESCRIPTION
## Summary

- Add auto-reconnect with exponential backoff (1s→16s, max 5 attempts) when WebRTC disconnects
- New "reconnecting" state in the connection state machine with UI feedback (attempt counter)
- Fatal vs recoverable error classification: auth/session errors stop retry; transient errors retry
- Manual "Retry" button appears after max auto-reconnect attempts exhausted
- "End Session" button enabled in all states (was disabled in disconnected state)
- Session state (transcript, events, sequence numbers) fully preserved across reconnections

Closes #8850

## Test plan

- [ ] Verify lint passes (0 errors)
- [ ] Verify typecheck passes
- [ ] Verify knip passes (no unused exports)
- [ ] Manual: disconnect WiFi briefly during voice chat → auto-reconnects when network returns
- [ ] Manual: kill WebRTC connection → shows "Reconnecting (1/5)..." and recovers
- [ ] Manual: if session ended server-side during disconnect → shows error state
- [ ] Manual: after 5 failed attempts → shows "Disconnected" with Retry button
- [ ] Manual: Retry button triggers new reconnect cycle
- [ ] Manual: End Session works from reconnecting/disconnected states

🤖 Generated with [Claude Code](https://claude.com/claude-code)