### PR TITLE
feat(core): enable sandbox reuse for staff org

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -242,6 +242,7 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "liangyou@vm0.ai",
     description: "Enable sandbox reuse (keep-alive) across conversation turns",
     enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
 };
 


### PR DESCRIPTION
## Summary
- Enable sandbox reuse (keep-alive) feature for staff org by adding `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` to the `SandboxReuse` feature switch
- Allows staff members to test VM reuse across conversation turns before broader rollout

## Test plan
- [ ] Verify staff org users see sandbox reuse enabled
- [ ] Verify non-staff org users still have sandbox reuse disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)