### PR TITLE
fix: sidebar collapse button closes mobile overlay

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -12,6 +12,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
+import { sidebarExpanded$, setSidebarExpanded$ } from "../../../signals/zero-page/zero-nav.ts";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
@@ -425,6 +426,30 @@ describe("zero sidebar - sidebar collapse button hides sidebar (SIDEBAR-D-022)",
     await waitFor(() => {
       expect(screen.getByLabelText("Expand sidebar")).toBeInTheDocument();
     });
+  });
+});
+
+describe("zero sidebar - collapse button closes mobile overlay (SIDEBAR-M-023)", () => {
+  it("sets sidebarExpanded to false when collapse button is clicked while sidebar is open as mobile overlay", async () => {
+    const user = userEvent.setup();
+    mockBaseAPIs();
+    detachedSetupPage({ context, path: "/" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("navigation", { name: "Sidebar" }),
+      ).toBeInTheDocument();
+    });
+
+    // Simulate mobile sidebar expanded state (as if "Open menu" was tapped)
+    context.store.set(setSidebarExpanded$, true);
+
+    expect(context.store.get(sidebarExpanded$)).toBe(true);
+
+    const collapseBtn = screen.getByLabelText("Collapse sidebar");
+    await user.click(collapseBtn);
+
+    expect(context.store.get(sidebarExpanded$)).toBe(false);
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/zero-sidebar-interaction.test.tsx
@@ -12,7 +12,10 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { screen, waitFor, within } from "@testing-library/react";
-import { sidebarExpanded$, setSidebarExpanded$ } from "../../../signals/zero-page/zero-nav.ts";
+import {
+  sidebarExpanded$,
+  setSidebarExpanded$,
+} from "../../../signals/zero-page/zero-nav.ts";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../mocks/server.ts";
@@ -444,12 +447,12 @@ describe("zero sidebar - collapse button closes mobile overlay (SIDEBAR-M-023)",
     // Simulate mobile sidebar expanded state (as if "Open menu" was tapped)
     context.store.set(setSidebarExpanded$, true);
 
-    expect(context.store.get(sidebarExpanded$)).toBe(true);
+    expect(context.store.get(sidebarExpanded$)).toBeTruthy();
 
     const collapseBtn = screen.getByLabelText("Collapse sidebar");
     await user.click(collapseBtn);
 
-    expect(context.store.get(sidebarExpanded$)).toBe(false);
+    expect(context.store.get(sidebarExpanded$)).toBeFalsy();
   });
 });
 

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -204,6 +204,7 @@ export function ZeroSidebar() {
   const expanded = useGet(sidebarExpanded$);
   const setExpanded = useSet(setSidebarExpanded$);
   const onCollapse = () => {
+    setExpanded(false);
     return toggleOff();
   };
   const rawOnSelect = useSet(handleZeroNavSelect$);


### PR DESCRIPTION
## Summary

- **Root cause**: `onCollapse` only called `toggleOff()` which toggles the desktop icon-only sidebar state (`sidebarOff$`). On mobile, the overlay is controlled by `sidebarExpanded$` — so tapping the collapse button had no effect.
- **Fix**: Also call `setExpanded(false)` in `onCollapse` so the mobile overlay closes when the button is tapped.
- **Test**: Added `SIDEBAR-M-023` — verifies that clicking "Collapse sidebar" sets `sidebarExpanded$` to `false`.

Fixes #8976

🤖 Generated with [Claude Code](https://claude.com/claude-code)