### PR TITLE
feat(mission-control): add voice chat banner with subtitle display

### DIFF
--- a/turbo/apps/platform/src/views/mission-control-page/voice-banner.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/voice-banner.tsx
@@ -78,6 +78,7 @@ export function VoiceBanner() {
   const status = useGet(vcStatus$);
   const transcript = useGet(vcTranscript$);
   const retryChat = useSet(retryVoiceChat$);
+  const endChat = useSet(endVoiceChat$);
   const pageSignal = useGet(pageSignal$);
 
   if (status === "idle") {
@@ -98,7 +99,7 @@ export function VoiceBanner() {
     );
   }
 
-  if (status === "disconnected" || status === "error") {
+  if (status === "disconnected") {
     return (
       <div className="flex items-center gap-2 px-6 py-2 text-xs text-destructive bg-destructive/5 border-b">
         <span>Voice disconnected</span>
@@ -111,6 +112,21 @@ export function VoiceBanner() {
         >
           <IconRefresh size={12} />
           Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="flex items-center gap-2 px-6 py-2 text-xs text-destructive bg-destructive/5 border-b">
+        <span>Voice error</span>
+        <button
+          type="button"
+          onClick={endChat}
+          className="inline-flex items-center gap-1 text-xs underline shrink-0"
+        >
+          Dismiss
         </button>
       </div>
     );


### PR DESCRIPTION
## Summary

- Add "Voice On" button to Mission Control title area, gated by voiceChat feature flag
- Add status banner below title: spinner during connection, live subtitle (last transcript entry) when connected, error/disconnect states
- Reuses existing voice chat signals (`vcStatus$`, `vcTranscript$`, etc.) — no new state

## Test plan

- [x] Type check passes
- [x] All mission-control tests pass (6/6)
- [x] Knip clean
- [ ] Manual: Voice On button appears when voiceChat feature flag is enabled
- [ ] Manual: Banner shows "Enabling..." during connection
- [ ] Manual: Banner shows live subtitle when connected
- [ ] Manual: Mute/End controls work
- [ ] Manual: Dismiss clears error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)