### PR TITLE
fix(runner): abort stdout drain task on wait_exit timeout or crash

### DIFF
--- a/crates/runner/src/executor.rs
+++ b/crates/runner/src/executor.rs
@@ -523,10 +523,10 @@ async fn run_in_sandbox(
     };
 
     // Wait for streaming to finish (channel closes when process exits).
-    // On cancel the VM process is still running (stop happens in the caller),
-    // so the stream channel may not close yet — abort instead of blocking.
+    // On cancel/timeout/crash the stream channel may not close — abort to
+    // prevent blocking indefinitely on the drain task.
     if let Some(task) = stream_task {
-        if cancel.is_cancelled() {
+        if cancel.is_cancelled() || result.is_err() {
             task.abort();
             let _ = task.await;
         } else if let Err(e) = task.await {
@@ -1268,6 +1268,7 @@ mod tests {
     use super::*;
     use crate::types::{ArtifactEntry, ResumeSession, StorageEntry, StorageManifest};
     use sandbox_mock::MockSandboxFactory;
+    use std::sync::Arc;
     use uuid::Uuid;
 
     fn minimal_context() -> ExecutionContext {
@@ -2392,6 +2393,29 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("no free devices"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn execute_inner_aborts_drain_task_on_wait_exit_error() {
+        // Simulate wait_exit timeout: stdout channel stays open (sender held
+        // alive by MockSandbox), wait_exit returns error.
+        // Without the fix, task.await blocks forever → test times out.
+        // With the fix, task is aborted immediately → test completes.
+        let dir = tempfile::tempdir().unwrap();
+        let config = test_executor_config(dir.path()).await;
+        let overrides = Arc::new(sandbox_mock::MockSandboxOverrides::with_wait_exit_error(
+            "wait timeout",
+        ));
+        let mut factory = sandbox_mock::MockSandboxFactory::with_overrides(overrides);
+        factory.startup().await.unwrap();
+
+        let (exit_code, error) =
+            run_execute_inner(&factory, &minimal_context(), &config, &default_params())
+                .await
+                .unwrap();
+        assert_eq!(exit_code, 1);
+        let error = error.unwrap();
+        assert!(error.contains("wait timeout"), "got: {error}");
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -50,6 +50,10 @@ pub struct MockSandboxOverrides {
     /// When set, `wait_exit` awaits this [`tokio::sync::Notify`] before
     /// returning — giving the test a window to cancel the job.
     wait_exit_gate: Option<Arc<tokio::sync::Notify>>,
+    /// When `Some`, `wait_exit` returns `Err(SandboxError::ExecFailed(msg))`
+    /// to simulate timeout or crash. The stdout channel sender is also kept
+    /// alive in `MockSandbox` so the drain task would block without the fix.
+    wait_exit_error: Option<String>,
 }
 
 impl MockSandboxOverrides {
@@ -58,6 +62,7 @@ impl MockSandboxOverrides {
             exec_matchers: Mutex::new(Vec::new()),
             wait_exit_code: None,
             wait_exit_gate: None,
+            wait_exit_error: None,
         }
     }
 
@@ -67,6 +72,7 @@ impl MockSandboxOverrides {
             exec_matchers: Mutex::new(Vec::new()),
             wait_exit_code: Some(code),
             wait_exit_gate: None,
+            wait_exit_error: None,
         }
     }
 
@@ -76,6 +82,19 @@ impl MockSandboxOverrides {
             exec_matchers: Mutex::new(Vec::new()),
             wait_exit_code: None,
             wait_exit_gate: Some(gate),
+            wait_exit_error: None,
+        }
+    }
+
+    /// Create overrides that make `wait_exit` return an error (simulating
+    /// timeout or crash). The stdout channel sender is kept alive so the
+    /// drain task blocks unless the caller aborts it.
+    pub fn with_wait_exit_error(msg: impl Into<String>) -> Self {
+        Self {
+            exec_matchers: Mutex::new(Vec::new()),
+            wait_exit_code: None,
+            wait_exit_gate: None,
+            wait_exit_error: Some(msg.into()),
         }
     }
 
@@ -109,6 +128,10 @@ pub struct MockSandbox {
     exec_results: Mutex<VecDeque<Result<ExecResult>>>,
     write_file_results: Mutex<VecDeque<Result<()>>>,
     overrides: Option<Arc<MockSandboxOverrides>>,
+    /// Holds the stdout channel sender alive when simulating a non-closing
+    /// channel (e.g. wait_exit_error override). Without this, the sender is
+    /// dropped immediately in `spawn_watch` and the drain task exits.
+    stdout_tx: Mutex<Option<tokio::sync::mpsc::UnboundedSender<Vec<u8>>>>,
 }
 
 impl MockSandbox {
@@ -119,6 +142,7 @@ impl MockSandbox {
             exec_results: Mutex::new(VecDeque::new()),
             write_file_results: Mutex::new(VecDeque::new()),
             overrides: None,
+            stdout_tx: Mutex::new(None),
         }
     }
 
@@ -129,6 +153,7 @@ impl MockSandbox {
             exec_results: Mutex::new(VecDeque::new()),
             write_file_results: Mutex::new(VecDeque::new()),
             overrides: Some(overrides),
+            stdout_tx: Mutex::new(None),
         }
     }
 
@@ -224,7 +249,16 @@ impl Sandbox for MockSandbox {
         _request: &ExecRequest<'_>,
         _stdout_log_path: Option<&str>,
     ) -> Result<SpawnHandle> {
-        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        // When simulating wait_exit error (timeout/crash), keep the sender
+        // alive so the stdout channel never closes — reproducing the real bug.
+        if self
+            .overrides
+            .as_ref()
+            .is_some_and(|o| o.wait_exit_error.is_some())
+        {
+            *self.stdout_tx.lock().unwrap_or_else(|e| e.into_inner()) = Some(tx);
+        }
         Ok(SpawnHandle {
             pid: 1,
             stdout_rx: Some(rx),
@@ -236,6 +270,10 @@ impl Sandbox for MockSandbox {
             // Block until the test signals (gives a window for cancellation).
             if let Some(gate) = &overrides.wait_exit_gate {
                 gate.notified().await;
+            }
+            // Return error when configured (simulates timeout or crash).
+            if let Some(ref msg) = overrides.wait_exit_error {
+                return Err(SandboxError::ExecFailed(msg.clone()));
             }
             // Return override exit code when configured.
             if let Some(code) = overrides.wait_exit_code {


### PR DESCRIPTION
## Summary

- Abort the `drain_stdout_to_file` task when `wait_exit` returns an error (timeout or crash), not just on cancellation
- Add `wait_exit_error` override to `MockSandboxOverrides` for testing error paths
- Add integration test verifying the executor doesn't hang when `wait_exit` times out

## Root Cause

In `executor.rs:528-534`, after `wait_exit` times out, the code calls `task.await` on the drain task without aborting it. The drain task blocks on `rx.recv()` waiting for the stdout channel to close, but the channel sender is never dropped because no `MSG_PROCESS_EXIT` was received (the process is still running or vsock-guest is stuck). This causes the executor to hang indefinitely, blocking runner drain/shutdown.

The fix adds `|| result.is_err()` to the abort condition so timeout/crash paths are treated the same as cancellation.

Closes #8970

## Test plan

- [x] New test `execute_inner_aborts_drain_task_on_wait_exit_error` verifies the executor returns promptly when `wait_exit` fails with a non-closing stdout channel
- [x] All existing executor tests pass (103 tests)
- [x] sandbox-mock tests pass (11 tests)
- [x] clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)