### PR TITLE
feat(platform): add tts read-aloud button and auto-read toggle

### DIFF
--- a/turbo/apps/platform/.oxlintrc.json
+++ b/turbo/apps/platform/.oxlintrc.json
@@ -117,7 +117,8 @@
       "files": [
         "src/signals/zero-page/zero-chat.ts",
         "src/signals/zero-page/chat-draft.ts",
-        "src/signals/voice-chat/voice-chat-session.ts"
+        "src/signals/voice-chat/voice-chat-session.ts",
+        "src/signals/voice-io/voice-io-tts.ts"
       ],
       "rules": {
         "no-restricted-imports": [

--- a/turbo/apps/platform/eslint.config.js
+++ b/turbo/apps/platform/eslint.config.js
@@ -129,6 +129,7 @@ export default [
       "src/signals/zero-page/chat-draft.ts",
       "src/signals/__tests__/fetch.test.ts",
       "src/signals/voice-chat/voice-chat-session.ts",
+      "src/signals/voice-io/voice-io-tts.ts",
       "src/views/zero-page/components/org-manage/org-general-tab.tsx",
       "src/views/agents-page/agents-page.tsx",
       "src/views/zero-page/zero-settings-tab.tsx",

--- a/turbo/apps/platform/src/lib/voice-io/tts-fetch.ts
+++ b/turbo/apps/platform/src/lib/voice-io/tts-fetch.ts
@@ -1,0 +1,23 @@
+/**
+ * Fetch TTS audio from the voice-io endpoint.
+ *
+ * Separated from the signal layer because the TTS endpoint returns binary
+ * audio (audio/mpeg) which ts-rest clients cannot handle. This is analogous
+ * to FormData uploads — both require raw fetch.
+ */
+export async function fetchTtsAudio(
+  fetchFn: (url: string, init?: RequestInit) => Promise<Response>,
+  text: string,
+): Promise<Blob | null> {
+  const response = await fetchFn("/api/zero/voice-io/tts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text: text.slice(0, 4096) }),
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return response.blob();
+}

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-settings.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-settings.ts
@@ -1,0 +1,13 @@
+import { command, computed } from "ccstate";
+import { localStorageSignals } from "../external/local-storage.ts";
+
+const { get$, set$ } = localStorageSignals("voiceIO.autoRead");
+
+export const autoReadEnabled$ = computed((get) => {
+  return get(get$) === "true";
+});
+
+export const toggleAutoRead$ = command(({ get, set }) => {
+  const current = get(get$) === "true";
+  set(set$, current ? "false" : "true");
+});

--- a/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
+++ b/turbo/apps/platform/src/signals/voice-io/voice-io-tts.ts
@@ -1,0 +1,189 @@
+import { command, computed, state } from "ccstate";
+import { autoReadEnabled$ } from "./voice-io-settings.ts";
+import { fetch$ } from "../fetch.ts";
+import { fetchTtsAudio } from "../../lib/voice-io/tts-fetch.ts";
+import { logger } from "../log.ts";
+
+const L = logger("VoiceIO:TTS");
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+const internalPlayingMessageId$ = state<string | null>(null);
+const internalAudioElement$ = state<HTMLAudioElement | null>(null);
+const internalBlobUrl$ = state<string | null>(null);
+
+// Auto-read tracking
+const internalSeenLoading$ = state<Set<string>>(new Set());
+const internalAutoReadTriggered$ = state<Set<string>>(new Set());
+
+// ---------------------------------------------------------------------------
+// Public computed
+// ---------------------------------------------------------------------------
+
+export const ttsPlayingMessageId$ = computed((get) => {
+  return get(internalPlayingMessageId$);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip common markdown formatting to produce natural-sounding TTS input.
+ */
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/\*{1,3}([^*]+)\*{1,3}/g, "$1")
+    .replace(/_{1,3}([^_]+)_{1,3}/g, "$1")
+    .replace(/^[-*_]{3,}\s*$/gm, "")
+    .replace(/^>\s+/gm, "")
+    .replace(/^[\s]*[-*+]\s+/gm, "")
+    .replace(/^[\s]*\d+\.\s+/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Internal commands
+// ---------------------------------------------------------------------------
+
+const cleanupAudio$ = command(({ get, set }) => {
+  const audio = get(internalAudioElement$);
+  if (audio) {
+    audio.pause();
+    audio.removeAttribute("src");
+    audio.load();
+  }
+
+  const blobUrl = get(internalBlobUrl$);
+  if (blobUrl) {
+    URL.revokeObjectURL(blobUrl);
+  }
+
+  set(internalPlayingMessageId$, null);
+  set(internalAudioElement$, null);
+  set(internalBlobUrl$, null);
+});
+
+const fetchAndPlay$ = command(
+  async (
+    { get, set },
+    messageId: string,
+    text: string,
+    _signal: AbortSignal,
+  ) => {
+    set(cleanupAudio$);
+
+    const plainText = stripMarkdown(text);
+    if (!plainText) {
+      return;
+    }
+
+    const fetchFn = get(fetch$);
+
+    let blob: Blob | null;
+    // eslint-disable-next-line no-restricted-syntax -- raw fetch for binary audio (not a ts-rest contract)
+    try {
+      blob = await fetchTtsAudio(fetchFn, plainText);
+    } catch (error) {
+      L.error("TTS fetch failed", error);
+      return;
+    }
+
+    if (!blob) {
+      L.error("TTS API returned error");
+      return;
+    }
+
+    const blobUrl = URL.createObjectURL(blob);
+    const audio = new Audio(blobUrl);
+
+    set(internalBlobUrl$, blobUrl);
+    set(internalAudioElement$, audio);
+    set(internalPlayingMessageId$, messageId);
+
+    const cleanup = () => {
+      URL.revokeObjectURL(blobUrl);
+      set(internalPlayingMessageId$, null);
+      set(internalAudioElement$, null);
+      set(internalBlobUrl$, null);
+    };
+
+    audio.addEventListener("ended", cleanup);
+    audio.addEventListener("error", () => {
+      L.error("Audio playback error");
+      cleanup();
+    });
+
+    // eslint-disable-next-line no-restricted-syntax -- audio.play() rejects on browser autoplay restrictions
+    try {
+      await audio.play();
+    } catch (error) {
+      L.error("Audio play failed", error);
+      cleanup();
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Public commands
+// ---------------------------------------------------------------------------
+
+export const stopTts$ = command(({ set }) => {
+  set(cleanupAudio$);
+});
+
+export const playTts$ = command(
+  async ({ set }, messageId: string, text: string, signal: AbortSignal) => {
+    await set(fetchAndPlay$, messageId, text, signal);
+  },
+);
+
+/**
+ * Mark a message as "seen loading" during this session.
+ */
+export const markMessageLoading$ = command(
+  ({ get, set }, messageId: string) => {
+    const seen = get(internalSeenLoading$);
+    if (!seen.has(messageId)) {
+      const next = new Set(seen);
+      next.add(messageId);
+      set(internalSeenLoading$, next);
+    }
+  },
+);
+
+/**
+ * Check if a completed message should be auto-read, and trigger playback.
+ */
+export const checkAutoRead$ = command(
+  async (
+    { get, set },
+    messageId: string,
+    content: string,
+    signal: AbortSignal,
+  ) => {
+    if (!get(autoReadEnabled$)) {
+      return;
+    }
+    if (!get(internalSeenLoading$).has(messageId)) {
+      return;
+    }
+    if (get(internalAutoReadTriggered$).has(messageId)) {
+      return;
+    }
+
+    const nextTriggered = new Set(get(internalAutoReadTriggered$));
+    nextTriggered.add(messageId);
+    set(internalAutoReadTriggered$, nextTriggered);
+
+    await set(fetchAndPlay$, messageId, content, signal);
+  },
+);

--- a/turbo/apps/platform/src/views/zero-page/use-auto-read.ts
+++ b/turbo/apps/platform/src/views/zero-page/use-auto-read.ts
@@ -1,0 +1,38 @@
+// useEffect needed for auto-read side effects (mark loading, check completion).
+// oxlint-disable-next-line no-restricted-imports
+import { useEffect } from "react";
+import { useGet, useSet } from "ccstate-react";
+import { pageSignal$ } from "../../signals/page-signal.ts";
+import {
+  markMessageLoading$,
+  checkAutoRead$,
+} from "../../signals/voice-io/voice-io-tts.ts";
+import { detach, Reason } from "../../signals/utils.ts";
+
+/**
+ * Track message loading→completed transitions and trigger auto-read TTS.
+ */
+export function useAutoRead(
+  messageId: string,
+  content: string,
+  isLoading: boolean,
+) {
+  const pageSignal = useGet(pageSignal$);
+  const markLoading = useSet(markMessageLoading$);
+  const checkAutoReadFn = useSet(checkAutoRead$);
+
+  useEffect(() => {
+    if (isLoading) {
+      markLoading(messageId);
+    }
+  }, [markLoading, messageId, isLoading]);
+
+  useEffect(() => {
+    if (content && !isLoading) {
+      detach(
+        checkAutoReadFn(messageId, content, pageSignal),
+        Reason.DomCallback,
+      );
+    }
+  }, [checkAutoReadFn, messageId, content, isLoading, pageSignal]);
+}

--- a/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
+++ b/turbo/apps/platform/src/views/zero-page/zero-chat-thread-page.tsx
@@ -17,15 +17,27 @@ import {
   IconCopy,
   IconCheck,
   IconPin,
+  IconVolume2,
 } from "@tabler/icons-react";
 import {
+  cn,
   Skeleton,
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@vm0/ui";
-import { RUN_ERROR_GUIDANCE } from "@vm0/core";
+import { FeatureSwitchKey, RUN_ERROR_GUIDANCE } from "@vm0/core";
+import { featureSwitch$ } from "../../signals/external/feature-switch.ts";
+import {
+  ttsPlayingMessageId$,
+  playTts$,
+  stopTts$,
+} from "../../signals/voice-io/voice-io-tts.ts";
+import {
+  autoReadEnabled$,
+  toggleAutoRead$,
+} from "../../signals/voice-io/voice-io-settings.ts";
 import { Markdown } from "../components/markdown.tsx";
 import { detach, Reason } from "../../signals/utils.ts";
 import { openQueueDrawer$ } from "../../signals/queue-page/queue-drawer-state.ts";
@@ -50,6 +62,7 @@ import {
 } from "../../signals/chat-page/create-chat-thread.ts";
 import { ZeroChatComposer } from "./zero-chat-composer.tsx";
 import { useAutoScroll } from "./use-auto-scroll.ts";
+import { useAutoRead } from "./use-auto-read.ts";
 import { AgentAvatarImg } from "./zero-sidebar-shared.tsx";
 import { Link } from "../router/link.tsx";
 import { setOrgManageDialogOpen$ } from "../../signals/zero-page/settings/org-manage-dialog.ts";
@@ -142,6 +155,10 @@ function PinPillButton({ thread }: { thread: ChatThreadSignals }) {
 
 function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
   const displayName = useLastResolved(thread.agentDisplayName$);
+  const features = useLastResolved(featureSwitch$);
+  const voiceIOEnabled = features?.[FeatureSwitchKey.VoiceIO] ?? false;
+  const autoRead = useGet(autoReadEnabled$);
+  const toggleAutoReadFn = useSet(toggleAutoRead$);
 
   return (
     <header className="hidden sm:flex shrink-0 bg-transparent px-6 py-3 items-center justify-between">
@@ -152,7 +169,34 @@ function ChatThreadHeader({ thread }: { thread: ChatThreadSignals }) {
         </div>
         <span className="font-semibold text-foreground">{displayName}</span>
       </div>
-      <div className="hidden sm:flex items-center gap-0.5" />
+      <div className="hidden sm:flex items-center gap-0.5">
+        {voiceIOEnabled && (
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => {
+                    toggleAutoReadFn();
+                  }}
+                  className={cn(
+                    "p-1.5 rounded-md transition-colors duration-150",
+                    autoRead
+                      ? "text-primary bg-primary/10"
+                      : "text-muted-foreground/60 hover:text-foreground hover:bg-accent",
+                  )}
+                  aria-label="Toggle auto-read"
+                >
+                  <IconVolume2 size={18} stroke={1.5} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {autoRead ? "Auto-read on" : "Auto-read off"}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
     </header>
   );
 }
@@ -756,6 +800,13 @@ function AssistantMessageActions({
   const copied = copiedId === message.id;
   const copyMessage = useSet(thread.copyMessage$);
 
+  const features = useLastResolved(featureSwitch$);
+  const voiceIOEnabled = features?.[FeatureSwitchKey.VoiceIO] ?? false;
+  const playingId = useGet(ttsPlayingMessageId$);
+  const isPlayingThis = playingId === message.id;
+  const playTts = useSet(playTts$);
+  const stopTts = useSet(stopTts$);
+
   if (!message.legacyRunId) {
     return null;
   }
@@ -765,6 +816,14 @@ function AssistantMessageActions({
       return;
     }
     detach(copyMessage(message.id, content, pageSignal), Reason.DomCallback);
+  };
+
+  const handleTts = () => {
+    if (isPlayingThis) {
+      detach(stopTts(), Reason.DomCallback);
+    } else {
+      detach(playTts(message.id, content, pageSignal), Reason.DomCallback);
+    }
   };
 
   return (
@@ -805,6 +864,29 @@ function AssistantMessageActions({
               </TooltipTrigger>
               <TooltipContent side="bottom">
                 {copied ? "Copied!" : "Copy message"}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+        {content && voiceIOEnabled && (
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleTts}
+                  className="p-1 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-accent transition-colors duration-150"
+                  aria-label={isPlayingThis ? "Stop reading" : "Read aloud"}
+                >
+                  {isPlayingThis ? (
+                    <IconPlayerStop size={18} stroke={1.5} />
+                  ) : (
+                    <IconVolume2 size={18} stroke={1.5} />
+                  )}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {isPlayingThis ? "Stop reading" : "Read aloud"}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -910,6 +992,9 @@ function StaticAssistantMessage({
   useAutoScroll(content, thread.autoScroll$);
 
   const showActivityLine = isRunActive(message);
+
+  useAutoRead(message.id, content, showActivityLine);
+
   const hasSummaries = message.summaries && message.summaries.length > 0;
 
   if (message.error) {


### PR DESCRIPTION
## Summary

- Add a speaker button on each assistant message to play/stop TTS audio via the VoiceIO backend
- Add an auto-read toggle in the chat header that automatically reads new messages aloud (tracks loading→completed transitions)
- Create ccstate signal layer for TTS playback state, auto-read tracking, and settings persistence (localStorage)
- All functionality gated behind `FeatureSwitchKey.VoiceIO` feature switch (disabled by default)

Depends on #9088 (VoiceIO feature switch + TTS backend endpoint)

Closes #9080

## Test plan

- [ ] Enable VoiceIO feature switch for a test org
- [ ] Verify speaker button appears on assistant messages and plays audio
- [ ] Verify clicking speaker again stops playback
- [ ] Verify auto-read toggle in header persists state to localStorage
- [ ] Verify auto-read only reads messages that transition from loading→completed (not pre-existing)
- [ ] Verify no speaker button or toggle appears when VoiceIO is disabled
- [ ] Verify lint, type-check, and format pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)