### PR TITLE
refactor(chat): extract navigation from create new chat thread command

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/__tests__/chat-message.test.ts
+++ b/turbo/apps/platform/src/signals/chat-page/__tests__/chat-message.test.ts
@@ -590,7 +590,7 @@ describe("zero-chat signals", () => {
   });
 
   describe("createNewChatThread$", () => {
-    it("should navigate to first thread when it has no title and matches agent", async () => {
+    it("should return first thread id when it has no title and matches agent", async () => {
       server.use(
         http.get("*/api/zero/chat-threads", () => {
           return HttpResponse.json({
@@ -616,10 +616,13 @@ describe("zero-chat signals", () => {
 
       await setup();
 
-      await context.store.set(createNewChatThread$, null, context.signal);
+      const threadId = await context.store.set(
+        createNewChatThread$,
+        null,
+        context.signal,
+      );
 
-      // Should navigate to the first empty thread, not the second
-      expect(context.store.get(currentChatThreadId$)).toBe("empty-thread-1");
+      expect(threadId).toBe("empty-thread-1");
     });
 
     it("should create new thread when first thread has a title", async () => {
@@ -652,11 +655,13 @@ describe("zero-chat signals", () => {
 
       await setup();
 
-      await context.store.set(createNewChatThread$, null, context.signal);
-
-      expect(context.store.get(currentChatThreadId$)).toBe(
-        "new-thread-created",
+      const threadId = await context.store.set(
+        createNewChatThread$,
+        null,
+        context.signal,
       );
+
+      expect(threadId).toBe("new-thread-created");
     });
 
     it("should create new thread when thread list is empty", async () => {
@@ -679,14 +684,16 @@ describe("zero-chat signals", () => {
 
       await setup();
 
-      await context.store.set(createNewChatThread$, null, context.signal);
-
-      expect(context.store.get(currentChatThreadId$)).toBe(
-        "new-thread-empty-list",
+      const threadId = await context.store.set(
+        createNewChatThread$,
+        null,
+        context.signal,
       );
+
+      expect(threadId).toBe("new-thread-empty-list");
     });
 
-    it("should not navigate to second thread when first has a title", async () => {
+    it("should not reuse second thread when first has a title", async () => {
       server.use(
         http.get("*/api/zero/chat-threads", () => {
           return HttpResponse.json({
@@ -723,10 +730,13 @@ describe("zero-chat signals", () => {
 
       await setup();
 
-      await context.store.set(createNewChatThread$, null, context.signal);
+      const threadId = await context.store.set(
+        createNewChatThread$,
+        null,
+        context.signal,
+      );
 
-      // Should NOT navigate to empty-second-thread; should create brand new
-      expect(context.store.get(currentChatThreadId$)).toBe("brand-new-thread");
+      expect(threadId).toBe("brand-new-thread");
     });
   });
 

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -669,20 +669,26 @@ export const startNewZeroSession$ = command(({ set }) => {
   set(internalLocalMessages$, []);
 });
 
-const internalCreatingPromise$ = state<Promise<void> | undefined>(undefined);
+const internalCreatingPromise$ = state<Promise<string | null> | undefined>(
+  undefined,
+);
 
 export const creatingNewSession$ = computed(async (get) => {
   await get(internalCreatingPromise$);
 });
 
 const internalCreateNewChatSession$ = command(
-  async ({ get, set }, agentComposeId: string | null, _signal: AbortSignal) => {
+  async (
+    { get, set },
+    agentComposeId: string | null,
+    _signal: AbortSignal,
+  ): Promise<string | null> => {
     const resolvedComposeId =
       agentComposeId ?? (await get(zeroOnboardingStatus$)).defaultAgentId;
 
     if (!resolvedComposeId) {
       toast.error("No agent available for new chat session");
-      return;
+      return null;
     }
 
     // A1: If currently viewing an empty thread for this agent, reuse it
@@ -694,10 +700,10 @@ const internalCreateNewChatSession$ = command(
       currentThread.unsavedRuns.length === 0
     ) {
       set(startNewZeroSession$);
-      return;
+      return currentThread.id;
     }
 
-    // A2: If the first thread in the list is empty, navigate to it
+    // A2: If the first thread in the list is empty, reuse it
     const threads = await get(chatThreads$);
     const firstThread = threads[0];
     if (
@@ -705,8 +711,7 @@ const internalCreateNewChatSession$ = command(
       firstThread.agentId === resolvedComposeId
     ) {
       set(startNewZeroSession$);
-      set(navigateToChat$, firstThread.id);
-      return;
+      return firstThread.id;
     }
 
     // Fallback: create a new thread
@@ -716,12 +721,16 @@ const internalCreateNewChatSession$ = command(
     const thread = await createChatThread(createClient, resolvedComposeId);
 
     set(reloadChatThreads$);
-    set(navigateToChat$, thread.id);
+    return thread.id;
   },
 );
 
 export const createNewChatThread$ = command(
-  ({ set }, agentComposeId: string | null, signal: AbortSignal) => {
+  async (
+    { set },
+    agentComposeId: string | null,
+    signal: AbortSignal,
+  ): Promise<string | null> => {
     const promise = set(internalCreateNewChatSession$, agentComposeId, signal);
     set(internalCreatingPromise$, promise);
     return promise;

--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -726,7 +726,7 @@ const internalCreateNewChatSession$ = command(
 );
 
 export const createNewChatThread$ = command(
-  async (
+  (
     { set },
     agentComposeId: string | null,
     signal: AbortSignal,

--- a/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
+++ b/turbo/apps/platform/src/views/zero-page/sidebar-threads.tsx
@@ -221,8 +221,16 @@ function ChatThreadsTitle() {
 
   const agentDisplayName = useLastResolved(currentChatAgentDisplayName$);
   const newChatDisabled = creatingLoadable.state === "loading";
+  const navigateToChat = useSet(navigateToChat$);
   const onNewChat = () => {
-    detach(createNewChat(currentChatAgentId, pageSignal), Reason.DomCallback);
+    detach(
+      createNewChat(currentChatAgentId, pageSignal).then((threadId) => {
+        if (threadId) {
+          navigateToChat(threadId);
+        }
+      }),
+      Reason.DomCallback,
+    );
     setExpanded(false);
   };
 

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-list-page.tsx
@@ -105,7 +105,11 @@ export function ZeroChatListPage() {
 
   const onNewChat = () => {
     detach(
-      createNewChat(currentChatAgentId ?? null, pageSignal),
+      createNewChat(currentChatAgentId ?? null, pageSignal).then((threadId) => {
+        if (threadId) {
+          navigateToChat(threadId);
+        }
+      }),
       Reason.DomCallback,
     );
   };

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -41,6 +41,7 @@ import {
   pinnedAgents$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
 import { createNewChatThread$ } from "../../signals/chat-page/chat-message.ts";
+import { navigateToChat$ } from "../../signals/zero-page/zero-nav.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
@@ -72,6 +73,7 @@ export function PinnedAgentListSection() {
   const [pinLoadable, savePinnedIds] = useLoadableSet(updatePinnedAgentIds$);
   const savingPinned = pinLoadable.state === "loading";
   const createNewChat = useSet(createNewChatThread$);
+  const navigateToChat = useSet(navigateToChat$);
   const setExpanded = useSet(setSidebarExpanded$);
   const pageSignal = useGet(pageSignal$);
 
@@ -80,7 +82,14 @@ export function PinnedAgentListSection() {
   };
 
   const onNewChat = (agentId: string | null) => {
-    detach(createNewChat(agentId, pageSignal), Reason.DomCallback);
+    detach(
+      createNewChat(agentId, pageSignal).then((threadId) => {
+        if (threadId) {
+          navigateToChat(threadId);
+        }
+      }),
+      Reason.DomCallback,
+    );
     setExpanded(false);
   };
   const defaultAgentId = useLastResolved(defaultAgentId$);

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar-pinned.tsx
@@ -17,6 +17,7 @@ import {
 import {
   isChatRoute,
   setSidebarExpanded$,
+  navigateToChat$,
 } from "../../signals/zero-page/zero-nav.ts";
 import { activeRoute$ } from "../../signals/active-route.ts";
 import {
@@ -41,7 +42,6 @@ import {
   pinnedAgents$,
 } from "../../signals/zero-page/zero-pinned-agents.ts";
 import { createNewChatThread$ } from "../../signals/chat-page/chat-message.ts";
-import { navigateToChat$ } from "../../signals/zero-page/zero-nav.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";


### PR DESCRIPTION
## Summary

- `createNewChatThread$` now returns the thread ID instead of navigating internally
- All 3 call sites updated to handle navigation themselves
- Enables reuse in Mission Control where navigation is not desired

## Test plan

- [x] Type check passes
- [x] All 25 chat-message tests pass (updated to verify return value instead of navigation side effect)
- [x] Knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)