### PR TITLE
chore: remove Instrument Sans font

### DIFF
--- a/turbo/apps/web/app/layout.tsx
+++ b/turbo/apps/web/app/layout.tsx
@@ -3,7 +3,6 @@ import type { Metadata } from "next";
 import Script from "next/script";
 import {
   Noto_Sans,
-  Instrument_Sans,
   Fira_Code,
   Fira_Mono,
   JetBrains_Mono,
@@ -25,14 +24,6 @@ const notoSans = Noto_Sans({
   variable: "--font-noto-sans",
   display: "swap",
   preload: true,
-});
-
-const instrumentSans = Instrument_Sans({
-  subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
-  variable: "--font-instrument-sans",
-  display: "swap",
-  preload: false,
 });
 
 const firaCode = Fira_Code({
@@ -184,7 +175,7 @@ export default function RootLayout({
           )}
         </head>
         <body
-          className={`${notoSans.variable} ${instrumentSans.variable} ${firaCode.variable} ${firaMono.variable} ${jetBrainsMono.variable}`}
+          className={`${notoSans.variable} ${firaCode.variable} ${firaMono.variable} ${jetBrainsMono.variable}`}
         >
           <Script
             id="json-ld"


### PR DESCRIPTION
## Summary
- Removes `Instrument_Sans` from the Next.js font loader in `turbo/apps/web/app/layout.tsx`
- The font variable `--font-instrument-sans` is not referenced anywhere in the codebase (CSS, TSX, or JS)
- Reduces one unused Google Fonts network request on page load

## Test plan
- [ ] Verify staging homepage visually — no layout or typography regressions expected
- [ ] Confirm no references to `--font-instrument-sans` or `Instrument_Sans` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)