### PR TITLE
fix(runner): shell-quote exec arguments before joining

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -590,8 +590,8 @@ jobs:
           done
           # Verify PostgreSQL can actually start (not just psql --version).
           # Test with TCP on localhost — users will connect via localhost:5432.
-          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- "mkdir -p /tmp/pgdata && /usr/lib/postgresql/16/bin/initdb -D /tmp/pgdata -A trust && /usr/lib/postgresql/16/bin/pg_ctl -D /tmp/pgdata -l /tmp/pgdata/log -o \"-c listen_addresses='localhost'\" start && pg_isready -h localhost && /usr/lib/postgresql/16/bin/pg_ctl -D /tmp/pgdata stop" \
-            || { sudo "$BIN_DIR/runner" exec "$RUN_ID" -- "cat /tmp/pgdata/log" 2>&1 || true; fail "PostgreSQL start"; }
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- sh -c "mkdir -p /tmp/pgdata && /usr/lib/postgresql/16/bin/initdb -D /tmp/pgdata -A trust && /usr/lib/postgresql/16/bin/pg_ctl -D /tmp/pgdata -l /tmp/pgdata/log -o \"-c listen_addresses='localhost'\" start && pg_isready -h localhost && /usr/lib/postgresql/16/bin/pg_ctl -D /tmp/pgdata stop" \
+            || { sudo "$BIN_DIR/runner" exec "$RUN_ID" -- cat /tmp/pgdata/log 2>&1 || true; fail "PostgreSQL start"; }
           echo "  PostgreSQL start/stop: ok"
           echo "PASS: runtime availability"
 
@@ -632,7 +632,7 @@ jobs:
           TLS_URL="https://www.vm0.ai"
           tls_check() {
             local label=$1 cmd=$2 t=${3:-15}
-            OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- "timeout $t $cmd" 2>&1) \
+            OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- sh -c "timeout $t $cmd" 2>&1) \
               || fail "HTTPS $label: $OUTPUT"
             echo "  HTTPS $label: ok"
           }
@@ -647,11 +647,11 @@ jobs:
           tls_check "chromium"  "chromium --headless --disable-gpu --no-sandbox --dump-dom $TLS_URL 2>/dev/null | head -1" 30
 
           # Java and Go need multi-line scripts — write temp files then run
-          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- "printf '%s\n' 'import java.net.*;import java.net.http.*;' 'var c=HttpClient.newHttpClient();' 'var r=HttpRequest.newBuilder(URI.create(\"$TLS_URL\")).build();' 'c.send(r,HttpResponse.BodyHandlers.discarding());' '/exit' | timeout 30 jshell -" \
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- sh -c "printf '%s\n' 'import java.net.*;import java.net.http.*;' 'var c=HttpClient.newHttpClient();' 'var r=HttpRequest.newBuilder(URI.create(\"$TLS_URL\")).build();' 'c.send(r,HttpResponse.BodyHandlers.discarding());' '/exit' | timeout 30 jshell -" \
             || fail "HTTPS java"
           echo "  HTTPS java: ok"
 
-          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- "cd /tmp && printf '%s\n' 'package main' 'import (' '\"net/http\"' '\"os\"' ')' 'func main(){r,e:=http.Get(os.Args[1]);if e!=nil{panic(e)};r.Body.Close()}' > tls.go && timeout 30 go run tls.go $TLS_URL" \
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- sh -c "cd /tmp && printf '%s\n' 'package main' 'import (' '\"net/http\"' '\"os\"' ')' 'func main(){r,e:=http.Get(os.Args[1]);if e!=nil{panic(e)};r.Body.Close()}' > tls.go && timeout 30 go run tls.go $TLS_URL" \
             || fail "HTTPS go"
           echo "  HTTPS go: ok"
           echo "PASS: HTTPS through proxy"
@@ -659,7 +659,7 @@ jobs:
           # Test 7: verify DNS resolution works inside sandbox
           # Uses getent (libc-bin, always available) instead of nslookup (requires dnsutils).
           echo "--- Test: DNS resolution ---"
