### PR TITLE
test(platform): add esc key regression test for schedule dialog unsaved-changes guard

### DIFF
--- a/turbo/apps/platform/src/views/zero-page/__tests__/schedule-dialog.test.tsx
+++ b/turbo/apps/platform/src/views/zero-page/__tests__/schedule-dialog.test.tsx
@@ -558,3 +558,31 @@ describe("schedule dialog - unsaved continue (SCHED-D-066)", () => {
     });
   });
 });
+
+describe("schedule dialog - ESC with unsaved changes (SCHED-D-067)", () => {
+  it("shows confirm overlay when ESC is pressed with a dirty form", async () => {
+    const user = userEvent.setup();
+    await openCreateDialog(user);
+    await user.type(screen.getByLabelText("Prompt"), "Some text");
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    });
+    // Dialog must remain open behind the confirm overlay.
+    expect(
+      screen.getByRole("heading", { name: "Add schedule" }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes dialog directly when ESC is pressed on a clean form", async () => {
+    const user = userEvent.setup();
+    await openCreateDialog(user);
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("heading", { name: "Add schedule" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `SCHED-D-067` integration tests for ESC key behavior on the schedule dialog.
- Verifies the existing unsaved-changes guard (feat #6154) actually runs when the user presses ESC — no previous test exercised that path.

## Background
Issue #8875 reported that ESC dismisses the schedule dialog silently even with unsaved edits. Investigation found the guard is already wired in `schedule-dialog.tsx`:

- `onEscapeKeyDown` calls `e.preventDefault()` and routes through `requestClose()`.
- `requestClose()` shows `ConfirmCloseOverlay` when `isDirty`.

The real gap was test coverage — `grep` of the test file finds no `Escape` usage, so a regression could slip in unnoticed. This PR closes that gap.

## Changes
- `apps/platform/src/views/zero-page/__tests__/schedule-dialog.test.tsx`:
  - `SCHED-D-067` / dirty form: press ESC → expect `alertdialog` role to appear AND the "Add schedule" heading to still be rendered (dialog stays open behind the overlay).
  - `SCHED-D-067` / clean form: press ESC → expect the "Add schedule" heading to disappear AND no `alertdialog` to be present.

## Test plan
- [x] New tests pass locally: `pnpm -F @vm0/app exec vitest run src/views/zero-page/__tests__/schedule-dialog.test.tsx` → 21 passed (19 pre-existing + 2 new).
- [x] Manual repro in dev — ESC with empty form closes; ESC with typed prompt shows confirmation.
- [ ] CI green.

Closes #8875