### PR TITLE
feat(usage): add daily credits chart and per-run records

### DIFF
--- a/turbo/apps/platform/src/signals/usage-page/usage-signals.ts
+++ b/turbo/apps/platform/src/signals/usage-page/usage-signals.ts
@@ -1,15 +1,178 @@
-import { computed } from "ccstate";
-import { zeroUsageMembersContract } from "@vm0/core";
+import { computed, state, command } from "ccstate";
+import {
+  zeroUsageMembersContract,
+  zeroUsageDailyContract,
+  zeroUsageRunsContract,
+} from "@vm0/core";
 import { zeroClient$ } from "../api-client.ts";
 import { accept } from "../../lib/accept.ts";
 
-/**
- * Async computed signal that fetches per-member usage data.
- * Throws on non-OK responses so useLoadable enters hasError state.
- */
+// --- Existing member usage signal ---
+
 export const usageMembersAsync$ = computed(async (get) => {
   const createClient = get(zeroClient$);
   const client = createClient(zeroUsageMembersContract);
   const result = await accept(client.get(), [200]);
+  return result.body;
+});
+
+// --- Tab state ---
+
+export type UsageTab = "overview" | "runs";
+
+const internalUsageTab$ = state<UsageTab>("overview");
+
+export const usageTab$ = computed((get) => {
+  return get(internalUsageTab$);
+});
+
+export const setUsageTab$ = command(({ set }, tab: UsageTab) => {
+  set(internalUsageTab$, tab);
+});
+
+// --- Daily credits chart signals ---
+
+export type ChartMode = "total" | "member";
+
+const internalChartMode$ = state<ChartMode>("total");
+const internalChartDateFrom$ = state<string | undefined>(undefined);
+const internalChartDateTo$ = state<string | undefined>(undefined);
+
+export const chartMode$ = computed((get) => {
+  return get(internalChartMode$);
+});
+
+export const setChartMode$ = command(({ set }, mode: ChartMode) => {
+  set(internalChartMode$, mode);
+});
+
+export type DatePreset = "last7" | "last14" | "last30" | "period";
+
+const internalDatePreset$ = state<DatePreset>("period");
+
+export const datePreset$ = computed((get) => {
+  return get(internalDatePreset$);
+});
+
+export const setDatePreset$ = command(({ set }, preset: DatePreset) => {
+  set(internalDatePreset$, preset);
+  if (preset === "period") {
+    set(internalChartDateFrom$, undefined);
+    set(internalChartDateTo$, undefined);
+  } else {
+    const now = new Date();
+    const from = new Date(now);
+    from.setDate(from.getDate() - Number(preset.replace("last", "")));
+    set(internalChartDateFrom$, from.toISOString());
+    set(internalChartDateTo$, now.toISOString());
+  }
+});
+
+interface ChartTooltipData {
+  x: number;
+  y: number;
+  date: string;
+  values: { label: string; value: number; color: string }[];
+}
+
+const internalChartTooltip$ = state<ChartTooltipData | null>(null);
+
+export const chartTooltip$ = computed((get) => {
+  return get(internalChartTooltip$);
+});
+
+export const setChartTooltip$ = command(
+  ({ set }, data: ChartTooltipData | null) => {
+    set(internalChartTooltip$, data);
+  },
+);
+
+const internalChartWidth$ = state(600);
+
+export const chartWidth$ = computed((get) => {
+  return get(internalChartWidth$);
+});
+
+export const setChartWidth$ = command(({ set }, width: number) => {
+  set(internalChartWidth$, width);
+});
+
+export type { ChartTooltipData };
+
+export const dailyCreditsAsync$ = computed(async (get) => {
+  const createClient = get(zeroClient$);
+  const mode = get(internalChartMode$);
+  const dateFrom = get(internalChartDateFrom$);
+  const dateTo = get(internalChartDateTo$);
+
+  const client = createClient(zeroUsageDailyContract);
+  const result = await accept(
+    client.get({ query: { mode, dateFrom, dateTo } }),
+    [200],
+  );
+  return result.body;
+});
+
+// --- Per-run records signals ---
+
+const internalRunsPage$ = state(1);
+const internalRunsAgentFilter$ = state<string | undefined>(undefined);
+const internalRunsMemberFilter$ = state<string | undefined>(undefined);
+const internalRunsDateFrom$ = state<string | undefined>(undefined);
+const internalRunsDateTo$ = state<string | undefined>(undefined);
+
+export const runsPage$ = computed((get) => {
+  return get(internalRunsPage$);
+});
+
+export const runsMemberFilter$ = computed((get) => {
+  return get(internalRunsMemberFilter$);
+});
+
+export const setRunsPage$ = command(({ set }, page: number) => {
+  set(internalRunsPage$, page);
+});
+
+export const setRunsFilter$ = command(
+  (
+    { set },
+    filter: {
+      agentId?: string;
+      userId?: string;
+      dateFrom?: string;
+      dateTo?: string;
+    },
+  ) => {
+    if (filter.agentId !== undefined) {
+      set(internalRunsAgentFilter$, filter.agentId || undefined);
+    }
+    if (filter.userId !== undefined) {
+      set(internalRunsMemberFilter$, filter.userId || undefined);
+    }
+    if (filter.dateFrom !== undefined) {
+      set(internalRunsDateFrom$, filter.dateFrom || undefined);
+    }
+    if (filter.dateTo !== undefined) {
+      set(internalRunsDateTo$, filter.dateTo || undefined);
+    }
+    set(internalRunsPage$, 1);
+  },
+);
+
+export const usageRunsAsync$ = computed(async (get) => {
+  const createClient = get(zeroClient$);
+  const page = get(internalRunsPage$);
+  const agentId = get(internalRunsAgentFilter$);
+  const userId = get(internalRunsMemberFilter$);
+  const dateFrom = get(internalRunsDateFrom$);
+  const dateTo = get(internalRunsDateTo$);
+
+  const client = createClient(zeroUsageRunsContract);
+  const result = await accept(
+    client.get({
+      query: { page, pageSize: 20, agentId, userId, dateFrom, dateTo },
+    }),
+    [200],
+  );
   return result.body;
 });

