### PR TITLE
feat: add Mission Control sidebar entry behind feature flag

### DIFF
--- a/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
+++ b/turbo/apps/platform/src/signals/zero-page/zero-nav.ts
@@ -61,6 +61,7 @@ export type SidebarNavId =
   | "queues"
   | "phone"
   | "voiceChat"
+  | "missionControl"
   | "lab";
 
 export function isChatRoute(key: RouteKey | null): boolean {
@@ -88,6 +89,7 @@ export const handleZeroNavSelect$ = command(({ set }, id: SidebarNavId) => {
       settingsUsage: ROUTES.settingsUsage,
       phone: ROUTES.phone,
       voiceChat: ROUTES.voiceChat,
+      missionControl: ROUTES.missionControl,
       lab: ROUTES.lab,
     } satisfies Record<
       Exclude<SidebarNavId, "queues">,

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -24,6 +24,7 @@ import {
   IconPhone,
   IconMicrophone,
   IconSparkles,
+  IconLayoutDashboard,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/core";
 import {
@@ -162,6 +163,15 @@ const FOOTER_NAV = [
     icon: IconMicrophone as NavIcon,
     iconImg: undefined,
     featureGate: FeatureSwitchKey.VoiceChat,
+  },
+  {
+    id: "missionControl",
+    activeKeys: ["missionControl"],
+    pathname: "/_/mission-control",
+    label: "Mission Control",
+    icon: IconLayoutDashboard as NavIcon,
+    iconImg: undefined,
+    featureGate: FeatureSwitchKey.MissionControlSidebar,
   },
   {
     id: "lab",

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -39,6 +39,7 @@ export enum FeatureSwitchKey {
   AuditLink = "auditLink",
   PhoneIntegration = "phoneIntegration",
   VoiceChat = "voiceChat",
+  MissionControlSidebar = "missionControlSidebar",
   AutoSkill = "autoSkill",
   SandboxReuse = "sandboxReuse",
 }

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -226,6 +226,12 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.MissionControlSidebar]: {
+    maintainer: "ethan@vm0.ai",
+    description: "Show the Mission Control page entry in the sidebar",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.AutoSkill]: {
     maintainer: "lancy@vm0.ai",
     description: "Enable automatic skill creation in agent prompts",


### PR DESCRIPTION
## Summary

- Adds a new `MissionControlSidebar` feature switch key in `@vm0/core` (off by default, enabled for staff orgs)
- Registers the feature switch definition with `ethan@vm0.ai` as maintainer
- Adds a **Mission Control** footer nav entry to the sidebar (icon: `IconLayoutDashboard`), gated on the new flag — mirrors the Voice Chat entry pattern exactly
- Adds `missionControl` to `SidebarNavId` and the `handleZeroNavSelect$` route map so navigation works correctly

## How it works

The new sidebar entry follows the same pattern as Voice Chat:
```ts
{
  id: "missionControl",
  activeKeys: ["missionControl"],
  pathname: "/_/mission-control",
  label: "Mission Control",
  icon: IconLayoutDashboard,
  featureGate: FeatureSwitchKey.MissionControlSidebar,
}
```

The entry is hidden unless `missionControlSidebar` is enabled for the org. To enable for testing, set it via the existing feature switch override mechanism.

## Test plan

- [ ] With flag disabled: Mission Control entry does not appear in sidebar
- [ ] With flag enabled (override via localStorage or DB): Mission Control entry appears in footer nav section
- [ ] Clicking the entry navigates to `/_/mission-control`
- [ ] Active state highlights correctly when on the Mission Control page

🤖 Generated with [Claude Code](https://claude.com/claude-code)