### PR TITLE
feat(voice-chat): add preparation timeout with auto-cancel and elapsed time

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -58,6 +58,8 @@ function upsertUserTranscript(
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
 const POLL_INTERVAL_MS = 2000;
+const PREP_TIMEOUT_CHAT_MS = 60_000;
+const PREP_TIMEOUT_MEETING_MS = 300_000;
 const REALTIME_MODEL = "gpt-realtime-1.5";
 
 const SESSION_TOOLS = [
@@ -177,6 +179,8 @@ const internalDc$ = state<RTCDataChannel | null>(null);
 const internalStream$ = state<MediaStream | null>(null);
 const internalAudioEl$ = state<HTMLAudioElement | null>(null);
 const internalPrompt$ = state<string | null>(null);
+const internalPrepStartTime$ = state<number | null>(null);
+const internalPrepElapsedMs$ = state(0);
 
 const meetingPromptInput$ = state("");
 
@@ -208,6 +212,9 @@ export const vcAgentId$ = computed(async (get) => {
 });
 export const vcPrompt$ = computed((get) => {
   return get(internalPrompt$);
+});
+export const vcPrepElapsedMs$ = computed((get) => {
+  return get(internalPrepElapsedMs$);
 });
 export const vcMeetingPromptInput$ = computed((get) => {
   return get(meetingPromptInput$);
@@ -660,16 +667,26 @@ const prepareActivateConnect$ = command(
     { get, set },
     sessionId: string,
     sessionSignal: AbortSignal,
+    timeoutMs: number,
     signal: AbortSignal,
   ) => {
     const fetchFn = get(fetch$);
+    const startTime = Date.now();
+    let preparationReady = false;
 
     // Start heartbeat during preparation to prevent session timeout
     const heartbeatPromise = set(startHeartbeat$, sessionSignal);
 
-    // Poll for preparation-ready event
+    // Poll for preparation-ready event with timeout
     await setLoop(
       async (loopSignal: AbortSignal) => {
+        const elapsed = Date.now() - startTime;
+        set(internalPrepElapsedMs$, elapsed);
+
+        if (elapsed > timeoutMs) {
+          return true;
+        }
+
         const sid = get(internalSessionId$);
         if (!sid) {
           return true;
@@ -702,6 +719,7 @@ const prepareActivateConnect$ = command(
               return e.type === "preparation-ready";
             })
           ) {
+            preparationReady = true;
             return true;
           }
         }
@@ -710,6 +728,26 @@ const prepareActivateConnect$ = command(
       POLL_INTERVAL_MS,
       sessionSignal,
     );
+    signal.throwIfAborted();
+
+    if (!preparationReady) {
+      if (!sessionSignal.aborted) {
+        set(internalPrepStartTime$, null);
+        set(internalPrepElapsedMs$, 0);
+        set(internalError$, "Preparation timed out");
+        set(internalStatus$, "error");
+        const sid = get(internalSessionId$);
+        if (sid) {
+          void fetchFn(`/api/zero/voice-chat/${sid}/end`, {
+            method: "POST",
+          }).catch(() => {
+            return undefined;
+          });
+        }
+      }
+      return;
+    }
+
     signal.throwIfAborted();
 
     // Activate session (preparing → active)
@@ -754,6 +792,7 @@ export const startVoiceChat$ = command(
     set(internalLastSeq$, 0);
     set(internalCurrentAssistant$, null);
     set(internalPrompt$, null);
+    set(internalPrepStartTime$, Date.now());
 
     const sessionSignal = set(resetSessionSignal$, signal);
 
@@ -790,7 +829,13 @@ export const startVoiceChat$ = command(
     signal.throwIfAborted();
     set(internalSessionId$, session.id);
 
-    await set(prepareActivateConnect$, session.id, sessionSignal, signal);
+    await set(
+      prepareActivateConnect$,
+      session.id,
+      sessionSignal,
+      PREP_TIMEOUT_CHAT_MS,
+      signal,
+    );
   },
 );
 
@@ -813,6 +858,7 @@ export const startVoiceMeeting$ = command(
     set(internalLastSeq$, 0);
     set(internalCurrentAssistant$, null);
     set(internalPrompt$, prompt);
+    set(internalPrepStartTime$, Date.now());
 
     const sessionSignal = set(resetSessionSignal$, signal);
 
@@ -849,7 +895,13 @@ export const startVoiceMeeting$ = command(
     signal.throwIfAborted();
     set(internalSessionId$, session.id);
 
-    await set(prepareActivateConnect$, session.id, sessionSignal, signal);
+    await set(
+      prepareActivateConnect$,
+      session.id,
+      sessionSignal,
+      PREP_TIMEOUT_MEETING_MS,
+      signal,
+    );
   },
 );
 
@@ -900,6 +952,8 @@ export const endVoiceChat$ = command(({ get, set }) => {
 
   set(internalSessionId$, null);
   set(internalPrompt$, null);
+  set(internalPrepStartTime$, null);
+  set(internalPrepElapsedMs$, 0);
   set(internalStatus$, "idle");
 });
 

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -20,6 +20,7 @@ import {
   vcEnabled$,
   vcAgentId$,
   vcPrompt$,
+  vcPrepElapsedMs$,
   vcMeetingPromptInput$,
   setMeetingPromptInput$,
   startVoiceChat$,
@@ -95,6 +96,7 @@ export function VoiceChatPage() {
   const endSession = useSet(endVoiceChat$);
   const toggleMute = useSet(toggleVoiceChatMute$);
   const prompt = useGet(vcPrompt$);
+  const prepElapsedMs = useGet(vcPrepElapsedMs$);
   const meetingPrompt = useGet(vcMeetingPromptInput$);
   const setMeetingPrompt = useSet(setMeetingPromptInput$);
   const agentName = useLastResolved(defaultAgentName$) ?? "Zero";
@@ -103,6 +105,8 @@ export function VoiceChatPage() {
 
   useTranscriptAutoScroll(transcript.length);
   useEventsAutoScroll(events.length);
+
+  const elapsedSeconds = Math.floor(prepElapsedMs / 1000);
 
   if (enabled === false) {
     return (
@@ -180,6 +184,12 @@ export function VoiceChatPage() {
             <h1 className="text-lg font-semibold">
               {prompt ? "Preparing Meeting" : "Preparing..."}
             </h1>
+            {elapsedSeconds > 0 && (
+              <span className="text-sm tabular-nums text-muted-foreground">
+                {Math.floor(elapsedSeconds / 60)}:
+                {String(elapsedSeconds % 60).padStart(2, "0")}
+              </span>
+            )}
             <StatusBadge status={status} />
           </div>
           <Button


### PR DESCRIPTION
## Summary

- Add configurable timeout to voice chat preparation phase (60s for chat, 5min for meetings) so users aren't stuck indefinitely if slow brain fails to emit `preparation-ready`
- On timeout, automatically cancel the session on the server and transition to error state with a clear message
- Display elapsed time in the preparation UI header, updated every poll cycle (~2s)

Closes #8848

## Changes

| File | Change |
|------|--------|
| `voice-chat-session.ts` | Add `PREP_TIMEOUT_CHAT_MS` / `PREP_TIMEOUT_MEETING_MS` constants, `internalPrepStartTime$` / `internalPrepElapsedMs$` signals, timeout check in `prepareActivateConnect$` polling loop, pass timeout from callers, reset on end |
| `voice-chat-page.tsx` | Import `vcPrepElapsedMs$`, compute and display `MM:SS` elapsed time in preparation header |

## Test plan

- [x] All 59 existing voice-chat backend tests pass (`pnpm -F web exec vitest run voice-chat`)
- [x] Lint passes (`pnpm turbo run lint --filter=platform`)
- [x] Type check passes (`pnpm check-types`)
- [x] Format passes (`pnpm format`)
- [x] Knip passes (no unused exports)
- [ ] Manual: start voice chat → observe elapsed time ticking → if slow brain doesn't respond within 60s → error state shown with "Preparation timed out"
- [ ] Manual: start voice meeting → longer 5min timeout applies
- [ ] Manual: cancel during preparation → session ends cleanly (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)