### PR TITLE
fix(platform): log detached promise rejections instead of rethrowing

### DIFF
--- a/turbo/apps/platform/src/signals/utils.ts
+++ b/turbo/apps/platform/src/signals/utils.ts
@@ -35,7 +35,9 @@ export function detach<T>(
     silencePromise = Promise.resolve(promise).then(
       () => {},
       (error: unknown) => {
-        throwIfNotAbort(error);
+        if (!isAbortError(error)) {
+          L.error(`Detached promise rejected [${reason}]`, error);
+        }
       },
     );
   }


### PR DESCRIPTION
## Summary

- Fix `detach()` in `utils.ts` to log non-AbortError rejections via `L.error()` instead of re-throwing them with `throwIfNotAbort()`, which created new unhandled rejections
- Errors are now reported through the logger → Sentry pipeline with proper context tags instead of surfacing as opaque non-Error objects

Closes #8984

## Test plan

- [x] Existing `utils.test.ts` (14 tests) all pass
- [x] Lint, format, knip all pass
- [x] Pre-commit hooks (prettier, knip, commitlint) all pass
- [ ] After merge, monitor Sentry for "Object captured as promise rejection with keys: code, data, message" — should stop occurring

🤖 Generated with [Claude Code](https://claude.com/claude-code)