### PR TITLE
refactor(mitm-addon): extract shared api request builder for platform calls

### DIFF
--- a/crates/runner/mitm-addon/src/auth.py
+++ b/crates/runner/mitm-addon/src/auth.py
@@ -39,6 +39,26 @@ def get_api_url() -> str:
     return ctx.options.vm0_api_url
 
 
+def make_api_request(url: str, data: bytes, sandbox_token: str) -> urllib.request.Request:
+    """Build a Request with standard platform API headers.
+
+    Centralises User-Agent, Authorization, Content-Type, and the optional
+    Vercel bypass header so that callers cannot accidentally omit them.
+    """
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {sandbox_token}",
+            "User-Agent": "vm0-mitm-addon/1.0",
+        },
+    )
+    if VERCEL_BYPASS:
+        req.add_header("x-vercel-protection-bypass", VERCEL_BYPASS)
+    return req
+
+
 def _fetch_firewall_headers_sync(
     encrypted_secrets: str,
     auth_headers: dict,
@@ -62,17 +82,7 @@ def _fetch_firewall_headers_sync(
     if vars_map:
         body["vars"] = vars_map
     data = json.dumps(body).encode()
-    req = urllib.request.Request(
-        url,
-        data=data,
-        headers={
-            "Authorization": f"Bearer {sandbox_token}",
-            "Content-Type": "application/json",
-            "User-Agent": "vm0-mitm-addon/1.0",
-        },
-    )
-    if VERCEL_BYPASS:
-        req.add_header("x-vercel-protection-bypass", VERCEL_BYPASS)
+    req = make_api_request(url, data, sandbox_token)
     resp = urllib.request.urlopen(req, timeout=10)
     return json.loads(resp.read())
 

--- a/crates/runner/mitm-addon/src/mitm_addon.py
+++ b/crates/runner/mitm-addon/src/mitm_addon.py
@@ -15,7 +15,6 @@ import os
 import time
 import urllib.error
 import urllib.parse
-import urllib.request
 import zlib
 from concurrent.futures import ThreadPoolExecutor
 
@@ -25,7 +24,13 @@ from mitmproxy import ctx, http, tcp, tls
 from mitmproxy.addonmanager import Loader
 
 # --- Sub-module imports (only symbols used in this file's own code) ---
-from auth import _firewall_header_cache, _opener, evict_stale_cache_keys, handle_firewall_request
+from auth import (
+    _firewall_header_cache,
+    _opener,
+    evict_stale_cache_keys,
+    handle_firewall_request,
+    make_api_request,
+)
 from logging_utils import add_firewall_metadata, log_network_entry
 from matching import FirewallAllow, FirewallBlock, match_firewall_request
 from url_utils import get_original_url
@@ -390,17 +395,7 @@ def _do_report_usage(api_url: str, sandbox_token: str, run_id: str, usage: dict)
     """POST extracted usage to the platform webhook.  Raises on failure."""
     url = f"{api_url}/api/webhooks/agent/usage"
     payload = json.dumps({"runId": run_id, "usage": usage}).encode()
-    req = urllib.request.Request(
-        url,
-        data=payload,
-        headers={
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {sandbox_token}",
-        },
-    )
-    vercel_bypass = os.environ.get("VERCEL_AUTOMATION_BYPASS_SECRET", "")
-    if vercel_bypass:
-        req.add_header("x-vercel-protection-bypass", vercel_bypass)
+    req = make_api_request(url, payload, sandbox_token)
     try:
         resp = _opener.open(req, timeout=10)
         resp.close()

--- a/crates/runner/mitm-addon/tests/test_handlers.py
+++ b/crates/runner/mitm-addon/tests/test_handlers.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import os
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -925,6 +924,7 @@ class TestDoReportUsage:
         assert req.full_url == "https://api.vm0.ai/api/webhooks/agent/usage"
         assert req.get_header("Content-type") == "application/json"
         assert req.get_header("Authorization") == "Bearer tok-123"
+        assert req.get_header("User-agent") == "vm0-mitm-addon/1.0"
         body = json.loads(req.data)
         assert body["runId"] == "run-1"
         assert body["usage"]["model"] == "claude-sonnet-4-6"
@@ -959,10 +959,7 @@ class TestDoReportUsage:
     def test_adds_vercel_bypass_header(self):
         with (
             patch.object(mitm_addon, "_opener") as mock_opener,
-            patch.dict(
-                os.environ,
-                {"VERCEL_AUTOMATION_BYPASS_SECRET": "bypass-secret"},
-            ),
+            patch.object(auth, "VERCEL_BYPASS", "bypass-secret"),
         ):
             mock_opener.open.return_value = MagicMock()
             mitm_addon._do_report_usage("https://api.vm0.ai", "tok", "run-1", {})


### PR DESCRIPTION
## Summary
- Extract `make_api_request()` in `auth.py` to centralise User-Agent, Authorization, Content-Type, and Vercel bypass headers for all platform API calls
- Fix missing `User-Agent` header in `_do_report_usage()` that caused Cloudflare 403 bot detection on default `Python-urllib/3.12` UA
- Remove now-unused `urllib.request` import from `mitm_addon.py`

## Test plan
- [x] Verify User-Agent is now set in usage reporting requests (`test_posts_correct_payload`)
- [x] Verify Vercel bypass header still works via module-level constant (`test_adds_vercel_bypass_header`)
- [x] Verify `_fetch_firewall_headers_sync` behaviour unchanged (`test_connectors.py` suite)
- [x] Full test suite passes (751 tests)

Closes #8885

🤖 Generated with [Claude Code](https://claude.com/claude-code)