### PR TITLE
feat(web): add integration description for web chat runs

### DIFF
--- a/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import {
   getTestZeroAgentId,
   insertOrgDefaultModelProvider,
   findTestCallbacksByRunId,
+  getTestRun,
 } from "../../../../../../src/__tests__/api-test-helpers";
 import {
   testContext,
@@ -221,6 +222,27 @@ describe("POST /api/zero/chat/messages", () => {
       const callbacks = await findTestCallbacksByRunId(data.runId);
       expect(callbacks.length).toBeGreaterThan(0);
       expect(callbacks[0]!.url).toContain("/api/internal/callbacks/chat");
+    });
+
+    it("should include web integration prompt in appendSystemPrompt", async () => {
+      const response = await POST(
+        createTestRequest(URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            agentId,
+            prompt: "test web integration prompt",
+          }),
+        }),
+      );
+      expect(response.status).toBe(201);
+      const data = await response.json();
+
+      const run = await getTestRun(data.runId);
+      expect(run.appendSystemPrompt).toContain(
+        "You are currently running inside: Web",
+      );
+      expect(run.appendSystemPrompt).toContain("web chat UI");
     });
 
     it("should skip title generation when hasTextContent is false (image-only message)", async () => {

--- a/turbo/apps/web/app/api/zero/chat/messages/route.ts
+++ b/turbo/apps/web/app/api/zero/chat/messages/route.ts
@@ -15,6 +15,7 @@ import {
   createZeroRunRecord,
   dispatchZeroRun,
 } from "../../../../../src/lib/zero/zero-run-service";
+import { buildWebChatPrompt } from "../../../../../src/lib/zero/integration-prompt";
 import { isApiError } from "../../../../../src/lib/shared/errors";
 import {
   createChatThread,
@@ -123,6 +124,7 @@ const router = tsr.router(chatMessagesContract, {
         sessionId,
         triggerSource: "web",
         modelProvider,
+        appendSystemPrompt: buildWebChatPrompt(),
         callbacks: [chatCallback],
       });
 

--- a/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
+++ b/turbo/apps/web/src/lib/zero/__tests__/integration-prompt.test.ts
@@ -7,6 +7,7 @@ import {
   buildPhonePrompt,
   buildTelegramPrompt,
   buildGitHubPrompt,
+  buildWebChatPrompt,
 } from "../integration-prompt";
 
 describe("buildIntegrationPrompt", () => {
@@ -230,5 +231,20 @@ describe("buildGitHubPrompt", () => {
     const result = buildGitHubPrompt("");
 
     expect(result).toContain("You are currently running inside: GitHub");
+  });
+});
+
+describe("buildWebChatPrompt", () => {
+  it("should include web integration header", () => {
+    const result = buildWebChatPrompt();
+
+    expect(result).toContain("You are currently running inside: Web");
+  });
+
+  it("should include web chat description", () => {
+    const result = buildWebChatPrompt();
+
+    expect(result).toContain("web chat UI");
+    expect(result).toContain("displayed to the user directly");
   });
 });

--- a/turbo/apps/web/src/lib/zero/integration-prompt.ts
+++ b/turbo/apps/web/src/lib/zero/integration-prompt.ts
@@ -9,7 +9,8 @@ type IntegrationPlatform =
   | "Schedule"
   | "Slack"
   | "Telegram"
-  | "Voice-Chat";
+  | "Voice-Chat"
+  | "Web";
 
 /**
  * Build the integration prompt header prepended to agent run prompts.
@@ -407,4 +408,18 @@ export function buildTelegramPrompt(threadContext: string): string {
 export function buildGitHubPrompt(issueContext: string): string {
   const header = buildIntegrationPrompt("GitHub");
   return [header, issueContext].filter(Boolean).join("\n\n");
+}
+
+/**
+ * Build the full appendSystemPrompt for Web Chat integration.
+ *
+ * The user is interacting through the web chat UI, so the final result of the
+ * run will be rendered directly to them. Keep this in mind when producing
+ * output — there is no separate delivery step.
+ */
+export function buildWebChatPrompt(): string {
+  const header = buildIntegrationPrompt("Web");
+  const description =
+    "You are communicating with the user through the web chat UI. The final result you return will be displayed to the user directly in the chat.";
+  return [header, description].join("\n\n");
 }


### PR DESCRIPTION
## Summary
- Extend the `IntegrationPlatform` type with `"Web"` and add `buildWebChatPrompt()` in `integration-prompt.ts` so web chat runs get the same kind of integration header that Slack/Email/Phone/etc. already have.
- Pass `appendSystemPrompt: buildWebChatPrompt()` into `createZeroRunRecord()` from the web chat API route, so the agent knows it is talking to a user through the web chat UI and its final result will be shown directly in the chat.

## Test plan
- [ ] Send a message from the web chat UI and verify the run's system prompt contains the new `# Current Integration` block with `You are currently running inside: Web`.
- [ ] Confirm Slack / Email / Phone / Voice-Chat flows are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)