### PR TITLE
fix(runner): drop discover future before shutdown to prevent mutex deadlock

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -740,6 +740,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
     // Shutdown — drain idle pool, release discovery resources, then drain running jobs
     // -----------------------------------------------------------------------
 
+    // Drop the pinned discover future so it releases the discovery Mutex.
+    // Without this, provider.shutdown() deadlocks trying to acquire the
+    // same Mutex that the still-alive discover_fut holds.
+    drop(discover_fut);
+
     // Drain idle pool first — these VMs hold budget reservations.
     let idle_entries = idle_pool.lock().await.drain();
     if !idle_entries.is_empty() {

--- a/crates/runner/src/provider/api.rs
+++ b/crates/runner/src/provider/api.rs
@@ -288,12 +288,13 @@ impl JobProvider for ApiProvider {
     /// # Ordering requirement
     ///
     /// `discover()` holds the discovery Mutex for its entire loop.
-    /// Callers must cancel the `CancellationToken` *before* calling
-    /// `shutdown()` so that `discover()` observes the cancellation,
-    /// returns `None`, and releases the lock. The main loop in
-    /// `start.rs` guarantees this: the signal handler cancels the
-    /// token, `discover()` returns `None` breaking the loop, and
-    /// then `shutdown()` is called.
+    /// The caller must ensure the `discover()` future is no longer
+    /// alive before calling `shutdown()`. Two paths accomplish this:
+    ///
+    /// 1. `discover()` observes the cancelled token and returns `None`,
+    ///    releasing the lock naturally.
+    /// 2. The main loop breaks (e.g. on `Draining` mode) and explicitly
+    ///    drops the pinned future, which releases the lock.
     async fn shutdown(&self) {
         let mut state = self.discovery.lock().await;
         // Drop Ably subscription to close WebSocket


### PR DESCRIPTION
## Summary

- Drop `discover_fut` before the shutdown sequence in `start.rs` to release the discovery Mutex
- Prevents deadlock where `provider.shutdown()` waits forever to acquire a Mutex held by the still-alive `discover_fut`

## Root Cause

When the main loop breaks on `RunnerMode::Draining`, the pinned `discover_fut` remains in scope holding the discovery Mutex. The cancellation token is cancelled by the signal handler, but `discover_fut` is never polled again to observe it — so it never returns `None` and never releases the lock. `provider.shutdown()` then deadlocks trying to acquire the same Mutex.

## Fix

Explicitly `drop(discover_fut)` at the start of the shutdown sequence, before idle pool drain and `provider.shutdown()`.

Closes #8890

🤖 Generated with [Claude Code](https://claude.com/claude-code)