### PR TITLE
fix(web): filter axios errors from termly resource-blocker in sentry

### DIFF
--- a/turbo/apps/platform/src/lib/sentry.ts
+++ b/turbo/apps/platform/src/lib/sentry.ts
@@ -52,6 +52,18 @@ export function initSentry(): void {
       // Expected API errors surfaced as toasts — not actionable in Sentry
       "Credits depleted",
       "Insufficient credits",
+      // Third-party scripts (we don't use axios — any AxiosError is external noise)
+      "AxiosError",
+    ],
+
+    // Filter out errors from browser extension and third-party scripts
+    denyUrls: [
+      /inpage\.js/,
+      /chrome-extension:\/\//,
+      /moz-extension:\/\//,
+      // Termly compliance/cookie consent script
+      /app\.termly\.io/,
+      /resource-blocker/,
     ],
   });
 }

--- a/turbo/apps/web/instrumentation-client.ts
+++ b/turbo/apps/web/instrumentation-client.ts
@@ -45,8 +45,17 @@ Sentry.init({
     "ResizeObserver loop",
     "func sseError not found",
     "Failed to connect to MetaMask",
+    // Third-party scripts (we don't use axios — any AxiosError is external noise)
+    "AxiosError",
   ],
 
   // Filter out errors from browser extension scripts
-  denyUrls: [/inpage\.js/, /chrome-extension:\/\//, /moz-extension:\/\//],
+  denyUrls: [
+    /inpage\.js/,
+    /chrome-extension:\/\//,
+    /moz-extension:\/\//,
+    // Termly compliance/cookie consent script
+    /app\.termly\.io/,
+    /resource-blocker/,
+  ],
 });


### PR DESCRIPTION
## Summary

- Add `"AxiosError"` to `ignoreErrors` in both web and platform Sentry configs to filter third-party axios errors
- Expand `denyUrls` in web config and add `denyUrls` to platform config to block errors from Termly resource-blocker and browser extensions
- Our codebase does not use axios — any AxiosError is noise from third-party scripts (Termly compliance/cookie consent)

Closes #8983

## Test plan

- [x] Lint passes (0 errors)
- [x] Format passes (unchanged)
- [x] Knip passes (no issues)
- [x] Type errors are pre-existing on main (not from this change)
- [ ] After deploy, verify AxiosError from resource-blocker no longer appears in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)