### PR TITLE
feat: add stt backend endpoint for voice transcription (#9079)

### DIFF
--- a/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../../../../src/mocks/server";
+import {
+  testContext,
+  uniqueId,
+} from "../../../../../../src/__tests__/test-helpers";
+import { createTestOrg } from "../../../../../../src/__tests__/api-test-helpers";
+import { mockClerk } from "../../../../../../src/__tests__/clerk-mock";
+import { reloadEnv } from "../../../../../../src/env";
+
+vi.mock("@vm0/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@vm0/core")>();
+  return {
+    ...actual,
+    isFeatureEnabled: vi.fn().mockReturnValue(true),
+  };
+});
+
+const { isFeatureEnabled } = await import("@vm0/core");
+const mockIsFeatureEnabled = isFeatureEnabled as ReturnType<typeof vi.fn>;
+
+vi.hoisted(() => {
+  vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+});
+
+const { POST } = await import("../route");
+
+const context = testContext();
+
+async function setupOrg(userId: string) {
+  const slug = uniqueId("stt");
+  const orgId = `org_mock_${userId}`;
+  mockClerk({ userId, orgId, orgRole: "org:admin" });
+  await createTestOrg(slug);
+  return { slug, orgId };
+}
+
+function createAudioFile(
+  size = 1024,
+  type = "audio/webm",
+  name = "recording.webm",
+): File {
+  const buffer = new ArrayBuffer(size);
+  return new File([buffer], name, { type });
+}
+
+function createSttRequest(file?: File): Request {
+  const formData = new FormData();
+  if (file) formData.append("file", file);
+  return new Request("http://localhost:3000/api/zero/voice-io/stt", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+describe("POST /api/zero/voice-io/stt", () => {
+  beforeEach(() => {
+    context.setupMocks();
+    mockIsFeatureEnabled.mockReturnValue(true);
+    vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+    reloadEnv();
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    mockClerk({ userId: null });
+    const response = await POST(createSttRequest(createAudioFile()));
+    const body = await response.json();
+    expect(response.status).toBe(401);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  it("should return 403 when feature flag is disabled", async () => {
+    const userId = uniqueId("stt-ff");
+    await setupOrg(userId);
+    mockIsFeatureEnabled.mockReturnValue(false);
+    const response = await POST(createSttRequest(createAudioFile()));
+    const body = await response.json();
+    expect(response.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should return 503 when OPENAI_API_KEY is not configured", async () => {
+    const userId = uniqueId("stt-nokey");
+    await setupOrg(userId);
+    vi.stubEnv("OPENAI_API_KEY", "");
+    reloadEnv();
+    const response = await POST(createSttRequest(createAudioFile()));
+    const body = await response.json();
+    expect(response.status).toBe(503);
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+  });
+
+  it("should return 400 when no file is provided", async () => {
+    const userId = uniqueId("stt-nofile");
+    await setupOrg(userId);
+    const response = await POST(createSttRequest());
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return 400 for unsupported file type", async () => {
+    const userId = uniqueId("stt-badtype");
+    await setupOrg(userId);
+    const file = createAudioFile(1024, "text/plain", "notes.txt");
+    const response = await POST(createSttRequest(file));
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return 400 for file exceeding 25MB", async () => {
+    const userId = uniqueId("stt-big");
+    await setupOrg(userId);
+    const file = createAudioFile(26 * 1024 * 1024);
+    const response = await POST(createSttRequest(file));
+    const body = await response.json();
+    expect(response.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  it("should return transcribed text on success", async () => {
+    const userId = uniqueId("stt-ok");
+    await setupOrg(userId);
+
+    server.use(
+      http.post("https://api.openai.com/v1/audio/transcriptions", () => {
+        return HttpResponse.json({ text: "Hello, world!" });
+      }),
+    );
+
+    const response = await POST(createSttRequest(createAudioFile()));
+    const body = await response.json();
+    expect(response.status).toBe(200);
+    expect(body.text).toBe("Hello, world!");
+  });
+
+  it("should return 500 when OpenAI API fails", async () => {
+    const userId = uniqueId("stt-fail");
+    await setupOrg(userId);
+
+    server.use(
+      http.post("https://api.openai.com/v1/audio/transcriptions", () => {
+        return HttpResponse.json(
+          { error: { message: "rate limit exceeded" } },
+          { status: 429 },
+        );
+      }),
+    );
+
+    const response = await POST(createSttRequest(createAudioFile()));
+    const body = await response.json();
+    expect(response.status).toBe(500);
+    expect(body.error.code).toBe("INTERNAL_SERVER_ERROR");
+  });
+});

--- a/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
@@ -105,41 +105,25 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   // 7. Call OpenAI Whisper API
-  try {
-    const openaiForm = new FormData();
-    openaiForm.append("file", file, file.name || "audio.webm");
-    openaiForm.append("model", "whisper-1");
-    openaiForm.append("response_format", "json");
+  const openaiForm = new FormData();
+  openaiForm.append("file", file, file.name || "audio.webm");
+  openaiForm.append("model", "whisper-1");
+  openaiForm.append("response_format", "json");
 
-    const openaiResponse = await fetch(
-      "https://api.openai.com/v1/audio/transcriptions",
-      {
-        method: "POST",
-        headers: { Authorization: `Bearer ${apiKey}` },
-        body: openaiForm,
-      },
-    );
+  const openaiResponse = await fetch(
+    "https://api.openai.com/v1/audio/transcriptions",
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: openaiForm,
+    },
+  );
 
-    if (!openaiResponse.ok) {
-      log.error("OpenAI Whisper API error", {
-        status: openaiResponse.status,
-        statusText: openaiResponse.statusText,
-      });
-      return NextResponse.json(
-        {
-          error: {
-            message: "Transcription failed",
-            code: "INTERNAL_SERVER_ERROR",
-          },
-        },
-        { status: 500 },
-      );
-    }
-
-    const result = (await openaiResponse.json()) as { text: string };
-    return NextResponse.json({ text: result.text });
-  } catch (error) {
-    log.error("Failed to transcribe audio", { error });
+  if (!openaiResponse.ok) {
+    log.error("OpenAI Whisper API error", {
+      status: openaiResponse.status,
+      statusText: openaiResponse.statusText,
+    });
     return NextResponse.json(
       {
         error: {
@@ -150,4 +134,7 @@ export async function POST(request: Request): Promise<Response> {
       { status: 500 },
     );
   }
+
+  const result = (await openaiResponse.json()) as { text: string };
+  return NextResponse.json({ text: result.text });
 }

--- a/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
+++ b/turbo/apps/web/app/api/zero/voice-io/stt/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from "next/server";
+import { FeatureSwitchKey, isFeatureEnabled } from "@vm0/core";
+import { getAuthContext } from "../../../../../src/lib/auth/get-auth-context";
+import { initServices } from "../../../../../src/lib/init-services";
+import { loadFeatureSwitchOverrides } from "../../../../../src/lib/zero/user/feature-switches-service";
+import { env } from "../../../../../src/env";
+import { logger } from "../../../../../src/lib/shared/logger";
+
+const log = logger("api:zero:voice-io:stt");
+
+const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MB (OpenAI limit)
+
+const ALLOWED_MIME_TYPES = new Set([
+  "audio/webm",
+  "audio/wav",
+  "audio/wave",
+  "audio/x-wav",
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/mp4",
+  "audio/m4a",
+  "audio/x-m4a",
+  "audio/mpga",
+]);
+
+export async function POST(request: Request): Promise<Response> {
+  initServices();
+
+  // 1. Auth check
+  const authHeader = request.headers.get("authorization");
+  const authCtx = await getAuthContext(authHeader ?? undefined);
+  if (!authCtx) {
+    return NextResponse.json(
+      { error: { message: "Not authenticated", code: "UNAUTHORIZED" } },
+      { status: 401 },
+    );
+  }
+
+  // 2. Feature switch check
+  const overrides = await loadFeatureSwitchOverrides(
+    authCtx.orgId,
+    authCtx.userId,
+  );
+  const enabled = isFeatureEnabled(FeatureSwitchKey.VoiceIO, {
+    orgId: authCtx.orgId,
+    userId: authCtx.userId,
+    overrides,
+  });
+  if (!enabled) {
+    return NextResponse.json(
+      { error: { message: "Voice I/O is not enabled", code: "FORBIDDEN" } },
+      { status: 403 },
+    );
+  }
+
+  // 3. API key check
+  const apiKey = env().OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "OpenAI API key not configured",
+          code: "SERVICE_UNAVAILABLE",
+        },
+      },
+      { status: 503 },
+    );
+  }
+
+  // 4. Parse multipart form data
+  const formData = await request.formData();
+  const file = formData.get("file");
+
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json(
+      { error: { message: "No audio file provided", code: "BAD_REQUEST" } },
+      { status: 400 },
+    );
+  }
+
+  // 5. Validate file size
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      {
+        error: {
+          message: "File too large (max 25 MB)",
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // 6. Validate file type
+  if (!ALLOWED_MIME_TYPES.has(file.type)) {
+    return NextResponse.json(
+      {
+        error: {
+          message: `Unsupported audio format: ${file.type}. Supported: webm, wav, mp3, m4a, mp4, mpeg, mpga`,
+          code: "BAD_REQUEST",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  // 7. Call OpenAI Whisper API
+  try {
+    const openaiForm = new FormData();
+    openaiForm.append("file", file, file.name || "audio.webm");
+    openaiForm.append("model", "whisper-1");
+    openaiForm.append("response_format", "json");
+
+    const openaiResponse = await fetch(
+      "https://api.openai.com/v1/audio/transcriptions",
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: openaiForm,
+      },
+    );
+
+    if (!openaiResponse.ok) {
+      log.error("OpenAI Whisper API error", {
+        status: openaiResponse.status,
+        statusText: openaiResponse.statusText,
+      });
+      return NextResponse.json(
+        {
+          error: {
+            message: "Transcription failed",
+            code: "INTERNAL_SERVER_ERROR",
+          },
+        },
+        { status: 500 },
+      );
+    }
+
+    const result = (await openaiResponse.json()) as { text: string };
+    return NextResponse.json({ text: result.text });
+  } catch (error) {
+    log.error("Failed to transcribe audio", { error });
+    return NextResponse.json(
+      {
+        error: {
+          message: "Transcription failed",
+          code: "INTERNAL_SERVER_ERROR",
+        },
+      },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Add new POST endpoint at `/api/zero/voice-io/stt` that accepts audio files via multipart form-data and returns transcribed text using OpenAI Whisper API (`whisper-1`)
- Gate the endpoint behind `VoiceIO` feature switch (new, staff-org-only) with auth, API key, file size (25MB max), and audio format validation
- Add 8 integration tests covering auth (401), feature gate (403), missing API key (503), file validation (400), success (200), and OpenAI API failure (500)

## Changes

| File | Change |
|------|--------|
| `turbo/packages/core/src/feature-switch-key.ts` | Add `VoiceIO` enum value |
| `turbo/packages/core/src/feature-switch.ts` | Add VoiceIO switch definition (staff-org-only) |
| `turbo/apps/web/app/api/zero/voice-io/stt/route.ts` | New STT endpoint handler |
| `turbo/apps/web/app/api/zero/voice-io/stt/__tests__/route.test.ts` | Integration tests |

## Test plan

- [x] All 8 integration tests pass (`pnpm -F web exec vitest run stt`)
- [x] All 687 core package tests pass
- [x] Lint passes (0 errors)
- [x] TypeScript type-check passes
- [x] Knip reports no issues
- [x] Format check passes

Closes #9079

🤖 Generated with [Claude Code](https://claude.com/claude-code)