### PR TITLE
feat: add descriptions for feature switches — batch a

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -54,6 +54,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.Agents]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable multi-agent orchestration in runs",
     enabled: true,
   },
   [FeatureSwitchKey.Secrets]: {
@@ -62,34 +63,42 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.Artifacts]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable artifact storage and management",
     enabled: false,
   },
   [FeatureSwitchKey.ApiKeys]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable platform-managed API key pool",
     enabled: false,
   },
   [FeatureSwitchKey.AhrefsConnector]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable the Ahrefs SEO connector",
     enabled: false,
   },
   [FeatureSwitchKey.CanvaConnector]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable the Canva design connector",
     enabled: false,
   },
   [FeatureSwitchKey.ComputerConnector]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable the Computer connector for local service tunneling",
     enabled: false,
   },
   [FeatureSwitchKey.DeelConnector]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable the Deel HR connector",
     enabled: false,
   },
   [FeatureSwitchKey.DocuSignConnector]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable the DocuSign e-signature connector",
     enabled: false,
   },
   [FeatureSwitchKey.DropboxConnector]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable the Dropbox file storage connector",
     enabled: false,
   },
   [FeatureSwitchKey.FigmaConnector]: {
@@ -118,6 +127,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.CloseConnector]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable the Close CRM connector",
     enabled: false,
   },
   [FeatureSwitchKey.WebflowConnector]: {
@@ -166,6 +176,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.DataExport]: {
     maintainer: "ethan@vm0.ai",
+    description: "Show the data export option in account menu",
     enabled: false,
   },
   [FeatureSwitchKey.ShowSystemPrompt]: {
@@ -178,10 +189,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.ConcurrentAddOn]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable the concurrent agent add-on purchase option",
     enabled: false,
   },
   [FeatureSwitchKey.CreditAddOn]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable the credit add-on purchase option",
     enabled: false,
   },
   [FeatureSwitchKey.ModelDetail]: {
@@ -198,6 +211,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.ComputerUse]: {
     maintainer: "ethan@vm0.ai",
+    description: "Enable remote desktop host registration",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
@@ -212,6 +226,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.AuditLink]: {
     maintainer: "ethan@vm0.ai",
+    description: "Show audit log links in Slack messages",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
@@ -227,6 +242,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
   },
   [FeatureSwitchKey.AutoSkill]: {
     maintainer: "lancy@vm0.ai",
+    description: "Enable automatic skill creation in agent prompts",
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },


### PR DESCRIPTION
## Summary
- Add `description` strings to 16 feature switch entries in the `FEATURE_SWITCHES` registry
- Descriptions researched by tracing each switch's usage in the codebase

## Switches Updated (16)

| # | Key | Description |
|---|-----|-------------|
| 1 | AhrefsConnector | Enable the Ahrefs SEO connector |
| 2 | Agents | Enable multi-agent orchestration in runs |
| 3 | ApiKeys | Enable platform-managed API key pool |
| 4 | Artifacts | Enable artifact storage and management |
| 5 | AuditLink | Show audit log links in Slack messages |
| 6 | AutoSkill | Enable automatic skill creation in agent prompts |
| 7 | CanvaConnector | Enable the Canva design connector |
| 8 | CloseConnector | Enable the Close CRM connector |
| 9 | ComputerConnector | Enable the Computer connector for local service tunneling |
| 10 | ComputerUse | Enable remote desktop host registration |
| 11 | ConcurrentAddOn | Enable the concurrent agent add-on purchase option |
| 12 | CreditAddOn | Enable the credit add-on purchase option |
| 13 | DataExport | Show the data export option in account menu |
| 14 | DeelConnector | Enable the Deel HR connector |
| 15 | DocuSignConnector | Enable the DocuSign e-signature connector |
| 16 | DropboxConnector | Enable the Dropbox file storage connector |

## Context
- Part of Epic #8869
- Closes #8871
- Depends on #8870 (infrastructure, already merged)
- Batches B (#8872) and C (#8873) follow sequentially

## Test plan
- [x] All existing core package tests pass (687/687)
- [x] Lint passes with 0 warnings
- [x] Type check passes for @vm0/core
- [x] Knip finds no issues
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)