### PR TITLE
feat(mission-control): implement tasks list with keyboard navigation

### DIFF
--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-page.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-page.ts
@@ -6,6 +6,10 @@ import { SidebarLayout } from "../../views/zero-page/sidebar-layout";
 import { MissionControlPage } from "../../views/mission-control-page/mission-control-page";
 import { hideAppSkeleton$ } from "../app-skeleton";
 import { onboardGuard$ } from "../zero-page/onboard-guard";
+import {
+  setupMissionControlKeyboard$,
+  setupMissionControlLoop$,
+} from "./mission-control.ts";
 
 export const setupMissionControlPage$ = command(
   async ({ set }, signal: AbortSignal) => {
@@ -14,11 +18,15 @@ export const setupMissionControlPage$ = command(
       createElement(SidebarLayout, null, createElement(MissionControlPage)),
     );
 
-    set(updateDocumentTitle$, "MissionControl");
+    set(updateDocumentTitle$, "Mission Control");
+    set(setupMissionControlKeyboard$, signal);
+
     await set(hideAppSkeleton$, signal);
 
     if (await set(onboardGuard$, signal)) {
       return;
     }
+
+    await set(setupMissionControlLoop$, signal);
   },
 );

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
@@ -1,6 +1,6 @@
 import { command, computed, state } from "ccstate";
+import { tasksContract, type TaskItem } from "@vm0/core";
 import { zeroClient$ } from "../api-client";
-import { tasksContract } from "@vm0/core";
 import { accept } from "../../lib/accept";
 import { detachedNavigateTo$ } from "../route.ts";
 import { onDomEventFn, setLoop } from "../utils.ts";
@@ -43,7 +43,30 @@ const selectNextTask$ = command(async ({ get, set }, signal: AbortSignal) => {
   });
 });
 
