### PR TITLE
feat: add voice-io feature switch and tts backend endpoint

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../../src/mocks/server";
+import { POST } from "../route";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { createTestOrg } from "../../../../../../src/__tests__/api-test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { reloadEnv } from "../../../../../../src/env";
+
+vi.mock("@vm0/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vm0/core")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+const { isFeatureEnabled } = await import("@vm0/core");
+const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
+
+vi.hoisted(() => {
+  vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+});
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("zvio");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function ttsRequest(body?: unknown) {
+  return new Request("http://localhost:3000/api/zero/voice-io/tts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/zero/voice-io/tts", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    mockIsFeatureEnabled.mockReturnValue(true);
+    vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+    reloadEnv();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+
+    const response = await POST(ttsRequest({ text: "hello" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 403 when feature switch is disabled", async () => {
+    const userId = uniqueId("zvio-ff");
+    await setupOrg(userId);
+    mockIsFeatureEnabled.mockReturnValue(false);
+
+    const response = await POST(ttsRequest({ text: "hello" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should return 400 when text is empty", async () => {
+    const userId = uniqueId("zvio-empty");
+    await setupOrg(userId);
+
+    const response = await POST(ttsRequest({ text: "" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return 400 when text exceeds max length", async () => {
+    const userId = uniqueId("zvio-long");
+    await setupOrg(userId);
+
+    const response = await POST(ttsRequest({ text: "x".repeat(4097) }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("4096");
+  });
+
+  it("should return 503 when OPENAI_API_KEY is not configured", async () => {
+    const userId = uniqueId("zvio-nokey");
+    await setupOrg(userId);
+    vi.stubEnv("OPENAI_API_KEY", "");
+    reloadEnv();
+
+    const response = await POST(ttsRequest({ text: "hello" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+  });
+
+  it("should return audio on successful TTS call", async () => {
+    const userId = uniqueId("zvio-ok");
+    await setupOrg(userId);
+
+    const fakeAudio = new Uint8Array([0xff, 0xfb, 0x90, 0x00]);
+
+    server.use(
+      http.post(
+        "https://api.openai.com/v1/audio/speech",
+        async ({ request }) => {
+          const reqBody = (await request.json()) as Record<string, unknown>;
+          expect(reqBody.model).toBe("tts-1-hd");
+          expect(reqBody.voice).toBe("verse");
+          expect(reqBody.input).toBe("hello world");
+          expect(reqBody.response_format).toBe("mp3");
+
+          return new HttpResponse(fakeAudio, {
+            headers: { "Content-Type": "audio/mpeg" },
+          });
+        },
+      ),
+    );
+
+    const response = await POST(ttsRequest({ text: "hello world" }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("audio/mpeg");
+
+    const buffer = await response.arrayBuffer();
+    expect(new Uint8Array(buffer)).toEqual(fakeAudio);
+  });
+
+  it("should return 500 when OpenAI API fails", async () => {
+    const userId = uniqueId("zvio-fail");
+    await setupOrg(userId);
+
+    server.use(
+      http.post("https://api.openai.com/v1/audio/speech", () => {
+        return HttpResponse.json(
+          { error: "rate_limit_exceeded" },
+          { status: 429 },
+        );
+      }),
+    );
+
+    const response = await POST(ttsRequest({ text: "hello" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error.code).toBe("INTERNAL_SERVER_ERROR");
+  });
+});

--- a/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/tts/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from "next/server";
+import { FeatureSwitchKey, isFeatureEnabled } from "@vm0/core";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { initServices } from "../../../../../src/lib/init-services";
+import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
+import { env } from "../../../../../src/env";
+import { logger } from "../../../../../src/lib/shared/logger";
+
+const log = logger("api:zero:voice-io:tts");
+
+const MAX_TEXT_LENGTH = 4096;
+
+const OPENAI_TTS_URL = "https://api.openai.com/v1/audio/speech";
+
+export async function POST(request: Request): Promise<Response> {
+  initServices();
+
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  const overrides = await loadFeatureSwitchOverrides(
+    authCtx.orgId,
+    authCtx.userId,
+  );
+  const enabled = isFeatureEnabled(FeatureSwitchKey.VoiceIO, {
+    orgId: authCtx.orgId,
+    userId: authCtx.userId,
+    overrides,
+  });
+  if (!enabled) {
+    return NextResponse.json(
+      { error: { message: "Voice IO is not enabled", code: "FORBIDDEN" } },
+      { status: 403 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: { message: "Invalid JSON body", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  const text =
+    typeof body === "object" && body !== null && "text" in body
+      ? (body as { text: unknown }).text
+      : undefined;
+
+  if (typeof text !== "string" || text.trim().length === 0) {
+    return NextResponse.json(
+      { error: { message: "text is required", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  if (text.length > MAX_TEXT_LENGTH) {
+    return NextResponse.json(
+      {
+        error: {
+          message: `text must be at most ${MAX_TEXT_LENGTH} characters`,
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const apiKey = env().OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "OpenAI API key not configured",
+          code: "SERVICE_UNAVAILABLE",
+        },
+      },
+      { status: 503 },
+    );
+  }
+
+  const response = await fetch(OPENAI_TTS_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "tts-1-hd",
+      voice: "verse",
+      input: text,
+      response_format: "mp3",
+    }),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    log.error("OpenAI TTS request failed", {
+      status: response.status,
+      body: errorBody,
+    });
+    return NextResponse.json(
+      {
+        error: {
+          message: "TTS generation failed",
+          code: "INTERNAL_SERVER_ERROR",
+        },
+      },
+      { status: 500 },
+    );
+  }
+
+  const audioBuffer = await response.arrayBuffer();
+
+  return new Response(audioBuffer, {
+    status: 200,
+    headers: {
+      "Content-Type": "audio/mpeg",
+      "Content-Length": String(audioBuffer.byteLength),
+    },
+  });
+}

--- a/turbo/packages/core/src/feature-switch-key.ts
+++ b/turbo/packages/core/src/feature-switch-key.ts
@@ -39,6 +39,7 @@ export enum FeatureSwitchKey {
   AuditLink = "auditLink",
   PhoneIntegration = "phoneIntegration",
   VoiceChat = "voiceChat",
+  VoiceIO = "voiceIO",
   MissionControlSidebar = "missionControlSidebar",
   AutoSkill = "autoSkill",
   SandboxReuse = "sandboxReuse",

--- a/turbo/packages/core/src/feature-switch.ts
+++ b/turbo/packages/core/src/feature-switch.ts
@@ -226,6 +226,13 @@ const FEATURE_SWITCHES: Record<FeatureSwitchKey, FeatureSwitch> = {
     enabled: false,
     enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
   },
+  [FeatureSwitchKey.VoiceIO]: {
+    maintainer: "lancy@vm0.ai",
+    description:
+      "Enable voice input/output features in chat (TTS read-aloud, auto-read, voice input)",
+    enabled: false,
+    enabledOrgIdHashes: STAFF_ORG_ID_HASHES,
+  },
   [FeatureSwitchKey.MissionControlSidebar]: {
     maintainer: "ethan@vm0.ai",
     description: "Show the Mission Control page entry in the sidebar",


### PR DESCRIPTION
## Summary

- Add `VoiceIO` feature switch to `@vm0/core` (disabled by default, staff-org gated)
- Create `POST /api/zero/voice-io/tts` endpoint that accepts `{ text: string }` and returns `audio/mpeg` via OpenAI `tts-1-hd` model with voice `verse`
- Endpoint gates on auth + VoiceIO feature switch + OPENAI_API_KEY availability
- Input validation: rejects empty text and text > 4096 characters

## Test plan

- [x] Auth rejection (no auth → 401)
- [x] Feature switch disabled → 403
- [x] Missing OPENAI_API_KEY → 503
- [x] Empty text → 400
- [x] Text exceeds max length → 400
- [x] Successful TTS call returns audio/mpeg (MSW mock)
- [x] OpenAI API failure → 500
- [x] All 7 integration tests pass
- [x] All 687 core package tests pass (no regression)
- [x] Lint, format, knip pass

Closes #9078

🤖 Generated with [Claude Code](https://claude.com/claude-code)