### PR TITLE
feat: acquire screen wake lock during voice chat sessions

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -193,6 +193,7 @@ const internalReconnectAttempt$ = state(0);
 const internalInputMode$ = state<"hands-free" | "push-to-talk">("hands-free");
 
 const internalParentSignal$ = state<AbortSignal | null>(null);
+const internalWakeLock$ = state<WakeLockSentinel | null>(null);
 
 const meetingPromptInput$ = state("");
 
@@ -792,6 +793,29 @@ const reconnectVoiceSession$ = command(
   },
 );
 
+// --- Wake lock ---
+
+const acquireWakeLock$ = command(async ({ set }) => {
+  if (!("wakeLock" in navigator)) {
+    return;
+  }
+  // eslint-disable-next-line no-restricted-syntax -- wakeLock.request can fail if document is not visible
+  try {
+    const lock = await navigator.wakeLock.request("screen");
+    set(internalWakeLock$, lock);
+  } catch {
+    // Wake lock request failed — non-critical, ignore
+  }
+});
+
+const releaseWakeLock$ = command(({ get, set }) => {
+  const lock = get(internalWakeLock$);
+  if (lock) {
+    void lock.release();
+    set(internalWakeLock$, null);
+  }
+});
+
 // --- Shared connection logic ---
 
 const connectVoiceSession$ = command(
@@ -852,6 +876,8 @@ const connectVoiceSession$ = command(
     if (!ok) {
       return;
     }
+
+    await set(acquireWakeLock$);
 
     await Promise.allSettled([
       set(startHeartbeat$, sessionSignal),
@@ -1126,6 +1152,7 @@ export const endVoiceChat$ = command(({ get, set }) => {
   }
 
   set(resetSessionSignal$);
+  set(releaseWakeLock$);
 
   const dc = get(internalDc$);
   if (dc) {

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -769,6 +769,7 @@ const reconnectVoiceSession$ = command(
       if (ok) {
         // Success — restart heartbeat and poll loops
         set(internalReconnectAttempt$, 0);
+        await set(acquireWakeLock$);
         const parentSignal = get(internalParentSignal$);
         if (!parentSignal) {
           set(internalError$, "No parent signal for reconnect");

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -797,21 +797,22 @@ const reconnectVoiceSession$ = command(
 
 // --- Wake lock ---
 
-const acquireWakeLock$ = command(
-  async ({ set }, signal: AbortSignal) => {
-    if (!("wakeLock" in navigator)) {
-      return;
-    }
-    // eslint-disable-next-line no-restricted-syntax -- wakeLock.request can fail if document is not visible
-    try {
-      const lock = await navigator.wakeLock.request("screen");
-      signal.throwIfAborted();
-      set(internalWakeLock$, lock);
-    } catch {
-      // Wake lock request failed or aborted — non-critical, ignore
-    }
-  },
-);
+const acquireWakeLock$ = command(async ({ set }, signal: AbortSignal) => {
+  if (!("wakeLock" in navigator)) {
+    return;
+  }
+  let lock: WakeLockSentinel | undefined;
+  // eslint-disable-next-line no-restricted-syntax -- wakeLock.request can fail if document is not visible
+  try {
+    lock = await navigator.wakeLock.request("screen");
+  } catch {
+    // Wake lock request failed — non-critical, ignore
+  }
+  signal.throwIfAborted();
+  if (lock) {
+    set(internalWakeLock$, lock);
+  }
+});
 
 const releaseWakeLock$ = command(({ get, set }) => {
   const lock = get(internalWakeLock$);

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -817,7 +817,9 @@ const acquireWakeLock$ = command(async ({ set }, signal: AbortSignal) => {
 const releaseWakeLock$ = command(({ get, set }) => {
   const lock = get(internalWakeLock$);
   if (lock) {
-    lock.release().catch(() => undefined);
+    lock.release().catch(() => {
+      return undefined;
+    });
     set(internalWakeLock$, null);
   }
 });

--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -769,7 +769,8 @@ const reconnectVoiceSession$ = command(
       if (ok) {
         // Success — restart heartbeat and poll loops
         set(internalReconnectAttempt$, 0);
-        await set(acquireWakeLock$);
+        await set(acquireWakeLock$, signal);
+        signal.throwIfAborted();
         const parentSignal = get(internalParentSignal$);
         if (!parentSignal) {
           set(internalError$, "No parent signal for reconnect");
@@ -796,23 +797,26 @@ const reconnectVoiceSession$ = command(
 
 // --- Wake lock ---
 
-const acquireWakeLock$ = command(async ({ set }) => {
-  if (!("wakeLock" in navigator)) {
-    return;
-  }
-  // eslint-disable-next-line no-restricted-syntax -- wakeLock.request can fail if document is not visible
-  try {
-    const lock = await navigator.wakeLock.request("screen");
-    set(internalWakeLock$, lock);
-  } catch {
-    // Wake lock request failed — non-critical, ignore
-  }
-});
+const acquireWakeLock$ = command(
+  async ({ set }, signal: AbortSignal) => {
+    if (!("wakeLock" in navigator)) {
+      return;
+    }
+    // eslint-disable-next-line no-restricted-syntax -- wakeLock.request can fail if document is not visible
+    try {
+      const lock = await navigator.wakeLock.request("screen");
+      signal.throwIfAborted();
+      set(internalWakeLock$, lock);
+    } catch {
+      // Wake lock request failed or aborted — non-critical, ignore
+    }
+  },
+);
 
 const releaseWakeLock$ = command(({ get, set }) => {
   const lock = get(internalWakeLock$);
   if (lock) {
-    void lock.release();
+    lock.release().catch(() => undefined);
     set(internalWakeLock$, null);
   }
 });
@@ -878,7 +882,8 @@ const connectVoiceSession$ = command(
       return;
     }
 
-    await set(acquireWakeLock$);
+    await set(acquireWakeLock$, sessionSignal);
+    sessionSignal.throwIfAborted();
 
     await Promise.allSettled([
       set(startHeartbeat$, sessionSignal),


### PR DESCRIPTION
## Summary

- Acquires a Screen Wake Lock when a voice session connects, preventing the screen from auto-locking during active voice calls
- Releases the wake lock when the session ends (via `endVoiceChat$`)
- Handles environments where the Wake Lock API is unavailable (feature check + silent failure)

## Motivation

When using voice chat on mobile, the screen auto-lock timeout interrupts the session by suspending JS and revoking microphone access. This fix keeps the screen on for the duration of the voice call.

## Compatibility

The Screen Wake Lock API (`navigator.wakeLock`) is supported on:
- iOS Safari 16.4+
- Chrome 84+ / Edge 84+ (desktop and Android)
- Not supported on Firefox (gracefully ignored)

## Changes

`turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts`
- Added `internalWakeLock$` state to track the sentinel
- Added `acquireWakeLock$` command (called after WebRTC connects)
- Added `releaseWakeLock$` command (called in `endVoiceChat$`)

## Test plan

- [ ] Start a voice chat session on iOS Safari 16.4+ — confirm screen stays on beyond normal auto-lock timeout
- [ ] End the session — confirm wake lock is released (screen auto-lock resumes normally)
- [ ] Test on Firefox — confirm no errors (graceful no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)