### PR TITLE
fix: align mitmproxy permission matching with frontend contract

### DIFF
--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -437,18 +437,20 @@ def _find_uncovered_graphql_fields(
     ]
 
 
-def _build_allow_set(
+def _build_block_set(
     fw_ref: str,
     network_policies: dict,
 ) -> set:
-    """Build a set of granted permission names for a firewall ref.
+    """Build a set of denied/asked permission names for a firewall ref.
 
-    Returns empty set when ref is absent from the map (fail-closed).
+    Returns empty set when ref is absent from the map (fully permissive —
+    consistent with the frontend contract where absent refs are treated
+    as all-granted + allow-unknown).
     """
     ref_grant = network_policies.get(fw_ref)
     if ref_grant is None:
         return set()
-    return set(ref_grant.get("allow", []))
+    return set(ref_grant.get("deny", [])) | set(ref_grant.get("ask", []))
 
 
 def _get_unknown_policy(
@@ -461,8 +463,8 @@ def _get_unknown_policy(
     """
     ref_grant = network_policies.get(fw_ref)
     if ref_grant is None:
-        return "deny"
-    return ref_grant.get("unknownPolicy", "deny")
+        return "allow"
+    return ref_grant.get("unknownPolicy", "allow")
 
 
 def match_firewall_request(
@@ -509,7 +511,7 @@ def match_firewall_request(
     for fw_entry in vm_firewalls:
         fw_name = fw_entry.get("name", "")
         fw_ref = fw_entry.get("ref", "")
-        allow_set = _build_allow_set(fw_ref, network_policies)
+        block_set = _build_block_set(fw_ref, network_policies)
 
         for api_entry in fw_entry.get("apis", []):
             base = api_entry.get("base", "").rstrip("/")
@@ -595,8 +597,8 @@ def match_firewall_request(
                         # Merge base params with rule params
                         all_params = {**base_params, **params}
 
-                        # Three-level: check if this permission is granted
-                        if perm_name in allow_set:
+                        # Three-level: not in deny/ask → allowed
+                        if perm_name not in block_set:
                             return FirewallAllow(
                                 api_entry,
                                 {

--- a/crates/runner/mitm-addon/src/matching.py
+++ b/crates/runner/mitm-addon/src/matching.py
@@ -443,6 +443,9 @@ def _build_block_set(
 ) -> set:
     """Build a set of denied/asked permission names for a firewall ref.
 
+    Only reads ``deny`` and ``ask`` fields — the ``allow`` field is not
+    consumed by the proxy (it exists for frontend display only).
+
     Returns empty set when ref is absent from the map (fully permissive —
     consistent with the frontend contract where absent refs are treated
     as all-granted + allow-unknown).

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -3630,58 +3630,58 @@ class TestThreeLevelMatching:
         )
 
     def test_allowed_permission_passes(self):
-        granted = {
+        policies = {
             "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "deny"}
         }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "repo-read"
 
     def test_denied_permission_blocked(self):
-        granted = {
+        policies = {
             "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "deny"}
         }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "PUT",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
 
     def test_uncategorized_permission_allowed(self):
         """Permission not in allow/deny/ask defaults to allowed."""
-        granted = {"github": {"allow": [], "deny": [], "ask": [], "unknownPolicy": "deny"}}
+        policies = {"github": {"allow": [], "deny": [], "ask": [], "unknownPolicy": "deny"}}
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "repo-read"
 
     def test_ask_permission_blocked(self):
         """Permission in ask list is treated as denied at proxy level."""
-        granted = {
+        policies = {
             "github": {"allow": [], "deny": [], "ask": ["repo-read"], "unknownPolicy": "allow"}
         }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
 
     def test_deny_and_ask_union(self):
         """Permissions in deny and ask are both blocked."""
-        granted = {
+        policies = {
             "github": {
                 "allow": [],
                 "deny": ["repo-read"],
@@ -3694,7 +3694,7 @@ class TestThreeLevelMatching:
             "https://api.github.com/repos/org/repo",
             "GET",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
         # repo-write in ask → blocked
@@ -3702,92 +3702,92 @@ class TestThreeLevelMatching:
             "https://api.github.com/repos/org/repo",
             "PUT",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
 
     def test_unknown_policy_key_missing_defaults_to_allow(self):
         """Ref present but unknownPolicy key absent → defaults to allow."""
-        granted = {"github": {"allow": ["repo-read"], "deny": ["repo-write"]}}
+        policies = {"github": {"allow": ["repo-read"], "deny": ["repo-write"]}}
         result = matching.match_firewall_request(
             "https://api.github.com/users/octocat",
             "GET",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == ""
 
     def test_permission_in_both_allow_and_deny_is_blocked(self):
         """deny takes precedence when permission appears in both allow and deny."""
-        granted = {
+        policies = {
             "github": {"allow": ["repo-read"], "deny": ["repo-read"], "unknownPolicy": "allow"}
         }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
 
     def test_unknown_endpoint_allowed_when_unknown_policy_allow(self):
-        granted = {
+        policies = {
             "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "allow"}
         }
         result = matching.match_firewall_request(
             "https://api.github.com/users/octocat",
             "GET",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == ""
         assert result.match_info["rule"] == ""
 
     def test_unknown_endpoint_blocked_when_unknown_policy_deny(self):
-        granted = {
+        policies = {
             "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "deny"}
         }
         result = matching.match_firewall_request(
             "https://api.github.com/users/octocat",
             "GET",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
 
     def test_unknown_endpoint_blocked_when_unknown_policy_ask(self):
         """unknownPolicy 'ask' is treated as deny at the proxy level."""
-        granted = {
+        policies = {
             "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "ask"}
         }
         result = matching.match_firewall_request(
             "https://api.github.com/users/octocat",
             "GET",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
 
     def test_ref_absent_allows(self):
         """Ref not in networkPolicies → fully permissive."""
-        granted = {}  # github not in map
+        policies = {}  # github not in map
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "PUT",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
 
     def test_no_base_match_returns_none(self):
-        granted = {}
+        policies = {}
         result = matching.match_firewall_request(
             "https://api.example.com/foo",
             "GET",
             self._firewalls(),
-            network_policies=granted,
+            network_policies=policies,
         )
         assert result is None
 
@@ -3822,18 +3822,18 @@ class TestThreeLevelMatching:
             name="hubspot",
             ref="hubspot",
         )
-        granted = {"hubspot": {"allow": [], "unknownPolicy": "allow"}}
+        policies = {"hubspot": {"allow": [], "unknownPolicy": "allow"}}
         result = matching.match_firewall_request(
             "https://api.hubspot.com/crm/v3/objects",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == ""
 
-    def test_overlapping_permissions_grants_if_any_granted(self):
-        """Same endpoint in two permissions — one denied, one granted → ALLOW."""
+    def test_overlapping_permissions_allows_if_any_not_blocked(self):
+        """Same endpoint in two permissions — one denied, one allowed → ALLOW."""
         fws = _wrap_firewalls(
             [
                 {
@@ -3848,19 +3848,19 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {
+        policies = {
             "github": {"allow": ["repo-admin"], "deny": ["repo-read"], "unknownPolicy": "deny"}
         }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "repo-admin"
 
-    def test_overlapping_permissions_denies_if_none_granted(self):
+    def test_overlapping_permissions_denies_if_all_blocked(self):
         """Same endpoint in two permissions — both denied → DENY."""
         fws = _wrap_firewalls(
             [
@@ -3876,7 +3876,7 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {
+        policies = {
             "github": {
                 "allow": ["issues-read"],
                 "deny": ["repo-read", "repo-admin"],
@@ -3887,13 +3887,13 @@ class TestThreeLevelMatching:
             "https://api.github.com/repos/org/repo",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ("repo-read", "repo-admin")
 
     def test_multi_firewall_different_refs(self):
-        """Two firewalls with different refs, each with own grants."""
+        """Two firewalls with different refs, each with own policies."""
         fws = [
             {
                 "name": "github",
@@ -3922,16 +3922,16 @@ class TestThreeLevelMatching:
                 ],
             },
         ]
-        granted = {
+        policies = {
             "github": {"allow": ["repo-read"], "deny": [], "unknownPolicy": "deny"},
             "slack": {"allow": [], "deny": ["channels:read"], "unknownPolicy": "allow"},
         }
-        # GitHub: granted → ALLOW
+        # GitHub: not in deny → ALLOW
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["ref"] == "github"
@@ -3941,7 +3941,7 @@ class TestThreeLevelMatching:
             "https://slack.com/api/conversations.list",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
 
@@ -3950,7 +3950,7 @@ class TestThreeLevelMatching:
             "https://slack.com/api/users.info",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["ref"] == "slack"
@@ -3970,7 +3970,7 @@ class TestThreeLevelMatching:
                 "apis": [{"base": "https://slack.com/api", "auth": {"headers": {}}}],
             },
         ]
-        granted = {
+        policies = {
             "github": {"allow": [], "deny": [], "unknownPolicy": "deny"},
             "slack": {"allow": [], "deny": [], "unknownPolicy": "allow"},
         }
@@ -3979,7 +3979,7 @@ class TestThreeLevelMatching:
             "https://api.github.com/anything",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
 
@@ -3988,7 +3988,7 @@ class TestThreeLevelMatching:
             "https://slack.com/api/anything",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
 
@@ -4007,12 +4007,12 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {"github": {"allow": [], "deny": ["repo-write"], "unknownPolicy": "allow"}}
+        policies = {"github": {"allow": [], "deny": ["repo-write"], "unknownPolicy": "allow"}}
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "PUT",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         # repo-write explicitly denied → DENY, not overridden by unknownPolicy
         assert isinstance(result, FirewallBlock)
@@ -4039,12 +4039,12 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {"github": {"allow": [], "deny": ["repo-read"], "unknownPolicy": "deny"}}
+        policies = {"github": {"allow": [], "deny": ["repo-read"], "unknownPolicy": "deny"}}
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ("repo-read",)
@@ -4065,18 +4065,18 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {
+        policies = {
             "github": {"allow": [], "deny": ["repo-read", "repo-write"], "unknownPolicy": "deny"}
         }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallBlock)
 
-    def test_ref_absent_from_granted_allows(self):
+    def test_ref_absent_from_policies_allows(self):
         """Firewall ref not in networkPolicies → fully permissive."""
         fws = _wrap_firewalls(
             [
@@ -4092,12 +4092,12 @@ class TestThreeLevelMatching:
             ref="github",
         )
         # networkPolicies exists but has no entry for "github" → fully permissive
-        granted = {"slack": {"allow": [], "unknownPolicy": "allow"}}
+        policies = {"slack": {"allow": [], "unknownPolicy": "allow"}}
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
 
@@ -4106,7 +4106,7 @@ class TestThreeLevelMatching:
             "https://api.github.com/users/octocat",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
 
@@ -4130,14 +4130,14 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {"github": {"allow": ["repo-read"], "deny": [], "unknownPolicy": "allow"}}
+        policies = {"github": {"allow": ["repo-read"], "deny": [], "unknownPolicy": "allow"}}
 
-        # First API: known permission granted → ALLOW
+        # First API: known permission not in deny → ALLOW
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "repo-read"
@@ -4147,7 +4147,7 @@ class TestThreeLevelMatching:
             "https://uploads.github.com/anything",
             "POST",
             fws,
-            network_policies=granted,
+            network_policies=policies,
         )
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == ""

--- a/crates/runner/mitm-addon/tests/test_connectors.py
+++ b/crates/runner/mitm-addon/tests/test_connectors.py
@@ -3630,7 +3630,9 @@ class TestThreeLevelMatching:
         )
 
     def test_allowed_permission_passes(self):
-        granted = {"github": {"allow": ["repo-read"], "unknownPolicy": "deny"}}
+        granted = {
+            "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "deny"}
+        }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
@@ -3640,8 +3642,10 @@ class TestThreeLevelMatching:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["permission"] == "repo-read"
 
-    def test_non_allowed_permission_denies(self):
-        granted = {"github": {"allow": ["repo-read"], "unknownPolicy": "deny"}}
+    def test_denied_permission_blocked(self):
+        granted = {
+            "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "deny"}
+        }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "PUT",
@@ -3650,8 +3654,87 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallBlock)
 
+    def test_uncategorized_permission_allowed(self):
+        """Permission not in allow/deny/ask defaults to allowed."""
+        granted = {"github": {"allow": [], "deny": [], "ask": [], "unknownPolicy": "deny"}}
+        result = matching.match_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._firewalls(),
+            network_policies=granted,
+        )
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["permission"] == "repo-read"
+
+    def test_ask_permission_blocked(self):
+        """Permission in ask list is treated as denied at proxy level."""
+        granted = {
+            "github": {"allow": [], "deny": [], "ask": ["repo-read"], "unknownPolicy": "allow"}
+        }
+        result = matching.match_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._firewalls(),
+            network_policies=granted,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_deny_and_ask_union(self):
+        """Permissions in deny and ask are both blocked."""
+        granted = {
+            "github": {
+                "allow": [],
+                "deny": ["repo-read"],
+                "ask": ["repo-write"],
+                "unknownPolicy": "allow",
+            }
+        }
+        # repo-read in deny → blocked
+        result = matching.match_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._firewalls(),
+            network_policies=granted,
+        )
+        assert isinstance(result, FirewallBlock)
+        # repo-write in ask → blocked
+        result = matching.match_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "PUT",
+            self._firewalls(),
+            network_policies=granted,
+        )
+        assert isinstance(result, FirewallBlock)
+
+    def test_unknown_policy_key_missing_defaults_to_allow(self):
+        """Ref present but unknownPolicy key absent → defaults to allow."""
+        granted = {"github": {"allow": ["repo-read"], "deny": ["repo-write"]}}
+        result = matching.match_firewall_request(
+            "https://api.github.com/users/octocat",
+            "GET",
+            self._firewalls(),
+            network_policies=granted,
+        )
+        assert isinstance(result, FirewallAllow)
+        assert result.match_info["permission"] == ""
+
+    def test_permission_in_both_allow_and_deny_is_blocked(self):
+        """deny takes precedence when permission appears in both allow and deny."""
+        granted = {
+            "github": {"allow": ["repo-read"], "deny": ["repo-read"], "unknownPolicy": "allow"}
+        }
+        result = matching.match_firewall_request(
+            "https://api.github.com/repos/org/repo",
+            "GET",
+            self._firewalls(),
+            network_policies=granted,
+        )
+        assert isinstance(result, FirewallBlock)
+
     def test_unknown_endpoint_allowed_when_unknown_policy_allow(self):
-        granted = {"github": {"allow": ["repo-read"], "unknownPolicy": "allow"}}
+        granted = {
+            "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "allow"}
+        }
         result = matching.match_firewall_request(
             "https://api.github.com/users/octocat",
             "GET",
@@ -3663,7 +3746,9 @@ class TestThreeLevelMatching:
         assert result.match_info["rule"] == ""
 
     def test_unknown_endpoint_blocked_when_unknown_policy_deny(self):
-        granted = {"github": {"allow": ["repo-read"], "unknownPolicy": "deny"}}
+        granted = {
+            "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "deny"}
+        }
         result = matching.match_firewall_request(
             "https://api.github.com/users/octocat",
             "GET",
@@ -3674,7 +3759,9 @@ class TestThreeLevelMatching:
 
     def test_unknown_endpoint_blocked_when_unknown_policy_ask(self):
         """unknownPolicy 'ask' is treated as deny at the proxy level."""
-        granted = {"github": {"allow": ["repo-read"], "unknownPolicy": "ask"}}
+        granted = {
+            "github": {"allow": ["repo-read"], "deny": ["repo-write"], "unknownPolicy": "ask"}
+        }
         result = matching.match_firewall_request(
             "https://api.github.com/users/octocat",
             "GET",
@@ -3683,8 +3770,8 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallBlock)
 
-    def test_ref_absent_denies(self):
-        """Ref not in networkPolicies → fail-closed."""
+    def test_ref_absent_allows(self):
+        """Ref not in networkPolicies → fully permissive."""
         granted = {}  # github not in map
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
@@ -3692,7 +3779,7 @@ class TestThreeLevelMatching:
             self._firewalls(),
             network_policies=granted,
         )
-        assert isinstance(result, FirewallBlock)
+        assert isinstance(result, FirewallAllow)
 
     def test_no_base_match_returns_none(self):
         granted = {}
@@ -3704,15 +3791,15 @@ class TestThreeLevelMatching:
         )
         assert result is None
 
-    def test_none_network_policies_denies_all(self):
-        """None networkPolicies → empty map → fail-closed."""
+    def test_none_network_policies_allows_all(self):
+        """None networkPolicies → empty map → absent refs are fully permissive."""
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
             self._firewalls(),
             network_policies=None,
         )
-        assert isinstance(result, FirewallBlock)
+        assert isinstance(result, FirewallAllow)
 
         result = matching.match_firewall_request(
             "https://api.github.com/users/octocat",
@@ -3720,7 +3807,7 @@ class TestThreeLevelMatching:
             self._firewalls(),
             network_policies=None,
         )
-        assert isinstance(result, FirewallBlock)
+        assert isinstance(result, FirewallAllow)
 
     def test_empty_permissions_with_unknown_policy_allow(self):
         """Firewall with no permission rules + unknownPolicy=allow allows all."""
@@ -3761,7 +3848,9 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {"github": {"allow": ["repo-admin"], "unknownPolicy": "deny"}}
+        granted = {
+            "github": {"allow": ["repo-admin"], "deny": ["repo-read"], "unknownPolicy": "deny"}
+        }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
@@ -3787,7 +3876,13 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {"github": {"allow": ["issues-read"], "unknownPolicy": "deny"}}
+        granted = {
+            "github": {
+                "allow": ["issues-read"],
+                "deny": ["repo-read", "repo-admin"],
+                "unknownPolicy": "deny",
+            }
+        }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
@@ -3828,8 +3923,8 @@ class TestThreeLevelMatching:
             },
         ]
         granted = {
-            "github": {"allow": ["repo-read"], "unknownPolicy": "deny"},
-            "slack": {"allow": [], "unknownPolicy": "allow"},
+            "github": {"allow": ["repo-read"], "deny": [], "unknownPolicy": "deny"},
+            "slack": {"allow": [], "deny": ["channels:read"], "unknownPolicy": "allow"},
         }
         # GitHub: granted → ALLOW
         result = matching.match_firewall_request(
@@ -3841,7 +3936,7 @@ class TestThreeLevelMatching:
         assert isinstance(result, FirewallAllow)
         assert result.match_info["ref"] == "github"
 
-        # Slack: channels:read not granted → DENY
+        # Slack: channels:read explicitly denied → DENY
         result = matching.match_firewall_request(
             "https://slack.com/api/conversations.list",
             "GET",
@@ -3876,8 +3971,8 @@ class TestThreeLevelMatching:
             },
         ]
         granted = {
-            "github": {"allow": [], "unknownPolicy": "deny"},
-            "slack": {"allow": [], "unknownPolicy": "allow"},
+            "github": {"allow": [], "deny": [], "unknownPolicy": "deny"},
+            "slack": {"allow": [], "deny": [], "unknownPolicy": "allow"},
         }
         # GitHub unknown → DENY (unknownPolicy: deny)
         result = matching.match_firewall_request(
@@ -3912,14 +4007,14 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {"github": {"allow": [], "unknownPolicy": "allow"}}
+        granted = {"github": {"allow": [], "deny": ["repo-write"], "unknownPolicy": "allow"}}
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "PUT",
             fws,
             network_policies=granted,
         )
-        # repo-write rule matches but is not granted → DENY, not overridden by unknownPolicy
+        # repo-write explicitly denied → DENY, not overridden by unknownPolicy
         assert isinstance(result, FirewallBlock)
         assert result.permissions == ("repo-write",)
 
@@ -3944,7 +4039,7 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {"github": {"allow": [], "unknownPolicy": "deny"}}
+        granted = {"github": {"allow": [], "deny": ["repo-read"], "unknownPolicy": "deny"}}
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
@@ -3955,7 +4050,7 @@ class TestThreeLevelMatching:
         assert result.permissions == ("repo-read",)
 
     def test_empty_permissions_list_denies_all_known(self):
-        """permissions: [] means nothing is granted — all known endpoints denied."""
+        """All permissions in deny list — all known endpoints denied."""
         fws = _wrap_firewalls(
             [
                 {
@@ -3970,7 +4065,9 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {"github": {"allow": [], "unknownPolicy": "deny"}}
+        granted = {
+            "github": {"allow": [], "deny": ["repo-read", "repo-write"], "unknownPolicy": "deny"}
+        }
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
             "GET",
@@ -3979,8 +4076,8 @@ class TestThreeLevelMatching:
         )
         assert isinstance(result, FirewallBlock)
 
-    def test_ref_absent_from_granted_denies(self):
-        """Firewall ref not in networkPolicies → fail-closed."""
+    def test_ref_absent_from_granted_allows(self):
+        """Firewall ref not in networkPolicies → fully permissive."""
         fws = _wrap_firewalls(
             [
                 {
@@ -3994,7 +4091,7 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        # networkPolicies exists but has no entry for "github"
+        # networkPolicies exists but has no entry for "github" → fully permissive
         granted = {"slack": {"allow": [], "unknownPolicy": "allow"}}
         result = matching.match_firewall_request(
             "https://api.github.com/repos/org/repo",
@@ -4002,16 +4099,16 @@ class TestThreeLevelMatching:
             fws,
             network_policies=granted,
         )
-        assert isinstance(result, FirewallBlock)
+        assert isinstance(result, FirewallAllow)
 
-        # Unknown endpoint also blocked (ref absent → fail-closed)
+        # Unknown endpoint also allowed (ref absent → fully permissive)
         result = matching.match_firewall_request(
             "https://api.github.com/users/octocat",
             "GET",
             fws,
             network_policies=granted,
         )
-        assert isinstance(result, FirewallBlock)
+        assert isinstance(result, FirewallAllow)
 
     def test_multi_api_mixed_permissions(self):
         """One API has permissions, another doesn't — mixed within same firewall."""
@@ -4033,7 +4130,7 @@ class TestThreeLevelMatching:
             name="github",
             ref="github",
         )
-        granted = {"github": {"allow": ["repo-read"], "unknownPolicy": "allow"}}
+        granted = {"github": {"allow": ["repo-read"], "deny": [], "unknownPolicy": "allow"}}
 
         # First API: known permission granted → ALLOW
         result = matching.match_firewall_request(


### PR DESCRIPTION
## Summary
- Switch mitmproxy permission matching from whitelist (`allow` set) to blocklist (`deny` + `ask` set), consistent with the frontend contract where "refs absent from the map are fully permissive"
- Change `_get_unknown_policy` fallback from `"deny"` to `"allow"` to match frontend `resolve-permissions.ts` default
- Add comprehensive edge case tests: uncategorized permissions, `ask` list blocking, deny+ask union, missing `unknownPolicy` key fallback, deny-takes-precedence when in both allow and deny

## Test plan
- [x] All 756 mitm-addon tests pass (`python3 -m pytest tests/ -q`)
- [x] Verified no other code in the project consumes the `allow` field for permission checking
- [x] Edge cases covered: ref absent, `network_policies=None`, deny+ask union, `unknownPolicy` key missing, permission in both allow and deny

Closes #8922

🤖 Generated with [Claude Code](https://claude.com/claude-code)