### PR TITLE
fix(voice-chat): send response.create after ptt commit to trigger agent response

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -1237,5 +1237,6 @@ export const stopPTT$ = command(({ get, set }) => {
   const dc = get(internalDc$);
   if (dc && dc.readyState === "open") {
     dc.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
+    dc.send(JSON.stringify({ type: "response.create" }));
   }
 });

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -141,8 +141,12 @@ function VoiceChatFooter({
             status !== "connected" && "pointer-events-none opacity-50",
           )}
         >
-          <TabsTrigger value="hands-free">Hands-free</TabsTrigger>
-          <TabsTrigger value="push-to-talk">Push to Talk</TabsTrigger>
+          <TabsTrigger value="hands-free" className="text-xs px-2">
+            Hands-free
+          </TabsTrigger>
+          <TabsTrigger value="push-to-talk" className="text-xs px-2">
+            Push to Talk
+          </TabsTrigger>
         </TabsList>
       </Tabs>
 


### PR DESCRIPTION
## Summary

- Add missing `response.create` message after `input_audio_buffer.commit` in `stopPTT$` command to trigger agent audio response in PTT mode
- Reduce segmented control ("Hands-free" / "Push to Talk") padding and font size for mobile viewport compatibility

## Problem

After releasing the Push to Talk button, user speech was transcribed but the agent did not generate an audio response. In PTT mode (`turn_detection: null`), the OpenAI Realtime API requires an explicit `response.create` after `input_audio_buffer.commit` — without it, the audio buffer is committed as a user message but the model never responds.

The segmented control was also too wide (~231px) for 375px mobile viewports, crowding the action button.

## Changes

| File | Change |
|------|--------|
| `turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts` | Add `response.create` send after `input_audio_buffer.commit` in `stopPTT$` |
| `turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx` | Add `text-xs px-2` classes to `TabsTrigger` elements |

## Test plan

- [ ] Start a voice chat session
- [ ] Switch to "Push to Talk" mode
- [ ] Press and hold the PTT button, speak, then release
- [ ] Verify the agent generates an audio response (not just transcription)
- [ ] Verify hands-free mode still works correctly
- [ ] Verify segmented control fits on 375px mobile viewport without crowding the action button
- [ ] All existing tests pass
- [ ] Lint, format, knip pass

Closes #8904

🤖 Generated with [Claude Code](https://claude.com/claude-code)