### PR TITLE
fix(guest-agent): add stdout drain deadline to prevent hanging on orphaned pipes

### DIFF
--- a/crates/guest-agent/src/cli.rs
+++ b/crates/guest-agent/src/cli.rs
@@ -178,6 +178,12 @@ pub async fn execute_cli(
 
     let mut cli_status: Option<std::process::ExitStatus> = None;
 
+    // Drain deadline: after child.wait() fires, allow up to N seconds for
+    // stdout EOF before breaking the loop.  Prevents indefinite hangs when
+    // orphaned child processes hold the stdout fd open.
+    let drain_deadline = tokio::time::sleep(Duration::MAX);
+    tokio::pin!(drain_deadline);
+
     // Stuck-tool watchdog: workaround for Claude Code bug where
     // WebSearch/WebFetch hang indefinitely. Track all in-flight tool calls;
     // if a network tool exceeds STUCK_TOOL_TIMEOUT_SECS without producing
@@ -260,9 +266,21 @@ pub async fn execute_cli(
                     Ok(s) => {
                         log_info!(LOG_TAG, "CLI process exited (status: {s}), draining stdout");
                         cli_status = Some(s);
+                        drain_deadline.as_mut().reset(
+                            tokio::time::Instant::now()
+                                + Duration::from_secs(constants::STDOUT_DRAIN_DEADLINE_SECS),
+                        );
                     }
                     Err(e) => break Err(AgentError::Io(e)),
                 }
+            }
+            () = &mut drain_deadline, if cli_status.is_some() => {
+                log_warn!(
+                    LOG_TAG,
+                    "Stdout drain deadline reached after {}s, possible orphaned child process",
+                    constants::STDOUT_DRAIN_DEADLINE_SECS,
+                );
+                break Ok(());
             }
             _ = stuck_tool_check.tick() => {
                 let timeout_secs = env::stuck_tool_timeout_secs();
@@ -343,7 +361,27 @@ pub async fn execute_cli(
         }
     };
 
-    let stderr_lines = stderr_handle.await.unwrap_or_default();
+    // Apply the same drain deadline to stderr — orphaned child processes
+    // may hold the stderr fd open just like stdout.
+    let stderr_lines = match tokio::time::timeout(
+        Duration::from_secs(constants::STDOUT_DRAIN_DEADLINE_SECS),
+        stderr_handle,
+    )
+    .await
+    {
+        Ok(Ok(lines)) => lines,
+        Ok(Err(e)) => {
+            log_warn!(LOG_TAG, "stderr collector panicked: {e}");
+            Vec::new()
+        }
+        Err(_) => {
+            log_warn!(
+                LOG_TAG,
+                "stderr drain timeout, possible orphaned child process"
+            );
+            Vec::new()
+        }
+    };
 
     // If event loop had an error, propagate it
     event_result?;

--- a/crates/guest-agent/src/constants.rs
+++ b/crates/guest-agent/src/constants.rs
@@ -33,3 +33,8 @@ pub const STUCK_TOOL_TIMEOUT_SECS: u64 = 60;
 
 /// How often (in seconds) to check for stuck tools in the select loop.
 pub const STUCK_TOOL_CHECK_INTERVAL_SECS: u64 = 5;
+
+/// After the CLI process exits, continue reading stdout for this many seconds.
+/// If EOF is not received within this deadline, break the loop to prevent
+/// hanging on orphaned child processes that inherited the stdout fd.
+pub const STDOUT_DRAIN_DEADLINE_SECS: u64 = 5;

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -6,7 +6,9 @@
 //! Usage: mock-claude [options] <prompt>
 //!
 //! Special test prefixes:
-//!   @fail:<message> - Output message to stderr and exit with code 1
+//!   @fail:<message>  - Output message to stderr and exit with code 1
+//!   @stuck-tool      - Emit WebFetch tool_use then hang (test stuck-tool watchdog)
+//!   @orphan-pipe     - Emit events, spawn child holding stdout, then exit
 
 use serde_json::{Value, json};
 use std::io::Write;
@@ -308,6 +310,51 @@ fn main() -> ExitCode {
             std::thread::sleep(std::time::Duration::from_secs(3600));
         }
         return ExitCode::from(1);
+    }
+
+    // Special test prefix: @orphan-pipe — emit events, spawn child that holds
+    // stdout open, then exit.  Simulates orphaned child processes that prevent
+    // guest-agent from seeing EOF on the CLI's stdout pipe.
+    if parsed.prompt.starts_with("@orphan-pipe") {
+        if parsed.output_format == "stream-json" {
+            let session_id = generate_session_id();
+
+            // Init event
+            println!(
+                "{}",
+                json!({
+                    "type": "system",
+                    "subtype": "init",
+                    "cwd": "/tmp",
+                    "session_id": session_id,
+                    "tools": ["Bash"],
+                    "model": "mock-claude"
+                })
+            );
+
+            // Result event
+            println!(
+                "{}",
+                json!({
+                    "type": "result",
+                    "subtype": "success",
+                    "session_id": session_id,
+                    "is_error": false,
+                    "duration_ms": 100,
+                    "num_turns": 1,
+                    "result": "Done.",
+                    "total_cost_usd": 0,
+                    "usage": {"input_tokens": 0, "output_tokens": 0}
+                })
+            );
+
+            let _ = std::io::stdout().flush();
+
+            // Spawn a child that inherits stdout and sleeps forever.
+            // This keeps the stdout pipe open after this process exits.
+            let _ = Command::new("sleep").arg("3600").spawn();
+        }
+        return ExitCode::SUCCESS;
     }
 
     let session_id = generate_session_id();

