### PR TITLE
refactor: extract navigation out of sendNewThreadMessage$

### DIFF
--- a/turbo/apps/platform/src/signals/chat-page/chat-message.ts
+++ b/turbo/apps/platform/src/signals/chat-page/chat-message.ts
@@ -859,16 +859,21 @@ const sendChatMessageRequest$ = command(
 );
 
 export const sendNewThreadMessage$ = command(
-  async ({ set }, agentId: string, prompt: string, signal: AbortSignal) => {
+  async (
+    { set },
+    agentId: string,
+    prompt: string,
+    signal: AbortSignal,
+  ): Promise<string | null> => {
     const message = await set(prepareChatMessage$, agentId, prompt, signal);
     if (!message) {
-      return;
+      return null;
     }
 
     const { threadId } = await set(sendChatMessageRequest$, message, signal);
 
     set(reloadChatThreads$);
-    set(navigateToChat$, threadId);
+    return threadId;
   },
 );
 

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -191,11 +191,13 @@ export function AgentChatPage() {
     startNewSession();
     const talkSignal = resetTalkSendSignal();
     detach(
-      sendNewThread(currentChatAgentId, message, talkSignal).then((threadId) => {
-        if (threadId) {
-          navigateToChatFn(threadId);
-        }
-      }),
+      sendNewThread(currentChatAgentId, message, talkSignal).then(
+        (threadId) => {
+          if (threadId) {
+            navigateToChatFn(threadId);
+          }
+        },
+      ),
       Reason.DomCallback,
     );
   };

--- a/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/agent-chat-page.tsx
@@ -52,6 +52,7 @@ import {
   sendNewThreadMessage$,
   startNewZeroSession$,
 } from "../../signals/chat-page/chat-message.ts";
+import { navigateToChat$ } from "../../signals/zero-page/zero-nav.ts";
 
 function getTagline(
   agentName: string,
@@ -181,6 +182,7 @@ export function AgentChatPage() {
   const sendNewThread = useSet(sendNewThreadMessage$);
   const startNewSession = useSet(startNewZeroSession$);
   const resetTalkSendSignal = useSet(resetTalkSendSignal$);
+  const navigateToChatFn = useSet(navigateToChat$);
 
   const handleSendMessage = (message: string) => {
     if (!currentChatAgentId) {
@@ -189,7 +191,11 @@ export function AgentChatPage() {
     startNewSession();
     const talkSignal = resetTalkSendSignal();
     detach(
-      sendNewThread(currentChatAgentId, message, talkSignal),
+      sendNewThread(currentChatAgentId, message, talkSignal).then((threadId) => {
+        if (threadId) {
+          navigateToChatFn(threadId);
+        }
+      }),
       Reason.DomCallback,
     );
   };


### PR DESCRIPTION
## Summary

- Extracts the navigation side-effect (`navigateToChat$`) out of `sendNewThreadMessage$` in `chat-message.ts`
- `sendNewThreadMessage$` now returns `Promise<string | null>` (the threadId) instead of navigating internally
- `AgentChatPage` chains `.then(navigateToChatFn)` to preserve identical user-facing behavior
- This gives callers control over post-send behavior (e.g., callers that don't want navigation)

## Test plan

- [ ] Open an agent chat page, send a new message — should create a new thread and navigate to it (same behavior as before)
- [ ] Verify existing chat functionality is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)