### PR TITLE
fix(ci): add ssh connection retry for cloudflared tunnel flakiness

### DIFF
--- a/.github/actions/setup-ssh-tunnel/action.yml
+++ b/.github/actions/setup-ssh-tunnel/action.yml
@@ -68,6 +68,7 @@ runs:
           "  StrictHostKeyChecking no" \
           "  UserKnownHostsFile /dev/null" \
           "  ConnectTimeout 10" \
+          "  ConnectionAttempts 3" \
           "  IdentityFile $HOME/.ssh/runner.pem" \
           "  ProxyCommand $HOME/.ssh/cf-proxy.sh %h")"
 


### PR DESCRIPTION
## Summary

- Add `ConnectionAttempts 3` to the SSH tunnel config so SSH automatically retries when cloudflared websocket handshake fails ("websocket: bad handshake" / "Connection closed by UNKNOWN port 65535")
- One-line change in the shared `setup-ssh-tunnel` action — covers all SSH calls across all CI jobs without modifying individual scripts

## Test plan

- [ ] Verify `deploy-runner-start` and `deploy-runner-prepare` jobs no longer fail on transient cloudflared tunnel errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)