### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -91,7 +91,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.98"
+CLAUDE_CODE_VERSION="2.1.101"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.25.3"

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -473,7 +473,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            hash, "605ae14645306d26aeade2e96b5fb7f32f5e91233c6ff19c753e05ce171f4ed9",
+            hash, "3b5860db624028922190b06a06e0b91610f12c8cf3d045f20e29cc2ac3a69027",
             "image hash changed — this invalidates ALL cached images on ALL hosts"
         );
     }


### PR DESCRIPTION
## Summary

Updated pinned package versions in `crates/runner/scripts/build-rootfs.sh`:

- **claude-code**: `2.1.98` → `2.1.101`

All other pinned versions are already at the latest:
- Go: `1.26.2` (latest)
- `@googleworkspace/cli`: `0.22.5` (latest)
- `@xdevplatform/xurl`: `1.0.3` (latest)
- `agent-browser`: `0.25.3` (latest)

The `image_hash_is_stable` expected hash in `crates/runner/src/cmd/build.rs` has been updated to reflect the new script hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)