### PR TITLE
fix: log directory iteration errors in gc instead of silently swallowing

### DIFF
--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -225,6 +225,9 @@ fn probe_lock(path: &Path) -> LockProbe {
 
 /// Like `next_entry()`, but logs a warning and returns `None` on I/O error
 /// instead of propagating — suitable for best-effort scans like GC.
+///
+/// Returning `None` terminates a `while let Some(entry)` loop, so an error
+/// stops iteration for the current directory (remaining entries are skipped).
 async fn next_entry_warn(
     entries: &mut tokio::fs::ReadDir,
     label: &str,

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -227,6 +227,22 @@ fn probe_lock(path: &Path) -> LockProbe {
     }
 }
 
+/// Like `next_entry()`, but logs a warning and returns `None` on I/O error
+/// instead of propagating — suitable for best-effort scans like GC.
+async fn next_entry_warn(
+    entries: &mut tokio::fs::ReadDir,
+    label: &str,
+    dir: &Path,
+) -> Option<tokio::fs::DirEntry> {
+    match entries.next_entry().await {
+        Ok(entry) => entry,
+        Err(e) => {
+            warn!("{label}: read entry in {}: {e}", dir.display());
+            None
+        }
+    }
+}
+
 /// Remove cached debootstrap tarballs, keeping the `keep_latest` most recent.
 async fn gc_debootstrap(
     home: &HomePaths,
@@ -324,7 +340,7 @@ async fn gc_orphaned_locks(home: &HomePaths, dry_run: bool) -> RunnerResult<u64>
 
     let mut removed = 0u64;
 
-    while let Ok(Some(entry)) = entries.next_entry().await {
+    while let Some(entry) = next_entry_warn(&mut entries, "gc_orphaned_locks", &locks_dir).await {
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
         if !name.ends_with(".lock") {
@@ -375,7 +391,7 @@ async fn gc_job_logs(home: &HomePaths, dry_run: bool) -> RunnerResult<(u64, u64)
     let mut removed = 0u64;
     let mut freed = 0u64;
 
-    while let Ok(Some(entry)) = entries.next_entry().await {
+    while let Some(entry) = next_entry_warn(&mut entries, "gc_job_logs", &logs_dir).await {
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
 
@@ -442,7 +458,7 @@ async fn dir_stats(dir: &Path) -> (u64, SystemTime) {
                 continue;
             }
         };
-        while let Ok(Some(entry)) = entries.next_entry().await {
+        while let Some(entry) = next_entry_warn(&mut entries, "dir_stats", &current).await {
             let Ok(meta) = entry.metadata().await else {
                 tracing::debug!("dir_stats: cannot stat {}", entry.path().display());
                 continue;
@@ -723,7 +739,8 @@ async fn gc_workspace_orphans(home: &HomePaths, dry_run: bool) -> RunnerResult<(
             }
         };
 
-        while let Ok(Some(entry)) = entries.next_entry().await {
+        while let Some(entry) = next_entry_warn(&mut entries, "workspace gc", &workspaces_dir).await
+        {
             let path = entry.path();
             let Ok(meta) = tokio::fs::metadata(&path).await else {
                 continue;

--- a/crates/runner/src/cmd/gc.rs
+++ b/crates/runner/src/cmd/gc.rs
@@ -120,11 +120,7 @@ async fn gc_dir(
 
     let mut candidates: Vec<GcCandidate> = Vec::new();
 
-    while let Some(entry) = entries
-        .next_entry()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("read entry in {}: {e}", dir.display())))?
-    {
+    while let Some(entry) = next_entry_warn(&mut entries, label, dir).await {
         let path = entry.path();
         let Some(hash) = path.file_name().and_then(|n| n.to_str()).map(String::from) else {
             continue;
@@ -262,11 +258,7 @@ async fn gc_debootstrap(
     };
 
     let mut files: Vec<(PathBuf, u64, SystemTime)> = Vec::new();
-    while let Some(entry) = entries
-        .next_entry()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("read entry in {}: {e}", dir.display())))?
-    {
+    while let Some(entry) = next_entry_warn(&mut entries, "gc_debootstrap", &dir).await {
         let path = entry.path();
         let meta = match tokio::fs::metadata(&path).await {
             Ok(m) => m,
@@ -503,11 +495,7 @@ async fn gc_versions(home: &HomePaths, dry_run: bool) -> RunnerResult<Vec<String
 
     let mut removed: Vec<String> = Vec::new();
 
-    while let Some(entry) = entries
-        .next_entry()
-        .await
-        .map_err(|e| RunnerError::Internal(format!("read entry in {}: {e}", bin_dir.display())))?
-    {
+    while let Some(entry) = next_entry_warn(&mut entries, "gc_versions", &bin_dir).await {
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
         if !is_semver_version(name) {


### PR DESCRIPTION
## Summary

- Extract `next_entry_warn` helper that logs a warning and returns `None` on I/O error from `ReadDir::next_entry()`, instead of silently swallowing
- Replace `while let Ok(Some(entry))` with the helper at 4 locations: `gc_orphaned_locks`, `gc_job_logs`, `dir_stats`, `gc_workspace_orphans`
- **Scope expansion (commit 2):** Also migrate `gc_dir`, `gc_debootstrap`, and `gc_versions` from `map_err` + `?` to `next_entry_warn`. These previously propagated errors and aborted the entire GC pipeline — a single I/O error in `gc_dir` would prevent `gc_job_logs`, `gc_versions`, etc. from running. The warn-and-continue approach is more appropriate for GC where partial cleanup is better than aborting everything.
- All 7 `next_entry` call sites in gc.rs now use a single consistent strategy

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -- gc` — 45 tests pass
- [ ] CI pipeline passes

Closes #9018

🤖 Generated with [Claude Code](https://claude.com/claude-code)