### PR TITLE
fix(web): persist zero_runs metadata before dispatch to fix activity source race

### DIFF
--- a/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/zero-run-service.test.ts
@@ -17,7 +17,7 @@ import {
   findTestRunnerJobEntry,
   insertUserCacheEntry,
 } from "../../../__tests__/api-test-helpers";
-import { createZeroRun } from "../zero-run-service";
+import { createZeroRun, createZeroRunRecord } from "../zero-run-service";
 import { verifyZeroToken } from "../../auth/sandbox-token";
 import { decryptSecretsMap } from "../../shared/crypto/secrets-encryption";
 import { reloadEnv } from "../../../env";
@@ -362,6 +362,38 @@ describe("createZeroRun()", () => {
       const triggerIdx = prompt.indexOf("Custom trigger context");
       expect(agentIdx).toBeLessThan(userInfoIdx);
       expect(userInfoIdx).toBeLessThan(triggerIdx);
+    });
+  });
+
+  describe("createZeroRunRecord early metadata persistence", () => {
+    it("should persist zero_runs row before dispatch so activity queries see correct triggerSource", async () => {
+      const result = await createZeroRunRecord({
+        userId: user.userId,
+        prompt: "test prompt",
+        agentId,
+        triggerSource: "web",
+      });
+
+      // Before dispatchZeroRun is called, the zero_runs row must already exist
+      const zeroRun = await findTestZeroRun(result.runId);
+      expect(zeroRun).toBeDefined();
+      expect(zeroRun!.triggerSource).toBe("web");
+    });
+
+    it("should persist triggerSource for all sources before dispatch", async () => {
+      const sources: TriggerSource[] = ["web", "slack", "schedule", "agent"];
+      for (const triggerSource of sources) {
+        const result = await createZeroRunRecord({
+          userId: user.userId,
+          prompt: "test",
+          agentId,
+          triggerSource,
+        });
+
+        const zeroRun = await findTestZeroRun(result.runId);
+        expect(zeroRun).toBeDefined();
+        expect(zeroRun!.triggerSource).toBe(triggerSource);
+      }
     });
   });
 

--- a/turbo/apps/web/src/lib/zero/zero-run-service.ts
+++ b/turbo/apps/web/src/lib/zero/zero-run-service.ts
@@ -419,6 +419,11 @@ export async function createZeroRunRecord(
 
   const transactionTime = Date.now();
 
+  // Persist zero-layer metadata immediately so that activity queries
+  // (LEFT JOIN zero_runs) see the correct triggerSource before dispatch
+  // completes. Model fields are updated later in dispatchZeroRun().
+  await persistZeroRunMetadata(run.id, params);
+
   const record: CreateRunRecordResult = {
     run: { id: run.id, createdAt: run.createdAt },
     composeContent: preloadedCompose.composeContent,
@@ -496,8 +501,12 @@ export async function dispatchZeroRun(
       },
     });
 
-    // 9. Persist zero-layer metadata (triggerSource + schedule + trigger agent + model fields)
-    await persistZeroRunMetadata(record.run.id, zeroParams, contextResult);
+    // 9. Update zero-layer metadata with model fields resolved during dispatch.
+    // The base row (triggerSource, scheduleId, triggerAgentId) was already
+    // inserted in createZeroRunRecord; here we only backfill model info.
+    if (contextResult?.resolvedModelProvider || contextResult?.selectedModel) {
+      await updateZeroRunModelInfo(record.run.id, contextResult);
+    }
 
     return dispatchResult;
   } catch (error) {
@@ -546,23 +555,39 @@ export async function createZeroRun(
 
 /**
  * Persist zero-layer metadata to zero_runs table.
- * Extracted to keep createZeroRun within complexity limits.
+ * Called eagerly during createZeroRunRecord so that activity queries see the
+ * correct triggerSource immediately (before dispatch completes).
  */
 async function persistZeroRunMetadata(
   runId: string,
   params: ZeroRunParams,
-  contextResult?: {
-    resolvedModelProvider: string | undefined;
-    selectedModel: string | undefined;
-  },
 ): Promise<void> {
   await globalThis.services.db.insert(zeroRuns).values({
     id: runId,
     triggerSource: params.triggerSource,
     scheduleId: params.scheduleId ?? null,
     triggerAgentId: params.triggerAgentId ?? null,
-    modelProvider:
-      contextResult?.resolvedModelProvider ?? params.modelProvider ?? null,
-    selectedModel: contextResult?.selectedModel ?? null,
+    modelProvider: params.modelProvider ?? null,
+    selectedModel: null,
   });
+}
+
+/**
+ * Update model-related fields on an existing zero_runs row.
+ * Called during dispatchZeroRun after model resolution.
+ */
+async function updateZeroRunModelInfo(
+  runId: string,
+  contextResult: {
+    resolvedModelProvider: string | undefined;
+    selectedModel: string | undefined;
+  },
+): Promise<void> {
+  await globalThis.services.db
+    .update(zeroRuns)
+    .set({
+      modelProvider: contextResult.resolvedModelProvider ?? undefined,
+      selectedModel: contextResult.selectedModel ?? undefined,
+    })
+    .where(eq(zeroRuns.id, runId));
 }


### PR DESCRIPTION
## Summary

- Activity list showed "cli" as source for web-created runs due to a race condition
- `createZeroRunRecord()` only created the `agent_runs` row; the `zero_runs` row (with `triggerSource`) was deferred to `dispatchZeroRun()`, which the chat messages route calls inside `after()`
- The activity list query (LEFT JOIN `zero_runs`) could arrive before the `zero_runs` row existed, falling back to "cli"
- **Fix:** Move `persistZeroRunMetadata()` into `createZeroRunRecord()` so the `zero_runs` row is written before the response is sent. `dispatchZeroRun()` now only updates model fields via `updateZeroRunModelInfo()`

## Test plan

- [x] Added test: `createZeroRunRecord` persists `zero_runs` row with correct `triggerSource` before dispatch
- [x] Added test: all trigger sources are persisted correctly before dispatch
- [x] Existing `zero-run-service` tests pass (33/33)
- [x] Existing `logs` route tests pass (42/42)
- [x] Existing `chat/messages` route tests pass (10/10)
- [x] Existing `zero/runs` route tests pass (8/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)