### PR TITLE
fix(ci): increase runner e2e bats timeout from 60s to 120s

### DIFF
--- a/.github/workflows/turbo.yml
+++ b/.github/workflows/turbo.yml
@@ -1806,7 +1806,7 @@ jobs:
           echo "=== Running Runner E2E Tests (Chunk ${{ matrix.index }}, ${PARALLEL} parallel, total capacity ${RUNNER_TOTAL_CAPACITY}) ==="
           echo "Files: ${{ matrix.files }}"
           mkdir -p e2e/results
-          BATS_TEST_TIMEOUT=60 ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files --report-formatter junit --output e2e/results ${{ matrix.files }}
+          BATS_TEST_TIMEOUT=120 ./e2e/test/libs/bats/bin/bats -T -j "${PARALLEL}" --no-parallelize-within-files --report-formatter junit --output e2e/results ${{ matrix.files }}
           echo "✅ Chunk ${{ matrix.index }} tests passed"
         env:
           RUNNER_TOTAL_CAPACITY: ${{ needs.deploy-runner-start.outputs.total-capacity }}

--- a/docs/testing/cli-e2e-testing.md
+++ b/docs/testing/cli-e2e-testing.md
@@ -419,5 +419,5 @@ Before committing E2E tests:
 ## Reference
 
 - BATS documentation: https://bats-core.readthedocs.io/en/stable/writing-tests.html
-- Test timeout: `BATS_TEST_TIMEOUT=30` (serial) / `BATS_TEST_TIMEOUT=60` (parallel/runner)
+- Test timeout: `BATS_TEST_TIMEOUT=30` (serial) / `BATS_TEST_TIMEOUT=120` (parallel/runner)
 - Parallelization: `-j 10 --no-parallelize-within-files`

--- a/e2e/helpers/trace-vm0.sh
+++ b/e2e/helpers/trace-vm0.sh
@@ -8,9 +8,9 @@
 #
 # Uses GNU timeout to ensure the entire process tree is killed on
 # timeout (timeout creates a process group and sends SIGTERM to the
-# whole group). CLI_TIMEOUT defaults to 55s, leaving headroom for
+# whole group). CLI_TIMEOUT defaults to 90s, leaving headroom for
 # BATS_TEST_TIMEOUT (typically 120s) to handle cleanup.
-CLI_TIMEOUT="${CLI_TIMEOUT:-55}"
+CLI_TIMEOUT="${CLI_TIMEOUT:-90}"
 TAG="[${BATS_TEST_FILENAME##*/}] ${BATS_TEST_NAME}"
 echo "$(date +%T) $TAG: START vm0 $*" >> /tmp/e2e-trace.log 2>/dev/null
 START=$SECONDS

--- a/e2e/helpers/trace-vm0.sh
+++ b/e2e/helpers/trace-vm0.sh
@@ -9,7 +9,7 @@
 # Uses GNU timeout to ensure the entire process tree is killed on
 # timeout (timeout creates a process group and sends SIGTERM to the
 # whole group). CLI_TIMEOUT defaults to 55s, leaving headroom for
-# BATS_TEST_TIMEOUT (typically 60s) to handle cleanup.
+# BATS_TEST_TIMEOUT (typically 120s) to handle cleanup.
 CLI_TIMEOUT="${CLI_TIMEOUT:-55}"
 TAG="[${BATS_TEST_FILENAME##*/}] ${BATS_TEST_NAME}"
 echo "$(date +%T) $TAG: START vm0 $*" >> /tmp/e2e-trace.log 2>/dev/null

--- a/e2e/helpers/trace-zero.sh
+++ b/e2e/helpers/trace-zero.sh
@@ -9,7 +9,7 @@
 # Uses GNU timeout to ensure the entire process tree is killed on
 # timeout (timeout creates a process group and sends SIGTERM to the
 # whole group). CLI_TIMEOUT defaults to 55s, leaving headroom for
-# BATS_TEST_TIMEOUT (typically 60s) to handle cleanup.
+# BATS_TEST_TIMEOUT (typically 120s) to handle cleanup.
 CLI_TIMEOUT="${CLI_TIMEOUT:-55}"
 TAG="[${BATS_TEST_FILENAME##*/}] ${BATS_TEST_NAME}"
 echo "$(date +%T) $TAG: START zero $*" >> /tmp/e2e-trace.log 2>/dev/null

--- a/e2e/helpers/trace-zero.sh
+++ b/e2e/helpers/trace-zero.sh
@@ -8,9 +8,9 @@
 #
 # Uses GNU timeout to ensure the entire process tree is killed on
 # timeout (timeout creates a process group and sends SIGTERM to the
-# whole group). CLI_TIMEOUT defaults to 55s, leaving headroom for
+# whole group). CLI_TIMEOUT defaults to 90s, leaving headroom for
 # BATS_TEST_TIMEOUT (typically 120s) to handle cleanup.
-CLI_TIMEOUT="${CLI_TIMEOUT:-55}"
+CLI_TIMEOUT="${CLI_TIMEOUT:-90}"
 TAG="[${BATS_TEST_FILENAME##*/}] ${BATS_TEST_NAME}"
 echo "$(date +%T) $TAG: START zero $*" >> /tmp/e2e-trace.log 2>/dev/null
 START=$SECONDS


### PR DESCRIPTION
## Summary
- Increase `BATS_TEST_TIMEOUT` for runner E2E tests from 60s to 120s
- The telemetry test (`t15`) runs an agent then polls logs across 8 steps (each `wait_for_log` up to 30s), regularly exceeding the 60s limit
- Example failure: https://github.com/vm0-ai/vm0/actions/runs/24248062171/job/70800220340

## Test plan
- [x] No behavior change — only CI timeout configuration
- [ ] Verify t15 passes in merge queue with the new timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)