### PR TITLE
fix(mitm-addon): decompress sse stream before usage extraction

### DIFF
--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -557,7 +557,7 @@ def _create_stream_decompressor(headers: http.Headers):
             try:
                 return obj.decompress(chunk)
             except zlib.error:
-                return chunk
+                return b""
 
         return decompress_zlib
     if encoding == "br":
@@ -567,7 +567,7 @@ def _create_stream_decompressor(headers: http.Headers):
             try:
                 return dec.process(chunk)
             except brotli.error:
-                return chunk
+                return b""
 
         return decompress_br
     if encoding == "zstd":
@@ -577,7 +577,7 @@ def _create_stream_decompressor(headers: http.Headers):
             try:
                 return obj.decompress(chunk)
             except zstandard.ZstdError:
-                return chunk
+                return b""
 
         return decompress_zstd
     return None

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -478,6 +478,7 @@ def responseheaders(flow: http.HTTPFlow) -> None:
     # For non-SSE model provider responses, disable buffer truncation so the
     # full JSON body is available for usage extraction in response().
     sse_parser = None
+    sse_decompressor = None
     is_model_provider = flow.metadata.get("firewall_name", "").startswith("model-provider:")
     if is_model_provider:
         content_type = flow.response.headers.get("content-type", "")
@@ -485,6 +486,7 @@ def responseheaders(flow: http.HTTPFlow) -> None:
             parser_fn, usage_dict = _create_sse_usage_extractor()
             sse_parser = parser_fn
             flow.metadata["proxy_usage"] = usage_dict
+            sse_decompressor = _create_stream_decompressor(flow.response.headers)
 
     # Model provider responses are never truncated so usage extraction
     # always has the complete body.  Other responses use the 64 KB limit.
@@ -502,7 +504,8 @@ def responseheaders(flow: http.HTTPFlow) -> None:
                     buf.extend(chunk[:remaining])
                     state["truncated"] = True
         if sse_parser is not None:
-            sse_parser(chunk)
+            plaintext = sse_decompressor(chunk) if sse_decompressor else chunk
+            sse_parser(plaintext)
         return chunk
 
     flow.response.stream = stream_and_buffer
@@ -535,6 +538,49 @@ _SENSITIVE_HEADER_KEYWORDS = (
     "password",
     "cookie",
 )
+
+
+def _create_stream_decompressor(headers: http.Headers):
+    """Create an incremental decompressor for streaming chunks.
+
+    Returns a callable that decompresses each chunk, maintaining state
+    across calls.  Returns None if the response is not compressed.
+    """
+    encoding = headers.get("content-encoding", "").strip().lower()
+    if not encoding or encoding == "identity":
+        return None
+    if encoding in ("gzip", "deflate"):
+        wbits = 16 + zlib.MAX_WBITS if encoding == "gzip" else zlib.MAX_WBITS
+        obj = zlib.decompressobj(wbits)
+
+        def decompress_zlib(chunk: bytes) -> bytes:
+            try:
+                return obj.decompress(chunk)
+            except zlib.error:
+                return chunk
+
+        return decompress_zlib
+    if encoding == "br":
+        dec = brotli.Decompressor()
+
+        def decompress_br(chunk: bytes) -> bytes:
+            try:
+                return dec.process(chunk)
+            except brotli.error:
+                return chunk
+
+        return decompress_br
+    if encoding == "zstd":
+        obj = zstandard.ZstdDecompressor().decompressobj()
+
+        def decompress_zstd(chunk: bytes) -> bytes:
+            try:
+                return obj.decompress(chunk)
+            except zstandard.ZstdError:
+                return chunk
+
+        return decompress_zstd
+    return None
 
 
 def _decompress_body(

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -995,6 +995,37 @@ class TestResponseHeadersSseParser:
         assert flow.metadata["proxy_usage"]["model"] == "claude-sonnet-4-6"
         assert flow.metadata["proxy_usage"]["input_tokens"] == 42
 
+    def test_decompresses_gzip_sse_before_parsing(self):
+        """Compressed SSE streams must be decompressed before usage extraction."""
+        import gzip
+
+        flow = _make_http_flow(host="api.anthropic.com")
+        flow.response = MagicMock()
+        flow.response.headers = {
+            "content-type": "text/event-stream; charset=utf-8",
+            "content-encoding": "gzip",
+        }
+        flow.response.stream = False
+        flow.metadata["firewall_name"] = "model-provider:anthropic-api-key"
+
+        mitm_addon.responseheaders(flow)
+
+        assert "proxy_usage" in flow.metadata
+        callback = flow.response.stream
+        plaintext = (
+            b"event: message_start\n"
+            b'data: {"type":"message_start","message":'
+            b'{"model":"claude-sonnet-4-6",'
+            b'"usage":{"input_tokens":99}}}\n\n'
+        )
+        compressed = gzip.compress(plaintext)
+        # Callback returns original compressed bytes to client
+        result = callback(compressed)
+        assert result == compressed
+        # But parser receives decompressed data
+        assert flow.metadata["proxy_usage"]["model"] == "claude-sonnet-4-6"
+        assert flow.metadata["proxy_usage"]["input_tokens"] == 99
+
     def test_no_sse_parser_for_non_model_provider(self):
         flow = _make_http_flow(host="api.github.com")
         flow.response = MagicMock()


### PR DESCRIPTION
## Summary

- Add `_create_stream_decompressor()` that creates an incremental decompressor (gzip/deflate/br/zstd) for streaming SSE chunks
- Decompress chunks before feeding to the SSE usage parser in `responseheaders()`
- Return original compressed bytes to the client unchanged
- Add regression test for gzip-compressed SSE streams

## Root Cause

The SSE usage parser in `stream_and_buffer()` receives raw compressed chunks when the upstream server returns `Content-Encoding: gzip`. The parser expects plaintext SSE data (`event: message_start\ndata: {...}\n`), so it silently fails to extract any usage — `proxy_usage` stays as `{}`.

Whether the response is compressed depends on the client's `Accept-Encoding` header — Claude Code sometimes sends it, sometimes doesn't. This is the root cause of empty `proxy_credit_usage` rows.

## Fix

Create an incremental decompressor in `responseheaders()` based on the `Content-Encoding` header. Each chunk is decompressed before passing to the SSE parser, while the original compressed bytes are returned to the client untouched.

Closes #8884

🤖 Generated with [Claude Code](https://claude.com/claude-code)