### PR TITLE
feat(voice-chat): add hands-free/push-to-talk input mode controls

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -186,6 +186,7 @@ const internalPrompt$ = state<string | null>(null);
 const internalPrepStartTime$ = state<number | null>(null);
 const internalPrepElapsedMs$ = state(0);
 const internalReconnectAttempt$ = state(0);
+const internalInputMode$ = state<"hands-free" | "push-to-talk">("hands-free");
 
 const internalParentSignal$ = state<AbortSignal | null>(null);
 
@@ -225,6 +226,9 @@ export const vcPrepElapsedMs$ = computed((get) => {
 });
 export const vcReconnectAttempt$ = computed((get) => {
   return get(internalReconnectAttempt$);
+});
+export const vcInputMode$ = computed((get) => {
+  return get(internalInputMode$);
 });
 export const vcMeetingPromptInput$ = computed((get) => {
   return get(meetingPromptInput$);
@@ -473,6 +477,17 @@ const setupWebRTC$ = command(
     set(internalDc$, dc);
 
     dc.addEventListener("open", () => {
+      const inputMode = get(internalInputMode$);
+      const turnDetection =
+        inputMode === "hands-free"
+          ? {
+              type: "server_vad",
+              threshold: 0.8,
+              prefix_padding_ms: 300,
+              silence_duration_ms: 600,
+            }
+          : null;
+
       dc.send(
         JSON.stringify({
           type: "session.update",
@@ -480,12 +495,7 @@ const setupWebRTC$ = command(
             modalities: ["text", "audio"],
             instructions: FAST_BRAIN_INSTRUCTIONS,
             input_audio_transcription: { model: "whisper-1" },
-            turn_detection: {
-              type: "server_vad",
-              threshold: 0.8,
-              prefix_padding_ms: 300,
-              silence_duration_ms: 600,
-            },
+            turn_detection: turnDetection,
             tools: SESSION_TOOLS,
           },
         }),
@@ -1133,6 +1143,7 @@ export const endVoiceChat$ = command(({ get, set }) => {
   set(internalPrepStartTime$, null);
   set(internalPrepElapsedMs$, 0);
   set(internalReconnectAttempt$, 0);
+  set(internalInputMode$, "hands-free");
   set(internalParentSignal$, null);
   set(internalStatus$, "idle");
 });
@@ -1159,4 +1170,81 @@ export const toggleVoiceChatMute$ = command(({ get, set }) => {
   const wasMuted = get(internalMuted$);
   track.enabled = wasMuted;
   set(internalMuted$, !wasMuted);
+});
+
+export const switchInputMode$ = command(
+  ({ get, set }, mode: "hands-free" | "push-to-talk") => {
+    const dc = get(internalDc$);
+    if (!dc || dc.readyState !== "open") {
+      return;
+    }
+
+    set(internalInputMode$, mode);
+
+    const turnDetection =
+      mode === "hands-free"
+        ? {
+            type: "server_vad",
+            threshold: 0.8,
+            prefix_padding_ms: 300,
+            silence_duration_ms: 600,
+          }
+        : null;
+
+    dc.send(
+      JSON.stringify({
+        type: "session.update",
+        session: { turn_detection: turnDetection },
+      }),
+    );
+
+    // PTT starts muted, hands-free starts unmuted
+    const stream = get(internalStream$);
+    if (!stream) {
+      return;
+    }
+    const track = stream.getAudioTracks()[0];
+    if (!track) {
+      return;
+    }
+
+    if (mode === "push-to-talk") {
+      track.enabled = false;
+      set(internalMuted$, true);
+    } else {
+      track.enabled = true;
+      set(internalMuted$, false);
+    }
+  },
+);
+
+export const startPTT$ = command(({ get, set }) => {
+  const stream = get(internalStream$);
+  if (!stream) {
+    return;
+  }
+  const track = stream.getAudioTracks()[0];
+  if (!track) {
+    return;
+  }
+  track.enabled = true;
+  set(internalMuted$, false);
+});
+
+export const stopPTT$ = command(({ get, set }) => {
+  const stream = get(internalStream$);
+  if (!stream) {
+    return;
+  }
+  const track = stream.getAudioTracks()[0];
+  if (!track) {
+    return;
+  }
+  track.enabled = false;
+  set(internalMuted$, true);
+
+  const dc = get(internalDc$);
+  if (dc && dc.readyState === "open") {
+    dc.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
+  }
 });

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -65,6 +65,12 @@ const PREP_TIMEOUT_MEETING_MS = 300_000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 1000;
 const REALTIME_MODEL = "gpt-realtime-1.5";
+const SERVER_VAD_CONFIG = {
+  type: "server_vad",
+  threshold: 0.8,
+  prefix_padding_ms: 300,
+  silence_duration_ms: 600,
+} as const;
 
 const SESSION_TOOLS = [
   {
@@ -479,14 +485,7 @@ const setupWebRTC$ = command(
     dc.addEventListener("open", () => {
       const inputMode = get(internalInputMode$);
       const turnDetection =
-        inputMode === "hands-free"
-          ? {
-              type: "server_vad",
-              threshold: 0.8,
-              prefix_padding_ms: 300,
-              silence_duration_ms: 600,
-            }
-          : null;
+        inputMode === "hands-free" ? SERVER_VAD_CONFIG : null;
 
       dc.send(
         JSON.stringify({
@@ -1181,15 +1180,7 @@ export const switchInputMode$ = command(
 
     set(internalInputMode$, mode);
 
-    const turnDetection =
-      mode === "hands-free"
-        ? {
-            type: "server_vad",
-            threshold: 0.8,
-            prefix_padding_ms: 300,
-            silence_duration_ms: 600,
-          }
-        : null;
+    const turnDetection = mode === "hands-free" ? SERVER_VAD_CONFIG : null;
 
     dc.send(
       JSON.stringify({

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -1,7 +1,7 @@
 // TODO(#8609): split large components to comply with max-lines-per-function (128)
 // oxlint-disable max-lines-per-function
 import { useGet, useLastResolved, useSet } from "ccstate-react";
-import { Button, cn } from "@vm0/ui";
+import { Button, Tabs, TabsList, TabsTrigger, cn } from "@vm0/ui";
 import {
   IconMicrophone,
   IconMicrophoneOff,
@@ -9,6 +9,7 @@ import {
   IconLoader2,
   IconRefresh,
 } from "@tabler/icons-react";
+import type { TouchEvent as ReactTouchEvent } from "react";
 import { defaultAgentName$ } from "../../signals/agent.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -30,6 +31,10 @@ import {
   endVoiceChat$,
   retryVoiceChat$,
   toggleVoiceChatMute$,
+  vcInputMode$,
+  switchInputMode$,
+  startPTT$,
+  stopPTT$,
 } from "../../signals/voice-chat/voice-chat-session.ts";
 import {
   setTranscriptScrollContainer$,
@@ -101,6 +106,105 @@ function StatusBadge({
   );
 }
 
+function VoiceChatFooter({
+  status,
+  inputMode,
+  muted,
+  switchMode,
+  toggleMute,
+  pttStart,
+  pttStop,
+  onRetry,
+}: {
+  status: string;
+  inputMode: "hands-free" | "push-to-talk";
+  muted: boolean;
+  switchMode: (mode: "hands-free" | "push-to-talk") => void;
+  toggleMute: () => void;
+  pttStart: () => void;
+  pttStop: () => void;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="border-t px-4 py-3 flex items-center justify-between gap-4">
+      {/* Left: Segmented Control */}
+      <Tabs
+        value={inputMode}
+        onValueChange={(v) => {
+          if (status === "connected") {
+            switchMode(v as "hands-free" | "push-to-talk");
+          }
+        }}
+      >
+        <TabsList
+          className={cn(
+            status !== "connected" && "pointer-events-none opacity-50",
+          )}
+        >
+          <TabsTrigger value="hands-free">Hands-free</TabsTrigger>
+          <TabsTrigger value="push-to-talk">Push to Talk</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      {/* Right: Context-Sensitive Action Button */}
+      {status === "disconnected" ? (
+        <Button
+          variant="secondary"
+          className="h-12 px-6 rounded-full"
+          onClick={onRetry}
+        >
+          <IconRefresh size={20} className="mr-2" />
+          Retry
+        </Button>
+      ) : inputMode === "push-to-talk" ? (
+        <Button
+          variant={muted ? "secondary" : "default"}
+          className="h-12 px-6 rounded-full select-none"
+          disabled={status !== "connected"}
+          onMouseDown={() => {
+            pttStart();
+          }}
+          onMouseUp={() => {
+            pttStop();
+          }}
+          onMouseLeave={() => {
+            if (!muted) {
+              pttStop();
+            }
+          }}
+          onTouchStart={(e: ReactTouchEvent) => {
+            e.preventDefault();
+            pttStart();
+          }}
+          onTouchEnd={(e: ReactTouchEvent) => {
+            e.preventDefault();
+            pttStop();
+          }}
+        >
+          <IconMicrophone size={20} className="mr-2" />
+          {muted ? "Hold to Talk" : "Recording..."}
+        </Button>
+      ) : (
+        <Button
+          variant={muted ? "destructive" : "secondary"}
+          className="h-12 px-6 rounded-full"
+          disabled={status !== "connected"}
+          onClick={() => {
+            toggleMute();
+          }}
+        >
+          {muted ? (
+            <IconMicrophoneOff size={20} className="mr-2" />
+          ) : (
+            <IconMicrophone size={20} className="mr-2" />
+          )}
+          {muted ? "Unmute" : "Mute"}
+        </Button>
+      )}
+    </div>
+  );
+}
+
 export function VoiceChatPage() {
   const pageSignal = useGet(pageSignal$);
   const enabled = useLastResolved(vcEnabled$);
@@ -116,6 +220,10 @@ export function VoiceChatPage() {
   const toggleMute = useSet(toggleVoiceChatMute$);
   const reconnectAttempt = useGet(vcReconnectAttempt$);
   const retrySession = useSet(retryVoiceChat$);
+  const inputMode = useGet(vcInputMode$);
+  const switchMode = useSet(switchInputMode$);
+  const pttStart = useSet(startPTT$);
+  const pttStop = useSet(stopPTT$);
   const prompt = useGet(vcPrompt$);
   const prepElapsedMs = useGet(vcPrepElapsedMs$);
   const meetingPrompt = useGet(vcMeetingPromptInput$);
@@ -376,46 +484,18 @@ export function VoiceChatPage() {
         </div>
       </div>
 
-      {/* Audio controls footer */}
-      <div className="border-t px-4 py-3 flex items-center justify-center gap-4">
-        <Button
-          variant={muted ? "destructive" : "secondary"}
-          size="icon"
-          className="h-12 w-12 rounded-full"
-          onClick={() => {
-            toggleMute();
-          }}
-          disabled={status !== "connected"}
-        >
-          {muted ? (
-            <IconMicrophoneOff size={20} />
-          ) : (
-            <IconMicrophone size={20} />
-          )}
-        </Button>
-        {status === "disconnected" && (
-          <Button
-            variant="secondary"
-            size="icon"
-            className="h-12 w-12 rounded-full"
-            onClick={() => {
-              detach(retrySession(pageSignal), Reason.DomCallback);
-            }}
-          >
-            <IconRefresh size={20} />
-          </Button>
-        )}
-        <Button
-          variant="destructive"
-          size="icon"
-          className="h-12 w-12 rounded-full"
-          onClick={() => {
-            endSession();
-          }}
-        >
-          <IconPhoneOff size={20} />
-        </Button>
-      </div>
+      <VoiceChatFooter
+        status={status}
+        inputMode={inputMode}
+        muted={muted}
+        switchMode={switchMode}
+        toggleMute={toggleMute}
+        pttStart={pttStart}
+        pttStop={pttStop}
+        onRetry={() => {
+          detach(retrySession(pageSignal), Reason.DomCallback);
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add segmented control for switching between Hands-free (VAD) and Push to Talk input modes in voice chat bottom controls
- Hands-free mode: action button toggles mute/unmute (preserves current behavior as default)
- Push to Talk mode: hold button to speak, release to send `input_audio_buffer.commit`
- Mode switch sends `session.update` with appropriate `turn_detection` value via data channel
- Remove redundant bottom End Session button (header button is sufficient)
- Extract `VoiceChatFooter` component to keep complexity under lint threshold

## Changes

### `voice-chat-session.ts` (Signal layer)
- `internalInputMode$` state atom: `"hands-free" | "push-to-talk"`, default `"hands-free"`
- `vcInputMode$` exported computed
- `switchInputMode$` command: sends `session.update`, toggles mic based on mode
- `startPTT$` / `stopPTT$` commands: unmute/mute mic, stopPTT sends `input_audio_buffer.commit`
- Dynamic `turn_detection` in dc `open` handler (preserves mode on reconnect)
- Reset to `"hands-free"` in `endVoiceChat$`

### `voice-chat-page.tsx` (UI layer)
- New `VoiceChatFooter` component with segmented control (Tabs) + context-sensitive action button
- PTT button wires mousedown/mouseup/mouseleave + touchstart/touchend for mobile support
- Segmented control disabled when not connected
- Disconnected state shows Retry button regardless of mode

## Test plan

- [ ] All 1620 existing tests pass (verified locally)
- [ ] Lint passes (0 errors, 0 warnings)
- [ ] Type check passes (no new errors)
- [ ] Knip passes (no unused exports)
- [ ] Manual: default mode is Hands-free with mute/unmute button
- [ ] Manual: switching to PTT mutes mic, shows "Hold to Talk" button
- [ ] Manual: holding PTT button unmutes, releasing mutes + sends commit
- [ ] Manual: mode switch sends session.update with correct turn_detection
- [ ] Manual: mode resets to Hands-free on End Session
- [ ] Manual: reconnect preserves selected mode

Closes #8893

🤖 Generated with [Claude Code](https://claude.com/claude-code)