### PR TITLE
feat: Mission Control multi-thread panel

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -14,6 +14,9 @@ import {
 import { chatMessagesContract, chatThreadByIdContract } from "@vm0/core";
 import { accept } from "../../lib/accept.ts";
 import { zeroClient$ } from "../api-client.ts";
+import { agentById } from "../agent.ts";
+import { pinnedAgentIds$ } from "../zero-page/zero-pinned-agents.ts";
+import { writeToClipboard } from "../zero-page/clipboard.ts";
 import {
   createActiveRunMessage,
   unsavedRunsToMessages,
@@ -35,6 +38,7 @@ const L = logger("ChatThread");
 // ---------------------------------------------------------------------------
 
 export interface ChatThreadSignals {
+  // ── Data signals ──────────────────────────────────────────────────────────
   threadData$: Computed<Promise<ChatThread | null>>;
   reloadThread$: Command<void, []>;
   messages$: Computed<Promise<ZeroChatMessage[]>>;
@@ -49,6 +53,15 @@ export interface ChatThreadSignals {
   draft: DraftSignals;
   composerFileInput$: Computed<HTMLElement | null>;
   setComposerFileInput$: Command<void, [HTMLElement | null]>;
+  // ── Agent info (derived from threadData$.agentId) ─────────────────────────
+  agentId$: Computed<Promise<string | null>>;
+  agentDisplayName$: Computed<Promise<string | null>>;
+  agentPinned$: Computed<Promise<boolean | null>>;
+  // ── Per-thread UI state ───────────────────────────────────────────────────
+  timelineExpandedIds$: Computed<Set<string>>;
+  toggleTimelineExpanded$: Command<void, [string]>;
+  copiedMessageId$: Computed<string | null>;
+  copyMessage$: Command<Promise<void>, [string, string, AbortSignal]>;
 }
 
 // ---------------------------------------------------------------------------
@@ -489,6 +502,105 @@ function createMessageCommands(deps: MessageCommandsDeps) {
 }
 
 // ---------------------------------------------------------------------------
+// Sub-factory: agent info
+// ---------------------------------------------------------------------------
+
+function createAgentInfoSignals(
+  threadData$: Computed<Promise<ChatThread | null>>,
+) {
+  const agentId$ = computed(async (get): Promise<string | null> => {
+    const thread = await get(threadData$);
+    return thread?.agentId ?? null;
+  });
+
+  const agentDisplayName$ = computed(async (get): Promise<string | null> => {
+    const agentId = await get(agentId$);
+    if (!agentId) {
+      return null;
+    }
+    const agent = await get(agentById(agentId));
+    return agent?.displayName ?? null;
+  });
+
+  const agentPinned$ = computed(async (get): Promise<boolean | null> => {
+    const agentId = await get(agentId$);
+    if (!agentId) {
+      return null;
+    }
+    const ids = await get(pinnedAgentIds$);
+    return ids.includes(agentId);
+  });
+
+  return { agentId$, agentDisplayName$, agentPinned$ };
+}
+
+// ---------------------------------------------------------------------------
+// Sub-factory: per-thread UI state (timeline expansion, copy)
+// ---------------------------------------------------------------------------
+
+function createThreadUIState() {
+  // Timeline expansion
+  const internalExpandedIds$ = state(new Set<string>());
+
+  const timelineExpandedIds$ = computed((get) => {
+    return get(internalExpandedIds$);
+  });
+
+  const toggleTimelineExpanded$ = command(
+    ({ get, set }, messageId: string) => {
+      const current = get(internalExpandedIds$);
+      const next = new Set(current);
+      if (next.has(messageId)) {
+        next.delete(messageId);
+      } else {
+        next.add(messageId);
+      }
+      set(internalExpandedIds$, next);
+    },
+  );
+
+  // Copy state with 2s auto-clear
+  const internalCopiedId$ = state<string | null>(null);
+  const internalCopiedTimerId$ = state<number | null>(null);
+
+  const copiedMessageId$ = computed((get) => {
+    return get(internalCopiedId$);
+  });
+
+  const copyMessage$ = command(
+    async (
+      { get, set },
+      messageId: string,
+      content: string,
+      signal: AbortSignal,
+    ) => {
+      const ok = await writeToClipboard(content);
+      signal.throwIfAborted();
+      if (!ok) {
+        return;
+      }
+      const existingTimerId = get(internalCopiedTimerId$);
+      if (existingTimerId !== null) {
+        window.clearTimeout(existingTimerId);
+      }
+      set(internalCopiedId$, messageId);
+      const timerId = window.setTimeout(() => {
+        set(internalCopiedId$, null);
+        set(internalCopiedTimerId$, null);
+      }, 2000);
+      set(internalCopiedTimerId$, timerId);
+    },
+  );
+
+  return {
+    timelineExpandedIds$,
+    toggleTimelineExpanded$,
+    copiedMessageId$,
+    copyMessage$,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
@@ -524,7 +636,7 @@ export const ensureDraft$ = command(({ get, set }, threadId: string) => {
   return draft;
 });
 
-function createChatThreadSignals(
+export function createChatThreadSignals(
   threadId: string,
   draft: DraftSignals,
 ): ChatThreadSignals {
@@ -539,6 +651,14 @@ function createChatThreadSignals(
   const { setScrollContainer$, autoScroll$ } = createScrollSignals();
   const { composerFileInput$, setComposerFileInput$ } =
     createComposerFileInput();
+  const { agentId$, agentDisplayName$, agentPinned$ } =
+    createAgentInfoSignals(threadData$);
+  const {
+    timelineExpandedIds$,
+    toggleTimelineExpanded$,
+    copiedMessageId$,
+    copyMessage$,
+  } = createThreadUIState();
 
   const internalThinkingMessage$ = state(
     THINKING_MESSAGES[Math.floor(Math.random() * THINKING_MESSAGES.length)],
@@ -578,6 +698,13 @@ function createChatThreadSignals(
     draft,
     composerFileInput$,
     setComposerFileInput$,
+    agentId$,
+    agentDisplayName$,
+    agentPinned$,
+    timelineExpandedIds$,
+    toggleTimelineExpanded$,
+    copiedMessageId$,
+    copyMessage$,
   };
 }
 

--- a/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
+++ b/turbo/apps/platform/src/signals/chat-page/create-chat-thread.ts
@@ -546,18 +546,16 @@ function createThreadUIState() {
     return get(internalExpandedIds$);
   });
 
-  const toggleTimelineExpanded$ = command(
-    ({ get, set }, messageId: string) => {
-      const current = get(internalExpandedIds$);
-      const next = new Set(current);
-      if (next.has(messageId)) {
-        next.delete(messageId);
-      } else {
-        next.add(messageId);
-      }
-      set(internalExpandedIds$, next);
-    },
-  );
+  const toggleTimelineExpanded$ = command(({ get, set }, messageId: string) => {
+    const current = get(internalExpandedIds$);
+    const next = new Set(current);
+    if (next.has(messageId)) {
+      next.delete(messageId);
+    } else {
+      next.add(messageId);
+    }
+    set(internalExpandedIds$, next);
+  });
 
   // Copy state with 2s auto-clear
   const internalCopiedId$ = state<string | null>(null);

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-threads.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-threads.ts
@@ -1,0 +1,61 @@
+import { command, computed, state } from "ccstate";
+import {
+  createChatThreadSignals,
+  ensureDraft$,
+  type ChatThreadSignals,
+} from "../chat-page/create-chat-thread.ts";
+
+// ---------------------------------------------------------------------------
+// Open thread registry — keyed by threadId
+// ---------------------------------------------------------------------------
+
+const openThreadsMap$ = state(new Map<string, ChatThreadSignals>());
+
+/**
+ * Whether the Mission Control thread panel is visible.
+ * True when at least one thread is open.
+ */
+export const missionControlPanelVisible$ = computed((get) => {
+  return get(openThreadsMap$).size > 0;
+});
+
+/**
+ * Ordered list of [threadId, ChatThreadSignals] entries for rendering.
+ */
+export const openThreadEntries$ = computed(
+  (get): [string, ChatThreadSignals][] => {
+    return [...get(openThreadsMap$).entries()];
+  },
+);
+
+/**
+ * Open a chat thread in the Mission Control panel.
+ * If the thread is already open, this is a no-op.
+ */
+export const openMissionControlThread$ = command(
+  ({ get, set }, threadId: string) => {
+    const map = get(openThreadsMap$);
+    if (map.has(threadId)) {
+      return;
+    }
+    const draft = set(ensureDraft$, threadId);
+    const signals = createChatThreadSignals(threadId, draft);
+    set(openThreadsMap$, new Map(map).set(threadId, signals));
+  },
+);
+
+/**
+ * Close a chat thread in the Mission Control panel.
+ * The ChatThreadSignals instance becomes unreferenced and is GC'd.
+ */
+export const closeMissionControlThread$ = command(
+  ({ get, set }, threadId: string) => {
+    const map = get(openThreadsMap$);
+    if (!map.has(threadId)) {
+      return;
+    }
+    const next = new Map(map);
+    next.delete(threadId);
+    set(openThreadsMap$, next);
+  },
+);

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-threads.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-threads.ts
@@ -31,9 +31,14 @@ export const openThreadEntries$ = computed(
 /**
  * Open a chat thread in the Mission Control panel.
  * If the thread is already open, this is a no-op.
+ * Callers should detach with Reason.DomCallback.
  */
 export const openMissionControlThread$ = command(
-  ({ get, set }, threadId: string) => {
+  async (
+    { get, set },
+    threadId: string,
+    signal: AbortSignal,
+  ): Promise<void> => {
     const map = get(openThreadsMap$);
     if (map.has(threadId)) {
       return;
@@ -41,6 +46,7 @@ export const openMissionControlThread$ = command(
     const draft = set(ensureDraft$, threadId);
     const signals = createChatThreadSignals(threadId, draft);
     set(openThreadsMap$, new Map(map).set(threadId, signals));
+    await set(signals.loadMessages$, signal);
   },
 );
 

--- a/turbo/apps/platform/src/signals/zero-page/zero-session-chat-ui.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-session-chat-ui.ts
@@ -2,29 +2,6 @@ import { state, computed, command } from "ccstate";
 import { writeToClipboard } from "./clipboard.ts";
 
 // ---------------------------------------------------------------------------
-// Collapsible timeline expanded state
-// ---------------------------------------------------------------------------
-
-const expandedTimelineIds$ = state(new Set<string>());
-
-export const timelineExpandedIds$ = computed((get) => {
-  return get(expandedTimelineIds$);
-});
-
-export const toggleTimelineExpanded$ = command(
-  ({ get, set }, messageId: string) => {
-    const current = get(expandedTimelineIds$);
-    const next = new Set(current);
-    if (next.has(messageId)) {
-      next.delete(messageId);
-    } else {
-      next.add(messageId);
-    }
-    set(expandedTimelineIds$, next);
-  },
-);
-
-// ---------------------------------------------------------------------------
 // Copy message state
 // ---------------------------------------------------------------------------
 

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -95,7 +95,7 @@ describe("mission control page", () => {
     });
   });
 
-  it("should navigate to chat thread when clicking a chat task", async () => {
+  it("should open thread panel when clicking a chat task", async () => {
     mockTasksAPI([
       {
         id: "task-chat",
@@ -111,6 +111,21 @@ describe("mission control page", () => {
       },
     ]);
 
+    server.use(
+      http.get("*/api/zero/chat-threads/thread-abc", () => {
+        return HttpResponse.json({
+          id: "thread-abc",
+          title: null,
+          agentId: null,
+          chatMessages: [],
+          latestSessionId: null,
+          unsavedRuns: [],
+          createdAt: "2026-04-10T10:00:00Z",
+          updatedAt: "2026-04-10T10:00:00Z",
+        });
+      }),
+    );
+
     const user = userEvent.setup();
 
     detachedSetupPage({ context, path: "/_/mission-control" });
@@ -122,8 +137,10 @@ describe("mission control page", () => {
     await user.click(title);
 
     await waitFor(() => {
-      expect(pathname()).toBe("/chats/thread-abc");
+      expect(screen.getByLabelText("Close thread")).toBeInTheDocument();
     });
+
+    expect(pathname()).toBe("/_/mission-control");
   });
 
   it("should navigate to activity when clicking a schedule task", async () => {

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -112,17 +112,20 @@ describe("mission control page", () => {
     ]);
 
     server.use(
-      http.get("*/api/zero/chat-threads/thread-abc", () => {
+      http.get("*/api/zero/chat-threads/:id", () => {
         return HttpResponse.json({
           id: "thread-abc",
           title: null,
-          agentId: null,
+          agentId: "00000000-0000-4000-a000-000000000000",
           chatMessages: [],
           latestSessionId: null,
           unsavedRuns: [],
           createdAt: "2026-04-10T10:00:00Z",
           updatedAt: "2026-04-10T10:00:00Z",
         });
+      }),
+      http.get("*/api/zero/chat-threads", () => {
+        return HttpResponse.json({ threads: [] });
       }),
     );
 

--- a/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
@@ -4,6 +4,7 @@ import {
   IconCalendar,
   IconBrandSlack,
   IconMail,
+  IconX,
 } from "@tabler/icons-react";
 import { Skeleton, Card } from "@vm0/ui";
 import type { TaskItem, TaskType } from "@vm0/core";
@@ -12,6 +13,13 @@ import {
   selectedTaskIndex$,
   navigateToTask$,
 } from "../../signals/mission-control-page/mission-control.ts";
+import {
+  missionControlPanelVisible$,
+  openThreadEntries$,
+  openMissionControlThread$,
+  closeMissionControlThread$,
+} from "../../signals/mission-control-page/mission-control-threads.ts";
+import { ZeroChatThreadPageInner } from "../zero-page/zero-chat-thread-page.tsx";
 import { StatusBadge } from "../zero-page/components/log-views/status-badge.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 
@@ -53,18 +61,63 @@ function getTaskTypeConfig(type: TaskType): {
 }
 
 export function MissionControlPage() {
+  const panelVisible = useGet(missionControlPanelVisible$);
+
   return (
-    <div className="flex flex-1 flex-col min-h-0">
-      <div className="shrink-0 px-6 pt-6 pb-2">
-        <h1 className="text-lg font-semibold">Mission Control</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Active tasks across all channels
-        </p>
+    <div className="flex flex-1 min-h-0">
+      {/* Left column: task list */}
+      <div
+        className={`flex flex-col min-h-0 transition-all duration-300 ${
+          panelVisible ? "w-[360px] shrink-0 border-r" : "flex-1"
+        }`}
+      >
+        <div className="shrink-0 px-6 pt-6 pb-2">
+          <h1 className="text-lg font-semibold">Mission Control</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Active tasks across all channels
+          </p>
+        </div>
+        <div className="flex-1 overflow-auto px-6 pb-6">
+          <TaskList />
+        </div>
       </div>
 
-      <div className="flex-1 overflow-auto px-6 pb-6">
-        <TaskList />
-      </div>
+      {/* Right column: thread panel, slides in */}
+      {panelVisible && <MissionControlThreadPanel />}
+    </div>
+  );
+}
+
+function MissionControlThreadPanel() {
+  const entries = useGet(openThreadEntries$);
+  const closeThread = useSet(closeMissionControlThread$);
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0 divide-y">
+      {entries.map(([threadId, signals]) => {
+        return (
+          <div key={threadId} className="flex flex-col flex-1 min-h-0">
+            <div className="shrink-0 flex items-center justify-between px-4 py-2 border-b bg-muted/30">
+              <span className="text-xs text-muted-foreground font-medium truncate">
+                Thread
+              </span>
+              <button
+                type="button"
+                onClick={() => {
+                  closeThread(threadId);
+                }}
+                className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                aria-label="Close thread"
+              >
+                <IconX size={14} stroke={1.5} />
+              </button>
+            </div>
+            <div className="flex-1 min-h-0 overflow-hidden">
+              <ZeroChatThreadPageInner thread={signals} />
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -137,9 +190,14 @@ function TaskCard({
   isSelected: boolean;
 }) {
   const navigate = useSet(navigateToTask$);
+  const openThread = useSet(openMissionControlThread$);
 
   const onClick = () => {
-    navigate(task);
+    if (task.type === "chat" && task.chatThreadId) {
+      openThread(task.chatThreadId);
+    } else {
+      navigate(task);
+    }
   };
 
   const config = getTaskTypeConfig(task.type);

--- a/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
@@ -1,4 +1,4 @@
-import { useGet, useSet, useLastLoadable } from "ccstate-react";
+import { useGet, useSet, useLastLoadable, useResolved } from "ccstate-react";
 import {
   IconMessageCircle,
   IconCalendar,
@@ -22,6 +22,9 @@ import {
 import { ZeroChatThreadPageInner } from "../zero-page/zero-chat-thread-page.tsx";
 import { StatusBadge } from "../zero-page/components/log-views/status-badge.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
+import { detach, Reason } from "../../signals/utils.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import type { ChatThreadSignals } from "../../signals/chat-page/create-chat-thread.ts";
 
 function getTaskTypeConfig(type: TaskType): {
   label: string;
@@ -90,34 +93,48 @@ export function MissionControlPage() {
 
 function MissionControlThreadPanel() {
   const entries = useGet(openThreadEntries$);
-  const closeThread = useSet(closeMissionControlThread$);
 
   return (
     <div className="flex flex-col flex-1 min-h-0 divide-y">
       {entries.map(([threadId, signals]) => {
         return (
-          <div key={threadId} className="flex flex-col flex-1 min-h-0">
-            <div className="shrink-0 flex items-center justify-between px-4 py-2 border-b bg-muted/30">
-              <span className="text-xs text-muted-foreground font-medium truncate">
-                Thread
-              </span>
-              <button
-                type="button"
-                onClick={() => {
-                  closeThread(threadId);
-                }}
-                className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-                aria-label="Close thread"
-              >
-                <IconX size={14} stroke={1.5} />
-              </button>
-            </div>
-            <div className="flex-1 min-h-0 overflow-hidden">
-              <ZeroChatThreadPageInner thread={signals} />
-            </div>
-          </div>
+          <ThreadCard key={threadId} threadId={threadId} signals={signals} />
         );
       })}
+    </div>
+  );
+}
+
+function ThreadCard({
+  threadId,
+  signals,
+}: {
+  threadId: string;
+  signals: ChatThreadSignals;
+}) {
+  const closeThread = useSet(closeMissionControlThread$);
+  const displayName = useResolved(signals.agentDisplayName$);
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="shrink-0 flex items-center justify-between px-4 py-2 border-b bg-muted/30">
+        <span className="text-xs text-muted-foreground font-medium truncate">
+          {displayName ?? threadId}
+        </span>
+        <button
+          type="button"
+          onClick={() => {
+            closeThread(threadId);
+          }}
+          className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          aria-label="Close thread"
+        >
+          <IconX size={14} stroke={1.5} />
+        </button>
+      </div>
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <ZeroChatThreadPageInner thread={signals} />
+      </div>
     </div>
   );
 }
@@ -191,10 +208,11 @@ function TaskCard({
 }) {
   const navigate = useSet(navigateToTask$);
   const openThread = useSet(openMissionControlThread$);
+  const pageSignal = useGet(pageSignal$);
 
   const onClick = () => {
     if (task.type === "chat" && task.chatThreadId) {
-      openThread(task.chatThreadId);
+      detach(openThread(task.chatThreadId, pageSignal), Reason.DomCallback);
     } else {
       navigate(task);
     }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -36,13 +36,8 @@ import {
   setLightboxUrl$ as setAttachmentLightboxUrl$,
 } from "../../signals/zero-page/zero-attachment-chips.ts";
 import {
-  currentChatAgentId$,
-  currentChatAgentDisplayName$,
-} from "../../signals/agent-chat.ts";
-import {
   pinnedAgentIds$,
   updatePinnedAgentIds$,
-  currentChatAgentPinned$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
 
 import type {
@@ -60,29 +55,23 @@ import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
 import { setActiveOrgManageTab$ } from "../../signals/zero-page/settings/org-manage-tabs-state.ts";
-import {
-  timelineExpandedIds$,
-  toggleTimelineExpanded$,
-  copiedMessageIdValue$,
-  copyMessageContent$,
-} from "../../signals/zero-page/zero-session-chat-ui.ts";
 
-function HeaderAgentAvatar() {
-  const currentChatAgentId = useResolved(currentChatAgentId$) ?? null;
+function HeaderAgentAvatar({ thread }: { thread: ChatThreadSignals }) {
+  const agentId = useResolved(thread.agentId$) ?? null;
 
-  if (currentChatAgentId) {
+  if (agentId) {
     return (
       <TooltipProvider delayDuration={200}>
         <Tooltip>
           <TooltipTrigger asChild>
             <Link
               pathname="/agents/:agentId"
-              options={{ pathParams: { agentId: currentChatAgentId } }}
+              options={{ pathParams: { agentId } }}
               className="h-8 w-8 shrink-0 overflow-hidden rounded-xl transition-colors duration-150 hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               aria-label="View agent profile"
             >
               <AgentAvatarImg
-                name={currentChatAgentId}
+                name={agentId}
                 alt=""
                 className="h-8 w-8 rounded-full object-cover object-top"
               />
@@ -107,25 +96,25 @@ function HeaderAgentAvatar() {
   );
 }
 
-function PinPillButton() {
+function PinPillButton({ thread }: { thread: ChatThreadSignals }) {
   const pageSignal = useGet(pageSignal$);
   const pinnedIds = useLastResolved(pinnedAgentIds$) ?? [];
-  const pinnedStatus = useLastResolved(currentChatAgentPinned$);
+  const pinnedStatus = useLastResolved(thread.agentPinned$);
   const showPinPill = pinnedStatus === false;
   const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
   const pinSaving = pinLoadable.state === "loading";
-  const currentChatAgentId = useResolved(currentChatAgentId$) ?? null;
+  const agentId = useResolved(thread.agentId$) ?? null;
 
   if (!showPinPill) {
     return null;
   }
 
   const handlePin = () => {
-    if (!currentChatAgentId) {
+    if (!agentId) {
       return;
     }
     detach(
-      savePinnedIds([...pinnedIds, currentChatAgentId], pageSignal),
+      savePinnedIds([...pinnedIds, agentId], pageSignal),
       Reason.DomCallback,
     );
   };
@@ -152,15 +141,15 @@ function PinPillButton() {
   );
 }
 
-function ChatThreadHeader() {
-  const displayName = useResolved(currentChatAgentDisplayName$);
+function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
+  const displayName = useResolved(thread.agentDisplayName$);
 
   return (
     <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
       <div className="flex items-center gap-3">
         <div className="relative shrink-0">
-          <HeaderAgentAvatar />
-          <PinPillButton />
+          <HeaderAgentAvatar thread={thread} />
+          <PinPillButton thread={thread} />
         </div>
         <span className="font-semibold text-foreground">{displayName}</span>
       </div>
@@ -183,7 +172,7 @@ export function ZeroChatThreadPage() {
   return <ZeroChatThreadPageInner thread={thread} />;
 }
 
-function ZeroChatThreadPageInner({ thread }: { thread: ChatThreadSignals }) {
+export function ZeroChatThreadPageInner({ thread }: { thread: ChatThreadSignals }) {
   const messagesLoadable = useLastLoadable(thread.messages$);
   const messages =
     messagesLoadable.state === "hasData" ? messagesLoadable.data : [];
@@ -198,7 +187,7 @@ function ZeroChatThreadPageInner({ thread }: { thread: ChatThreadSignals }) {
 
   return (
     <div className="flex flex-1 flex-col min-h-0 bg-transparent">
-      <ChatThreadHeader />
+      <ChatThreadHeader thread={thread} />
 
       {/* Scrollable area — messages + sticky composer share the same scroll context */}
       <div
@@ -252,7 +241,7 @@ function ChatThreadComposer({ thread }: { thread: ChatThreadSignals }) {
   const messagesLoadable = useLastLoadable(thread.messages$);
   const hasMessages =
     messagesLoadable.state === "hasData" && messagesLoadable.data.length > 0;
-  const displayName = useResolved(currentChatAgentDisplayName$) ?? "Zero";
+  const displayName = useResolved(thread.agentDisplayName$) ?? "Zero";
   const allFinishedLoadable = useLoadable(thread.allFinished$);
   const sending =
     allFinishedLoadable.state === "hasData" ? !allFinishedLoadable.data : true;
@@ -592,10 +581,16 @@ function queueLabel(position: number): string {
   return `In queue, ${position - 1} task${position - 1 === 1 ? "" : "s"} ahead...`;
 }
 
-function CollapsibleTimeline({ message }: { message: AssistantChatMessage }) {
-  const expandedIds = useGet(timelineExpandedIds$);
+function CollapsibleTimeline({
+  message,
+  thread,
+}: {
+  message: AssistantChatMessage;
+  thread: ChatThreadSignals;
+}) {
+  const expandedIds = useGet(thread.timelineExpandedIds$);
   const expanded = expandedIds.has(message.id);
-  const toggleExpanded = useSet(toggleTimelineExpanded$);
+  const toggleExpanded = useSet(thread.toggleTimelineExpanded$);
   const summaries = message.summaries ?? [];
 
   if (summaries.length === 0) {
@@ -735,14 +730,16 @@ function isRunActive(message: AssistantChatMessage): boolean {
 function AssistantMessageActions({
   message,
   content,
+  thread,
 }: {
   message: AssistantChatMessage;
   content: string;
+  thread: ChatThreadSignals;
 }) {
   const pageSignal = useGet(pageSignal$);
-  const copiedId = useGet(copiedMessageIdValue$);
+  const copiedId = useGet(thread.copiedMessageId$);
   const copied = copiedId === message.id;
-  const copyMessage = useSet(copyMessageContent$);
+  const copyMessage = useSet(thread.copyMessage$);
 
   if (!message.legacyRunId) {
     return null;
@@ -873,12 +870,12 @@ function AssistantErrorContent({ error }: { error: string }) {
   );
 }
 
-function AssistantBubbleAvatar() {
-  const currentChatAgentId = useResolved(currentChatAgentId$) ?? "";
+function AssistantBubbleAvatar({ thread }: { thread: ChatThreadSignals }) {
+  const agentId = useResolved(thread.agentId$) ?? "";
   return (
     <div className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 shrink-0 @[900px]:mt-0.5 overflow-hidden rounded-xl">
       <AgentAvatarImg
-        name={currentChatAgentId}
+        name={agentId}
         alt=""
         className="h-7 w-7 @[900px]:h-9 @[900px]:w-9 rounded-full object-cover object-top"
       />
@@ -907,13 +904,13 @@ function StaticAssistantMessage({
         className="group flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300"
       >
         <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
-          <AssistantBubbleAvatar />
+          <AssistantBubbleAvatar thread={thread} />
           <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
-            {hasSummaries && <CollapsibleTimeline message={message} />}
+            {hasSummaries && <CollapsibleTimeline message={message} thread={thread} />}
             <AssistantErrorContent error={message.error} />
           </div>
         </div>
-        <AssistantMessageActions message={message} content={content} />
+        <AssistantMessageActions message={message} content={content} thread={thread} />
       </div>
     );
   }
@@ -922,9 +919,9 @@ function StaticAssistantMessage({
     return (
       <div className="group flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300">
         <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
-          <AssistantBubbleAvatar />
+          <AssistantBubbleAvatar thread={thread} />
           <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
-            {hasSummaries && <CollapsibleTimeline message={message} />}
+            {hasSummaries && <CollapsibleTimeline message={message} thread={thread} />}
             <Markdown source={content} />
             {message.cancelled && (
               <div className="mt-3 pt-3 border-t flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -934,7 +931,7 @@ function StaticAssistantMessage({
             )}
           </div>
         </div>
-        <AssistantMessageActions message={message} content={content} />
+        <AssistantMessageActions message={message} content={content} thread={thread} />
       </div>
     );
   }
@@ -946,7 +943,7 @@ function StaticAssistantMessage({
       className="flex flex-col gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300"
     >
       <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
-        <AssistantBubbleAvatar />
+        <AssistantBubbleAvatar thread={thread} />
         <div className="zero-chat-bubble-assistant rounded-xl py-4 text-sm leading-relaxed min-w-0 overflow-hidden">
           {showActivityLine ? (
             <MessageRunActivityLine message={message} thread={thread} />
@@ -961,7 +958,7 @@ function StaticAssistantMessage({
           )}
         </div>
       </div>
-      <AssistantMessageActions message={message} content={content} />
+      <AssistantMessageActions message={message} content={content} thread={thread} />
     </div>
   );
 }

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -172,7 +172,11 @@ export function ZeroChatThreadPage() {
   return <ZeroChatThreadPageInner thread={thread} />;
 }
 
-export function ZeroChatThreadPageInner({ thread }: { thread: ChatThreadSignals }) {
+export function ZeroChatThreadPageInner({
+  thread,
+}: {
+  thread: ChatThreadSignals;
+}) {
   const messagesLoadable = useLastLoadable(thread.messages$);
   const messages =
     messagesLoadable.state === "hasData" ? messagesLoadable.data : [];
@@ -906,11 +910,17 @@ function StaticAssistantMessage({
         <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
           <AssistantBubbleAvatar thread={thread} />
           <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
-            {hasSummaries && <CollapsibleTimeline message={message} thread={thread} />}
+            {hasSummaries && (
+              <CollapsibleTimeline message={message} thread={thread} />
+            )}
             <AssistantErrorContent error={message.error} />
           </div>
         </div>
-        <AssistantMessageActions message={message} content={content} thread={thread} />
+        <AssistantMessageActions
+          message={message}
+          content={content}
+          thread={thread}
+        />
       </div>
     );
   }
@@ -921,7 +931,9 @@ function StaticAssistantMessage({
         <div className="flex flex-col gap-2 @[900px]:grid @[900px]:grid-cols-[36px_1fr] @[900px]:gap-2.5 @[900px]:-ml-[46px] @[900px]:items-start">
           <AssistantBubbleAvatar thread={thread} />
           <div className="zero-chat-bubble-assistant px-0 @[900px]:pt-2.5 text-sm leading-relaxed min-w-0 break-words">
-            {hasSummaries && <CollapsibleTimeline message={message} thread={thread} />}
+            {hasSummaries && (
+              <CollapsibleTimeline message={message} thread={thread} />
+            )}
             <Markdown source={content} />
             {message.cancelled && (
               <div className="mt-3 pt-3 border-t flex items-center gap-1.5 text-xs text-muted-foreground">
@@ -931,7 +943,11 @@ function StaticAssistantMessage({
             )}
           </div>
         </div>
-        <AssistantMessageActions message={message} content={content} thread={thread} />
+        <AssistantMessageActions
+          message={message}
+          content={content}
+          thread={thread}
+        />
       </div>
     );
   }
@@ -958,7 +974,11 @@ function StaticAssistantMessage({
           )}
         </div>
       </div>
-      <AssistantMessageActions message={message} content={content} thread={thread} />
+      <AssistantMessageActions
+        message={message}
+        content={content}
+        thread={thread}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Closes #8942

## Summary

- **`create-chat-thread.ts`**: Export `createChatThreadSignals`; add `createAgentInfoSignals` sub-factory (`agentId$`, `agentDisplayName$`, `agentPinned$`) and `createThreadUIState` sub-factory (`timelineExpandedIds$`, `toggleTimelineExpanded$`, `copiedMessageId$`, `copyMessage$`)
- **`zero-chat-thread-page.tsx`**: Remove all route-coupled singleton imports; replace with `thread` prop reads throughout; export `ZeroChatThreadPageInner` for reuse by Mission Control
- **`mission-control-threads.ts`**: New signal file — `openMissionControlThread$`, `closeMissionControlThread$`, `missionControlPanelVisible$`, `openThreadEntries$`
- **`mission-control-page.tsx`**: Two-column layout with slide-in thread panel; clicking a chat task opens it inline instead of navigating away

## How it works

Clicking a chat task card in Mission Control opens the thread in a right-side panel rather than navigating to the full chat page. Multiple threads stack vertically (equal height, each independently scrollable). The panel slides in on first open and collapses when all threads are closed. Signals are destroyed immediately on close.

## Test plan

- [ ] Navigate to Mission Control — task list renders as before
- [ ] Click a chat task — right panel slides in with thread
- [ ] Click another chat task — second thread appears stacked below
- [ ] Click ✕ on a thread — it closes; panel remains if others open
- [ ] Close all threads — panel collapses
- [ ] Click a non-chat task (email/schedule/slack) — navigates away as before
- [ ] Existing `/chats/:threadId` route still works end-to-end
- [ ] Agent avatar, display name, pin button render correctly in both contexts
- [ ] Timeline expand/collapse is independent per thread
- [ ] Copy message button works and shows ✓ per thread independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)