### PR TITLE
feat: add feature flag to control sandbox reuse logic

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1128,7 +1128,7 @@ jobs:
           # shellcheck disable=SC2088
           BIN_DIR="/var/lib/vm0-runner/bin/${JOB_REF}"
 
-          echo "=== Generating config (keep-alive enabled) ==="
+          echo "=== Generating config ==="
           # shellcheck disable=SC2029
           ssh "$REMOTE" "sudo ${BIN_DIR}/runner config \
             --profile vm0/default \
@@ -1137,7 +1137,6 @@ jobs:
             --group vm0/keepalive-${JOB_REF} \
             --runner-dirname ${JOB_REF}-keepalive \
             --max-concurrent 2 \
-            --keep-alive \
             --api-url https://not-a-real-server.test \
             --token vm0_official_${OFFICIAL_RUNNER_SECRET}"
 
@@ -1160,24 +1159,26 @@ jobs:
           # Clean up any residual transient unit from a previous CI run
           sudo "$BIN_DIR/runner" service stop --name "$SVC" 2>/dev/null || true
 
-          # Start transient runner service with keep-alive
-          echo "--- Starting runner (keep-alive enabled) ---"
+          # Start transient runner service
+          echo "--- Starting runner ---"
           sudo "$BIN_DIR/runner" service start --name "$SVC" \
             --config "$RUNNER_DIR/runner.yaml" --local --env USE_MOCK_CLAUDE=true
 
-          # Turn 1: submit job with session ID — creates a marker file in guest
+          # Turn 1: submit job with session ID and sandboxReuse flag — creates a marker file in guest
           echo "--- Turn 1: create marker file ---"
           sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
             --session-id "$SESSION_ID" \
+            --feature-flag sandboxReuse=true \
             --prompt 'touch /tmp/keepalive-marker && echo turn1-done' \
             || fail "Turn 1 failed"
 
-          # Turn 2: submit job with same session ID — should reuse the VM.
+          # Turn 2: submit job with same session ID and flag — should reuse the VM.
           # If VM was reused, the marker file from turn 1 still exists (exit 0).
           # If a new VM was created, the file is missing and test exits non-zero.
           echo "--- Turn 2: verify marker file persists (VM reused) ---"
           sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
             --session-id "$SESSION_ID" \
+            --feature-flag sandboxReuse=true \
             --prompt 'test -f /tmp/keepalive-marker' \
             || fail "Turn 2: marker file not found — VM was not reused"
           echo "PASS: Turn 2 completed (VM reused, filesystem persisted)"
@@ -1187,6 +1188,7 @@ jobs:
           echo "--- Turn 3: different session creates new VM ---"
           sudo "$BIN_DIR/runner" local submit --group "$GROUP" \
             --session-id "different-session" \
+            --feature-flag sandboxReuse=true \
             --prompt 'test ! -f /tmp/keepalive-marker' \
             || fail "Turn 3: marker file found — session isolation broken"
           echo "PASS: Turn 3 completed (new VM for different session)"

--- a/crates/runner/src/cmd/config.rs
+++ b/crates/runner/src/cmd/config.rs
@@ -38,10 +38,6 @@ pub struct ConfigArgs {
     #[arg(long, default_value_t = DEFAULT_CONCURRENCY_FACTOR)]
     concurrency_factor: f64,
 
-    /// Keep VMs alive between conversation turns for session reuse
-    #[arg(long)]
-    keep_alive: bool,
-
     /// vm0 API URL
     #[arg(long, env = "VM0_API_URL")]
     api_url: String,
@@ -113,7 +109,6 @@ pub async fn run_config(args: ConfigArgs) -> RunnerResult<()> {
         sandbox: SandboxConfig {
             max_concurrent: args.max_concurrent,
             concurrency_factor: args.concurrency_factor,
-            keep_alive: args.keep_alive,
             ..SandboxConfig::default()
         },
         server: Some(ServerConfig {

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -36,9 +36,12 @@ pub struct SubmitArgs {
     /// VM profile to use (e.g. "vm0/default")
     #[arg(long)]
     profile: Option<String>,
-    /// Session ID for keep-alive VM reuse across conversation turns
+    /// Session ID for sandbox reuse across conversation turns
     #[arg(long)]
     session_id: Option<String>,
+    /// Feature flags (repeatable, format: key=value, e.g. --feature-flag sandboxReuse=true)
+    #[arg(long = "feature-flag")]
+    feature_flags: Vec<String>,
     /// Timeout in seconds waiting for a runner to complete the job
     #[arg(long, default_value_t = 300)]
     timeout: u64,
@@ -96,6 +99,24 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
         RunnerError::Config(format!("create group dir {}: {e}", group_dir.display()))
     })?;
 
+    let feature_flags = if args.feature_flags.is_empty() {
+        None
+    } else {
+        let mut map = std::collections::HashMap::new();
+        for flag in &args.feature_flags {
+            let (key, value) = flag.split_once('=').ok_or_else(|| {
+                RunnerError::Config(format!("invalid feature flag (expected key=value): {flag}"))
+            })?;
+            let bool_val = value.parse::<bool>().map_err(|_| {
+                RunnerError::Config(format!(
+                    "invalid feature flag value (expected true/false): {flag}"
+                ))
+            })?;
+            map.insert(key.to_string(), bool_val);
+        }
+        Some(map)
+    };
+
     let job_id = Uuid::new_v4();
     let request = JobRequest {
         job_id,
@@ -107,6 +128,7 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
         user_timezone: detect_system_timezone(),
         profile: args.profile,
         session_id: args.session_id,
+        feature_flags,
     };
 
     let json = serde_json::to_vec(&request)
@@ -278,6 +300,7 @@ mod tests {
             cli_agent_type: "claude-code".into(),
             profile: Some("bad-name".into()),
             session_id: None,
+            feature_flags: vec![],
             timeout: 1,
         };
         let err = run_submit(args).await.unwrap_err();
@@ -296,6 +319,7 @@ mod tests {
             cli_agent_type: "claude-code".into(),
             profile: Some("vm0/default".into()),
             session_id: None,
+            feature_flags: vec![],
             timeout: 1,
         };
         // Should pass validation and fail later (HomePaths or timeout), not on profile.

--- a/crates/runner/src/cmd/local/submit.rs
+++ b/crates/runner/src/cmd/local/submit.rs
@@ -92,13 +92,6 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
         )));
     }
 
