### PR TITLE
fix(voice-chat): skip response.create for slow-brain thinking events

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -427,14 +427,18 @@ const injectSlowBrainEvents$ = command(
       return;
     }
 
-    // Interrupt if model is mid-speech
+    const needsResponse = slowBrainEvents.some((e) => {
+      return e.type === "directive" || e.type === "observation";
+    });
+
+    // Interrupt if model is mid-speech and we need a response
     const current = get(internalCurrentAssistant$);
-    if (current) {
+    if (current && needsResponse) {
       dc.send(JSON.stringify({ type: "response.cancel" }));
       set(internalCurrentAssistant$, null);
     }
 
-    // Inject each event as a user message
+    // Inject each event as a user message (all types, for context)
     for (const event of slowBrainEvents) {
       dc.send(
         JSON.stringify({
@@ -450,8 +454,10 @@ const injectSlowBrainEvents$ = command(
       );
     }
 
-    // Trigger model to respond to injected content
-    dc.send(JSON.stringify({ type: "response.create" }));
+    // Only trigger response for actionable events
+    if (needsResponse) {
+      dc.send(JSON.stringify({ type: "response.create" }));
+    }
   },
 );
 


### PR DESCRIPTION
## Summary

- Gate both `response.cancel` and `response.create` in `injectSlowBrainEvents$` behind a `needsResponse` check
- Only `directive` and `observation` events trigger fast-brain responses; `thinking` events are injected as context only
- Prevents redundant fast-brain responses when slow-brain posts progress updates

Closes #8920

## Test plan

- [ ] Lint, type-check, format pass
- [ ] Existing tests pass (no frontend tests for this function — backend event tests unaffected)
- [ ] Manual: start voice-chat session, trigger slow-brain thinking event, verify fast-brain does NOT generate redundant response
- [ ] Manual: trigger slow-brain directive event, verify fast-brain responds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)