### PR TITLE
test(runner): cover edge cases with mock sandbox overrides

### DIFF
--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1620,6 +1620,26 @@ mod tests {
         keep_alive: bool,
         make_provider: impl FnOnce(CancellationToken) -> (Arc<MockJobProvider>, MockProviderHandle),
     ) -> (RunConfig, MockRunEnv) {
+        build_mock_run_config_with_runtime(
+            profiles,
+            budget_vcpu,
+            budget_memory_mb,
+            max_concurrent,
+            keep_alive,
+            make_provider,
+            Box::new(MockSandboxRuntime::new()),
+        )
+    }
+
+    fn build_mock_run_config_with_runtime(
+        profiles: BTreeMap<String, config::ProfileConfig>,
+        budget_vcpu: u32,
+        budget_memory_mb: u32,
+        max_concurrent: usize,
+        keep_alive: bool,
+        make_provider: impl FnOnce(CancellationToken) -> (Arc<MockJobProvider>, MockProviderHandle),
+        runtime: Box<dyn sandbox::SandboxRuntime>,
+    ) -> (RunConfig, MockRunEnv) {
         let temp_dir = tempfile::tempdir().unwrap();
         let cancel = CancellationToken::new();
         let (provider, handle) = make_provider(cancel.clone());
@@ -1646,7 +1666,7 @@ mod tests {
             name: "test".into(),
             group: "test-group".into(),
             profiles,
-            runtime: Box::new(MockSandboxRuntime::new()),
+            runtime,
             home,
             budget: Arc::new(ResourceBudget::new(
                 budget_vcpu,
@@ -2666,17 +2686,15 @@ mod tests {
         keep_alive: bool,
         overrides: Arc<sandbox_mock::MockSandboxOverrides>,
     ) -> (RunConfig, MockRunEnv) {
-        let make_provider = |cancel: CancellationToken| MockJobProvider::new(cancel.clone());
-        let (mut config, env) = build_mock_run_config(
+        build_mock_run_config_with_runtime(
             profiles,
             budget_vcpu,
             budget_memory_mb,
             max_concurrent,
             keep_alive,
-            make_provider,
-        );
-        config.runtime = Box::new(MockSandboxRuntime::with_overrides(overrides));
-        (config, env)
+            MockJobProvider::new,
+            Box::new(MockSandboxRuntime::with_overrides(overrides)),
+        )
     }
 
     async fn wait_cancel_token(
@@ -2830,11 +2848,14 @@ mod tests {
         // After eviction: old entry destroyed + old budget released,
         // new entry parked + new budget held → net count = 1.
         wait_budget_count(&budget, 1, Duration::from_secs(2)).await;
+        let pool = idle_pool.lock().await;
+        assert_eq!(pool.len(), 1, "pool should have the newly parked entry");
         assert_eq!(
-            idle_pool.lock().await.len(),
-            1,
-            "pool should have the newly parked entry"
+            pool.held_sessions(),
+            vec!["sess-evict"],
+            "parked session should match guest_session_id"
         );
+        drop(pool);
 
         shutdown(&env, run_handle).await;
     }

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1646,7 +1646,7 @@ mod tests {
             name: "test".into(),
             group: "test-group".into(),
             profiles,
-            runtime: Box::new(MockSandboxRuntime),
+            runtime: Box::new(MockSandboxRuntime::new()),
             home,
             budget: Arc::new(ResourceBudget::new(
                 budget_vcpu,
@@ -2650,6 +2650,191 @@ mod tests {
             "pool should have 1 entry after two sequential jobs"
         );
         assert_eq!(budget.allocated().2, 1, "only one VM should hold budget");
+
+        shutdown(&env, run_handle).await;
+    }
+
+    // =======================================================================
+    // Tests 20-22: Edge cases requiring MockSandboxOverrides
+    // =======================================================================
+
+    fn mock_run_config_with_overrides(
+        profiles: BTreeMap<String, config::ProfileConfig>,
+        budget_vcpu: u32,
+        budget_memory_mb: u32,
+        max_concurrent: usize,
+        keep_alive: bool,
+        overrides: Arc<sandbox_mock::MockSandboxOverrides>,
+    ) -> (RunConfig, MockRunEnv) {
+        let make_provider = |cancel: CancellationToken| MockJobProvider::new(cancel.clone());
+        let (mut config, env) = build_mock_run_config(
+            profiles,
+            budget_vcpu,
+            budget_memory_mb,
+            max_concurrent,
+            keep_alive,
+            make_provider,
+        );
+        config.runtime = Box::new(MockSandboxRuntime::with_overrides(overrides));
+        (config, env)
+    }
+
+    async fn wait_cancel_token(
+        tokens: &Arc<tokio::sync::Mutex<HashMap<Uuid, CancellationToken>>>,
+        run_id: Uuid,
+        timeout: Duration,
+    ) -> CancellationToken {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Some(token) = tokens.lock().await.get(&run_id).cloned() {
+                return token;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "cancel token for {run_id} not found within {timeout:?}",
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// Test 20: Failed job with session context is not parked.
+    ///
+    /// When `wait_exit` returns a non-zero exit code, `spawn_job()` skips
+    /// parking (because `exit_code == 0` is false) and destroys the sandbox.
+    #[tokio::test(start_paused = true)]
+    async fn failed_job_with_session_not_parked() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_code(1));
+        let (config, env) = mock_run_config_with_overrides(
+            test_profiles(),
+            4,
+            8192,
+            4,
+            true, // keep_alive enabled
+            overrides,
+        );
+        let budget = Arc::clone(&config.budget);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = Uuid::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-fail")),
+        );
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "job should complete");
+        assert_eq!(c.unwrap().exit_code, 1);
+
+        wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+        assert_eq!(idle_pool.lock().await.len(), 0, "failed job must not park");
+
+        shutdown(&env, run_handle).await;
+    }
+
+    /// Test 21: Cancelled job is not parked.
+    ///
+    /// `wait_exit_gate` blocks the agent execution. The test cancels the job
+    /// via the cancel token, causing `select!` in the executor to take the
+    /// cancellation branch. `job_cancel.is_cancelled()` is true, so
+    /// `parkable_session` is `None` → sandbox destroyed.
+    #[tokio::test(start_paused = true)]
+    async fn cancelled_job_not_parked() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
+            gate,
+        ));
+        let (config, env) =
+            mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, true, overrides);
+        let budget = Arc::clone(&config.budget);
+        let idle_pool = Arc::clone(&config.idle_pool);
+        let cancel_tokens = Arc::clone(&config.cancel_tokens);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = Uuid::new_v4();
+        push_job(
+            &env,
+            run_id,
+            "vm0/default",
+            Some(context_with_session(run_id, "sess-cancel")),
+        );
+
+        // Wait for the job to be claimed (cancel token inserted).
+        let token = wait_cancel_token(&cancel_tokens, run_id, Duration::from_secs(5)).await;
+        // Cancel the job — executor's select! takes the cancelled branch.
+        token.cancel();
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "cancelled job should still complete");
+        let c = c.unwrap();
+        assert_eq!(c.exit_code, 137, "cancellation yields synthetic SIGKILL");
+        assert_eq!(c.error.as_deref(), Some("cancelled by user"));
+
+        wait_budget_count(&budget, 0, Duration::from_secs(2)).await;
+        assert_eq!(
+            idle_pool.lock().await.len(),
+            0,
+            "cancelled job must not park"
+        );
+
+        shutdown(&env, run_handle).await;
+    }
+
+    /// Test 22: `ParkResult::Evicted` via `guest_session_id`.
+    ///
+    /// A first-run job (no `resume_session`) reads a CLI-generated session ID
+    /// from the guest filesystem. When that session already has an entry in
+    /// the idle pool, `pool.park()` returns `Evicted(old)`, the old VM is
+    /// destroyed, and the new VM takes its place.
+    #[tokio::test(start_paused = true)]
+    async fn park_evicts_via_guest_session_id() {
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::new());
+        overrides.add_exec_matcher(sandbox_mock::ExecMatcher {
+            pattern: "cat /tmp/vm0-session-".into(),
+            exit_code: 0,
+            stdout: b"sess-evict".to_vec(),
+            stderr: Vec::new(),
+        });
+        let (config, env) =
+            mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, true, overrides);
+        let budget = Arc::clone(&config.budget);
+        let idle_pool = Arc::clone(&config.idle_pool);
+
+        // Pre-seed idle pool with session "sess-evict".
+        seed_idle_pool(&idle_pool, &budget, "sess-evict", "vm0/default", 2, 4096).await;
+        assert_eq!(budget.allocated().2, 1, "pre-seeded entry holds budget");
+
+        let run_handle = tokio::spawn(run(config));
+
+        // Push job WITHOUT resume_session — first run, no session context.
+        // read_guest_session_id() will be called and return "sess-evict"
+        // via the exec matcher.
+        let run_id = Uuid::new_v4();
+        push_job(&env, run_id, "vm0/default", Some(minimal_context(run_id)));
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "job should complete");
+        assert_eq!(c.unwrap().exit_code, 0);
+
+        // After eviction: old entry destroyed + old budget released,
+        // new entry parked + new budget held → net count = 1.
+        wait_budget_count(&budget, 1, Duration::from_secs(2)).await;
+        assert_eq!(
+            idle_pool.lock().await.len(),
+            1,
+            "pool should have the newly parked entry"
+        );
 
         shutdown(&env, run_handle).await;
     }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -5,6 +5,11 @@
 //! or [`MockSandboxControl::push_exec_remote_result`] to queue custom responses
 //! consumed in FIFO order.
 //!