-export const navigateToSelectedTask$ = command(
+export const navigateToTask$ = command(({ set }, task: TaskItem) => {
+  switch (task.type) {
+    case "chat": {
+      if (task.chatThreadId) {
+        set(detachedNavigateTo$, "/chats/:threadId", {
+          pathParams: { threadId: task.chatThreadId },
+        });
+      }
+      break;
+    }
+    case "email":
+    case "schedule":
+    case "slack": {
+      if (task.latestRunId) {
+        set(detachedNavigateTo$, "/activities/:runId", {
+          pathParams: { runId: task.latestRunId },
+        });
+      }
+      break;
+    }
+  }
+});
+
+const navigateToSelectedTask$ = command(
   async ({ get, set }, signal: AbortSignal) => {
     const tasks = await get(tasks$);
     signal.throwIfAborted();
@@ -54,26 +77,7 @@ export const navigateToSelectedTask$ = command(
       return;
     }
 
-    switch (task.type) {
-      case "chat": {
-        if (task.chatThreadId) {
-          set(detachedNavigateTo$, "/chats/:threadId", {
-            pathParams: { threadId: task.chatThreadId },
-          });
-        }
-        break;
-      }
-      case "email":
-      case "schedule":
-      case "slack": {
-        if (task.latestRunId) {
-          set(detachedNavigateTo$, "/activities/:runId", {
-            pathParams: { runId: task.latestRunId },
-          });
-        }
-        break;
-      }
-    }
+    set(navigateToTask$, task);
   },
 );
 
@@ -82,8 +86,15 @@ export const setupMissionControlKeyboard$ = command(
     document.addEventListener(
       "keydown",
       onDomEventFn(async (e: KeyboardEvent) => {
-        const target = e.target as HTMLElement;
-        if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") {
+        const target = e.target;
+        if (!(target instanceof HTMLElement)) {
+          return;
+        }
+        if (
+          target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable
+        ) {
           return;
         }
 

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
@@ -1,0 +1,119 @@
+import { command, computed, state } from "ccstate";
+import { zeroClient$ } from "../api-client";
+import { tasksContract } from "@vm0/core";
+import { accept } from "../../lib/accept";
+import { detachedNavigateTo$ } from "../route.ts";
+import { onDomEventFn, setLoop } from "../utils.ts";
+
+const internalReloadTasks$ = state(0);
+
+export const tasks$ = computed(async (get) => {
+  get(internalReloadTasks$);
+
+  const client = get(zeroClient$)(tasksContract);
+  const taskRequest = await accept(client.list({ query: {} }), [200]);
+
+  return taskRequest.body.tasks;
+});
+
+const reloadTasks$ = command(({ set }) => {
+  set(internalReloadTasks$, (x) => {
+    return x + 1;
+  });
+});
+
+const internalSelectedTaskIndex$ = state(0);
+
+export const selectedTaskIndex$ = computed((get) => {
+  return get(internalSelectedTaskIndex$);
+});
+
+const selectPrevTask$ = command(({ set }) => {
+  set(internalSelectedTaskIndex$, (x) => {
+    return Math.max(x - 1, 0);
+  });
+});
+
+const selectNextTask$ = command(async ({ get, set }, signal: AbortSignal) => {
+  const tasks = await get(tasks$);
+  signal.throwIfAborted();
+
+  set(internalSelectedTaskIndex$, (x) => {
+    return Math.min(x + 1, tasks.length - 1);
+  });
+});
+
+export const navigateToSelectedTask$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    const tasks = await get(tasks$);
+    signal.throwIfAborted();
+
+    const index = get(selectedTaskIndex$);
+    const task = tasks[index];
+    if (!task) {
+      return;
+    }
+
+    switch (task.type) {
+      case "chat": {
+        if (task.chatThreadId) {
+          set(detachedNavigateTo$, "/chats/:threadId", {
+            pathParams: { threadId: task.chatThreadId },
+          });
+        }
+        break;
+      }
+      case "email":
+      case "schedule":
+      case "slack": {
+        if (task.latestRunId) {
+          set(detachedNavigateTo$, "/activities/:runId", {
+            pathParams: { runId: task.latestRunId },
+          });
+        }
+        break;
+      }
+    }
+  },
+);
+
+export const setupMissionControlKeyboard$ = command(
+  ({ set }, signal: AbortSignal) => {
+    document.addEventListener(
+      "keydown",
+      onDomEventFn(async (e: KeyboardEvent) => {
+        const target = e.target as HTMLElement;
+        if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") {
+          return;
+        }
+
+        if (e.key === "k") {
+          e.preventDefault();
+          set(selectPrevTask$);
+        } else if (e.key === "j") {
+          e.preventDefault();
+          await set(selectNextTask$, signal);
+        } else if (e.key === "Enter") {
+          e.preventDefault();
+          await set(navigateToSelectedTask$, signal);
+        }
+      }),
+      { signal },
+    );
+  },
+);
+
+export const setupMissionControlLoop$ = command(
+  async ({ set, get }, signal: AbortSignal) => {
+    await setLoop(
+      async () => {
+        set(reloadTasks$);
+        await get(tasks$);
+        signal.throwIfAborted();
+        return false;
+      },
+      10_000,
+      signal,
+    );
+  },
+);

--- a/turbo/apps/platform/src/signals/route-paths.ts
+++ b/turbo/apps/platform/src/signals/route-paths.ts
@@ -30,9 +30,9 @@ export const ROUTES = {
   insights: "/insights",
   internalConnectorLogos: "/__internal-connector-logos",
   reportError: "/runs/:runId/report-error",
+  missionControl: "/_/mission-control",
   skeleton: "/_/skeleton",
   error: "/_/error",
-  missionControl: "/_/mission-control",
 } as const;
 
 export type RouteKey = keyof typeof ROUTES;

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../mocks/server.ts";
+import { testContext } from "../../../signals/__tests__/test-helpers.ts";
+import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
+import { pathname } from "../../../signals/location.ts";
+
+const context = testContext();
+
+function createAgent() {
+  return {
+    id: "agent-1",
+    name: "test-agent",
+    displayName: "Test Agent",
+    avatarUrl: null,
+  };
+}
+
+function mockTasksAPI(
+  tasks: {
+    id: string;
+    type: "chat" | "schedule" | "slack" | "email";
+    title: string | null;
+    agent: {
+      id: string;
+      name: string;
+      displayName: string | null;
+      avatarUrl: string | null;
+    };
+    latestRunId: string | null;
+    status: string | null;
+    chatThreadId?: string;
+    scheduleId?: string;
+    slackThreadSessionId?: string;
+    emailThreadSessionId?: string;
+    createdAt: string;
+    updatedAt: string;
+  }[],
+) {
+  server.use(
+    http.get("*/api/zero/tasks", () => {
+      return HttpResponse.json({ tasks });
+    }),
+  );
+}
+
+describe("mission control page", () => {
+  it("should render tasks list with task cards", async () => {
+    mockTasksAPI([
+      {
+        id: "task-1",
+        type: "chat",
+        title: "Help with code review",
+        agent: createAgent(),
+        latestRunId: null,
+        status: null,
+        chatThreadId: "thread-1",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+      {
+        id: "task-2",
+        type: "schedule",
+        title: "Daily report",
+        agent: createAgent(),
+        latestRunId: "run-1",
+        status: "completed",
+        scheduleId: "sched-1",
+        createdAt: "2026-04-10T09:00:00Z",
+        updatedAt: "2026-04-10T09:30:00Z",
+      },
+    ]);
+
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Help with code review")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Daily report")).toBeInTheDocument();
+    expect(screen.getByText("Chat")).toBeInTheDocument();
+    expect(screen.getByText("Schedule")).toBeInTheDocument();
+  });
+
+  it("should show empty state when no tasks exist", async () => {
+    mockTasksAPI([]);
+
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    await waitFor(() => {
+      expect(screen.getByText("No active tasks")).toBeInTheDocument();
+    });
+  });
+
+  it("should navigate to chat thread when clicking a chat task", async () => {
+    mockTasksAPI([
+      {
+        id: "task-chat",
+        type: "chat",
+        title: "Chat task",
+        agent: createAgent(),
+        latestRunId: null,
+        status: null,
+        chatThreadId: "thread-abc",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    const user = userEvent.setup();
+
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const title = await waitFor(() => {
+      return screen.getByText("Chat task");
+    });
+
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/chats/thread-abc");
+    });
+  });
+
+  it("should navigate to activity when clicking a schedule task", async () => {
+    mockTasksAPI([
+      {
+        id: "task-sched",
+        type: "schedule",
+        title: "Scheduled task",
+        agent: createAgent(),
+        latestRunId: "run-xyz",
+        status: "completed",
+        scheduleId: "sched-1",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    const user = userEvent.setup();
+
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const title = await waitFor(() => {
+      return screen.getByText("Scheduled task");
+    });
+
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/activities/run-xyz");
+    });
+  });
+
+  it("should navigate to activity when clicking an email task", async () => {
+    mockTasksAPI([
+      {
+        id: "task-email",
+        type: "email",
+        title: "Email task",
+        agent: createAgent(),
+        latestRunId: "run-email-1",
+        status: "running",
+        emailThreadSessionId: "email-session-1",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    const user = userEvent.setup();
+
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const title = await waitFor(() => {
+      return screen.getByText("Email task");
+    });
+
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/activities/run-email-1");
+    });
+  });
+
+  it("should navigate to activity when clicking a slack task", async () => {
+    mockTasksAPI([
+      {
+        id: "task-slack",
+        type: "slack",
+        title: "Slack task",
+        agent: createAgent(),
+        latestRunId: "run-slack-1",
+        status: "running",
+        slackThreadSessionId: "slack-session-1",
+        createdAt: "2026-04-10T10:00:00Z",
+        updatedAt: "2026-04-10T10:00:00Z",
+      },
+    ]);
+
+    const user = userEvent.setup();
+
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    const title = await waitFor(() => {
+      return screen.getByText("Slack task");
+    });
+
+    await user.click(title);
+
+    await waitFor(() => {
+      expect(pathname()).toBe("/activities/run-slack-1");
+    });
+  });
+});

--- a/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
@@ -1,3 +1,207 @@
+import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import {
+  IconMessageCircle,
+  IconCalendar,
+  IconBrandSlack,
+  IconMail,
+} from "@tabler/icons-react";
+import { Skeleton, Card } from "@vm0/ui";
+import type { TaskItem, TaskType } from "@vm0/core";
+import {
+  tasks$,
+  selectedTaskIndex$,
+  navigateToSelectedTask$,
+} from "../../signals/mission-control-page/mission-control.ts";
+import { StatusBadge } from "../zero-page/components/log-views/status-badge.tsx";
+import { AgentAvatarImg } from "../zero-page/zero-sidebar-shared.tsx";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+
+function getTaskTypeConfig(): Record<
+  TaskType,
+  { label: string; icon: typeof IconMessageCircle; iconClassName: string }
+> {
+  return {
+    chat: {
+      label: "Chat",
+      icon: IconMessageCircle,
+      iconClassName: "text-sky-500",
+    },
+    schedule: {
+      label: "Schedule",
+      icon: IconCalendar,
+      iconClassName: "text-violet-500",
+    },
+    slack: {
+      label: "Slack",
+      icon: IconBrandSlack,
+      iconClassName: "text-emerald-500",
+    },
+    email: {
+      label: "Email",
+      icon: IconMail,
+      iconClassName: "text-amber-500",
+    },
+  };
+}
+
 export function MissionControlPage() {
-  return <div>MissionControl</div>;
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      <div className="shrink-0 px-6 pt-6 pb-2">
+        <h1 className="text-lg font-semibold">Mission Control</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Active tasks across all channels
+        </p>
+      </div>
+
+      <div className="flex-1 overflow-auto px-6 pb-6">
+        <TaskList />
+      </div>
+    </div>
+  );
+}
+
+function TaskList() {
+  const tasksLoadable = useLastLoadable(tasks$);
+  const tasks = tasksLoadable.state === "hasData" ? tasksLoadable.data : [];
+  const loading = tasksLoadable.state === "loading";
+  const error =
+    tasksLoadable.state === "hasError"
+      ? tasksLoadable.error instanceof Error
+        ? tasksLoadable.error.message
+        : "Failed to load tasks"
+      : null;
+
+  const selectedIndex = useGet(selectedTaskIndex$);
+
+  if (loading && tasks.length === 0) {
+    return (
+      <div className="flex flex-col gap-3 mt-2">
+        {Array.from({ length: 5 }, (_, i) => {
+          return (
+            <Card key={i} className="p-4">
+              <div className="flex items-center gap-3">
+                <Skeleton className="h-8 w-8 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-2/3" />
+                  <Skeleton className="h-3 w-1/3" />
+                </div>
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="py-8 text-sm text-destructive">{error}</p>;
+  }
+
+  if (tasks.length === 0) {
+    return (
+      <p className="py-8 text-sm text-muted-foreground text-center">
+        No active tasks
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 mt-2">
+      {tasks.map((task, index) => {
+        return (
+          <TaskCard
+            key={task.id}
+            task={task}
+            isSelected={index === selectedIndex}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function TaskCard({
+  task,
+  isSelected,
+}: {
+  task: TaskItem;
+  isSelected: boolean;
+}) {
+  const navigateToTask = useSet(navigateToSelectedTask$);
+  const pageSignal = useGet(pageSignal$);
+
+  const onClick = () => {
+    detach(navigateToTask(pageSignal), Reason.DomCallback);
+  };
+
+  const config = getTaskTypeConfig()[task.type];
+  const TypeIcon = config.icon;
+
+  return (
+    <Card
+      ref={(el) => {
+        if (isSelected && el) {
+          el.scrollIntoView({ block: "nearest" });
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      className={`p-4 cursor-pointer transition-colors ${
+        isSelected ? "ring-2 ring-primary bg-accent" : "hover:bg-accent/50"
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <AgentAvatarImg
+          name={task.agent.name}
+          alt={task.agent.displayName ?? task.agent.name}
+          className="h-8 w-8 rounded-full object-cover object-top shrink-0"
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium truncate">
+              {task.title ?? task.agent.displayName ?? task.agent.name}
+            </span>
+            {task.status && <StatusBadge status={task.status} zeroStyle />}
+          </div>
+          <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+            <TypeIcon size={13} stroke={1.5} className={config.iconClassName} />
+            <span>{config.label}</span>
+            <span className="text-border">·</span>
+            <span>{task.agent.displayName ?? task.agent.name}</span>
+            <span className="text-border">·</span>
+            <span>{formatRelativeTime(task.updatedAt)}</span>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function formatRelativeTime(iso: string): string {
+  const now = Date.now();
+  const then = new Date(iso).getTime();
+  const diffMs = now - then;
+  const diffMin = Math.floor(diffMs / 60_000);
+
+  if (diffMin < 1) {
+    return "just now";
+  }
+  if (diffMin < 60) {
+    return `${diffMin}m ago`;
+  }
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) {
+    return `${diffHr}h ago`;
+  }
+  const diffDay = Math.floor(diffHr / 24);
+  return `${diffDay}d ago`;
 }

--- a/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
@@ -10,39 +10,46 @@ import type { TaskItem, TaskType } from "@vm0/core";
 import {
   tasks$,
   selectedTaskIndex$,
-  navigateToSelectedTask$,
+  navigateToTask$,
 } from "../../signals/mission-control-page/mission-control.ts";
 import { StatusBadge } from "../zero-page/components/log-views/status-badge.tsx";
 import { AgentAvatarImg } from "../zero-page/zero-sidebar-shared.tsx";
-import { pageSignal$ } from "../../signals/page-signal.ts";
-import { detach, Reason } from "../../signals/utils.ts";
 
-function getTaskTypeConfig(): Record<
-  TaskType,
-  { label: string; icon: typeof IconMessageCircle; iconClassName: string }
-> {
-  return {
-    chat: {
-      label: "Chat",
-      icon: IconMessageCircle,
-      iconClassName: "text-sky-500",
-    },
-    schedule: {
-      label: "Schedule",
-      icon: IconCalendar,
-      iconClassName: "text-violet-500",
-    },
-    slack: {
-      label: "Slack",
-      icon: IconBrandSlack,
-      iconClassName: "text-emerald-500",
-    },
-    email: {
-      label: "Email",
-      icon: IconMail,
-      iconClassName: "text-amber-500",
-    },
-  };
+function getTaskTypeConfig(type: TaskType): {
+  label: string;
+  icon: typeof IconMessageCircle;
+  iconClassName: string;
+} {
+  switch (type) {
+    case "chat": {
+      return {
+        label: "Chat",
+        icon: IconMessageCircle,
+        iconClassName: "text-sky-500",
+      };
+    }
+    case "schedule": {
+      return {
+        label: "Schedule",
+        icon: IconCalendar,
+        iconClassName: "text-violet-500",
+      };
+    }
+    case "slack": {
+      return {
+        label: "Slack",
+        icon: IconBrandSlack,
+        iconClassName: "text-emerald-500",
+      };
+    }
+    case "email": {
+      return {
+        label: "Email",
+        icon: IconMail,
+        iconClassName: "text-amber-500",
+      };
+    }
+  }
 }
 
 export function MissionControlPage() {
@@ -129,14 +136,13 @@ function TaskCard({
   task: TaskItem;
   isSelected: boolean;
 }) {
-  const navigateToTask = useSet(navigateToSelectedTask$);
-  const pageSignal = useGet(pageSignal$);
+  const navigate = useSet(navigateToTask$);
 
   const onClick = () => {
-    detach(navigateToTask(pageSignal), Reason.DomCallback);
+    navigate(task);
   };
 
-  const config = getTaskTypeConfig()[task.type];
+  const config = getTaskTypeConfig(task.type);
   const TypeIcon = config.icon;
 
   return (

--- a/turbo/package.json
+++ b/turbo/package.json
@@ -61,7 +61,8 @@
       "picomatch": ">=4.0.4",
       "yaml": ">=2.8.3",
       "smol-toml": ">=1.6.1",
-      "@opentelemetry/instrumentation": ">=0.213.0"
+      "@opentelemetry/instrumentation": ">=0.213.0",
+      "zod": "4.3.6"
     }
   },
   "packageManager": "pnpm@10.15.0",

--- a/turbo/pnpm-lock.yaml
+++ b/turbo/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   yaml: '>=2.8.3'
   smol-toml: '>=1.6.1'
   '@opentelemetry/instrumentation': '>=0.213.0'
+  zod: 4.3.6
 
 importers:
 
@@ -135,7 +136,7 @@ importers:
         specifier: '>=2.8.3'
         version: 2.8.3
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
 
   apps/platform:
@@ -418,7 +419,7 @@ importers:
         specifier: ^3.6.7
         version: 3.6.7
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@tailwindcss/postcss':
@@ -512,7 +513,7 @@ importers:
         specifier: '>=2.8.3'
         version: 2.8.3
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@vm0/eslint-config':
@@ -3908,7 +3909,7 @@ packages:
       arktype: ^2.1.0
       typescript: '>=5.0.0'
       valibot: ^1.0.0-beta.7 || ^1.0.0
-      zod: ^3.24.0 || ^4.0.0
+      zod: 4.3.6
     peerDependenciesMeta:
       arktype:
         optional: true
@@ -3925,7 +3926,7 @@ packages:
       arktype: ^2.1.0
       typescript: '>=5.0.0'
       valibot: ^1.0.0-beta.7 || ^1.0.0
-      zod: ^3.24.0 || ^4.0.0
+      zod: 4.3.6
     peerDependenciesMeta:
       arktype:
         optional: true
@@ -4590,7 +4591,7 @@ packages:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
       typescript: '>=5.0.4'
-      zod: ^3.22.0 || ^4.0.0
+      zod: 4.3.6
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -8261,10 +8262,7 @@ packages:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-
-  zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+      zod: 4.3.6
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -11892,7 +11890,7 @@ snapshots:
       ajv-formats: 2.1.1
       graphql: 16.13.2
       lodash.get: 4.4.2
-      zod: 3.22.4
+      zod: 4.3.6
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -16755,8 +16753,6 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
-
-  zod@3.22.4: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Summary
- Implement mission control tasks list page with card-based UI, reusing existing `Card`, `StatusBadge`, and `AgentAvatarImg` components
- Add keyboard navigation (j/k to move selection, Enter to navigate) via page-level signal
- Add 10s polling loop to keep tasks list fresh
- Route by task type: chat → `/chats/:threadId`, email/schedule/slack → `/activities/:runId`
- Fix zod v3/v4 conflict causing 169 TypeScript errors (`@team-plain/typescript-sdk` pulled zod@3.22.4 into pnpm hoisted scope, breaking ts-rest type resolution)
- Remove duplicate `missionControl` key in route-paths

## Test plan
- [ ] Verify tasks list renders with loading skeleton, empty state, and populated state
- [ ] Verify j/k keyboard navigation moves selection and auto-scrolls
- [ ] Verify Enter navigates to correct route per task type
- [ ] Verify `pnpm check-types` passes with 0 errors (zod override fix)
- [ ] Verify lint and knip pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)