### PR TITLE
feat(web): group feature-gated sidebar footer items into more menu

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -262,6 +262,27 @@ export function ZeroSidebar() {
     footerNavGated.some((item) => {
       return (item.activeKeys as readonly RouteKey[]).includes(activeId);
     });
+  const renderGatedDropdownItems = () => {
+    return footerNavGated.map(({ id, activeKeys, label, icon: Icon }) => {
+      const isActive =
+        activeId !== null &&
+        (activeKeys as readonly RouteKey[]).includes(activeId);
+      return (
+        <DropdownMenuItem
+          key={id}
+          onSelect={() => {
+            onSelect(id);
+          }}
+          className={`gap-2 px-2 py-1.5 rounded-md ${
+            isActive ? "bg-gray-200 text-gray-900" : ""
+          }`}
+        >
+          <Icon size={16} className="shrink-0" />
+          <span className="truncate flex-1">{label}</span>
+        </DropdownMenuItem>
+      );
+    });
+  };
 
   const allNavItems = [
     ...manageNav.map(({ id, activeKeys, pathname: p, label, icon }) => {
@@ -385,29 +406,7 @@ export function ZeroSidebar() {
                     sideOffset={8}
                     className="w-[220px]"
                   >
-                    {footerNavGated.map(
-                      ({ id, activeKeys, label, icon: Icon }) => {
-                        const isActive =
-                          activeId !== null &&
-                          (activeKeys as readonly RouteKey[]).includes(
-                            activeId,
-                          );
-                        return (
-                          <DropdownMenuItem
-                            key={id}
-                            onSelect={() => {
-                              onSelect(id);
-                            }}
-                            className={`gap-2 px-2 py-1.5 rounded-md ${
-                              isActive ? "bg-gray-200 text-gray-900" : ""
-                            }`}
-                          >
-                            <Icon size={16} className="shrink-0" />
-                            <span className="truncate flex-1">{label}</span>
-                          </DropdownMenuItem>
-                        );
-                      },
-                    )}
+                    {renderGatedDropdownItems()}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
@@ -642,27 +641,7 @@ export function ZeroSidebar() {
                   sideOffset={8}
                   className="w-[220px]"
                 >
-                  {footerNavGated.map(
-                    ({ id, activeKeys, label, icon: Icon }) => {
-                      const isActive =
-                        activeId !== null &&
-                        (activeKeys as readonly RouteKey[]).includes(activeId);
-                      return (
-                        <DropdownMenuItem
-                          key={id}
-                          onSelect={() => {
-                            onSelect(id);
-                          }}
-                          className={`gap-2 px-2 py-1.5 rounded-md ${
-                            isActive ? "bg-gray-200 text-gray-900" : ""
-                          }`}
-                        >
-                          <Icon size={16} className="shrink-0" />
-                          <span className="truncate flex-1">{label}</span>
-                        </DropdownMenuItem>
-                      );
-                    },
-                  )}
+                  {renderGatedDropdownItems()}
                 </DropdownMenuContent>
               </DropdownMenu>
             )}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -25,6 +25,7 @@ import {
   IconMicrophone,
   IconSparkles,
   IconLayoutDashboard,
+  IconDots,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/core";
 import {
@@ -32,6 +33,10 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
 } from "@vm0/ui";
 import slackIcon from "./components/settings/icons/slack.svg";
 import { detach, Reason } from "../../signals/utils.ts";
@@ -246,6 +251,17 @@ export function ZeroSidebar() {
       label: item.label.replace("Zero", defaultDisplayName),
     };
   });
+  const footerNavRegular = footerNav.filter((item) => {
+    return !item.featureGate;
+  });
+  const footerNavGated = footerNav.filter((item) => {
+    return Boolean(item.featureGate);
+  });
+  const isGatedActive =
+    activeId !== null &&
+    footerNavGated.some((item) => {
+      return (item.activeKeys as readonly RouteKey[]).includes(activeId);
+    });
 
   const allNavItems = [
     ...manageNav.map(({ id, activeKeys, pathname: p, label, icon }) => {
@@ -258,7 +274,7 @@ export function ZeroSidebar() {
       label: "New chat",
       icon: IconEdit as NavIcon,
     },
-    ...footerNav.map(({ id, activeKeys, pathname: p, label, icon }) => {
+    ...footerNavRegular.map(({ id, activeKeys, pathname: p, label, icon }) => {
       return { id, activeKeys, pathname: p, label, icon };
     }),
   ];
@@ -340,6 +356,61 @@ export function ZeroSidebar() {
                   </div>
                 );
               },
+            )}
+            {footerNavGated.length > 0 && (
+              <div className="flex w-full shrink-0 justify-center">
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200 ${
+                            isGatedActive
+                              ? "bg-gray-200 text-gray-900"
+                              : "text-sidebar-foreground hover:bg-sidebar-accent"
+                          }`}
+                        >
+                          <IconDots size={16} className="shrink-0" />
+                        </button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">
+                      <p className="text-xs">More</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent
+                    side="right"
+                    align="end"
+                    sideOffset={8}
+                    className="w-[220px]"
+                  >
+                    {footerNavGated.map(
+                      ({ id, activeKeys, label, icon: Icon }) => {
+                        const isActive =
+                          activeId !== null &&
+                          (activeKeys as readonly RouteKey[]).includes(
+                            activeId,
+                          );
+                        return (
+                          <DropdownMenuItem
+                            key={id}
+                            onSelect={() => {
+                              onSelect(id);
+                            }}
+                            className={`gap-2 px-2 py-1.5 rounded-md ${
+                              isActive ? "bg-gray-200 text-gray-900" : ""
+                            }`}
+                          >
+                            <Icon size={16} className="shrink-0" />
+                            <span className="truncate flex-1">{label}</span>
+                          </DropdownMenuItem>
+                        );
+                      },
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             )}
           </TooltipProvider>
         </nav>
@@ -499,7 +570,7 @@ export function ZeroSidebar() {
         {/* Footer nav */}
         <div className="p-2">
           <div className="flex flex-col gap-1">
-            {footerNav.map(
+            {footerNavRegular.map(
               ({
                 id,
                 activeKeys,
@@ -549,6 +620,51 @@ export function ZeroSidebar() {
                   </Link>
                 );
               },
+            )}
+            {footerNavGated.length > 0 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className={`flex w-full h-8 items-center gap-2 rounded-lg p-2 text-left text-sm leading-5 transition-colors duration-200 ${
+                      isGatedActive
+                        ? "bg-gray-200 text-gray-900 font-medium"
+                        : "text-sidebar-foreground hover:bg-sidebar-accent"
+                    }`}
+                  >
+                    <IconDots size={16} className="shrink-0" />
+                    <span className="truncate flex-1">More</span>
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  side="top"
+                  align="start"
+                  sideOffset={8}
+                  className="w-[220px]"
+                >
+                  {footerNavGated.map(
+                    ({ id, activeKeys, label, icon: Icon }) => {
+                      const isActive =
+                        activeId !== null &&
+                        (activeKeys as readonly RouteKey[]).includes(activeId);
+                      return (
+                        <DropdownMenuItem
+                          key={id}
+                          onSelect={() => {
+                            onSelect(id);
+                          }}
+                          className={`gap-2 px-2 py-1.5 rounded-md ${
+                            isActive ? "bg-gray-200 text-gray-900" : ""
+                          }`}
+                        >
+                          <Icon size={16} className="shrink-0" />
+                          <span className="truncate flex-1">{label}</span>
+                        </DropdownMenuItem>
+                      );
+                    },
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             )}
             <div className="h-px bg-border/30 mx-1 my-1" />
             {/* Insights + Account */}

--- a/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-sidebar.tsx
@@ -25,7 +25,7 @@ import {
   IconMicrophone,
   IconSparkles,
   IconLayoutDashboard,
-  IconDots,
+  IconMenu2,
 } from "@tabler/icons-react";
 import { FeatureSwitchKey } from "@vm0/core";
 import {
@@ -371,7 +371,7 @@ export function ZeroSidebar() {
                               : "text-sidebar-foreground hover:bg-sidebar-accent"
                           }`}
                         >
-                          <IconDots size={16} className="shrink-0" />
+                          <IconMenu2 size={16} className="shrink-0" />
                         </button>
                       </DropdownMenuTrigger>
                     </TooltipTrigger>
@@ -632,7 +632,7 @@ export function ZeroSidebar() {
                         : "text-sidebar-foreground hover:bg-sidebar-accent"
                     }`}
                   >
-                    <IconDots size={16} className="shrink-0" />
+                    <IconMenu2 size={16} className="shrink-0" />
                     <span className="truncate flex-1">More</span>
                   </button>
                 </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary
- Split footer nav in `zero-sidebar.tsx` into ungated items (rendered as before) and feature-gated items (Usage, Phone, Voice Chat, Mission Control, Lab)
- Added a **More** dropdown button at the bottom-left of both expanded and collapsed sidebar that opens a二级菜单 listing the gated items
- The More trigger inherits an active style when the current route lives inside the gated group, and is hidden entirely when no gated items pass their feature flag

## Test plan
- [ ] Toggle `Usage`, `PhoneIntegration`, `VoiceChat`, `MissionControlSidebar`, `Lab` feature flags and confirm each appears inside the **More** menu only when its flag is on
- [ ] Click each item inside the menu and verify it navigates to the correct route
- [ ] Collapse the sidebar and confirm the **More** icon trigger appears with a tooltip and the same dropdown
- [ ] With every gated flag off, confirm the **More** trigger is not rendered
- [ ] Navigate to `/phone` (or any gated route) and confirm the More trigger adopts the active style

🤖 Generated with [Claude Code](https://claude.com/claude-code)