+//! For advanced control, create [`MockSandboxOverrides`] and pass it via
+//! [`MockSandboxRuntime::with_overrides`]. This enables pattern-matched exec
+//! results, custom `wait_exit` exit codes, and blocking gates for
+//! cancellation testing.
+//!
 //! ```toml
 //! [dev-dependencies]
 //! sandbox-mock = { workspace = true }

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -41,7 +41,7 @@ pub struct MockSandboxOverrides {
     /// consumed (one-shot).
     exec_matchers: Mutex<Vec<ExecMatcher>>,
     /// When `Some`, `wait_exit` returns this exit code instead of 0.
-    wait_exit_code: Mutex<Option<i32>>,
+    wait_exit_code: Option<i32>,
     /// When set, `wait_exit` awaits this [`tokio::sync::Notify`] before
     /// returning — giving the test a window to cancel the job.
     wait_exit_gate: Option<Arc<tokio::sync::Notify>>,
@@ -51,7 +51,7 @@ impl MockSandboxOverrides {
     pub fn new() -> Self {
         Self {
             exec_matchers: Mutex::new(Vec::new()),
-            wait_exit_code: Mutex::new(None),
+            wait_exit_code: None,
             wait_exit_gate: None,
         }
     }
@@ -60,7 +60,7 @@ impl MockSandboxOverrides {
     pub fn with_wait_exit_code(code: i32) -> Self {
         Self {
             exec_matchers: Mutex::new(Vec::new()),
-            wait_exit_code: Mutex::new(Some(code)),
+            wait_exit_code: Some(code),
             wait_exit_gate: None,
         }
     }
@@ -69,7 +69,7 @@ impl MockSandboxOverrides {
     pub fn with_wait_exit_gate(gate: Arc<tokio::sync::Notify>) -> Self {
         Self {
             exec_matchers: Mutex::new(Vec::new()),
-            wait_exit_code: Mutex::new(None),
+            wait_exit_code: None,
             wait_exit_gate: Some(gate),
         }
     }
@@ -233,11 +233,7 @@ impl Sandbox for MockSandbox {
                 gate.notified().await;
             }
             // Return override exit code when configured.
-            if let Some(code) = *overrides
-                .wait_exit_code
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-            {
+            if let Some(code) = overrides.wait_exit_code {
                 return Ok(ProcessExit {
                     pid: handle.pid,
                     exit_code: code,

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -12,11 +12,82 @@
 
 use std::collections::VecDeque;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use sandbox::*;
+
+// ---------------------------------------------------------------------------
+// MockSandboxOverrides
+// ---------------------------------------------------------------------------
+
+/// Behavior override applied to exec calls whose command contains the pattern.
+pub struct ExecMatcher {
+    /// Substring to match against `ExecRequest.cmd`.
+    pub pattern: String,
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+/// Shared behavior overrides propagated from runtime → factory → sandbox.
+///
+/// Tests create this via [`MockSandboxRuntime::with_overrides`] so every
+/// sandbox produced by the factory checks these overrides before falling
+/// back to the default FIFO-queue behaviour.
+pub struct MockSandboxOverrides {
+    /// Pattern-matched exec results. First matching pattern wins and is
+    /// consumed (one-shot).
+    exec_matchers: Mutex<Vec<ExecMatcher>>,
+    /// When `Some`, `wait_exit` returns this exit code instead of 0.
+    wait_exit_code: Mutex<Option<i32>>,
+    /// When set, `wait_exit` awaits this [`tokio::sync::Notify`] before
+    /// returning — giving the test a window to cancel the job.
+    wait_exit_gate: Option<Arc<tokio::sync::Notify>>,
+}
+
+impl MockSandboxOverrides {
+    pub fn new() -> Self {
+        Self {
+            exec_matchers: Mutex::new(Vec::new()),
+            wait_exit_code: Mutex::new(None),
+            wait_exit_gate: None,
+        }
+    }
+
+    /// Create overrides that make `wait_exit` return a custom exit code.
+    pub fn with_wait_exit_code(code: i32) -> Self {
+        Self {
+            exec_matchers: Mutex::new(Vec::new()),
+            wait_exit_code: Mutex::new(Some(code)),
+            wait_exit_gate: None,
+        }
+    }
+
+    /// Create overrides that block `wait_exit` until the gate is notified.
+    pub fn with_wait_exit_gate(gate: Arc<tokio::sync::Notify>) -> Self {
+        Self {
+            exec_matchers: Mutex::new(Vec::new()),
+            wait_exit_code: Mutex::new(None),
+            wait_exit_gate: Some(gate),
+        }
+    }
+
+    /// Register a pattern matcher consumed on first match.
+    pub fn add_exec_matcher(&self, matcher: ExecMatcher) {
+        self.exec_matchers
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(matcher);
+    }
+}
+
+impl Default for MockSandboxOverrides {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // MockSandbox
@@ -32,6 +103,7 @@ pub struct MockSandbox {
     source_ip: String,
     exec_results: Mutex<VecDeque<Result<ExecResult>>>,
     write_file_results: Mutex<VecDeque<Result<()>>>,
+    overrides: Option<Arc<MockSandboxOverrides>>,
 }
 
 impl MockSandbox {
@@ -41,6 +113,17 @@ impl MockSandbox {
             source_ip: "10.0.0.1".into(),
             exec_results: Mutex::new(VecDeque::new()),
             write_file_results: Mutex::new(VecDeque::new()),
+            overrides: None,
+        }
+    }
+
+    fn with_overrides(id: impl Into<String>, overrides: Arc<MockSandboxOverrides>) -> Self {
+        Self {
+            id: id.into(),
+            source_ip: "10.0.0.1".into(),
+            exec_results: Mutex::new(VecDeque::new()),
+            write_file_results: Mutex::new(VecDeque::new()),
+            overrides: Some(overrides),
         }
     }
 
@@ -97,7 +180,25 @@ impl Sandbox for MockSandbox {
         Ok(())
     }
 
-    async fn exec(&self, _request: &ExecRequest<'_>) -> Result<ExecResult> {
+    async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult> {
+        // Check pattern matchers before the FIFO queue.
+        if let Some(overrides) = &self.overrides {
+            let mut matchers = overrides
+                .exec_matchers
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if let Some(idx) = matchers
+                .iter()
+                .position(|m| request.cmd.contains(&m.pattern))
+            {
+                let m = matchers.remove(idx);
+                return Ok(ExecResult {
+                    exit_code: m.exit_code,
+                    stdout: m.stdout,
+                    stderr: m.stderr,
+                });
+            }
+        }
         self.exec_results
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -126,6 +227,25 @@ impl Sandbox for MockSandbox {
     }
 
     async fn wait_exit(&self, handle: SpawnHandle, _timeout: Duration) -> Result<ProcessExit> {
+        if let Some(overrides) = &self.overrides {
+            // Block until the test signals (gives a window for cancellation).
+            if let Some(gate) = &overrides.wait_exit_gate {
+                gate.notified().await;
+            }
+            // Return override exit code when configured.
+            if let Some(code) = *overrides
+                .wait_exit_code
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+            {
+                return Ok(ProcessExit {
+                    pid: handle.pid,
+                    exit_code: code,
+                    stdout: Vec::new(),
+                    stderr: Vec::new(),
+                });
+            }
+        }
         Ok(ProcessExit {
             pid: handle.pid,
             exit_code: 0,
@@ -145,12 +265,21 @@ impl Sandbox for MockSandbox {
 /// When the queue is empty, `create` returns a default `MockSandbox`.
 pub struct MockSandboxFactory {
     create_results: Mutex<VecDeque<Result<()>>>,
+    overrides: Option<Arc<MockSandboxOverrides>>,
 }
 
 impl MockSandboxFactory {
     pub fn new() -> Self {
         Self {
             create_results: Mutex::new(VecDeque::new()),
+            overrides: None,
+        }
+    }
+
+    pub fn with_overrides(overrides: Arc<MockSandboxOverrides>) -> Self {
+        Self {
+            create_results: Mutex::new(VecDeque::new()),
+            overrides: Some(overrides),
         }
     }
 
@@ -194,7 +323,11 @@ impl SandboxFactory for MockSandboxFactory {
         {
             result?;
         }
-        Ok(Box::new(MockSandbox::new(config.id.to_string())))
+        let sandbox = match &self.overrides {
+            Some(o) => MockSandbox::with_overrides(config.id.to_string(), Arc::clone(o)),
+            None => MockSandbox::new(config.id.to_string()),
+        };
+        Ok(Box::new(sandbox))
     }
 
     async fn destroy(&self, _sandbox: Box<dyn Sandbox>) {}
@@ -207,12 +340,36 @@ impl SandboxFactory for MockSandboxFactory {
 // ---------------------------------------------------------------------------
 
 /// A mock [`SandboxRuntime`] that creates [`MockSandboxFactory`] instances.
-pub struct MockSandboxRuntime;
+pub struct MockSandboxRuntime {
+    overrides: Option<Arc<MockSandboxOverrides>>,
+}
+
+impl MockSandboxRuntime {
+    pub fn new() -> Self {
+        Self { overrides: None }
+    }
+
+    pub fn with_overrides(overrides: Arc<MockSandboxOverrides>) -> Self {
+        Self {
+            overrides: Some(overrides),
+        }
+    }
+}
+
+impl Default for MockSandboxRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 #[async_trait]
 impl SandboxRuntime for MockSandboxRuntime {
     async fn create_factory(&self, _config: FactoryConfig) -> Result<Box<dyn SandboxFactory>> {
-        Ok(Box::new(MockSandboxFactory::new()))
+        let factory = match &self.overrides {
+            Some(o) => MockSandboxFactory::with_overrides(Arc::clone(o)),
+            None => MockSandboxFactory::new(),
+        };
+        Ok(Box::new(factory))
     }
 
     async fn shutdown(&mut self) {}
@@ -228,7 +385,7 @@ pub struct MockRuntimeProvider;
 #[async_trait]
 impl RuntimeProvider for MockRuntimeProvider {
     async fn create_runtime(&self, _config: RuntimeConfig) -> Result<Box<dyn SandboxRuntime>> {
-        Ok(Box::new(MockSandboxRuntime))
+        Ok(Box::new(MockSandboxRuntime::new()))
     }
 }
 
@@ -402,7 +559,7 @@ mod tests {
 
     #[tokio::test]
     async fn runtime_creates_factory() {
-        let mut runtime = MockSandboxRuntime;
+        let mut runtime = MockSandboxRuntime::new();
         let factory_config = FactoryConfig {
             profile: "test".into(),
             binary_path: "/bin/test".into(),


### PR DESCRIPTION
## Summary

- Add `MockSandboxOverrides` and `ExecMatcher` to `sandbox-mock` crate — shared behavior overrides propagated through Runtime → Factory → Sandbox chain
- Three new capabilities: pattern-matching exec results, wait_exit exit code override, wait_exit blocking gate
- 3 new integration tests covering previously untestable `spawn_job()` parking branches:
  - **Test 20**: failed job with session → not parked (`exit_code != 0`)
  - **Test 21**: cancelled job → not parked (`job_cancel.is_cancelled()`)
  - **Test 22**: `ParkResult::Evicted` via `guest_session_id` (first-run parking)
- All 475 runner tests pass, zero clippy warnings

## Test plan

- [x] `cargo test -p sandbox-mock` — 11 tests pass (no regressions)
- [x] `cargo test -p runner` — 475 tests pass (472 existing + 3 new)
- [x] `cargo clippy -p sandbox-mock -p runner` — zero warnings

Closes #8959

🤖 Generated with [Claude Code](https://claude.com/claude-code)