-    let home = HomePaths::new()?;
-    let group_dir = home.groups_dir().join(&args.group);
-
-    std::fs::create_dir_all(&group_dir).map_err(|e| {
-        RunnerError::Config(format!("create group dir {}: {e}", group_dir.display()))
-    })?;
-
     let feature_flags = if args.feature_flags.is_empty() {
         None
     } else {
@@ -116,6 +109,13 @@ pub async fn run_submit(args: SubmitArgs) -> RunnerResult<ExitCode> {
         }
         Some(map)
     };
+
+    let home = HomePaths::new()?;
+    let group_dir = home.groups_dir().join(&args.group);
+
+    std::fs::create_dir_all(&group_dir).map_err(|e| {
+        RunnerError::Config(format!("create group dir {}: {e}", group_dir.display()))
+    })?;
 
     let job_id = Uuid::new_v4();
     let request = JobRequest {
@@ -327,5 +327,40 @@ mod tests {
         if let Err(e) = &result {
             assert!(!e.to_string().contains("invalid profile name"), "got: {e}");
         }
+    }
+
+    #[tokio::test]
+    async fn rejects_feature_flag_missing_equals() {
+        let args = SubmitArgs {
+            group: "test/group".into(),
+            prompt: "hello".into(),
+            working_dir: "/workspace".into(),
+            cli_agent_type: "claude-code".into(),
+            profile: None,
+            session_id: None,
+            feature_flags: vec!["sandboxReuse".into()],
+            timeout: 1,
+        };
+        let err = run_submit(args).await.unwrap_err();
+        assert!(err.to_string().contains("expected key=value"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_feature_flag_non_boolean() {
+        let args = SubmitArgs {
+            group: "test/group".into(),
+            prompt: "hello".into(),
+            working_dir: "/workspace".into(),
+            cli_agent_type: "claude-code".into(),
+            profile: None,
+            session_id: None,
+            feature_flags: vec!["sandboxReuse=yes".into()],
+            timeout: 1,
+        };
+        let err = run_submit(args).await.unwrap_err();
+        assert!(
+            err.to_string().contains("expected true/false"),
+            "got: {err}"
+        );
     }
 }

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1569,6 +1569,7 @@ mod tests {
     struct MockRunEnv {
         handle: MockProviderHandle,
         provider: Arc<MockJobProvider>,
+        idle_pool: SharedIdlePool,
         mode_tx: tokio::sync::watch::Sender<RunnerMode>,
         cancel: CancellationToken,
         _temp_dir: tempfile::TempDir,
@@ -1654,6 +1655,11 @@ mod tests {
         let (mitm, mitm_crash_rx) = proxy::MitmProxy::noop();
         let min_vcpu = profiles_min_vcpu(&profiles);
         let min_memory_mb = profiles_min_memory(&profiles);
+        let idle_pool: SharedIdlePool =
+            Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
+                default_timeout: Duration::from_secs(300),
+                max_idle: 10,
+            })));
 
         let config = RunConfig {
             id: "test-runner".into(),
@@ -1668,10 +1674,7 @@ mod tests {
                 1.0,
                 max_concurrent,
             )),
-            idle_pool: Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-                default_timeout: Duration::from_secs(300),
-                max_idle: 10,
-            }))),
+            idle_pool: Arc::clone(&idle_pool),
             status: Arc::new(StatusTracker::new(
                 temp_dir.path().join("status.json"),
                 max_concurrent,
@@ -1703,6 +1706,7 @@ mod tests {
         let env = MockRunEnv {
             handle,
             provider: provider_ref,
+            idle_pool,
             mode_tx,
             cancel,
             _temp_dir: temp_dir,
@@ -2083,7 +2087,87 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Test 9: Budget full → job skipped (not claimed) → budget freed → next job succeeds
+    // Test 9: sandboxReuse feature flag gates idle pool park/take
+    //
+    // With the flag ON and a session ID, the VM is parked after execution.
+    // With the flag OFF (default), the VM is destroyed.
+    // -----------------------------------------------------------------------
+
+    fn context_with_reuse(
+        run_id: Uuid,
+        reuse: bool,
+        session_id: Option<&str>,
+    ) -> crate::types::ExecutionContext {
+        let mut ctx = minimal_context(run_id);
+        if reuse {
+            ctx.feature_flags = Some(HashMap::from([(
+                crate::types::feature_flags::SANDBOX_REUSE.to_string(),
+                true,
+            )]));
+        }
+        if let Some(sid) = session_id {
+            ctx.resume_session = Some(crate::types::ResumeSession {
+                session_id: sid.to_string(),
+                session_history: String::new(),
+            });
+        }
+        ctx
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sandbox_reuse_flag_on_parks_vm() {
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = Uuid::new_v4();
+        let ctx = context_with_reuse(run_id, true, Some("sess-1"));
+        push_job(&env, run_id, "vm0/default", Some(ctx));
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "job should complete");
+        assert_eq!(c.unwrap().exit_code, 0);
+
+        let pool = env.idle_pool.lock().await;
+        assert_eq!(pool.len(), 1, "VM should be parked when sandboxReuse is on");
+        assert!(pool.held_sessions().contains(&"sess-1".to_string()));
+        drop(pool);
+
+        shutdown(&env, run_handle).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sandbox_reuse_flag_off_destroys_vm() {
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = Uuid::new_v4();
+        // Flag OFF (default) — even with a session ID, VM should not be parked.
+        let ctx = context_with_reuse(run_id, false, Some("sess-1"));
+        push_job(&env, run_id, "vm0/default", Some(ctx));
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "job should complete");
+        assert_eq!(c.unwrap().exit_code, 0);
+
+        let pool = env.idle_pool.lock().await;
+        assert_eq!(
+            pool.len(),
+            0,
+            "VM should NOT be parked when sandboxReuse is off"
+        );
+        drop(pool);
+
+        shutdown(&env, run_handle).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 11: Budget full → job skipped (not claimed) → budget freed → next job succeeds
     //
     // Different from test 4 (claim failure): here try_reserve returns false
     // so claim() is never called. The job stays in the channel but the main

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -1620,7 +1620,6 @@ mod tests {
             budget_vcpu,
             budget_memory_mb,
             max_concurrent,
-            keep_alive,
             make_provider,
             Box::new(MockSandboxRuntime::new()),
         )
@@ -1631,7 +1630,6 @@ mod tests {
         budget_vcpu: u32,
         budget_memory_mb: u32,
         max_concurrent: usize,
-        keep_alive: bool,
         make_provider: impl FnOnce(CancellationToken) -> (Arc<MockJobProvider>, MockProviderHandle),
         runtime: Box<dyn sandbox::SandboxRuntime>,
     ) -> (RunConfig, MockRunEnv) {
@@ -2222,9 +2220,13 @@ mod tests {
     // (eviction), shutdown drain, and edge cases (pool-full, reuse cycle).
     // =======================================================================
 
-    /// ExecutionContext with a resume_session for idle pool reuse testing.
+    /// ExecutionContext with a resume_session and sandboxReuse flag for idle pool testing.
     fn context_with_session(run_id: Uuid, session_id: &str) -> crate::types::ExecutionContext {
         let mut ctx = minimal_context(run_id);
+        ctx.feature_flags = Some(HashMap::from([(
+            crate::types::feature_flags::SANDBOX_REUSE.to_string(),
+            true,
+        )]));
         ctx.resume_session = Some(crate::types::ResumeSession {
             session_id: session_id.into(),
             session_history: String::new(),
@@ -2351,7 +2353,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn successful_job_parks_in_idle_pool() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, true);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let idle_pool = Arc::clone(&config.idle_pool);
         let budget = Arc::clone(&config.budget);
         let run_handle = tokio::spawn(run(config));
@@ -2395,7 +2397,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn job_without_session_destroys_sandbox() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, true);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let idle_pool = Arc::clone(&config.idle_pool);
         let budget = Arc::clone(&config.budget);
         let run_handle = tokio::spawn(run(config));
@@ -2428,7 +2430,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn park_triggers_immediate_heartbeat() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, true);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
         // Wait for the first heartbeat tick to fire (initial interval fires
@@ -2467,7 +2469,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn session_affinity_reuses_idle_vm() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, true);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let idle_pool = Arc::clone(&config.idle_pool);
         let budget = Arc::clone(&config.budget);
 
@@ -2515,7 +2517,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn profile_mismatch_destroys_stale_vm() {
-        let (config, env) = mock_run_config(two_profiles(), 16, 32768, 4, true);
+        let (config, env) = mock_run_config(two_profiles(), 16, 32768, 4);
         let idle_pool = Arc::clone(&config.idle_pool);
         let budget = Arc::clone(&config.budget);
 
@@ -2563,7 +2565,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn cleanup_tick_evicts_expired_entries() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, true);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let idle_pool = Arc::clone(&config.idle_pool);
         let budget = Arc::clone(&config.budget);
 
@@ -2601,7 +2603,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn budget_exhausted_evicts_idle_and_admits_job() {
         // Budget: exactly 1 default job (2 vcpu, 4096 MB).
-        let (config, env) = mock_run_config(test_profiles(), 2, 4096, 2, true);
+        let (config, env) = mock_run_config(test_profiles(), 2, 4096, 2);
         let idle_pool = Arc::clone(&config.idle_pool);
         let budget = Arc::clone(&config.budget);
 
@@ -2637,7 +2639,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn shutdown_drains_idle_pool() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, true);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let idle_pool = Arc::clone(&config.idle_pool);
         let budget = Arc::clone(&config.budget);
 
@@ -2659,27 +2661,22 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Test 18: Pool disabled (keep_alive=false) → PoolFull → budget released
+    // Test 18: sandboxReuse flag OFF → VM destroyed, budget released
     //
-    // When keep_alive is disabled, park() returns PoolFull. The sandbox must
-    // be destroyed and the budget released (not leaked).
+    // When the feature flag is off, park is skipped even with a session.
+    // The sandbox must be destroyed and the budget released (not leaked).
     // -----------------------------------------------------------------------
 
     #[tokio::test(start_paused = true)]
-    async fn pool_disabled_rejects_park_and_releases_budget() {
-        // keep_alive=false → IdlePoolConfig.enabled=false → park always PoolFull
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, false);
+    async fn reuse_flag_off_destroys_and_releases_budget() {
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let budget = Arc::clone(&config.budget);
         let run_handle = tokio::spawn(run(config));
 
         let run_id = Uuid::new_v4();
-        // Job has a session, so parking IS attempted — but pool rejects it.
-        push_job(
-            &env,
-            run_id,
-            "vm0/default",
-            Some(context_with_session(run_id, "sess-rejected")),
-        );
+        // Job has a session but flag is OFF — parking is skipped.
+        let ctx = context_with_reuse(run_id, false, Some("sess-rejected"));
+        push_job(&env, run_id, "vm0/default", Some(ctx));
 
         let completion = env
             .handle
@@ -2688,7 +2685,7 @@ mod tests {
         assert!(completion.is_some(), "job should complete");
         assert_eq!(completion.unwrap().exit_code, 0);
 
-        // PoolFull path: sandbox destroyed, budget must be released.
+        // Flag OFF: sandbox destroyed, budget must be released.
         wait_budget_count(&budget, 0, Duration::from_secs(5)).await;
 
         shutdown(&env, run_handle).await;
@@ -2704,7 +2701,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn sequential_same_session_reuse_cycle() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, true);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let idle_pool = Arc::clone(&config.idle_pool);
         let budget = Arc::clone(&config.budget);
         let run_handle = tokio::spawn(run(config));
@@ -2759,7 +2756,6 @@ mod tests {
         budget_vcpu: u32,
         budget_memory_mb: u32,
         max_concurrent: usize,
-        keep_alive: bool,
         overrides: Arc<sandbox_mock::MockSandboxOverrides>,
     ) -> (RunConfig, MockRunEnv) {
         build_mock_run_config_with_runtime(
@@ -2767,7 +2763,6 @@ mod tests {
             budget_vcpu,
             budget_memory_mb,
             max_concurrent,
-            keep_alive,
             MockJobProvider::new,
             Box::new(MockSandboxRuntime::with_overrides(overrides)),
         )
@@ -2798,14 +2793,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn failed_job_with_session_not_parked() {
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_code(1));
-        let (config, env) = mock_run_config_with_overrides(
-            test_profiles(),
-            4,
-            8192,
-            4,
-            true, // keep_alive enabled
-            overrides,
-        );
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, overrides);
         let budget = Arc::clone(&config.budget);
         let idle_pool = Arc::clone(&config.idle_pool);
         let run_handle = tokio::spawn(run(config));
@@ -2843,8 +2831,7 @@ mod tests {
         let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_gate(
             gate,
         ));
-        let (config, env) =
-            mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, true, overrides);
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 4, 8192, 4, overrides);
         let budget = Arc::clone(&config.budget);
         let idle_pool = Arc::clone(&config.idle_pool);
         let cancel_tokens = Arc::clone(&config.cancel_tokens);
@@ -2897,8 +2884,7 @@ mod tests {
             stdout: b"sess-evict".to_vec(),
             stderr: Vec::new(),
         });
-        let (config, env) =
-            mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, true, overrides);
+        let (config, env) = mock_run_config_with_overrides(test_profiles(), 8, 16384, 4, overrides);
         let budget = Arc::clone(&config.budget);
         let idle_pool = Arc::clone(&config.idle_pool);
 

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -204,9 +204,8 @@ pub async fn run_start(
     let config::SandboxConfig {
         max_concurrent,
         concurrency_factor,
-        keep_alive,
-        keep_alive_timeout_secs,
-        keep_alive_max_idle,
+        idle_timeout_secs,
+        max_idle,
     } = runner_config.sandbox;
     let host_cpus = host::cpu_count()?;
     let host_memory_mb = host::memory_mb()?;
@@ -227,18 +226,13 @@ pub async fn run_start(
         "resource budget initialized"
     );
 
-    // Idle sandbox pool for VM keep-alive across conversation turns.
+    // Idle sandbox pool for VM reuse across conversation turns.
+    // Whether individual jobs use the pool is controlled by the per-job
+    // `sandboxReuse` feature flag; the pool itself is always available.
     let idle_pool = Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-        enabled: keep_alive,
-        default_timeout: Duration::from_secs(keep_alive_timeout_secs),
-        max_idle: keep_alive_max_idle,
+        default_timeout: Duration::from_secs(idle_timeout_secs),
+        max_idle,
     })));
-    if keep_alive {
-        info!(
-            keep_alive_timeout_secs,
-            keep_alive_max_idle, "VM keep-alive enabled"
-        );
-    }
 
     // Estimated capacity for status reporting.
     // Derived from the smallest profile to cover the worst case.
@@ -612,7 +606,11 @@ async fn run(config: RunConfig) -> RunnerResult<()> {
                 status.add_run(run_id).await;
 
                 // Check idle pool for a reusable VM (same session + same profile).
-                let reuse_entry = if let Some(session_id) = context.session_id() {
+                // Only attempt reuse when the per-job sandboxReuse flag is on.
+                let reuse_enabled = context.feature_enabled(crate::types::feature_flags::SANDBOX_REUSE);
+                let reuse_entry = if reuse_enabled
+                    && let Some(session_id) = context.session_id()
+                {
                     let mut pool = idle_pool.lock().await;
                     match pool.take(session_id) {
                         Some(entry) if entry.profile_name == profile_name => {
@@ -869,8 +867,9 @@ struct SpawnContext {
 /// If `reuse_entry` is `Some`, the job reuses an existing idle sandbox.
 /// Otherwise it creates a new one via the factory.
 ///
-/// After execution, if keep-alive is enabled and the job succeeded,
-/// the sandbox is parked in the idle pool instead of being destroyed.
+/// After execution, if the per-job `sandboxReuse` feature flag is enabled
+/// and the job succeeded, the sandbox is parked in the idle pool instead
+/// of being destroyed.
 fn spawn_job(
     context: ExecutionContext,
     job_profile: JobProfile,
@@ -880,6 +879,7 @@ fn spawn_job(
 ) {
     let run_id = context.run_id;
     let session_id = context.session_id().map(String::from);
+    let reuse_enabled = context.feature_enabled(crate::types::feature_flags::SANDBOX_REUSE);
     let vcpu = job_profile.vcpu;
     let memory_mb = job_profile.memory_mb;
     let profile_name = job_profile.profile_name;
@@ -946,16 +946,19 @@ fn spawn_job(
             }
         };
 
-        // Decide: park sandbox for keep-alive, or stop + destroy.
+        // Decide: park sandbox for reuse, or stop + destroy.
         let parked = if let Some(sandbox) = sandbox {
-            let parkable_session =
-                if exit_code == 0 && !job_cancel.is_cancelled() && mode == RunnerMode::Running {
-                    // Prefer context session_id (from resume_session), fall back to
-                    // guest-reported session ID (first run — CLI generated it).
-                    session_id.as_deref().or(guest_session_id.as_deref())
-                } else {
-                    None
-                };
+            let parkable_session = if reuse_enabled
+                && exit_code == 0
+                && !job_cancel.is_cancelled()
+                && mode == RunnerMode::Running
+            {
+                // Prefer context session_id (from resume_session), fall back to
+                // guest-reported session ID (first run — CLI generated it).
+                session_id.as_deref().or(guest_session_id.as_deref())
+            } else {
+                None
+            };
 
             if let Some(session_id) = parkable_session {
                 let mut pool = idle_pool.lock().await;
@@ -974,7 +977,7 @@ fn spawn_job(
                 };
                 match pool.park(session_id.to_string(), entry) {
                     ParkResult::Parked => {
-                        info!(run_id = %run_id, session_id, "VM parked for keep-alive");
+                        info!(run_id = %run_id, session_id, "VM parked for reuse");
                         drop(pool);
                         park_notify.notify_one();
                         true
@@ -1454,7 +1457,6 @@ mod tests {
         budget.try_reserve(2, 4096);
         budget.try_reserve(2, 4096);
         let pool = IdlePool::new(IdlePoolConfig {
-            enabled: true,
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
         });
@@ -1481,7 +1483,6 @@ mod tests {
         budget.try_reserve(2, 4096);
         budget.try_reserve(2, 4096);
         let mut pool = IdlePool::new(IdlePoolConfig {
-            enabled: true,
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
         });
@@ -1512,7 +1513,6 @@ mod tests {
         budget.try_reserve(2, 4096);
         budget.try_reserve(2, 4096);
         let mut pool = IdlePool::new(IdlePoolConfig {
-            enabled: true,
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
         });
@@ -1539,7 +1539,6 @@ mod tests {
         let budget = ResourceBudget::new(8, 32768, 1.0, 4);
         // budget_running = 0 but pool has 1 entry (inconsistent)
         let mut pool = IdlePool::new(IdlePoolConfig {
-            enabled: true,
             default_timeout: Duration::from_secs(300),
             max_idle: 0,
         });
@@ -1581,14 +1580,12 @@ mod tests {
         budget_vcpu: u32,
         budget_memory_mb: u32,
         max_concurrent: usize,
-        keep_alive: bool,
     ) -> (RunConfig, MockRunEnv) {
         build_mock_run_config(
             profiles,
             budget_vcpu,
             budget_memory_mb,
             max_concurrent,
-            keep_alive,
             MockJobProvider::new,
         )
     }
@@ -1599,7 +1596,6 @@ mod tests {
         budget_vcpu: u32,
         budget_memory_mb: u32,
         max_concurrent: usize,
-        keep_alive: bool,
         poll_delay: Duration,
     ) -> (RunConfig, MockRunEnv) {
         build_mock_run_config(
@@ -1607,7 +1603,6 @@ mod tests {
             budget_vcpu,
             budget_memory_mb,
             max_concurrent,
-            keep_alive,
             |cancel| MockJobProvider::with_poll_delay(cancel, Some(poll_delay)),
         )
     }
@@ -1617,7 +1612,6 @@ mod tests {
         budget_vcpu: u32,
         budget_memory_mb: u32,
         max_concurrent: usize,
-        keep_alive: bool,
         make_provider: impl FnOnce(CancellationToken) -> (Arc<MockJobProvider>, MockProviderHandle),
     ) -> (RunConfig, MockRunEnv) {
         build_mock_run_config_with_runtime(
@@ -1675,7 +1669,6 @@ mod tests {
                 max_concurrent,
             )),
             idle_pool: Arc::new(tokio::sync::Mutex::new(IdlePool::new(IdlePoolConfig {
-                enabled: keep_alive,
                 default_timeout: Duration::from_secs(300),
                 max_idle: 10,
             }))),
@@ -1788,7 +1781,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn main_loop_discover_claim_execute_complete() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, false);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
         let run_id = Uuid::new_v4();
@@ -1825,7 +1818,6 @@ mod tests {
             8,
             32768,
             4,
-            false,
             Duration::from_secs(20), // poll delay: 20s
         );
         let run_handle = tokio::spawn(run(config));
@@ -1876,7 +1868,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_completes_without_deadlock() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, false);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
         // Let the main loop start and enter select!.
@@ -1905,7 +1897,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn claim_failure_rolls_back_budget() {
         // Budget for exactly 1 job (2 vcpu, 4096 MB matches the test profile).
-        let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1, false);
+        let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
         let run_handle = tokio::spawn(run(config));
 
         // First job: claim returns None (409 conflict)
@@ -1943,7 +1935,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn shutdown_drains_running_jobs() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, false);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
         let run_id = Uuid::new_v4();
@@ -1965,7 +1957,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn unknown_profile_skipped() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, false);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
         // Push a job with a profile that doesn't exist in the profiles map.
@@ -2014,7 +2006,7 @@ mod tests {
     async fn duplicate_discovery_deduplicated() {
         // Budget for 2 jobs — enough for the duplicate to pass the budget
         // check and reach the cancel_tokens dedup logic.
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, false);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
         let run_id = Uuid::new_v4();
@@ -2061,7 +2053,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn two_sequential_jobs_complete() {
-        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4, false);
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
         let run_handle = tokio::spawn(run(config));
 
         // First job
@@ -2102,7 +2094,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn budget_full_skips_then_resumes() {
         // Budget for exactly 1 job (2 vcpu, 4096 MB).
-        let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1, false);
+        let (config, env) = mock_run_config(test_profiles(), 2, 4096, 1);
         let run_handle = tokio::spawn(run(config));
 
         // First job: claims the entire budget.

--- a/crates/runner/src/cmd/start.rs
+++ b/crates/runner/src/cmd/start.rs
@@ -2164,6 +2164,34 @@ mod tests {
         shutdown(&env, run_handle).await;
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn sandbox_reuse_flag_on_without_session_does_not_park() {
+        let (config, env) = mock_run_config(test_profiles(), 8, 32768, 4);
+        let run_handle = tokio::spawn(run(config));
+
+        let run_id = Uuid::new_v4();
+        // Flag ON but no session — parking requires a session ID.
+        let ctx = context_with_reuse(run_id, true, None);
+        push_job(&env, run_id, "vm0/default", Some(ctx));
+
+        let c = env
+            .handle
+            .wait_completion(run_id, Duration::from_secs(5))
+            .await;
+        assert!(c.is_some(), "job should complete");
+        assert_eq!(c.unwrap().exit_code, 0);
+
+        let pool = env.idle_pool.lock().await;
+        assert_eq!(
+            pool.len(),
+            0,
+            "VM should NOT be parked without a session ID"
+        );
+        drop(pool);
+
+        shutdown(&env, run_handle).await;
+    }
+
     // -----------------------------------------------------------------------
     // Test 11: Budget full → job skipped (not claimed) → budget freed → next job succeeds
     //

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -44,12 +44,10 @@ pub struct SandboxConfig {
     pub max_concurrent: usize,
     /// Overcommit factor applied to both CPU and memory budgets (default: 1.0).
     pub concurrency_factor: f64,
-    /// Keep VMs alive between conversation turns for session reuse (default: false).
-    pub keep_alive: bool,
-    /// Idle timeout in seconds for kept-alive VMs (default: 300).
-    pub keep_alive_timeout_secs: u64,
+    /// Idle timeout in seconds for reusable VMs (default: 300).
+    pub idle_timeout_secs: u64,
     /// Maximum number of idle VMs to keep (0 = no limit, default: 0).
-    pub keep_alive_max_idle: usize,
+    pub max_idle: usize,
 }
 
 impl Default for SandboxConfig {
@@ -57,9 +55,8 @@ impl Default for SandboxConfig {
         Self {
             max_concurrent: DEFAULT_MAX_CONCURRENT,
             concurrency_factor: DEFAULT_CONCURRENCY_FACTOR,
-            keep_alive: false,
-            keep_alive_timeout_secs: 300,
-            keep_alive_max_idle: 0,
+            idle_timeout_secs: 300,
+            max_idle: 0,
         }
     }
 }
@@ -706,7 +703,7 @@ profiles:
     }
 
     #[tokio::test]
-    async fn keep_alive_config_round_trip() {
+    async fn idle_pool_config_round_trip() {
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");
         let kernel = dir.path().join("vmlinux");
@@ -726,9 +723,8 @@ profiles:
             sandbox: SandboxConfig {
                 max_concurrent: 4,
                 concurrency_factor: 1.5,
-                keep_alive: true,
-                keep_alive_timeout_secs: 600,
-                keep_alive_max_idle: 10,
+                idle_timeout_secs: 600,
+                max_idle: 10,
             },
             server: None,
         };
@@ -738,14 +734,13 @@ profiles:
         let loaded = load_with_home(&runner_dir.join("runner.yaml"), &home)
             .await
             .unwrap();
-        assert!(loaded.sandbox.keep_alive);
-        assert_eq!(loaded.sandbox.keep_alive_timeout_secs, 600);
-        assert_eq!(loaded.sandbox.keep_alive_max_idle, 10);
+        assert_eq!(loaded.sandbox.idle_timeout_secs, 600);
+        assert_eq!(loaded.sandbox.max_idle, 10);
         assert_eq!(loaded, config);
     }
 
     #[tokio::test]
-    async fn keep_alive_defaults_when_omitted() {
+    async fn idle_pool_defaults_when_omitted() {
         let dir = tempfile::tempdir().unwrap();
         let fc = dir.path().join("firecracker");
         let kernel = dir.path().join("vmlinux");
@@ -754,7 +749,7 @@ profiles:
         }
         let home = test_home_with_artifacts(dir.path(), &["abc"]).await;
 
-        // YAML without any keep_alive fields
+        // YAML without any idle pool fields
         let yaml = format!(
             r#"
 name: test
@@ -781,8 +776,7 @@ profiles:
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
         let config = load_with_home(&config_path, &home).await.unwrap();
-        assert!(!config.sandbox.keep_alive);
-        assert_eq!(config.sandbox.keep_alive_timeout_secs, 300);
-        assert_eq!(config.sandbox.keep_alive_max_idle, 0);
+        assert_eq!(config.sandbox.idle_timeout_secs, 300);
+        assert_eq!(config.sandbox.max_idle, 0);
     }
 }

--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -2554,7 +2554,6 @@ mod tests {
 
         // Park in idle pool
         let mut pool = IdlePool::new(IdlePoolConfig {
-            enabled: true,
             default_timeout: std::time::Duration::from_secs(300),
             max_idle: 0,
         });
@@ -2596,7 +2595,6 @@ mod tests {
         use crate::idle_pool::{IdlePool, IdlePoolConfig};
 
         let mut pool = IdlePool::new(IdlePoolConfig {
-            enabled: true,
             default_timeout: std::time::Duration::from_secs(300),
             max_idle: 0,
         });

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -113,7 +113,7 @@ impl IdlePool {
     /// Park a sandbox in the pool. Returns the previously parked entry
     /// for this session if one existed (caller must destroy it).
     ///
-    /// Returns `PoolFull(entry)` if the pool is disabled or at capacity.
+    /// Returns `PoolFull(entry)` if the pool is drained or at capacity.
     pub fn park(&mut self, session_id: String, entry: IdleEntry) -> ParkResult {
         if self.drained {
             return ParkResult::PoolFull(entry);

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -47,8 +47,6 @@ impl StorageFingerprints {
 /// Configuration for the idle sandbox pool.
 #[derive(Debug, Clone)]
 pub struct IdlePoolConfig {
-    /// Whether VM keep-alive is enabled.
-    pub enabled: bool,
     /// Default idle timeout for parked VMs.
     pub default_timeout: Duration,
     /// Maximum number of idle VMs (0 = unlimited).
@@ -58,7 +56,6 @@ pub struct IdlePoolConfig {
 impl Default for IdlePoolConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
             default_timeout: Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS),
             max_idle: 0,
         }
@@ -100,6 +97,8 @@ impl IdleEntry {
 pub struct IdlePool {
     entries: HashMap<String, IdleEntry>,
     config: IdlePoolConfig,
+    /// Set by `drain()` to reject park attempts after shutdown.
+    drained: bool,
 }
 
 impl IdlePool {
@@ -107,6 +106,7 @@ impl IdlePool {
         Self {
             entries: HashMap::new(),
             config,
+            drained: false,
         }
     }
 
@@ -115,7 +115,7 @@ impl IdlePool {
     ///
     /// Returns `PoolFull(entry)` if the pool is disabled or at capacity.
     pub fn park(&mut self, session_id: String, entry: IdleEntry) -> ParkResult {
-        if !self.config.enabled {
+        if self.drained {
             return ParkResult::PoolFull(entry);
         }
         if self.config.max_idle > 0 && self.entries.len() >= self.config.max_idle {
@@ -173,10 +173,10 @@ impl IdlePool {
         self.entries.len()
     }
 
-    /// Whether keep-alive is enabled.
+    /// Whether the pool has been drained (rejects new park calls).
     #[cfg(test)]
-    pub fn is_enabled(&self) -> bool {
-        self.config.enabled
+    pub fn is_drained(&self) -> bool {
+        self.drained
     }
 
     /// The default idle timeout.
@@ -189,7 +189,7 @@ impl IdlePool {
     /// Also disables the pool so that concurrent job tasks that still hold
     /// a stale `mode == Running` snapshot cannot park new entries after drain.
     pub fn drain(&mut self) -> Vec<IdleEntry> {
-        self.config.enabled = false;
+        self.drained = true;
         self.entries.drain().map(|(_, v)| v).collect()
     }
 }
@@ -250,7 +250,6 @@ mod tests {
 
     fn pool_config(max_idle: usize) -> IdlePoolConfig {
         IdlePoolConfig {
-            enabled: true,
             default_timeout: Duration::from_secs(300),
             max_idle,
         }
@@ -393,31 +392,17 @@ mod tests {
         let drained = pool.drain();
         assert_eq!(drained.len(), 2);
         assert_eq!(pool.len(), 0);
-        // drain disables the pool to prevent post-shutdown parking
-        assert!(!pool.is_enabled());
-    }
-
-    #[test]
-    fn disabled_pool() {
-        let pool = IdlePool::new(IdlePoolConfig::default());
-        assert!(!pool.is_enabled());
-    }
-
-    #[test]
-    fn disabled_pool_rejects_park() {
-        let mut pool = IdlePool::new(IdlePoolConfig::default());
-        let result = pool.park("s1".into(), make_entry(2, 2048));
-        assert!(matches!(result, ParkResult::PoolFull(_)));
-        assert_eq!(pool.len(), 0);
+        // drain marks the pool as drained to prevent post-shutdown parking
+        assert!(pool.is_drained());
     }
 
     #[test]
     fn park_after_drain_rejected() {
-        // drain() disables the pool — subsequent park() calls are rejected.
+        // drain() marks pool as drained — subsequent park() calls are rejected.
         let mut pool = IdlePool::new(pool_config(0));
         let _ = pool.park("s1".into(), make_entry(2, 2048));
         pool.drain();
-        assert!(!pool.is_enabled());
+        assert!(pool.is_drained());
 
         let result = pool.park("s2".into(), make_entry(4, 4096));
         assert!(matches!(result, ParkResult::PoolFull(_)));
@@ -442,7 +427,7 @@ mod tests {
         let mut pool = IdlePool::new(pool_config(0));
         let drained = pool.drain();
         assert!(drained.is_empty());
-        assert!(!pool.is_enabled());
+        assert!(pool.is_drained());
     }
 
     #[test]

--- a/crates/runner/src/provider/local.rs
+++ b/crates/runner/src/provider/local.rs
@@ -35,9 +35,11 @@ pub(crate) struct JobRequest {
     pub(crate) user_timezone: Option<String>,
     #[serde(default)]
     pub(crate) profile: Option<String>,
-    /// Session ID for keep-alive VM reuse across conversation turns.
+    /// Session ID for sandbox reuse across conversation turns.
     #[serde(default)]
     pub(crate) session_id: Option<String>,
+    #[serde(default)]
+    pub(crate) feature_flags: Option<HashMap<String, bool>>,
 }
 
 /// Job response written by the runner as a `{job_id}.result` file.
@@ -254,7 +256,7 @@ impl JobProvider for LocalProvider {
             tools: None,
             settings: None,
             experimental_profile: req.profile,
-            feature_flags: None,
+            feature_flags: req.feature_flags,
         })
     }
 
@@ -323,6 +325,7 @@ mod tests {
             user_timezone: None,
             profile: profile.map(String::from),
             session_id: None,
+            feature_flags: None,
         };
         let json = serde_json::to_vec(&req).unwrap();
         std::fs::write(dir.join(format!("{job_id}.job")), &json).unwrap();

--- a/crates/runner/src/types.rs
+++ b/crates/runner/src/types.rs
@@ -195,14 +195,27 @@ pub struct ResumeSession {
     pub session_history: String,
 }
 
+/// Feature flag keys (must match TypeScript `FeatureSwitchKey` values).
+pub mod feature_flags {
+    pub const SANDBOX_REUSE: &str = "sandboxReuse";
+}
+
 impl ExecutionContext {
-    /// Extract the session ID from `resume_session` for keep-alive VM reuse.
+    /// Extract the session ID from `resume_session` for sandbox reuse.
     ///
     /// Returns `Some` for continued sessions. For first runs this returns
     /// `None`; the executor reads the CLI-generated session ID from the
     /// guest filesystem post-execution (see `read_guest_session_id`).
     pub fn session_id(&self) -> Option<&str> {
         self.resume_session.as_ref().map(|r| r.session_id.as_str())
+    }
+
+    /// Check whether a feature flag is enabled for this job.
+    pub fn feature_enabled(&self, flag: &str) -> bool {
+        self.feature_flags
+            .as_ref()
+            .and_then(|f| f.get(flag).copied())
+            .unwrap_or(false)
     }
 }
 

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -40,4 +40,5 @@ export enum FeatureSwitchKey {
   PhoneIntegration = "phoneIntegration",
   VoiceChat = "voiceChat",
   AutoSkill = "autoSkill",
+  SandboxReuse = "sandboxReuse",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -232,6 +232,11 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.SandboxReuse]: {
+    maintainer: "liangyou@vm0.ai",
+    description: "Enable sandbox reuse (keep-alive) across conversation turns",
+    enabled: false,
+  },
 };
 
 interface ResolvedHashes {


### PR DESCRIPTION
## Summary

- Add `sandboxReuse` feature flag (default: disabled) to control per-job sandbox reuse
- Remove runner-level `keep_alive` static config from `SandboxConfig` and CLI
- Idle pool is always structurally enabled; per-job flag gates take/park
- `IdlePoolConfig.enabled` replaced with `IdlePool.drained` for shutdown safety
- Rename config fields: `keep_alive_timeout_secs` → `idle_timeout_secs`, `keep_alive_max_idle` → `max_idle`
- Add `ExecutionContext::feature_enabled()` helper and `feature_flags::SANDBOX_REUSE` constant

## Test plan

- [x] All 460 runner tests pass
- [ ] Verify sandbox reuse works when flag is enabled for an org
- [ ] Verify no reuse occurs when flag is disabled (default)

Closes #8924

🤖 Generated with [Claude Code](https://claude.com/claude-code)