### PR TITLE
feat(mission-control): add voice chat task to mission control

### DIFF
--- a/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
@@ -5,6 +5,7 @@ import {
   IconBrandSlack,
   IconMail,
   IconMicrophone,
+  IconRobot,
 } from "@tabler/icons-react";
 import { Card, Shortcut } from "@vm0/ui";
 import type { TaskItem, TaskType } from "@vm0/core";
@@ -53,6 +54,13 @@ function getTaskTypeConfig(type: TaskType): {
         label: "Voice Chat",
         icon: IconMicrophone,
         iconClassName: "text-rose-500",
+      };
+    }
+    case "agent": {
+      return {
+        label: "Agent",
+        icon: IconRobot,
+        iconClassName: "text-cyan-500",
       };
     }
   }

--- a/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/task-card.tsx
@@ -4,6 +4,7 @@ import {
   IconCalendar,
   IconBrandSlack,
   IconMail,
+  IconMicrophone,
 } from "@tabler/icons-react";
 import { Card, Shortcut } from "@vm0/ui";
 import type { TaskItem, TaskType } from "@vm0/core";
@@ -45,6 +46,13 @@ function getTaskTypeConfig(type: TaskType): {
         label: "Email",
         icon: IconMail,
         iconClassName: "text-amber-500",
+      };
+    }
+    case "voice_chat": {
+      return {
+        label: "Voice Chat",
+        icon: IconMicrophone,
+        iconClassName: "text-rose-500",
       };
     }
   }

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and, inArray } from "drizzle-orm";
+import { initServices } from "../../../../../src/lib/init-services";
+import { verifyCallback } from "../../../../../src/lib/infra/callback";
+import {
+  voiceChatSessions,
+  voiceChatEvents,
+} from "../../../../../src/db/schema/voice-chat";
+import { agentRuns } from "../../../../../src/db/schema/agent-run";
+import { getRunOutputText } from "../../../../../src/lib/infra/run/extract-run-output";
+import { saveRunSummary } from "../../../../../src/lib/zero/run-summary";
+import type { VoiceChatCallbackPayload } from "../../../../../src/lib/infra/callback/callback-payloads";
+import { logger } from "../../../../../src/lib/shared/logger";
+
+const log = logger("callback:voice-chat");
+
+function parsePayload(payload: unknown): VoiceChatCallbackPayload | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  if (typeof p.sessionId !== "string") return null;
+  return { sessionId: p.sessionId };
+}
+
+/**
+ * POST /api/internal/callbacks/voice-chat
+ *
+ * Voice-chat callback handler for slow-brain run completion.
+ * When the run reaches a terminal state, ends the voice-chat session
+ * (if still active) and generates a run summary.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  initServices();
+
+  const result = await verifyCallback<VoiceChatCallbackPayload>(request, log);
+  if (!result.ok) return result.response;
+
+  const { runId, status } = result.data;
+  const payload = parsePayload(result.data.payload);
+  if (!payload) {
+    return NextResponse.json(
+      { error: "Invalid or missing payload" },
+      { status: 400 },
+    );
+  }
+
+  // Ignore progress notifications — only act on terminal states
+  if (status === "progress") {
+    return NextResponse.json({ success: true });
+  }
+
+  const { sessionId } = payload;
+  const db = globalThis.services.db;
+
+  log.debug("Processing voice-chat callback", { runId, status, sessionId });
+
+  // End session if still active/preparing
+  const [session] = await db
+    .select({ id: voiceChatSessions.id, status: voiceChatSessions.status })
+    .from(voiceChatSessions)
+    .where(
+      and(
+        eq(voiceChatSessions.id, sessionId),
+        inArray(voiceChatSessions.status, ["active", "preparing"]),
+      ),
+    )
+    .limit(1);
+
+  if (session) {
+    await db.transaction(async (tx) => {
+      await tx.insert(voiceChatEvents).values({
+        sessionId,
+        source: "system",
+        type: "session-end",
+      });
+      await tx
+        .update(voiceChatSessions)
+        .set({ status: "ended", endedAt: new Date() })
+        .where(eq(voiceChatSessions.id, sessionId));
+    });
+    log.info("Voice-chat session ended via callback", { sessionId, runId });
+  }
+
+  // Generate run summary (best-effort)
+  if (status === "completed") {
+    const [run] = await db
+      .select({ prompt: agentRuns.prompt })
+      .from(agentRuns)
+      .where(eq(agentRuns.id, runId))
+      .limit(1);
+
+    if (run) {
+      const resultText = await getRunOutputText(runId).catch(() => undefined);
+      await saveRunSummary(runId, "voice-chat", run.prompt, resultText ?? "");
+    }
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat/route.ts
@@ -89,7 +89,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       .limit(1);
 
     if (run) {
-      const resultText = await getRunOutputText(runId).catch(() => {
+      const resultText = await getRunOutputText(runId).catch((err: unknown) => {
+        log.warn("Failed to extract run output text", { runId, err });
         return undefined;
       });
       await saveRunSummary(runId, "voice-chat", run.prompt, resultText ?? "");

--- a/turbo/apps/web/app/api/internal/callbacks/voice-chat/route.ts
+++ b/turbo/apps/web/app/api/internal/callbacks/voice-chat/route.ts
@@ -89,7 +89,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       .limit(1);
 
     if (run) {
-      const resultText = await getRunOutputText(runId).catch(() => undefined);
+      const resultText = await getRunOutputText(runId).catch(() => {
+        return undefined;
+      });
       await saveRunSummary(runId, "voice-chat", run.prompt, resultText ?? "");
     }
   }

--- a/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
+++ b/turbo/apps/web/src/lib/infra/callback/callback-payloads.ts
@@ -78,6 +78,10 @@ export interface ChatCallbackPayload {
   agentId: string;
 }
 
+export interface VoiceChatCallbackPayload {
+  sessionId: string;
+}
+
 export interface PhoneCallbackPayload {
   callId: string;
   userId: string;
@@ -95,4 +99,5 @@ export type CallbackPayload =
   | ScheduleCronCallbackPayload
   | GitHubIssuesCallbackPayload
   | ChatCallbackPayload
-  | PhoneCallbackPayload;
+  | PhoneCallbackPayload
+  | VoiceChatCallbackPayload;

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -523,7 +523,9 @@ async function listVoiceChatTasks(
     .limit(1);
 
   return rows
-    .filter((r): r is typeof r & { agentId: string } => r.agentId !== null)
+    .filter((r): r is typeof r & { agentId: string } => {
+      return r.agentId !== null;
+    })
     .map((r) => {
       return {
         id: r.id,

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -471,7 +471,9 @@ async function listAgentTasks(
       eq(agentComposeVersions.id, agentRuns.agentComposeVersionId),
     )
     .innerJoin(zeroAgents, eq(zeroAgents.id, agentComposeVersions.composeId))
-    .where(and(...conditions));
+    .where(and(...conditions))
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(TASKS_LIMIT);
 
   return rows.map((r) => {
     return {

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -10,6 +10,7 @@ import { agentSessions } from "../../../db/schema/agent-session";
 import { agentRuns } from "../../../db/schema/agent-run";
 import { agentComposeVersions } from "../../../db/schema/agent-compose";
 import { zeroRuns } from "../../../db/schema/zero-run";
+import { voiceChatSessions } from "../../../db/schema/voice-chat";
 import { zeroAgents } from "../../../db/schema/zero-agent";
 
 const TASKS_LIMIT = 25;
@@ -41,14 +42,21 @@ export async function listTasks(
 ): Promise<TaskItem[]> {
   const db = globalThis.services.db;
 
-  const [chatTasks, scheduleTasks, slackTasks, emailTasks, inFlightEmailTasks] =
-    await Promise.all([
-      listChatTasks(db, userId, orgId, agentId),
-      listScheduleTasks(db, userId, orgId, agentId),
-      listSlackTasks(db, userId, orgId, agentId),
-      listEmailTasks(db, userId, orgId, agentId),
-      listInFlightEmailTasks(db, userId, orgId, agentId),
-    ]);
+  const [
+    chatTasks,
+    scheduleTasks,
+    slackTasks,
+    emailTasks,
+    inFlightEmailTasks,
+    voiceChatTasks,
+  ] = await Promise.all([
+    listChatTasks(db, userId, orgId, agentId),
+    listScheduleTasks(db, userId, orgId, agentId),
+    listSlackTasks(db, userId, orgId, agentId),
+    listEmailTasks(db, userId, orgId, agentId),
+    listInFlightEmailTasks(db, userId, orgId, agentId),
+    listVoiceChatTasks(db, userId, orgId, agentId),
+  ]);
 
   const allTasks = [
     ...chatTasks,
@@ -56,6 +64,7 @@ export async function listTasks(
     ...slackTasks,
     ...emailTasks,
     ...inFlightEmailTasks,
+    ...voiceChatTasks,
   ];
 
   // Batch-fetch run info for all tasks with a latestRunId
@@ -125,6 +134,9 @@ export async function listTasks(
         break;
       case "email":
         task.emailThreadSessionId = raw.id;
+        break;
+      case "voice_chat":
+        task.voiceChatSessionId = raw.id;
         break;
     }
 
@@ -416,4 +428,55 @@ async function listInFlightEmailTasks(
       sourceUpdatedAt: r.createdAt,
     };
   });
+}
+
+/**
+ * Return the most recent voice-chat session for this user/org as a single task.
+ * At most one voice-chat task is shown regardless of how many sessions exist.
+ */
+async function listVoiceChatTasks(
+  db: DB,
+  userId: string,
+  orgId: string,
+  agentId?: string,
+): Promise<RawTask[]> {
+  const conditions = [
+    eq(voiceChatSessions.userId, userId),
+    eq(voiceChatSessions.orgId, orgId),
+  ];
+  if (agentId) conditions.push(eq(voiceChatSessions.agentId, agentId));
+
+  const rows = await db
+    .select({
+      id: voiceChatSessions.id,
+      agentId: voiceChatSessions.agentId,
+      agentName: zeroAgents.name,
+      agentDisplayName: zeroAgents.displayName,
+      agentAvatarUrl: zeroAgents.avatarUrl,
+      runId: voiceChatSessions.runId,
+      createdAt: voiceChatSessions.createdAt,
+    })
+    .from(voiceChatSessions)
+    .innerJoin(zeroAgents, eq(voiceChatSessions.agentId, zeroAgents.id))
+    .where(and(...conditions))
+    .orderBy(desc(voiceChatSessions.createdAt))
+    .limit(1);
+
+  return rows
+    .filter((r): r is typeof r & { agentId: string } => r.agentId !== null)
+    .map((r) => {
+      return {
+        id: r.id,
+        type: "voice_chat" as const,
+        title: null,
+        agent: {
+          id: r.agentId,
+          name: r.agentName,
+          displayName: r.agentDisplayName,
+          avatarUrl: r.agentAvatarUrl,
+        },
+        latestRunId: r.runId,
+        sourceUpdatedAt: r.createdAt,
+      };
+    });
 }

