### PR TITLE
fix(credit): only flag proxy usage undercount, not overcount

### DIFF
--- a/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/credit/__tests__/proxy-usage-comparison-service.test.ts
@@ -25,7 +25,7 @@ function callsForOrg(
 ): Array<Record<string, unknown>> {
   return spy.mock.calls
     .filter((call) => {
-      return call[0] === "Proxy usage mismatch";
+      return call[0] === "Proxy usage undercount";
     })
     .map((call) => {
       return call[1] as Record<string, unknown>;
@@ -105,8 +105,42 @@ describe("compareRecentRunsProxyUsage", () => {
     expect(callsForOrg(logSpy, orgId)).toHaveLength(0);
   });
 
-  it("logs error for mismatching usage within window", async () => {
-    const { orgId, userId } = await context.setupUser({ prefix: "mismatch" });
+  it("logs error when proxy undercount (proxy < client)", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "under" });
+
+    const runId = await createCompletedRun(
+      orgId,
+      userId,
+      new Date(Date.now() - 120_000),
+    );
+    await insertTestCreditUsageForRun({
+      runId,
+      orgId,
+      userId,
+      status: "processed",
+    });
+    await insertTestProxyCreditUsage({
+      runId,
+      orgId,
+      userId,
+      inputTokens: 30,
+      outputTokens: 50,
+    });
+
+    await compareRecentRunsProxyUsage();
+
+    const calls = callsForOrg(logSpy, orgId);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      runId,
+      field: "inputTokens",
+      clientValue: 100,
+      proxyValue: 30,
+    });
+  });
+
+  it("does not log when proxy overcounts (subagent usage)", async () => {
+    const { orgId, userId } = await context.setupUser({ prefix: "over" });
 
     const runId = await createCompletedRun(
       orgId,
@@ -129,14 +163,7 @@ describe("compareRecentRunsProxyUsage", () => {
 
     await compareRecentRunsProxyUsage();
 
-    const calls = callsForOrg(logSpy, orgId);
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toMatchObject({
-      runId,
-      field: "inputTokens",
-      clientValue: 100,
-      proxyValue: 200,
-    });
+    expect(callsForOrg(logSpy, orgId)).toHaveLength(0);
   });
 
   it("does not log when usage matches", async () => {
@@ -218,7 +245,7 @@ describe("compareRecentRunsProxyUsage", () => {
       runId: run2,
       orgId: user2.orgId,
       userId: user2.userId,
-      inputTokens: 300,
+      inputTokens: 30,
     });
 
     await compareRecentRunsProxyUsage();

--- a/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
@@ -143,8 +143,8 @@ async function compareProxyUsage(
     for (const field of fields) {
       const clientVal = client[field] ?? 0;
       const proxyVal = proxy[field] ?? 0;
-      if (clientVal !== proxyVal) {
-        log.error("Proxy usage mismatch", {
+      if (proxyVal < clientVal) {
+        log.error("Proxy usage undercount", {
           orgId,
           runId: client.runId,
           field,

--- a/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
+++ b/turbo/apps/web/src/lib/zero/credit/proxy-usage-comparison-service.ts
@@ -143,6 +143,8 @@ async function compareProxyUsage(
     for (const field of fields) {
       const clientVal = client[field] ?? 0;
       const proxyVal = proxy[field] ?? 0;
+      // Only flag undercounts. Proxy sees all API calls (main + subagents)
+      // while client reports main thread only, so proxy >= client is normal.
       if (proxyVal < clientVal) {
         log.error("Proxy usage undercount", {
           orgId,


### PR DESCRIPTION
## Summary

- Change proxy usage comparison from `!=` to `proxy < client` (only flag undercounts)
- Proxy overcounts from subagent usage are normal and no longer flagged
- Update error message from "Proxy usage mismatch" to "Proxy usage undercount"

## Why

Proxy captures all API calls (main thread + subagents) while client only reports main thread usage. `proxy >= client` is the expected invariant. The previous `!=` comparison produced false-positive errors for every run with subagents.

| Scenario | Before | After |
|---|---|---|
| proxy < client | error | error (possible data loss) |
| proxy > client | error (false positive) | silent (subagent usage) |
| proxy == client | silent | silent |

## Test Changes

- Renamed "mismatching" test to "proxy undercount" (proxy=30 < client=100 → error)
- Added "proxy overcounts" test (proxy=200 > client=100 → no error)
- Updated multi-org test to use undercount scenario

Closes #8899

🤖 Generated with [Claude Code](https://claude.com/claude-code)