### PR TITLE
chore(runner): bump default idle timeout to 30 minutes

### DIFF
--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -48,7 +48,7 @@ pub struct SandboxConfig {
     pub max_concurrent: usize,
     /// Overcommit factor applied to both CPU and memory budgets (default: 1.0).
     pub concurrency_factor: f64,
-    /// Idle timeout in seconds for reusable VMs (default: 300).
+    /// Idle timeout in seconds for reusable VMs (default: 1800).
     pub idle_timeout_secs: u64,
     /// Maximum number of idle VMs to keep (0 = no limit, default: 0).
     pub max_idle: usize,
@@ -59,7 +59,7 @@ impl Default for SandboxConfig {
         Self {
             max_concurrent: DEFAULT_MAX_CONCURRENT,
             concurrency_factor: DEFAULT_CONCURRENCY_FACTOR,
-            idle_timeout_secs: 300,
+            idle_timeout_secs: 1800,
             max_idle: 0,
         }
     }
@@ -955,7 +955,7 @@ profiles:
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
         let config = load_with_home(&config_path, &home).await.unwrap();
-        assert_eq!(config.sandbox.idle_timeout_secs, 300);
+        assert_eq!(config.sandbox.idle_timeout_secs, 1800);
         assert_eq!(config.sandbox.max_idle, 0);
     }
 }

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{RunnerError, RunnerResult};
+use crate::idle_pool::DEFAULT_IDLE_TIMEOUT_SECS;
 use crate::paths::{HomePaths, ImagePaths};
 use crate::profile;
 
@@ -48,7 +49,8 @@ pub struct SandboxConfig {
     pub max_concurrent: usize,
     /// Overcommit factor applied to both CPU and memory budgets (default: 1.0).
     pub concurrency_factor: f64,
-    /// Idle timeout in seconds for reusable VMs (default: 1800).
+    /// Idle timeout in seconds for reusable VMs
+    /// (default: [`DEFAULT_IDLE_TIMEOUT_SECS`]).
     pub idle_timeout_secs: u64,
     /// Maximum number of idle VMs to keep (0 = no limit, default: 0).
     pub max_idle: usize,
@@ -59,7 +61,7 @@ impl Default for SandboxConfig {
         Self {
             max_concurrent: DEFAULT_MAX_CONCURRENT,
             concurrency_factor: DEFAULT_CONCURRENCY_FACTOR,
-            idle_timeout_secs: 1800,
+            idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
             max_idle: 0,
         }
     }
@@ -955,7 +957,7 @@ profiles:
         tokio::fs::write(&config_path, &yaml).await.unwrap();
 
         let config = load_with_home(&config_path, &home).await.unwrap();
-        assert_eq!(config.sandbox.idle_timeout_secs, 1800);
+        assert_eq!(config.sandbox.idle_timeout_secs, DEFAULT_IDLE_TIMEOUT_SECS);
         assert_eq!(config.sandbox.max_idle, 0);
     }
 }

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -6,8 +6,8 @@ use sandbox::{Sandbox, SandboxFactory};
 
 use crate::types::StorageManifest;
 
-/// Default idle timeout for kept-alive VMs (5 minutes).
-const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 300;
+/// Default idle timeout for kept-alive VMs (30 minutes).
+const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 1800;
 
 /// Compact version fingerprints for storage manifest entries.
 /// Used to skip re-downloading unchanged storages on VM reuse.

--- a/crates/runner/src/idle_pool.rs
+++ b/crates/runner/src/idle_pool.rs
@@ -7,7 +7,10 @@ use sandbox::{Sandbox, SandboxFactory};
 use crate::types::StorageManifest;
 
 /// Default idle timeout for kept-alive VMs (30 minutes).
-const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 1800;
+///
+/// Re-exported via `SandboxConfig::default()` so the YAML default and
+/// the in-process fallback stay locked together.
+pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 1800;
 
 /// Compact version fingerprints for storage manifest entries.
 /// Used to skip re-downloading unchanged storages on VM reuse.


### PR DESCRIPTION
## Summary

- Bump `SandboxConfig::idle_timeout_secs` default from `300` (5 min) to `1800` (30 min).
- Keep `DEFAULT_IDLE_TIMEOUT_SECS` constant in `idle_pool.rs` in sync (used by `IdlePoolConfig::Default` fallback only; not on the production path, but referenced in docs).
- Update the `idle_pool_defaults_when_omitted` test assertion accordingly.

## Why

Typical agent turn intervals are P50 1–3 min, P90 ~15 min. The 5-minute default missed the common "user steps away briefly" case (reading output, switching context, joining a meeting), forcing a cold start on return. 30 min covers P90 turn intervals while staying well below the 2-hour active session ceiling that the system already supports.

## Trade-off considered

- **Resource footprint**: a parked VM holds the same RSS as an active one. Since the system already supports 2-hour active sessions, extending the unobserved-but-running window to 30 min adds at most 25 min of headroom per session — strictly less than what active execution already allows. Resource reduction work is tracked in #9068.
- **Liveness gap**: `IdlePool::take()` does not currently health-check parked VMs. This pre-existed and is independent of the timeout value, but a longer idle window enlarges the unobserved-failure surface. Tracked in #9069.
- **Other staleness concerns** (DNS cache, TCP keepalive, auth tokens, conntrack, clock drift): all already tolerated by the 2-hour active path, so 30 min idle does not introduce new failure modes.

## Test plan

- [x] `cargo test -p runner --bin runner config::` — 17 passed including `idle_pool_defaults_when_omitted`
- [x] `cargo build -p runner` — clean
- [x] cargo-fmt + cargo-clippy via lefthook pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)