### PR TITLE
feat(mission-control): optimistic task signal for instant chat thread visibility

### DIFF
--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control-tasks.ts
@@ -14,6 +14,8 @@ import {
 } from "./create-activity-signals.ts";
 import { maximizedTaskId$ } from "./mission-control-panels.ts";
 
+const OPTIMISTIC_TTL_MS = 30_000;
+
 // ---------------------------------------------------------------------------
 // TaskPanelEntry — discriminated union for open panels
 // ---------------------------------------------------------------------------
@@ -28,6 +30,8 @@ export type TaskPanelEntry =
 
 export interface TaskSignals {
   task: TaskItem;
+  optimistic: boolean;
+  optimisticInsertedAt: number | null;
   open$: Computed<boolean>;
   openedAt$: Computed<number | null>;
   panelEntry$: Computed<TaskPanelEntry | null>;
@@ -71,6 +75,8 @@ function createTaskSignals(initialTask: TaskItem): TaskSignals {
 
   // Mutable ref so openTask$ always reads the latest API data
   const taskRef = { value: initialTask };
+  const optimisticRef = { value: false };
+  const optimisticInsertedAtRef = { value: null as number | null };
 
   const openTask$ = command(
     async ({ get, set }, signal: AbortSignal): Promise<void> => {
@@ -142,6 +148,18 @@ function createTaskSignals(initialTask: TaskItem): TaskSignals {
     set task(t: TaskItem) {
       taskRef.value = t;
     },
+    get optimistic() {
+      return optimisticRef.value;
+    },
+    set optimistic(v: boolean) {
+      optimisticRef.value = v;
+    },
+    get optimisticInsertedAt() {
+      return optimisticInsertedAtRef.value;
+    },
+    set optimisticInsertedAt(v: number | null) {
+      optimisticInsertedAtRef.value = v;
+    },
     open$,
     openedAt$,
     panelEntry$,
@@ -196,21 +214,40 @@ export const setupTasksLoop$ = command(
 
         const taskSignals = new Map(get(internalTaskSignals$));
 
-        // Prune stale entries
+        // Prune stale entries (skip optimistic entries — server hasn't confirmed yet)
         for (const [id, ts] of taskSignals) {
-          if (!taskIds.has(id)) {
-            set(ts.closeTask$);
-            taskSignals.delete(id);
+          if (taskIds.has(id)) {
+            continue;
           }
+          if (ts.optimistic) {
+            continue;
+          }
+          set(ts.closeTask$);
+          taskSignals.delete(id);
         }
 
-        // Add new entries
+        // Add new entries, clearing optimistic flag when server confirms
         for (const task of tasks) {
           const existing = taskSignals.get(task.id);
           if (existing) {
             existing.task = task;
+            existing.optimistic = false;
+            existing.optimisticInsertedAt = null;
           } else {
             taskSignals.set(task.id, createTaskSignals(task));
+          }
+        }
+
+        // TTL prune: remove stale optimistic entries that were never confirmed
+        const now = Date.now();
+        for (const [id, ts] of taskSignals) {
+          if (
+            ts.optimistic &&
+            ts.optimisticInsertedAt !== null &&
+            now - ts.optimisticInsertedAt > OPTIMISTIC_TTL_MS
+          ) {
+            set(ts.closeTask$);
+            taskSignals.delete(id);
           }
         }
 
@@ -226,19 +263,33 @@ export const setupTasksLoop$ = command(
 
 /**
  * Ordered list of TaskSignals derived from the reconciled cache.
- * Matches the order of the latest tasks$ fetch.
+ * Optimistic entries (not yet confirmed by server) are prepended at the top.
+ * Server-confirmed entries follow in server order.
  */
 export const taskSignals$ = computed(async (get) => {
   const tasks = await get(tasks$);
-  const taskSignals = get(internalTaskSignals$);
+  const signals = get(internalTaskSignals$);
+  const serverIds = new Set(
+    tasks.map((t) => {
+      return t.id;
+    }),
+  );
 
-  return tasks
+  // Optimistic entries not yet confirmed by server — prepend at top
+  const optimisticEntries = [...signals.values()].filter((ts) => {
+    return ts.optimistic && !serverIds.has(ts.task.id);
+  });
+
+  // Server-confirmed entries in server order
+  const serverEntries = tasks
     .map((task) => {
-      return taskSignals.get(task.id);
+      return signals.get(task.id);
     })
     .filter((ts): ts is TaskSignals => {
       return ts !== undefined;
     });
+
+  return [...optimisticEntries, ...serverEntries];
 });
 
 // ---------------------------------------------------------------------------
@@ -272,6 +323,59 @@ export const archiveTask$ = command(
     const updated = new Map(get(internalTaskSignals$));
     updated.delete(taskId);
     set(internalTaskSignals$, updated);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Optimistic task insertion
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert an optimistic task entry for a newly created chat thread.
+ * If an entry already exists for this threadId, returns the existing entry (no-op).
+ * The entry is protected from pruning until the server confirms it (or TTL expires).
+ */
+export const addOptimisticTask$ = command(
+  (
+    { get, set },
+    agentId: string,
+    threadId: string,
+    agentDisplayName: string | null,
+    agentAvatarUrl: string | null,
+  ): TaskSignals => {
+    const existing = get(internalTaskSignals$).get(threadId);
+    if (existing) {
+      return existing;
+    }
+
+    const now = new Date().toISOString();
+    const syntheticTask: TaskItem = {
+      id: threadId,
+      type: "chat",
+      title: null,
+      summary: null,
+      agent: {
+        id: agentId,
+        name: agentId,
+        displayName: agentDisplayName,
+        avatarUrl: agentAvatarUrl,
+      },
+      latestRunId: null,
+      status: null,
+      chatThreadId: threadId,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const ts = createTaskSignals(syntheticTask);
+    ts.optimistic = true;
+    ts.optimisticInsertedAt = Date.now();
+
+    const updated = new Map(get(internalTaskSignals$));
+    updated.set(threadId, ts);
+    set(internalTaskSignals$, updated);
+
+    return ts;
   },
 );
 

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
@@ -153,6 +153,7 @@ export const createAndShowChatTask$ = command(
     // Step 1: Create (or reuse) chat thread
     const threadId = await set(createNewChatThread$, agentId, signal);
     signal.throwIfAborted();
+    // If null, createNewChatThread$ already showed a toast (e.g. "No agent available")
     if (!threadId) {
       return;
     }
@@ -163,8 +164,11 @@ export const createAndShowChatTask$ = command(
     const resolvedAgentId =
       agentId ??
       (await get(zeroOnboardingStatus$)).defaultAgentId ??
-      allAgents[0]?.id ??
-      "";
+      allAgents[0]?.id;
+    if (!resolvedAgentId) {
+      // No agent available — cannot create a meaningful optimistic entry
+      return;
+    }
     const agentInfo = allAgents.find((a) => {
       return a.id === resolvedAgentId;
     });

--- a/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
+++ b/turbo/apps/platform/src/signals/mission-control-page/mission-control.ts
@@ -1,8 +1,15 @@
 import { command, computed, state } from "ccstate";
 import { toggleTaskList$ } from "./mission-control-panels.ts";
-import { archiveTask$, setupTasksLoop$ } from "./mission-control-tasks.ts";
+import {
+  addOptimisticTask$,
+  archiveTask$,
+  setupTasksLoop$,
+} from "./mission-control-tasks.ts";
 import { setupGlobalShortcut } from "../../lib/setup-global-shortcut.ts";
 import { onRef, throwIfNotAbort } from "../utils.ts";
+import { agents$ } from "../agent.ts";
+import { zeroOnboardingStatus$ } from "../zero-page/zero-onboarding.ts";
+import { createNewChatThread$ } from "../chat-page/chat-message.ts";
 
 // ---------------------------------------------------------------------------
 // Task list container ref
@@ -127,6 +134,54 @@ export const setupMissionControlKeyboard$ = command(
       },
       signal,
     );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Create and show chat task (optimistic flow)
+// ---------------------------------------------------------------------------
+
+/**
+ * Full flow: create chat thread → insert optimistic task card → open panel → focus input.
+ */
+export const createAndShowChatTask$ = command(
+  async (
+    { get, set },
+    agentId: string | null,
+    signal: AbortSignal,
+  ): Promise<void> => {
+    // Step 1: Create (or reuse) chat thread
+    const threadId = await set(createNewChatThread$, agentId, signal);
+    signal.throwIfAborted();
+    if (!threadId) {
+      return;
+    }
+
+    // Step 2: Resolve agent info for the optimistic entry
+    const allAgents = await get(agents$);
+    signal.throwIfAborted();
+    const resolvedAgentId =
+      agentId ??
+      (await get(zeroOnboardingStatus$)).defaultAgentId ??
+      allAgents[0]?.id ??
+      "";
+    const agentInfo = allAgents.find((a) => {
+      return a.id === resolvedAgentId;
+    });
+
+    // Step 3: Insert optimistic task signal (no-op if entry already exists)
+    const ts = set(
+      addOptimisticTask$,
+      resolvedAgentId,
+      threadId,
+      agentInfo?.displayName ?? null,
+      agentInfo?.avatarUrl ?? null,
+    );
+
+    // Step 4: Open the panel and focus input
+    await set(ts.openTask$, signal);
+    signal.throwIfAborted();
+    set(ts.focusInput$);
   },
 );
 

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
@@ -6,6 +6,13 @@ import { server } from "../../../mocks/server.ts";
 import { testContext } from "../../../signals/__tests__/test-helpers.ts";
 import { detachedSetupPage } from "../../../__tests__/page-helper.ts";
 import { pathname } from "../../../signals/location.ts";
+import {
+  addOptimisticTask$,
+  setupTasksLoop$,
+  taskSignals$,
+} from "../../../signals/mission-control-page/mission-control-tasks.ts";
+import { createAndShowChatTask$ } from "../../../signals/mission-control-page/mission-control.ts";
+import { detach, Reason } from "../../../signals/utils.ts";
 
 const context = testContext();
 
@@ -365,6 +372,90 @@ describe("mission control page", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Close task")).toBeInTheDocument();
     });
+  });
+
+  it("should prune stale optimistic entry after TTL expires", async () => {
+    // Tasks API always returns empty — no server confirmation arrives
+    server.use(
+      http.get("*/api/zero/tasks", () => {
+        return HttpResponse.json({ tasks: [] });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/_/mission-control",
+      withoutRender: true,
+    });
+
+    // Insert optimistic entry with optimisticInsertedAt set 31 seconds in the past
+    const staleInsertedAt = Date.now() - 31_000;
+    const dateSpy = vi.spyOn(Date, "now").mockReturnValue(staleInsertedAt);
+    context.store.set(
+      addOptimisticTask$,
+      "agent-1",
+      "stale-thread-ttl",
+      "Test Agent",
+      null,
+    );
+    dateSpy.mockRestore();
+
+    // Entry must exist before the loop runs
+    const signalsBefore = await context.store.get(taskSignals$);
+    expect(
+      signalsBefore.some((ts) => {
+        return ts.task.id === "stale-thread-ttl";
+      }),
+    ).toBeTruthy();
+
+    // Run the loop with the test-scoped signal — Date.now() returns real time
+    // (31s after staleInsertedAt), so the TTL check fires and prunes the entry.
+    // The loop is aborted by afterEach when the test context signal is aborted.
+    detach(context.store.set(setupTasksLoop$, context.signal), Reason.Daemon);
+
+    await waitFor(async () => {
+      const signals = await context.store.get(taskSignals$);
+      expect(
+        signals.some((ts) => {
+          return ts.task.id === "stale-thread-ttl";
+        }),
+      ).toBeFalsy();
+    });
+  });
+
+  it("should return early from createAndShowChatTask$ when no agent is available", async () => {
+    // Return empty agent list and no defaultAgentId so resolvedAgentId is undefined
+    server.use(
+      http.get("*/api/zero/team", () => {
+        return HttpResponse.json([]);
+      }),
+      http.get("*/api/zero/onboarding/status", () => {
+        return HttpResponse.json({
+          needsOnboarding: false,
+          isAdmin: true,
+          hasOrg: true,
+          hasDefaultAgent: false,
+          defaultAgentId: null,
+          defaultAgentMetadata: null,
+          defaultAgentSkills: [],
+        });
+      }),
+      http.get("*/api/zero/tasks", () => {
+        return HttpResponse.json({ tasks: [] });
+      }),
+    );
+
+    detachedSetupPage({
+      context,
+      path: "/_/mission-control",
+      withoutRender: true,
+    });
+
+    // createAndShowChatTask$ should return early without inserting any optimistic entry
+    await context.store.set(createAndShowChatTask$, null, context.signal);
+
+    const signals = await context.store.get(taskSignals$);
+    expect(signals).toHaveLength(0);
   });
 
   it("should remove task from list when archive button is clicked", async () => {

--- a/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/__tests__/mission-control-page.test.tsx
@@ -331,6 +331,42 @@ describe("mission control page", () => {
     });
   });
 
+  it("should show task card immediately after creating a new chat via the c shortcut", async () => {
+    // Start with empty task list
+    server.use(
+      http.get("*/api/zero/tasks", () => {
+        return HttpResponse.json({ tasks: [] });
+      }),
+    );
+
+    const user = userEvent.setup();
+    detachedSetupPage({ context, path: "/_/mission-control" });
+
+    // Wait for empty state to render
+    await waitFor(() => {
+      expect(screen.getByText("No active tasks")).toBeInTheDocument();
+    });
+
+    // Press 'c' to open new chat dialog
+    await user.keyboard("c");
+
+    // The dialog should show — click the lead agent button (displayed as "Zero")
+    const agentName = await waitFor(() => {
+      return screen.getByText("Zero");
+    });
+    await user.click(agentName);
+
+    // Optimistic task card should appear immediately (no polling needed)
+    await waitFor(() => {
+      expect(screen.queryByText("No active tasks")).not.toBeInTheDocument();
+    });
+
+    // Chat panel should be open
+    await waitFor(() => {
+      expect(screen.getByLabelText("Close task")).toBeInTheDocument();
+    });
+  });
+
   it("should remove task from list when archive button is clicked", async () => {
     let archiveRequestBody: unknown = null;
 

--- a/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
+++ b/turbo/apps/platform/src/views/mission-control-page/mission-control-page.tsx
@@ -15,9 +15,9 @@ import {
   setTaskListRef$,
   newChatDialogOpen$,
   setNewChatDialogOpen$,
+  createAndShowChatTask$,
 } from "../../signals/mission-control-page/mission-control.ts";
 import { subagents$, defaultAgentName$ } from "../../signals/agent.ts";
-import { createNewChatThread$ } from "../../signals/chat-page/chat-message.ts";
 import { pageSignal$ } from "../../signals/page-signal.ts";
 import { detach, Reason } from "../../signals/utils.ts";
 import { AgentListDialog } from "../zero-page/zero-sidebar-dialogs.tsx";
@@ -36,12 +36,12 @@ export function MissionControlPage() {
   const setNewChatOpen = useSet(setNewChatDialogOpen$);
   const subagents = useLastResolved(subagents$) ?? [];
   const displayName = useLastResolved(defaultAgentName$) ?? "Zero";
-  const createNewChat = useSet(createNewChatThread$);
+  const createAndShowChatTask = useSet(createAndShowChatTask$);
   const pageSignal = useGet(pageSignal$);
 
   const onNewChat = (agentId: string | null) => {
-    detach(createNewChat(agentId, pageSignal), Reason.DomCallback);
     setNewChatOpen(false);
+    detach(createAndShowChatTask(agentId, pageSignal), Reason.DomCallback);
   };
 
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({


### PR DESCRIPTION
Closes #9075

## Summary

- Added `optimistic` and `optimisticInsertedAt` fields to `TaskSignals` interface and `createTaskSignals` factory
- Modified `setupTasksLoop$` reconciliation to skip pruning optimistic entries and clear the flag when server confirms the task
- Updated `taskSignals$` computed to prepend unconfirmed optimistic entries at the top of the list
- Added `addOptimisticTask$` command to insert a synthetic `TaskItem` with `optimistic = true`
- Added `createAndShowChatTask$` command that orchestrates: create thread → insert optimistic task → open panel → focus input
- Replaced `createNewChatThread$` usage in `MissionControlPage` with the new `createAndShowChatTask$` command
- Added 30s TTL cleanup for stale optimistic entries never confirmed by the server

## Test plan

- [x] New integration test: "should show task card immediately after creating a new chat via the c shortcut" — presses `c`, selects agent, verifies card appears without waiting for poll
- [x] All 9 existing mission-control page tests still pass
- [x] TypeScript types pass (`pnpm check-types`)
- [x] Lint passes (`pnpm turbo run lint`)
- [x] Format unchanged (`pnpm format`)
- [x] Knip reports no unused exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)