### PR TITLE
fix(web): add non-localized blog routes to public route matcher

### DIFF
--- a/turbo/apps/web/proxy.ts
+++ b/turbo/apps/web/proxy.ts
@@ -30,6 +30,8 @@ const isPublicRoute = createRouteMatcher([
   "/:locale/security",
   "/:locale/use-cases",
   "/:locale/use-cases/:slug",
+  "/blog",
+  "/blog/posts/:slug",
   "/:locale/blog",
   "/:locale/blog/posts/:slug",
   "/sign-in(.*)",


### PR DESCRIPTION
## Summary
- Googlebot was crawling `/blog/posts/:slug` **without a locale prefix**, which did not match the existing locale-only patterns in `isPublicRoute` ([proxy.ts:20-46](turbo/apps/web/proxy.ts#L20-L46)).
- Clerk then called `auth.protect()` and redirected the crawler to `/sign-in`, a path disallowed in [robots.ts:12](turbo/apps/web/app/robots.ts#L12).
- Google Search Console reported **"Indexed, though blocked by robots.txt"** for `https://www.vm0.ai/blog/posts/building-in-public`.
- Fix: add the non-localized `/blog` and `/blog/posts/:slug` patterns so the request passes Clerk and lets the i18n layer 308-redirect to the locale-prefixed URL.

## Test plan
- [ ] Verify proxy unit tests still pass (`pnpm -F @vm0/web exec vitest proxy`)
- [ ] After deploy, request `https://www.vm0.ai/blog/posts/building-in-public` unauthenticated and confirm 308 to `/{locale}/blog/posts/building-in-public` (not a Clerk sign-in redirect)
- [ ] Submit "Validate Fix" in GSC for the affected URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)