### PR TITLE
fix: mitmproxy unknownPolicy fallback defaults to allow, not deny

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -461,8 +461,8 @@ def _get_unknown_policy(
     """
     ref_grant = network_policies.get(fw_ref)
     if ref_grant is None:
-        return "deny"
-    return ref_grant.get("unknownPolicy", "deny")
+        return "allow"
+    return ref_grant.get("unknownPolicy", "allow")
 
 
 def match_firewall_request(


### PR DESCRIPTION
## Summary

- Changes `_get_unknown_policy` in `matching.py` to return `"allow"` instead of `"deny"` for both fallback cases
- Aligns mitmproxy behavior with the frontend (`resolve-permissions.ts:118`), which always defaults `unknownPolicy` to `"allow"`

## Background

The frontend always writes an explicit `unknownPolicy: "allow"` for every connector in `networkPolicies`, so the normal code path is unaffected. The fix only matters for edge cases:
- A connector's `fw_ref` is absent from `network_policies` (e.g., policy propagation lag)
- A connector entry exists but has no `unknownPolicy` field (e.g., legacy data)

In both cases the old code silently denied traffic that the UI showed as allowed.

Closes #8922

🤖 Generated with [Claude Code](https://claude.com/claude-code)