### PR TITLE
fix(core): make AutoSkill feature switch opt-in for staff org

### DIFF
--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -236,7 +236,6 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     maintainer: "lancy@vm0.ai",
     description: "Enable automatic skill creation in agent prompts",
     enabled: false,
-    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
   [FeatureSwitchKey.SandboxReuse]: {
     maintainer: "liangyou@vm0.ai",


### PR DESCRIPTION
## Summary
- Remove `enabledOrgIdHashes: STAFF_ORG_ID_HASHES` from the `AutoSkill` feature switch definition
- Staff org members now need to manually enable AutoSkill via the Lab page instead of having it auto-enabled

## Test plan
- [x] Lint passes
- [x] Type check passes
- [x] Format passes
- [x] Tests pass (`@vm0/core` — 687 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)