### PR TITLE
refactor: remove unrestricted permission from model-provider firewalls

### DIFF
--- a/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
+++ b/turbo/apps/web/app/api/cron/aggregate-insights/route.ts
@@ -262,15 +262,12 @@ function aggregateNetworkDataPerUser(
 
     if (row.firewall_permission || row.action === "DENY") {
       const hasPerm = !!row.firewall_permission;
-      const isUnrestricted = row.firewall_permission === "unrestricted";
-      const permKey =
-        !hasPerm || isUnrestricted
-          ? row.firewall_ref
-          : `${row.firewall_ref}:${row.firewall_permission}`;
-      const label =
-        !hasPerm || isUnrestricted
-          ? row.firewall_ref
-          : getPermissionLabel(row.firewall_ref, row.firewall_permission);
+      const permKey = hasPerm
+        ? `${row.firewall_ref}:${row.firewall_permission}`
+        : row.firewall_ref;
+      const label = hasPerm
+        ? getPermissionLabel(row.firewall_ref, row.firewall_permission)
+        : row.firewall_ref;
       const perm = userData.permMap.get(permKey) ?? {
         label,
         connectorType: row.firewall_ref,

--- a/turbo/packages/core/src/contracts/model-providers.ts
+++ b/turbo/packages/core/src/contracts/model-providers.ts
@@ -412,7 +412,7 @@ function mpFirewall(
       {
         base: getFirewallBaseUrl(type),
         auth: { headers: { [authHeader.name]: headerValue } },
-        permissions: [{ name: "unrestricted", rules: ["ANY /{path*}"] }],
+        permissions: [],
       },
     ],
     placeholders: { [secretName]: placeholderValue },


### PR DESCRIPTION
## Summary

- Remove hardcoded `unrestricted` permission (`ANY /{path*}`) from model-provider firewall configs — the mitmproxy `unknownPolicy: "allow"` mechanism already handles unrecognized endpoints, making it redundant (consistent with connector firewalls post-#6840)
- Remove dead `isUnrestricted` check in aggregate-insights — unknown endpoint requests are identified by empty `firewall_permission` field

## Test plan

- [ ] Verify model-provider API calls still pass through the firewall (unknown endpoint path: `permissions: []` → no rule match → `unknownPolicy: "allow"` → FirewallAllow)
- [ ] Verify aggregate-insights correctly groups model-provider requests by `firewall_ref` (empty `firewall_permission` → `!hasPerm` → ref-level aggregation)

Closes #8925

🤖 Generated with [Claude Code](https://claude.com/claude-code)