### PR TITLE
fix: remove 'Platform' text from auth page logo

### DIFF
--- a/turbo/apps/web/app/components/auth/AuthLayout.tsx
+++ b/turbo/apps/web/app/components/auth/AuthLayout.tsx
@@ -407,7 +407,6 @@ export function AuthLayout({ children }: AuthLayoutProps) {
             priority
             className="hidden dark:block"
           />
-          <span className="text-2xl text-foreground">Platform</span>
         </Link>
 
         {children}


### PR DESCRIPTION
## Summary
- Removes the "Platform" word next to the VM0 logo on the sign-in/sign-up page header
- The logo now shows just "VM0" instead of "VM0 Platform"

## Change
`turbo/apps/web/app/components/auth/AuthLayout.tsx` — deleted the `<span>` element containing "Platform" text next to the logo image.

## Screenshot
Before: **VM0 Platform** in the top-left of the auth page
After: **VM0** only