### PR TITLE
fix(vsock-guest): kill su child process group on timeout

### DIFF
--- a/crates/vsock-guest/src/lib.rs
+++ b/crates/vsock-guest/src/lib.rs
@@ -171,6 +171,99 @@ pub fn log(level: &str, msg: &str) {
     eprintln!("[vsock-guest] [{level}] {msg}");
 }
 
+/// Parse ppid and pgid from a `/proc/[pid]/stat` line.
+///
+/// Format: `"pid (comm) state ppid pgid session ..."` — the comm field can
+/// contain spaces and parentheses, so we locate the LAST `)` first.
+fn parse_stat_ppid_pgid(stat: &str) -> Option<(u32, u32)> {
+    let close_paren = stat.rfind(')')?;
+    if close_paren + 2 >= stat.len() {
+        return None;
+    }
+    let remainder = &stat[close_paren + 2..]; // skip ") "
+    let fields: Vec<&str> = remainder.split_whitespace().collect();
+    // fields: [0]=state [1]=ppid [2]=pgid [3]=session ...
+    let ppid = fields.get(1)?.parse().ok()?;
+    let pgid = fields.get(2)?.parse().ok()?;
+    Some((ppid, pgid))
+}
+
+/// Find the process-group ID of a direct child of `parent_pid`.
+///
+/// In release builds, commands are wrapped in `su - user -c "..."`.
+/// `su` forks internally and the child calls `setsid()`, creating a new
+/// session and process group. `kill(-parent_pid, SIGKILL)` only reaches
+/// the `su` process's group — the child's group (where the actual command
+/// runs) is missed.
+///
+/// This function scans `/proc` to find that child and returns its PGID so
+/// the timeout killer can send SIGKILL to both process groups.
+///
+/// Must be called BEFORE killing the parent, because once the parent dies
+/// the child's PPID changes to 1 (init).
+fn find_child_pgid(parent_pid: u32) -> Option<u32> {
+    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
+        let name = entry.file_name();
+        let Ok(pid) = name.to_string_lossy().parse::<u32>() else {
+            continue;
+        };
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            continue;
+        };
+
+        let Some((ppid, pgid)) = parse_stat_ppid_pgid(&stat) else {
+            continue;
+        };
+
+        if ppid == parent_pid {
+            return Some(pgid);
+        }
+    }
+    None
+}
+
+/// Kill a process group and, if `su -` created a child session, also kill
+/// that child's process group.
+///
+/// # Safety
+///
+/// `child_id` must be a valid PID from `Command::spawn()`.
+/// Returns `true` if the primary kill (the direct child's group) succeeded.
+unsafe fn kill_process_tree(child_id: u32) -> bool {
+    // Find su's child PGID BEFORE killing — after kill, PPID changes to 1.
+    let child_pgid = find_child_pgid(child_id);
+
+    // Kill the direct child's process group (the su wrapper).
+    let ret = unsafe { libc::kill(-(child_id as i32), libc::SIGKILL) };
+    if ret != 0 {
+        let err = std::io::Error::last_os_error();
+        log(
+            "WARN",
+            &format!("timeout kill(-{child_id}, SIGKILL) failed: {err}"),
+        );
+        return false;
+    }
+
+    // Kill the session/process group created by su's child after setsid().
+    // Skip if the child is in the same group (no setsid happened, e.g. debug builds).
+    // Guard pgid != 0: kill(0, sig) sends to the calling process's own group.
+    if let Some(pgid) = child_pgid
+        && pgid != 0
+        && pgid != child_id
+    {
+        let ret = unsafe { libc::kill(-(pgid as i32), libc::SIGKILL) };
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            log(
+                "WARN",
+                &format!("timeout kill(-{pgid}, SIGKILL) for su child group failed: {err}"),
+            );
+        }
+    }
+
+    true
+}
+
 /// Run a child process with timeout. Returns (exit_code, stdout, stderr).
 /// Returns exit code 124 on timeout (same as bash timeout command).
 fn wait_with_timeout(child: std::process::Child, timeout_ms: u32) -> (i32, Vec<u8>, Vec<u8>) {
@@ -192,18 +285,10 @@ fn wait_with_timeout(child: std::process::Child, timeout_ms: u32) -> (i32, Vec<u
     thread::spawn(move || {
         // Wait for either timeout or signal that process completed
         if rx.recv_timeout(timeout).is_err() {
-            // Timeout reached — kill the entire process group.
-            // SAFETY: child_id is a valid PID from Command::spawn (Linux PIDs < 4M,
-            // so u32→i32 cast never overflows). Negative pid kills the process group.
-            let ret = unsafe { libc::kill(-(child_id as i32), libc::SIGKILL) };
-            if ret == 0 {
+            // Timeout reached — kill the entire process tree.
+            // SAFETY: child_id is a valid PID from Command::spawn.
+            if unsafe { kill_process_tree(child_id) } {
                 killed_by_timeout_clone.store(true, Ordering::SeqCst);
-            } else {
-                let err = std::io::Error::last_os_error();
-                log(
-                    "WARN",
-                    &format!("timeout kill(-{child_id}, SIGKILL) failed: {err}"),
-                );
             }
         }
     });
@@ -498,16 +583,9 @@ fn spawn_streaming_monitor(
             let (tx, rx) = std::sync::mpsc::channel::<()>();
             thread::spawn(move || {
                 if rx.recv_timeout(timeout).is_err() {
-                    // SAFETY: child_id is a valid PID. Negative pid kills the process group.
-                    let ret = unsafe { libc::kill(-(child_id as i32), libc::SIGKILL) };
-                    if ret == 0 {
+                    // SAFETY: child_id is a valid PID.
+                    if unsafe { kill_process_tree(child_id) } {
                         killed_clone.store(true, Ordering::SeqCst);
-                    } else {
-                        let err = std::io::Error::last_os_error();
-                        log(
-                            "WARN",
-                            &format!("timeout kill(-{child_id}, SIGKILL) failed: {err}"),
-                        );
                     }
                 }
             });
@@ -1465,5 +1543,53 @@ mod tests {
         let _ = std::fs::remove_file(&log_path);
         drop(host_stream);
         let _ = handle.join();
+    }
+
+    #[test]
+    fn parse_stat_ppid_pgid_normal() {
+        let stat = "42 (bash) S 10 42 42 0 -1 4194560 100 0 0 0 0 0 0 0 20 0 1 0 100 0 0\n";
+        assert_eq!(parse_stat_ppid_pgid(stat), Some((10, 42)));
+    }
+
+    #[test]
+    fn parse_stat_ppid_pgid_comm_with_spaces() {
+        // comm can contain spaces and parens
+        let stat = "99 (Web Content (123)) S 50 99 99 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 0 0 0\n";
+        assert_eq!(parse_stat_ppid_pgid(stat), Some((50, 99)));
+    }
+
+    #[test]
+    fn parse_stat_ppid_pgid_setsid_child() {
+        // After setsid(): pgid (77) differs from parent's pgid
+        let stat = "77 (su) S 42 77 77 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 0 0 0\n";
+        assert_eq!(parse_stat_ppid_pgid(stat), Some((42, 77)));
+    }
+
+    #[test]
+    fn parse_stat_ppid_pgid_empty() {
+        assert_eq!(parse_stat_ppid_pgid(""), None);
+    }
+
+    #[test]
+    fn parse_stat_ppid_pgid_truncated() {
+        // Only has closing paren, no fields after
+        assert_eq!(parse_stat_ppid_pgid("1 (x)"), None);
+    }
+
+    #[test]
+    fn parse_stat_ppid_pgid_not_enough_fields() {
+        // Has state but no ppid/pgid
+        assert_eq!(parse_stat_ppid_pgid("1 (x) S\n"), None);
+    }
+
+    #[test]
+    fn parse_stat_ppid_pgid_empty_comm() {
+        let stat = "1 () S 10 42 42 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\n";
+        assert_eq!(parse_stat_ppid_pgid(stat), Some((10, 42)));
+    }
+
+    #[test]
+    fn parse_stat_ppid_pgid_no_closing_paren() {
+        assert_eq!(parse_stat_ppid_pgid("1 bash S 10 42 42"), None);
     }
 }


### PR DESCRIPTION
## Summary

- Before killing the process group on timeout, scan `/proc` to find `su`'s child process and its PGID
- `su - user -c` internally forks and calls `setsid()`, placing the command in a separate process group that `kill(-child_id, SIGKILL)` cannot reach — the timeout killer only killed the `su` wrapper while guest-agent survived
- Now kills both process groups: the `su` wrapper's group and the child's group (where guest-agent runs)
- Preserves all `su -` behavior (PAM session, `/etc/environment`, login shell, cwd)

Closes #8973

## Test plan

- [x] `cargo build -p vsock-guest` — compiles
- [x] `cargo clippy -p vsock-guest` — no warnings
- [x] `cargo test -p vsock-guest` — all 30 tests pass (8 new for /proc stat parsing)
- [ ] E2E: sandbox creation + timeout kill verifies guest-agent is killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)