--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -49,6 +49,7 @@ export async function listTasks(
     emailTasks,
     inFlightEmailTasks,
     voiceChatTasks,
+    agentTasks,
   ] = await Promise.all([
     listChatTasks(db, userId, orgId, agentId),
     listScheduleTasks(db, userId, orgId, agentId),
@@ -56,6 +57,7 @@ export async function listTasks(
     listEmailTasks(db, userId, orgId, agentId),
     listInFlightEmailTasks(db, userId, orgId, agentId),
     listVoiceChatTasks(db, userId, orgId, agentId),
+    listAgentTasks(db, userId, orgId, agentId),
   ]);
 
   const allTasks = [
@@ -65,6 +67,7 @@ export async function listTasks(
     ...emailTasks,
     ...inFlightEmailTasks,
     ...voiceChatTasks,
+    ...agentTasks,
   ];
 
   // Batch-fetch run info for all tasks with a latestRunId
@@ -137,6 +140,9 @@ export async function listTasks(
         break;
       case "voice_chat":
         task.voiceChatSessionId = raw.id;
+        break;
+      case "agent":
+        task.agentRunId = raw.id;
         break;
     }
 
@@ -417,6 +423,60 @@ async function listInFlightEmailTasks(
     return {
       id: r.id,
       type: "email" as const,
+      title: null,
+      agent: {
+        id: r.agentId,
+        name: r.agentName,
+        displayName: r.agentDisplayName,
+        avatarUrl: r.agentAvatarUrl,
+      },
+      latestRunId: r.id,
+      sourceUpdatedAt: r.createdAt,
+    };
+  });
+}
+
+/**
+ * Return agent-triggered runs (triggerSource = 'agent') as individual tasks.
+ * Each delegation run becomes its own task showing the delegated agent's info.
+ */
+async function listAgentTasks(
+  db: DB,
+  userId: string,
+  orgId: string,
+  agentId?: string,
+): Promise<RawTask[]> {
+  const conditions = [
+    eq(agentRuns.userId, userId),
+    eq(agentRuns.orgId, orgId),
+    eq(zeroRuns.triggerSource, "agent"),
+  ];
+  if (agentId) {
+    conditions.push(eq(zeroAgents.id, agentId));
+  }
+
+  const rows = await db
+    .select({
+      id: agentRuns.id,
+      agentId: zeroAgents.id,
+      agentName: zeroAgents.name,
+      agentDisplayName: zeroAgents.displayName,
+      agentAvatarUrl: zeroAgents.avatarUrl,
+      createdAt: agentRuns.createdAt,
+    })
+    .from(agentRuns)
+    .innerJoin(zeroRuns, eq(zeroRuns.id, agentRuns.id))
+    .innerJoin(
+      agentComposeVersions,
+      eq(agentComposeVersions.id, agentRuns.agentComposeVersionId),
+    )
+    .innerJoin(zeroAgents, eq(zeroAgents.id, agentComposeVersions.composeId))
+    .where(and(...conditions));
+
+  return rows.map((r) => {
+    return {
+      id: r.id,
+      type: "agent" as const,
       title: null,
       agent: {
         id: r.agentId,

--- a/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/session-service.ts
@@ -12,6 +12,8 @@ import {
 } from "../integration-prompt";
 import { conflict, notFound, badRequest, forbidden } from "../../shared/errors";
 import { logger } from "../../shared/logger";
+import { generateCallbackSecret, getApiUrl } from "../../infra/callback";
+import type { VoiceChatCallbackPayload } from "../../infra/callback/callback-payloads";
 
 const log = logger("zero:voice-chat:session");
 
@@ -173,12 +175,23 @@ export async function dispatchSlowBrain(
     });
   }
 
+  const callbackPayload: VoiceChatCallbackPayload = {
+    sessionId: session.id,
+  };
+
   const result = await createZeroRun({
     userId,
     agentId,
     prompt,
     appendSystemPrompt,
     triggerSource: "voice-chat",
+    callbacks: [
+      {
+        url: `${getApiUrl()}/api/internal/callbacks/voice-chat`,
+        secret: generateCallbackSecret(),
+        payload: callbackPayload,
+      },
+    ],
   });
 
   // Update session with runId

--- a/turbo/packages/core/src/contracts/tasks.ts
+++ b/turbo/packages/core/src/contracts/tasks.ts
@@ -5,7 +5,13 @@ import { runStatusSchema } from "./runs";
 
 const c = initContract();
 
-const taskTypeSchema = z.enum(["chat", "schedule", "slack", "email"]);
+const taskTypeSchema = z.enum([
+  "chat",
+  "schedule",
+  "slack",
+  "email",
+  "voice_chat",
+]);
 
 const taskAgentSchema = z.object({
   id: z.string(),
@@ -26,6 +32,7 @@ const taskItemSchema = z.object({
   scheduleId: z.string().optional(),
   slackThreadSessionId: z.string().optional(),
   emailThreadSessionId: z.string().optional(),
+  voiceChatSessionId: z.string().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/turbo/packages/core/src/contracts/tasks.ts
+++ b/turbo/packages/core/src/contracts/tasks.ts
@@ -11,6 +11,7 @@ const taskTypeSchema = z.enum([
   "slack",
   "email",
   "voice_chat",
+  "agent",
 ]);
 
 const taskAgentSchema = z.object({
@@ -33,6 +34,7 @@ const taskItemSchema = z.object({
   slackThreadSessionId: z.string().optional(),
   emailThreadSessionId: z.string().optional(),
   voiceChatSessionId: z.string().optional(),
+  agentRunId: z.string().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });


### PR DESCRIPTION
## Summary
- Add `voice_chat` as a new task type in Mission Control, showing the most recent voice chat session (at most one) with its slow-brain run activity
- Register a run completion callback on slow-brain dispatch so the voice chat session auto-ends when the run finishes, and a run summary is generated
- Add `IconMicrophone` (rose-500) to the task card UI for voice chat tasks

## Test plan
- [ ] Start a voice chat session and verify it appears as a task in Mission Control
- [ ] Click the voice chat task card to open the activity panel showing slow-brain run events
- [ ] End the voice chat and verify the task reflects the completed run status
- [ ] Start a new voice chat and verify the task updates to the new session (only one shown)
- [ ] Verify the run completion callback ends the session if the slow-brain run completes before user ends it

🤖 Generated with [Claude Code](https://claude.com/claude-code)