-          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- "getent hosts localhost" 2>&1) \
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- getent hosts localhost 2>&1) \
             || fail "localhost resolution failed: $OUTPUT"
           echo "  localhost: $OUTPUT"
           OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- getent hosts github.com 2>&1) \
@@ -931,7 +931,7 @@ jobs:
           # Write script via base64 to avoid quoting issues with runner exec.
           echo "--- Test 2: balloon deflate under memory pressure ---"
           ALLOC_B64=$(printf 'import ctypes,time\nb=bytearray(300*1024*1024)\nctypes.memset((ctypes.c_char*len(b)).from_buffer(b),1,len(b))\ntime.sleep(120)\n' | base64 -w0)
-          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- "echo $ALLOC_B64 | base64 -d > /tmp/alloc.py"
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- sh -c "echo $ALLOC_B64 | base64 -d > /tmp/alloc.py"
           # Run allocator in guest foreground, host background
           sudo "$BIN_DIR/runner" exec "$RUN_ID" -- python3 /tmp/alloc.py &
           ALLOC_PID=$!
@@ -963,7 +963,7 @@ jobs:
 
           # Kill guest-side allocator — balloon has already deflated (Test 2
           # passed), so guest has ~250 MiB available, enough for pkill exec.
-          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- "pkill -f alloc.py" 2>/dev/null || true
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- pkill -f alloc.py 2>/dev/null || true
 
           # Wait for balloon to re-inflate past midpoint between deflate and original inflate
           MIDPOINT=$(( (INFLATE_MIB + DEFLATE_MIB) / 2 ))

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -573,6 +573,15 @@ jobs:
           [ "$OUTPUT" = '$HOME' ] || fail "variable expanded: got '$OUTPUT'"
           OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- echo '*.nonexistent')
           [ "$OUTPUT" = '*.nonexistent' ] || fail "glob expanded: got '$OUTPUT'"
+          # Backtick command substitution must NOT be executed (injection guard)
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- echo '`date`')
+          [ "$OUTPUT" = '`date`' ] || fail "backtick expanded: got '$OUTPUT'"
+          # Double quote inside an argument survives the round-trip
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- echo 'say "hi"')
+          [ "$OUTPUT" = 'say "hi"' ] || fail "double quote in arg: got '$OUTPUT'"
+          # Non-ASCII UTF-8 in an argument
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- echo "你好")
+          [ "$OUTPUT" = "你好" ] || fail "utf-8 arg: got '$OUTPUT'"
           # Explicit shell: pipes and redirects work through `sh -c`
           OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- sh -c 'printf abc | wc -c')
           [ "$(echo "$OUTPUT" | tr -d ' ')" = '3' ] || fail "sh -c pipe: got '$OUTPUT'"
@@ -584,6 +593,9 @@ jobs:
           OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- cat "/tmp/spaced file.txt")
           [ "$OUTPUT" = 'content' ] || fail "space in path: got '$OUTPUT'"
           sudo "$BIN_DIR/runner" exec "$RUN_ID" -- rm "/tmp/spaced file.txt"
+          # --sudo flag must not bypass argv quoting
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" --sudo -- echo "root with space")
+          [ "$OUTPUT" = "root with space" ] || fail "--sudo quoting: got '$OUTPUT'"
           echo "PASS: argv boundary preservation"
 
           # Test 5: verify pre-installed language runtimes and databases

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -954,12 +954,10 @@ jobs:
           # in the guest to push available below deflate threshold (192 MiB).
           # After inflate stabilizes (~1438 MiB), guest has ~476 MiB available.
           # 300 MiB alloc drops available to ~176 MiB < 192 MiB threshold.
-          # Write script via base64 to avoid quoting issues with runner exec.
+          # Trailing `# BALLOON_ALLOC_MARKER` is a unique string pkill can
+          # match on to terminate the guest-side allocator below.
           echo "--- Test 2: balloon deflate under memory pressure ---"
