### PR TITLE
fix: render schedule list items as real anchor links (#8690)

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/schedule-list-view.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/schedule-list-view.test.tsx
@@ -284,6 +284,30 @@ describe("schedule list view - row click navigates to detail (SCHED-D-087)", () 
   });
 });
 
+describe("schedule list view - row renders as anchor link (SCHED-D-087b)", () => {
+  it("renders schedule rows as <a> elements with href so middle/right-click open in new tab works", async () => {
+    mockScheduleAPI();
+    detachedSetupPage({ context, path: "/schedules" });
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByLabelText(
+          /Open schedule Summarize yesterday's threads/,
+        )[0],
+      ).toBeInTheDocument();
+    });
+
+    const link = screen.getAllByLabelText(
+      /Open schedule Summarize yesterday's threads/,
+    )[0];
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute(
+      "href",
+      "/schedules/f0000001-0000-4000-a000-000000000001",
+    );
+  });
+});
+
 describe("schedule list view - toggle switch (SCHED-D-088)", () => {
   it("sends enable action when a disabled schedule toggle is clicked", async () => {
     const user = userEvent.setup();

--- a/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
+++ b/turbo/apps/platform/src/views/zero-page/schedule-list-view.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuItem,
 } from "@vm0/ui";
 import { LoadingSwitch } from "../components/loading-switch.tsx";
+import { Link } from "../router/link.tsx";
 import type { ScheduleEntry } from "./schedule-utils";
 import emptyScheduleImg from "./assets/empty-schedule.webp";
 
@@ -53,27 +54,13 @@ function ScheduleListRow<T extends ScheduleEntry>({
     <tr
       className={cn(
         "border-b border-border/50 last:border-0 transition-colors",
-        clickable &&
-          "hover:bg-muted/25 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring",
+        clickable && "hover:bg-muted/25 cursor-pointer",
         dimmed && "opacity-75",
       )}
-      role={clickable ? "link" : undefined}
-      tabIndex={clickable ? 0 : undefined}
-      aria-label={clickable ? `Open schedule ${entry.prompt}` : undefined}
       onClick={
         clickable
           ? () => {
               return onOpenDetails(entry);
-            }
-          : undefined
-      }
-      onKeyDown={
-        clickable
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onOpenDetails(entry);
-              }
             }
           : undefined
       }
@@ -86,14 +73,31 @@ function ScheduleListRow<T extends ScheduleEntry>({
         </td>
       )}
       <td className="py-2.5 pr-4 align-middle min-w-0 max-w-[1px]">
-        <span
-          className={cn(
-            "text-sm text-foreground leading-snug block truncate whitespace-nowrap",
-            dimmed && "text-muted-foreground",
-          )}
-        >
-          {entry.description || entry.prompt}
-        </span>
+        {clickable ? (
+          <Link
+            pathname="/schedules/:scheduleId"
+            options={{ pathParams: { scheduleId: entry.id } }}
+            aria-label={`Open schedule ${entry.prompt}`}
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+            className={cn(
+              "text-sm text-foreground leading-snug block truncate whitespace-nowrap focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring rounded-sm",
+              dimmed && "text-muted-foreground",
+            )}
+          >
+            {entry.description || entry.prompt}
+          </Link>
+        ) : (
+          <span
+            className={cn(
+              "text-sm text-foreground leading-snug block truncate whitespace-nowrap",
+              dimmed && "text-muted-foreground",
+            )}
+          >
+            {entry.description || entry.prompt}
+          </span>
+        )}
       </td>
       <td
         className={cn(
@@ -251,33 +255,23 @@ function ScheduleListCard<T extends ScheduleEntry>({
   return (
     <div
       className={cn(
-        "flex items-center gap-2 px-5 py-3 border-b border-border/50 last:border-0 transition-colors",
-        clickable && "cursor-pointer hover:bg-muted/25",
+        "relative flex items-center gap-2 px-5 py-3 border-b border-border/50 last:border-0 transition-colors",
+        clickable && "hover:bg-muted/25",
         dimmed && "opacity-75",
       )}
-      role={clickable ? "button" : undefined}
-      tabIndex={clickable ? 0 : undefined}
-      aria-label={clickable ? `Open schedule ${entry.prompt}` : undefined}
-      onClick={
-        clickable
-          ? () => {
-              return onOpenDetails(entry);
-            }
-          : undefined
-      }
-      onKeyDown={
-        clickable
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onOpenDetails(entry);
-              }
-            }
-          : undefined
-      }
     >
-      {/* Left: text content */}
-      <div className="min-w-0 flex-1 flex flex-col gap-0.5">
+      {clickable && (
+        <Link
+          pathname="/schedules/:scheduleId"
+          options={{ pathParams: { scheduleId: entry.id } }}
+          aria-label={`Open schedule ${entry.prompt}`}
+          className="absolute inset-0 z-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring rounded-sm"
+        >
+          <span className="sr-only">Open schedule {entry.prompt}</span>
+        </Link>
+      )}
+      {/* Left: text content — pointer-events disabled so clicks pass through to the Link overlay */}
+      <div className="min-w-0 flex-1 flex flex-col gap-0.5 pointer-events-none">
         {showAgent && (
           <span className="block text-sm font-medium text-foreground truncate">
             {agentLabel}
@@ -307,13 +301,8 @@ function ScheduleListCard<T extends ScheduleEntry>({
         </span>
       </div>
 
-      {/* Right: toggle + more button */}
-      <div
-        className="flex items-center gap-4 shrink-0"
-        onClick={(e) => {
-          return e.stopPropagation();
-        }}
-      >
+      {/* Right: toggle + more button — relative + z-10 so they sit above the link overlay */}
+      <div className="relative z-10 flex items-center gap-4 shrink-0">
         {onToggle && (
           <LoadingSwitch
             checked={entry.enabled !== false}


### PR DESCRIPTION
## Summary
- Replaces the `div`/`tr` + `onClick` schedule list rows with the existing `Link` component so they render as real `<a href>` elements
- Restores native browser behaviors broken before this change: middle-click to open in a new tab, `Cmd/Ctrl/Shift+click`, and the right-click "Open Link in New Tab" context menu
- Desktop table: the description cell becomes a `Link` (with `e.stopPropagation()` so the row's `onClick` still works for the rest of the row)
- Mobile card: an absolute-positioned `Link` overlay covers the card; text content is `pointer-events-none` and the toggle/action controls sit on `relative z-10` so they remain clickable

## Test plan
- [x] `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/schedule-list-view.test.tsx` — 13/13 passing
- [x] `pnpm format` and `oxlint` clean
- [ ] Manual: middle-click a schedule row → opens detail in a new tab
- [ ] Manual: right-click a schedule row → "Open Link in New Tab" works
- [ ] Manual: `Cmd/Ctrl+click` opens in a new tab; plain click still navigates in-app
- [ ] Manual: toggle switch and action menu still work without navigating

Closes #8690