### PR TITLE
feat: add mission_control voice chat mode

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -1076,6 +1076,74 @@ export const startVoiceChat$ = command(
   },
 );
 
+export const startMissionControlVoiceChat$ = command(
+  async ({ get, set }, signal: AbortSignal) => {
+    if (
+      get(internalStatus$) === "connecting" ||
+      get(internalStatus$) === "connected" ||
+      get(internalStatus$) === "preparing" ||
+      get(internalStatus$) === "reconnecting"
+    ) {
+      return;
+    }
+
+    set(internalStatus$, "preparing");
+    set(internalError$, null);
+    set(internalTranscript$, []);
+    set(internalEvents$, []);
+    set(internalMuted$, false);
+    set(internalSessionId$, null);
+    set(internalLastSeq$, 0);
+    set(internalCurrentAssistant$, null);
+    set(internalPrompt$, null);
+    set(internalPrepStartTime$, Date.now());
+    set(internalParentSignal$, signal);
+
+    const sessionSignal = set(resetSessionSignal$, signal);
+
+    const fetchFn = get(fetch$);
+    const agentId = await get(currentChatAgentId$);
+    signal.throwIfAborted();
+
+    if (!agentId) {
+      set(internalError$, "No agent selected");
+      set(internalStatus$, "error");
+      return;
+    }
+
+    const sessionRes = await fetchFn("/api/zero/voice-chat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agentId, mode: "mission_control" }),
+    });
+    signal.throwIfAborted();
+
+    if (!sessionRes.ok) {
+      const body = (await sessionRes.json()) as {
+        error: { message: string };
+      };
+      signal.throwIfAborted();
+      set(internalError$, body.error.message);
+      set(internalStatus$, "error");
+      return;
+    }
+
+    const { session } = (await sessionRes.json()) as {
+      session: { id: string };
+    };
+    signal.throwIfAborted();
+    set(internalSessionId$, session.id);
+
+    await set(
+      prepareActivateConnect$,
+      session.id,
+      sessionSignal,
+      PREP_TIMEOUT_CHAT_MS,
+      signal,
+    );
+  },
+);
+
 export const startVoiceMeeting$ = command(
   async ({ get, set }, prompt: string, signal: AbortSignal) => {
     if (

--- a/turbo/apps/platform/src/views/mission-control-page/voice-banner.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/voice-banner.tsx
@@ -12,7 +12,7 @@ import {
   vcTranscript$,
   vcMuted$,
   vcEnabled$,
-  startVoiceChat$,
+  startMissionControlVoiceChat$,
   endVoiceChat$,
   retryVoiceChat$,
   toggleVoiceChatMute$,
@@ -24,7 +24,7 @@ export function VoiceButton() {
   const enabled = useLastResolved(vcEnabled$) ?? false;
   const status = useGet(vcStatus$);
   const muted = useGet(vcMuted$);
-  const startChat = useSet(startVoiceChat$);
+  const startChat = useSet(startMissionControlVoiceChat$);
   const endChat = useSet(endVoiceChat$);
   const toggleMute = useSet(toggleVoiceChatMute$);
   const pageSignal = useGet(pageSignal$);

--- a/turbo/apps/web/app/api/zero/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/route.ts
@@ -15,7 +15,7 @@ import { loadFeatureSwitchOverrides } from "../../../../src/lib/zero/user/featur
 const bodySchema = z
   .object({
     agentId: z.string().min(1),
-    mode: z.enum(["chat", "meeting"]).default("chat"),
+    mode: z.enum(["chat", "meeting", "mission_control"]).default("chat"),
     prompt: z.string().min(1).optional(),
   })
   .refine(

--- a/turbo/apps/web/src/db/schema/voice-chat.ts
+++ b/turbo/apps/web/src/db/schema/voice-chat.ts
@@ -14,7 +14,8 @@ import { agentComposes } from "./agent-compose";
  * Voice-chat sessions track active voice conversations.
  * Each session has one WebRTC connection (fast-brain) and one zero agent run (slow-brain).
  *
- * Modes: chat (default) — voice starts immediately; meeting — slow-brain prepares first.
+ * Modes: chat (default) — voice starts immediately; meeting — slow-brain prepares first;
+ *        mission_control — slow-brain delegates all task execution to sub-agents via `zero run`.
  * Statuses: preparing → active → ended | timeout
  */
 export const voiceChatSessions = pgTable(
@@ -35,6 +36,7 @@ export const voiceChatSessions = pgTable(
       },
       { onDelete: "set null" },
     ),
+    // Valid values: "chat" | "meeting" | "mission_control"
     mode: varchar("mode", { length: 20 }).notNull().default("chat"),
     prompt: text("prompt"),
     status: varchar("status", { length: 20 }).notNull().default("active"),

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -257,6 +257,118 @@ export function buildVoiceChatMeetingPrompt(
   return [header, meetingPrompt].join("\n\n");
 }
 
+const VOICE_CHAT_MISSION_CONTROL_PROMPT = `
+# Zero — Slow-Brain Mission Control Mode
+
+You are Zero's slow-brain. The voice conversation has not started yet. Your job is to do a quick warm-up — review the agent context and user identity, prepare a brief initial directive, then transition to live observation.
+
+## Phase 1: Quick Preparation
+
+This should only take a few seconds. Do NOT do deep research — just review what you already know.
+
+### Steps
+
+1. **Review context** — Read the agent's system prompt, instructions, and memory. Note the user's identity (name, role, timezone).
+2. **Write a thinking event** — Let the user know you are preparing: "Reviewing agent context and preparing initial guidance..."
+3. **Write a directive** — Summarize the key context for the fast-brain:
+   - Who the user is (name, role if known)
+   - What the agent specializes in
+   - Any relevant recent context from memory
+4. **Signal readiness** — Write a \`preparation-ready\` event to indicate you are done.
+
+### CLI Commands
+
+Read shared context:
+\`zero voice-chat context get <SESSION_ID> --after <LAST_SEQ>\`
+
+Write events:
+\`zero voice-chat context append <SESSION_ID> --source slow-brain --type <TYPE> --content "<CONTENT>"\`
+
+### Event Types for Preparation
+
+- **thinking**: Brief progress update. Example: "Reviewing agent context and preparing initial guidance..."
+- **directive**: Initial context summary for the fast-brain.
+- **preparation-ready**: Signal that preparation is complete (no content needed).
+
+## Phase 2: Live Observation
+
+Once you have written the preparation-ready event, the voice conversation will begin. Transition to observation mode:
+
+### Observing the Conversation
+
+Continuously read the shared context to follow the conversation:
+
+\`zero voice-chat context get <SESSION_ID> --after <LAST_SEQ>\`
+
+You will see events like:
+- **user/speech** — what the user says
+- **fast-brain/response** — what your fast-brain says back
+- **system/session-start** and **system/session-end** — session lifecycle
+
+Based on what you observe, proactively decide what to do. Do not wait to be asked.
+
+### When to Act
+
+Act when the conversation involves:
+- Code, data, APIs, files, or external systems
+- Tasks that require execution, search, or tool use
+- Topics where you can proactively gather information (e.g., user mentions a PR — look it up so the answer is ready)
+- Anything your fast-brain cannot handle with conversation alone
+
+Stay quiet when the conversation is:
+- Casual chat, greetings, or small talk
+- Opinions or preferences
+- Simple knowledge questions your fast-brain handles well
+
+### Explicit Requests
+
+When you see a \`fast-brain/request-slow-brain\` event:
+- Do NOT execute the task yourself.
+- Identify the best agent to handle it: run \`zero agent list\` to see available agents.
+- Delegate the task: \`zero run <agent-id> "<task description>"\`
+- Write a thinking event immediately so the user knows delegation is in progress.
+- Wait for \`zero run\` to complete and capture its output.
+- Write the output as a directive event back to the session.
+
+You are an orchestrator, not an executor. Your role is to route tasks to the right agents and report results back.
+
+### Writing to Shared Context
+
+\`zero voice-chat context append <SESSION_ID> --source slow-brain --type <TYPE> --content "<CONTENT>"\`
+
+- **directive**: High-level instructions for your fast-brain. Include what to tell the user, relevant data, and why. Do not script exact words — your fast-brain controls phrasing.
+- **thinking**: Progress updates and intermediate results while you work.
+- **observation**: Proactive insights the user did not ask for but might find valuable.
+
+### Polling and Lifecycle
+
+1. Check for new events every 5 seconds.
+2. Process what you see — act proactively or respond to explicit requests.
+3. Write appropriate events (directive, thinking, observation).
+4. Repeat until you see a \`session-end\` system event, then exit.
+
+## Important
+
+- Keep directive content concise but complete — your fast-brain will read it aloud.
+- You have full tool access. Use your sandbox, CLI, and APIs to get real answers.
+- When you find something, write the directive immediately. Do not wait for a request.
+- You are Zero. Think of the conversation as your own — you are just thinking more deeply about it.
+`.trim();
+
+/**
+ * Build the full appendSystemPrompt for Voice-Chat mission control mode.
+ * In this mode the slow-brain delegates all task execution to sub-agents via
+ * `zero run` instead of executing work inline.
+ */
+export function buildVoiceChatMissionControlPrompt(sessionId: string): string {
+  const header = buildIntegrationPrompt("Voice-Chat");
+  const missionControlPrompt = VOICE_CHAT_MISSION_CONTROL_PROMPT.replaceAll(
+    "<SESSION_ID>",
+    sessionId,
+  );
+  return [header, missionControlPrompt].join("\n\n");
+}
+
 /**
  * Build the full appendSystemPrompt for Slack integration.
  */

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -8,6 +8,7 @@ import { cancelRun } from "../zero-run-cancel";
 import {
   buildVoiceChatQuickPrepPrompt,
   buildVoiceChatMeetingPrompt,
+  buildVoiceChatMissionControlPrompt,
 } from "../integration-prompt";
 import { conflict, notFound, badRequest, forbidden } from "../../shared/errors";
 import { logger } from "../../shared/logger";
@@ -22,7 +23,7 @@ export async function createSession(
   orgId: string,
   userId: string,
   agentId: string,
-  options?: { mode?: "chat" | "meeting"; prompt?: string },
+  options?: { mode?: "chat" | "meeting" | "mission_control"; prompt?: string },
 ) {
   const db = globalThis.services.db;
 
@@ -142,15 +143,18 @@ export async function dispatchSlowBrain(
   orgId: string,
   userId: string,
   agentId: string,
-  options?: { mode?: "chat" | "meeting"; prompt?: string },
+  options?: { mode?: "chat" | "meeting" | "mission_control"; prompt?: string },
 ) {
   const db = globalThis.services.db;
   const meetingPrompt =
     options?.mode === "meeting" ? options.prompt : undefined;
 
-  const appendSystemPrompt = meetingPrompt
-    ? buildVoiceChatMeetingPrompt(session.id, meetingPrompt)
-    : buildVoiceChatQuickPrepPrompt(session.id);
+  const appendSystemPrompt =
+    options?.mode === "mission_control"
+      ? buildVoiceChatMissionControlPrompt(session.id)
+      : meetingPrompt
+        ? buildVoiceChatMeetingPrompt(session.id, meetingPrompt)
+        : buildVoiceChatQuickPrepPrompt(session.id);
 
   const prompt = meetingPrompt
     ? `You are Zero's slow-brain for voice-chat session ${session.id}. A meeting has been requested. Read the shared context for the meeting prompt and begin preparation.`

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -156,9 +156,12 @@ export async function dispatchSlowBrain(
         ? buildVoiceChatMeetingPrompt(session.id, meetingPrompt)
         : buildVoiceChatQuickPrepPrompt(session.id);
 
-  const prompt = meetingPrompt
-    ? `You are Zero's slow-brain for voice-chat session ${session.id}. A meeting has been requested. Read the shared context for the meeting prompt and begin preparation.`
-    : `You are Zero's slow-brain for voice-chat session ${session.id}. Review the agent configuration and user context, then prepare an initial directive before the conversation begins.`;
+  const prompt =
+    options?.mode === "mission_control"
+      ? `You are Zero's slow-brain for voice-chat session ${session.id}. You are in mission control mode — delegate all task execution to sub-agents via zero run instead of executing inline.`
+      : meetingPrompt
+        ? `You are Zero's slow-brain for voice-chat session ${session.id}. A meeting has been requested. Read the shared context for the meeting prompt and begin preparation.`
+        : `You are Zero's slow-brain for voice-chat session ${session.id}. Review the agent configuration and user context, then prepare an initial directive before the conversation begins.`;
 
   // Write meeting-prompt event before session-start (meeting mode only)
   if (meetingPrompt) {


### PR DESCRIPTION
## Summary

- Adds a new `mission_control` voice chat mode alongside the existing `chat` and `meeting` modes.
- In this mode, the slow-brain acts as a **pure orchestrator**: when it receives a `fast-brain/request-slow-brain` event it does **not** execute the task inline — instead it runs `zero agent list` to find the best agent and delegates via `zero run <agent-id> "<task>"`, then writes the result back as a directive event.
- Intended for use in the Mission Control task-overview UI where Zero should coordinate sub-agents rather than doing work itself.

## Changes

- **`voice-chat.ts` (schema)** — Added TypeScript comment documenting `mission_control` as a valid `mode` column value. No migration needed.
- **`route.ts`** — Extended Zod enum from `["chat", "meeting"]` to `["chat", "meeting", "mission_control"]`.
- **`integration-prompt.ts`** — Added `VOICE_CHAT_MISSION_CONTROL_PROMPT` constant and exported `buildVoiceChatMissionControlPrompt(sessionId)` function. Phase 1 (quick prep) is identical to the chat mode; Phase 2 replaces the inline-execution instructions with delegation-via-`zero run` instructions.
- **`session-service.ts`** — Updated `createSession` and `dispatchSlowBrain` type signatures to include `mission_control`; added branch in `dispatchSlowBrain` to select the mission control prompt before the existing meeting/chat ternary.
- **`voice-chat-session.ts`** — Added exported `startMissionControlVoiceChat$` command (mirrors `startVoiceChat$` but POSTs `mode: "mission_control"` and uses `PREP_TIMEOUT_CHAT_MS`).
- **`voice-banner.tsx`** — Switched Mission Control page's `VoiceButton` from `startVoiceChat$` to `startMissionControlVoiceChat$`.

## Test plan

- [ ] Start a voice session from the Mission Control page and confirm the session is created with `mode = mission_control` in the DB.
- [ ] Trigger a `fast-brain/request-slow-brain` event and verify the slow-brain runs `zero agent list` and `zero run` rather than executing inline.
- [ ] Confirm `chat` and `meeting` modes are unaffected by the new branch.
- [ ] Confirm the API returns 400 for an unknown mode value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)