-          ALLOC_B64=$(printf 'import ctypes,time\nb=bytearray(300*1024*1024)\nctypes.memset((ctypes.c_char*len(b)).from_buffer(b),1,len(b))\ntime.sleep(120)\n' | base64 -w0)
-          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- sh -c "echo $ALLOC_B64 | base64 -d > /tmp/alloc.py"
-          # Run allocator in guest foreground, host background
-          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- python3 /tmp/alloc.py &
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- python3 -c 'import ctypes,time; b=bytearray(300*1024*1024); ctypes.memset((ctypes.c_char*len(b)).from_buffer(b),1,len(b)); time.sleep(120)  # BALLOON_ALLOC_MARKER' &
           ALLOC_PID=$!
 
           # Wait for balloon to deflate (actual_mib decreases)
@@ -989,7 +987,7 @@ jobs:
 
           # Kill guest-side allocator — balloon has already deflated (Test 2
           # passed), so guest has ~250 MiB available, enough for pkill exec.
-          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- pkill -f alloc.py 2>/dev/null || true
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- pkill -f BALLOON_ALLOC_MARKER 2>/dev/null || true
 
           # Wait for balloon to re-inflate past midpoint between deflate and original inflate
           MIDPOINT=$(( (INFLATE_MIB + DEFLATE_MIB) / 2 ))

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -560,7 +560,33 @@ jobs:
           [ -n "$OUTPUT" ] || fail "prefix match returned empty output"
           echo "PASS: prefix matching"
 
-          # Test 4: verify pre-installed language runtimes and databases
+          # Test 4: argv boundary preservation — regression guard for #9019
+          echo "--- Test: argv boundary preservation ---"
+          # Space in an argument is preserved as one token
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- echo "hello world")
+          [ "$OUTPUT" = "hello world" ] || fail "space in arg: got '$OUTPUT'"
+          # Single quote in an argument is escaped correctly
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- echo "it's working")
+          [ "$OUTPUT" = "it's working" ] || fail "single quote in arg: got '$OUTPUT'"
+          # Shell metachars must NOT be expanded by the guest shell
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- echo '$HOME')
+          [ "$OUTPUT" = '$HOME' ] || fail "variable expanded: got '$OUTPUT'"
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- echo '*.nonexistent')
+          [ "$OUTPUT" = '*.nonexistent' ] || fail "glob expanded: got '$OUTPUT'"
+          # Explicit shell: pipes and redirects work through `sh -c`
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- sh -c 'printf abc | wc -c')
+          [ "$(echo "$OUTPUT" | tr -d ' ')" = '3' ] || fail "sh -c pipe: got '$OUTPUT'"
+          # env VAR=val PROG: env (not shell) sets the variable for PROG
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- env FOO=bar printenv FOO)
+          [ "$OUTPUT" = 'bar' ] || fail "env VAR=val: got '$OUTPUT'"
+          # Path containing a space — the original issue case
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- sh -c 'echo content > "/tmp/spaced file.txt"'
+          OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- cat "/tmp/spaced file.txt")
+          [ "$OUTPUT" = 'content' ] || fail "space in path: got '$OUTPUT'"
+          sudo "$BIN_DIR/runner" exec "$RUN_ID" -- rm "/tmp/spaced file.txt"
+          echo "PASS: argv boundary preservation"
+
+          # Test 5: verify pre-installed language runtimes and databases
           echo "--- Test: runtime availability ---"
           for cmd in \
             "node --version" \
@@ -595,7 +621,7 @@ jobs:
           echo "  PostgreSQL start/stop: ok"
           echo "PASS: runtime availability"
 
-          # Test 5: verify /etc/environment is loaded for both user and root
+          # Test 6: verify /etc/environment is loaded for both user and root
           # [sync:etc-environment] Keep in sync with: crates/runner/scripts/build-rootfs.sh
           echo "--- Test: environment variables ---"
           EXPECTED_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -626,7 +652,7 @@ jobs:
           check_env "root" "--sudo"
           echo "PASS: environment variables"
 
-          # Test 6: verify HTTPS works through proxy for each runtime
+          # Test 7: verify HTTPS works through proxy for each runtime
           # All traffic goes through mitmproxy, so TLS must trust the proxy CA.
           echo "--- Test: HTTPS through proxy ---"
           TLS_URL="https://www.vm0.ai"
