### PR TITLE
perf(sandbox-fc): skip plain namespace pre-warm when proxy is configured

### DIFF
--- a/crates/sandbox-fc/src/network/pool.rs
+++ b/crates/sandbox-fc/src/network/pool.rs
@@ -714,19 +714,24 @@ impl NetnsPool {
             let mut plain_set = tokio::task::JoinSet::new();
             let mut proxy_set = tokio::task::JoinSet::new();
 
-            // Plain namespaces (connectivity only).
-            for _ in 0..BUFFER_SIZE {
-                let ns_index = pool.next_ns_index;
-                pool.next_ns_index += 1;
-                let pool_index = pool.pool_index;
-                let default_iface = pool.default_iface.clone();
-                plain_set.spawn(create_single_namespace(
-                    pool_index,
-                    ns_index,
-                    default_iface,
-                    None,
-                    None,
-                ));
+            // Plain namespaces (connectivity only). Only needed when proxy
+            // is disabled; with proxy configured, `acquire()` always routes
+            // to the proxy queue, so plain entries would be unreachable
+            // until `cleanup()`.
+            if pool.proxy_port.is_none() {
+                for _ in 0..BUFFER_SIZE {
+                    let ns_index = pool.next_ns_index;
+                    pool.next_ns_index += 1;
+                    let pool_index = pool.pool_index;
+                    let default_iface = pool.default_iface.clone();
+                    plain_set.spawn(create_single_namespace(
+                        pool_index,
+                        ns_index,
+                        default_iface,
+                        None,
+                        None,
+                    ));
+                }
             }
 
             // Proxy namespaces (connectivity + REDIRECT rules).


### PR DESCRIPTION
## Summary

`NetnsPool::create()` unconditionally pre-warmed `BUFFER_SIZE` plain namespaces, but `acquire()` strictly routes to `proxy_queue` when `proxy_port` is configured. The pre-warmed plain entries were never consumed and sat idle until `cleanup()`, wasting one network namespace + TAP device + veth pair + iptables rules + routing entries per slot.

Mirror the existing capacity gate at L697 (`proxy_queue`) and the short-circuit in `maybe_replenish_proxy`: only pre-warm plain when proxy is disabled.

## Verification

- `acquire()`/`release()`/`maybe_replenish_*` already strictly gate on `proxy_port` — removing plain pre-warm cannot leave dead reads (verified)
- `snapshot.rs` (the only `proxy_port = None` caller) is unaffected — `is_none()` is true, pre-warm runs as before
- `cleanup_namespaces_by_index` matches by pool prefix, not `ns_index` — `next_ns_index` offset change is harmless
- Forward-compatible with old version: cleanup matches whatever count was created previously

## Test plan

- [x] `cargo build -p sandbox-fc`
- [x] `cargo clippy -p sandbox-fc --all-targets -- -D warnings`
- [x] `cargo test -p sandbox-fc` (111 tests pass)
- [ ] Production observation post-deploy: startup log changes from `plain=4 proxy=4` to `plain=0 proxy=4` for proxy pools

No new test added. `NetnsPool::create()` requires root + CAP_NET_ADMIN (`ip netns add`, `iptables`), making unit-level coverage of this guard infeasible without significant scaffolding. The fix mirrors an existing correct pattern (L697 capacity gate) — pattern conformance + code review provides regression protection. Detailed analysis in [issue #9065 deep-dive comments](https://github.com/vm0-ai/vm0/issues/9065).

Closes #9065