--- a/crates/guest-mock-claude/src/main.rs
+++ b/crates/guest-mock-claude/src/main.rs
@@ -318,35 +318,40 @@ fn main() -> ExitCode {
     if parsed.prompt.starts_with("@orphan-pipe") {
         if parsed.output_format == "stream-json" {
             let session_id = generate_session_id();
+            let cwd = std::env::current_dir()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|_| "/".to_string());
 
-            // Init event
-            println!(
-                "{}",
-                json!({
-                    "type": "system",
-                    "subtype": "init",
-                    "cwd": "/tmp",
-                    "session_id": session_id,
-                    "tools": ["Bash"],
-                    "model": "mock-claude"
-                })
-            );
+            let init_event = json!({
+                "type": "system",
+                "subtype": "init",
+                "cwd": cwd,
+                "session_id": session_id,
+                "tools": ["Bash"],
+                "model": "mock-claude"
+            });
+            println!("{}", init_event);
 
-            // Result event
-            println!(
-                "{}",
-                json!({
-                    "type": "result",
-                    "subtype": "success",
-                    "session_id": session_id,
-                    "is_error": false,
-                    "duration_ms": 100,
-                    "num_turns": 1,
-                    "result": "Done.",
-                    "total_cost_usd": 0,
-                    "usage": {"input_tokens": 0, "output_tokens": 0}
-                })
-            );
+            let result_event = json!({
+                "type": "result",
+                "subtype": "success",
+                "session_id": session_id,
+                "is_error": false,
+                "duration_ms": 100,
+                "num_turns": 1,
+                "result": "Done.",
+                "total_cost_usd": 0,
+                "usage": {"input_tokens": 0, "output_tokens": 0}
+            });
+            println!("{}", result_event);
+
+            // Write session history file — checkpoint requires it.
+            if let Some(path) = create_session_history(&session_id, &cwd)
+                && let Ok(mut file) = std::fs::File::create(&path)
+            {
+                let _ = writeln!(file, "{init_event}");
+                let _ = writeln!(file, "{result_event}");
+            }
 
             let _ = std::io::stdout().flush();
 

--- a/e2e/tests/03-runner/t48-orphan-pipe-drain.bats
+++ b/e2e/tests/03-runner/t48-orphan-pipe-drain.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+# Test stdout drain deadline: guest-agent exits cleanly when orphaned child
+# processes hold the stdout pipe open after CLI exits.
+#
+# Uses @orphan-pipe mock-claude mode which spawns a sleep child that inherits
+# stdout, then exits.  Without the drain deadline, guest-agent would hang
+# indefinitely waiting for EOF.
+#
+# See: https://github.com/vm0-ai/vm0/issues/8967
+
+load '../../helpers/setup'
+
+setup() {
+    export TEST_DIR="$(mktemp -d)"
+    export UNIQUE_ID="$(date +%s%3N)-$RANDOM"
+    export AGENT_NAME="e2e-orphan-pipe-${UNIQUE_ID}"
+}
+
+teardown() {
+    if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+@test "orphan-pipe drain deadline allows agent to exit" {
+    if $VM0_CLI auth status 2>&1 | grep -q "Not authenticated"; then
+        skip "Not authenticated"
+    fi
+
+    cd "$TEST_DIR"
+
+    cat > vm0.yaml <<EOF
+version: "1.0"
+
+agents:
+  $AGENT_NAME:
+    description: "Orphan pipe drain deadline test"
+    framework: claude-code
+    working_dir: /home/user/workspace
+EOF
+
+    echo "# Step 1: Compose agent..."
+    run $VM0_CLI compose vm0.yaml
+    assert_success
+
+    echo "# Step 2: Run with @orphan-pipe prompt..."
+    # The mock-claude emits events, spawns a child holding stdout open, then
+    # exits.  The drain deadline (5s) should allow guest-agent to break out
+    # of the stdout loop and complete the run successfully.
+    run $VM0_CLI run "$AGENT_NAME" --no-auto-update "@orphan-pipe"
+
+    echo "# Step 3: Verify run succeeded..."
+    assert_success
+
+    # Extract Run ID
+    RUN_ID=$(echo "$output" | grep -oP 'Run ID:\s+\K[a-f0-9-]{36}' | head -1)
+    [ -n "$RUN_ID" ] || {
+        echo "# Failed to extract Run ID from output"
+        echo "$output"
+        return 1
+    }
+
+    echo "# Step 4: Verify system logs contain drain deadline message..."
+    wait_for_log "$RUN_ID" --system -- "drain deadline"
+}


### PR DESCRIPTION
## Summary

- Re-introduce 5-second stdout drain deadline after CLI exits, preventing indefinite hangs when orphaned child processes hold the stdout fd open
- Add matching 5-second timeout to stderr collector (orphaned children inherit both fds)
- Add `@orphan-pipe` test prefix to guest-mock-claude for simulating the scenario
- Add E2E test `t48-orphan-pipe-drain.bats` to verify drain deadline behavior

## Context

Originally fixed in PR #3409, the drain deadline was incorrectly removed in PR #3859 under the assumption that "orphaned children holding the pipe doesn't occur in practice." A production incident on prod-3 (job `673f66d4` running 5+ hours) proved otherwise.

The current event architecture (background mpsc channel from PR #3884) makes it safe to re-introduce — all enqueued events are processed by the background sender regardless of when the loop breaks.

## Test plan

- [x] `cargo clippy -p guest-agent -p guest-mock-claude` passes
- [x] `cargo test -p guest-agent -p guest-mock-claude` passes (100 tests)
- [ ] E2E `t48-orphan-pipe-drain.bats` validates drain deadline triggers and run succeeds

Closes #8967

🤖 Generated with [Claude Code](https://claude.com/claude-code)