@@ -656,7 +682,7 @@ jobs:
           echo "  HTTPS go: ok"
           echo "PASS: HTTPS through proxy"
 
-          # Test 7: verify DNS resolution works inside sandbox
+          # Test 8: verify DNS resolution works inside sandbox
           # Uses getent (libc-bin, always available) instead of nslookup (requires dnsutils).
           echo "--- Test: DNS resolution ---"
           OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- getent hosts localhost 2>&1) \

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -560,7 +560,12 @@ jobs:
           [ -n "$OUTPUT" ] || fail "prefix match returned empty output"
           echo "PASS: prefix matching"
 
-          # Test 4: argv boundary preservation — regression guard for #9019
+          # Test 4: argv boundary preservation — regression guard for #9019.
+          # NOTE: each assertion relies on the local bash to tokenise quoted
+          # arguments correctly and pass them to runner as separate argv
+          # entries. For example `echo "hello world"` reaches runner as
+          # ["echo", "hello world"] (two tokens); runner then shell-quotes
+          # each before sending to the guest sh.
           echo "--- Test: argv boundary preservation ---"
           # Space in an argument is preserved as one token
           OUTPUT=$(sudo "$BIN_DIR/runner" exec "$RUN_ID" -- echo "hello world")

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -561,9 +561,10 @@ jobs:
           echo "PASS: prefix matching"
 
           # Test 4: argv boundary preservation — regression guard for #9019.
-          # NOTE: each assertion relies on the local bash to tokenise quoted
-          # arguments correctly and pass them to runner as separate argv
-          # entries. For example `echo "hello world"` reaches runner as
+          # NOTE: each assertion relies on the surrounding bash (this
+          # heredoc, running on the metal runner) to tokenise quoted
+          # arguments and pass them to runner as separate argv entries.
+          # For example `echo "hello world"` reaches runner as
           # ["echo", "hello world"] (two tokens); runner then shell-quotes
           # each before sending to the guest sh.
           echo "--- Test: argv boundary preservation ---"

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -26,7 +26,14 @@ pub struct ExecArgs {
     #[arg(long)]
     sudo: bool,
 
-    /// Command to execute (after --)
+    /// Command to execute inside the VM (after `--`).
+    ///
+    /// Arguments are preserved as argv — pipes, redirects, globs, and
+    /// variable expansion must be invoked explicitly via a shell:
+    ///
+    /// ```text
+    /// runner exec <id> -- sh -c 'ls /tmp | wc -l'
+    /// ```
     #[arg(last = true, required = true)]
     command: Vec<String>,
 }
@@ -35,11 +42,27 @@ pub struct ExecArgs {
 // Entry point
 // ---------------------------------------------------------------------------
 
-/// POSIX shell-quote a single argument by wrapping it in single quotes and
-/// escaping any embedded `'` as `'\''`. This preserves argument boundaries
-/// when the resulting string is re-interpreted by `sh -c` on the guest.
+/// POSIX shell-quote a single argument so its boundary is preserved when the
+/// resulting command string is re-parsed by `sh -c` on the guest.
+///
+/// Arguments consisting entirely of alphanumerics and a small safe punctuation
+/// set (`_-./:+@%`) pass through unquoted for readability. Anything else is
+/// wrapped in single quotes, with embedded `'` escaped as `'\''`.
+///
+/// Note: `=` is intentionally excluded so that an argv like `["FOO=bar", ...]`
+/// is emitted as `'FOO=bar' ...` and the guest shell treats it as a command
+/// name rather than a variable assignment.
 fn shell_quote(arg: &str) -> String {
-    format!("'{}'", arg.replace('\'', "'\\''"))
+    let is_safe = !arg.is_empty()
+        && arg.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(b, b'_' | b'-' | b'.' | b'/' | b':' | b'+' | b'@' | b'%')
+        });
+    if is_safe {
+        arg.to_string()
+    } else {
+        format!("'{}'", arg.replace('\'', "'\\''"))
+    }
 }
 
 pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerResult<ExitCode> {
@@ -86,6 +109,15 @@ mod tests {
             timeout: 5,
             sudo: false,
             command: command.split_whitespace().map(String::from).collect(),
+        }
+    }
+
+    fn make_args_vec(command: Vec<&str>) -> ExecArgs {
+        ExecArgs {
+            run_id: "id".into(),
+            timeout: 5,
+            sudo: false,
+            command: command.into_iter().map(String::from).collect(),
         }
     }
 
