### PR TITLE
fix(web): fall back to truncated prompt when task summary is missing

### DIFF
--- a/turbo/apps/web/src/lib/zero/task/task-service.ts
+++ b/turbo/apps/web/src/lib/zero/task/task-service.ts
@@ -14,6 +14,12 @@ import { voiceChatSessions } from "../../../db/schema/voice-chat";
 import { zeroAgents } from "../../../db/schema/zero-agent";
 
 const TASKS_LIMIT = 25;
+const PROMPT_SUMMARY_MAX_LENGTH = 100;
+
+function truncatePrompt(prompt: string): string {
+  if (prompt.length <= PROMPT_SUMMARY_MAX_LENGTH) return prompt;
+  return prompt.slice(0, PROMPT_SUMMARY_MAX_LENGTH) + "…";
+}
 
 interface AgentInfo {
   id: string;
@@ -91,6 +97,7 @@ export async function listTasks(
         status: agentRuns.status,
         createdAt: agentRuns.createdAt,
         summary: zeroRuns.summary,
+        prompt: agentRuns.prompt,
       })
       .from(agentRuns)
       .leftJoin(zeroRuns, eq(agentRuns.id, zeroRuns.id))
@@ -100,7 +107,7 @@ export async function listTasks(
       runInfoMap.set(run.id, {
         status: run.status,
         createdAt: run.createdAt,
-        summary: run.summary,
+        summary: run.summary ?? truncatePrompt(run.prompt),
       });
     }
   }


### PR DESCRIPTION
## Summary

- When a task run has no AI-generated summary (e.g. the run is still in progress or the summary hasn't been generated yet), display a truncated version of the original prompt (up to 100 characters) as fallback text
- Adds `truncatePrompt` helper and fetches `agentRuns.prompt` in the batch run query
- Ensures Mission Control task list always shows meaningful preview text instead of blank summaries

## Test plan

- [ ] Verify tasks with existing summaries still display the summary unchanged
- [ ] Verify tasks without summaries now show a truncated prompt instead of null
- [ ] Verify prompts longer than 100 characters are properly truncated with ellipsis

🤖 Generated with [Claude Code](https://claude.com/claude-code)