### PR TITLE
feat(voice-chat): add realtime model selector

### DIFF
--- a/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
+++ b/turbo/apps/platform/src/signals/voice-chat/voice-chat-session.ts
@@ -64,7 +64,8 @@ const PREP_TIMEOUT_CHAT_MS = 60_000;
 const PREP_TIMEOUT_MEETING_MS = 300_000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 1000;
-const REALTIME_MODEL = "gpt-realtime-1.5";
+export type RealtimeModel = "gpt-realtime" | "gpt-realtime-mini";
+
 const HANDS_FREE_VAD_CONFIG = {
   type: "semantic_vad",
   eagerness: "medium",
@@ -191,6 +192,7 @@ const internalPrepStartTime$ = state<number | null>(null);
 const internalPrepElapsedMs$ = state(0);
 const internalReconnectAttempt$ = state(0);
 const internalInputMode$ = state<"hands-free" | "push-to-talk">("hands-free");
+const internalModel$ = state<RealtimeModel>("gpt-realtime");
 
 const internalParentSignal$ = state<AbortSignal | null>(null);
 const internalWakeLock$ = state<WakeLockSentinel | null>(null);
@@ -240,6 +242,12 @@ export const vcMeetingPromptInput$ = computed((get) => {
 });
 export const setMeetingPromptInput$ = command(({ set }, value: string) => {
   set(meetingPromptInput$, value);
+});
+export const vcModel$ = computed((get) => {
+  return get(internalModel$);
+});
+export const setVcModel$ = command(({ set }, model: RealtimeModel) => {
+  set(internalModel$, model);
 });
 
 // --- Internal commands ---
@@ -465,6 +473,7 @@ const setupWebRTC$ = command(
     { get, set },
     stream: MediaStream,
     token: string,
+    model: RealtimeModel,
     signal: AbortSignal,
   ): Promise<boolean> => {
     const pc = new RTCPeerConnection();
@@ -550,7 +559,7 @@ const setupWebRTC$ = command(
     signal.throwIfAborted();
 
     const sdpRes = await globalThis.fetch(
-      `https://api.openai.com/v1/realtime?model=${REALTIME_MODEL}`,
+      `https://api.openai.com/v1/realtime?model=${model}`,
       {
         method: "POST",
         headers: {
@@ -714,9 +723,12 @@ const reconnectVoiceSession$ = command(
       // Clean up old WebRTC resources
       set(cleanupWebRTC$);
 
-      // Fetch new token
+      // Fetch new token with selected model
+      const model = get(internalModel$);
       const tokenRes = await fetchFn("/api/zero/voice-chat/token", {
         method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model }),
         signal,
       });
       if (!tokenRes.ok) {
@@ -765,7 +777,13 @@ const reconnectVoiceSession$ = command(
       signal.throwIfAborted();
 
       // Setup new WebRTC connection
-      const ok = await set(setupWebRTC$, stream, clientSecret.value, signal);
+      const ok = await set(
+        setupWebRTC$,
+        stream,
+        clientSecret.value,
+        model,
+        signal,
+      );
       if (ok) {
         // Success — restart heartbeat and poll loops
         set(internalReconnectAttempt$, 0);
@@ -829,11 +847,14 @@ const releaseWakeLock$ = command(({ get, set }) => {
 const connectVoiceSession$ = command(
   async ({ get, set }, sessionSignal: AbortSignal) => {
     const fetchFn = get(fetch$);
+    const model = get(internalModel$);
 
     set(internalStatus$, "connecting");
 
     const tokenRes = await fetchFn("/api/zero/voice-chat/token", {
       method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model }),
     });
     sessionSignal.throwIfAborted();
 
@@ -878,6 +899,7 @@ const connectVoiceSession$ = command(
       setupWebRTC$,
       stream,
       clientSecret.value,
+      model,
       sessionSignal,
     );
     sessionSignal.throwIfAborted();
@@ -1264,6 +1286,7 @@ export const endVoiceChat$ = command(({ get, set }) => {
   set(internalPrepElapsedMs$, 0);
   set(internalReconnectAttempt$, 0);
   set(internalInputMode$, "hands-free");
+  set(internalModel$, "gpt-realtime");
   set(internalParentSignal$, null);
   set(internalStatus$, "idle");
 });

--- a/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
+++ b/turbo/apps/platform/src/views/voice-chat/voice-chat-page.tsx
@@ -36,6 +36,9 @@ import {
   switchInputMode$,
   startPTT$,
   stopPTT$,
+  vcModel$,
+  setVcModel$,
+  type RealtimeModel,
 } from "../../signals/voice-chat/voice-chat-session.ts";
 import {
   setTranscriptScrollContainer$,
@@ -233,6 +236,8 @@ export function VoiceChatPage() {
   const prepElapsedMs = useGet(vcPrepElapsedMs$);
   const meetingPrompt = useGet(vcMeetingPromptInput$);
   const setMeetingPrompt = useSet(setMeetingPromptInput$);
+  const model = useGet(vcModel$);
+  const setModel = useSet(setVcModel$);
   const agentName = useLastResolved(defaultAgentName$) ?? "Zero";
   const setTranscriptContainer = useSet(setTranscriptScrollContainer$);
   const setEventsContainer = useSet(setEventsScrollContainer$);
@@ -267,6 +272,21 @@ export function VoiceChatPage() {
             No agent selected. Please select an agent first.
           </p>
         )}
+        <Tabs
+          value={model}
+          onValueChange={(v) => {
+            setModel(v as RealtimeModel);
+          }}
+        >
+          <TabsList>
+            <TabsTrigger value="gpt-realtime" className="text-xs px-3">
+              GPT Realtime
+            </TabsTrigger>
+            <TabsTrigger value="gpt-realtime-mini" className="text-xs px-3">
+              GPT Realtime Mini
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
         <div className="w-full max-w-md rounded-lg border border-input p-5 flex flex-col gap-3">
           <h2 className="text-lg font-semibold">Quick Chat</h2>
           <p className="text-sm text-muted-foreground">

--- a/turbo/apps/web/app/api/zero/voice-chat/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/__tests__/route.test.ts
@@ -35,9 +35,13 @@ async function setupOrg(userId: string) {
   return { slug, orgId };
 }
 
-function tokenRequest() {
+function tokenRequest(body?: Record<string, unknown>) {
   return new Request("http://localhost:3000/api/zero/voice-chat/token", {
     method: "POST",
+    ...(body && {
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
   });
 }
 
@@ -125,5 +129,86 @@ describe("POST /api/zero/voice-chat/token", () => {
 
     expect(response.status).toBe(500);
     expect(body.error.code).toBe("INTERNAL_SERVER_ERROR");
+  });
+
+  it("should pass explicit model to OpenAI API", async () => {
+    const userId = uniqueId("zvc-model");
+    await setupOrg(userId);
+
+    let capturedModel: string | undefined;
+    server.use(
+      http.post(
+        "https://api.openai.com/v1/realtime/sessions",
+        async ({ request }) => {
+          const reqBody = (await request.json()) as { model?: string };
+          capturedModel = reqBody.model;
+          return HttpResponse.json({
+            client_secret: {
+              value: "eph_mini_token",
+              expires_at: 1700000000,
+            },
+          });
+        },
+      ),
+    );
+
+    const response = await POST(tokenRequest({ model: "gpt-realtime-mini" }));
+
+    expect(response.status).toBe(200);
+    expect(capturedModel).toBe("gpt-realtime-mini");
+  });
+
+  it("should default to gpt-realtime when no model is provided", async () => {
+    const userId = uniqueId("zvc-nomodel");
+    await setupOrg(userId);
+
+    let capturedModel: string | undefined;
+    server.use(
+      http.post(
+        "https://api.openai.com/v1/realtime/sessions",
+        async ({ request }) => {
+          const reqBody = (await request.json()) as { model?: string };
+          capturedModel = reqBody.model;
+          return HttpResponse.json({
+            client_secret: {
+              value: "eph_default_token",
+              expires_at: 1700000000,
+            },
+          });
+        },
+      ),
+    );
+
+    const response = await POST(tokenRequest());
+
+    expect(response.status).toBe(200);
+    expect(capturedModel).toBe("gpt-realtime");
+  });
+
+  it("should fall back to gpt-realtime for invalid model", async () => {
+    const userId = uniqueId("zvc-invalid");
+    await setupOrg(userId);
+
+    let capturedModel: string | undefined;
+    server.use(
+      http.post(
+        "https://api.openai.com/v1/realtime/sessions",
+        async ({ request }) => {
+          const reqBody = (await request.json()) as { model?: string };
+          capturedModel = reqBody.model;
+          return HttpResponse.json({
+            client_secret: {
+              value: "eph_fallback_token",
+              expires_at: 1700000000,
+            },
+          });
+        },
+      ),
+    );
+
+    const response = await POST(tokenRequest({ model: "invalid-model" }));
+
+    expect(response.status).toBe(200);
+    expect(capturedModel).toBe("gpt-realtime");
   });
 });

--- a/turbo/apps/web/app/api/zero/voice-chat/token/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-chat/token/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { FeatureSwitchKey, isFeatureEnabled } from "@vm0/core";
 import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
 import { initServices } from "../../../../../src/lib/init-services";
@@ -8,6 +9,8 @@ import { createEphemeralToken } from "../../../../../src/lib/zero/voice-chat/ope
 import { logger } from "../../../../../src/lib/shared/logger";
 
 const log = logger("api:zero:voice-chat:token");
+
+const bodySchema = z.object({ model: z.string().optional() }).optional();
 
 export async function POST(request: Request): Promise<Response> {
   initServices();
@@ -50,7 +53,11 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
-    const result = await createEphemeralToken();
+    const raw = await request.json().catch(() => {
+      return undefined;
+    });
+    const body = bodySchema.parse(raw);
+    const result = await createEphemeralToken(body?.model);
     return NextResponse.json(result);
   } catch (error) {
     log.error("Failed to create ephemeral token", { error });

--- a/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
+++ b/turbo/apps/web/src/lib/zero/voice-chat/openai-token.ts
@@ -5,6 +5,16 @@ const log = logger("voice-chat:openai-token");
 
 const OPENAI_REALTIME_URL = "https://api.openai.com/v1/realtime/sessions";
 
+const ALLOWED_MODELS = ["gpt-realtime", "gpt-realtime-mini"] as const;
+type RealtimeModel = (typeof ALLOWED_MODELS)[number];
+
+function resolveModel(input?: string): RealtimeModel {
+  if (input && ALLOWED_MODELS.includes(input as RealtimeModel)) {
+    return input as RealtimeModel;
+  }
+  return "gpt-realtime";
+}
+
 interface EphemeralTokenResponse {
   client_secret: {
     value: string;
@@ -12,11 +22,15 @@ interface EphemeralTokenResponse {
   };
 }
 
-export async function createEphemeralToken(): Promise<EphemeralTokenResponse> {
+export async function createEphemeralToken(
+  model?: string,
+): Promise<EphemeralTokenResponse> {
   const apiKey = env().OPENAI_API_KEY;
   if (!apiKey) {
     throw new Error("OPENAI_API_KEY not configured");
   }
+
+  const resolvedModel = resolveModel(model);
 
   const response = await fetch(OPENAI_REALTIME_URL, {
     method: "POST",
@@ -25,7 +39,7 @@ export async function createEphemeralToken(): Promise<EphemeralTokenResponse> {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-realtime-1.5",
+      model: resolvedModel,
       voice: "verse",
     }),
   });


### PR DESCRIPTION
## Summary

- Add model selector segment control to the voice chat idle page allowing users to choose between `gpt-realtime` (standard, ~$0.30/min) and `gpt-realtime-mini` (cost-effective, ~$0.09/min) before starting a session
- Selected model is passed through to the OpenAI token endpoint (server-side validation via allowlist) and WebRTC SDP URL (client-side)
- Default model is `gpt-realtime`; invalid model values fall back to default

## Changes

### Token service (`openai-token.ts`)
- Added `model` parameter to `createEphemeralToken()` with allowlist validation
- Replaced hardcoded `gpt-realtime-1.5` with resolved model

### Token API route (`token/route.ts`)
- Parse optional `model` field from request JSON body using zod
- Pass model through to `createEphemeralToken()`

### Signal layer (`voice-chat-session.ts`)
- Added `RealtimeModel` type, `vcModel$` computed, and `setVcModel$` command
- Removed hardcoded `REALTIME_MODEL` constant
- `connectVoiceSession$` and `reconnectVoiceSession$` send `{ model }` in token POST body
- `setupWebRTC$` uses selected model in SDP URL
- Model resets to default on `endVoiceChat$`

### UI (`voice-chat-page.tsx`)
- Added `Tabs`/`TabsList`/`TabsTrigger` model selector in idle state (reuses existing components)
- Wired to `vcModel$` / `setVcModel$` signals

## Test plan

- [x] 3 new integration tests added to existing token route test file
  - Explicit model (`gpt-realtime-mini`) passed correctly to OpenAI API
  - No model provided defaults to `gpt-realtime`
  - Invalid model falls back to `gpt-realtime`
- [x] All 8 tests pass (5 existing + 3 new)
- [x] Lint passes (0 errors)
- [x] Knip passes (no unused exports)

Closes #9074

🤖 Generated with [Claude Code](https://claude.com/claude-code)