### PR TITLE
fix: focus run summary on results rather than user input

### DIFF
--- a/turbo/apps/web/src/lib/zero/ai/lightweight-model.ts
+++ b/turbo/apps/web/src/lib/zero/ai/lightweight-model.ts
@@ -197,11 +197,11 @@ export async function generateRunSummary(
     [
       {
         role: "system",
-        content: `Summarize this ${triggerSource} agent run in at most 50 words as plain text. No markdown, no quotes. Focus on what the user asked and what the agent did.`,
+        content: `Summarize the result of this ${triggerSource} agent run in at most 50 words as plain text. No markdown, no quotes. Focus on what was accomplished or produced — the user's original request is provided only for context.`,
       },
       {
         role: "user",
-        content: `User prompt:\n${promptSnippet}\n\nAgent result:\n${resultSnippet}`,
+        content: `Context (user request):\n${promptSnippet}\n\nResult:\n${resultSnippet}`,
       },
     ],
     80,


### PR DESCRIPTION
## Summary
- Adjusted the `generateRunSummary` prompt to focus on **what was accomplished or produced** instead of summarizing both the user's request and the agent's actions
- User input is still passed to the model but framed as context, not the focus of the summary
- No functional changes — same truncation, same model, same token limits

## Context
The current prompt tells the lightweight model to "focus on what the user asked and what the agent did", which causes summaries to echo the user's input. Summaries should describe outcomes/results; the user's request is only needed to help the small model understand what the result means.

## Test plan
- [x] All 22 existing `lightweight-model.test.ts` tests pass
- [ ] Verify generated summaries in staging are result-focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)