### PR TITLE
fix(runner): add drop impl to kmsg handle to prevent task leak on early return

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -191,7 +191,8 @@ pub async fn run_start(
 
     // Start background kmsg monitor for non-TCP traffic logging.
     let ip_log_map = kmsg_log::new_ip_log_map();
-    let kmsg_handle = kmsg_log::spawn(ip_log_map.clone());
+    let kmsg_handle = kmsg_log::spawn(ip_log_map.clone())
+        .map_err(|e| RunnerError::Internal(format!("kmsg monitor: {e}")))?;
 
     // Start DNS proxy (dnsmasq) for domain-level DNS interception and logging.
     // Shares ip_log_map with kmsg — both use source IP (peer veth) as key.

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -34,13 +34,16 @@ pub fn new_ip_log_map() -> IpLogMap {
 pub struct KmsgHandle {
     cancel: CancellationToken,
     task: tokio::task::JoinHandle<()>,
+    child: tokio::process::Child,
 }
 
 impl KmsgHandle {
-    /// Stop the kmsg monitor and wait for the child process to be reaped.
-    pub async fn stop(self) {
+    /// Stop the kmsg monitor and wait for cleanup.
+    pub async fn stop(mut self) {
         self.cancel.cancel();
-        let _ = self.task.await;
+        let _ = self.child.start_kill();
+        let _ = self.child.wait().await;
+        let _ = (&mut self.task).await;
         info!("kmsg monitor stopped");
     }
 
@@ -57,29 +60,23 @@ impl KmsgHandle {
     }
 }
 
+impl Drop for KmsgHandle {
+    /// Kill dmesg and abort the log task if `stop()` was never called.
+    ///
+    /// Prevents a leaked `dmesg -w` process when `run()` returns early
+    /// (e.g., factory creation failure). Harmless if `stop()` already ran —
+    /// `start_kill` on an exited child is a no-op.
+    fn drop(&mut self) {
+        let _ = self.child.start_kill();
+        self.cancel.cancel();
+        self.task.abort();
+    }
+}
+
 /// Spawn a background async task that tails `dmesg -w` and writes
 /// network log entries. Returns a handle; call [`KmsgHandle::stop`] during
 /// shutdown so the tokio runtime can exit cleanly.
-pub fn spawn(ip_log_map: IpLogMap) -> KmsgHandle {
-    let cancel = CancellationToken::new();
-    let token = cancel.clone();
-    let task = tokio::spawn(async move {
-        if let Err(e) = run_async(&ip_log_map, token).await {
-            warn!(error = %e, "kmsg log monitor exited");
-        }
-    });
-    KmsgHandle { cancel, task }
-}
-
-/// Async loop that reads kernel log messages via `dmesg -w`.
-///
-/// The runner runs as root, so `dmesg -w` works directly without sudo.
-///
-/// `dmesg -w` outputs lines like:
-/// ```text
-/// [12345.678901] VM0:10.200.0.2:IN=vm0-ve-00-00 OUT=ens5 SRC=10.200.0.2 DST=8.8.8.8 LEN=64 ...
-/// ```
-async fn run_async(ip_log_map: &IpLogMap, cancel: CancellationToken) -> std::io::Result<()> {
+pub fn spawn(ip_log_map: IpLogMap) -> std::io::Result<KmsgHandle> {
     let mut child = tokio::process::Command::new("dmesg")
         .args(["-w"])
         .stdout(Stdio::piped())
@@ -91,9 +88,11 @@ async fn run_async(ip_log_map: &IpLogMap, cancel: CancellationToken) -> std::io:
         .take()
         .ok_or_else(|| std::io::Error::other("failed to capture dmesg stdout"))?;
 
+    let cancel = CancellationToken::new();
+    let token = cancel.clone();
+
     // Log stderr in a background task so dmesg errors are visible.
-    // Shares the cancel token so the task exits promptly on shutdown,
-    // dropping the pipe and allowing the orphaned dmesg to receive SIGPIPE.
+    // Shares the cancel token so the task exits promptly on shutdown.
     if let Some(stderr) = child.stderr.take() {
         let stderr_cancel = cancel.clone();
         tokio::spawn(async move {
@@ -115,6 +114,23 @@ async fn run_async(ip_log_map: &IpLogMap, cancel: CancellationToken) -> std::io:
         });
     }
 
+    let task = tokio::spawn(async move {
+        run_loop(&ip_log_map, token, stdout).await;
+    });
+    Ok(KmsgHandle {
+        cancel,
+        task,
+        child,
+    })
+}
+
+/// Read kernel log lines from `dmesg -w` stdout, parse iptables LOG
+/// entries, and write matching entries to per-run network JSONL files.
+async fn run_loop(
+    ip_log_map: &IpLogMap,
+    cancel: CancellationToken,
+    stdout: tokio::process::ChildStdout,
+) {
     let mut lines = tokio::io::BufReader::new(stdout).lines();
     loop {
         tokio::select! {
@@ -142,13 +158,6 @@ async fn run_async(ip_log_map: &IpLogMap, cancel: CancellationToken) -> std::io:
             }
         }
     }
-
-    // Kill the child and reap it. start_kill may fail if dmesg already
-    // exited (e.g. stdout EOF triggered the break above) — that's fine,
-    // but we must still wait() to avoid a zombie process.
-    let _ = child.start_kill();
-    let _ = child.wait().await;
-    Ok(())
 }
 
 /// Parsed fields from a single iptables LOG line.

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -34,34 +34,30 @@ pub fn new_ip_log_map() -> IpLogMap {
 pub struct KmsgHandle {
     cancel: CancellationToken,
     task: tokio::task::JoinHandle<()>,
-    child: tokio::process::Child,
+    child: Option<tokio::process::Child>,
 }
 
 impl KmsgHandle {
     /// Stop the kmsg monitor and wait for cleanup.
     pub async fn stop(mut self) {
         self.cancel.cancel();
-        let _ = self.child.start_kill();
-        let _ = self.child.wait().await;
+        if let Some(ref mut child) = self.child {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+        }
         let _ = (&mut self.task).await;
         info!("kmsg monitor stopped");
     }
 
-    /// Create a noop handle for testing. The background task simply waits
-    /// for cancellation — no `dmesg` process is spawned.
+    /// Create a noop handle for testing. No `dmesg` process is spawned.
     #[cfg(test)]
     pub fn noop() -> Self {
         let cancel = CancellationToken::new();
         let token = cancel.clone();
-        // Spawn a trivial child that exits immediately — satisfies the `child`
-        // field without needing root or `/dev/kmsg`.
-        let child = tokio::process::Command::new("true")
-            .spawn()
-            .expect("failed to spawn `true`");
         Self {
             cancel,
             task: tokio::spawn(async move { token.cancelled().await }),
-            child,
+            child: None,
         }
     }
 }
@@ -73,7 +69,9 @@ impl Drop for KmsgHandle {
     /// (e.g., factory creation failure). Harmless if `stop()` already ran —
     /// `start_kill` on an exited child is a no-op.
     fn drop(&mut self) {
-        let _ = self.child.start_kill();
+        if let Some(ref mut child) = self.child {
+            let _ = child.start_kill();
+        }
         self.cancel.cancel();
         self.task.abort();
     }
@@ -126,7 +124,7 @@ pub fn spawn(ip_log_map: IpLogMap) -> std::io::Result<KmsgHandle> {
     Ok(KmsgHandle {
         cancel,
         task,
-        child,
+        child: Some(child),
     })
 }
 

--- a/crates/runner/src/kmsg_log.rs
+++ b/crates/runner/src/kmsg_log.rs
@@ -53,9 +53,15 @@ impl KmsgHandle {
     pub fn noop() -> Self {
         let cancel = CancellationToken::new();
         let token = cancel.clone();
+        // Spawn a trivial child that exits immediately — satisfies the `child`
+        // field without needing root or `/dev/kmsg`.
+        let child = tokio::process::Command::new("true")
+            .spawn()
+            .expect("failed to spawn `true`");
         Self {
             cancel,
             task: tokio::spawn(async move { token.cancelled().await }),
+            child,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Move `dmesg -w` child process from a local variable inside the async task to a field on `KmsgHandle`, matching the existing `DnsProxy` pattern
- Add `Drop` impl that calls `start_kill()` on the child, `cancel()` on the token, and `abort()` on the task
- Refactor `stop()` to explicitly kill and reap the child before awaiting the task
- `spawn()` now returns `std::io::Result<KmsgHandle>` to propagate dmesg startup failures

Closes #8951

## Test plan

- [ ] `cargo check -p runner` passes
- [ ] `cargo clippy -p runner` passes
- [ ] `cargo test -p runner` passes (existing parse/write tests unaffected)
- [ ] Deploy to dev runner and verify `kmsg monitor stopped` appears in shutdown logs
- [ ] Verify no orphaned `dmesg -w` processes after runner restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)