### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -91,7 +91,7 @@ ROOTFS_DIR=""
 
 # Pinned versions (changes here invalidate the rootfs cache via script hash)
 GO_VERSION="1.26.2"
-CLAUDE_CODE_VERSION="2.1.101"
+CLAUDE_CODE_VERSION="2.1.104"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
 AGENT_BROWSER_VERSION="0.25.3"

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -473,7 +473,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            hash, "3b5860db624028922190b06a06e0b91610f12c8cf3d045f20e29cc2ac3a69027",
+            hash, "097669f3bfa59605f8b1580c6e1ffea94b3a8ee243a2b439943a7da9432e1fc7",
             "image hash changed — this invalidates ALL cached images on ALL hosts"
         );
     }


### PR DESCRIPTION
## Summary

- **claude-code**: `2.1.101` → `2.1.104`
- Updated the `image_hash_is_stable` test expected hash in `crates/runner/src/cmd/build.rs` to match the new script hash

## No changes needed for

- Go: `1.26.2` (already latest)
- `@googleworkspace/cli`: `0.22.5` (already latest)
- `@xdevplatform/xurl`: `1.0.3` (already latest)
- `agent-browser`: `0.25.3` (already latest)

## Test plan

- [x] `cargo test -p runner image_hash_is_stable` passes with the updated hash