@@ -144,60 +176,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn arg_with_space_is_quoted_as_single_token() {
-        let control = MockSandboxControl::new("/tmp");
-        let args = ExecArgs {
-            run_id: "test-id".into(),
-            timeout: 5,
-            sudo: false,
-            command: vec!["cat".into(), "/var/log/some file.log".into()],
-        };
-
-        run_exec(args, &control).await.unwrap();
-
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'cat' '/var/log/some file.log'".to_string()],
-        );
-    }
-
-    #[tokio::test]
-    async fn arg_with_single_quote_is_escaped() {
-        let control = MockSandboxControl::new("/tmp");
-        let args = ExecArgs {
-            run_id: "id".into(),
-            timeout: 5,
-            sudo: false,
-            command: vec!["echo".into(), "it's".into()],
-        };
-
-        run_exec(args, &control).await.unwrap();
-
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'echo' 'it'\\''s'".to_string()],
-        );
-    }
-
-    #[tokio::test]
-    async fn pipeline_inside_quoted_arg_is_preserved() {
-        let control = MockSandboxControl::new("/tmp");
-        let args = ExecArgs {
-            run_id: "id".into(),
-            timeout: 5,
-            sudo: false,
-            command: vec!["bash".into(), "-c".into(), "echo a | tr a b".into()],
-        };
-
-        run_exec(args, &control).await.unwrap();
-
-        assert_eq!(
-            control.recorded_commands(),
-            vec!["'bash' '-c' 'echo a | tr a b'".to_string()],
-        );
-    }
-
-    #[tokio::test]
     async fn exit_code_truncated_to_u8() {
         let control = MockSandboxControl::new("/tmp");
         // 256 truncates to 0 via `as u8`
@@ -218,5 +196,105 @@ mod tests {
 
         let r2 = run_exec(make_args("id", "test"), &control).await.unwrap();
         assert_eq!(r2, ExitCode::from(255));
+    }
+
+    // ---- argument quoting -------------------------------------------------
+
+    #[tokio::test]
+    async fn safe_ascii_args_pass_through_unquoted() {
+        let control = MockSandboxControl::new("/tmp");
+        run_exec(make_args_vec(vec!["ls", "-la", "/var/log"]), &control)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            control.recorded_commands(),
+            vec!["ls -la /var/log".to_string()],
+        );
+    }
+
+    #[tokio::test]
+    async fn arg_with_space_is_quoted_as_single_token() {
+        let control = MockSandboxControl::new("/tmp");
+        run_exec(
+            make_args_vec(vec!["cat", "/var/log/some file.log"]),
+            &control,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            control.recorded_commands(),
+            vec!["cat '/var/log/some file.log'".to_string()],
+        );
+    }
+
+    #[tokio::test]
+    async fn arg_with_single_quote_is_escaped() {
+        let control = MockSandboxControl::new("/tmp");
+        run_exec(make_args_vec(vec!["echo", "it's"]), &control)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            control.recorded_commands(),
+            vec!["echo 'it'\\''s'".to_string()],
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_inside_quoted_arg_is_preserved() {
+        let control = MockSandboxControl::new("/tmp");
+        run_exec(
+            make_args_vec(vec!["bash", "-c", "echo a | tr a b"]),
+            &control,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            control.recorded_commands(),
+            vec!["bash -c 'echo a | tr a b'".to_string()],
+        );
+    }
+
+    #[tokio::test]
+    async fn shell_metachar_in_arg_is_quoted() {
+        let control = MockSandboxControl::new("/tmp");
+        run_exec(make_args_vec(vec!["echo", "$HOME"]), &control)
+            .await
+            .unwrap();
+
+        // `$` must be quoted so the guest shell does not expand it.
+        assert_eq!(
+            control.recorded_commands(),
+            vec!["echo '$HOME'".to_string()],
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_arg_is_quoted() {
+        let control = MockSandboxControl::new("/tmp");
+        run_exec(make_args_vec(vec!["echo", ""]), &control)
+            .await
+            .unwrap();
+
+        assert_eq!(control.recorded_commands(), vec!["echo ''".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn assignment_syntax_arg_is_quoted() {
+        let control = MockSandboxControl::new("/tmp");
+        run_exec(make_args_vec(vec!["FOO=bar", "env"]), &control)
+            .await
+            .unwrap();
+
+        // `=` is not in the safe set, so `FOO=bar` is quoted. This prevents
+        // the guest shell from interpreting it as a variable assignment —
+        // it is treated as a command name, matching argv semantics.
+        assert_eq!(
+            control.recorded_commands(),
+            vec!["'FOO=bar' env".to_string()],
+        );
     }
 }

--- a/crates/runner/src/cmd/exec.rs
+++ b/crates/runner/src/cmd/exec.rs
@@ -35,8 +35,20 @@ pub struct ExecArgs {
 // Entry point
 // ---------------------------------------------------------------------------
 
+/// POSIX shell-quote a single argument by wrapping it in single quotes and
+/// escaping any embedded `'` as `'\''`. This preserves argument boundaries
+/// when the resulting string is re-interpreted by `sh -c` on the guest.
+fn shell_quote(arg: &str) -> String {
+    format!("'{}'", arg.replace('\'', "'\\''"))
+}
+
 pub async fn run_exec(args: ExecArgs, control: &dyn SandboxControl) -> RunnerResult<ExitCode> {
-    let command = args.command.join(" ");
+    let command = args
+        .command
+        .iter()
+        .map(|a| shell_quote(a))
+        .collect::<Vec<_>>()
+        .join(" ");
     let timeout = Duration::from_secs(u64::from(args.timeout));
 
     match control
@@ -129,6 +141,60 @@ mod tests {
 
         let result = run_exec(make_args("test-id", "test"), &control).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn arg_with_space_is_quoted_as_single_token() {
+        let control = MockSandboxControl::new("/tmp");
+        let args = ExecArgs {
+            run_id: "test-id".into(),
+            timeout: 5,
+            sudo: false,
+            command: vec!["cat".into(), "/var/log/some file.log".into()],
+        };
+
+        run_exec(args, &control).await.unwrap();
+
+        assert_eq!(
+            control.recorded_commands(),
+            vec!["'cat' '/var/log/some file.log'".to_string()],
+        );
+    }
+
+    #[tokio::test]
+    async fn arg_with_single_quote_is_escaped() {
+        let control = MockSandboxControl::new("/tmp");
+        let args = ExecArgs {
+            run_id: "id".into(),
+            timeout: 5,
+            sudo: false,
+            command: vec!["echo".into(), "it's".into()],
+        };
+
+        run_exec(args, &control).await.unwrap();
+
+        assert_eq!(
+            control.recorded_commands(),
+            vec!["'echo' 'it'\\''s'".to_string()],
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_inside_quoted_arg_is_preserved() {
+        let control = MockSandboxControl::new("/tmp");
+        let args = ExecArgs {
+            run_id: "id".into(),
+            timeout: 5,
+            sudo: false,
+            command: vec!["bash".into(), "-c".into(), "echo a | tr a b".into()],
+        };
+
+        run_exec(args, &control).await.unwrap();
+
+        assert_eq!(
+            control.recorded_commands(),
+            vec!["'bash' '-c' 'echo a | tr a b'".to_string()],
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -471,6 +471,7 @@ impl SnapshotProvider for MockSnapshotProvider {
 pub struct MockSandboxControl {
     base_dir: PathBuf,
     exec_results: Mutex<VecDeque<std::result::Result<RemoteExecResult, SandboxControlError>>>,
+    recorded_commands: Mutex<Vec<String>>,
 }
 
 impl MockSandboxControl {
@@ -478,6 +479,7 @@ impl MockSandboxControl {
         Self {
             base_dir: base_dir.into(),
             exec_results: Mutex::new(VecDeque::new()),
+            recorded_commands: Mutex::new(Vec::new()),
         }
     }
 
@@ -491,6 +493,14 @@ impl MockSandboxControl {
             .unwrap_or_else(|e| e.into_inner())
             .push_back(result);
     }
+
+    /// Return every command string passed to `exec_remote`, in call order.
+    pub fn recorded_commands(&self) -> Vec<String> {
+        self.recorded_commands
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
 }
 
 #[async_trait]
@@ -498,10 +508,14 @@ impl SandboxControl for MockSandboxControl {
     async fn exec_remote(
         &self,
         _sandbox_id: &str,
-        _command: &str,
+        command: &str,
         _timeout: Duration,
         _sudo: bool,
     ) -> std::result::Result<RemoteExecResult, SandboxControlError> {
+        self.recorded_commands
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(command.to_string());
         self.exec_results
             .lock()
             .unwrap_or_else(|e| e.into_inner())
@@ -683,6 +697,24 @@ mod tests {
             },
         };
         factory.create(config2).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn sandbox_control_records_commands() {
+        let control = MockSandboxControl::new("/tmp/test");
+        control
+            .exec_remote("sandbox-1", "echo one", Duration::from_secs(5), false)
+            .await
+            .unwrap();
+        control
+            .exec_remote("sandbox-1", "echo two", Duration::from_secs(5), true)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            control.recorded_commands(),
+            vec!["echo one".to_string(), "echo two".to_string()],
+        );
     }
 
     #[tokio::test]

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -17,11 +17,26 @@
 
 use std::collections::VecDeque;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use sandbox::*;
+
+/// Ignore mutex poisoning and take the lock anyway.
+///
+/// Tests do not care about poison state — if a previous test panicked while
+/// holding the lock, we still want to observe the inner state rather than
+/// surface the poison as a test failure.
+trait LockIgnoringPoison<T> {
+    fn lock_ignoring_poison(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T> LockIgnoringPoison<T> for Mutex<T> {
+    fn lock_ignoring_poison(&self) -> MutexGuard<'_, T> {
+        self.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
 
 // ---------------------------------------------------------------------------
 // MockSandboxOverrides
@@ -100,10 +115,7 @@ impl MockSandboxOverrides {
 
     /// Register a pattern matcher consumed on first match.
     pub fn add_exec_matcher(&self, matcher: ExecMatcher) {
-        self.exec_matchers
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .push(matcher);
+        self.exec_matchers.lock_ignoring_poison().push(matcher);
     }
 }
 
@@ -164,18 +176,14 @@ impl MockSandbox {
 
     /// Queue an exec result. Results are consumed in FIFO order.
     pub fn push_exec_result(&self, result: Result<ExecResult>) {
-        self.exec_results
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .push_back(result);
+        self.exec_results.lock_ignoring_poison().push_back(result);
     }
 
     /// Queue a write_file result. Results are consumed in FIFO order.
     /// When the queue is empty, write_file returns `Ok(())`.
     pub fn push_write_file_result(&self, result: Result<()>) {
         self.write_file_results
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .lock_ignoring_poison()
             .push_back(result);
     }
 }
@@ -213,10 +221,7 @@ impl Sandbox for MockSandbox {
     async fn exec(&self, request: &ExecRequest<'_>) -> Result<ExecResult> {
         // Check pattern matchers before the FIFO queue.
         if let Some(overrides) = &self.overrides {
-            let mut matchers = overrides
-                .exec_matchers
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+            let mut matchers = overrides.exec_matchers.lock_ignoring_poison();
             if let Some(idx) = matchers
                 .iter()
                 .position(|m| request.cmd.contains(&m.pattern))
@@ -230,16 +235,14 @@ impl Sandbox for MockSandbox {
             }
         }
         self.exec_results
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .lock_ignoring_poison()
             .pop_front()
             .unwrap_or_else(|| Ok(default_exec_result()))
     }
 
     async fn write_file(&self, _path: &str, _content: &[u8]) -> Result<()> {
         self.write_file_results
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .lock_ignoring_poison()
             .pop_front()
             .unwrap_or(Ok(()))
     }
@@ -257,7 +260,7 @@ impl Sandbox for MockSandbox {
             .as_ref()
             .is_some_and(|o| o.wait_exit_error.is_some())
         {
-            *self.stdout_tx.lock().unwrap_or_else(|e| e.into_inner()) = Some(tx);
+            *self.stdout_tx.lock_ignoring_poison() = Some(tx);
         }
         Ok(SpawnHandle {
             pid: 1,
@@ -326,10 +329,7 @@ impl MockSandboxFactory {
     /// `Err(...)` makes `create` return that error.
     /// Results are consumed in FIFO order.
     pub fn push_create_result(&self, result: Result<()>) {
-        self.create_results
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .push_back(result);
+        self.create_results.lock_ignoring_poison().push_back(result);
     }
 }
 
@@ -354,12 +354,7 @@ impl SandboxFactory for MockSandboxFactory {
     }
 
     async fn create(&self, config: SandboxConfig) -> Result<Box<dyn Sandbox>> {
-        if let Some(result) = self
-            .create_results
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .pop_front()
-        {
+        if let Some(result) = self.create_results.lock_ignoring_poison().pop_front() {
             result?;
         }
         let sandbox = match &self.overrides {
@@ -488,18 +483,12 @@ impl MockSandboxControl {
         &self,
         result: std::result::Result<RemoteExecResult, SandboxControlError>,
     ) {
-        self.exec_results
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .push_back(result);
+        self.exec_results.lock_ignoring_poison().push_back(result);
     }
 
     /// Return every command string passed to `exec_remote`, in call order.
     pub fn recorded_commands(&self) -> Vec<String> {
-        self.recorded_commands
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
+        self.recorded_commands.lock_ignoring_poison().clone()
     }
 }
 
@@ -513,12 +502,10 @@ impl SandboxControl for MockSandboxControl {
         _sudo: bool,
     ) -> std::result::Result<RemoteExecResult, SandboxControlError> {
         self.recorded_commands
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .lock_ignoring_poison()
             .push(command.to_string());
         self.exec_results
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+            .lock_ignoring_poison()
             .pop_front()
             .unwrap_or_else(|| {
                 Ok(RemoteExecResult {

--- a/crates/sandbox-mock/src/lib.rs
+++ b/crates/sandbox-mock/src/lib.rs
@@ -25,9 +25,8 @@ use sandbox::*;
 
 /// Ignore mutex poisoning and take the lock anyway.
 ///
-/// Tests do not care about poison state — if a previous test panicked while
-/// holding the lock, we still want to observe the inner state rather than
-/// surface the poison as a test failure.
+/// Callers here are test doubles; surfacing a poison error would appear as
+/// a spurious test failure rather than a real issue to propagate.
 trait LockIgnoringPoison<T> {
     fn lock_ignoring_poison(&self) -> MutexGuard<'_, T>;
 }


### PR DESCRIPTION
## Summary

- `runner exec <id> -- <cmd...>` joined argv tokens with a single space before sending the string to the guest, where it runs under `sh -c`. Any argument containing spaces was silently re-split by the shell — `cat \"/var/log/some file.log\"` read three wrong files.
- Per-arg POSIX single-quote escaping preserves argument boundaries; `bash -c \"pipeline\"` still works because the pipeline lives inside a single quoted token.
- Adds three regression tests (space / single-quote / pipeline) exercising `run_exec` via `MockSandboxControl` (now records commands).

Fixes #9019

## Test plan

- [x] `cargo test -p runner --bin runner cmd::exec` — all 9 tests pass (6 existing + 3 new)
- [x] `cargo test -p sandbox-mock` — all 12 tests pass (11 existing + 1 new)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: `runner exec <id> -- cat \"/tmp/file with spaces.txt\"` reads the right file
- [ ] Manual: `runner exec <id> -- bash -c \"ls /etc | wc -l\"` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)