### PR TITLE
feat: add description infrastructure to feature switch system

### DIFF
--- a/turbo/apps/platform/src/views/lab-page/lab-page.tsx
+++ b/turbo/apps/platform/src/views/lab-page/lab-page.tsx
@@ -1,6 +1,6 @@
 import { useGet, useLastResolved, useSet } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import { FeatureSwitchKey } from "@vm0/core";
+import { FeatureSwitchKey, getFeatureSwitchDescriptions } from "@vm0/core";
 import { Switch, Button } from "@vm0/ui";
 import {
   featureSwitch$,
@@ -18,6 +18,7 @@ export function LabPage() {
   const [resetLoadable, reset] = useLoadableSet(resetFeatureSwitchOverrides$);
   const resetting = resetLoadable.state === "loading";
   const pageSignal = useGet(pageSignal$);
+  const descriptions = getFeatureSwitchDescriptions();
 
   const handleToggle = (key: FeatureSwitchKey, checked: boolean) => {
     const override = { [key]: checked } as Partial<
@@ -76,7 +77,14 @@ export function LabPage() {
                     key={key}
                     className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-muted/50 transition-colors"
                   >
-                    <span className="text-sm text-foreground">{key}</span>
+                    <div className="flex flex-col">
+                      <span className="text-sm text-foreground">{key}</span>
+                      {descriptions[key] && (
+                        <span className="text-xs text-muted-foreground">
+                          {descriptions[key]}
+                        </span>
+                      )}
+                    </div>
                     <Switch
                       checked={enabled}
                       onCheckedChange={(checked) => {

--- a/turbo/packages/core/src/__tests__/feature-switch.test.ts
+++ b/turbo/packages/core/src/__tests__/feature-switch.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { FeatureSwitchKey } from "../feature-switch-key";
-import { isFeatureEnabled, getAllFeatureStates } from "../feature-switch";
+import {
+  isFeatureEnabled,
+  getAllFeatureStates,
+  getFeatureSwitchDescriptions,
+} from "../feature-switch";
 
 describe("isFeatureEnabled", () => {
   it("should return true for globally enabled switch", () => {
@@ -99,6 +103,20 @@ describe("getAllFeatureStates", () => {
     expect(states[FeatureSwitchKey.Dummy]).toBe(false);
     // Other enabled features stay true
     expect(states[FeatureSwitchKey.Pricing]).toBe(true);
+  });
+});
+
+describe("getFeatureSwitchDescriptions", () => {
+  it("should return a record with all feature switch keys", () => {
+    const descriptions = getFeatureSwitchDescriptions();
+    for (const key of Object.values(FeatureSwitchKey)) {
+      expect(descriptions).toHaveProperty(key);
+    }
+  });
+
+  it("should return undefined for switches without description", () => {
+    const descriptions = getFeatureSwitchDescriptions();
+    expect(descriptions[FeatureSwitchKey.Dummy]).toBeUndefined();
   });
 });
 

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -9,6 +9,7 @@ import { FeatureSwitchKey } from "./feature-switch-key";
 
 export interface FeatureSwitch {
   readonly maintainer: string;
+  readonly description?: string;
   readonly enabled: boolean;
   readonly enabledUserHashes?: readonly string[];
   readonly enabledEmailHashes?: readonly string[];
@@ -294,6 +295,20 @@ export function getAllFeatureStates(
     }
   }
 
+  return result;
+}
+
+/**
+ * Return the description for every feature switch.
+ */
+export function getFeatureSwitchDescriptions(): Record<
+  FeatureSwitchKey,
+  string | undefined
+> {
+  const result = {} as Record<FeatureSwitchKey, string | undefined>;
+  for (const key of Object.values(FeatureSwitchKey)) {
+    result[key] = FEATURE_SWITCHES[key].description;
+  }
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Add optional `description` field to `FeatureSwitch` interface
- Export `getFeatureSwitchDescriptions()` getter function from `@vm0/core`
- Update Lab page to render description below each switch name

Closes #8870

## Test plan
- [x] `getFeatureSwitchDescriptions()` returns a record with all feature switch keys
- [x] Returns `undefined` for switches without description set
- [x] All 19 feature switch tests pass
- [x] Knip clean, lint clean, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)