--- a/turbo/apps/platform/src/signals/usage-page/usage-signals.ts
+++ b/turbo/apps/platform/src/signals/usage-page/usage-signals.ts
@@ -18,7 +18,7 @@ export const usageMembersAsync$ = computed(async (get) => {
 
 // --- Tab state ---
 
-export type UsageTab = "overview" | "runs";
+export type UsageTab = "overview" | "daily" | "runs";
 
 const internalUsageTab$ = state<UsageTab>("overview");
 
@@ -33,10 +33,32 @@ export const setUsageTab$ = command(({ set }, tab: UsageTab) => {
 // --- Daily credits chart signals ---
 
 export type ChartMode = "total" | "member";
+export type ChartType = "line" | "bar";
+
+const internalChartType$ = state<ChartType>("line");
+
+export const chartType$ = computed((get) => {
+  return get(internalChartType$);
+});
+
+export const setChartType$ = command(({ set }, type: ChartType) => {
+  set(internalChartType$, type);
+});
+
+const DEFAULT_PRESET_DAYS = 14;
+
+function initialDateRange(): { from: string; to: string } {
+  const to = new Date();
+  const from = new Date(to);
+  from.setDate(from.getDate() - DEFAULT_PRESET_DAYS);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
 
 const internalChartMode$ = state<ChartMode>("total");
-const internalChartDateFrom$ = state<string | undefined>(undefined);
-const internalChartDateTo$ = state<string | undefined>(undefined);
+const internalChartDateFrom$ = state<string | undefined>(
+  initialDateRange().from,
+);
+const internalChartDateTo$ = state<string | undefined>(initialDateRange().to);
 
 export const chartMode$ = computed((get) => {
   return get(internalChartMode$);
@@ -48,7 +70,7 @@ export const setChartMode$ = command(({ set }, mode: ChartMode) => {
 
 export type DatePreset = "last7" | "last14" | "last30" | "period";
 
-const internalDatePreset$ = state<DatePreset>("period");
+const internalDatePreset$ = state<DatePreset>("last14");
 
 export const datePreset$ = computed((get) => {
   return get(internalDatePreset$);
@@ -97,6 +119,29 @@ export const setChartWidth$ = command(({ set }, width: number) => {
   set(internalChartWidth$, width);
 });
 
+// Member line focus state (legend click selects a single member; null = show all)
+const internalSelectedMember$ = state<string | null>(null);
+
+export const selectedMember$ = computed((get) => {
+  return get(internalSelectedMember$);
+});
+
+export const toggleSelectedMember$ = command(({ set, get }, label: string) => {
+  const current = get(internalSelectedMember$);
+  set(internalSelectedMember$, current === label ? null : label);
+});
+
+// Member line hover state (legend hover dims other lines; null = neutral)
+const internalHoveredMember$ = state<string | null>(null);
+
+export const hoveredMember$ = computed((get) => {
+  return get(internalHoveredMember$);
+});
+
+export const setHoveredMember$ = command(({ set }, label: string | null) => {
+  set(internalHoveredMember$, label);
+});
+
 export type { ChartTooltipData };
 
 export const dailyCreditsAsync$ = computed(async (get) => {
@@ -116,6 +161,7 @@ export const dailyCreditsAsync$ = computed(async (get) => {
 // --- Per-run records signals ---
 
 const internalRunsPage$ = state(1);
+const internalRunsPageSize$ = state(20);
 const internalRunsAgentFilter$ = state<string | undefined>(undefined);
 const internalRunsMemberFilter$ = state<string | undefined>(undefined);
 const internalRunsDateFrom$ = state<string | undefined>(undefined);
@@ -125,12 +171,21 @@ export const runsPage$ = computed((get) => {
   return get(internalRunsPage$);
 });
 
+export const runsPageSize$ = computed((get) => {
+  return get(internalRunsPageSize$);
+});
+
 export const runsMemberFilter$ = computed((get) => {
   return get(internalRunsMemberFilter$);
 });
 
 export const setRunsPage$ = command(({ set }, page: number) => {
   set(internalRunsPage$, page);
+});
+
+export const setRunsPageSize$ = command(({ set }, pageSize: number) => {
+  set(internalRunsPageSize$, pageSize);
+  set(internalRunsPage$, 1);
 });
 
 export const setRunsFilter$ = command(
@@ -162,6 +217,7 @@ export const setRunsFilter$ = command(
 export const usageRunsAsync$ = computed(async (get) => {
   const createClient = get(zeroClient$);
   const page = get(internalRunsPage$);
+  const pageSize = get(internalRunsPageSize$);
   const agentId = get(internalRunsAgentFilter$);
   const userId = get(internalRunsMemberFilter$);
   const dateFrom = get(internalRunsDateFrom$);
@@ -170,7 +226,14 @@ export const usageRunsAsync$ = computed(async (get) => {
   const client = createClient(zeroUsageRunsContract);
   const result = await accept(
     client.get({
-      query: { page, pageSize: 20, agentId, userId, dateFrom, dateTo },
+      query: {
+        page,
+        pageSize,
+        agentId,
+        userIds: userId,
+        dateFrom,
+        dateTo,
+      },
     }),
     [200],
   );

--- a/turbo/apps/platform/src/views/usage-page/components/credits-chart.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/credits-chart.tsx
@@ -1,0 +1,537 @@
+import { useLoadable, useGet, useSet } from "ccstate-react";
+import {
+  dailyCreditsAsync$,
+  chartMode$,
+  setChartMode$,
+  datePreset$,
+  setDatePreset$,
+  chartTooltip$,
+  setChartTooltip$,
+  chartWidth$,
+  setChartWidth$,
+  type ChartMode,
+  type DatePreset,
+  type ChartTooltipData,
+} from "../../../signals/usage-page/usage-signals.ts";
+import type { DailyCredit, DailyCreditByMember } from "@vm0/core";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui";
+
+// --- Constants ---
+
+const CHART_PADDING = { top: 20, right: 16, bottom: 32, left: 60 } as const;
+const CHART_HEIGHT = 220;
+const MEMBER_COLORS = [
+  "hsl(var(--primary))",
+  "#f59e0b",
+  "#10b981",
+  "#8b5cf6",
+  "#ec4899",
+  "#06b6d4",
+  "#f97316",
+  "#84cc16",
+] as const;
+const MAX_MEMBER_LINES = 7;
+
+// --- Helpers ---
+
+function formatCredits(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)}M`;
+  }
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(1)}K`;
+  }
+  return String(n);
+}
+
+function formatDateLabel(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function niceStep(range: number, targetTicks: number): number {
+  const rough = range / targetTicks;
+  const pow = Math.pow(10, Math.floor(Math.log10(rough)));
+  const normalized = rough / pow;
+  const nice =
+    normalized < 1.5 ? 1 : normalized < 3 ? 2 : normalized < 7 ? 5 : 10;
+  return nice * pow;
+}
+
+function generateYTicks(max: number): number[] {
+  if (max <= 0) {
+    return [0];
+  }
+  const step = niceStep(max, 4);
+  const ticks: number[] = [];
+  for (let v = 0; v <= max + step * 0.01; v += step) {
+    ticks.push(Math.round(v));
+  }
+  if (ticks.length < 2) {
+    ticks.push(Math.round(max));
+  }
+  return ticks;
+}
+
+function getDatePresetLabel(preset: DatePreset): string {
+  switch (preset) {
+    case "last7": {
+      return "Last 7 days";
+    }
+    case "last14": {
+      return "Last 14 days";
+    }
+    case "last30": {
+      return "Last 30 days";
+    }
+    case "period": {
+      return "Billing period";
+    }
+  }
+}
+
+// --- Tooltip ---
+
+function ChartTooltip({ data }: { data: ChartTooltipData }) {
+  return (
+    <div
+      className="pointer-events-none absolute z-10 rounded-md border border-border bg-popover px-3 py-2 text-xs shadow-md"
+      style={{
+        left: data.x + 12,
+        top: data.y - 8,
+        transform: "translateY(-100%)",
+      }}
+    >
+      <div className="font-medium text-foreground mb-1">
+        {formatDateLabel(data.date)}
+      </div>
+      {data.values.map((v) => {
+        return (
+          <div key={v.label} className="flex items-center gap-2">
+            <span
+              className="inline-block h-2 w-2 rounded-full"
+              style={{ backgroundColor: v.color }}
+            />
+            <span className="text-muted-foreground">{v.label}:</span>
+            <span className="font-medium tabular-nums text-foreground">
+              {v.value.toLocaleString()}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- Line data types ---
+
+interface LineData {
+  label: string;
+  color: string;
+  points: { date: string; value: number }[];
+}
+
+// --- SVG rendering helpers ---
+
+function renderYGrid(
+  yTicks: number[],
+  yScale: (v: number) => number,
+  left: number,
+  right: number,
+) {
+  return yTicks.map((tick) => {
+    return (
+      <g key={tick}>
+        <line
+          x1={left}
+          y1={yScale(tick)}
+          x2={right}
+          y2={yScale(tick)}
+          stroke="hsl(var(--border))"
+          strokeDasharray={tick === 0 ? undefined : "2,3"}
+          strokeWidth={tick === 0 ? 1 : 0.5}
+        />
+        <text
+          x={left - 8}
+          y={yScale(tick)}
+          textAnchor="end"
+          dominantBaseline="middle"
+          className="fill-muted-foreground"
+          fontSize={11}
+        >
+          {formatCredits(tick)}
+        </text>
+      </g>
+    );
+  });
+}
+
+function renderXLabels(
+  dates: string[],
+  xScale: (i: number) => number,
+  labelInterval: number,
+) {
+  return dates.map((date, i) => {
+    if (i % labelInterval !== 0 && i !== dates.length - 1) {
+      return null;
+    }
+    return (
+      <text
+        key={date}
+        x={xScale(i)}
+        y={CHART_HEIGHT - 4}
+        textAnchor="middle"
+        className="fill-muted-foreground"
+        fontSize={11}
+      >
+        {formatDateLabel(date)}
+      </text>
+    );
+  });
+}
+
+function renderLines(
+  lines: LineData[],
+  xScale: (i: number) => number,
+  yScale: (v: number) => number,
+) {
+  return lines.map((line) => {
+    if (line.points.length === 1) {
+      return (
+        <circle
+          key={line.label}
+          cx={xScale(0)}
+          cy={yScale(line.points[0]!.value)}
+          r={4}
+          fill={line.color}
+        />
+      );
+    }
+    const d = line.points
+      .map((p, i) => {
+        return `${i === 0 ? "M" : "L"}${xScale(i)},${yScale(p.value)}`;
+      })
+      .join(" ");
+    return (
+      <path
+        key={line.label}
+        d={d}
+        fill="none"
+        stroke={line.color}
+        strokeWidth={2}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    );
+  });
+}
+
+// --- Line chart SVG ---
+
+function SvgLineChart({ lines, width }: { lines: LineData[]; width: number }) {
+  const tooltip = useGet(chartTooltip$);
+  const setTooltip = useSet(setChartTooltip$);
+
+  const allValues = lines.flatMap((l) => {
+    return l.points.map((p) => {
+      return p.value;
+    });
+  });
+  const maxValue = Math.max(...allValues, 1);
+  const yTicks = generateYTicks(maxValue);
+  const yMax = yTicks[yTicks.length - 1] ?? maxValue;
+
+  const dates =
+    lines[0]?.points.map((p) => {
+      return p.date;
+    }) ?? [];
+  const drawW = width - CHART_PADDING.left - CHART_PADDING.right;
+  const drawH = CHART_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom;
+
+  const xScale = (i: number) => {
+    return (
+      CHART_PADDING.left +
+      (dates.length > 1 ? (i / (dates.length - 1)) * drawW : drawW / 2)
+    );
+  };
+  const yScale = (v: number) => {
+    return CHART_PADDING.top + drawH - (v / yMax) * drawH;
+  };
+
+  const labelInterval = Math.max(
+    1,
+    Math.ceil(dates.length / Math.floor(drawW / 50)),
+  );
+
+  if (dates.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-[220px] text-sm text-muted-foreground">
+        No data for the selected period
+      </div>
+    );
+  }
+
+  const handleMouseMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+
+    let closestIdx = 0;
+    let closestDist = Infinity;
+    for (let i = 0; i < dates.length; i++) {
+      const dist = Math.abs(xScale(i) - mx);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestIdx = i;
+      }
+    }
+
+    const values = lines.map((line) => {
+      return {
+        label: line.label,
+        value: line.points[closestIdx]?.value ?? 0,
+        color: line.color,
+      };
+    });
+
+    setTooltip({
+      x: xScale(closestIdx),
+      y: my,
+      date: dates[closestIdx]!,
+      values,
+    });
+  };
+
+  const handleMouseLeave = () => {
+    setTooltip(null);
+  };
+
+  return (
+    <div className="relative">
+      <svg
+        width={width}
+        height={CHART_HEIGHT}
+        className="select-none"
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+      >
+        {renderYGrid(
+          yTicks,
+          yScale,
+          CHART_PADDING.left,
+          width - CHART_PADDING.right,
+        )}
+        {renderXLabels(dates, xScale, labelInterval)}
+        {renderLines(lines, xScale, yScale)}
+        {tooltip && (
+          <line
+            x1={tooltip.x}
+            y1={CHART_PADDING.top}
+            x2={tooltip.x}
+            y2={CHART_PADDING.top + drawH}
+            stroke="hsl(var(--muted-foreground))"
+            strokeWidth={1}
+            strokeDasharray="3,3"
+            opacity={0.5}
+          />
+        )}
+      </svg>
+      {tooltip && <ChartTooltip data={tooltip} />}
+    </div>
+  );
+}
+
+// --- Transform data into line format ---
+
+function toTotalLines(daily: DailyCredit[]): LineData[] {
+  return [
+    {
+      label: "Total",
+      color: "hsl(var(--primary))",
+      points: daily.map((d) => {
+        return { date: d.date, value: d.creditsCharged };
+      }),
+    },
+  ];
+}
+
+function toMemberLines(dailyByMember: DailyCreditByMember[]): LineData[] {
+  const memberTotals = new Map<string, { email: string; total: number }>();
+  for (const day of dailyByMember) {
+    for (const m of day.members) {
+      const existing = memberTotals.get(m.userId);
+      if (existing) {
+        existing.total += m.creditsCharged;
+      } else {
+        memberTotals.set(m.userId, { email: m.email, total: m.creditsCharged });
+      }
+    }
+  }
+
+  const sorted = [...memberTotals.entries()].sort((a, b) => {
+    return b[1].total - a[1].total;
+  });
+  const topMembers = sorted.slice(0, MAX_MEMBER_LINES);
+  const topIds = new Set(
+    topMembers.map(([id]) => {
+      return id;
+    }),
+  );
+  const hasOthers = sorted.length > MAX_MEMBER_LINES;
+
+  const lines: LineData[] = topMembers.map(([userId, { email }], i) => {
+    return {
+      label: email,
+      color: MEMBER_COLORS[i % MEMBER_COLORS.length]!,
+      points: dailyByMember.map((day) => {
+        const m = day.members.find((x) => {
+          return x.userId === userId;
+        });
+        return { date: day.date, value: m?.creditsCharged ?? 0 };
+      }),
+    };
+  });
+
+  if (hasOthers) {
+    lines.push({
+      label: "Others",
+      color: "hsl(var(--muted-foreground))",
+      points: dailyByMember.map((day) => {
+        const sum = day.members
+          .filter((m) => {
+            return !topIds.has(m.userId);
+          })
+          .reduce((acc, m) => {
+            return acc + m.creditsCharged;
+          }, 0);
+        return { date: day.date, value: sum };
+      }),
+    });
+  }
+
+  return lines;
+}
+
+// --- Legend ---
+
+function ChartLegend({ lines }: { lines: LineData[] }) {
+  if (lines.length <= 1) {
+    return null;
+  }
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 px-1 pt-2 text-xs text-muted-foreground">
+      {lines.map((line) => {
+        return (
+          <div key={line.label} className="flex items-center gap-1.5">
+            <span
+              className="inline-block h-2 w-2 rounded-full"
+              style={{ backgroundColor: line.color }}
+            />
+            <span className="truncate max-w-[120px]">{line.label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- ResizeObserver setup via ref callback ---
+
+function useChartResizeRef(setWidth: (w: number) => void) {
+  let observer: ResizeObserver | null = null;
+
+  return (el: HTMLDivElement | null) => {
+    if (observer) {
+      observer.disconnect();
+      observer = null;
+    }
+    if (el) {
+      observer = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (entry) {
+          setWidth(entry.contentRect.width);
+        }
+      });
+      observer.observe(el);
+    }
+  };
+}
+
+// --- Main component ---
+
+export function CreditsChart() {
+  const loadable = useLoadable(dailyCreditsAsync$);
+  const mode = useGet(chartMode$);
+  const setMode = useSet(setChartMode$);
+  const preset = useGet(datePreset$);
+  const setPreset = useSet(setDatePreset$);
+  const width = useGet(chartWidth$);
+  const setWidth = useSet(setChartWidth$);
+
+  const containerRef = useChartResizeRef(setWidth);
+
+  const handleModeChange = (val: string) => {
+    setMode(val as ChartMode);
+  };
+
+  const handlePresetChange = (val: string) => {
+    setPreset(val as DatePreset);
+  };
+
+  const isLoading = loadable.state === "loading";
+  const data = loadable.state === "hasData" ? loadable.data : null;
+
+  const lines =
+    data && mode === "member"
+      ? toMemberLines(data.dailyByMember)
+      : data
+        ? toTotalLines(data.daily)
+        : [];
+
+  return (
+    <div className="zero-card p-4">
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <h2 className="text-sm font-medium text-foreground">Daily Credits</h2>
+        <div className="flex items-center gap-2">
+          <Select value={mode} onValueChange={handleModeChange}>
+            <SelectTrigger className="h-8 w-[120px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="total">Total</SelectItem>
+              <SelectItem value="member">By Member</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={preset} onValueChange={handlePresetChange}>
+            <SelectTrigger className="h-8 w-[140px] text-xs">
+              <SelectValue>{getDatePresetLabel(preset)}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="last7">Last 7 days</SelectItem>
+              <SelectItem value="last14">Last 14 days</SelectItem>
+              <SelectItem value="last30">Last 30 days</SelectItem>
+              <SelectItem value="period">Billing period</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div ref={containerRef} className="w-full overflow-hidden">
+        {isLoading ? (
+          <div className="h-[220px] animate-pulse bg-muted/20 rounded" />
+        ) : (
+          <>
+            <SvgLineChart lines={lines} width={width} />
+            <ChartLegend lines={lines} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/usage-page/components/credits-chart.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/credits-chart.tsx
@@ -9,7 +9,14 @@ import {
   setChartTooltip$,
   chartWidth$,
   setChartWidth$,
+  selectedMember$,
+  toggleSelectedMember$,
+  hoveredMember$,
+  setHoveredMember$,
+  chartType$,
+  setChartType$,
   type ChartMode,
+  type ChartType,
   type DatePreset,
   type ChartTooltipData,
 } from "../../../signals/usage-page/usage-signals.ts";
@@ -69,8 +76,11 @@ function generateYTicks(max: number): number[] {
     return [0];
   }
   const step = niceStep(max, 4);
+  // Always leave one step of headroom above max so peak values don't touch
+  // the top edge of the drawing area (which would clip half the stroke).
+  const top = Math.floor(max / step) * step + step;
   const ticks: number[] = [];
-  for (let v = 0; v <= max + step * 0.01; v += step) {
+  for (let v = 0; v <= top + step * 0.01; v += step) {
     ticks.push(Math.round(v));
   }
   if (ticks.length < 2) {
@@ -98,14 +108,27 @@ function getDatePresetLabel(preset: DatePreset): string {
 
 // --- Tooltip ---
 
-function ChartTooltip({ data }: { data: ChartTooltipData }) {
+const TOOLTIP_ESTIMATED_WIDTH = 200;
+
+function ChartTooltip({
+  data,
+  containerWidth,
+}: {
+  data: ChartTooltipData;
+  containerWidth: number;
+}) {
+  // Flip tooltip to the left side of the cursor when it would overflow the right edge.
+  const flipLeft = data.x + 12 + TOOLTIP_ESTIMATED_WIDTH > containerWidth;
+  const left = flipLeft ? data.x - 12 : data.x + 12;
+  const translateX = flipLeft ? "-100%" : "0";
+
   return (
     <div
       className="pointer-events-none absolute z-10 rounded-md border border-border bg-popover px-3 py-2 text-xs shadow-md"
       style={{
-        left: data.x + 12,
+        left,
         top: data.y - 8,
-        transform: "translateY(-100%)",
+        transform: `translate(${translateX}, -100%)`,
       }}
     >
       <div className="font-medium text-foreground mb-1">
@@ -196,12 +219,53 @@ function renderXLabels(
   });
 }
 
+function renderBars(
+  lines: LineData[],
+  xScale: (i: number) => number,
+  yScale: (v: number) => number,
+  barSlotWidth: number,
+  getOpacity: (label: string) => number,
+) {
+  const dates =
+    lines[0]?.points.map((p) => {
+      return p.date;
+    }) ?? [];
+  const width = Math.max(2, barSlotWidth * 0.7);
+  return dates.flatMap((date, dateIdx) => {
+    let cumulative = 0;
+    return lines.map((line) => {
+      const value = line.points[dateIdx]?.value ?? 0;
+      if (value <= 0) {
+        return null;
+      }
+      const yBottom = yScale(cumulative);
+      cumulative += value;
+      const yTop = yScale(cumulative);
+      const height = Math.max(0, yBottom - yTop);
+      const cx = xScale(dateIdx);
+      return (
+        <rect
+          key={`${line.label}-${date}`}
+          x={cx - width / 2}
+          y={yTop}
+          width={width}
+          height={height}
+          fill={line.color}
+          opacity={getOpacity(line.label)}
+        />
+      );
+    });
+  });
+}
+
 function renderLines(
   lines: LineData[],
   xScale: (i: number) => number,
   yScale: (v: number) => number,
+  getOpacity: (label: string) => number,
 ) {
   return lines.map((line) => {
+    const opacity = getOpacity(line.label);
     if (line.points.length === 1) {
       return (
         <circle
@@ -210,6 +274,7 @@ function renderLines(
           cy={yScale(line.points[0]!.value)}
           r={4}
           fill={line.color}
+          opacity={opacity}
         />
       );
     }
@@ -227,6 +292,7 @@ function renderLines(
         strokeWidth={2}
         strokeLinejoin="round"
         strokeLinecap="round"
+        opacity={opacity}
       />
     );
   });
@@ -234,27 +300,104 @@ function renderLines(
 
 // --- Line chart SVG ---
 
-function SvgLineChart({ lines, width }: { lines: LineData[]; width: number }) {
+function computeTooltipAt(
+  mx: number,
+  my: number,
+  dates: string[],
+  visibleLines: LineData[],
+  xScale: (i: number) => number,
+): ChartTooltipData | null {
+  if (dates.length === 0) {
+    return null;
+  }
+  let closestIdx = 0;
+  let closestDist = Infinity;
+  for (let i = 0; i < dates.length; i++) {
+    const dist = Math.abs(xScale(i) - mx);
+    if (dist < closestDist) {
+      closestDist = dist;
+      closestIdx = i;
+    }
+  }
+
+  const values = visibleLines.map((line) => {
+    return {
+      label: line.label,
+      value: line.points[closestIdx]?.value ?? 0,
+      color: line.color,
+    };
+  });
+
+  return {
+    x: xScale(closestIdx),
+    y: my,
+    date: dates[closestIdx]!,
+    values,
+  };
+}
+
+function SvgLineChart({
+  lines,
+  width,
+  chartType,
+}: {
+  lines: LineData[];
+  width: number;
+  chartType: ChartType;
+}) {
   const tooltip = useGet(chartTooltip$);
   const setTooltip = useSet(setChartTooltip$);
+  const selected = useGet(selectedMember$);
+  const hovered = useGet(hoveredMember$);
 
-  const allValues = lines.flatMap((l) => {
-    return l.points.map((p) => {
-      return p.value;
-    });
-  });
-  const maxValue = Math.max(...allValues, 1);
+  // Filter down to the selected member when one is pinned; otherwise show all.
+  const visibleLines =
+    selected !== null
+      ? lines.filter((l) => {
+          return l.label === selected;
+        })
+      : lines;
+
+  const getOpacity = (label: string): number => {
+    if (hovered !== null && hovered !== label) {
+      return 0.2;
+    }
+    return 1;
+  };
+
+  // In bar mode, bars stack — yMax must reflect per-day totals, not per-line.
+  const pointCount = visibleLines[0]?.points.length ?? 0;
+  const perDayTotals =
+    chartType === "bar"
+      ? Array.from({ length: pointCount }, (_, i) => {
+          return visibleLines.reduce((s, l) => {
+            return s + (l.points[i]?.value ?? 0);
+          }, 0);
+        })
+      : visibleLines.flatMap((l) => {
+          return l.points.map((p) => {
+            return p.value;
+          });
+        });
+  const maxValue = Math.max(...perDayTotals, 1);
   const yTicks = generateYTicks(maxValue);
   const yMax = yTicks[yTicks.length - 1] ?? maxValue;
 
   const dates =
-    lines[0]?.points.map((p) => {
+    visibleLines[0]?.points.map((p) => {
       return p.date;
     }) ?? [];
   const drawW = width - CHART_PADDING.left - CHART_PADDING.right;
   const drawH = CHART_HEIGHT - CHART_PADDING.top - CHART_PADDING.bottom;
 
+  // Line chart: first/last points sit at the edges of the draw area.
+  // Bar chart: bars are centered within slots so the first bar doesn't
+  // overlap the Y axis.
+  const slotWidth = dates.length > 0 ? drawW / dates.length : drawW;
   const xScale = (i: number) => {
+    if (chartType === "bar") {
+      return CHART_PADDING.left + (i + 0.5) * slotWidth;
+    }
     return (
       CHART_PADDING.left +
       (dates.length > 1 ? (i / (dates.length - 1)) * drawW : drawW / 2)
@@ -281,31 +424,10 @@ function SvgLineChart({ lines, width }: { lines: LineData[]; width: number }) {
     const rect = e.currentTarget.getBoundingClientRect();
     const mx = e.clientX - rect.left;
     const my = e.clientY - rect.top;
-
-    let closestIdx = 0;
-    let closestDist = Infinity;
-    for (let i = 0; i < dates.length; i++) {
-      const dist = Math.abs(xScale(i) - mx);
-      if (dist < closestDist) {
-        closestDist = dist;
-        closestIdx = i;
-      }
+    const tooltipData = computeTooltipAt(mx, my, dates, visibleLines, xScale);
+    if (tooltipData) {
+      setTooltip(tooltipData);
     }
-
-    const values = lines.map((line) => {
-      return {
-        label: line.label,
-        value: line.points[closestIdx]?.value ?? 0,
-        color: line.color,
-      };
-    });
-
-    setTooltip({
-      x: xScale(closestIdx),
-      y: my,
-      date: dates[closestIdx]!,
-      values,
-    });
   };
 
   const handleMouseLeave = () => {
@@ -328,7 +450,6 @@ function SvgLineChart({ lines, width }: { lines: LineData[]; width: number }) {
           width - CHART_PADDING.right,
         )}
         {renderXLabels(dates, xScale, labelInterval)}
-        {renderLines(lines, xScale, yScale)}
         {tooltip && (
           <line
             x1={tooltip.x}
@@ -341,8 +462,11 @@ function SvgLineChart({ lines, width }: { lines: LineData[]; width: number }) {
             opacity={0.5}
           />
         )}
+        {chartType === "bar"
+          ? renderBars(visibleLines, xScale, yScale, slotWidth, getOpacity)
+          : renderLines(visibleLines, xScale, yScale, getOpacity)}
       </svg>
-      {tooltip && <ChartTooltip data={tooltip} />}
+      {tooltip && <ChartTooltip data={tooltip} containerWidth={width} />}
     </div>
   );
 }
@@ -421,20 +545,44 @@ function toMemberLines(dailyByMember: DailyCreditByMember[]): LineData[] {
 // --- Legend ---
 
 function ChartLegend({ lines }: { lines: LineData[] }) {
+  const selected = useGet(selectedMember$);
+  const hovered = useGet(hoveredMember$);
+  const toggle = useSet(toggleSelectedMember$);
+  const setHovered = useSet(setHoveredMember$);
+
   if (lines.length <= 1) {
     return null;
   }
   return (
     <div className="flex flex-wrap gap-x-4 gap-y-1 px-1 pt-2 text-xs text-muted-foreground">
       {lines.map((line) => {
+        const isSelected = selected === line.label;
+        const dimmed =
+          (selected !== null && !isSelected) ||
+          (hovered !== null && hovered !== line.label);
         return (
-          <div key={line.label} className="flex items-center gap-1.5">
+          <button
+            key={line.label}
+            type="button"
+            onClick={() => {
+              toggle(line.label);
+            }}
+            onPointerEnter={() => {
+              setHovered(line.label);
+            }}
+            onPointerLeave={() => {
+              setHovered(null);
+            }}
+            className={`flex items-center gap-1.5 rounded transition-opacity hover:text-foreground ${
+              dimmed ? "opacity-40" : "opacity-100"
+            } ${isSelected ? "text-foreground font-medium" : ""}`}
+          >
             <span
               className="inline-block h-2 w-2 rounded-full"
               style={{ backgroundColor: line.color }}
             />
             <span className="truncate max-w-[120px]">{line.label}</span>
-          </div>
+          </button>
         );
       })}
     </div>
@@ -473,6 +621,8 @@ export function CreditsChart() {
   const setPreset = useSet(setDatePreset$);
   const width = useGet(chartWidth$);
   const setWidth = useSet(setChartWidth$);
+  const chartType = useGet(chartType$);
+  const setType = useSet(setChartType$);
 
   const containerRef = useChartResizeRef(setWidth);
 
@@ -482,6 +632,10 @@ export function CreditsChart() {
 
   const handlePresetChange = (val: string) => {
     setPreset(val as DatePreset);
+  };
+
+  const handleTypeChange = (val: string) => {
+    setType(val as ChartType);
   };
 
   const isLoading = loadable.state === "loading";
@@ -499,6 +653,15 @@ export function CreditsChart() {
       <div className="flex items-center justify-between gap-3 mb-3">
         <h2 className="text-sm font-medium text-foreground">Daily Credits</h2>
         <div className="flex items-center gap-2">
+          <Select value={chartType} onValueChange={handleTypeChange}>
+            <SelectTrigger className="h-8 w-[90px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="line">Line</SelectItem>
+              <SelectItem value="bar">Bar</SelectItem>
+            </SelectContent>
+          </Select>
           <Select value={mode} onValueChange={handleModeChange}>
             <SelectTrigger className="h-8 w-[120px] text-xs">
               <SelectValue />
@@ -527,7 +690,7 @@ export function CreditsChart() {
           <div className="h-[220px] animate-pulse bg-muted/20 rounded" />
         ) : (
           <>
-            <SvgLineChart lines={lines} width={width} />
+            <SvgLineChart lines={lines} width={width} chartType={chartType} />
             <ChartLegend lines={lines} />
           </>
         )}

--- a/turbo/apps/platform/src/views/usage-page/components/runs-tab.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/runs-tab.tsx
@@ -2,41 +2,28 @@ import { useLoadable, useGet, useSet } from "ccstate-react";
 import {
   usageRunsAsync$,
   runsPage$,
+  runsPageSize$,
   runsMemberFilter$,
   setRunsPage$,
+  setRunsPageSize$,
   setRunsFilter$,
-  usageMembersAsync$,
 } from "../../../signals/usage-page/usage-signals.ts";
+import { orgMembers$ } from "../../../signals/external/org-members.ts";
 import {
-  Button,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
 } from "@vm0/ui";
+import { IconUsers } from "@tabler/icons-react";
 import type { UsageRun } from "@vm0/core";
+import { Pagination } from "../../components/pagination.tsx";
 
 // --- Helpers ---
 
 function formatNumber(n: number): string {
   return n.toLocaleString();
-}
-
-function formatDuration(ms: number | null): string {
-  if (ms === null) {
-    return "-";
-  }
-  if (ms < 1000) {
-    return `${ms}ms`;
-  }
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 60) {
-    return `${seconds}s`;
-  }
-  const minutes = Math.floor(seconds / 60);
-  const remaining = seconds % 60;
-  return `${minutes}m ${remaining}s`;
 }
 
 function formatTime(iso: string): string {
@@ -48,59 +35,43 @@ function formatTime(iso: string): string {
   });
 }
 
-const STATUS_STYLES = {
-  completed: "bg-emerald-500/10 text-emerald-600",
-  failed: "bg-red-500/10 text-red-600",
-  running: "bg-blue-500/10 text-blue-600",
-  timeout: "bg-amber-500/10 text-amber-600",
-  cancelled: "bg-gray-500/10 text-gray-500",
-  queued: "bg-gray-500/10 text-gray-500",
-  pending: "bg-gray-500/10 text-gray-500",
-} as const;
-
-function StatusBadge({ status }: { status: string }) {
-  const style =
-    (STATUS_STYLES as Record<string, string>)[status] ??
-    "bg-gray-500/10 text-gray-500";
-  return (
-    <span
-      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${style}`}
-    >
-      {status}
-    </span>
-  );
-}
-
 // --- Filters ---
 
 function RunsFilters() {
   const memberFilter = useGet(runsMemberFilter$);
   const setFilter = useSet(setRunsFilter$);
-  const membersLoadable = useLoadable(usageMembersAsync$);
+  const membersLoadable = useLoadable(orgMembers$);
 
   const members =
-    membersLoadable.state === "hasData" ? membersLoadable.data.members : [];
+    membersLoadable.state === "hasData" ? membersLoadable.data : [];
 
-  const uniqueMembers = members.map((m) => {
-    return { value: m.userId, label: m.email };
-  });
+  const memberOptions = [
+    { value: "all", label: "All members" },
+    ...members.map((m) => {
+      const name = [m.firstName, m.lastName].filter(Boolean).join(" ");
+      return { value: m.userId, label: name || m.email };
+    }),
+  ];
 
-  const handleMemberChange = (val: string) => {
-    setFilter({ userId: val === "all" ? "" : val });
+  const handleMemberChange = (value: string) => {
+    setFilter({ userId: value === "all" ? "" : value });
   };
 
   return (
     <div className="flex flex-wrap items-center gap-2 mb-4">
       <Select value={memberFilter ?? "all"} onValueChange={handleMemberChange}>
-        <SelectTrigger className="h-8 w-[180px] text-xs">
-          <SelectValue placeholder="All members" />
+        <SelectTrigger
+          aria-label="Member filter"
+          className="zero-btn-morandi h-9 w-auto gap-1.5 rounded-lg px-3.5 text-sm font-medium"
+        >
+          <IconUsers size={14} stroke={1.5} className="shrink-0" />
+          <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="all">All members</SelectItem>
-          {uniqueMembers.map((m) => {
+          {memberOptions.map((opt) => {
             return (
-              <SelectItem key={m.value} value={m.value}>
-                {m.label}
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
               </SelectItem>
             );
           })}
@@ -118,27 +89,17 @@ function RunRow({ run }: { run: UsageRun }) {
       <td className="px-3 py-2.5 text-foreground truncate max-w-[140px]">
         {run.agentName ?? "-"}
       </td>
-      <td className="px-3 py-2.5 text-foreground truncate max-w-[160px]">
-        {run.memberEmail}
-      </td>
-      <td className="px-3 py-2.5 text-foreground text-xs truncate max-w-[100px]">
-        {run.model}
-      </td>
-      <td className="px-3 py-2.5">
-        <StatusBadge status={run.status} />
-      </td>
-      <td className="px-3 py-2.5 text-right tabular-nums text-foreground">
-        {formatDuration(run.durationMs)}
-      </td>
-      <td className="px-3 py-2.5 text-right tabular-nums text-muted-foreground text-xs">
-        <span title="Input">{formatNumber(run.inputTokens)}</span>
-        {" / "}
-        <span title="Output">{formatNumber(run.outputTokens)}</span>
-        {" / "}
-        <span title="Cache">{formatNumber(run.cacheTokens)}</span>
+      <td
+        className="px-3 py-2.5 text-foreground text-xs truncate max-w-[240px]"
+        title={run.prompt}
+      >
+        {run.prompt}
       </td>
       <td className="px-3 py-2.5 text-right tabular-nums font-medium text-foreground">
         {formatNumber(run.creditsCharged)}
+      </td>
+      <td className="px-3 py-2.5 text-foreground truncate max-w-[160px]">
+        {run.memberEmail}
       </td>
       <td className="px-3 py-2.5 text-right text-xs text-muted-foreground whitespace-nowrap">
         {formatTime(run.createdAt)}
@@ -147,64 +108,22 @@ function RunRow({ run }: { run: UsageRun }) {
   );
 }
 
-function Pagination({
-  page,
-  pageSize,
-  total,
-}: {
-  page: number;
-  pageSize: number;
-  total: number;
-}) {
-  const setPage = useSet(setRunsPage$);
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
-  const from = (page - 1) * pageSize + 1;
-  const to = Math.min(page * pageSize, total);
-
-  return (
-    <div className="flex items-center justify-between pt-3 px-1">
-      <span className="text-xs text-muted-foreground">
-        {total > 0 ? `${from}–${to} of ${total}` : "No records"}
-      </span>
-      <div className="flex items-center gap-1">
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 text-xs"
-          disabled={page <= 1}
-          onClick={() => {
-            setPage(page - 1);
-          }}
-        >
-          Previous
-        </Button>
-        <span className="text-xs text-muted-foreground px-2">
-          {page} / {totalPages}
-        </span>
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-7 text-xs"
-          disabled={page >= totalPages}
-          onClick={() => {
-            setPage(page + 1);
-          }}
-        >
-          Next
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 // --- Main component ---
 
 export function RunsTab() {
   const loadable = useLoadable(usageRunsAsync$);
   const page = useGet(runsPage$);
+  const pageSize = useGet(runsPageSize$);
+  const setPage = useSet(setRunsPage$);
+  const setPageSize = useSet(setRunsPageSize$);
 
   const isLoading = loadable.state === "loading";
   const data = loadable.state === "hasData" ? loadable.data : null;
+
+  const total = data?.pagination.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const hasNext = page < totalPages;
+  const hasPrev = page > 1;
 
   return (
     <div>
@@ -228,22 +147,13 @@ export function RunsTab() {
                     Agent
                   </th>
                   <th className="px-3 py-2.5 text-left font-medium text-muted-foreground">
-                    Member
-                  </th>
-                  <th className="px-3 py-2.5 text-left font-medium text-muted-foreground">
-                    Model
-                  </th>
-                  <th className="px-3 py-2.5 text-left font-medium text-muted-foreground">
-                    Status
-                  </th>
-                  <th className="px-3 py-2.5 text-right font-medium text-muted-foreground">
-                    Duration
-                  </th>
-                  <th className="px-3 py-2.5 text-right font-medium text-muted-foreground">
-                    Tokens (I/O/C)
+                    Prompt
                   </th>
                   <th className="px-3 py-2.5 text-right font-medium text-muted-foreground">
                     Credits
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-medium text-muted-foreground">
+                    Member
                   </th>
                   <th className="px-3 py-2.5 text-right font-medium text-muted-foreground">
                     Time
@@ -257,13 +167,36 @@ export function RunsTab() {
               </tbody>
             </table>
           </div>
-          <div className="border-t border-border px-3 py-2">
-            <Pagination
-              page={page}
-              pageSize={data.pagination.pageSize}
-              total={data.pagination.total}
-            />
-          </div>
+        </div>
+      )}
+
+      {(totalPages > 1 || pageSize !== 20) && (
+        <div className="pt-3">
+          <Pagination
+            currentPage={page}
+            totalPages={totalPages}
+            rowsPerPage={pageSize}
+            hasNext={hasNext}
+            hasPrev={hasPrev}
+            isLoading={isLoading}
+            labelClassName="font-normal text-muted-foreground"
+            buttonClassName="bg-transparent border-border/70"
+            onNextPage={() => {
+              setPage(page + 1);
+            }}
+            onPrevPage={() => {
+              setPage(page - 1);
+            }}
+            onForwardTwoPages={() => {
+              setPage(Math.min(totalPages, page + 2));
+            }}
+            onBackTwoPages={() => {
+              setPage(Math.max(1, page - 2));
+            }}
+            onRowsPerPageChange={(limit) => {
+              setPageSize(limit);
+            }}
+          />
         </div>
       )}
     </div>

--- a/turbo/apps/platform/src/views/usage-page/components/runs-tab.tsx
+++ b/turbo/apps/platform/src/views/usage-page/components/runs-tab.tsx
@@ -1,0 +1,271 @@
+import { useLoadable, useGet, useSet } from "ccstate-react";
+import {
+  usageRunsAsync$,
+  runsPage$,
+  runsMemberFilter$,
+  setRunsPage$,
+  setRunsFilter$,
+  usageMembersAsync$,
+} from "../../../signals/usage-page/usage-signals.ts";
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@vm0/ui";
+import type { UsageRun } from "@vm0/core";
+
+// --- Helpers ---
+
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) {
+    return "-";
+  }
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  return `${minutes}m ${remaining}s`;
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+const STATUS_STYLES = {
+  completed: "bg-emerald-500/10 text-emerald-600",
+  failed: "bg-red-500/10 text-red-600",
+  running: "bg-blue-500/10 text-blue-600",
+  timeout: "bg-amber-500/10 text-amber-600",
+  cancelled: "bg-gray-500/10 text-gray-500",
+  queued: "bg-gray-500/10 text-gray-500",
+  pending: "bg-gray-500/10 text-gray-500",
+} as const;
+
+function StatusBadge({ status }: { status: string }) {
+  const style =
+    (STATUS_STYLES as Record<string, string>)[status] ??
+    "bg-gray-500/10 text-gray-500";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${style}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+// --- Filters ---
+
+function RunsFilters() {
+  const memberFilter = useGet(runsMemberFilter$);
+  const setFilter = useSet(setRunsFilter$);
+  const membersLoadable = useLoadable(usageMembersAsync$);
+
+  const members =
+    membersLoadable.state === "hasData" ? membersLoadable.data.members : [];
+
+  const uniqueMembers = members.map((m) => {
+    return { value: m.userId, label: m.email };
+  });
+
+  const handleMemberChange = (val: string) => {
+    setFilter({ userId: val === "all" ? "" : val });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-4">
+      <Select value={memberFilter ?? "all"} onValueChange={handleMemberChange}>
+        <SelectTrigger className="h-8 w-[180px] text-xs">
+          <SelectValue placeholder="All members" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All members</SelectItem>
+          {uniqueMembers.map((m) => {
+            return (
+              <SelectItem key={m.value} value={m.value}>
+                {m.label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+// --- Table ---
+
+function RunRow({ run }: { run: UsageRun }) {
+  return (
+    <tr className="border-b border-border last:border-0 hover:bg-muted/10">
+      <td className="px-3 py-2.5 text-foreground truncate max-w-[140px]">
+        {run.agentName ?? "-"}
+      </td>
+      <td className="px-3 py-2.5 text-foreground truncate max-w-[160px]">
+        {run.memberEmail}
+      </td>
+      <td className="px-3 py-2.5 text-foreground text-xs truncate max-w-[100px]">
+        {run.model}
+      </td>
+      <td className="px-3 py-2.5">
+        <StatusBadge status={run.status} />
+      </td>
+      <td className="px-3 py-2.5 text-right tabular-nums text-foreground">
+        {formatDuration(run.durationMs)}
+      </td>
+      <td className="px-3 py-2.5 text-right tabular-nums text-muted-foreground text-xs">
+        <span title="Input">{formatNumber(run.inputTokens)}</span>
+        {" / "}
+        <span title="Output">{formatNumber(run.outputTokens)}</span>
+        {" / "}
+        <span title="Cache">{formatNumber(run.cacheTokens)}</span>
+      </td>
+      <td className="px-3 py-2.5 text-right tabular-nums font-medium text-foreground">
+        {formatNumber(run.creditsCharged)}
+      </td>
+      <td className="px-3 py-2.5 text-right text-xs text-muted-foreground whitespace-nowrap">
+        {formatTime(run.createdAt)}
+      </td>
+    </tr>
+  );
+}
+
+function Pagination({
+  page,
+  pageSize,
+  total,
+}: {
+  page: number;
+  pageSize: number;
+  total: number;
+}) {
+  const setPage = useSet(setRunsPage$);
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const from = (page - 1) * pageSize + 1;
+  const to = Math.min(page * pageSize, total);
+
+  return (
+    <div className="flex items-center justify-between pt-3 px-1">
+      <span className="text-xs text-muted-foreground">
+        {total > 0 ? `${from}–${to} of ${total}` : "No records"}
+      </span>
+      <div className="flex items-center gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          disabled={page <= 1}
+          onClick={() => {
+            setPage(page - 1);
+          }}
+        >
+          Previous
+        </Button>
+        <span className="text-xs text-muted-foreground px-2">
+          {page} / {totalPages}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          disabled={page >= totalPages}
+          onClick={() => {
+            setPage(page + 1);
+          }}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// --- Main component ---
+
+export function RunsTab() {
+  const loadable = useLoadable(usageRunsAsync$);
+  const page = useGet(runsPage$);
+
+  const isLoading = loadable.state === "loading";
+  const data = loadable.state === "hasData" ? loadable.data : null;
+
+  return (
+    <div>
+      <RunsFilters />
+
+      {isLoading ? (
+        <div className="zero-card h-64 animate-pulse bg-muted/20" />
+      ) : !data || data.runs.length === 0 ? (
+        <div className="zero-card flex items-center justify-center p-12">
+          <p className="text-sm text-muted-foreground">
+            No run records found for the selected filters.
+          </p>
+        </div>
+      ) : (
+        <div className="zero-card overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border bg-muted/30">
+                  <th className="px-3 py-2.5 text-left font-medium text-muted-foreground">
+                    Agent
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-medium text-muted-foreground">
+                    Member
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-medium text-muted-foreground">
+                    Model
+                  </th>
+                  <th className="px-3 py-2.5 text-left font-medium text-muted-foreground">
+                    Status
+                  </th>
+                  <th className="px-3 py-2.5 text-right font-medium text-muted-foreground">
+                    Duration
+                  </th>
+                  <th className="px-3 py-2.5 text-right font-medium text-muted-foreground">
+                    Tokens (I/O/C)
+                  </th>
+                  <th className="px-3 py-2.5 text-right font-medium text-muted-foreground">
+                    Credits
+                  </th>
+                  <th className="px-3 py-2.5 text-right font-medium text-muted-foreground">
+                    Time
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.runs.map((run) => {
+                  return <RunRow key={run.runId} run={run} />;
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div className="border-t border-border px-3 py-2">
+            <Pagination
+              page={page}
+              pageSize={data.pagination.pageSize}
+              total={data.pagination.total}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/turbo/apps/platform/src/views/usage-page/usage-page.tsx
+++ b/turbo/apps/platform/src/views/usage-page/usage-page.tsx
@@ -1,5 +1,14 @@
-import { useLoadable } from "ccstate-react";
-import { usageMembersAsync$ } from "../../signals/usage-page/usage-signals.ts";
+import { useLoadable, useGet, useSet } from "ccstate-react";
+import {
+  usageMembersAsync$,
+  usageTab$,
+  setUsageTab$,
+  type UsageTab,
+} from "../../signals/usage-page/usage-signals.ts";
+import { isOrgAdmin$ } from "../../signals/org.ts";
+import { Tabs, TabsList, TabsTrigger } from "@vm0/ui";
+import { CreditsChart } from "./components/credits-chart.tsx";
+import { RunsTab } from "./components/runs-tab.tsx";
 
 function formatNumber(n: number): string {
   return n.toLocaleString();
@@ -33,7 +42,166 @@ function EmptyState({ message, testId }: { message: string; testId: string }) {
   );
 }
 
-export function UsagePage() {
+function MembersTable() {
+  const loadable = useLoadable(usageMembersAsync$);
+
+  const isLoading = loadable.state === "loading";
+  const hasError = loadable.state === "hasError";
+  const data = loadable.state === "hasData" ? loadable.data : null;
+
+  if (isLoading) {
+    return <UsageSkeleton />;
+  }
+  if (hasError) {
+    return (
+      <EmptyState
+        message="Failed to load usage data. Please try again later."
+        testId="usage-page-error"
+      />
+    );
+  }
+  if (!data?.period) {
+    return (
+      <EmptyState
+        message="No active billing period. Usage tracking is available for paid plans."
+        testId="usage-page-no-period"
+      />
+    );
+  }
+  if (data.members.length === 0) {
+    return (
+      <EmptyState
+        message="No usage recorded in this billing period."
+        testId="usage-page-no-members"
+      />
+    );
+  }
+
+  return (
+    <div className="zero-card overflow-hidden">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border bg-muted/30">
+            <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+              Member
+            </th>
+            <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+              Input Tokens
+            </th>
+            <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+              Output Tokens
+            </th>
+            <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+              Cache Tokens
+            </th>
+            <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+              Credits
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.members.map((member) => {
+            return (
+              <tr
+                key={member.userId}
+                className="border-b border-border last:border-0 hover:bg-muted/10"
+              >
+                <td className="px-4 py-3 text-foreground">{member.email}</td>
+                <td className="px-4 py-3 text-right tabular-nums text-foreground">
+                  {formatNumber(member.inputTokens)}
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums text-foreground">
+                  {formatNumber(member.outputTokens)}
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums text-foreground">
+                  {formatNumber(
+                    member.cacheReadInputTokens +
+                      member.cacheCreationInputTokens,
+                  )}
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums font-medium text-foreground">
+                  {formatNumber(member.creditsCharged)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function OverviewTab() {
+  return (
+    <div className="flex flex-col gap-6">
+      <CreditsChart />
+      <MembersTable />
+    </div>
+  );
+}
+
+function AdminUsagePage() {
+  const tab = useGet(usageTab$);
+  const setTab = useSet(setUsageTab$);
+  const loadable = useLoadable(usageMembersAsync$);
+  const data = loadable.state === "hasData" ? loadable.data : null;
+
+  const handleTabChange = (value: string) => {
+    setTab(value as UsageTab);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col min-h-0">
+      <header className="shrink-0 px-4 sm:px-6 pt-10 pb-3">
+        <div className="mx-auto max-w-[900px]">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">
+            Usage
+          </h1>
+          {data?.period ? (
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              {formatDate(data.period.start)} &ndash;{" "}
+              {formatDate(data.period.end)}
+            </p>
+          ) : (
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              Per-member credit consumption in the current billing period.
+            </p>
+          )}
+        </div>
+      </header>
+
+      <div className="shrink-0 px-4 sm:px-6 pb-4">
+        <div className="mx-auto max-w-[900px]">
+          <Tabs value={tab} onValueChange={handleTabChange}>
+            <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
+              <TabsTrigger
+                value="overview"
+                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
+              >
+                Overview
+              </TabsTrigger>
+              <TabsTrigger
+                value="runs"
+                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
+              >
+                Runs
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
+      </div>
+
+      <main className="flex-1 overflow-auto px-4 sm:px-6 pt-0 pb-8">
+        <div className="mx-auto max-w-[900px]">
+          {tab === "overview" && <OverviewTab />}
+          {tab === "runs" && <RunsTab />}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function MemberUsagePage() {
   const loadable = useLoadable(usageMembersAsync$);
 
   const isLoading = loadable.state === "loading";
@@ -79,61 +247,22 @@ export function UsagePage() {
               testId="usage-page-no-members"
             />
           ) : (
-            <div className="zero-card overflow-hidden">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-border bg-muted/30">
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Member
-                    </th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">
-                      Input Tokens
-                    </th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">
-                      Output Tokens
-                    </th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">
-                      Cache Tokens
-                    </th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">
-                      Credits
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.members.map((member) => {
-                    return (
-                      <tr
-                        key={member.userId}
-                        className="border-b border-border last:border-0 hover:bg-muted/10"
-                      >
-                        <td className="px-4 py-3 text-foreground">
-                          {member.email}
-                        </td>
-                        <td className="px-4 py-3 text-right tabular-nums text-foreground">
-                          {formatNumber(member.inputTokens)}
-                        </td>
-                        <td className="px-4 py-3 text-right tabular-nums text-foreground">
-                          {formatNumber(member.outputTokens)}
-                        </td>
-                        <td className="px-4 py-3 text-right tabular-nums text-foreground">
-                          {formatNumber(
-                            member.cacheReadInputTokens +
-                              member.cacheCreationInputTokens,
-                          )}
-                        </td>
-                        <td className="px-4 py-3 text-right tabular-nums font-medium text-foreground">
-                          {formatNumber(member.creditsCharged)}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+            <MembersTable />
           )}
         </div>
       </main>
     </div>
   );
+}
+
+export function UsagePage() {
+  const adminLoadable = useLoadable(isOrgAdmin$);
+  const isAdmin =
+    adminLoadable.state === "hasData" ? adminLoadable.data : false;
+
+  if (isAdmin) {
+    return <AdminUsagePage />;
+  }
+
+  return <MemberUsagePage />;
 }

--- a/turbo/apps/platform/src/views/usage-page/usage-page.tsx
+++ b/turbo/apps/platform/src/views/usage-page/usage-page.tsx
@@ -1,14 +1,5 @@
-import { useLoadable, useGet, useSet } from "ccstate-react";
-import {
-  usageMembersAsync$,
-  usageTab$,
-  setUsageTab$,
-  type UsageTab,
-} from "../../signals/usage-page/usage-signals.ts";
-import { isOrgAdmin$ } from "../../signals/org.ts";
-import { Tabs, TabsList, TabsTrigger } from "@vm0/ui";
-import { CreditsChart } from "./components/credits-chart.tsx";
-import { RunsTab } from "./components/runs-tab.tsx";
+import { useLoadable } from "ccstate-react";
+import { usageMembersAsync$ } from "../../signals/usage-page/usage-signals.ts";
 
 function formatNumber(n: number): string {
   return n.toLocaleString();
@@ -42,166 +33,7 @@ function EmptyState({ message, testId }: { message: string; testId: string }) {
   );
 }
 
-function MembersTable() {
-  const loadable = useLoadable(usageMembersAsync$);
-
-  const isLoading = loadable.state === "loading";
-  const hasError = loadable.state === "hasError";
-  const data = loadable.state === "hasData" ? loadable.data : null;
-
-  if (isLoading) {
-    return <UsageSkeleton />;
-  }
-  if (hasError) {
-    return (
-      <EmptyState
-        message="Failed to load usage data. Please try again later."
-        testId="usage-page-error"
-      />
-    );
-  }
-  if (!data?.period) {
-    return (
-      <EmptyState
-        message="No active billing period. Usage tracking is available for paid plans."
-        testId="usage-page-no-period"
-      />
-    );
-  }
-  if (data.members.length === 0) {
-    return (
-      <EmptyState
-        message="No usage recorded in this billing period."
-        testId="usage-page-no-members"
-      />
-    );
-  }
-
-  return (
-    <div className="zero-card overflow-hidden">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-border bg-muted/30">
-            <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-              Member
-            </th>
-            <th className="px-4 py-3 text-right font-medium text-muted-foreground">
-              Input Tokens
-            </th>
-            <th className="px-4 py-3 text-right font-medium text-muted-foreground">
-              Output Tokens
-            </th>
-            <th className="px-4 py-3 text-right font-medium text-muted-foreground">
-              Cache Tokens
-            </th>
-            <th className="px-4 py-3 text-right font-medium text-muted-foreground">
-              Credits
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {data.members.map((member) => {
-            return (
-              <tr
-                key={member.userId}
-                className="border-b border-border last:border-0 hover:bg-muted/10"
-              >
-                <td className="px-4 py-3 text-foreground">{member.email}</td>
-                <td className="px-4 py-3 text-right tabular-nums text-foreground">
-                  {formatNumber(member.inputTokens)}
-                </td>
-                <td className="px-4 py-3 text-right tabular-nums text-foreground">
-                  {formatNumber(member.outputTokens)}
-                </td>
-                <td className="px-4 py-3 text-right tabular-nums text-foreground">
-                  {formatNumber(
-                    member.cacheReadInputTokens +
-                      member.cacheCreationInputTokens,
-                  )}
-                </td>
-                <td className="px-4 py-3 text-right tabular-nums font-medium text-foreground">
-                  {formatNumber(member.creditsCharged)}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-function OverviewTab() {
-  return (
-    <div className="flex flex-col gap-6">
-      <CreditsChart />
-      <MembersTable />
-    </div>
-  );
-}
-
-function AdminUsagePage() {
-  const tab = useGet(usageTab$);
-  const setTab = useSet(setUsageTab$);
-  const loadable = useLoadable(usageMembersAsync$);
-  const data = loadable.state === "hasData" ? loadable.data : null;
-
-  const handleTabChange = (value: string) => {
-    setTab(value as UsageTab);
-  };
-
-  return (
-    <div className="flex flex-1 flex-col min-h-0">
-      <header className="shrink-0 px-4 sm:px-6 pt-10 pb-3">
-        <div className="mx-auto max-w-[900px]">
-          <h1 className="text-xl font-semibold tracking-tight text-foreground">
-            Usage
-          </h1>
-          {data?.period ? (
-            <p className="mt-0.5 text-sm text-muted-foreground">
-              {formatDate(data.period.start)} &ndash;{" "}
-              {formatDate(data.period.end)}
-            </p>
-          ) : (
-            <p className="mt-0.5 text-sm text-muted-foreground">
-              Per-member credit consumption in the current billing period.
-            </p>
-          )}
-        </div>
-      </header>
-
-      <div className="shrink-0 px-4 sm:px-6 pb-4">
-        <div className="mx-auto max-w-[900px]">
-          <Tabs value={tab} onValueChange={handleTabChange}>
-            <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
-              <TabsTrigger
-                value="overview"
-                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
-              >
-                Overview
-              </TabsTrigger>
-              <TabsTrigger
-                value="runs"
-                className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
-              >
-                Runs
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-        </div>
-      </div>
-
-      <main className="flex-1 overflow-auto px-4 sm:px-6 pt-0 pb-8">
-        <div className="mx-auto max-w-[900px]">
-          {tab === "overview" && <OverviewTab />}
-          {tab === "runs" && <RunsTab />}
-        </div>
-      </main>
-    </div>
-  );
-}
-
-function MemberUsagePage() {
+export function UsagePage() {
   const loadable = useLoadable(usageMembersAsync$);
 
   const isLoading = loadable.state === "loading";
@@ -247,22 +79,61 @@ function MemberUsagePage() {
               testId="usage-page-no-members"
             />
           ) : (
-            <MembersTable />
+            <div className="zero-card overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/30">
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Member
+                    </th>
+                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+                      Input Tokens
+                    </th>
+                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+                      Output Tokens
+                    </th>
+                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+                      Cache Tokens
+                    </th>
+                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+                      Credits
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.members.map((member) => {
+                    return (
+                      <tr
+                        key={member.userId}
+                        className="border-b border-border last:border-0 hover:bg-muted/10"
+                      >
+                        <td className="px-4 py-3 text-foreground">
+                          {member.email}
+                        </td>
+                        <td className="px-4 py-3 text-right tabular-nums text-foreground">
+                          {formatNumber(member.inputTokens)}
+                        </td>
+                        <td className="px-4 py-3 text-right tabular-nums text-foreground">
+                          {formatNumber(member.outputTokens)}
+                        </td>
+                        <td className="px-4 py-3 text-right tabular-nums text-foreground">
+                          {formatNumber(
+                            member.cacheReadInputTokens +
+                              member.cacheCreationInputTokens,
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-right tabular-nums font-medium text-foreground">
+                          {formatNumber(member.creditsCharged)}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
           )}
         </div>
       </main>
     </div>
   );
-}
-
-export function UsagePage() {
-  const adminLoadable = useLoadable(isOrgAdmin$);
-  const isAdmin =
-    adminLoadable.state === "hasData" ? adminLoadable.data : false;
-
-  if (isAdmin) {
-    return <AdminUsagePage />;
-  }
-
-  return <MemberUsagePage />;
 }

--- a/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
+++ b/turbo/apps/platform/src/views/zero-page/components/org-manage/org-usage-tab.tsx
@@ -1,15 +1,29 @@
-// TODO(#8609): split large components to comply with max-lines-per-function (128)
-// oxlint-disable max-lines-per-function
-import { useGet, useLoadable, useSet } from "ccstate-react";
+import { useGet, useLoadable, useSet, useLastResolved } from "ccstate-react";
 import { useLoadableSet } from "ccstate-react/experimental";
-import type { OrgMember, MemberUsage } from "@vm0/core";
+import { FeatureSwitchKey, type OrgMember, type MemberUsage } from "@vm0/core";
 import { IconUsers } from "@tabler/icons-react";
-import { Input, Popover, PopoverAnchor, PopoverContent } from "@vm0/ui";
+import { featureSwitch$ } from "../../../../signals/external/feature-switch.ts";
+import {
+  Input,
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "@vm0/ui";
 import { toast } from "@vm0/ui/components/ui/sonner";
 import { pageSignal$ } from "../../../../signals/page-signal.ts";
-import { usageMembersAsync$ } from "../../../../signals/usage-page/usage-signals.ts";
+import {
+  usageMembersAsync$,
+  usageTab$,
+  setUsageTab$,
+  type UsageTab,
+} from "../../../../signals/usage-page/usage-signals.ts";
 import { orgMembers$ } from "../../../../signals/external/org-members.ts";
 import { isOrgAdmin$ } from "../../../../signals/org.ts";
+import { CreditsChart } from "../../../usage-page/components/credits-chart.tsx";
+import { RunsTab } from "../../../usage-page/components/runs-tab.tsx";
 import {
   billingStatusAsync$,
   apiTierToBillingTier,
@@ -286,10 +300,10 @@ function LoadingSkeleton() {
 }
 
 // ---------------------------------------------------------------------------
-// Main component
+// Overview section
 // ---------------------------------------------------------------------------
 
-export function OrgUsageTab() {
+function OverviewSection() {
   const usageLoadable = useLoadable(usageMembersAsync$);
   const membersLoadable = useLoadable(orgMembers$);
   const adminLoadable = useLoadable(isOrgAdmin$);
@@ -398,73 +412,144 @@ export function OrgUsageTab() {
             </p>
           </div>
         ) : (
-          <div className="overflow-hidden rounded-xl bg-card zero-border">
-            {/* Header */}
-            <div className="grid grid-cols-[1fr_7rem_6rem_5.5rem] gap-x-4 items-center px-5 py-2.5 text-[13px] font-medium text-foreground">
-              <span>Member</span>
-              <span>Used</span>
-              <span>Remaining</span>
-              <span>Limit cap</span>
-            </div>
-            {members.map((member) => {
-              const orgMember = memberMap.get(member.userId);
-              const name = orgMember ? displayName(orgMember) : "";
-              const label = name || member.email;
-              const initial = label.charAt(0).toUpperCase();
-              const remaining =
-                member.creditCap !== null
-                  ? Math.max(0, member.creditCap - member.creditsCharged)
-                  : null;
-
-              return (
-                <div key={member.userId}>
-                  <div className="h-0 zero-border-t mx-5" />
-                  <div className="grid grid-cols-[1fr_7rem_6rem_5.5rem] gap-x-4 items-center px-5 py-3">
-                    <div className="flex items-center gap-3 min-w-0">
-                      <MemberAvatar
-                        imageUrl={orgMember?.imageUrl ?? ""}
-                        initial={initial}
-                        name={label}
-                      />
-                      <div className="min-w-0">
-                        {name ? (
-                          <>
-                            <p className="truncate text-sm font-medium text-foreground">
-                              {name}
-                            </p>
-                            <p className="truncate text-[13px] text-muted-foreground">
-                              {member.email}
-                            </p>
-                          </>
-                        ) : (
-                          <p className="truncate text-sm font-medium text-foreground">
-                            {member.email}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                    <span className="text-[13px] tabular-nums text-foreground">
-                      {member.creditsCharged.toLocaleString()}
-                    </span>
-                    <span className="text-[13px] tabular-nums text-muted-foreground/50">
-                      {remaining !== null ? remaining.toLocaleString() : "–"}
-                    </span>
-                    {isAdmin ? (
-                      <InlineCapInput member={member} />
-                    ) : (
-                      <span className="text-[13px] tabular-nums text-muted-foreground">
-                        {member.creditCap !== null
-                          ? member.creditCap.toLocaleString()
-                          : "—"}
-                      </span>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
+          <MembersTable
+            members={members}
+            memberMap={memberMap}
+            isAdmin={isAdmin}
+          />
         )}
       </section>
+    </div>
+  );
+}
+
+function MembersTable({
+  members,
+  memberMap,
+  isAdmin,
+}: {
+  members: MemberUsage[];
+  memberMap: Map<string, OrgMember>;
+  isAdmin: boolean;
+}) {
+  return (
+    <div className="overflow-hidden rounded-xl bg-card zero-border">
+      {/* Header */}
+      <div className="grid grid-cols-[1fr_7rem_6rem_5.5rem] gap-x-4 items-center px-5 py-2.5 text-[13px] font-medium text-foreground">
+        <span>Member</span>
+        <span>Used</span>
+        <span>Remaining</span>
+        <span>Limit cap</span>
+      </div>
+      {members.map((member) => {
+        const orgMember = memberMap.get(member.userId);
+        const name = orgMember ? displayName(orgMember) : "";
+        const label = name || member.email;
+        const initial = label.charAt(0).toUpperCase();
+        const remaining =
+          member.creditCap !== null
+            ? Math.max(0, member.creditCap - member.creditsCharged)
+            : null;
+
+        return (
+          <div key={member.userId}>
+            <div className="h-0 zero-border-t mx-5" />
+            <div className="grid grid-cols-[1fr_7rem_6rem_5.5rem] gap-x-4 items-center px-5 py-3">
+              <div className="flex items-center gap-3 min-w-0">
+                <MemberAvatar
+                  imageUrl={orgMember?.imageUrl ?? ""}
+                  initial={initial}
+                  name={label}
+                />
+                <div className="min-w-0">
+                  {name ? (
+                    <>
+                      <p className="truncate text-sm font-medium text-foreground">
+                        {name}
+                      </p>
+                      <p className="truncate text-[13px] text-muted-foreground">
+                        {member.email}
+                      </p>
+                    </>
+                  ) : (
+                    <p className="truncate text-sm font-medium text-foreground">
+                      {member.email}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <span className="text-[13px] tabular-nums text-foreground">
+                {member.creditsCharged.toLocaleString()}
+              </span>
+              <span className="text-[13px] tabular-nums text-muted-foreground/50">
+                {remaining !== null ? remaining.toLocaleString() : "–"}
+              </span>
+              {isAdmin ? (
+                <InlineCapInput member={member} />
+              ) : (
+                <span className="text-[13px] tabular-nums text-muted-foreground">
+                  {member.creditCap !== null
+                    ? member.creditCap.toLocaleString()
+                    : "—"}
+                </span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function OrgUsageTab() {
+  const adminLoadable = useLoadable(isOrgAdmin$);
+  const isAdmin =
+    adminLoadable.state === "hasData" ? adminLoadable.data : false;
+
+  const tab = useGet(usageTab$);
+  const setTab = useSet(setUsageTab$);
+  const handleTabChange = (value: string) => {
+    setTab(value as UsageTab);
+  };
+
+  const features = useLastResolved(featureSwitch$);
+  const analyticsEnabled = features?.[FeatureSwitchKey.UsageAnalytics] ?? false;
+
+  if (!isAdmin || !analyticsEnabled) {
+    return <OverviewSection />;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Tabs value={tab} onValueChange={handleTabChange}>
+        <TabsList className="zero-tabs h-9 gap-1 px-1 py-1">
+          <TabsTrigger
+            value="overview"
+            className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
+          >
+            Overview
+          </TabsTrigger>
+          <TabsTrigger
+            value="daily"
+            className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
+          >
+            Daily
+          </TabsTrigger>
+          <TabsTrigger
+            value="runs"
+            className="gap-1.5 text-sm data-[state=active]:bg-background px-3"
+          >
+            Runs
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
+      {tab === "overview" && <OverviewSection />}
+      {tab === "daily" && <CreditsChart />}
+      {tab === "runs" && <RunsTab />}
     </div>
   );
 }

--- a/turbo/apps/web/app/api/zero/usage/daily/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/daily/__tests__/route.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  insertTestCreditUsage,
+  updateOrgStripeFields,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const stripeMocks = vi.hoisted(() => {
+  return {
+    subscriptionsRetrieve: vi.fn(),
+    subscriptionsUpdate: vi.fn(),
+    subscriptionsCancel: vi.fn(),
+    invoicesRetrieve: vi.fn(),
+    invoicesList: vi.fn(),
+    customersCreate: vi.fn(),
+    checkoutSessionsCreate: vi.fn(),
+    billingPortalSessionsCreate: vi.fn(),
+    constructEvent: vi.fn(),
+  };
+});
+
+vi.mock("stripe", () => {
+  return {
+    default: function MockStripe() {
+      return {
+        subscriptions: {
+          retrieve: stripeMocks.subscriptionsRetrieve,
+          update: stripeMocks.subscriptionsUpdate,
+          cancel: stripeMocks.subscriptionsCancel,
+        },
+        invoices: {
+          retrieve: stripeMocks.invoicesRetrieve,
+          list: stripeMocks.invoicesList,
+        },
+        customers: { create: stripeMocks.customersCreate },
+        checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+        billingPortal: {
+          sessions: { create: stripeMocks.billingPortalSessionsCreate },
+        },
+        webhooks: { constructEvent: stripeMocks.constructEvent },
+      };
+    },
+  };
+});
+
+import { GET } from "../route";
+
+const context = testContext();
+
+describe("GET /api/zero/usage/daily", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/daily",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    const { userId, orgId } = await context.user;
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/daily",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns empty result for free tier org", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/daily",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.period).toBeNull();
+    expect(data.daily).toEqual([]);
+    expect(data.dailyByMember).toEqual([]);
+  });
+
+  it("returns daily credit totals in total mode", async () => {
+    const { userId, orgId } = await context.user;
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus"),
+      stripeSubscriptionId: uniqueId("sub"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      tier: "pro",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      creditsCharged: 50,
+      status: "processed",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      creditsCharged: 100,
+      status: "processed",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/daily?mode=total",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.period).not.toBeNull();
+    expect(data.daily.length).toBeGreaterThanOrEqual(1);
+
+    // Both records are on the same day, so total should be 150
+    const totalCredits = data.daily.reduce(
+      (sum: number, d: { creditsCharged: number }) => {
+        return sum + d.creditsCharged;
+      },
+      0,
+    );
+    expect(totalCredits).toBe(150);
+  });
+
+  it("returns per-member breakdown in member mode", async () => {
+    const { orgId } = await context.user;
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus"),
+      stripeSubscriptionId: uniqueId("sub"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      tier: "pro",
+    });
+
+    const user1 = uniqueId("user-alpha");
+    const user2 = uniqueId("user-beta");
+
+    await insertTestCreditUsage(orgId, {
+      userId: user1,
+      creditsCharged: 50,
+      status: "processed",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId: user2,
+      creditsCharged: 100,
+      status: "processed",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/daily?mode=member",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.dailyByMember.length).toBeGreaterThanOrEqual(1);
+
+    // Check that members are present in the breakdown
+    const firstDay = data.dailyByMember[0];
+    expect(firstDay.members.length).toBe(2);
+  });
+
+  it("excludes pending records", async () => {
+    const { userId, orgId } = await context.user;
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus"),
+      stripeSubscriptionId: uniqueId("sub"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      tier: "pro",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      creditsCharged: 50,
+      status: "processed",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      creditsCharged: 999,
+      status: "pending",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/daily?mode=total",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    const totalCredits = data.daily.reduce(
+      (sum: number, d: { creditsCharged: number }) => {
+        return sum + d.creditsCharged;
+      },
+      0,
+    );
+    expect(totalCredits).toBe(50);
+  });
+});

--- a/turbo/apps/web/app/api/zero/usage/daily/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/daily/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   createTestRequest,
   insertTestCreditUsage,
+  setTestCreditUsageCreatedAt,
   updateOrgStripeFields,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
@@ -159,6 +160,62 @@ describe("GET /api/zero/usage/daily", () => {
     // Check that members are present in the breakdown
     const firstDay = data.dailyByMember[0];
     expect(firstDay.members.length).toBe(2);
+  });
+
+  it("filters by dateFrom and dateTo query params", async () => {
+    const { userId, orgId } = await context.user;
+    const periodEnd = new Date("2026-04-20T00:00:00Z");
+
+    await updateOrgStripeFields(orgId, {
+      stripeCustomerId: uniqueId("cus"),
+      stripeSubscriptionId: uniqueId("sub"),
+      subscriptionStatus: "active",
+      currentPeriodEnd: periodEnd,
+      tier: "pro",
+    });
+
+    // Insert three records, then back-date them to span a known range.
+    const oldId = await insertTestCreditUsage(orgId, {
+      userId,
+      creditsCharged: 10,
+      status: "processed",
+    });
+    const inRangeId = await insertTestCreditUsage(orgId, {
+      userId,
+      creditsCharged: 20,
+      status: "processed",
+    });
+    const newId = await insertTestCreditUsage(orgId, {
+      userId,
+      creditsCharged: 30,
+      status: "processed",
+    });
+
+    await setTestCreditUsageCreatedAt(oldId, new Date("2026-03-01T12:00:00Z"));
+    await setTestCreditUsageCreatedAt(
+      inRangeId,
+      new Date("2026-03-15T12:00:00Z"),
+    );
+    await setTestCreditUsageCreatedAt(newId, new Date("2026-04-01T12:00:00Z"));
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/daily?mode=total&dateFrom=2026-03-10T00:00:00Z&dateTo=2026-03-20T00:00:00Z",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    // Only the in-range record (creditsCharged=20) should be aggregated.
+    const totalCredits = data.daily.reduce(
+      (sum: number, d: { creditsCharged: number }) => {
+        return sum + d.creditsCharged;
+      },
+      0,
+    );
+    expect(totalCredits).toBe(20);
+    expect(data.daily.length).toBe(1);
+    expect(data.daily[0].date).toBe("2026-03-15");
   });
 
   it("excludes pending records", async () => {

--- a/turbo/apps/web/app/api/zero/usage/daily/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/daily/__tests__/route.test.ts
@@ -10,17 +10,12 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 
+// Only the subscriptions/invoices retrieve methods can be reached transitively
+// via getOrgBillingPeriod() when an org has a stripeSubscriptionId.
 const stripeMocks = vi.hoisted(() => {
   return {
     subscriptionsRetrieve: vi.fn(),
-    subscriptionsUpdate: vi.fn(),
-    subscriptionsCancel: vi.fn(),
     invoicesRetrieve: vi.fn(),
-    invoicesList: vi.fn(),
-    customersCreate: vi.fn(),
-    checkoutSessionsCreate: vi.fn(),
-    billingPortalSessionsCreate: vi.fn(),
-    constructEvent: vi.fn(),
   };
 });
 
@@ -28,21 +23,8 @@ vi.mock("stripe", () => {
   return {
     default: function MockStripe() {
       return {
-        subscriptions: {
-          retrieve: stripeMocks.subscriptionsRetrieve,
-          update: stripeMocks.subscriptionsUpdate,
-          cancel: stripeMocks.subscriptionsCancel,
-        },
-        invoices: {
-          retrieve: stripeMocks.invoicesRetrieve,
-          list: stripeMocks.invoicesList,
-        },
-        customers: { create: stripeMocks.customersCreate },
-        checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
-        billingPortal: {
-          sessions: { create: stripeMocks.billingPortalSessionsCreate },
-        },
-        webhooks: { constructEvent: stripeMocks.constructEvent },
+        subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+        invoices: { retrieve: stripeMocks.invoicesRetrieve },
       };
     },
   };

--- a/turbo/apps/web/app/api/zero/usage/daily/route.ts
+++ b/turbo/apps/web/app/api/zero/usage/daily/route.ts
@@ -1,0 +1,45 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroUsageDailyContract, createErrorResponse } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
+import { getDailyCredits } from "../../../../../src/lib/zero/billing/usage-service";
+
+const router = tsr.router(zeroUsageDailyContract, {
+  get: async ({ query, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const { org, member } = await resolveOrg(authCtx);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only org admins can view daily usage",
+      );
+    }
+
+    const response = await getDailyCredits(org.orgId, {
+      dateFrom: query.dateFrom,
+      dateTo: query.dateTo,
+      mode: query.mode,
+    });
+
+    return { status: 200 as const, body: response };
+  },
+});
+
+const handler = createHandler(zeroUsageDailyContract, router, {
+  errorHandler: createSafeErrorHandler("zero-usage-daily"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/app/api/zero/usage/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/runs/__tests__/route.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   createTestRequest,
   insertTestCreditUsage,
-  updateOrgStripeFields,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -10,17 +9,12 @@ import {
 } from "../../../../../../src/__tests__/test-helpers";
 import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
 
+// Only the subscriptions/invoices retrieve methods can be reached transitively
+// via getOrgBillingPeriod() when an org has a stripeSubscriptionId.
 const stripeMocks = vi.hoisted(() => {
   return {
     subscriptionsRetrieve: vi.fn(),
-    subscriptionsUpdate: vi.fn(),
-    subscriptionsCancel: vi.fn(),
     invoicesRetrieve: vi.fn(),
-    invoicesList: vi.fn(),
-    customersCreate: vi.fn(),
-    checkoutSessionsCreate: vi.fn(),
-    billingPortalSessionsCreate: vi.fn(),
-    constructEvent: vi.fn(),
   };
 });
 
@@ -28,21 +22,8 @@ vi.mock("stripe", () => {
   return {
     default: function MockStripe() {
       return {
-        subscriptions: {
-          retrieve: stripeMocks.subscriptionsRetrieve,
-          update: stripeMocks.subscriptionsUpdate,
-          cancel: stripeMocks.subscriptionsCancel,
-        },
-        invoices: {
-          retrieve: stripeMocks.invoicesRetrieve,
-          list: stripeMocks.invoicesList,
-        },
-        customers: { create: stripeMocks.customersCreate },
-        checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
-        billingPortal: {
-          sessions: { create: stripeMocks.billingPortalSessionsCreate },
-        },
-        webhooks: { constructEvent: stripeMocks.constructEvent },
+        subscriptions: { retrieve: stripeMocks.subscriptionsRetrieve },
+        invoices: { retrieve: stripeMocks.invoicesRetrieve },
       };
     },
   };
@@ -183,7 +164,7 @@ describe("GET /api/zero/usage/runs", () => {
     });
 
     const request = createTestRequest(
-      `http://localhost:3000/api/zero/usage/runs?userId=${user1}`,
+      `http://localhost:3000/api/zero/usage/runs?userIds=${user1}`,
     );
     const response = await GET(request);
 

--- a/turbo/apps/web/app/api/zero/usage/runs/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/usage/runs/__tests__/route.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  createTestRequest,
+  insertTestCreditUsage,
+  updateOrgStripeFields,
+} from "../../../../../../src/__tests__/api-test-helpers";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+
+const stripeMocks = vi.hoisted(() => {
+  return {
+    subscriptionsRetrieve: vi.fn(),
+    subscriptionsUpdate: vi.fn(),
+    subscriptionsCancel: vi.fn(),
+    invoicesRetrieve: vi.fn(),
+    invoicesList: vi.fn(),
+    customersCreate: vi.fn(),
+    checkoutSessionsCreate: vi.fn(),
+    billingPortalSessionsCreate: vi.fn(),
+    constructEvent: vi.fn(),
+  };
+});
+
+vi.mock("stripe", () => {
+  return {
+    default: function MockStripe() {
+      return {
+        subscriptions: {
+          retrieve: stripeMocks.subscriptionsRetrieve,
+          update: stripeMocks.subscriptionsUpdate,
+          cancel: stripeMocks.subscriptionsCancel,
+        },
+        invoices: {
+          retrieve: stripeMocks.invoicesRetrieve,
+          list: stripeMocks.invoicesList,
+        },
+        customers: { create: stripeMocks.customersCreate },
+        checkout: { sessions: { create: stripeMocks.checkoutSessionsCreate } },
+        billingPortal: {
+          sessions: { create: stripeMocks.billingPortalSessionsCreate },
+        },
+        webhooks: { constructEvent: stripeMocks.constructEvent },
+      };
+    },
+  };
+});
+
+import { GET } from "../route";
+
+const context = testContext();
+
+describe("GET /api/zero/usage/runs", () => {
+  beforeEach(async () => {
+    context.setupMocks();
+    await context.setupUser();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/runs",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    const { userId, orgId } = await context.user;
+    mockClerk({ userId, orgId, orgRole: "org:member" });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/runs",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns empty result when no runs with credit usage", async () => {
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/runs",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.runs).toEqual([]);
+    expect(data.pagination.total).toBe(0);
+  });
+
+  it("returns per-run records with credit totals", async () => {
+    const { userId, orgId } = await context.user;
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadInputTokens: 200,
+      cacheCreationInputTokens: 100,
+      creditsCharged: 50,
+      status: "processed",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      inputTokens: 2000,
+      outputTokens: 1000,
+      creditsCharged: 100,
+      status: "processed",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/runs",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    // Each insertTestCreditUsage creates a separate run
+    expect(data.runs).toHaveLength(2);
+    expect(data.pagination.total).toBe(2);
+
+    // Sorted by createdAt DESC — most recent first
+    expect(data.runs[0].creditsCharged).toBe(100);
+    expect(data.runs[1].creditsCharged).toBe(50);
+  });
+
+  it("paginates results correctly", async () => {
+    const { userId, orgId } = await context.user;
+
+    // Create 3 runs
+    for (let i = 0; i < 3; i++) {
+      await insertTestCreditUsage(orgId, {
+        userId,
+        creditsCharged: (i + 1) * 10,
+        status: "processed",
+      });
+    }
+
+    // Page 1 with pageSize=2
+    const request1 = createTestRequest(
+      "http://localhost:3000/api/zero/usage/runs?page=1&pageSize=2",
+    );
+    const response1 = await GET(request1);
+    const data1 = await response1.json();
+
+    expect(data1.runs).toHaveLength(2);
+    expect(data1.pagination.total).toBe(3);
+    expect(data1.pagination.page).toBe(1);
+    expect(data1.pagination.pageSize).toBe(2);
+
+    // Page 2
+    const request2 = createTestRequest(
+      "http://localhost:3000/api/zero/usage/runs?page=2&pageSize=2",
+    );
+    const response2 = await GET(request2);
+    const data2 = await response2.json();
+
+    expect(data2.runs).toHaveLength(1);
+    expect(data2.pagination.page).toBe(2);
+  });
+
+  it("filters by userId", async () => {
+    const { orgId } = await context.user;
+    const user1 = uniqueId("user-alpha");
+    const user2 = uniqueId("user-beta");
+
+    await insertTestCreditUsage(orgId, {
+      userId: user1,
+      creditsCharged: 50,
+      status: "processed",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId: user2,
+      creditsCharged: 100,
+      status: "processed",
+    });
+
+    const request = createTestRequest(
+      `http://localhost:3000/api/zero/usage/runs?userId=${user1}`,
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.runs).toHaveLength(1);
+    expect(data.runs[0].creditsCharged).toBe(50);
+  });
+
+  it("excludes runs with only pending credit usage", async () => {
+    const { userId, orgId } = await context.user;
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      creditsCharged: 50,
+      status: "processed",
+    });
+
+    await insertTestCreditUsage(orgId, {
+      userId,
+      creditsCharged: 0,
+      status: "pending",
+    });
+
+    const request = createTestRequest(
+      "http://localhost:3000/api/zero/usage/runs",
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    // Only the processed run should appear
+    expect(data.runs).toHaveLength(1);
+    expect(data.runs[0].creditsCharged).toBe(50);
+  });
+});

--- a/turbo/apps/web/app/api/zero/usage/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/usage/runs/route.ts
@@ -28,11 +28,20 @@ const router = tsr.router(zeroUsageRunsContract, {
       );
     }
 
+    const userIds = query.userIds
+      ? query.userIds
+          .split(",")
+          .map((s) => {
+            return s.trim();
+          })
+          .filter(Boolean)
+      : undefined;
+
     const response = await getUsageRuns(org.orgId, {
       page: query.page,
       pageSize: query.pageSize,
       agentId: query.agentId,
-      userId: query.userId,
+      userIds,
       dateFrom: query.dateFrom,
       dateTo: query.dateTo,
     });

--- a/turbo/apps/web/app/api/zero/usage/runs/route.ts
+++ b/turbo/apps/web/app/api/zero/usage/runs/route.ts
@@ -1,0 +1,48 @@
+import {
+  createHandler,
+  createSafeErrorHandler,
+  tsr,
+} from "../../../../../src/lib/ts-rest-handler";
+import { zeroUsageRunsContract, createErrorResponse } from "@vm0/core";
+import { initServices } from "../../../../../src/lib/init-services";
+import {
+  requireAuth,
+  isAuthError,
+} from "../../../../../src/lib/auth/require-auth";
+import { resolveOrg } from "../../../../../src/lib/zero/org/resolve-org";
+import { getUsageRuns } from "../../../../../src/lib/zero/billing/usage-service";
+
+const router = tsr.router(zeroUsageRunsContract, {
+  get: async ({ query, headers }) => {
+    initServices();
+
+    const authCtx = await requireAuth(headers.authorization);
+    if (isAuthError(authCtx)) return authCtx;
+
+    const { org, member } = await resolveOrg(authCtx);
+
+    if (member.role !== "admin") {
+      return createErrorResponse(
+        "FORBIDDEN",
+        "Only org admins can view run usage",
+      );
+    }
+
+    const response = await getUsageRuns(org.orgId, {
+      page: query.page,
+      pageSize: query.pageSize,
+      agentId: query.agentId,
+      userId: query.userId,
+      dateFrom: query.dateFrom,
+      dateTo: query.dateTo,
+    });
+
+    return { status: 200 as const, body: response };
+  },
+});
+
+const handler = createHandler(zeroUsageRunsContract, router, {
+  errorHandler: createSafeErrorHandler("zero-usage-runs"),
+});
+
+export { handler as GET };

--- a/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
+++ b/turbo/apps/web/src/__tests__/api-test-helpers/credits.ts
@@ -385,6 +385,21 @@ export async function findTestClientCreditUsagesByRunId(runId: string): Promise<
 }
 
 /**
+ * Back-date an existing credit_usage record's createdAt for testing
+ * date-range filtering.
+ */
+export async function setTestCreditUsageCreatedAt(
+  id: string,
+  createdAt: Date,
+): Promise<void> {
+  initServices();
+  await globalThis.services.db
+    .update(creditUsage)
+    .set({ createdAt })
+    .where(eq(creditUsage.id, id));
+}
+
+/**
  * Read a credit_usage record by ID.
  */
 export async function findTestCreditUsage(id: string): Promise<

--- a/turbo/apps/web/src/lib/zero/billing/usage-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-service.ts
@@ -80,50 +80,11 @@ export async function getUsageMembers(
     };
   }
 
-  // Resolve user emails from user_cache
+  // Resolve user emails
   const userIds = rows.map((r) => {
     return r.userId;
   });
-  const cachedUsers = await db
-    .select({ userId: userCache.userId, email: userCache.email })
-    .from(userCache)
-    .where(inArray(userCache.userId, userIds));
-
-  const emailMap = new Map(
-    cachedUsers.map((u) => {
-      return [u.userId, u.email];
-    }),
-  );
-
-  // Find missing users and fetch from Clerk
-  const missingIds = userIds.filter((id) => {
-    return !emailMap.has(id);
-  });
-  if (missingIds.length > 0) {
-    const client = await clerkClient();
-    const clerkUsers = await client.users.getUserList({
-      userId: missingIds,
-      limit: missingIds.length,
-    });
-
-    const now = new Date();
-    for (const user of clerkUsers.data) {
-      const primaryEmail = user.emailAddresses.find((e) => {
-        return e.id === user.primaryEmailAddressId;
-      });
-      const email = primaryEmail?.emailAddress ?? "unknown";
-      emailMap.set(user.id, email);
-
-      // Upsert into user_cache
-      await db
-        .insert(userCache)
-        .values({ userId: user.id, email, cachedAt: now })
-        .onConflictDoUpdate({
-          target: userCache.userId,
-          set: { email, cachedAt: now },
-        });
-    }
-  }
+  const emailMap = await resolveEmails(userIds);
 
   // Fetch credit caps for all members in one query
   const capRows = await db
@@ -175,7 +136,9 @@ export async function getUsageMembers(
  * Resolve emails for a set of user IDs using user_cache + Clerk fallback.
  */
 async function resolveEmails(userIds: string[]): Promise<Map<string, string>> {
-  if (userIds.length === 0) return new Map();
+  if (userIds.length === 0) {
+    return new Map();
+  }
 
   const db = globalThis.services.db;
   const cachedUsers = await db

--- a/turbo/apps/web/src/lib/zero/billing/usage-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-service.ts
@@ -1,4 +1,4 @@
-import { sql, and, eq, gte, lt, lte, inArray, desc, count } from "drizzle-orm";
+import { sql, and, eq, gte, lt, inArray, desc, count } from "drizzle-orm";
 import {
   type MemberUsage,
   type UsageMembersResponse,
@@ -401,7 +401,7 @@ export async function getUsageRuns(
     conditions.push(gte(agentRuns.createdAt, new Date(options.dateFrom)));
   }
   if (options.dateTo) {
-    conditions.push(lte(agentRuns.createdAt, new Date(options.dateTo)));
+    conditions.push(lt(agentRuns.createdAt, new Date(options.dateTo)));
   }
 
   // Count query

--- a/turbo/apps/web/src/lib/zero/billing/usage-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-service.ts
@@ -1,7 +1,19 @@
-import { sql, and, eq, gte, lt, inArray } from "drizzle-orm";
-import { type MemberUsage, type UsageMembersResponse } from "@vm0/core";
+import { sql, and, eq, gte, lt, lte, inArray, desc, count } from "drizzle-orm";
+import {
+  type MemberUsage,
+  type UsageMembersResponse,
+  type UsageDailyResponse,
+  type UsageRunsResponse,
+} from "@vm0/core";
 import { getOrgBillingPeriod } from "../org/org-metadata-service";
 import { creditUsage } from "../../../db/schema/credit-usage";
+import { agentRuns } from "../../../db/schema/agent-run";
+import { zeroRuns } from "../../../db/schema/zero-run";
+import {
+  agentComposes,
+  agentComposeVersions,
+} from "../../../db/schema/agent-compose";
+import { zeroAgents } from "../../../db/schema/zero-agent";
 import { userCache } from "../../../db/schema/user-cache";
 import { orgMembersMetadata } from "../../../db/schema/org-members-metadata";
 import { clerkClient } from "@clerk/nextjs/server";
@@ -156,5 +168,338 @@ export async function getUsageMembers(
       end: billingPeriod.end.toISOString(),
     },
     members,
+  };
+}
+
+/**
+ * Resolve emails for a set of user IDs using user_cache + Clerk fallback.
+ */
+async function resolveEmails(userIds: string[]): Promise<Map<string, string>> {
+  if (userIds.length === 0) return new Map();
+
+  const db = globalThis.services.db;
+  const cachedUsers = await db
+    .select({ userId: userCache.userId, email: userCache.email })
+    .from(userCache)
+    .where(inArray(userCache.userId, userIds));
+
+  const emailMap = new Map(
+    cachedUsers.map((u) => {
+      return [u.userId, u.email];
+    }),
+  );
+
+  const missingIds = userIds.filter((id) => {
+    return !emailMap.has(id);
+  });
+  if (missingIds.length > 0) {
+    const client = await clerkClient();
+    const clerkUsers = await client.users.getUserList({
+      userId: missingIds,
+      limit: missingIds.length,
+    });
+
+    const now = new Date();
+    for (const user of clerkUsers.data) {
+      const primaryEmail = user.emailAddresses.find((e) => {
+        return e.id === user.primaryEmailAddressId;
+      });
+      const email = primaryEmail?.emailAddress ?? "unknown";
+      emailMap.set(user.id, email);
+
+      await db
+        .insert(userCache)
+        .values({ userId: user.id, email, cachedAt: now })
+        .onConflictDoUpdate({
+          target: userCache.userId,
+          set: { email, cachedAt: now },
+        });
+    }
+  }
+
+  return emailMap;
+}
+
+interface DailyCreditsOptions {
+  dateFrom?: string;
+  dateTo?: string;
+  mode: "total" | "member";
+}
+
+/**
+ * Get daily credit usage for an org.
+ * mode=total: aggregate all members into a single daily total.
+ * mode=member: break down by member per day.
+ */
+export async function getDailyCredits(
+  orgId: string,
+  options: DailyCreditsOptions,
+): Promise<UsageDailyResponse> {
+  const billingPeriod = await getOrgBillingPeriod(orgId);
+
+  if (!billingPeriod) {
+    return { period: null, daily: [], dailyByMember: [] };
+  }
+
+  const db = globalThis.services.db;
+
+  const dateFrom = options.dateFrom
+    ? new Date(options.dateFrom)
+    : billingPeriod.start;
+  const dateTo = options.dateTo ? new Date(options.dateTo) : billingPeriod.end;
+
+  const period = {
+    start: billingPeriod.start.toISOString(),
+    end: billingPeriod.end.toISOString(),
+  };
+
+  if (options.mode === "member") {
+    const rows = await db
+      .select({
+        date: sql<string>`DATE(${creditUsage.createdAt})`.as("date"),
+        userId: creditUsage.userId,
+        creditsCharged:
+          sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
+            "credits_charged",
+          ),
+      })
+      .from(creditUsage)
+      .where(
+        and(
+          eq(creditUsage.orgId, orgId),
+          eq(creditUsage.status, "processed"),
+          gte(creditUsage.createdAt, dateFrom),
+          lt(creditUsage.createdAt, dateTo),
+        ),
+      )
+      .groupBy(sql`DATE(${creditUsage.createdAt})`, creditUsage.userId)
+      .orderBy(sql`DATE(${creditUsage.createdAt})`);
+
+    const uniqueUserIds = [
+      ...new Set(
+        rows.map((r) => {
+          return r.userId;
+        }),
+      ),
+    ];
+    const emailMap = await resolveEmails(uniqueUserIds);
+
+    // Group by date
+    const byDate = new Map<
+      string,
+      { userId: string; email: string; creditsCharged: number }[]
+    >();
+    for (const row of rows) {
+      const dateStr = String(row.date);
+      if (!byDate.has(dateStr)) {
+        byDate.set(dateStr, []);
+      }
+      byDate.get(dateStr)!.push({
+        userId: row.userId,
+        email: emailMap.get(row.userId) ?? "unknown",
+        creditsCharged: Number(row.creditsCharged),
+      });
+    }
+
+    const dailyByMember = [...byDate.entries()].map(([date, members]) => {
+      return { date, members };
+    });
+
+    return { period, daily: [], dailyByMember };
+  }
+
+  // mode=total
+  const rows = await db
+    .select({
+      date: sql<string>`DATE(${creditUsage.createdAt})`.as("date"),
+      creditsCharged:
+        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
+          "credits_charged",
+        ),
+    })
+    .from(creditUsage)
+    .where(
+      and(
+        eq(creditUsage.orgId, orgId),
+        eq(creditUsage.status, "processed"),
+        gte(creditUsage.createdAt, dateFrom),
+        lt(creditUsage.createdAt, dateTo),
+      ),
+    )
+    .groupBy(sql`DATE(${creditUsage.createdAt})`)
+    .orderBy(sql`DATE(${creditUsage.createdAt})`);
+
+  const daily = rows.map((row) => {
+    return {
+      date: String(row.date),
+      creditsCharged: Number(row.creditsCharged),
+    };
+  });
+
+  return { period, daily, dailyByMember: [] };
+}
+
+interface UsageRunsOptions {
+  page: number;
+  pageSize: number;
+  agentId?: string;
+  userId?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+/**
+ * Get per-run credit usage records for an org with pagination and filtering.
+ * Only includes runs that have processed credit_usage records.
+ */
+export async function getUsageRuns(
+  orgId: string,
+  options: UsageRunsOptions,
+): Promise<UsageRunsResponse> {
+  const db = globalThis.services.db;
+
+  // Subquery: aggregate credit_usage per run_id
+  const creditSub = db
+    .select({
+      runId: creditUsage.runId,
+      inputTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.inputTokens}), 0)::bigint`.as(
+          "input_tokens_sum",
+        ),
+      outputTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.outputTokens}), 0)::bigint`.as(
+          "output_tokens_sum",
+        ),
+      cacheTokens:
+        sql<number>`COALESCE(SUM(${creditUsage.cacheReadInputTokens}) + SUM(${creditUsage.cacheCreationInputTokens}), 0)::bigint`.as(
+          "cache_tokens_sum",
+        ),
+      creditsCharged:
+        sql<number>`COALESCE(SUM(${creditUsage.creditsCharged}), 0)::bigint`.as(
+          "credits_sum",
+        ),
+      model: sql<string>`MAX(${creditUsage.model})`.as("model"),
+      userId: sql<string>`MAX(${creditUsage.userId})`.as("cu_user_id"),
+    })
+    .from(creditUsage)
+    .where(
+      and(eq(creditUsage.orgId, orgId), eq(creditUsage.status, "processed")),
+    )
+    .groupBy(creditUsage.runId)
+    .as("credit_sub");
+
+  // Build filter conditions
+  const conditions = [eq(agentRuns.orgId, orgId)];
+
+  if (options.agentId) {
+    conditions.push(eq(agentComposes.id, options.agentId));
+  }
+  if (options.userId) {
+    conditions.push(eq(agentRuns.userId, options.userId));
+  }
+  if (options.dateFrom) {
+    conditions.push(gte(agentRuns.createdAt, new Date(options.dateFrom)));
+  }
+  if (options.dateTo) {
+    conditions.push(lte(agentRuns.createdAt, new Date(options.dateTo)));
+  }
+
+  // Count query
+  const [countResult] = await db
+    .select({ total: count() })
+    .from(agentRuns)
+    .innerJoin(creditSub, eq(agentRuns.id, creditSub.runId))
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .leftJoin(
+      agentComposes,
+      eq(agentComposeVersions.composeId, agentComposes.id),
+    )
+    .where(and(...conditions));
+
+  const total = countResult?.total ?? 0;
+
+  // Data query with pagination
+  const offset = (options.page - 1) * options.pageSize;
+
+  const rows = await db
+    .select({
+      runId: agentRuns.id,
+      status: agentRuns.status,
+      createdAt: agentRuns.createdAt,
+      startedAt: agentRuns.startedAt,
+      completedAt: agentRuns.completedAt,
+      userId: agentRuns.userId,
+      triggerSource: zeroRuns.triggerSource,
+      agentName: zeroAgents.displayName,
+      inputTokens: creditSub.inputTokens,
+      outputTokens: creditSub.outputTokens,
+      cacheTokens: creditSub.cacheTokens,
+      creditsCharged: creditSub.creditsCharged,
+      model: creditSub.model,
+    })
+    .from(agentRuns)
+    .innerJoin(creditSub, eq(agentRuns.id, creditSub.runId))
+    .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
+    .leftJoin(
+      agentComposeVersions,
+      eq(agentRuns.agentComposeVersionId, agentComposeVersions.id),
+    )
+    .leftJoin(
+      agentComposes,
+      eq(agentComposeVersions.composeId, agentComposes.id),
+    )
+    .leftJoin(zeroAgents, eq(agentComposes.id, zeroAgents.id))
+    .where(and(...conditions))
+    .orderBy(desc(agentRuns.createdAt))
+    .limit(options.pageSize)
+    .offset(offset);
+
+  // Resolve emails
+  const uniqueUserIds = [
+    ...new Set(
+      rows.map((r) => {
+        return r.userId;
+      }),
+    ),
+  ];
+  const emailMap = await resolveEmails(uniqueUserIds);
+
+  const runs = rows.map((row) => {
+    const startedAt = row.startedAt?.toISOString() ?? null;
+    const completedAt = row.completedAt?.toISOString() ?? null;
+    const durationMs =
+      row.startedAt && row.completedAt
+        ? row.completedAt.getTime() - row.startedAt.getTime()
+        : null;
+
+    return {
+      runId: row.runId,
+      agentName: row.agentName ?? null,
+      memberEmail: emailMap.get(row.userId) ?? "unknown",
+      userId: row.userId,
+      triggerSource: row.triggerSource ?? null,
+      model: row.model ?? "unknown",
+      status: row.status,
+      startedAt,
+      completedAt,
+      durationMs,
+      inputTokens: Number(row.inputTokens),
+      outputTokens: Number(row.outputTokens),
+      cacheTokens: Number(row.cacheTokens),
+      creditsCharged: Number(row.creditsCharged),
+      createdAt: row.createdAt.toISOString(),
+    };
+  });
+
+  return {
+    runs,
+    pagination: {
+      page: options.page,
+      pageSize: options.pageSize,
+      total,
+    },
   };
 }

--- a/turbo/apps/web/src/lib/zero/billing/usage-service.ts
+++ b/turbo/apps/web/src/lib/zero/billing/usage-service.ts
@@ -199,22 +199,23 @@ export async function getDailyCredits(
   options: DailyCreditsOptions,
 ): Promise<UsageDailyResponse> {
   const billingPeriod = await getOrgBillingPeriod(orgId);
-
-  if (!billingPeriod) {
-    return { period: null, daily: [], dailyByMember: [] };
-  }
-
   const db = globalThis.services.db;
 
-  const dateFrom = options.dateFrom
-    ? new Date(options.dateFrom)
-    : billingPeriod.start;
-  const dateTo = options.dateTo ? new Date(options.dateTo) : billingPeriod.end;
+  // Fall back to last 30 days when no billing period (free tier / no subscription).
+  const now = new Date();
+  const defaultFrom =
+    billingPeriod?.start ?? new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const defaultTo = billingPeriod?.end ?? now;
 
-  const period = {
-    start: billingPeriod.start.toISOString(),
-    end: billingPeriod.end.toISOString(),
-  };
+  const dateFrom = options.dateFrom ? new Date(options.dateFrom) : defaultFrom;
+  const dateTo = options.dateTo ? new Date(options.dateTo) : defaultTo;
+
+  const period = billingPeriod
+    ? {
+        start: billingPeriod.start.toISOString(),
+        end: billingPeriod.end.toISOString(),
+      }
+    : null;
 
   if (options.mode === "member") {
     const rows = await db
@@ -306,7 +307,7 @@ interface UsageRunsOptions {
   page: number;
   pageSize: number;
   agentId?: string;
-  userId?: string;
+  userIds?: string[];
   dateFrom?: string;
   dateTo?: string;
 }
@@ -357,8 +358,8 @@ export async function getUsageRuns(
   if (options.agentId) {
     conditions.push(eq(agentComposes.id, options.agentId));
   }
-  if (options.userId) {
-    conditions.push(eq(agentRuns.userId, options.userId));
+  if (options.userIds && options.userIds.length > 0) {
+    conditions.push(inArray(agentRuns.userId, options.userIds));
   }
   if (options.dateFrom) {
     conditions.push(gte(agentRuns.createdAt, new Date(options.dateFrom)));
@@ -395,6 +396,7 @@ export async function getUsageRuns(
       startedAt: agentRuns.startedAt,
       completedAt: agentRuns.completedAt,
       userId: agentRuns.userId,
+      prompt: agentRuns.prompt,
       triggerSource: zeroRuns.triggerSource,
       agentName: zeroAgents.displayName,
       inputTokens: creditSub.inputTokens,
@@ -446,6 +448,7 @@ export async function getUsageRuns(
       triggerSource: row.triggerSource ?? null,
       model: row.model ?? "unknown",
       status: row.status,
+      prompt: row.prompt,
       startedAt,
       completedAt,
       durationMs,

--- a/turbo/packages/core/src/contracts/index.ts
+++ b/turbo/packages/core/src/contracts/index.ts
@@ -724,6 +724,17 @@ export {
   type UsageMembersResponse,
 } from "./zero-usage";
 export {
+  zeroUsageDailyContract,
+  zeroUsageRunsContract,
+  type ZeroUsageDailyContract,
+  type ZeroUsageRunsContract,
+  type UsageDailyResponse,
+  type DailyCredit,
+  type DailyCreditByMember,
+  type UsageRun,
+  type UsageRunsResponse,
+} from "./zero-usage-daily";
+export {
   zeroTeamContract,
   teamComposeItemSchema,
   type ZeroTeamContract,

--- a/turbo/packages/core/src/contracts/zero-usage-daily.ts
+++ b/turbo/packages/core/src/contracts/zero-usage-daily.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+import { authHeadersSchema, initContract } from "./base";
+import { apiErrorSchema } from "./errors";
+
+const c = initContract();
+
+// --- Daily Credits Contract ---
+
+const dailyCreditSchema = z.object({
+  date: z.string(),
+  creditsCharged: z.number(),
+});
+
+const dailyCreditByMemberSchema = z.object({
+  date: z.string(),
+  members: z.array(
+    z.object({
+      userId: z.string(),
+      email: z.string(),
+      creditsCharged: z.number(),
+    }),
+  ),
+});
+
+const usageDailyResponseSchema = z.object({
+  period: z
+    .object({
+      start: z.string(),
+      end: z.string(),
+    })
+    .nullable(),
+  daily: z.array(dailyCreditSchema),
+  dailyByMember: z.array(dailyCreditByMemberSchema),
+});
+
+export const zeroUsageDailyContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/usage/daily",
+    headers: authHeadersSchema,
+    query: z.object({
+      dateFrom: z.string().optional(),
+      dateTo: z.string().optional(),
+      mode: z.enum(["total", "member"]).default("total"),
+    }),
+    responses: {
+      200: usageDailyResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get daily credit usage for the org",
+  },
+});
+
+// --- Per-Run Records Contract ---
+
+const usageRunSchema = z.object({
+  runId: z.string(),
+  agentName: z.string().nullable(),
+  memberEmail: z.string(),
+  userId: z.string(),
+  triggerSource: z.string().nullable(),
+  model: z.string(),
+  status: z.string(),
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+  durationMs: z.number().nullable(),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+  cacheTokens: z.number(),
+  creditsCharged: z.number(),
+  createdAt: z.string(),
+});
+
+const usageRunsResponseSchema = z.object({
+  runs: z.array(usageRunSchema),
+  pagination: z.object({
+    page: z.number(),
+    pageSize: z.number(),
+    total: z.number(),
+  }),
+});
+
+export const zeroUsageRunsContract = c.router({
+  get: {
+    method: "GET",
+    path: "/api/zero/usage/runs",
+    headers: authHeadersSchema,
+    query: z.object({
+      page: z.coerce.number().int().positive().default(1),
+      pageSize: z.coerce.number().int().positive().max(100).default(20),
+      agentId: z.string().optional(),
+      userId: z.string().optional(),
+      dateFrom: z.string().optional(),
+      dateTo: z.string().optional(),
+    }),
+    responses: {
+      200: usageRunsResponseSchema,
+      401: apiErrorSchema,
+      403: apiErrorSchema,
+      500: apiErrorSchema,
+    },
+    summary: "Get per-run credit usage records for the org",
+  },
+});
+
+export type ZeroUsageDailyContract = typeof zeroUsageDailyContract;
+export type ZeroUsageRunsContract = typeof zeroUsageRunsContract;
+
+export type UsageDailyResponse = z.infer<typeof usageDailyResponseSchema>;
+export type DailyCredit = z.infer<typeof dailyCreditSchema>;
+export type DailyCreditByMember = z.infer<typeof dailyCreditByMemberSchema>;
+export type UsageRun = z.infer<typeof usageRunSchema>;
+export type UsageRunsResponse = z.infer<typeof usageRunsResponseSchema>;

--- a/turbo/packages/core/src/contracts/zero-usage-daily.ts
+++ b/turbo/packages/core/src/contracts/zero-usage-daily.ts
@@ -63,6 +63,7 @@ const usageRunSchema = z.object({
   triggerSource: z.string().nullable(),
   model: z.string(),
   status: z.string(),
+  prompt: z.string(),
   startedAt: z.string().nullable(),
   completedAt: z.string().nullable(),
   durationMs: z.number().nullable(),
@@ -91,7 +92,8 @@ export const zeroUsageRunsContract = c.router({
       page: z.coerce.number().int().positive().default(1),
       pageSize: z.coerce.number().int().positive().max(100).default(20),
       agentId: z.string().optional(),
-      userId: z.string().optional(),
+      // Comma-separated list of user IDs to filter by. Empty string = no filter.
+      userIds: z.string().optional(),
       dateFrom: z.string().optional(),
       dateTo: z.string().optional(),
     }),

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -30,6 +30,7 @@ export enum FeatureSwitchKey {
   SpotifyConnector = "spotifyConnector",
   ShowSystemPrompt = "showSystemPrompt",
   Usage = "usage",
+  UsageAnalytics = "usageAnalytics",
   ModelDetail = "modelDetail",
   ActivityLogList = "activityLogList",
   ZeroDebug = "zeroDebug",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -175,6 +175,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
       "Show the Usage page with per-member credit and token consumption",
     enabled: false,
   },
+  [FeatureSwitchKey.UsageAnalytics]: {
+    maintainer: "ethan@vm0.ai",
+    description:
+      "Show admin-only daily credits chart and per-run records on Usage page",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.ModelDetail]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the selected model name in activity details",


### PR DESCRIPTION
## Summary

- Add daily credits consumption SVG line chart to admin usage page with total/per-member view modes and date range presets (last 7/14/30 days, billing period)
- Add per-run consumption records table with member filtering and pagination
- Both features are gated to org admins only; non-admin members see the existing member table unchanged

## Implementation

**API layer:**
- `GET /api/zero/usage/daily` - daily credit aggregates with total/member modes and date range filtering
- `GET /api/zero/usage/runs` - paginated per-run records with member/agent/date filters
- ts-rest contracts with Zod schemas in `@vm0/core`

**Frontend:**
- Pure SVG line chart component using ccstate signals (no React hooks)
- Runs table with status badges, token breakdown, and pagination
- Overview/Runs tabs on admin usage page

**Tests:**
- Integration tests for both API routes (auth, authorization, data, pagination, filtering, pending exclusion)

Closes #8841

## Test plan

- [x] `GET /api/zero/usage/daily` returns 401/403 for unauthorized/non-admin users
- [x] `GET /api/zero/usage/daily` returns daily totals and per-member breakdowns
- [x] `GET /api/zero/usage/daily` excludes pending records
- [x] `GET /api/zero/usage/runs` returns paginated per-run records
- [x] `GET /api/zero/usage/runs` filters by userId
- [x] `GET /api/zero/usage/runs` excludes pending-only runs
- [ ] Visual verification: chart renders correctly with test data
- [ ] Visual verification: runs table pagination works

🤖 Generated with [Claude Code](https://claude.com/claude-code)