### PR TITLE
fix(mitm-addon): replace --quiet with flow_detail=0 + termlog_verbosity=warn

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -154,7 +154,6 @@ async def request(flow: http.HTTPFlow) -> None:
 
     if not vm_info:
         # Not a registered VM, pass through without proxying
-        ctx.log.info(f"No VM registration for {client_ip}, passing through")
         return
 
     run_id = vm_info.get("runId", "")
@@ -182,7 +181,6 @@ async def request(flow: http.HTTPFlow) -> None:
         parsed_api = urllib.parse.urlparse(api_url)
         api_hostname = parsed_api.hostname.lower() if parsed_api.hostname else ""
         if api_hostname and (hostname == api_hostname or hostname.endswith(f".{api_hostname}")):
-            ctx.log.info(f"[{run_id}] Auto-allow VM0 API: {hostname}")
             flow.metadata["firewall_action"] = "ALLOW"
             return
 
@@ -230,7 +228,6 @@ async def request(flow: http.HTTPFlow) -> None:
 
     # No firewall match — pass through directly
     flow.metadata["firewall_action"] = "ALLOW"
-    ctx.log.info(f"[{run_id}] ALLOW: {hostname}")
 
 
 _STREAM_BUFFER_LIMIT = 64 * 1024  # 64 KB
@@ -795,8 +792,7 @@ def response(flow: http.HTTPFlow) -> None:
         api_id = flow.metadata.get("firewall_api_id", "")
         if api_id:
             cache_key = (run_id, api_id)
-            if _firewall_header_cache.pop(cache_key, None):
-                ctx.log.info(f"[{run_id}] Firewall {api_id}: 401 - cleared header cache")
+            _firewall_header_cache.pop(cache_key, None)
 
     # Log errors to mitmproxy console
     if flow.response and flow.response.status_code >= 400:

--- a/crates/runner/src/proxy.rs
+++ b/crates/runner/src/proxy.rs
@@ -270,7 +270,10 @@ pub(crate) async fn spawn_mitmdump(
         ))
         .arg("--scripts")
         .arg(config.addon_dir.join("mitm_addon.py"))
-        .arg("--quiet")
+        .arg("--set")
+        .arg("flow_detail=0")
+        .arg("--set")
+        .arg("termlog_verbosity=warn")
         .arg("--set")
         .arg(format!(
             "ssl_verify_upstream_trusted_ca={}",


### PR DESCRIPTION
## Summary

- Replace mitmproxy `--quiet` flag with `--set flow_detail=0 --set termlog_verbosity=warn` in `proxy.rs`
- Remove 4 redundant `ctx.log.info` calls from `mitm_addon.py` (ALLOW/pass-through decisions already captured in per-run network logs)

## Why

`--quiet` sets `termlog_verbosity=error`, which suppresses all `ctx.log.info` and `ctx.log.warn` output from addon scripts. This makes it impossible to debug firewall denials, usage reporting failures, and other critical diagnostics.

The new flags suppress flow display output and connection lifecycle spam while keeping addon `ctx.log.warn` visible.

## Verification

Confirmed via mitmproxy v12.2.1 source:
- `--quiet` → `termlog_verbosity="error"` + `flow_detail=0` ([source](https://github.com/mitmproxy/mitmproxy/blob/v12.2.1/mitmproxy/tools/main.py#L27-L30))
- Connection lifecycle logs (`client connect`/`server connect`/`server disconnect`) are INFO level ([source](https://github.com/mitmproxy/mitmproxy/blob/v12.2.1/mitmproxy/proxy/server.py))
- `termlog_verbosity=warn` filters INFO but passes WARNING+ ([source](https://github.com/mitmproxy/mitmproxy/blob/v12.2.1/mitmproxy/addons/termlog.py))

Closes #8882

🤖 Generated with [Claude Code](https://claude.com/claude-code)