### PR TITLE
feat(mission-control): replace selected task state with dom focus navigation

### DIFF
--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
@@ -60,6 +60,7 @@ function createTaskSignals(initialTask: TaskItem): TaskSignals {
   const closeTask$ = command(({ set }) => {
     set(internalOpen$, false);
     set(internalPanelEntry$, null);
+    set(internalInputFocused$, false);
   });
 
   // Mutable ref so openTask$ always reads the latest API data

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
@@ -2,7 +2,7 @@ import { command, computed, state, type Command, type Computed } from "ccstate";
 import { tasksContract, type TaskItem } from "@vm0/core";
 import { zeroClient$ } from "../api-client";
 import { accept } from "../../lib/accept";
-import { onRef } from "../utils.ts";
+import { onRef, setLoop } from "../utils.ts";
 import {
   createChatThreadSignals,
   ensureDraft$,
@@ -12,7 +12,6 @@ import {
   createActivitySignals,
   type ActivitySignals,
 } from "./create-activity-signals.ts";
-import { setLoop } from "../utils.ts";
 import { maximizedTaskId$ } from "./mission-control-panels.ts";
 
 // ---------------------------------------------------------------------------
@@ -237,7 +236,7 @@ export const taskSignals$ = computed(async (get) => {
 // ---------------------------------------------------------------------------
 
 export const closeAndFocusNextInput$ = command(
-  async ({ get, set }, taskId: string) => {
+  async ({ get, set }, taskId: string, _signal: AbortSignal) => {
     const tasks = await get(taskSignals$);
     const currentIndex = tasks.findIndex((ts) => {
       return ts.task.id === taskId;

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
@@ -2,6 +2,7 @@ import { command, computed, state, type Command, type Computed } from "ccstate";
 import { tasksContract, type TaskItem } from "@vm0/core";
 import { zeroClient$ } from "../api-client";
 import { accept } from "../../lib/accept";
+import { onRef } from "../utils.ts";
 import {
   createChatThreadSignals,
   ensureDraft$,
@@ -33,6 +34,11 @@ export interface TaskSignals {
   openTask$: Command<Promise<void>, [AbortSignal]>;
   closeTask$: Command<void, []>;
   focusInput$: Command<void, []>;
+  setCardRef$: Command<void | (() => void), [HTMLElement | null]>;
+  focusCard$: Command<void, []>;
+  scrollCardIntoView$: Command<void, []>;
+  inputFocused$: Computed<boolean>;
+  setInputFocused$: Command<void, [boolean]>;
 }
 
 // ---------------------------------------------------------------------------
@@ -92,6 +98,34 @@ function createTaskSignals(initialTask: TaskItem): TaskSignals {
     }
   });
 
+  const internalCardRef$ = state<HTMLElement | null>(null);
+  const setCardRef$ = onRef(
+    command(({ set }, el: HTMLElement, signal: AbortSignal) => {
+      signal.addEventListener("abort", () => {
+        set(internalCardRef$, null);
+      });
+      set(internalCardRef$, el);
+    }),
+  );
+  const scrollCardIntoView$ = command(({ get }) => {
+    const el = get(internalCardRef$);
+    if (el) {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  });
+  const focusCard$ = command(({ get, set }) => {
+    set(scrollCardIntoView$);
+    get(internalCardRef$)?.focus();
+  });
+
+  const internalInputFocused$ = state(false);
+  const inputFocused$ = computed((get) => {
+    return get(internalInputFocused$);
+  });
+  const setInputFocused$ = command(({ set }, focused: boolean) => {
+    set(internalInputFocused$, focused);
+  });
+
   return {
     get task() {
       return taskRef.value;
@@ -104,6 +138,11 @@ function createTaskSignals(initialTask: TaskItem): TaskSignals {
     openTask$,
     closeTask$,
     focusInput$,
+    setCardRef$,
+    focusCard$,
+    scrollCardIntoView$,
+    inputFocused$,
+    setInputFocused$,
   };
 }
 
@@ -191,6 +230,32 @@ export const taskSignals$ = computed(async (get) => {
       return ts !== undefined;
     });
 });
+
+// ---------------------------------------------------------------------------
+// Cross-task commands
+// ---------------------------------------------------------------------------
+
+export const closeAndFocusNextInput$ = command(
+  async ({ get, set }, taskId: string) => {
+    const tasks = await get(taskSignals$);
+    const currentIndex = tasks.findIndex((ts) => {
+      return ts.task.id === taskId;
+    });
+    if (currentIndex === -1) {
+      return;
+    }
+
+    set(tasks[currentIndex].closeTask$);
+
+    for (let i = 1; i < tasks.length; i++) {
+      const idx = (currentIndex + i) % tasks.length;
+      if (get(tasks[idx].open$)) {
+        set(tasks[idx].focusInput$);
+        return;
+      }
+    }
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Derived computeds

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
@@ -1,78 +1,82 @@
-import { command, computed, state } from "ccstate";
+import { command, state } from "ccstate";
 import { toggleTaskList$ } from "./mission-control-panels.ts";
-import { taskSignals$, setupTasksLoop$ } from "./mission-control-tasks.ts";
+import { setupTasksLoop$ } from "./mission-control-tasks.ts";
 import { setupGlobalShortcut } from "../../lib/setup-global-shortcut.ts";
+import { onRef } from "../utils.ts";
 
 // ---------------------------------------------------------------------------
-// Selection — id-based
+// Task list container ref
 // ---------------------------------------------------------------------------
 
-const internalSelectedTaskId$ = state<string | null>(null);
+const internalTaskListRef$ = state<HTMLElement | null>(null);
 
-export const selectedTaskId$ = computed((get) => {
-  return get(internalSelectedTaskId$);
-});
-
-const selectPrevTask$ = command(async ({ get, set }, signal: AbortSignal) => {
-  const tasks = await get(taskSignals$);
-  signal.throwIfAborted();
-
-  if (tasks.length === 0) {
-    return;
-  }
-
-  const currentId = get(internalSelectedTaskId$);
-  const currentIndex = tasks.findIndex((ts) => {
-    return ts.task.id === currentId;
-  });
-
-  if (currentIndex <= 0) {
-    set(internalSelectedTaskId$, tasks[0].task.id);
-  } else {
-    set(internalSelectedTaskId$, tasks[currentIndex - 1].task.id);
-  }
-});
-
-const selectNextTask$ = command(async ({ get, set }, signal: AbortSignal) => {
-  const tasks = await get(taskSignals$);
-  signal.throwIfAborted();
-
-  if (tasks.length === 0) {
-    return;
-  }
-
-  const currentId = get(internalSelectedTaskId$);
-  const currentIndex = tasks.findIndex((ts) => {
-    return ts.task.id === currentId;
-  });
-
-  if (currentIndex === -1 || currentIndex >= tasks.length - 1) {
-    set(internalSelectedTaskId$, tasks[tasks.length - 1].task.id);
-  } else {
-    set(internalSelectedTaskId$, tasks[currentIndex + 1].task.id);
-  }
-});
-
-const toggleSelectedTask$ = command(
-  async ({ get, set }, signal: AbortSignal) => {
-    const tasks = await get(taskSignals$);
-    signal.throwIfAborted();
-
-    const selectedId = get(internalSelectedTaskId$);
-    const ts = tasks.find((t) => {
-      return t.task.id === selectedId;
+export const setTaskListRef$ = onRef(
+  command(({ set }, el: HTMLElement, signal: AbortSignal) => {
+    signal.addEventListener("abort", () => {
+      set(internalTaskListRef$, null);
     });
-    if (!ts) {
-      return;
-    }
-
-    if (get(ts.open$)) {
-      set(ts.closeTask$);
-    } else {
-      await set(ts.openTask$, signal);
-    }
-  },
+    set(internalTaskListRef$, el);
+  }),
 );
+
+// ---------------------------------------------------------------------------
+// DOM-based task list navigation
+// ---------------------------------------------------------------------------
+
+function isFullyVisible(card: Element, container: Element): boolean {
+  const cr = card.getBoundingClientRect();
+  const vr = container.getBoundingClientRect();
+  return cr.top >= vr.top && cr.bottom <= vr.bottom;
+}
+
+const navigateTaskList$ = command(({ get }, direction: "next" | "prev") => {
+  const container = get(internalTaskListRef$);
+  if (!container) {
+    return;
+  }
+
+  const cards = Array.from(
+    container.querySelectorAll<HTMLElement>("[tabindex='0']"),
+  );
+  if (cards.length === 0) {
+    return;
+  }
+
+  const active = document.activeElement;
+  const currentIndex = active ? cards.indexOf(active as HTMLElement) : -1;
+
+  let target: HTMLElement | undefined;
+
+  if (currentIndex !== -1) {
+    // Already focused on a card — move to sibling, clamp at boundary
+    if (direction === "next" && currentIndex < cards.length - 1) {
+      target = cards[currentIndex + 1];
+    } else if (direction === "prev" && currentIndex > 0) {
+      target = cards[currentIndex - 1];
+    }
+  } else {
+    // No card focused — pick first/last fully visible
+    if (direction === "next") {
+      target = cards.find((c) => {
+        return isFullyVisible(c, container);
+      });
+    } else {
+      for (let i = cards.length - 1; i >= 0; i--) {
+        if (isFullyVisible(cards[i], container)) {
+          target = cards[i];
+          break;
+        }
+      }
+    }
+    // Fallback: first or last card if none fully visible
+    target ??= direction === "next" ? cards[0] : cards[cards.length - 1];
+  }
+
+  if (target) {
+    target.focus();
+    target.scrollIntoView({ block: "nearest" });
+  }
+});
 
 // ---------------------------------------------------------------------------
 // Keyboard shortcuts
@@ -82,14 +86,11 @@ export const setupMissionControlKeyboard$ = command(
   ({ set }, signal: AbortSignal) => {
     setupGlobalShortcut(
       {
-        k: async () => {
-          await set(selectPrevTask$, signal);
+        k: () => {
+          set(navigateTaskList$, "prev");
         },
-        j: async () => {
-          await set(selectNextTask$, signal);
-        },
-        " ": async () => {
-          await set(toggleSelectedTask$, signal);
+        j: () => {
+          set(navigateTaskList$, "next");
         },
         "mod+b": () => {
           set(toggleTaskList$);

--- a/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
@@ -15,6 +15,7 @@ import { setTaskListRef$ } from "../../signals/mission-control-page/mission-cont
 import { TaskList } from "./task-list.tsx";
 import { TaskPanel } from "./task-panel.tsx";
 import { CollapsedTaskListBar } from "./collapsed-task-list-bar.tsx";
+import { VoiceButton, VoiceBanner } from "./voice-banner.tsx";
 
 export function MissionControlPage() {
   const panelVisible = useLastResolved(missionControlPanelVisible$) ?? false;
@@ -53,11 +54,17 @@ export function MissionControlPage() {
         ) : (
           <div className="flex flex-col min-h-0 h-full">
             <div className="shrink-0 px-6 pt-6 pb-2">
-              <h1 className="text-lg font-semibold">Mission Control</h1>
-              <p className="text-sm text-muted-foreground mt-1">
-                Active tasks across all channels
-              </p>
+              <div className="flex items-center justify-between">
+                <div>
+                  <h1 className="text-lg font-semibold">Mission Control</h1>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    Active tasks across all channels
+                  </p>
+                </div>
+                <VoiceButton />
+              </div>
             </div>
+            <VoiceBanner />
             <div ref={setListRef} className="flex-1 overflow-auto px-6 pb-6">
               <TaskList />
             </div>

--- a/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
@@ -11,6 +11,7 @@ import {
   setTaskListPanelRef$,
   setTaskListCollapsed$,
 } from "../../signals/mission-control-page/mission-control-panels.ts";
+import { setTaskListRef$ } from "../../signals/mission-control-page/mission-control.ts";
 import { TaskList } from "./task-list.tsx";
 import { TaskPanel } from "./task-panel.tsx";
 import { CollapsedTaskListBar } from "./collapsed-task-list-bar.tsx";
@@ -20,6 +21,7 @@ export function MissionControlPage() {
   const collapsed = useGet(taskListCollapsed$);
   const setCollapsed = useSet(setTaskListCollapsed$);
   const setPanelRef = useSet(setTaskListPanelRef$);
+  const setListRef = useSet(setTaskListRef$);
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: "mc-main",
@@ -56,7 +58,7 @@ export function MissionControlPage() {
                 Active tasks across all channels
               </p>
             </div>
-            <div className="flex-1 overflow-auto px-6 pb-6">
+            <div ref={setListRef} className="flex-1 overflow-auto px-6 pb-6">
               <TaskList />
             </div>
           </div>

--- a/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
@@ -4,15 +4,9 @@ import {
   IconCalendar,
   IconBrandSlack,
   IconMail,
-  IconCircleCheck,
-  IconClock,
-  IconPlayerPlay,
-  IconCircleX,
-  IconClockExclamation,
-  IconBan,
 } from "@tabler/icons-react";
 import { Card, Shortcut } from "@vm0/ui";
-import type { TaskItem, TaskType, RunStatus } from "@vm0/core";
+import type { TaskItem, TaskType } from "@vm0/core";
 import type { TaskSignals } from "../../signals/mission-control-page/mission-control-tasks.ts";
 import { StatusBadge } from "../zero-page/components/log-views/status-badge.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
@@ -179,42 +173,4 @@ export function TaskTypeIcon({ task }: { task: TaskItem }) {
       className={`${config.iconClassName} shrink-0`}
     />
   );
-}
-
-function getStatusIconConfig(status: RunStatus): {
-  icon: typeof IconCircleCheck;
-  iconClassName: string;
-} {
-  switch (status) {
-    case "queued": {
-      return { icon: IconClock, iconClassName: "text-gray-400" };
-    }
-    case "pending": {
-      return { icon: IconClock, iconClassName: "text-yellow-600" };
-    }
-    case "running": {
-      return { icon: IconPlayerPlay, iconClassName: "text-sky-600" };
-    }
-    case "completed": {
-      return { icon: IconCircleCheck, iconClassName: "text-green-600" };
-    }
-    case "failed": {
-      return { icon: IconCircleX, iconClassName: "text-red-600" };
-    }
-    case "timeout": {
-      return { icon: IconClockExclamation, iconClassName: "text-orange-600" };
-    }
-    case "cancelled": {
-      return { icon: IconBan, iconClassName: "text-gray-600" };
-    }
-  }
-}
-
-export function TaskStatusIcon({ task }: { task: TaskItem }) {
-  if (!task.status) {
-    return null;
-  }
-  const config = getStatusIconConfig(task.status);
-  const Icon = config.icon;
-  return <Icon size={12} className={`${config.iconClassName} shrink-0`} />;
 }

--- a/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
@@ -119,13 +119,9 @@ export function TaskCard({ taskSignals }: { taskSignals: TaskSignals }) {
         role="button"
         tabIndex={0}
         onClick={openOrFocusInput}
-        className={`p-4 cursor-pointer transition-colors focus:outline focus:outline-2 focus:outline-primary ${
-          inputFocused
-            ? "bg-accent"
-            : isOpen
-              ? "bg-accent/50"
-              : "hover:bg-accent/50"
-        }`}
+        className={`p-4 cursor-pointer transition-colors hover:bg-accent/50 focus:outline focus:outline-2 focus:outline-primary ${
+          inputFocused ? "bg-accent" : ""
+        } ${isOpen ? "border-primary" : ""}`}
       >
         <div className="flex flex-col gap-1.5">
           <div className="flex items-center gap-2">

--- a/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
@@ -94,9 +94,9 @@ export function TaskCard({ taskSignals }: { taskSignals: TaskSignals }) {
     }
   };
 
-  const clickOrEnter = () => {
+  const openOrFocusInput = () => {
     if (isOpen) {
-      closeTask();
+      focusInput();
     } else {
       detach(
         openTask(pageSignal).then(() => {
@@ -110,7 +110,7 @@ export function TaskCard({ taskSignals }: { taskSignals: TaskSignals }) {
   return (
     <Shortcut
       binding={{
-        enter: clickOrEnter,
+        enter: openOrFocusInput,
         " ": toggle,
       }}
     >
@@ -118,7 +118,7 @@ export function TaskCard({ taskSignals }: { taskSignals: TaskSignals }) {
         ref={setCardRef}
         role="button"
         tabIndex={0}
-        onClick={clickOrEnter}
+        onClick={openOrFocusInput}
         className={`p-4 cursor-pointer transition-colors focus:outline focus:outline-2 focus:outline-primary ${
           inputFocused
             ? "bg-accent"

--- a/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
@@ -76,13 +76,7 @@ function formatRelativeTime(iso: string): string {
   return `${diffDay}d ago`;
 }
 
-export function TaskCard({
-  taskSignals,
-  isSelected,
-}: {
-  taskSignals: TaskSignals;
-  isSelected: boolean;
-}) {
+export function TaskCard({ taskSignals }: { taskSignals: TaskSignals }) {
   const openTask = useSet(taskSignals.openTask$);
   const pageSignal = useGet(pageSignal$);
   const isOpen = useGet(taskSignals.open$);
@@ -91,7 +85,14 @@ export function TaskCard({
 
   const closeTask = useSet(taskSignals.closeTask$);
 
-  const onClick = () => {
+  const config = getTaskTypeConfig(task.type);
+  const TypeIcon = config.icon;
+
+  const focusInput = useSet(taskSignals.focusInput$);
+  const setCardRef = useSet(taskSignals.setCardRef$);
+  const inputFocused = useGet(taskSignals.inputFocused$);
+
+  const toggle = () => {
     if (isOpen) {
       closeTask();
     } else {
@@ -99,77 +100,69 @@ export function TaskCard({
     }
   };
 
-  const config = getTaskTypeConfig(task.type);
-  const TypeIcon = config.icon;
-
-  const focusInput = useSet(taskSignals.focusInput$);
+  const clickOrEnter = () => {
+    if (isOpen) {
+      closeTask();
+    } else {
+      detach(
+        openTask(pageSignal).then(() => {
+          focusInput();
+        }),
+        Reason.DomCallback,
+      );
+    }
+  };
 
   return (
     <Shortcut
       binding={{
-        enter: () => {
-          if (isOpen) {
-            focusInput();
-          }
-        },
-        " ": () => {
-          onClick();
-        },
+        enter: clickOrEnter,
+        " ": toggle,
       }}
     >
       <Card
-        ref={(el) => {
-          if (isSelected && el) {
-            el.scrollIntoView({ block: "nearest" });
-          }
-        }}
+        ref={setCardRef}
         role="button"
         tabIndex={0}
-        onClick={onClick}
-        className={`p-4 cursor-pointer transition-colors ${
-          isOpen ? "bg-accent" : ""
-        } ${isSelected ? "ring-2 ring-primary" : ""} ${
-          !isOpen ? "hover:bg-accent/50" : ""
+        onClick={clickOrEnter}
+        className={`p-4 cursor-pointer transition-colors focus:outline focus:outline-2 focus:outline-primary ${
+          inputFocused
+            ? "bg-accent"
+            : isOpen
+              ? "bg-accent/50"
+              : "hover:bg-accent/50"
         }`}
       >
-        <div className="flex items-start gap-3">
-          <div className="flex flex-col items-center shrink-0 gap-1">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
             <AvatarFromUrl
               avatarUrl={task.agent.avatarUrl}
               alt={task.agent.displayName ?? task.agent.name}
-              className="h-8 w-8 rounded-full object-cover object-top"
+              className="h-5 w-5 rounded-full object-cover object-top"
             />
-            <span className="text-[10px] text-muted-foreground truncate max-w-[4rem] leading-tight">
+            <span className="text-xs font-medium truncate">
               {task.agent.displayName ?? task.agent.name}
             </span>
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <TypeIcon
-                size={14}
-                stroke={1.5}
-                className={config.iconClassName}
-              />
-              <span className="text-sm font-medium truncate">
-                {task.title ?? task.agent.displayName ?? task.agent.name}
-              </span>
-              {task.status && (
-                <div className="ml-auto shrink-0">
-                  <StatusBadge status={task.status} zeroStyle />
-                </div>
-              )}
-            </div>
-            {task.summary && (
-              <p className="text-xs text-muted-foreground mt-1 line-clamp-3">
-                {task.summary}
-              </p>
+            {task.status && (
+              <div className="ml-auto shrink-0">
+                <StatusBadge status={task.status} zeroStyle />
+              </div>
             )}
-            <div className="flex justify-end mt-1">
-              <span className="text-xs text-muted-foreground">
-                {formatRelativeTime(task.updatedAt)}
-              </span>
-            </div>
           </div>
+          <div className="flex items-center gap-1.5">
+            <TypeIcon size={14} stroke={1.5} className={config.iconClassName} />
+            <span className="text-sm font-medium truncate">
+              {task.title ?? task.agent.displayName ?? task.agent.name}
+            </span>
+          </div>
+          {task.summary && (
+            <p className="text-xs text-muted-foreground line-clamp-2">
+              {task.summary}
+            </p>
+          )}
+          <span className="text-xs text-muted-foreground">
+            {formatRelativeTime(task.updatedAt)}
+          </span>
         </div>
       </Card>
     </Shortcut>

--- a/turbo/apps/platform/src/views/mission-control-page/task-list.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-list.tsx
@@ -1,7 +1,6 @@
-import { useGet, useLastLoadable } from "ccstate-react";
+import { useLastLoadable } from "ccstate-react";
 import { Skeleton, Card } from "@vm0/ui";
 import { taskSignals$ } from "../../signals/mission-control-page/mission-control-tasks.ts";
-import { selectedTaskId$ } from "../../signals/mission-control-page/mission-control.ts";
 import { TaskCard } from "./task-card.tsx";
 
 function TaskListSkeleton() {
@@ -39,8 +38,6 @@ export function TaskList() {
         : "Failed to load tasks"
       : null;
 
-  const selectedId = useGet(selectedTaskId$);
-
   if (loading && tasks.length === 0) {
     return <TaskListSkeleton />;
   }
@@ -60,13 +57,7 @@ export function TaskList() {
   return (
     <div className="flex flex-col gap-2 mt-2">
       {tasks.map((ts) => {
-        return (
-          <TaskCard
-            key={ts.task.id}
-            taskSignals={ts}
-            isSelected={ts.task.id === selectedId}
-          />
-        );
+        return <TaskCard key={ts.task.id} taskSignals={ts} />;
       })}
     </div>
   );

--- a/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
@@ -4,7 +4,6 @@ import {
   IconArrowsMaximize,
   IconArrowsMinimize,
 } from "@tabler/icons-react";
-import { Group, Panel, Separator } from "react-resizable-panels";
 import { processShortcut } from "@vm0/ui";
 import {
   visibleTasks$,
@@ -20,29 +19,29 @@ import {
 import { ZeroChatThreadPageInner } from "../zero-page/zero-chat-thread-page.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 import { ActivityPanelContent } from "./activity-panel-content.tsx";
-import { TaskTypeIcon, TaskStatusIcon } from "./task-card.tsx";
+import { TaskTypeIcon } from "./task-card.tsx";
 
 export function TaskPanel() {
   const entries = useLastResolved(visibleTasks$) ?? [];
 
   return (
-    <Group orientation="horizontal" id="mc-tasks" className="flex-1 min-h-0">
+    <div className="flex flex-1 min-h-0">
       {entries.flatMap((ts, index) => {
         const taskId = ts.task.id;
         const elements = [];
         if (index > 0) {
           elements.push(
-            <Separator key={`sep-${taskId}`} className="w-px bg-border" />,
+            <div key={`sep-${taskId}`} className="w-px bg-border shrink-0" />,
           );
         }
         elements.push(
-          <Panel key={taskId} id={`task-${taskId}`} minSize="60%">
+          <div key={taskId} className="flex-1 min-w-0">
             <TaskPanelCard taskSignals={ts} />
-          </Panel>,
+          </div>,
         );
         return elements;
       })}
-    </Group>
+    </div>
   );
 }
 
@@ -102,7 +101,6 @@ function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
       <div className="shrink-0 flex items-center justify-between gap-2 px-4 py-2 border-b bg-muted/30">
         <TaskPanelTitle taskSignals={taskSignals} />
         <div className="flex items-center gap-0.5 shrink-0">
-          <TaskStatusIcon task={taskSignals.task} />
           <button
             type="button"
             onClick={() => {

--- a/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
@@ -8,9 +8,11 @@ import { Group, Panel, Separator } from "react-resizable-panels";
 import { processShortcut } from "@vm0/ui";
 import {
   visibleTasks$,
+  closeAndFocusNextInput$,
   type TaskSignals,
   type TaskPanelEntry,
 } from "../../signals/mission-control-page/mission-control-tasks.ts";
+import { detach, Reason } from "../../signals/utils.ts";
 import {
   maximizedTaskId$,
   toggleMaximizeTask$,
@@ -47,6 +49,10 @@ export function TaskPanel() {
 function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
   const closeTask = useSet(taskSignals.closeTask$);
   const toggleMaximize = useSet(toggleMaximizeTask$);
+  const focusCard = useSet(taskSignals.focusCard$);
+  const scrollCardIntoView = useSet(taskSignals.scrollCardIntoView$);
+  const setInputFocused = useSet(taskSignals.setInputFocused$);
+  const closeAndFocusNext = useSet(closeAndFocusNextInput$);
   const maximizedId = useGet(maximizedTaskId$);
 
   const taskId = taskSignals.task.id;
@@ -55,11 +61,38 @@ function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
   return (
     <div
       className="flex flex-col h-full min-h-0"
+      onFocus={(e) => {
+        if (e.target instanceof HTMLTextAreaElement) {
+          scrollCardIntoView();
+          setInputFocused(true);
+        }
+      }}
+      onBlur={(e) => {
+        if (e.target instanceof HTMLTextAreaElement) {
+          setInputFocused(false);
+        }
+      }}
       onKeyDown={(e) => {
+        if (
+          e.key === "d" &&
+          e.ctrlKey &&
+          !e.metaKey &&
+          !e.shiftKey &&
+          !e.altKey &&
+          e.target instanceof HTMLTextAreaElement &&
+          e.target.value === ""
+        ) {
+          e.preventDefault();
+          detach(closeAndFocusNext(taskId), Reason.DomCallback);
+          return;
+        }
         processShortcut(
           {
             "mod+shift+enter": () => {
               toggleMaximize(taskId);
+            },
+            escape: () => {
+              focusCard();
             },
           },
           e,

--- a/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
@@ -25,7 +25,7 @@ export function TaskPanel() {
   const entries = useLastResolved(visibleTasks$) ?? [];
 
   return (
-    <div className="flex flex-1 min-h-0">
+    <div className="flex h-full min-h-0">
       {entries.flatMap((ts, index) => {
         const taskId = ts.task.id;
         const elements = [];
@@ -35,7 +35,7 @@ export function TaskPanel() {
           );
         }
         elements.push(
-          <div key={taskId} className="flex-1 min-w-0">
+          <div key={taskId} className="flex-1 min-w-0 h-full">
             <TaskPanelCard taskSignals={ts} />
           </div>,
         );
@@ -127,7 +127,7 @@ function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
           </button>
         </div>
       </div>
-      <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
+      <div className="flex flex-col flex-1 min-h-0 overflow-auto">
         <TaskPanelContent taskSignals={taskSignals} />
       </div>
     </div>

--- a/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-panel.tsx
@@ -16,6 +16,7 @@ import {
   maximizedTaskId$,
   toggleMaximizeTask$,
 } from "../../signals/mission-control-page/mission-control-panels.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
 import { ZeroChatThreadPageInner } from "../zero-page/zero-chat-thread-page.tsx";
 import { AvatarFromUrl } from "../zero-page/zero-sidebar-shared.tsx";
 import { ActivityPanelContent } from "./activity-panel-content.tsx";
@@ -52,6 +53,7 @@ function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
   const scrollCardIntoView = useSet(taskSignals.scrollCardIntoView$);
   const setInputFocused = useSet(taskSignals.setInputFocused$);
   const closeAndFocusNext = useSet(closeAndFocusNextInput$);
+  const pageSignal = useGet(pageSignal$);
   const maximizedId = useGet(maximizedTaskId$);
 
   const taskId = taskSignals.task.id;
@@ -82,7 +84,7 @@ function TaskPanelCard({ taskSignals }: { taskSignals: TaskSignals }) {
           e.target.value === ""
         ) {
           e.preventDefault();
-          detach(closeAndFocusNext(taskId), Reason.DomCallback);
+          detach(closeAndFocusNext(taskId, pageSignal), Reason.DomCallback);
           return;
         }
         processShortcut(

--- a/turbo/apps/platform/src/views/mission-control-page/voice-banner.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/voice-banner.tsx
@@ -1,0 +1,140 @@
+import { useGet, useLastResolved, useSet } from "ccstate-react";
+import {
+  IconMicrophone,
+  IconMicrophoneOff,
+  IconPhoneOff,
+  IconLoader2,
+  IconRefresh,
+} from "@tabler/icons-react";
+import { Button } from "@vm0/ui";
+import {
+  vcStatus$,
+  vcTranscript$,
+  vcMuted$,
+  vcEnabled$,
+  startVoiceChat$,
+  endVoiceChat$,
+  retryVoiceChat$,
+  toggleVoiceChatMute$,
+} from "../../signals/voice-chat/voice-chat-session.ts";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+
+export function VoiceButton() {
+  const enabled = useLastResolved(vcEnabled$) ?? false;
+  const status = useGet(vcStatus$);
+  const muted = useGet(vcMuted$);
+  const startChat = useSet(startVoiceChat$);
+  const endChat = useSet(endVoiceChat$);
+  const toggleMute = useSet(toggleVoiceChatMute$);
+  const pageSignal = useGet(pageSignal$);
+
+  if (!enabled) {
+    return null;
+  }
+
+  if (status === "idle") {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          detach(startChat(pageSignal), Reason.DomCallback);
+        }}
+      >
+        <IconMicrophone size={14} stroke={1.5} />
+        Voice On
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={toggleMute}
+        className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        aria-label={muted ? "Unmute" : "Mute"}
+      >
+        {muted ? (
+          <IconMicrophoneOff size={14} stroke={1.5} />
+        ) : (
+          <IconMicrophone size={14} stroke={1.5} />
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={endChat}
+        className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        aria-label="End voice"
+      >
+        <IconPhoneOff size={14} stroke={1.5} />
+      </button>
+    </div>
+  );
+}
+
+export function VoiceBanner() {
+  const status = useGet(vcStatus$);
+  const transcript = useGet(vcTranscript$);
+  const retryChat = useSet(retryVoiceChat$);
+  const pageSignal = useGet(pageSignal$);
+
+  if (status === "idle") {
+    return null;
+  }
+
+  if (
+    status === "preparing" ||
+    status === "connecting" ||
+    status === "reconnecting"
+  ) {
+    const label = status === "reconnecting" ? "Reconnecting..." : "Enabling...";
+    return (
+      <div className="flex items-center gap-2 px-6 py-2 text-xs text-muted-foreground bg-muted/30 border-b">
+        <IconLoader2 size={12} className="animate-spin" />
+        {label}
+      </div>
+    );
+  }
+
+  if (status === "disconnected" || status === "error") {
+    return (
+      <div className="flex items-center gap-2 px-6 py-2 text-xs text-destructive bg-destructive/5 border-b">
+        <span>Voice disconnected</span>
+        <button
+          type="button"
+          onClick={() => {
+            detach(retryChat(pageSignal), Reason.DomCallback);
+          }}
+          className="inline-flex items-center gap-1 text-xs underline"
+        >
+          <IconRefresh size={12} />
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  // connected — show last transcript entry
+  const last = transcript[transcript.length - 1];
+  if (!last) {
+    return (
+      <div className="flex items-center gap-2 px-6 py-2 text-xs text-muted-foreground bg-muted/30 border-b">
+        <span className="h-1.5 w-1.5 rounded-full bg-green-500 shrink-0" />
+        Listening...
+      </div>
+    );
+  }
+
+  const prefix = last.role === "user" ? "You" : "AI";
+
+  return (
+    <div className="flex items-center gap-2 px-6 py-2 text-xs bg-muted/30 border-b">
+      <span className="h-1.5 w-1.5 rounded-full bg-green-500 shrink-0" />
+      <span className="truncate">
+        <span className="font-medium">{prefix}:</span> {last.text}
+      </span>
+    </div>
+  );
+}

--- a/turbo/apps/web/app/api/internal/callbacks/schedule/cron/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/schedule/cron/route.ts
@@ -17,11 +17,10 @@ const MAX_CONSECUTIVE_FAILURES = 3;
 function parsePayload(payload: unknown): ScheduleCronCallbackPayload | null {
   if (!payload || typeof payload !== "object") return null;
   const p = payload as Record<string, unknown>;
-  if (
-    typeof p.scheduleId !== "string" ||
-    typeof p.cronExpression !== "string" ||
-    typeof p.timezone !== "string"
-  ) {
+  if (typeof p.scheduleId !== "string" || typeof p.timezone !== "string") {
+    return null;
+  }
+  if (p.cronExpression !== undefined && typeof p.cronExpression !== "string") {
     return null;
   }
   return p as unknown as ScheduleCronCallbackPayload;
@@ -47,7 +46,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return errorResponse("Invalid or missing payload", 400);
   }
 
-  const { scheduleId, cronExpression, timezone } = payload;
+  const { scheduleId, cronExpression } = payload;
 
   // Ignore progress notifications — only act on terminal states
   if (status === "progress") {
@@ -83,9 +82,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const newFailureCount =
     status === "completed" ? 0 : schedule.consecutiveFailures + 1;
   const shouldDisable = newFailureCount >= MAX_CONSECUTIVE_FAILURES;
-  const nextRunAt = shouldDisable
-    ? null
-    : calculateNextRun(cronExpression, timezone);
+  const nextRunAt =
+    shouldDisable || !cronExpression
+      ? null
+      : calculateNextRun(cronExpression, schedule.timezone);
 
   await globalThis.services.db
     .update(zeroAgentSchedules)

--- a/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
+++ b/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
@@ -58,7 +58,7 @@ export interface ScheduleLoopCallbackPayload {
 
 export interface ScheduleCronCallbackPayload {
   scheduleId: string;
-  cronExpression: string;
+  cronExpression?: string;
   timezone: string;
 }
 

--- a/turbo/apps/web/src/lib/zero/ai/lightweight-model.ts
+++ b/turbo/apps/web/src/lib/zero/ai/lightweight-model.ts
@@ -1,5 +1,8 @@
 import "server-only";
 import { env } from "../../../env";
+import { logger } from "../../shared/logger";
+
+const log = logger("lightweight-model");
 
 const BASE_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MODEL = "google/gemini-3.1-flash-lite-preview";
@@ -32,6 +35,7 @@ async function generateText(
   const { OPENROUTER_API_KEY } = env();
 
   if (!OPENROUTER_API_KEY) {
+    log.warn("OPENROUTER_API_KEY not configured, skipping text generation");
     return null;
   }
 

--- a/turbo/apps/web/src/lib/zero/run-summary.ts
+++ b/turbo/apps/web/src/lib/zero/run-summary.ts
@@ -20,7 +20,13 @@ export async function saveRunSummary(
 ): Promise<void> {
   try {
     const summary = await generateRunSummary(triggerSource, prompt, resultText);
-    if (!summary) return;
+    if (!summary) {
+      log.warn("Run summary generation returned null (API key missing?)", {
+        runId,
+        triggerSource,
+      });
+      return;
+    }
 
     await globalThis.services.db
       .update(zeroRuns)

--- a/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
+++ b/turbo/apps/web/src/lib/zero/schedule/schedule-service.ts
@@ -869,11 +869,13 @@ export async function executeSchedule(
     });
   }
 
-  // Cron schedule completion callback (tracks failures and advances next run)
-  if (schedule.triggerType === "cron") {
+  // Cron/once schedule completion callback (tracks failures, advances next run, generates summary)
+  if (schedule.triggerType === "cron" || schedule.triggerType === "once") {
     const cronPayload: ScheduleCronCallbackPayload = {
       scheduleId: schedule.id,
-      cronExpression: schedule.cronExpression!,
+      ...(schedule.cronExpression && {
+        cronExpression: schedule.cronExpression,
+      }),
       timezone: schedule.timezone,
     };
     callbacks.push({

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql, desc, isNotNull } from "drizzle-orm";
+import { and, eq, inArray, sql, desc } from "drizzle-orm";
 import type { TaskItem } from "@vm0/core";
 import { chatThreads, chatThreadRuns } from "../../../db/schema/chat-thread";
 import { zeroAgentSchedules } from "../../../db/schema/zero-agent-schedule";
@@ -200,7 +200,6 @@ async function listScheduleTasks(
   const conditions = [
     eq(zeroAgentSchedules.userId, userId),
     eq(zeroAgentSchedules.orgId, orgId),
-    isNotNull(zeroAgentSchedules.lastRunId),
   ];
   if (agentId) conditions.push(eq(zeroAgentSchedules.agentId, agentId));
 

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql, desc } from "drizzle-orm";
+import { and, eq, inArray, sql, desc, isNotNull } from "drizzle-orm";
 import type { TaskItem } from "@vm0/core";
 import { chatThreads, chatThreadRuns } from "../../../db/schema/chat-thread";
 import { zeroAgentSchedules } from "../../../db/schema/zero-agent-schedule";
@@ -200,6 +200,7 @@ async function listScheduleTasks(
   const conditions = [
     eq(zeroAgentSchedules.userId, userId),
     eq(zeroAgentSchedules.orgId, orgId),
+    isNotNull(zeroAgentSchedules.lastRunId),
   ];
   if (agentId) conditions.push(eq(zeroAgentSchedules.agentId, agentId));
 


### PR DESCRIPTION
## Summary

- Replace stored `selectedTaskId$` state with native DOM focus for task card navigation — j/k now move focus directly via DOM traversal (sync, no async task list lookup)
- Add cross-panel focus tracking: `inputFocused$` signal drives task card background color when the corresponding panel's input is focused
- Add keyboard shortcuts: `Ctrl+D` (close task + focus next input), `ESC` (return focus to task card), `Enter`/click (open + focus input), `Space` (toggle only)
- Redesign task card layout to 4-row structure: avatar+name | title | summary | time

## Test plan

- [x] Type check passes (`pnpm -F @vm0/app exec tsc --noEmit`)
- [x] All mission-control tests pass (6/6)
- [x] Lint passes
- [x] Knip passes (no unused exports)
- [ ] Manual: j/k navigates task cards with outline + scroll-into-view
- [ ] Manual: Enter/click opens task and focuses input, Space toggles without focusing
- [ ] Manual: ESC in input returns focus to task card
- [ ] Manual: Ctrl+D in empty input closes task and focuses next open task
- [ ] Manual: Task card shows bg-accent when corresponding input is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)