### PR TITLE
fix(voice-chat): move prep event injection into dc open handler

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -491,6 +491,12 @@ const setupWebRTC$ = command(
         }),
       );
       set(internalStatus$, "connected");
+
+      // Inject slow-brain events collected during preparation phase
+      const prepEvents = get(internalEvents$);
+      if (prepEvents.length > 0) {
+        set(injectSlowBrainEvents$, prepEvents);
+      }
     });
 
     dc.addEventListener(
@@ -819,12 +825,6 @@ const connectVoiceSession$ = command(
     sessionSignal.throwIfAborted();
     if (!ok) {
       return;
-    }
-
-    // Inject slow-brain events collected during preparation phase
-    const existingEvents = get(internalEvents$);
-    if (existingEvents.length > 0) {
-      set(injectSlowBrainEvents$, existingEvents);
     }
 
     await Promise.allSettled([


### PR DESCRIPTION
## Summary

- Move slow-brain preparation event injection from `connectVoiceSession$` into the data channel `open` handler in `setupWebRTC$`
- Fixes race condition where prep events were silently dropped because the data channel was still in "connecting" state when injection was attempted
- The dc `open` handler guarantees the channel is ready, so `injectSlowBrainEvents$` guard will pass

## Problem

PR #8855 added prep event injection in `connectVoiceSession$` right after `setupWebRTC$` returns. But `setupWebRTC$` returns after `pc.setRemoteDescription()`, while the data channel only transitions to "open" 1-2s later (after ICE + DTLS). The `injectSlowBrainEvents$` guard checks `dc.readyState !== "open"` and silently drops all events.

## Changes

**`turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts`**
- Added prep event injection inside dc `open` handler (after `set(internalStatus$, "connected")`)
- Removed broken injection from `connectVoiceSession$`

## Test plan

- [ ] All existing tests pass (no frontend signal tests for this file — WebRTC APIs not available in Node.js)
- [ ] Lint, type-check, format pass
- [ ] Manual: voice-chat session confirms fast-brain receives user identity and agent rules from turn 1

Closes #8867

🤖 Generated with [Claude Code](https://claude.com/claude-code)