### PR TITLE
fix(sandbox-fc): add drop impl to firecracker factory

### DIFF
--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -550,6 +550,9 @@ impl Drop for FirecrackerFactory {
     /// Safety net for abnormal paths (e.g., panic during startup).
     /// Harmless if `shutdown()` already ran — the handle is `None`.
     fn drop(&mut self) {
+        // Mirror shutdown(): close the sender first so the drain task's
+        // rx.recv() returns None, then abort as the immediate backstop.
+        self.leak_tx.take();
         if let Some(h) = self.leak_cleanup_handle.take() {
             h.abort();
         }

--- a/crates/sandbox-fc/src/factory.rs
+++ b/crates/sandbox-fc/src/factory.rs
@@ -544,6 +544,18 @@ impl SandboxFactory for FirecrackerFactory {
     }
 }
 
+impl Drop for FirecrackerFactory {
+    /// Abort the leak cleanup task if `shutdown()` was never called.
+    ///
+    /// Safety net for abnormal paths (e.g., panic during startup).
+    /// Harmless if `shutdown()` already ran — the handle is `None`.
+    fn drop(&mut self) {
+        if let Some(h) = self.leak_cleanup_handle.take() {
+            h.abort();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Add `Drop` impl to `FirecrackerFactory` that aborts the leak cleanup task as safety net
- Prevents the drain task from outliving the factory when sandbox sender clones keep the mpsc channel open
- `shutdown()` retains `abort()` (not cancel+await) because the drain task performs multi-step async cleanup that could block — bounded shutdown is more important than completing a partial cleanup that `runner gc` handles anyway

Closes #8957

## Test plan

- [x] `cargo build -p sandbox-fc` — compiles
- [x] `cargo test -p sandbox-fc` — all 111 existing tests pass
- [x] `cargo clippy -p sandbox-fc` — no warnings
- [x] `cargo build -p runner` — runner (depends on sandbox-fc) compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)