### PR TITLE
fix(web): handle non-slug-conflict clerk 422 in onboarding setup

### DIFF
--- a/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
+++ b/turbo/apps/web/app/api/zero/onboarding/setup/route.ts
@@ -171,7 +171,14 @@ const router = tsr.router(onboardingSetupContract, {
         instructions: SEED_INSTRUCTIONS,
       }),
       body.workspaceName?.trim()
-        ? updateOrgNameAndSlug(org.orgId, body.workspaceName)
+        ? updateOrgNameAndSlug(org.orgId, body.workspaceName).catch(
+            (error: unknown) => {
+              log.warn("Failed to update org name/slug (non-blocking)", {
+                orgId: org.orgId,
+                error,
+              });
+            },
+          )
         : Promise.resolve(),
     ]);
 

--- a/turbo/apps/web/src/__tests__/onboarding-setup.test.ts
+++ b/turbo/apps/web/src/__tests__/onboarding-setup.test.ts
@@ -238,6 +238,35 @@ describe("POST /api/zero/onboarding/setup", () => {
     expect(lastCall![1]).toEqual({ name: "My Workspace" });
   });
 
+  it("should succeed when Clerk org update fails with non-slug-conflict error", async () => {
+    const { userId, orgId } = await context.setupUser();
+    mockClerk({ userId, orgId, orgRole: "org:admin" });
+
+    const client = await clerkClient();
+    client.organizations.updateOrganization = vi.fn().mockRejectedValue(
+      Object.assign(new Error("Unprocessable Entity"), {
+        status: 422,
+        errors: [
+          {
+            code: "form_param_value_invalid",
+            message: "Name is invalid",
+            meta: { paramName: "name" },
+          },
+        ],
+      }),
+    ) as unknown as typeof client.organizations.updateOrganization;
+
+    const response = await postSetup({
+      displayName: "Zero",
+      workspaceName: "Test Workspace",
+    });
+
+    // Onboarding should still succeed — org rename is non-blocking
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.agentId).toBeTruthy();
+  });
+
   it("should update name and slug for valid Latin workspace names", async () => {
     const { userId, orgId } = await context.setupUser();
     mockClerk({ userId, orgId, orgRole: "org:admin" });


### PR DESCRIPTION
## Summary

- Make `updateOrgNameAndSlug()` non-blocking by wrapping with `.catch()` — org name/slug update is cosmetic and should never crash the entire onboarding flow
- Add integration test verifying onboarding succeeds when Clerk throws a non-slug-conflict 422 error

## Root Cause

The `updateOrgNameAndSlug()` function only caught slug conflict errors from Clerk. Any other 422 (invalid name, unexpected validation) propagated as an unhandled rejection, crashing the entire onboarding setup (3 occurrences in production on 2026-04-07).

Closes #8986

## Test plan

- [x] New test: `should succeed when Clerk org update fails with non-slug-conflict error`
- [x] All 12 existing onboarding tests pass
- [x] Lint, format, knip checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)