### PR TITLE
chore: update rootfs package versions

### DIFF
--- a/crates/runner/scripts/build-rootfs.sh
+++ b/crates/runner/scripts/build-rootfs.sh
@@ -94,7 +94,7 @@ GO_VERSION="1.26.2"
 CLAUDE_CODE_VERSION="2.1.104"
 GWS_CLI_VERSION="0.22.5"
 XURL_VERSION="1.0.3"
-AGENT_BROWSER_VERSION="0.25.3"
+AGENT_BROWSER_VERSION="0.25.4"
 
 # ---------------------------------------------------------------------------
 # Dependency checks

--- a/crates/runner/src/cmd/build.rs
+++ b/crates/runner/src/cmd/build.rs
@@ -473,7 +473,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            hash, "097669f3bfa59605f8b1580c6e1ffea94b3a8ee243a2b439943a7da9432e1fc7",
+            hash, "355fc6702197b6b7956560d1c04cb3a8701bf3a214215ad85f72dcba3621d1f7",
             "image hash changed — this invalidates ALL cached images on ALL hosts"
         );
     }


### PR DESCRIPTION
## Summary

Routine daily check of pinned package versions in `crates/runner/scripts/build-rootfs.sh`.

### Updated packages

| Package | Old version | New version |
|---------|-------------|-------------|
| `agent-browser` (npm) | `0.25.3` | `0.25.4` |

### No changes needed

- Go: `1.26.2` (already latest)
- `@anthropic-ai/claude-code`: `2.1.104` (already latest)
- `@googleworkspace/cli`: `0.22.5` (already latest)
- `@xdevplatform/xurl`: `1.0.3` (already latest)

### Hash update

Updated the expected image hash in `crates/runner/src/cmd/build.rs` (`image_hash_is_stable` test):
- Old: `097669f3bfa59605f8b1580c6e1ffea94b3a8ee243a2b439943a7da9432e1fc7`
- New: `355fc6702197b6b7956560d1c04cb3a8701bf3a214215ad85f72dcba3621d1f7`

Test `cargo test -p runner image_hash_is_stable` passes with the new hash.